### PR TITLE
Make clap optional.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ path = "src/lib.rs"
 name = "bindgen"
 path = "src/main.rs"
 doc = false
+required-features = ["clap"]
 
 [dev-dependencies]
 diff = "0.1"
@@ -47,7 +48,7 @@ bitflags = "1.0.3"
 cexpr = "0.3.3"
 cfg-if = "0.1.0"
 # This kinda sucks: https://github.com/rust-lang/cargo/issues/1982
-clap = "2"
+clap = { version = "2", optional = true }
 clang-sys = { version = "0.28.0", features = ["runtime", "clang_6_0"] }
 lazy_static = "1"
 peeking_take_while = "0.1.2"
@@ -69,7 +70,7 @@ optional = true
 version = "0.4"
 
 [features]
-default = ["logging"]
+default = ["logging", "clap"]
 logging = ["env_logger", "log"]
 static = []
 


### PR DESCRIPTION
This allows to opt out of clap support if you're using the lib version of bindgen.