### PR TITLE
tutorial/readme fixes and cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+[![crates.io](https://img.shields.io/crates/v/bindgen.svg)](https://crates.io/crates/bindgen)
+[![docs.rs](https://docs.rs/bindgen/badge.svg)](https://docs.rs/bindgen/)
+
 # `bindgen`
 
 **`bindgen` automatically generates Rust FFI bindings to C (and some C++) libraries.**

--- a/book/src/chapter_1.md
+++ b/book/src/chapter_1.md
@@ -1,1 +1,0 @@
-# Chapter 1

--- a/book/src/requirements.md
+++ b/book/src/requirements.md
@@ -23,6 +23,11 @@ greater.
 Download and install the official pre-built binary from
 [LLVM download page](http://releases.llvm.org/download.html).
 
+You will also need to set `LIBCLANG_PATH` as an [environment
+variable](https://www.techjunkie.com/environment-variables-windows-10/) pointing
+to the `bin` directory of your LLVM install. For example, if you installed LLVM
+to `D:\programs\LLVM`, then you'd set the value to be `D:\programs\LLVM\bin`
+
 #### macOS
 
 If you use Homebrew:

--- a/book/src/tutorial-1.md
+++ b/book/src/tutorial-1.md
@@ -1,9 +1,15 @@
 # Add `bindgen` as a Build Dependency
 
-Declare a build-time dependency on `bindgen` by adding it to the
-`[build-dependencies]` section of our crate's `Cargo.toml` metadata file:
+First we need to declare a build-time dependency on `bindgen` by adding it to
+the `[build-dependencies]` section of our crate's `Cargo.toml` file.
+
+Please always use the latest version of `bindgen`, it has the most fixes and
+best compatibility. At the time of writing the latest bindgen is `0.49.0`, but
+you can always check [the bindgen page of
+crates.io](https://crates.io/crates/bindgen) to verify the latest version if
+you're unsure.
 
 ```toml
 [build-dependencies]
-bindgen = "0.42.2"
+bindgen = "0.49.0"
 ```


### PR DESCRIPTION
* Fixes https://github.com/rust-lang/rust-bindgen/issues/1548
* Adds crates.io and docs.rs badges to the readme
* Explains `LIBCLANG_PATH` on win32