### PR TITLE
Remove deprecated calls to trim_(right|left)_matches

### DIFF
--- a/src/ir/comment.rs
+++ b/src/ir/comment.rs
@@ -48,7 +48,7 @@ fn preprocess_single_lines(comment: &str, indent: usize) -> String {
     let mut is_first = true;
     let lines: Vec<_> = comment
         .lines()
-        .map(|l| l.trim().trim_left_matches('/'))
+        .map(|l| l.trim().trim_start_matches('/'))
         .map(|l| {
             let indent = if is_first { "" } else { &*indent };
             is_first = false;
@@ -60,15 +60,15 @@ fn preprocess_single_lines(comment: &str, indent: usize) -> String {
 
 fn preprocess_multi_line(comment: &str, indent: usize) -> String {
     let comment = comment
-        .trim_left_matches('/')
-        .trim_right_matches('/')
-        .trim_right_matches('*');
+        .trim_start_matches('/')
+        .trim_end_matches('/')
+        .trim_end_matches('*');
 
     let indent = make_indent(indent);
     // Strip any potential `*` characters preceding each line.
     let mut is_first = true;
     let mut lines: Vec<_> = comment.lines()
-        .map(|line| line.trim().trim_left_matches('*').trim_left_matches('!'))
+        .map(|line| line.trim().trim_start_matches('*').trim_start_matches('!'))
         .skip_while(|line| line.trim().is_empty()) // Skip the first empty lines.
         .map(|line| {
             let indent = if is_first { "" } else { &*indent };


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust-bindgen/issues/1480