### PR TITLE
Update clang-sys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,7 +52,7 @@ dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "cexpr 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "clang-sys 0.26.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clang-sys 0.27.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "diff 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -97,7 +97,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "clang-sys"
-version = "0.26.4"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -413,7 +413,7 @@ dependencies = [
 "checksum cc 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)" = "f159dfd43363c4d08055a07703eb7a3406b0dac4d0584d96965a3262db3c9d16"
 "checksum cexpr 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8fc0086be9ca82f7fc89fc873435531cb898b86e850005850de1f820e2db6e9b"
 "checksum cfg-if 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "0c4e7bb64a8ebb0d856483e1e682ea3422f883c5f5615a90d51a2c82fe87fdd3"
-"checksum clang-sys 0.26.4 (registry+https://github.com/rust-lang/crates.io-index)" = "6ef0c1bcf2e99c649104bd7a7012d8f8802684400e03db0ec0af48583c6fa0e4"
+"checksum clang-sys 0.27.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4d1a299f75fb3364b4dab6c9402f57b57ad8c81be070a85410dbb4747eb73889"
 "checksum clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b957d88f4b6a63b9d70d5f454ac8011819c6efa7727858f458ab71c756ce2d3e"
 "checksum diff 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "3c2b69f912779fbb121ceb775d74d51e915af17aaebc38d28a592843a2dd0a3a"
 "checksum env_logger 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "afb070faf94c85d17d50ca44f6ad076bce18ae92f0037d350947240a36e9d42e"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ cexpr = "0.3.3"
 cfg-if = "0.1.0"
 # This kinda sucks: https://github.com/rust-lang/cargo/issues/1982
 clap = "2"
-clang-sys = { version = "0.26.4", features = ["runtime", "clang_6_0"] }
+clang-sys = { version = "0.27.0", features = ["runtime", "clang_6_0"] }
 lazy_static = "1"
 peeking_take_while = "0.1.2"
 quote = { version = "0.6", default-features = false }


### PR DESCRIPTION
This update of `clang-sys` is intended to improve the `libclang` version selection when linking dynamically as described [here](https://github.com/KyleMayes/clang-sys/tree/d32189424610cf671fe362bb9ad13dca20b4b6ee#selection).

In short, `libclang` shared library versions are no longer determined by the filename, they are determined by loading the library and [attempting to load functions until the version can be determined](https://github.com/KyleMayes/clang-sys/blob/d32189424610cf671fe362bb9ad13dca20b4b6ee/build/dynamic.rs#L101-L119).

This should improve behavior when there are multiple instances of `libclang` available and should resolve several issues, namely servo/servo#21478 and servo/servo#22384.