### PR TITLE
Some perf tweaks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,6 +56,7 @@ dependencies = [
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "diff 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fxhash 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "peeking_take_while 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -69,6 +70,11 @@ dependencies = [
 [[package]]
 name = "bitflags"
 version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "byteorder"
+version = "1.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -136,6 +142,14 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "backtrace 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -389,6 +403,7 @@ dependencies = [
 "checksum backtrace 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "89a47830402e9981c5c41223151efcced65a0510c13097c769cede7efb34782a"
 "checksum backtrace-sys 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)" = "c66d56ac8dabd07f6aacdaf633f4b8262f5b3601a810a0dcddffd5c22c69daa0"
 "checksum bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12"
+"checksum byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "94f88df23a25417badc922ab0f5716cc1330e87f71ddd9203b3a3ccd9cedf75d"
 "checksum cc 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)" = "f159dfd43363c4d08055a07703eb7a3406b0dac4d0584d96965a3262db3c9d16"
 "checksum cexpr 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8fc0086be9ca82f7fc89fc873435531cb898b86e850005850de1f820e2db6e9b"
 "checksum cfg-if 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "0c4e7bb64a8ebb0d856483e1e682ea3422f883c5f5615a90d51a2c82fe87fdd3"
@@ -397,6 +412,7 @@ dependencies = [
 "checksum diff 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "3c2b69f912779fbb121ceb775d74d51e915af17aaebc38d28a592843a2dd0a3a"
 "checksum env_logger 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "afb070faf94c85d17d50ca44f6ad076bce18ae92f0037d350947240a36e9d42e"
 "checksum failure 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6dd377bcc1b1b7ce911967e3ec24fa19c3224394ec05b54aa7b083d498341ac7"
+"checksum fxhash 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
 "checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
 "checksum humantime 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0484fda3e7007f2a4a0d9c3a703ca38c71c54c55602ce4660c419fd32e188c9e"
 "checksum lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ca488b89a5657b0a2ecd45b95609b3e848cf1755da332a0da46e2b2b1cb371a7"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,7 +56,7 @@ dependencies = [
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "diff 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "fxhash 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hashbrown 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "peeking_take_while 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -145,17 +145,18 @@ dependencies = [
 ]
 
 [[package]]
-name = "fxhash"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "glob"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "hashbrown"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "humantime"
@@ -275,6 +276,11 @@ dependencies = [
 [[package]]
 name = "rustc-demangle"
 version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "scopeguard"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -412,8 +418,8 @@ dependencies = [
 "checksum diff 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "3c2b69f912779fbb121ceb775d74d51e915af17aaebc38d28a592843a2dd0a3a"
 "checksum env_logger 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "afb070faf94c85d17d50ca44f6ad076bce18ae92f0037d350947240a36e9d42e"
 "checksum failure 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6dd377bcc1b1b7ce911967e3ec24fa19c3224394ec05b54aa7b083d498341ac7"
-"checksum fxhash 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
 "checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
+"checksum hashbrown 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "64b7d419d0622ae02fe5da6b9a5e1964b610a65bb37923b976aeebb6dbb8f86e"
 "checksum humantime 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0484fda3e7007f2a4a0d9c3a703ca38c71c54c55602ce4660c419fd32e188c9e"
 "checksum lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ca488b89a5657b0a2ecd45b95609b3e848cf1755da332a0da46e2b2b1cb371a7"
 "checksum libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)" = "76e3a3ef172f1a0b9a9ff0dd1491ae5e6c948b94479a3021819ba7d860c8645d"
@@ -430,6 +436,7 @@ dependencies = [
 "checksum regex 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "2069749032ea3ec200ca51e4a31df41759190a88edca0d2d86ee8bedf7073341"
 "checksum regex-syntax 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "747ba3b235651f6e2f67dfa8bcdcd073ddb7c243cb21c442fc12395dfcac212d"
 "checksum rustc-demangle 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "bcfe5b13211b4d78e5c2cadfebd7769197d95c639c35a50057eb4c05de811395"
+"checksum scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27"
 "checksum shlex 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7fdf1b9db47230893d76faad238fd6097fd6d6a9245cd7a4d90dbd639536bbd2"
 "checksum strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"
 "checksum termcolor 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4096add70612622289f2fdcdbd5086dc81c1e2675e6ae58d6c4f62a16c6d7f2f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ peeking_take_while = "0.1.2"
 quote = { version = "0.6", default-features = false }
 regex = "1.0"
 which = "2.0"
+fxhash = "0.2"
 # New validation in 0.3.6 breaks bindgen-integration:
 # https://github.com/alexcrichton/proc-macro2/commit/489c642.
 proc-macro2 = { version = "0.4", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ peeking_take_while = "0.1.2"
 quote = { version = "0.6", default-features = false }
 regex = "1.0"
 which = "2.0"
-fxhash = "0.2"
+hashbrown = "0.1"
 # New validation in 0.3.6 breaks bindgen-integration:
 # https://github.com/alexcrichton/proc-macro2/commit/489c642.
 proc-macro2 = { version = "0.4", default-features = false }

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -3546,11 +3546,12 @@ pub(crate) fn codegen(context: BindgenContext) -> (Vec<proc_macro2::TokenStream>
 
         debug!("codegen: {:?}", context.options());
 
-        let codegen_items = context.codegen_items();
         if context.options().emit_ir {
-            for &id in codegen_items {
-                let item = context.resolve_item(id);
-                println!("ir: {:?} = {:#?}", id, item);
+            let codegen_items = context.codegen_items();
+            for (id, item) in context.items() {
+                if codegen_items.contains(&id) {
+                    println!("ir: {:?} = {:#?}", id, item);
+                }
             }
         }
 

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -44,12 +44,11 @@ use std;
 use std::borrow::Cow;
 use std::cell::Cell;
 use std::collections::VecDeque;
-use std::collections::hash_map::Entry;
 use std::fmt::Write;
 use std::iter;
 use std::ops;
 use std::str::FromStr;
-use {HashMap, HashSet};
+use {HashMap, HashSet, Entry};
 
 // Name of type defined in constified enum module
 pub static CONSTIFIED_ENUM_MODULE_REPR_NAME: &'static str = "Type";

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -43,12 +43,13 @@ use proc_macro2::{self, Ident, Span};
 use std;
 use std::borrow::Cow;
 use std::cell::Cell;
-use std::collections::{HashSet, VecDeque};
-use std::collections::hash_map::{Entry, HashMap};
+use std::collections::VecDeque;
+use std::collections::hash_map::Entry;
 use std::fmt::Write;
 use std::iter;
 use std::ops;
 use std::str::FromStr;
+use {HashMap, HashSet};
 
 // Name of type defined in constified enum module
 pub static CONSTIFIED_ENUM_MODULE_REPR_NAME: &'static str = "Type";
@@ -2638,7 +2639,7 @@ impl CodeGenerator for Enum {
         );
 
         // A map where we keep a value -> variant relation.
-        let mut seen_values = HashMap::<_, Ident>::new();
+        let mut seen_values = HashMap::<_, Ident>::default();
         let enum_rust_ty = item.to_rust_ty_or_opaque(ctx, &());
         let is_toplevel = item.is_toplevel(ctx);
 

--- a/src/ir/analysis/derive_copy.rs
+++ b/src/ir/analysis/derive_copy.rs
@@ -11,8 +11,7 @@ use ir::template::TemplateParameters;
 use ir::traversal::EdgeKind;
 use ir::ty::RUST_DERIVE_IN_ARRAY_LIMIT;
 use ir::ty::TypeKind;
-use std::collections::HashMap;
-use std::collections::HashSet;
+use {HashMap, HashSet};
 
 /// An analysis that finds for each IR item whether copy cannot be derived.
 ///
@@ -103,7 +102,7 @@ impl<'ctx> MonotoneFramework for CannotDeriveCopy<'ctx> {
     type Output = HashSet<ItemId>;
 
     fn new(ctx: &'ctx BindgenContext) -> CannotDeriveCopy<'ctx> {
-        let cannot_derive_copy = HashSet::new();
+        let cannot_derive_copy = HashSet::default();
         let dependencies = generate_dependencies(ctx, Self::consider_edge);
 
         CannotDeriveCopy {

--- a/src/ir/analysis/derive_debug.rs
+++ b/src/ir/analysis/derive_debug.rs
@@ -10,8 +10,7 @@ use ir::item::IsOpaque;
 use ir::traversal::EdgeKind;
 use ir::ty::RUST_DERIVE_IN_ARRAY_LIMIT;
 use ir::ty::TypeKind;
-use std::collections::HashMap;
-use std::collections::HashSet;
+use {HashMap, HashSet};
 
 /// An analysis that finds for each IR item whether debug cannot be derived.
 ///
@@ -104,7 +103,7 @@ impl<'ctx> MonotoneFramework for CannotDeriveDebug<'ctx> {
     type Output = HashSet<ItemId>;
 
     fn new(ctx: &'ctx BindgenContext) -> CannotDeriveDebug<'ctx> {
-        let cannot_derive_debug = HashSet::new();
+        let cannot_derive_debug = HashSet::default();
         let dependencies = generate_dependencies(ctx, Self::consider_edge);
 
         CannotDeriveDebug {

--- a/src/ir/analysis/derive_default.rs
+++ b/src/ir/analysis/derive_default.rs
@@ -12,8 +12,7 @@ use ir::traversal::EdgeKind;
 use ir::traversal::Trace;
 use ir::ty::RUST_DERIVE_IN_ARRAY_LIMIT;
 use ir::ty::TypeKind;
-use std::collections::HashMap;
-use std::collections::HashSet;
+use {HashMap, HashSet};
 
 /// An analysis that finds for each IR item whether default cannot be derived.
 ///
@@ -99,8 +98,8 @@ impl<'ctx> MonotoneFramework for CannotDeriveDefault<'ctx> {
     type Output = HashSet<ItemId>;
 
     fn new(ctx: &'ctx BindgenContext) -> CannotDeriveDefault<'ctx> {
-        let mut dependencies = HashMap::new();
-        let cannot_derive_default = HashSet::new();
+        let mut dependencies = HashMap::default();
+        let cannot_derive_default = HashSet::default();
 
         let whitelisted_items: HashSet<_> =
             ctx.whitelisted_items().iter().cloned().collect();

--- a/src/ir/analysis/derive_hash.rs
+++ b/src/ir/analysis/derive_hash.rs
@@ -10,8 +10,7 @@ use ir::item::IsOpaque;
 use ir::traversal::EdgeKind;
 use ir::ty::RUST_DERIVE_IN_ARRAY_LIMIT;
 use ir::ty::TypeKind;
-use std::collections::HashMap;
-use std::collections::HashSet;
+use {HashMap, HashSet};
 
 /// An analysis that finds for each IR item whether hash cannot be derived.
 ///
@@ -96,7 +95,7 @@ impl<'ctx> MonotoneFramework for CannotDeriveHash<'ctx> {
     type Output = HashSet<ItemId>;
 
     fn new(ctx: &'ctx BindgenContext) -> CannotDeriveHash<'ctx> {
-        let cannot_derive_hash = HashSet::new();
+        let cannot_derive_hash = HashSet::default();
         let dependencies = generate_dependencies(ctx, Self::consider_edge);
 
         CannotDeriveHash {

--- a/src/ir/analysis/derive_partialeq_or_partialord.rs
+++ b/src/ir/analysis/derive_partialeq_or_partialord.rs
@@ -9,8 +9,7 @@ use ir::item::{Item, IsOpaque};
 use ir::traversal::{EdgeKind, Trace};
 use ir::ty::RUST_DERIVE_IN_ARRAY_LIMIT;
 use ir::ty::{TypeKind, Type};
-use std::collections::HashMap;
-use std::collections::hash_map::Entry;
+use {HashMap, Entry};
 
 /// An analysis that finds for each IR item whether `PartialEq`/`PartialOrd`
 /// cannot be derived.
@@ -326,7 +325,7 @@ impl<'ctx> MonotoneFramework for CannotDerivePartialEqOrPartialOrd<'ctx> {
     fn new(
         ctx: &'ctx BindgenContext,
     ) -> CannotDerivePartialEqOrPartialOrd<'ctx> {
-        let can_derive_partialeq_or_partialord = HashMap::new();
+        let can_derive_partialeq_or_partialord = HashMap::default();
         let dependencies = generate_dependencies(ctx, Self::consider_edge);
 
         CannotDerivePartialEqOrPartialOrd {

--- a/src/ir/analysis/has_destructor.rs
+++ b/src/ir/analysis/has_destructor.rs
@@ -5,8 +5,7 @@ use ir::context::{BindgenContext, ItemId};
 use ir::traversal::EdgeKind;
 use ir::comp::{CompKind, Field, FieldMethods};
 use ir::ty::TypeKind;
-use std::collections::HashMap;
-use std::collections::HashSet;
+use {HashMap, HashSet};
 
 /// An analysis that finds for each IR item whether it has a destructor or not
 ///
@@ -73,7 +72,7 @@ impl<'ctx> MonotoneFramework for HasDestructorAnalysis<'ctx> {
     type Output = HashSet<ItemId>;
 
     fn new(ctx: &'ctx BindgenContext) -> Self {
-        let have_destructor = HashSet::new();
+        let have_destructor = HashSet::default();
         let dependencies = generate_dependencies(ctx, Self::consider_edge);
 
         HasDestructorAnalysis {

--- a/src/ir/analysis/has_float.rs
+++ b/src/ir/analysis/has_float.rs
@@ -1,8 +1,7 @@
 //! Determining which types has float.
 
 use super::{ConstrainResult, MonotoneFramework, generate_dependencies};
-use std::collections::HashSet;
-use std::collections::HashMap;
+use {HashSet, HashMap};
 use ir::context::{BindgenContext, ItemId};
 use ir::traversal::EdgeKind;
 use ir::ty::TypeKind;
@@ -84,7 +83,7 @@ impl<'ctx> MonotoneFramework for HasFloat<'ctx> {
     type Output = HashSet<ItemId>;
 
     fn new(ctx: &'ctx BindgenContext) -> HasFloat<'ctx> {
-        let has_float = HashSet::new();
+        let has_float = HashSet::default();
         let dependencies = generate_dependencies(ctx, Self::consider_edge);
 
         HasFloat {

--- a/src/ir/analysis/has_type_param_in_array.rs
+++ b/src/ir/analysis/has_type_param_in_array.rs
@@ -6,8 +6,7 @@ use ir::comp::FieldMethods;
 use ir::context::{BindgenContext, ItemId};
 use ir::traversal::EdgeKind;
 use ir::ty::TypeKind;
-use std::collections::HashMap;
-use std::collections::HashSet;
+use {HashMap, HashSet};
 
 /// An analysis that finds for each IR item whether it has array or not.
 ///
@@ -92,7 +91,7 @@ impl<'ctx> MonotoneFramework for HasTypeParameterInArray<'ctx> {
     fn new(
         ctx: &'ctx BindgenContext,
     ) -> HasTypeParameterInArray<'ctx> {
-        let has_type_parameter_in_array = HashSet::new();
+        let has_type_parameter_in_array = HashSet::default();
         let dependencies = generate_dependencies(ctx, Self::consider_edge);
 
         HasTypeParameterInArray {

--- a/src/ir/analysis/has_vtable.rs
+++ b/src/ir/analysis/has_vtable.rs
@@ -5,9 +5,8 @@ use ir::context::{BindgenContext, ItemId};
 use ir::traversal::EdgeKind;
 use ir::ty::TypeKind;
 use std::cmp;
-use std::collections::HashMap;
-use std::collections::hash_map::Entry;
 use std::ops;
+use {HashMap, Entry};
 
 /// The result of the `HasVtableAnalysis` for an individual item.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Ord)]
@@ -148,7 +147,7 @@ impl<'ctx> MonotoneFramework for HasVtableAnalysis<'ctx> {
     type Output = HashMap<ItemId, HasVtableResult>;
 
     fn new(ctx: &'ctx BindgenContext) -> HasVtableAnalysis<'ctx> {
-        let have_vtable = HashMap::new();
+        let have_vtable = HashMap::default();
         let dependencies = generate_dependencies(ctx, Self::consider_edge);
 
         HasVtableAnalysis {

--- a/src/ir/analysis/mod.rs
+++ b/src/ir/analysis/mod.rs
@@ -64,7 +64,7 @@ pub use self::sizedness::{Sizedness, SizednessAnalysis, SizednessResult};
 use ir::context::{BindgenContext, ItemId};
 
 use ir::traversal::{EdgeKind, Trace};
-use std::collections::HashMap;
+use HashMap;
 use std::fmt;
 use std::ops;
 
@@ -190,7 +190,7 @@ pub fn generate_dependencies<F>(
 where
     F: Fn(EdgeKind) -> bool,
 {
-    let mut dependencies = HashMap::new();
+    let mut dependencies = HashMap::default();
 
     for &item in ctx.whitelisted_items() {
         dependencies.entry(item).or_insert(vec![]);
@@ -219,7 +219,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::collections::{HashMap, HashSet};
+    use {HashMap, HashSet};
 
     // Here we find the set of nodes that are reachable from any given
     // node. This is a lattice mapping nodes to subsets of all nodes. Our join
@@ -334,14 +334,14 @@ mod tests {
             // implementation. Don't copy this code outside of this test!
 
             let original_size =
-                self.reachable.entry(node).or_insert(HashSet::new()).len();
+                self.reachable.entry(node).or_insert(HashSet::default()).len();
 
             for sub_node in self.graph.0[&node].iter() {
                 self.reachable.get_mut(&node).unwrap().insert(*sub_node);
 
                 let sub_reachable = self.reachable
                     .entry(*sub_node)
-                    .or_insert(HashSet::new())
+                    .or_insert(HashSet::default())
                     .clone();
 
                 for transitive in sub_reachable {
@@ -386,7 +386,7 @@ mod tests {
             nodes.as_ref().iter().cloned().map(Node).collect()
         }
 
-        let mut expected = HashMap::new();
+        let mut expected = HashMap::default();
         expected.insert(Node(1), nodes([3, 4, 5, 6, 7, 8]));
         expected.insert(Node(2), nodes([2]));
         expected.insert(Node(3), nodes([3, 4, 5, 6, 7, 8]));

--- a/src/ir/analysis/sizedness.rs
+++ b/src/ir/analysis/sizedness.rs
@@ -5,10 +5,8 @@ use ir::context::{BindgenContext, TypeId};
 use ir::item::IsOpaque;
 use ir::traversal::EdgeKind;
 use ir::ty::TypeKind;
-use std::cmp;
-use std::collections::HashMap;
-use std::collections::hash_map::Entry;
-use std::ops;
+use std::{cmp, ops};
+use {HashMap, Entry};
 
 /// The result of the `Sizedness` analysis for an individual item.
 ///
@@ -194,7 +192,7 @@ impl<'ctx> MonotoneFramework for SizednessAnalysis<'ctx> {
             })
             .collect();
 
-        let sized = HashMap::new();
+        let sized = HashMap::default();
 
         SizednessAnalysis {
             ctx,

--- a/src/ir/analysis/template_params.rs
+++ b/src/ir/analysis/template_params.rs
@@ -94,7 +94,7 @@ use ir::item::{Item, ItemSet};
 use ir::template::{TemplateInstantiation, TemplateParameters};
 use ir::traversal::{EdgeKind, Trace};
 use ir::ty::TypeKind;
-use std::collections::{HashMap, HashSet};
+use {HashMap, HashSet};
 
 /// An analysis that finds for each IR item its set of template parameters that
 /// it uses.
@@ -373,8 +373,8 @@ impl<'ctx> MonotoneFramework for UsedTemplateParameters<'ctx> {
     fn new(
         ctx: &'ctx BindgenContext,
     ) -> UsedTemplateParameters<'ctx> {
-        let mut used = HashMap::new();
-        let mut dependencies = HashMap::new();
+        let mut used = HashMap::default();
+        let mut dependencies = HashMap::default();
         let whitelisted_items: HashSet<_> =
             ctx.whitelisted_items().iter().cloned().collect();
 

--- a/src/ir/comp.rs
+++ b/src/ir/comp.rs
@@ -17,7 +17,7 @@ use peeking_take_while::PeekableExt;
 use std::cmp;
 use std::io;
 use std::mem;
-use std::collections::HashMap;
+use HashMap;
 
 /// The kind of compound type.
 #[derive(Debug, Copy, Clone, PartialEq)]

--- a/src/ir/dot.rs
+++ b/src/ir/dot.rs
@@ -32,7 +32,7 @@ where
     let mut err: Option<io::Result<_>> = None;
 
     for (id, item) in ctx.items() {
-        let is_whitelisted = ctx.whitelisted_items().contains(id);
+        let is_whitelisted = ctx.whitelisted_items().contains(&id);
 
         writeln!(
             &mut dot_file,

--- a/src/ir/objc.rs
+++ b/src/ir/objc.rs
@@ -131,10 +131,9 @@ impl ObjCInterface {
                                     if protocol.is_protocol
                                     {
                                         debug!("Checking protocol {}, ty.name {:?}", protocol.name, ty.name());
-                                        if Some(needle.as_ref()) == ty.name()
-                                        {
+                                        if Some(needle.as_ref()) == ty.name() {
                                             debug!("Found conforming protocol {:?}", item);
-                                            interface.conforms_to.push(*id);
+                                            interface.conforms_to.push(id);
                                             break;
                                         }
                                     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@ extern crate cexpr;
 #[allow(unused_extern_crates)]
 extern crate cfg_if;
 extern crate clang_sys;
-extern crate fxhash;
+extern crate hashbrown;
 #[macro_use]
 extern crate lazy_static;
 extern crate peeking_take_while;
@@ -97,9 +97,9 @@ use std::process::{Command, Stdio};
 use std::sync::Arc;
 
 // Some convenient typedefs for a fast hash map and hash set.
-type HashMap<K, V> = ::fxhash::FxHashMap<K, V>;
-type HashSet<K> = ::fxhash::FxHashSet<K>;
-pub(crate) use ::std::collections::hash_map::Entry;
+type HashMap<K, V> = ::hashbrown::HashMap<K, V>;
+type HashSet<K> = ::hashbrown::HashSet<K>;
+pub(crate) use ::hashbrown::hash_map::Entry;
 
 fn args_are_cpp(clang_args: &[String]) -> bool {
     return clang_args

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,7 @@ extern crate cexpr;
 #[allow(unused_extern_crates)]
 extern crate cfg_if;
 extern crate clang_sys;
+extern crate fxhash;
 #[macro_use]
 extern crate lazy_static;
 extern crate peeking_take_while;
@@ -88,13 +89,17 @@ use regex_set::RegexSet;
 pub use codegen::EnumVariation;
 
 use std::borrow::Cow;
-use std::collections::HashMap;
 use std::fs::{File, OpenOptions};
 use std::io::{self, Write};
 use std::iter;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::sync::Arc;
+
+// Some convenient typedefs for a fast hash map and hash set.
+type HashMap<K, V> = ::fxhash::FxHashMap<K, V>;
+type HashSet<K> = ::fxhash::FxHashSet<K>;
+pub(crate) use ::std::collections::hash_map::Entry;
 
 fn args_are_cpp(clang_args: &[String]) -> bool {
     return clang_args


### PR DESCRIPTION
I did a bit of profiling today, for no good reason. I wanted to get rid of some of our hash maps from before hand so it's good to know that this really helps.

```
$ time ./bindgen-old tests/stylo.hpp --no-rustfmt-bindings >/dev/null 2>&1                                                                                                                           
./bindgen-old tests/stylo.hpp --no-rustfmt-bindings > /dev/null 2>  6.06s user 0.76s system 98% cpu 6.912 total
$ time ./bindgen-new tests/stylo.hpp --no-rustfmt-bindings >/dev/null 2>&1                                                                                                                                      
./bindgen-new tests/stylo.hpp --no-rustfmt-bindings > /dev/null 2>&1  4.51s user 0.63s system 98% cpu 5.198 total
```