### PR TITLE
fix one argument block pointer issue, #1378

### DIFF
--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -3961,7 +3961,7 @@ mod utils {
         };
 
         quote! {
-            *const ::block::Block<(#(#args),*), #ret_ty>
+            *const ::block::Block<(#(#args,)*), #ret_ty>
         }
     }
 }

--- a/tests/expectations/tests/blocks-signature.rs
+++ b/tests/expectations/tests/blocks-signature.rs
@@ -11,14 +11,19 @@
 extern crate block;
 extern "C" {
     #[link_name = "\u{1}_Z8atexit_bU13block_pointerFvvE"]
-    pub fn atexit_b(arg1: _bindgen_ty_id_20);
+    pub fn atexit_b(arg1: _bindgen_ty_id_25);
 }
 pub type dispatch_data_t = *mut ::std::os::raw::c_void;
-pub type dispatch_data_applier_t = _bindgen_ty_id_27;
+pub type dispatch_data_applier_t = _bindgen_ty_id_32;
 extern "C" {
     #[link_name = "\u{1}_Z19dispatch_data_applyPvU13block_pointerFbS_yPKvyE"]
     pub fn dispatch_data_apply(data: dispatch_data_t, applier: dispatch_data_applier_t) -> bool;
 }
-pub type _bindgen_ty_id_20 = *const ::block::Block<(), ()>;
-pub type _bindgen_ty_id_27 =
+extern "C" {
+    #[link_name = "\u{1}_Z3fooU13block_pointerFvyE"]
+    pub fn foo(arg1: _bindgen_ty_id_42) -> bool;
+}
+pub type _bindgen_ty_id_25 = *const ::block::Block<(), ()>;
+pub type _bindgen_ty_id_32 =
     *const ::block::Block<(dispatch_data_t, usize, *const ::std::os::raw::c_void, usize), bool>;
+pub type _bindgen_ty_id_42 = *const ::block::Block<(usize,), ()>;

--- a/tests/expectations/tests/blocks.rs
+++ b/tests/expectations/tests/blocks.rs
@@ -18,3 +18,7 @@ extern "C" {
     #[link_name = "\u{1}_Z19dispatch_data_applyPvU13block_pointerFbS_yPKvyE"]
     pub fn dispatch_data_apply(data: dispatch_data_t, applier: dispatch_data_applier_t) -> bool;
 }
+extern "C" {
+    #[link_name = "\u{1}_Z3fooU13block_pointerFvyE"]
+    pub fn foo(arg1: *mut ::std::os::raw::c_void) -> bool;
+}

--- a/tests/headers/blocks.hpp
+++ b/tests/headers/blocks.hpp
@@ -14,3 +14,5 @@ typedef bool (^dispatch_data_applier_t)(dispatch_data_t region,
 
 bool dispatch_data_apply(dispatch_data_t data,
                          dispatch_data_applier_t applier);
+
+bool foo(void (^)(size_t bar));


### PR DESCRIPTION
The block pointer with one argument 
```objc
bool foo(void (^)(size_t bar));
```
should be generated as `*const ::block::Block<(usize,), ()>` instead of `*const ::block::Block<(usize), ()>`
