### PR TITLE
updated `default-enum-variant` to `default-enum-style`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -224,7 +224,7 @@ impl Builder {
         output_vector.push(self.options.rust_target.into());
 
         if self.options.default_enum_style != Default::default() {
-            output_vector.push("--default-enum-variant=".into());
+            output_vector.push("--default-enum-style=".into());
             output_vector.push(match self.options.default_enum_style {
                 codegen::EnumVariation::Rust => "rust",
                 codegen::EnumVariation::Bitfield => "bitfield",


### PR DESCRIPTION
`command_line_flags` returns an invalid option `--default-enum-variant` which I replaced with the right `--default-enum-style`