### PR TITLE
Cleanup wchar_t layout computation to happen later.

### DIFF
--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -3060,8 +3060,9 @@ impl TryToRustTy for Type {
                     IntKind::ULong => Ok(raw_type(ctx, "c_ulong")),
                     IntKind::LongLong => Ok(raw_type(ctx, "c_longlong")),
                     IntKind::ULongLong => Ok(raw_type(ctx, "c_ulonglong")),
-                    IntKind::WChar { size } => {
-                        let ty = Layout::known_type_for_size(ctx, size)
+                    IntKind::WChar => {
+                        let layout = self.layout(ctx).expect("Couldn't compute wchar_t's layout?");
+                        let ty = Layout::known_type_for_size(ctx, layout.size)
                             .expect("Non-representable wchar_t?");
                         let ident = ctx.rust_ident_raw(ty);
                         Ok(quote! { #ident })

--- a/src/ir/context.rs
+++ b/src/ir/context.rs
@@ -2011,11 +2011,7 @@ If you encounter an error missing from this list, please file an issue or a PR!"
             CXType_UChar => TypeKind::Int(IntKind::UChar),
             CXType_Short => TypeKind::Int(IntKind::Short),
             CXType_UShort => TypeKind::Int(IntKind::UShort),
-            CXType_WChar => {
-                TypeKind::Int(IntKind::WChar {
-                    size: ty.fallible_size(self).expect("Couldn't compute size of wchar_t?"),
-                })
-            },
+            CXType_WChar => TypeKind::Int(IntKind::WChar),
             CXType_Char16 => TypeKind::Int(IntKind::U16),
             CXType_Char32 => TypeKind::Int(IntKind::U32),
             CXType_Long => TypeKind::Int(IntKind::Long),

--- a/src/ir/int.rs
+++ b/src/ir/int.rs
@@ -13,10 +13,7 @@ pub enum IntKind {
     UChar,
 
     /// An `wchar_t`.
-    WChar {
-        /// The size of the wchar_t in bytes, which will be 2 or 4.
-        size: usize,
-    },
+    WChar,
 
     /// A platform-dependent `char` type, with the signedness support.
     Char {
@@ -97,7 +94,7 @@ impl IntKind {
             // to know whether it is or not right now (unlike char, there's no
             // WChar_S / WChar_U).
             Bool | UChar | UShort | UInt | ULong | ULongLong | U8 | U16 |
-            WChar { .. } | U32 | U64 | U128 => false,
+            WChar | U32 | U64 | U128 => false,
 
             SChar | Short | Int | Long | LongLong | I8 | I16 | I32 | I64 |
             I128 => true,


### PR DESCRIPTION
This is a breaking cheange since WChar is exposed, but should be no behavior
change otherwise.