### PR TITLE
Fix book links when viewing via Github

### DIFF
--- a/book/src/blacklisting.md
+++ b/book/src/blacklisting.md
@@ -5,7 +5,7 @@ because you need to wrap one of its fields in an `UnsafeCell`), you can
 explicitly blacklist generation of its definition. Uses of the blacklisted type
 will still appear in other types' definitions. (If you don't want the type to
 appear in the bindings at
-all, [make it opaque](./opaque.html) instead of
+all, [make it opaque](./opaque.md) instead of
 blacklisting it.)
 
 Blacklisted types are pessimistically assumed not to be able to `derive` any

--- a/book/src/cpp.md
+++ b/book/src/cpp.md
@@ -11,14 +11,14 @@ it ends in `.hpp`. If it doesn't, adding `-x c++` clang args can be used to
 force C++ mode. You probably also want to use `-std=c++14` or similar clang args
 as well.
 
-You pretty much **must** use [whitelisting](./whitelisting.html) when working
+You pretty much **must** use [whitelisting](./whitelisting.md) when working
 with C++ to avoid pulling in all of the `std::*` types, many of which `bindgen`
 cannot handle. Additionally, you may want to mark other types as
-[opaque](./opaque.html) that `bindgen` stumbles on. It is recommended to mark
+[opaque](./opaque.md) that `bindgen` stumbles on. It is recommended to mark
 all of `std::*` opaque, and to whitelist only precisely the functions and types
 you intend to use.
 
-You should read up on the [FAQs](./faq.html) as well.
+You should read up on the [FAQs](./faq.md) as well.
 
 ## Supported Features
 
@@ -50,7 +50,7 @@ Without further ado, here are C++ features that `bindgen` does not support or
 cannot translate into Rust:
 
 * Inline functions and methods: see
-["Why isn't `bindgen` generating bindings to inline functions?"](./faq.html#why-isnt-bindgen-generating-bindings-to-inline-functions)
+["Why isn't `bindgen` generating bindings to inline functions?"](./faq.md#why-isnt-bindgen-generating-bindings-to-inline-functions)
 
 * Template functions, methods of template classes and structs. We don't know
   which monomorphizations exist, and can't create new ones because we aren't a

--- a/book/src/replacing-types.md
+++ b/book/src/replacing-types.md
@@ -24,4 +24,4 @@ That way, after code generation, the bindings for the `nsTArray` type are
 the ones that would be generated for `nsTArray_Simple`.
 
 Replacing is only available as an annotation. To replace a C or C++ definition
-with a Rust definition, use [blacklisting](./blacklisting.html).
+with a Rust definition, use [blacklisting](./blacklisting.md).

--- a/book/src/tutorial-2.md
+++ b/book/src/tutorial-2.md
@@ -14,7 +14,7 @@ Here is our `wrapper.h`:
 #include <bzlib.h>
 ```
 
-This is also where we would add any [replacement types](./replacing-types.html),
+This is also where we would add any [replacement types](./replacing-types.md),
 if we were using some.
 
 [spidermonkey]: https://developer.mozilla.org/en-US/docs/Mozilla/Projects/SpiderMonkey/How_to_embed_the_JavaScript_engine


### PR DESCRIPTION
 * Some pages of the book's documentation markdown pages used `.html` in their links rather than `.md`.  This evidently works with `mdBook`, but fails when viewing the pages of the book from the Github source tree.
 * The `.html` links were replaced with `.md` to fix this.

Since Google searches often end up leading to the non-GH pages version of the book, this change makes it a lot easier for users to navigate between different pages of the book when viewing it through Github directly.