### PR TITLE
Update rustfmt.toml options for compatibility with modern rustfmt

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,6 +1,5 @@
 max_width = 80
-fn_brace_style = "SameLineWhere"
-item_brace_style = "SameLineWhere"
-struct_lit_multiline_style = "ForceMulti"
+brace_style = "SameLineWhere"
+struct_lit_single_line = false
 where_trailing_comma = true
 normalize_comments = false


### PR DESCRIPTION
Running `cargo fmt` or `cargo +nightly fmt` gives the following warnings:
```
Warning: Unknown configuration option `fn_brace_style`
Warning: Unknown configuration option `item_brace_style`
Warning: Unknown configuration option `struct_lit_multiline_style`
Warning: Unknown configuration option `where_trailing_comma`
```

rustfmt changed these options here, and this PR reflects the changes:
* `fn_brace_style` and `item_brace_style` were folded into `brace_style`: https://github.com/rust-lang/rustfmt/commit/f8074b340d328513077b59084e0ea3856181e699#diff-6d8a5e2104954a026de2bfe2b936aea4R541
* `struct_lit_multiline_style` option was renamed to `struct_lit_single_line`: https://github.com/rust-lang/rustfmt/commit/45d4f7a2dd1c95e47d4ae4dc413dfb71e53c16ff#diff-9de0a570da3404ffd4b364ef6a9f8195L1749
* `where_trailing_comma` was removed, but appears to have no replacement: https://github.com/rust-lang/rustfmt/commit/6a58d9123952de104b1e02640261b7e90908bb0e#diff-6d8a5e2104954a026de2bfe2b936aea4L369
   So I left it in.

Running `cargo fmt` over the bindgen codebase produces a _lot_ of changes, so I haven't done that. But I think it'd be a good idea to do it at some point: opening PRs against a project that has its own rustfmt.toml file but doesn't seem to follow it is a confusing process.