### PR TITLE
Rename C overloads based on the typenames of their arguments

### DIFF
--- a/bindgen-integration/src/lib.rs
+++ b/bindgen-integration/src/lib.rs
@@ -49,7 +49,7 @@ fn test_constructor() {
 
 #[test]
 fn test_overload() {
-    let test = unsafe { bindings::Test::new1(5.0) };
+    let test = unsafe { bindings::Test::new_double(5.0) };
     assert_eq!(test.m_int, 0);
     assert_eq!(test.m_double, 5.0);
 }

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -2057,9 +2057,9 @@ impl MethodCodegen for Method {
         let function = function_item.expect_function();
         let signature_item = ctx.resolve_item(function.signature());
         let mut name = match self.kind() {
-            MethodKind::Constructor => "new".into(),
-            MethodKind::Destructor => "destruct".into(),
-            _ => function.name().to_owned(),
+            MethodKind::Constructor => function_item.overload_mangled(ctx, "new").into_owned(),
+            MethodKind::Destructor => function_item.overload_mangled(ctx, "destruct").into_owned(),
+            _ => function_item.overload_mangled(ctx, function.name()).into_owned(),
         };
 
         let signature = match *signature_item.expect_type().kind() {

--- a/src/ir/ty.rs
+++ b/src/ir/ty.rs
@@ -146,6 +146,15 @@ impl Type {
         }
     }
 
+    /// Cast this type to a function kind, or `None` if it is not a function
+    /// type.
+    pub fn as_function(&self) -> Option<&FunctionSig> {
+        match self.kind {
+            TypeKind::Function(ref fn_kind) => Some(&fn_kind),
+            _ => None,
+        }
+    }
+
     /// Is this an enum type?
     pub fn is_enum(&self) -> bool {
         match self.kind {

--- a/tests/expectations/tests/class.rs
+++ b/tests/expectations/tests/class.rs
@@ -425,15 +425,17 @@ fn bindgen_test_layout_RealAbstractionWithTonsOfMethods() {
 }
 extern "C" {
     #[link_name = "\u{1}_ZNK32RealAbstractionWithTonsOfMethods3barEv"]
-    pub fn RealAbstractionWithTonsOfMethods_bar(this: *const RealAbstractionWithTonsOfMethods);
+    pub fn RealAbstractionWithTonsOfMethods_bar_const(
+        this: *const RealAbstractionWithTonsOfMethods,
+    );
 }
 extern "C" {
     #[link_name = "\u{1}_ZN32RealAbstractionWithTonsOfMethods3barEv"]
-    pub fn RealAbstractionWithTonsOfMethods_bar1(this: *mut RealAbstractionWithTonsOfMethods);
+    pub fn RealAbstractionWithTonsOfMethods_bar(this: *mut RealAbstractionWithTonsOfMethods);
 }
 extern "C" {
     #[link_name = "\u{1}_ZN32RealAbstractionWithTonsOfMethods3barEi"]
-    pub fn RealAbstractionWithTonsOfMethods_bar2(
+    pub fn RealAbstractionWithTonsOfMethods_bar_int(
         this: *mut RealAbstractionWithTonsOfMethods,
         foo: ::std::os::raw::c_int,
     );
@@ -444,16 +446,16 @@ extern "C" {
 }
 impl RealAbstractionWithTonsOfMethods {
     #[inline]
-    pub unsafe fn bar(&self) {
+    pub unsafe fn bar_const(&self) {
+        RealAbstractionWithTonsOfMethods_bar_const(self)
+    }
+    #[inline]
+    pub unsafe fn bar(&mut self) {
         RealAbstractionWithTonsOfMethods_bar(self)
     }
     #[inline]
-    pub unsafe fn bar1(&mut self) {
-        RealAbstractionWithTonsOfMethods_bar1(self)
-    }
-    #[inline]
-    pub unsafe fn bar2(&mut self, foo: ::std::os::raw::c_int) {
-        RealAbstractionWithTonsOfMethods_bar2(self, foo)
+    pub unsafe fn bar_int(&mut self, foo: ::std::os::raw::c_int) {
+        RealAbstractionWithTonsOfMethods_bar_int(self, foo)
     }
     #[inline]
     pub unsafe fn sta() {

--- a/tests/expectations/tests/class_1_0.rs
+++ b/tests/expectations/tests/class_1_0.rs
@@ -478,15 +478,17 @@ fn bindgen_test_layout_RealAbstractionWithTonsOfMethods() {
 }
 extern "C" {
     #[link_name = "\u{1}_ZNK32RealAbstractionWithTonsOfMethods3barEv"]
-    pub fn RealAbstractionWithTonsOfMethods_bar(this: *const RealAbstractionWithTonsOfMethods);
+    pub fn RealAbstractionWithTonsOfMethods_bar_const(
+        this: *const RealAbstractionWithTonsOfMethods,
+    );
 }
 extern "C" {
     #[link_name = "\u{1}_ZN32RealAbstractionWithTonsOfMethods3barEv"]
-    pub fn RealAbstractionWithTonsOfMethods_bar1(this: *mut RealAbstractionWithTonsOfMethods);
+    pub fn RealAbstractionWithTonsOfMethods_bar(this: *mut RealAbstractionWithTonsOfMethods);
 }
 extern "C" {
     #[link_name = "\u{1}_ZN32RealAbstractionWithTonsOfMethods3barEi"]
-    pub fn RealAbstractionWithTonsOfMethods_bar2(
+    pub fn RealAbstractionWithTonsOfMethods_bar_int(
         this: *mut RealAbstractionWithTonsOfMethods,
         foo: ::std::os::raw::c_int,
     );
@@ -502,16 +504,16 @@ impl Clone for RealAbstractionWithTonsOfMethods {
 }
 impl RealAbstractionWithTonsOfMethods {
     #[inline]
-    pub unsafe fn bar(&self) {
+    pub unsafe fn bar_const(&self) {
+        RealAbstractionWithTonsOfMethods_bar_const(self)
+    }
+    #[inline]
+    pub unsafe fn bar(&mut self) {
         RealAbstractionWithTonsOfMethods_bar(self)
     }
     #[inline]
-    pub unsafe fn bar1(&mut self) {
-        RealAbstractionWithTonsOfMethods_bar1(self)
-    }
-    #[inline]
-    pub unsafe fn bar2(&mut self, foo: ::std::os::raw::c_int) {
-        RealAbstractionWithTonsOfMethods_bar2(self, foo)
+    pub unsafe fn bar_int(&mut self, foo: ::std::os::raw::c_int) {
+        RealAbstractionWithTonsOfMethods_bar_int(self, foo)
     }
     #[inline]
     pub unsafe fn sta() {

--- a/tests/expectations/tests/constructors.rs
+++ b/tests/expectations/tests/constructors.rs
@@ -28,7 +28,7 @@ extern "C" {
 }
 extern "C" {
     #[link_name = "\u{1}_ZN12TestOverloadC1Ed"]
-    pub fn TestOverload_TestOverload1(this: *mut TestOverload, arg1: f64);
+    pub fn TestOverload_TestOverload_double(this: *mut TestOverload, arg1: f64);
 }
 impl TestOverload {
     #[inline]
@@ -38,9 +38,9 @@ impl TestOverload {
         __bindgen_tmp
     }
     #[inline]
-    pub unsafe fn new1(arg1: f64) -> Self {
+    pub unsafe fn new_double(arg1: f64) -> Self {
         let mut __bindgen_tmp = ::std::mem::uninitialized();
-        TestOverload_TestOverload1(&mut __bindgen_tmp, arg1);
+        TestOverload_TestOverload_double(&mut __bindgen_tmp, arg1);
         __bindgen_tmp
     }
 }

--- a/tests/expectations/tests/issue-1350-attribute-overloadable.rs
+++ b/tests/expectations/tests/issue-1350-attribute-overloadable.rs
@@ -13,5 +13,5 @@ extern "C" {
 }
 extern "C" {
     #[link_name = "\u{1}_Z11my_functionPKc"]
-    pub fn my_function1(a: *const ::std::os::raw::c_char);
+    pub fn my_function_ptr_const_char(a: *const ::std::os::raw::c_char);
 }

--- a/tests/expectations/tests/overloading.rs
+++ b/tests/expectations/tests/overloading.rs
@@ -10,7 +10,38 @@ extern "C" {
 }
 extern "C" {
     #[link_name = "\u{1}_Z8Evaluateii"]
-    pub fn Evaluate1(x: ::std::os::raw::c_int, y: ::std::os::raw::c_int) -> bool;
+    pub fn Evaluate_int_int(x: ::std::os::raw::c_int, y: ::std::os::raw::c_int) -> bool;
+}
+extern "C" {
+    #[link_name = "\u{1}_Z13CanonicalLastc"]
+    pub fn CanonicalLast_char(r: ::std::os::raw::c_char);
+}
+extern "C" {
+    #[link_name = "\u{1}_Z13CanonicalLastv"]
+    pub fn CanonicalLast();
+}
+extern "C" {
+    #[link_name = "\u{1}_Z6CommonPii"]
+    pub fn Common(arg1: *mut ::std::os::raw::c_int, y: ::std::os::raw::c_int) -> f32;
+}
+extern "C" {
+    #[link_name = "\u{1}_Z6CommonPiPb"]
+    pub fn Common_ptr_bool(arg1: *mut ::std::os::raw::c_int, y: *mut bool) -> f32;
+}
+extern "C" {
+    #[link_name = "\u{1}_Z6CommonPiPKc"]
+    pub fn Common_ptr_const_char(
+        arg1: *mut ::std::os::raw::c_int,
+        y: *const ::std::os::raw::c_char,
+    ) -> f32;
+}
+extern "C" {
+    #[link_name = "\u{1}_Z23CanonicalLastWithCommonPii"]
+    pub fn CanonicalLastWithCommon_int(arg1: *mut ::std::os::raw::c_int, y: ::std::os::raw::c_int);
+}
+extern "C" {
+    #[link_name = "\u{1}_Z23CanonicalLastWithCommonPi"]
+    pub fn CanonicalLastWithCommon(arg1: *mut ::std::os::raw::c_int);
 }
 extern "C" {
     #[link_name = "\u{1}_ZN3foo10MyFunctionEv"]

--- a/tests/expectations/tests/virtual_overloaded.rs
+++ b/tests/expectations/tests/virtual_overloaded.rs
@@ -35,5 +35,5 @@ extern "C" {
 }
 extern "C" {
     #[link_name = "\u{1}_ZN1C8do_thingEi"]
-    pub fn C_do_thing1(this: *mut ::std::os::raw::c_void, arg1: ::std::os::raw::c_int);
+    pub fn C_do_thing_int(this: *mut ::std::os::raw::c_void, arg1: ::std::os::raw::c_int);
 }

--- a/tests/headers/overloading.hpp
+++ b/tests/headers/overloading.hpp
@@ -1,6 +1,16 @@
 extern bool Evaluate(char r);
 extern bool Evaluate(int x, int y);
 
+extern void CanonicalLast(char r);
+extern void CanonicalLast(void);
+
+extern float Common(int*, int y);
+extern float Common(int*, bool *y);
+extern float Common(int*, const char *y);
+
+extern void CanonicalLastWithCommon(int*, int y);
+extern void CanonicalLastWithCommon(int*);
+
 namespace foo {
     extern void MyFunction();
 }


### PR DESCRIPTION
Previously, the following C code:

```
extern float Common(int*, int y);
extern float Common(int*, bool y);
extern float Common(int*, const char *y);
```

would generate bindings similar to:

```
extern "C" {
    #[link_name = "\u{1}_Z6CommonPii"]
    pub fn Common(arg1: *mut c_int, y: c_int) -> f32;
}
extern "C" {
    #[link_name = "\u{1}_Z6CommonPib"]
    pub fn Common1(arg1: *mut c_int, y: bool) -> f32;
}
extern "C" {
    #[link_name = "\u{1}_Z6CommonPiPKc"]
    pub fn Common2(arg1: *mut c_int, y: *const c_char) -> f32;
}
```

This patch changes the function suffixes to be based on each overload's
signature instead of just its order in the source file:

```
extern "C" {
    #[link_name = "\u{1}_Z6CommonPii"]
    pub fn Common(arg1: *mut c_int, y: c_int) -> f32;
}
extern "C" {
    #[link_name = "\u{1}_Z6CommonPib"]
    pub fn Common_bool(arg1: *mut c_int, y: bool) -> f32;
}
extern "C" {
    #[link_name = "\u{1}_Z6CommonPiPKc"]
    pub fn Common_ptr_const_char(arg1: *mut c_int, y: *const c_char) -> f32;
}
```

When does renaming occur:

 - If a function has no overloads, its Rust name is unchanged.
 - If there are overloads, the function which occurs first in the c file
   is unchanged in name (if possible*). The other overloads are renamed.

How is the new function name chosen for some particular overload:

 1. Strip out as many arguments from the left which are common to all overloads.
 2. Convert the remaining argument typenames to a string and join them with '_'.
 3. Append this to the original C function name along with another '_'.

How are argument types converted to string:
I use the `Type::canonical_type` method for this, which seems to follow these rules:

 - Types are converted based on their C name, with spaces replaced by '_'.
       unsigned int => 'unsigned_int'
       struct foo_bar => 'struct_foo_bar'
 - Pointers follow the above rules but prefixed with 'ptr_', or 'ptr_const_' for pointers to const values.
       struct foo_bar * => 'ptr_struct_foo_bar'
       const int * => 'ptr_const_int'
 - Typedefs are resolved to their underlying type before being converted.

Hopefully the updated test code serve to provide concrete examples of this renaming logic.

------

This renaming logic is what I'm finding useful in my practice. Actually, I'm thinking about adding logic to map `const char*` to `cstr` instead of `ptr_const_char`, and similarly mapping `unsigned int` to `uint` instead, removing `struct_` from the typenames, etc. The decision to not rename the first overload is similarly arbitrary (although it does match the previous behavior). It's also subject to an edge case (*) where an overload with zero arguments comes after an overload with arguments, in which case the zero-argument overload gets the canonical name and the first overload actually *is* renamed, to avoid collision.

So I'm not sure if this belongs behind some configuration flag, or if it requires more thought about how to enable user configuration first (some new fn on the `ParseCallbacks` trait?).

Thanks for your work in maintaining this incredibly useful project!