### PR TITLE
callbacks: Allow reporting string macros

### DIFF
--- a/bindgen-integration/cpp/Test.h
+++ b/bindgen-integration/cpp/Test.h
@@ -2,6 +2,10 @@
 
 #define TESTMACRO
 
+#define TESTMACRO_INTEGER 42
+#define TESTMACRO_STRING "Hello Preprocessor!"
+#define TESTMACRO_STRING_EXPANDED TESTMACRO_STRING
+
 #include <cwchar>
 
 enum {

--- a/src/callbacks.rs
+++ b/src/callbacks.rs
@@ -35,6 +35,11 @@ pub trait ParseCallbacks: fmt::Debug + UnwindSafe {
         None
     }
 
+    /// This will be run on every string macro. The callback can not influence the further
+    /// treatment of the macro, but may use the value to generate additional code or configuration.
+    fn str_macro(&self, _name: &str, _value: &[u8]) {
+    }
+
     /// This function should return whether, given an enum variant
     /// name, and value, this enum variant will forcibly be a constant.
     fn enum_variant_behavior(

--- a/src/ir/var.rs
+++ b/src/ir/var.rs
@@ -199,6 +199,9 @@ impl ClangSubItemParser for Var {
                             true,
                             ctx,
                         );
+                        if let Some(callbacks) = ctx.parse_callbacks() {
+                            callbacks.str_macro(&name, &val);
+                        }
                         (TypeKind::Pointer(char_ty), VarType::String(val))
                     }
                     EvalResult::Int(Wrapping(value)) => {


### PR DESCRIPTION
This is the minimum necessary change to have a str_macro in analogy to the int_macro callback. Unlike int_callback, this can't change anything about how code is generated, but it is still usable to influence the build system based on it. For example, in the course of [making Rust usable on the RIOT embedded operating system](https://github.com/RIOT-OS/RIOT/issues/9799), I'd print `cargo:rustc-config=riot_board="..."` from bindgen with a value from a string define.