### PR TITLE
Update broken links: Rust-lang-nursery => Rust-lang

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -14,7 +14,7 @@
 // Use the `--dump-preprocessed-input` flag or the
 // `bindgen::Builder::dump_preprocessed_input` method to make your test case
 // standalone and without `#include`s, and then use C-Reduce to minimize it:
-// https://github.com/rust-lang-nursery/rust-bindgen/blob/master/CONTRIBUTING.md#using-creduce-to-minimize-test-cases
+// https://github.com/rust-lang/rust-bindgen/blob/master/CONTRIBUTING.md#using-creduce-to-minimize-test-cases
 ```
 
 ### Bindgen Invocation

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,9 +11,9 @@ categories = ["external-ffi-bindings", "development-tools::ffi"]
 license = "BSD-3-Clause"
 name = "bindgen"
 readme = "README.md"
-repository = "https://github.com/rust-lang-nursery/rust-bindgen"
+repository = "https://github.com/rust-lang/rust-bindgen"
 documentation = "https://docs.rs/bindgen"
-homepage = "https://rust-lang-nursery.github.io/rust-bindgen/"
+homepage = "https://rust-lang.github.io/rust-bindgen/"
 version = "0.43.2"
 build = "build.rs"
 
@@ -27,7 +27,7 @@ include = [
 ]
 
 [badges]
-travis-ci = { repository = "rust-lang-nursery/rust-bindgen" }
+travis-ci = { repository = "rust-lang/rust-bindgen" }
 
 [lib]
 path = "src/lib.rs"

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ extern "C" {
 
 ## Users Guide
 
-[📚 Read the `bindgen` users guide here! 📚](https://rust-lang-nursery.github.io/rust-bindgen)
+[📚 Read the `bindgen` users guide here! 📚](https://rust-lang.github.io/rust-bindgen)
 
 ## API Reference
 


### PR DESCRIPTION
There is also one broken link in the github project details (that I think can not be changed with a pull request).