### PR TITLE
 Fix #1571: For rust-target >= 1.30, make {__BindgenBitfieldUnit,__BindgenUnionField,__IncompleteArrayField}::new `const fn`

### DIFF
--- a/src/codegen/bitfield_unit.rs
+++ b/src/codegen/bitfield_unit.rs
@@ -9,7 +9,7 @@ pub struct __BindgenBitfieldUnit<Storage, Align>
 impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align>
 {
     #[inline]
-    pub fn new(storage: Storage) -> Self {
+    pub const fn new(storage: Storage) -> Self {
         Self {
             storage,
             align: [],

--- a/src/codegen/bitfield_unit.rs
+++ b/src/codegen/bitfield_unit.rs
@@ -1,16 +1,12 @@
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct __BindgenBitfieldUnit<Storage, Align>
-where
-    Storage: AsRef<[u8]> + AsMut<[u8]>,
 {
     storage: Storage,
     align: [Align; 0],
 }
 
 impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align>
-where
-    Storage: AsRef<[u8]> + AsMut<[u8]>,
 {
     #[inline]
     pub fn new(storage: Storage) -> Self {
@@ -19,7 +15,12 @@ where
             align: [],
         }
     }
+}
 
+impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align>
+where
+    Storage: AsRef<[u8]> + AsMut<[u8]>,
+{
     #[inline]
     pub fn get_bit(&self, index: usize) -> bool {
         debug_assert!(index / 8 < self.storage.as_ref().len());

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -3770,6 +3770,14 @@ mod utils {
     ) {
         let prefix = ctx.trait_prefix();
 
+        // If the target supports `const fn`, declare eligible functions
+        // as `const fn` else just `fn`.
+        let const_fn = if ctx.options().rust_features().min_const_fn {
+            quote!{ const fn }
+        } else {
+            quote!{ fn }
+        };
+
         let incomplete_array_decl = quote! {
             #[repr(C)]
             #[derive(Default)]
@@ -3780,7 +3788,7 @@ mod utils {
         let incomplete_array_impl = quote! {
             impl<T> __IncompleteArrayField<T> {
                 #[inline]
-                pub fn new() -> Self {
+                pub #const_fn new() -> Self {
                     __IncompleteArrayField(::#prefix::marker::PhantomData, [])
                 }
 

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -3663,6 +3663,14 @@ mod utils {
     ) {
         let prefix = ctx.trait_prefix();
 
+        // If the target supports `const fn`, declare eligible functions
+        // as `const fn` else just `fn`.
+        let const_fn = if ctx.options().rust_features().min_const_fn {
+            quote!{ const fn }
+        } else {
+            quote!{ fn }
+        };
+
         // TODO(emilio): The fmt::Debug impl could be way nicer with
         // std::intrinsics::type_name, but...
         let union_field_decl = quote! {
@@ -3673,7 +3681,7 @@ mod utils {
         let union_field_impl = quote! {
             impl<T> __BindgenUnionField<T> {
                 #[inline]
-                pub fn new() -> Self {
+                pub #const_fn new() -> Self {
                     __BindgenUnionField(::#prefix::marker::PhantomData)
                 }
 

--- a/src/features.rs
+++ b/src/features.rs
@@ -102,6 +102,8 @@ macro_rules! rust_target_base {
             => Stable_1_27 => 1.27;
             /// Rust stable 1.28
             => Stable_1_28 => 1.28;
+            /// Rust stable 1.30
+            => Stable_1_30 => 1.30;
             /// Rust stable 1.33
             => Stable_1_33 => 1.33;
             /// Nightly rust
@@ -191,6 +193,11 @@ rust_feature_def!(
     Stable_1_28 {
         /// repr(transparent) ([PR](https://github.com/rust-lang/rust/pull/51562))
         => repr_transparent;
+    }
+    Stable_1_30 {
+        /// `const fn` support for limited cases
+        /// ([PR](https://github.com/rust-lang/rust/pull/54835/)
+        => min_const_fn;
     }
     Stable_1_33 {
         /// repr(packed(N)) ([PR](https://github.com/rust-lang/rust/pull/57049))

--- a/tests/expectations/tests/bitfield-32bit-overflow.rs
+++ b/tests/expectations/tests/bitfield-32bit-overflow.rs
@@ -9,21 +9,20 @@
 
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct __BindgenBitfieldUnit<Storage, Align>
-where
-    Storage: AsRef<[u8]> + AsMut<[u8]>,
-{
+pub struct __BindgenBitfieldUnit<Storage, Align> {
     storage: Storage,
     align: [Align; 0],
+}
+impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align> {
+    #[inline]
+    pub fn new(storage: Storage) -> Self {
+        Self { storage, align: [] }
+    }
 }
 impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align>
 where
     Storage: AsRef<[u8]> + AsMut<[u8]>,
 {
-    #[inline]
-    pub fn new(storage: Storage) -> Self {
-        Self { storage, align: [] }
-    }
     #[inline]
     pub fn get_bit(&self, index: usize) -> bool {
         debug_assert!(index / 8 < self.storage.as_ref().len());

--- a/tests/expectations/tests/bitfield-32bit-overflow.rs
+++ b/tests/expectations/tests/bitfield-32bit-overflow.rs
@@ -15,7 +15,7 @@ pub struct __BindgenBitfieldUnit<Storage, Align> {
 }
 impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align> {
     #[inline]
-    pub fn new(storage: Storage) -> Self {
+    pub const fn new(storage: Storage) -> Self {
         Self { storage, align: [] }
     }
 }

--- a/tests/expectations/tests/bitfield-large.rs
+++ b/tests/expectations/tests/bitfield-large.rs
@@ -9,21 +9,20 @@
 
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct __BindgenBitfieldUnit<Storage, Align>
-where
-    Storage: AsRef<[u8]> + AsMut<[u8]>,
-{
+pub struct __BindgenBitfieldUnit<Storage, Align> {
     storage: Storage,
     align: [Align; 0],
+}
+impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align> {
+    #[inline]
+    pub fn new(storage: Storage) -> Self {
+        Self { storage, align: [] }
+    }
 }
 impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align>
 where
     Storage: AsRef<[u8]> + AsMut<[u8]>,
 {
-    #[inline]
-    pub fn new(storage: Storage) -> Self {
-        Self { storage, align: [] }
-    }
     #[inline]
     pub fn get_bit(&self, index: usize) -> bool {
         debug_assert!(index / 8 < self.storage.as_ref().len());

--- a/tests/expectations/tests/bitfield-large.rs
+++ b/tests/expectations/tests/bitfield-large.rs
@@ -15,7 +15,7 @@ pub struct __BindgenBitfieldUnit<Storage, Align> {
 }
 impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align> {
     #[inline]
-    pub fn new(storage: Storage) -> Self {
+    pub const fn new(storage: Storage) -> Self {
         Self { storage, align: [] }
     }
 }

--- a/tests/expectations/tests/bitfield-method-same-name.rs
+++ b/tests/expectations/tests/bitfield-method-same-name.rs
@@ -9,21 +9,20 @@
 
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct __BindgenBitfieldUnit<Storage, Align>
-where
-    Storage: AsRef<[u8]> + AsMut<[u8]>,
-{
+pub struct __BindgenBitfieldUnit<Storage, Align> {
     storage: Storage,
     align: [Align; 0],
+}
+impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align> {
+    #[inline]
+    pub fn new(storage: Storage) -> Self {
+        Self { storage, align: [] }
+    }
 }
 impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align>
 where
     Storage: AsRef<[u8]> + AsMut<[u8]>,
 {
-    #[inline]
-    pub fn new(storage: Storage) -> Self {
-        Self { storage, align: [] }
-    }
     #[inline]
     pub fn get_bit(&self, index: usize) -> bool {
         debug_assert!(index / 8 < self.storage.as_ref().len());

--- a/tests/expectations/tests/bitfield-method-same-name.rs
+++ b/tests/expectations/tests/bitfield-method-same-name.rs
@@ -15,7 +15,7 @@ pub struct __BindgenBitfieldUnit<Storage, Align> {
 }
 impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align> {
     #[inline]
-    pub fn new(storage: Storage) -> Self {
+    pub const fn new(storage: Storage) -> Self {
         Self { storage, align: [] }
     }
 }

--- a/tests/expectations/tests/bitfield_align.rs
+++ b/tests/expectations/tests/bitfield_align.rs
@@ -9,21 +9,20 @@
 
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct __BindgenBitfieldUnit<Storage, Align>
-where
-    Storage: AsRef<[u8]> + AsMut<[u8]>,
-{
+pub struct __BindgenBitfieldUnit<Storage, Align> {
     storage: Storage,
     align: [Align; 0],
+}
+impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align> {
+    #[inline]
+    pub fn new(storage: Storage) -> Self {
+        Self { storage, align: [] }
+    }
 }
 impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align>
 where
     Storage: AsRef<[u8]> + AsMut<[u8]>,
 {
-    #[inline]
-    pub fn new(storage: Storage) -> Self {
-        Self { storage, align: [] }
-    }
     #[inline]
     pub fn get_bit(&self, index: usize) -> bool {
         debug_assert!(index / 8 < self.storage.as_ref().len());

--- a/tests/expectations/tests/bitfield_align.rs
+++ b/tests/expectations/tests/bitfield_align.rs
@@ -15,7 +15,7 @@ pub struct __BindgenBitfieldUnit<Storage, Align> {
 }
 impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align> {
     #[inline]
-    pub fn new(storage: Storage) -> Self {
+    pub const fn new(storage: Storage) -> Self {
         Self { storage, align: [] }
     }
 }

--- a/tests/expectations/tests/bitfield_align_2.rs
+++ b/tests/expectations/tests/bitfield_align_2.rs
@@ -9,21 +9,20 @@
 
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct __BindgenBitfieldUnit<Storage, Align>
-where
-    Storage: AsRef<[u8]> + AsMut<[u8]>,
-{
+pub struct __BindgenBitfieldUnit<Storage, Align> {
     storage: Storage,
     align: [Align; 0],
+}
+impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align> {
+    #[inline]
+    pub fn new(storage: Storage) -> Self {
+        Self { storage, align: [] }
+    }
 }
 impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align>
 where
     Storage: AsRef<[u8]> + AsMut<[u8]>,
 {
-    #[inline]
-    pub fn new(storage: Storage) -> Self {
-        Self { storage, align: [] }
-    }
     #[inline]
     pub fn get_bit(&self, index: usize) -> bool {
         debug_assert!(index / 8 < self.storage.as_ref().len());

--- a/tests/expectations/tests/bitfield_align_2.rs
+++ b/tests/expectations/tests/bitfield_align_2.rs
@@ -15,7 +15,7 @@ pub struct __BindgenBitfieldUnit<Storage, Align> {
 }
 impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align> {
     #[inline]
-    pub fn new(storage: Storage) -> Self {
+    pub const fn new(storage: Storage) -> Self {
         Self { storage, align: [] }
     }
 }

--- a/tests/expectations/tests/bitfield_method_mangling.rs
+++ b/tests/expectations/tests/bitfield_method_mangling.rs
@@ -9,21 +9,20 @@
 
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct __BindgenBitfieldUnit<Storage, Align>
-where
-    Storage: AsRef<[u8]> + AsMut<[u8]>,
-{
+pub struct __BindgenBitfieldUnit<Storage, Align> {
     storage: Storage,
     align: [Align; 0],
+}
+impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align> {
+    #[inline]
+    pub fn new(storage: Storage) -> Self {
+        Self { storage, align: [] }
+    }
 }
 impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align>
 where
     Storage: AsRef<[u8]> + AsMut<[u8]>,
 {
-    #[inline]
-    pub fn new(storage: Storage) -> Self {
-        Self { storage, align: [] }
-    }
     #[inline]
     pub fn get_bit(&self, index: usize) -> bool {
         debug_assert!(index / 8 < self.storage.as_ref().len());

--- a/tests/expectations/tests/bitfield_method_mangling.rs
+++ b/tests/expectations/tests/bitfield_method_mangling.rs
@@ -15,7 +15,7 @@ pub struct __BindgenBitfieldUnit<Storage, Align> {
 }
 impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align> {
     #[inline]
-    pub fn new(storage: Storage) -> Self {
+    pub const fn new(storage: Storage) -> Self {
         Self { storage, align: [] }
     }
 }

--- a/tests/expectations/tests/class.rs
+++ b/tests/expectations/tests/class.rs
@@ -12,7 +12,7 @@
 pub struct __IncompleteArrayField<T>(::std::marker::PhantomData<T>, [T; 0]);
 impl<T> __IncompleteArrayField<T> {
     #[inline]
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         __IncompleteArrayField(::std::marker::PhantomData, [])
     }
     #[inline]

--- a/tests/expectations/tests/derive-bitfield-method-same-name.rs
+++ b/tests/expectations/tests/derive-bitfield-method-same-name.rs
@@ -9,21 +9,20 @@
 
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct __BindgenBitfieldUnit<Storage, Align>
-where
-    Storage: AsRef<[u8]> + AsMut<[u8]>,
-{
+pub struct __BindgenBitfieldUnit<Storage, Align> {
     storage: Storage,
     align: [Align; 0],
+}
+impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align> {
+    #[inline]
+    pub fn new(storage: Storage) -> Self {
+        Self { storage, align: [] }
+    }
 }
 impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align>
 where
     Storage: AsRef<[u8]> + AsMut<[u8]>,
 {
-    #[inline]
-    pub fn new(storage: Storage) -> Self {
-        Self { storage, align: [] }
-    }
     #[inline]
     pub fn get_bit(&self, index: usize) -> bool {
         debug_assert!(index / 8 < self.storage.as_ref().len());

--- a/tests/expectations/tests/derive-bitfield-method-same-name.rs
+++ b/tests/expectations/tests/derive-bitfield-method-same-name.rs
@@ -15,7 +15,7 @@ pub struct __BindgenBitfieldUnit<Storage, Align> {
 }
 impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align> {
     #[inline]
-    pub fn new(storage: Storage) -> Self {
+    pub const fn new(storage: Storage) -> Self {
         Self { storage, align: [] }
     }
 }

--- a/tests/expectations/tests/derive-debug-bitfield-core.rs
+++ b/tests/expectations/tests/derive-debug-bitfield-core.rs
@@ -17,7 +17,7 @@ pub struct __BindgenBitfieldUnit<Storage, Align> {
 }
 impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align> {
     #[inline]
-    pub fn new(storage: Storage) -> Self {
+    pub const fn new(storage: Storage) -> Self {
         Self { storage, align: [] }
     }
 }

--- a/tests/expectations/tests/derive-debug-bitfield-core.rs
+++ b/tests/expectations/tests/derive-debug-bitfield-core.rs
@@ -11,21 +11,20 @@ extern crate core;
 
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct __BindgenBitfieldUnit<Storage, Align>
-where
-    Storage: AsRef<[u8]> + AsMut<[u8]>,
-{
+pub struct __BindgenBitfieldUnit<Storage, Align> {
     storage: Storage,
     align: [Align; 0],
+}
+impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align> {
+    #[inline]
+    pub fn new(storage: Storage) -> Self {
+        Self { storage, align: [] }
+    }
 }
 impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align>
 where
     Storage: AsRef<[u8]> + AsMut<[u8]>,
 {
-    #[inline]
-    pub fn new(storage: Storage) -> Self {
-        Self { storage, align: [] }
-    }
     #[inline]
     pub fn get_bit(&self, index: usize) -> bool {
         debug_assert!(index / 8 < self.storage.as_ref().len());

--- a/tests/expectations/tests/derive-debug-bitfield.rs
+++ b/tests/expectations/tests/derive-debug-bitfield.rs
@@ -9,21 +9,20 @@
 
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct __BindgenBitfieldUnit<Storage, Align>
-where
-    Storage: AsRef<[u8]> + AsMut<[u8]>,
-{
+pub struct __BindgenBitfieldUnit<Storage, Align> {
     storage: Storage,
     align: [Align; 0],
+}
+impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align> {
+    #[inline]
+    pub fn new(storage: Storage) -> Self {
+        Self { storage, align: [] }
+    }
 }
 impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align>
 where
     Storage: AsRef<[u8]> + AsMut<[u8]>,
 {
-    #[inline]
-    pub fn new(storage: Storage) -> Self {
-        Self { storage, align: [] }
-    }
     #[inline]
     pub fn get_bit(&self, index: usize) -> bool {
         debug_assert!(index / 8 < self.storage.as_ref().len());

--- a/tests/expectations/tests/derive-debug-bitfield.rs
+++ b/tests/expectations/tests/derive-debug-bitfield.rs
@@ -15,7 +15,7 @@ pub struct __BindgenBitfieldUnit<Storage, Align> {
 }
 impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align> {
     #[inline]
-    pub fn new(storage: Storage) -> Self {
+    pub const fn new(storage: Storage) -> Self {
         Self { storage, align: [] }
     }
 }

--- a/tests/expectations/tests/derive-hash-struct-with-incomplete-array.rs
+++ b/tests/expectations/tests/derive-hash-struct-with-incomplete-array.rs
@@ -12,7 +12,7 @@
 pub struct __IncompleteArrayField<T>(::std::marker::PhantomData<T>, [T; 0]);
 impl<T> __IncompleteArrayField<T> {
     #[inline]
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         __IncompleteArrayField(::std::marker::PhantomData, [])
     }
     #[inline]

--- a/tests/expectations/tests/derive-partialeq-bitfield.rs
+++ b/tests/expectations/tests/derive-partialeq-bitfield.rs
@@ -9,21 +9,20 @@
 
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct __BindgenBitfieldUnit<Storage, Align>
-where
-    Storage: AsRef<[u8]> + AsMut<[u8]>,
-{
+pub struct __BindgenBitfieldUnit<Storage, Align> {
     storage: Storage,
     align: [Align; 0],
+}
+impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align> {
+    #[inline]
+    pub fn new(storage: Storage) -> Self {
+        Self { storage, align: [] }
+    }
 }
 impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align>
 where
     Storage: AsRef<[u8]> + AsMut<[u8]>,
 {
-    #[inline]
-    pub fn new(storage: Storage) -> Self {
-        Self { storage, align: [] }
-    }
     #[inline]
     pub fn get_bit(&self, index: usize) -> bool {
         debug_assert!(index / 8 < self.storage.as_ref().len());

--- a/tests/expectations/tests/derive-partialeq-bitfield.rs
+++ b/tests/expectations/tests/derive-partialeq-bitfield.rs
@@ -15,7 +15,7 @@ pub struct __BindgenBitfieldUnit<Storage, Align> {
 }
 impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align> {
     #[inline]
-    pub fn new(storage: Storage) -> Self {
+    pub const fn new(storage: Storage) -> Self {
         Self { storage, align: [] }
     }
 }

--- a/tests/expectations/tests/divide-by-zero-in-struct-layout.rs
+++ b/tests/expectations/tests/divide-by-zero-in-struct-layout.rs
@@ -9,21 +9,20 @@
 
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct __BindgenBitfieldUnit<Storage, Align>
-where
-    Storage: AsRef<[u8]> + AsMut<[u8]>,
-{
+pub struct __BindgenBitfieldUnit<Storage, Align> {
     storage: Storage,
     align: [Align; 0],
+}
+impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align> {
+    #[inline]
+    pub fn new(storage: Storage) -> Self {
+        Self { storage, align: [] }
+    }
 }
 impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align>
 where
     Storage: AsRef<[u8]> + AsMut<[u8]>,
 {
-    #[inline]
-    pub fn new(storage: Storage) -> Self {
-        Self { storage, align: [] }
-    }
     #[inline]
     pub fn get_bit(&self, index: usize) -> bool {
         debug_assert!(index / 8 < self.storage.as_ref().len());

--- a/tests/expectations/tests/divide-by-zero-in-struct-layout.rs
+++ b/tests/expectations/tests/divide-by-zero-in-struct-layout.rs
@@ -15,7 +15,7 @@ pub struct __BindgenBitfieldUnit<Storage, Align> {
 }
 impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align> {
     #[inline]
-    pub fn new(storage: Storage) -> Self {
+    pub const fn new(storage: Storage) -> Self {
         Self { storage, align: [] }
     }
 }

--- a/tests/expectations/tests/issue-1034.rs
+++ b/tests/expectations/tests/issue-1034.rs
@@ -9,21 +9,20 @@
 
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct __BindgenBitfieldUnit<Storage, Align>
-where
-    Storage: AsRef<[u8]> + AsMut<[u8]>,
-{
+pub struct __BindgenBitfieldUnit<Storage, Align> {
     storage: Storage,
     align: [Align; 0],
+}
+impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align> {
+    #[inline]
+    pub fn new(storage: Storage) -> Self {
+        Self { storage, align: [] }
+    }
 }
 impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align>
 where
     Storage: AsRef<[u8]> + AsMut<[u8]>,
 {
-    #[inline]
-    pub fn new(storage: Storage) -> Self {
-        Self { storage, align: [] }
-    }
     #[inline]
     pub fn get_bit(&self, index: usize) -> bool {
         debug_assert!(index / 8 < self.storage.as_ref().len());

--- a/tests/expectations/tests/issue-1034.rs
+++ b/tests/expectations/tests/issue-1034.rs
@@ -15,7 +15,7 @@ pub struct __BindgenBitfieldUnit<Storage, Align> {
 }
 impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align> {
     #[inline]
-    pub fn new(storage: Storage) -> Self {
+    pub const fn new(storage: Storage) -> Self {
         Self { storage, align: [] }
     }
 }

--- a/tests/expectations/tests/issue-1076-unnamed-bitfield-alignment.rs
+++ b/tests/expectations/tests/issue-1076-unnamed-bitfield-alignment.rs
@@ -9,21 +9,20 @@
 
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct __BindgenBitfieldUnit<Storage, Align>
-where
-    Storage: AsRef<[u8]> + AsMut<[u8]>,
-{
+pub struct __BindgenBitfieldUnit<Storage, Align> {
     storage: Storage,
     align: [Align; 0],
+}
+impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align> {
+    #[inline]
+    pub fn new(storage: Storage) -> Self {
+        Self { storage, align: [] }
+    }
 }
 impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align>
 where
     Storage: AsRef<[u8]> + AsMut<[u8]>,
 {
-    #[inline]
-    pub fn new(storage: Storage) -> Self {
-        Self { storage, align: [] }
-    }
     #[inline]
     pub fn get_bit(&self, index: usize) -> bool {
         debug_assert!(index / 8 < self.storage.as_ref().len());

--- a/tests/expectations/tests/issue-1076-unnamed-bitfield-alignment.rs
+++ b/tests/expectations/tests/issue-1076-unnamed-bitfield-alignment.rs
@@ -15,7 +15,7 @@ pub struct __BindgenBitfieldUnit<Storage, Align> {
 }
 impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align> {
     #[inline]
-    pub fn new(storage: Storage) -> Self {
+    pub const fn new(storage: Storage) -> Self {
         Self { storage, align: [] }
     }
 }

--- a/tests/expectations/tests/issue-493.rs
+++ b/tests/expectations/tests/issue-493.rs
@@ -11,7 +11,7 @@
 pub struct __BindgenUnionField<T>(::std::marker::PhantomData<T>);
 impl<T> __BindgenUnionField<T> {
     #[inline]
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         __BindgenUnionField(::std::marker::PhantomData)
     }
     #[inline]

--- a/tests/expectations/tests/issue-643-inner-struct.rs
+++ b/tests/expectations/tests/issue-643-inner-struct.rs
@@ -12,7 +12,7 @@
 pub struct __IncompleteArrayField<T>(::std::marker::PhantomData<T>, [T; 0]);
 impl<T> __IncompleteArrayField<T> {
     #[inline]
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         __IncompleteArrayField(::std::marker::PhantomData, [])
     }
     #[inline]

--- a/tests/expectations/tests/issue-739-pointer-wide-bitfield.rs
+++ b/tests/expectations/tests/issue-739-pointer-wide-bitfield.rs
@@ -9,21 +9,20 @@
 
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct __BindgenBitfieldUnit<Storage, Align>
-where
-    Storage: AsRef<[u8]> + AsMut<[u8]>,
-{
+pub struct __BindgenBitfieldUnit<Storage, Align> {
     storage: Storage,
     align: [Align; 0],
+}
+impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align> {
+    #[inline]
+    pub fn new(storage: Storage) -> Self {
+        Self { storage, align: [] }
+    }
 }
 impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align>
 where
     Storage: AsRef<[u8]> + AsMut<[u8]>,
 {
-    #[inline]
-    pub fn new(storage: Storage) -> Self {
-        Self { storage, align: [] }
-    }
     #[inline]
     pub fn get_bit(&self, index: usize) -> bool {
         debug_assert!(index / 8 < self.storage.as_ref().len());

--- a/tests/expectations/tests/issue-739-pointer-wide-bitfield.rs
+++ b/tests/expectations/tests/issue-739-pointer-wide-bitfield.rs
@@ -15,7 +15,7 @@ pub struct __BindgenBitfieldUnit<Storage, Align> {
 }
 impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align> {
     #[inline]
-    pub fn new(storage: Storage) -> Self {
+    pub const fn new(storage: Storage) -> Self {
         Self { storage, align: [] }
     }
 }

--- a/tests/expectations/tests/issue-816.rs
+++ b/tests/expectations/tests/issue-816.rs
@@ -9,21 +9,20 @@
 
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct __BindgenBitfieldUnit<Storage, Align>
-where
-    Storage: AsRef<[u8]> + AsMut<[u8]>,
-{
+pub struct __BindgenBitfieldUnit<Storage, Align> {
     storage: Storage,
     align: [Align; 0],
+}
+impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align> {
+    #[inline]
+    pub fn new(storage: Storage) -> Self {
+        Self { storage, align: [] }
+    }
 }
 impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align>
 where
     Storage: AsRef<[u8]> + AsMut<[u8]>,
 {
-    #[inline]
-    pub fn new(storage: Storage) -> Self {
-        Self { storage, align: [] }
-    }
     #[inline]
     pub fn get_bit(&self, index: usize) -> bool {
         debug_assert!(index / 8 < self.storage.as_ref().len());

--- a/tests/expectations/tests/issue-816.rs
+++ b/tests/expectations/tests/issue-816.rs
@@ -15,7 +15,7 @@ pub struct __BindgenBitfieldUnit<Storage, Align> {
 }
 impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align> {
     #[inline]
-    pub fn new(storage: Storage) -> Self {
+    pub const fn new(storage: Storage) -> Self {
         Self { storage, align: [] }
     }
 }

--- a/tests/expectations/tests/jsval_layout_opaque.rs
+++ b/tests/expectations/tests/jsval_layout_opaque.rs
@@ -9,21 +9,20 @@
 
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct __BindgenBitfieldUnit<Storage, Align>
-where
-    Storage: AsRef<[u8]> + AsMut<[u8]>,
-{
+pub struct __BindgenBitfieldUnit<Storage, Align> {
     storage: Storage,
     align: [Align; 0],
+}
+impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align> {
+    #[inline]
+    pub fn new(storage: Storage) -> Self {
+        Self { storage, align: [] }
+    }
 }
 impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align>
 where
     Storage: AsRef<[u8]> + AsMut<[u8]>,
 {
-    #[inline]
-    pub fn new(storage: Storage) -> Self {
-        Self { storage, align: [] }
-    }
     #[inline]
     pub fn get_bit(&self, index: usize) -> bool {
         debug_assert!(index / 8 < self.storage.as_ref().len());

--- a/tests/expectations/tests/jsval_layout_opaque.rs
+++ b/tests/expectations/tests/jsval_layout_opaque.rs
@@ -15,7 +15,7 @@ pub struct __BindgenBitfieldUnit<Storage, Align> {
 }
 impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align> {
     #[inline]
-    pub fn new(storage: Storage) -> Self {
+    pub const fn new(storage: Storage) -> Self {
         Self { storage, align: [] }
     }
 }

--- a/tests/expectations/tests/jsval_layout_opaque_1_0.rs
+++ b/tests/expectations/tests/jsval_layout_opaque_1_0.rs
@@ -9,21 +9,20 @@
 
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct __BindgenBitfieldUnit<Storage, Align>
-where
-    Storage: AsRef<[u8]> + AsMut<[u8]>,
-{
+pub struct __BindgenBitfieldUnit<Storage, Align> {
     storage: Storage,
     align: [Align; 0],
+}
+impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align> {
+    #[inline]
+    pub fn new(storage: Storage) -> Self {
+        Self { storage, align: [] }
+    }
 }
 impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align>
 where
     Storage: AsRef<[u8]> + AsMut<[u8]>,
 {
-    #[inline]
-    pub fn new(storage: Storage) -> Self {
-        Self { storage, align: [] }
-    }
     #[inline]
     pub fn get_bit(&self, index: usize) -> bool {
         debug_assert!(index / 8 < self.storage.as_ref().len());

--- a/tests/expectations/tests/layout_align.rs
+++ b/tests/expectations/tests/layout_align.rs
@@ -9,21 +9,20 @@
 
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct __BindgenBitfieldUnit<Storage, Align>
-where
-    Storage: AsRef<[u8]> + AsMut<[u8]>,
-{
+pub struct __BindgenBitfieldUnit<Storage, Align> {
     storage: Storage,
     align: [Align; 0],
+}
+impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align> {
+    #[inline]
+    pub fn new(storage: Storage) -> Self {
+        Self { storage, align: [] }
+    }
 }
 impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align>
 where
     Storage: AsRef<[u8]> + AsMut<[u8]>,
 {
-    #[inline]
-    pub fn new(storage: Storage) -> Self {
-        Self { storage, align: [] }
-    }
     #[inline]
     pub fn get_bit(&self, index: usize) -> bool {
         debug_assert!(index / 8 < self.storage.as_ref().len());

--- a/tests/expectations/tests/layout_align.rs
+++ b/tests/expectations/tests/layout_align.rs
@@ -15,7 +15,7 @@ pub struct __BindgenBitfieldUnit<Storage, Align> {
 }
 impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align> {
     #[inline]
-    pub fn new(storage: Storage) -> Self {
+    pub const fn new(storage: Storage) -> Self {
         Self { storage, align: [] }
     }
 }

--- a/tests/expectations/tests/layout_align.rs
+++ b/tests/expectations/tests/layout_align.rs
@@ -93,7 +93,7 @@ where
 pub struct __IncompleteArrayField<T>(::std::marker::PhantomData<T>, [T; 0]);
 impl<T> __IncompleteArrayField<T> {
     #[inline]
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         __IncompleteArrayField(::std::marker::PhantomData, [])
     }
     #[inline]

--- a/tests/expectations/tests/layout_eth_conf.rs
+++ b/tests/expectations/tests/layout_eth_conf.rs
@@ -9,21 +9,20 @@
 
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct __BindgenBitfieldUnit<Storage, Align>
-where
-    Storage: AsRef<[u8]> + AsMut<[u8]>,
-{
+pub struct __BindgenBitfieldUnit<Storage, Align> {
     storage: Storage,
     align: [Align; 0],
+}
+impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align> {
+    #[inline]
+    pub fn new(storage: Storage) -> Self {
+        Self { storage, align: [] }
+    }
 }
 impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align>
 where
     Storage: AsRef<[u8]> + AsMut<[u8]>,
 {
-    #[inline]
-    pub fn new(storage: Storage) -> Self {
-        Self { storage, align: [] }
-    }
     #[inline]
     pub fn get_bit(&self, index: usize) -> bool {
         debug_assert!(index / 8 < self.storage.as_ref().len());

--- a/tests/expectations/tests/layout_eth_conf.rs
+++ b/tests/expectations/tests/layout_eth_conf.rs
@@ -15,7 +15,7 @@ pub struct __BindgenBitfieldUnit<Storage, Align> {
 }
 impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align> {
     #[inline]
-    pub fn new(storage: Storage) -> Self {
+    pub const fn new(storage: Storage) -> Self {
         Self { storage, align: [] }
     }
 }

--- a/tests/expectations/tests/layout_eth_conf_1_0.rs
+++ b/tests/expectations/tests/layout_eth_conf_1_0.rs
@@ -9,21 +9,20 @@
 
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct __BindgenBitfieldUnit<Storage, Align>
-where
-    Storage: AsRef<[u8]> + AsMut<[u8]>,
-{
+pub struct __BindgenBitfieldUnit<Storage, Align> {
     storage: Storage,
     align: [Align; 0],
+}
+impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align> {
+    #[inline]
+    pub fn new(storage: Storage) -> Self {
+        Self { storage, align: [] }
+    }
 }
 impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align>
 where
     Storage: AsRef<[u8]> + AsMut<[u8]>,
 {
-    #[inline]
-    pub fn new(storage: Storage) -> Self {
-        Self { storage, align: [] }
-    }
     #[inline]
     pub fn get_bit(&self, index: usize) -> bool {
         debug_assert!(index / 8 < self.storage.as_ref().len());

--- a/tests/expectations/tests/layout_large_align_field.rs
+++ b/tests/expectations/tests/layout_large_align_field.rs
@@ -12,7 +12,7 @@
 pub struct __IncompleteArrayField<T>(::std::marker::PhantomData<T>, [T; 0]);
 impl<T> __IncompleteArrayField<T> {
     #[inline]
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         __IncompleteArrayField(::std::marker::PhantomData, [])
     }
     #[inline]

--- a/tests/expectations/tests/layout_mbuf.rs
+++ b/tests/expectations/tests/layout_mbuf.rs
@@ -9,21 +9,20 @@
 
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct __BindgenBitfieldUnit<Storage, Align>
-where
-    Storage: AsRef<[u8]> + AsMut<[u8]>,
-{
+pub struct __BindgenBitfieldUnit<Storage, Align> {
     storage: Storage,
     align: [Align; 0],
+}
+impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align> {
+    #[inline]
+    pub fn new(storage: Storage) -> Self {
+        Self { storage, align: [] }
+    }
 }
 impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align>
 where
     Storage: AsRef<[u8]> + AsMut<[u8]>,
 {
-    #[inline]
-    pub fn new(storage: Storage) -> Self {
-        Self { storage, align: [] }
-    }
     #[inline]
     pub fn get_bit(&self, index: usize) -> bool {
         debug_assert!(index / 8 < self.storage.as_ref().len());

--- a/tests/expectations/tests/layout_mbuf.rs
+++ b/tests/expectations/tests/layout_mbuf.rs
@@ -15,7 +15,7 @@ pub struct __BindgenBitfieldUnit<Storage, Align> {
 }
 impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align> {
     #[inline]
-    pub fn new(storage: Storage) -> Self {
+    pub const fn new(storage: Storage) -> Self {
         Self { storage, align: [] }
     }
 }

--- a/tests/expectations/tests/layout_mbuf_1_0.rs
+++ b/tests/expectations/tests/layout_mbuf_1_0.rs
@@ -9,21 +9,20 @@
 
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct __BindgenBitfieldUnit<Storage, Align>
-where
-    Storage: AsRef<[u8]> + AsMut<[u8]>,
-{
+pub struct __BindgenBitfieldUnit<Storage, Align> {
     storage: Storage,
     align: [Align; 0],
+}
+impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align> {
+    #[inline]
+    pub fn new(storage: Storage) -> Self {
+        Self { storage, align: [] }
+    }
 }
 impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align>
 where
     Storage: AsRef<[u8]> + AsMut<[u8]>,
 {
-    #[inline]
-    pub fn new(storage: Storage) -> Self {
-        Self { storage, align: [] }
-    }
     #[inline]
     pub fn get_bit(&self, index: usize) -> bool {
         debug_assert!(index / 8 < self.storage.as_ref().len());

--- a/tests/expectations/tests/only_bitfields.rs
+++ b/tests/expectations/tests/only_bitfields.rs
@@ -9,21 +9,20 @@
 
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct __BindgenBitfieldUnit<Storage, Align>
-where
-    Storage: AsRef<[u8]> + AsMut<[u8]>,
-{
+pub struct __BindgenBitfieldUnit<Storage, Align> {
     storage: Storage,
     align: [Align; 0],
+}
+impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align> {
+    #[inline]
+    pub fn new(storage: Storage) -> Self {
+        Self { storage, align: [] }
+    }
 }
 impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align>
 where
     Storage: AsRef<[u8]> + AsMut<[u8]>,
 {
-    #[inline]
-    pub fn new(storage: Storage) -> Self {
-        Self { storage, align: [] }
-    }
     #[inline]
     pub fn get_bit(&self, index: usize) -> bool {
         debug_assert!(index / 8 < self.storage.as_ref().len());

--- a/tests/expectations/tests/only_bitfields.rs
+++ b/tests/expectations/tests/only_bitfields.rs
@@ -15,7 +15,7 @@ pub struct __BindgenBitfieldUnit<Storage, Align> {
 }
 impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align> {
     #[inline]
-    pub fn new(storage: Storage) -> Self {
+    pub const fn new(storage: Storage) -> Self {
         Self { storage, align: [] }
     }
 }

--- a/tests/expectations/tests/struct_with_bitfields.rs
+++ b/tests/expectations/tests/struct_with_bitfields.rs
@@ -9,21 +9,20 @@
 
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct __BindgenBitfieldUnit<Storage, Align>
-where
-    Storage: AsRef<[u8]> + AsMut<[u8]>,
-{
+pub struct __BindgenBitfieldUnit<Storage, Align> {
     storage: Storage,
     align: [Align; 0],
+}
+impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align> {
+    #[inline]
+    pub fn new(storage: Storage) -> Self {
+        Self { storage, align: [] }
+    }
 }
 impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align>
 where
     Storage: AsRef<[u8]> + AsMut<[u8]>,
 {
-    #[inline]
-    pub fn new(storage: Storage) -> Self {
-        Self { storage, align: [] }
-    }
     #[inline]
     pub fn get_bit(&self, index: usize) -> bool {
         debug_assert!(index / 8 < self.storage.as_ref().len());

--- a/tests/expectations/tests/struct_with_bitfields.rs
+++ b/tests/expectations/tests/struct_with_bitfields.rs
@@ -15,7 +15,7 @@ pub struct __BindgenBitfieldUnit<Storage, Align> {
 }
 impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align> {
     #[inline]
-    pub fn new(storage: Storage) -> Self {
+    pub const fn new(storage: Storage) -> Self {
         Self { storage, align: [] }
     }
 }

--- a/tests/expectations/tests/union_bitfield.rs
+++ b/tests/expectations/tests/union_bitfield.rs
@@ -9,21 +9,20 @@
 
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct __BindgenBitfieldUnit<Storage, Align>
-where
-    Storage: AsRef<[u8]> + AsMut<[u8]>,
-{
+pub struct __BindgenBitfieldUnit<Storage, Align> {
     storage: Storage,
     align: [Align; 0],
+}
+impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align> {
+    #[inline]
+    pub fn new(storage: Storage) -> Self {
+        Self { storage, align: [] }
+    }
 }
 impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align>
 where
     Storage: AsRef<[u8]> + AsMut<[u8]>,
 {
-    #[inline]
-    pub fn new(storage: Storage) -> Self {
-        Self { storage, align: [] }
-    }
     #[inline]
     pub fn get_bit(&self, index: usize) -> bool {
         debug_assert!(index / 8 < self.storage.as_ref().len());

--- a/tests/expectations/tests/union_bitfield.rs
+++ b/tests/expectations/tests/union_bitfield.rs
@@ -15,7 +15,7 @@ pub struct __BindgenBitfieldUnit<Storage, Align> {
 }
 impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align> {
     #[inline]
-    pub fn new(storage: Storage) -> Self {
+    pub const fn new(storage: Storage) -> Self {
         Self { storage, align: [] }
     }
 }

--- a/tests/expectations/tests/union_bitfield_1_0.rs
+++ b/tests/expectations/tests/union_bitfield_1_0.rs
@@ -9,21 +9,20 @@
 
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct __BindgenBitfieldUnit<Storage, Align>
-where
-    Storage: AsRef<[u8]> + AsMut<[u8]>,
-{
+pub struct __BindgenBitfieldUnit<Storage, Align> {
     storage: Storage,
     align: [Align; 0],
+}
+impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align> {
+    #[inline]
+    pub fn new(storage: Storage) -> Self {
+        Self { storage, align: [] }
+    }
 }
 impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align>
 where
     Storage: AsRef<[u8]> + AsMut<[u8]>,
 {
-    #[inline]
-    pub fn new(storage: Storage) -> Self {
-        Self { storage, align: [] }
-    }
     #[inline]
     pub fn get_bit(&self, index: usize) -> bool {
         debug_assert!(index / 8 < self.storage.as_ref().len());

--- a/tests/expectations/tests/union_with_anon_struct_bitfield.rs
+++ b/tests/expectations/tests/union_with_anon_struct_bitfield.rs
@@ -9,21 +9,20 @@
 
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct __BindgenBitfieldUnit<Storage, Align>
-where
-    Storage: AsRef<[u8]> + AsMut<[u8]>,
-{
+pub struct __BindgenBitfieldUnit<Storage, Align> {
     storage: Storage,
     align: [Align; 0],
+}
+impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align> {
+    #[inline]
+    pub fn new(storage: Storage) -> Self {
+        Self { storage, align: [] }
+    }
 }
 impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align>
 where
     Storage: AsRef<[u8]> + AsMut<[u8]>,
 {
-    #[inline]
-    pub fn new(storage: Storage) -> Self {
-        Self { storage, align: [] }
-    }
     #[inline]
     pub fn get_bit(&self, index: usize) -> bool {
         debug_assert!(index / 8 < self.storage.as_ref().len());

--- a/tests/expectations/tests/union_with_anon_struct_bitfield.rs
+++ b/tests/expectations/tests/union_with_anon_struct_bitfield.rs
@@ -15,7 +15,7 @@ pub struct __BindgenBitfieldUnit<Storage, Align> {
 }
 impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align> {
     #[inline]
-    pub fn new(storage: Storage) -> Self {
+    pub const fn new(storage: Storage) -> Self {
         Self { storage, align: [] }
     }
 }

--- a/tests/expectations/tests/union_with_anon_struct_bitfield_1_0.rs
+++ b/tests/expectations/tests/union_with_anon_struct_bitfield_1_0.rs
@@ -9,21 +9,20 @@
 
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct __BindgenBitfieldUnit<Storage, Align>
-where
-    Storage: AsRef<[u8]> + AsMut<[u8]>,
-{
+pub struct __BindgenBitfieldUnit<Storage, Align> {
     storage: Storage,
     align: [Align; 0],
+}
+impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align> {
+    #[inline]
+    pub fn new(storage: Storage) -> Self {
+        Self { storage, align: [] }
+    }
 }
 impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align>
 where
     Storage: AsRef<[u8]> + AsMut<[u8]>,
 {
-    #[inline]
-    pub fn new(storage: Storage) -> Self {
-        Self { storage, align: [] }
-    }
     #[inline]
     pub fn get_bit(&self, index: usize) -> bool {
         debug_assert!(index / 8 < self.storage.as_ref().len());

--- a/tests/expectations/tests/weird_bitfields.rs
+++ b/tests/expectations/tests/weird_bitfields.rs
@@ -9,21 +9,20 @@
 
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct __BindgenBitfieldUnit<Storage, Align>
-where
-    Storage: AsRef<[u8]> + AsMut<[u8]>,
-{
+pub struct __BindgenBitfieldUnit<Storage, Align> {
     storage: Storage,
     align: [Align; 0],
+}
+impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align> {
+    #[inline]
+    pub fn new(storage: Storage) -> Self {
+        Self { storage, align: [] }
+    }
 }
 impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align>
 where
     Storage: AsRef<[u8]> + AsMut<[u8]>,
 {
-    #[inline]
-    pub fn new(storage: Storage) -> Self {
-        Self { storage, align: [] }
-    }
     #[inline]
     pub fn get_bit(&self, index: usize) -> bool {
         debug_assert!(index / 8 < self.storage.as_ref().len());

--- a/tests/expectations/tests/weird_bitfields.rs
+++ b/tests/expectations/tests/weird_bitfields.rs
@@ -15,7 +15,7 @@ pub struct __BindgenBitfieldUnit<Storage, Align> {
 }
 impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align> {
     #[inline]
-    pub fn new(storage: Storage) -> Self {
+    pub const fn new(storage: Storage) -> Self {
         Self { storage, align: [] }
     }
 }

--- a/tests/expectations/tests/zero-size-array-align.rs
+++ b/tests/expectations/tests/zero-size-array-align.rs
@@ -12,7 +12,7 @@
 pub struct __IncompleteArrayField<T>(::std::marker::PhantomData<T>, [T; 0]);
 impl<T> __IncompleteArrayField<T> {
     #[inline]
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         __IncompleteArrayField(::std::marker::PhantomData, [])
     }
     #[inline]

--- a/tests/expectations/tests/zero-sized-array.rs
+++ b/tests/expectations/tests/zero-sized-array.rs
@@ -12,7 +12,7 @@
 pub struct __IncompleteArrayField<T>(::std::marker::PhantomData<T>, [T; 0]);
 impl<T> __IncompleteArrayField<T> {
     #[inline]
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         __IncompleteArrayField(::std::marker::PhantomData, [])
     }
     #[inline]


### PR DESCRIPTION
This allows one to create static instances of these types or use them inside other `const fn`s. Fixes #1571 