### PR TITLE
Allow to override rustfmt path with an environment variable.

### DIFF
--- a/ci/script.sh
+++ b/ci/script.sh
@@ -13,8 +13,8 @@ case "$BINDGEN_JOB" in
     "test")
         # Need rustfmt to compare the test expectations.
         rustup update nightly
-        rustup run nightly cargo install -f rustfmt-nightly
-
+        rustup component add rustfmt
+	export RUSTFMT="$(rustup which rustfmt)"
         cargo test $BINDGEN_PROFILE --features "$BINDGEN_FEATURES"
         ./ci/assert-no-diff.sh
         ;;


### PR DESCRIPTION
Fixes #1601