### PR TITLE
User-guide link update on docs.rs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@
 //!
 //! See the [`Builder`](./struct.Builder.html) struct for usage.
 //!
-//! See the [Users Guide](https://rust-lang-nursery.github.io/rust-bindgen/) for
+//! See the [Users Guide](https://rust-lang.github.io/rust-bindgen/) for
 //! additional documentation.
 #![deny(missing_docs)]
 #![deny(warnings)]


### PR DESCRIPTION
The link to the user guide pointed to https://rust-lang-nursery.github.io/rust-bindgen/