### PR TITLE
options: Add an option to opt-out of include path detection.

### DIFF
--- a/src/options.rs
+++ b/src/options.rs
@@ -203,6 +203,9 @@ where
             Arg::with_name("no-prepend-enum-name")
                 .long("no-prepend-enum-name")
                 .help("Do not prepend the enum name to bitfield or constant variants."),
+            Arg::with_name("no-include-path-detection")
+                .long("no-include-path-detection")
+                .help("Do not try to detect default include paths"),
             Arg::with_name("unstable-rust")
                 .long("unstable-rust")
                 .help("Generate unstable Rust code (deprecated; use --rust-target instead).")
@@ -445,6 +448,10 @@ where
 
     if matches.is_present("no-prepend-enum-name") {
         builder = builder.prepend_enum_name(false);
+    }
+
+    if matches.is_present("no-include-path-detection") {
+        builder = builder.detect_include_paths(false);
     }
 
     if matches.is_present("time-phases") {


### PR DESCRIPTION
And don't do it conditionally on the presence of --target. We pass the clang
arguments to clang-sys now, so it doesn't get the wrong path.

Fixes #1542.