### PR TITLE
Produce a more useful error message when rustfmt can't be found. Fixes #1205

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,4 @@ __bindgen.*
 csmith-fuzzing/platform.info
 
 # Backups of test cases from C-Reduce
-**.orig
+**/*.orig

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1835,7 +1835,7 @@ impl Bindings {
                 writer.write(rustfmt_bindings.as_bytes())?;
             },
             Err(err) => {
-                eprintln!("{:?}", err);
+                eprintln!("Failed to run rustfmt: {} (non-fatal, continuing)", err);
                 writer.write(bindings.as_bytes())?;
             },
         }


### PR DESCRIPTION
Prior to this change bindgen would simply print any error that occurred
while attempting to run rustfmt straight to stderr using `fmt::Debug`.
Combined with the fact that rustfmt is enabled by default now this meant
that if rustfmt was missing or not working a cryptic error would be
printed.

Without this patch:
```
$ PATH= ./target/debug/bindgen /tmp/foo.h
Custom { kind: Other, error: StringError("Cannot find binary path") }
/* automatically generated by rust-bindgen */
```

With this patch:
```
$ PATH= ./target/debug/bindgen /tmp/foo.h
Failed to run rustfmt: Cannot find binary path (non-fatal, continuing)
/* automatically generated by rust-bindgen */
```

I changed the error handling to use `fmt::Display` instead, since this
is user-visible output, and also added "Failed to run rustfmt:" to make the
source of the error clearer. Additionally since bindgen does not treat this
as fatal I noted that in the output as well.