### PR TITLE
Bump clang-sys to 0.28.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ cexpr = "0.3.3"
 cfg-if = "0.1.0"
 # This kinda sucks: https://github.com/rust-lang/cargo/issues/1982
 clap = "2"
-clang-sys = { version = "0.26.4", features = ["runtime", "clang_6_0"] }
+clang-sys = { version = "0.28.0", features = ["runtime", "clang_6_0"] }
 lazy_static = "1"
 peeking_take_while = "0.1.2"
 quote = { version = "0.6", default-features = false }


### PR DESCRIPTION
Signed-off-by: Robert-André Mauchin <zebob.m@gmail.com>

Tested in Fedora Rawhide.