### PR TITLE
Add a feature to make which dependency optional

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,20 +14,28 @@ env:
     - LLVM_VERSION="3.8" BINDGEN_JOB="test"         BINDGEN_PROFILE="--release"
     - LLVM_VERSION="3.8" BINDGEN_JOB="integration"  BINDGEN_PROFILE=
     - LLVM_VERSION="3.8" BINDGEN_JOB="integration"  BINDGEN_PROFILE="--release"
+    - LLVM_VERSION="3.8" BINDGEN_JOB="nofeatures"   BINDGEN_PROFILE=
+    - LLVM_VERSION="3.8" BINDGEN_JOB="nofeatures"   BINDGEN_PROFILE="--release"
     - LLVM_VERSION="3.9" BINDGEN_JOB="test"         BINDGEN_PROFILE=
     - LLVM_VERSION="3.9" BINDGEN_JOB="test"         BINDGEN_PROFILE="--release"
     - LLVM_VERSION="3.9" BINDGEN_JOB="integration"  BINDGEN_PROFILE=
     - LLVM_VERSION="3.9" BINDGEN_JOB="integration"  BINDGEN_PROFILE="--release"
+    - LLVM_VERSION="3.9" BINDGEN_JOB="nofeatures"   BINDGEN_PROFILE=
+    - LLVM_VERSION="3.9" BINDGEN_JOB="nofeatures"   BINDGEN_PROFILE="--release"
     - LLVM_VERSION="4.0" BINDGEN_JOB="test"         BINDGEN_PROFILE=
     - LLVM_VERSION="4.0" BINDGEN_JOB="test"         BINDGEN_PROFILE="--release"
     - LLVM_VERSION="4.0" BINDGEN_JOB="integration"  BINDGEN_PROFILE=
     - LLVM_VERSION="4.0" BINDGEN_JOB="integration"  BINDGEN_PROFILE="--release"
+    - LLVM_VERSION="4.0" BINDGEN_JOB="nofeatures"   BINDGEN_PROFILE=
+    - LLVM_VERSION="4.0" BINDGEN_JOB="nofeatures"   BINDGEN_PROFILE="--release"
     - LLVM_VERSION="5.0" BINDGEN_JOB="test"         BINDGEN_PROFILE=
     - LLVM_VERSION="5.0" BINDGEN_JOB="test"         BINDGEN_PROFILE="--release"
     - LLVM_VERSION="5.0" BINDGEN_JOB="test"         BINDGEN_PROFILE=            BINDGEN_FEATURES="testing_only_extra_assertions"
     - LLVM_VERSION="5.0" BINDGEN_JOB="test"         BINDGEN_PROFILE="--release" BINDGEN_FEATURES="testing_only_extra_assertions"
     - LLVM_VERSION="5.0" BINDGEN_JOB="integration"  BINDGEN_PROFILE=
     - LLVM_VERSION="5.0" BINDGEN_JOB="integration"  BINDGEN_PROFILE="--release"
+    - LLVM_VERSION="5.0" BINDGEN_JOB="nofeatures"   BINDGEN_PROFILE=
+    - LLVM_VERSION="5.0" BINDGEN_JOB="nofeatures"   BINDGEN_PROFILE="--release"
     - LLVM_VERSION="5.0" BINDGEN_JOB="expectations" BINDGEN_PROFILE=
     - LLVM_VERSION="5.0" BINDGEN_JOB="expectations" BINDGEN_PROFILE="--release"
     - LLVM_VERSION="5.0" BINDGEN_JOB="misc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ lazy_static = "1"
 peeking_take_while = "0.1.2"
 quote = { version = "1", default-features = false }
 regex = "1.0"
-which = ">=1.0, <3.0"
+which = { version = ">=1.0, <3.0", optional = true }
 shlex = "0.1"
 fxhash = "0.2"
 # New validation in 0.3.6 breaks bindgen-integration:
@@ -70,9 +70,11 @@ optional = true
 version = "0.4"
 
 [features]
-default = ["logging", "clap"]
+default = ["logging", "clap", "which-rustfmt"]
 logging = ["env_logger", "log"]
 static = []
+# Dynamically discover a `rustfmt` binary using the `which` crate
+which-rustfmt = ["which"]
 
 # These features only exist for CI testing -- don't use them if you're not hacking
 # on bindgen!

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -43,6 +43,10 @@ case "$BINDGEN_JOB" in
         # TODO: Actually run quickchecks once `bindgen` is reliable enough.
         cargo test
         ;;
+    "nofeatures")
+        cargo test $BINDGEN_PROFILE --no-default-features
+        ./ci/assert-no-diff.sh
+        ;;
     *)
         echo "Error! Unknown \$BINDGEN_JOB: '$BINDGEN_JOB'"
         exit 1

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -14,19 +14,25 @@ case "$BINDGEN_JOB" in
         # Need rustfmt to compare the test expectations.
         rustup update nightly
         rustup component add rustfmt
-	export RUSTFMT="$(rustup which rustfmt)"
-        cargo test $BINDGEN_PROFILE --features "$BINDGEN_FEATURES"
+        RUSTFMT="$(rustup which rustfmt)"
+        export RUSTFMT
+        cargo test "$BINDGEN_PROFILE" --features "$BINDGEN_FEATURES"
         ./ci/assert-no-diff.sh
         ;;
 
     "integration")
         cd ./bindgen-integration
-        cargo test $BINDGEN_PROFILE --features "$BINDGEN_FEATURES"
+        cargo test "$BINDGEN_PROFILE" --features "$BINDGEN_FEATURES"
+        ;;
+
+    "nofeatures")
+        cargo test "$BINDGEN_PROFILE" --no-default-features
+        ./ci/assert-no-diff.sh
         ;;
 
     "expectations")
         cd ./tests/expectations
-        cargo test $BINDGEN_PROFILE
+        cargo test "$BINDGEN_PROFILE"
         ;;
 
     "misc")
@@ -43,10 +49,7 @@ case "$BINDGEN_JOB" in
         # TODO: Actually run quickchecks once `bindgen` is reliable enough.
         cargo test
         ;;
-    "nofeatures")
-        cargo test $BINDGEN_PROFILE --no-default-features
-        ./ci/assert-no-diff.sh
-        ;;
+
     *)
         echo "Error! Unknown \$BINDGEN_JOB: '$BINDGEN_JOB'"
         exit 1

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -26,6 +26,10 @@ case "$BINDGEN_JOB" in
         ;;
 
     "nofeatures")
+        rustup update nightly
+        rustup component add rustfmt
+        RUSTFMT="$(rustup which rustfmt)"
+        export RUSTFMT
         cargo test "$BINDGEN_PROFILE" --no-default-features
         ./ci/assert-no-diff.sh
         ;;

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -14,6 +14,7 @@ case "$BINDGEN_JOB" in
         # Need rustfmt to compare the test expectations.
         rustup update nightly
         rustup component add rustfmt
+        rustup component add --toolchain nightly rustfmt
         RUSTFMT="$(rustup which rustfmt)"
         export RUSTFMT
         cargo test "$BINDGEN_PROFILE" --features "$BINDGEN_FEATURES"
@@ -28,6 +29,7 @@ case "$BINDGEN_JOB" in
     "nofeatures")
         rustup update nightly
         rustup component add rustfmt
+        rustup component add --toolchain nightly rustfmt
         RUSTFMT="$(rustup which rustfmt)"
         export RUSTFMT
         cargo test "$BINDGEN_PROFILE" --no-default-features

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,7 @@ extern crate quote;
 extern crate proc_macro2;
 extern crate regex;
 extern crate shlex;
+#[cfg(feature = "which-rustfmt")]
 extern crate which;
 
 #[cfg(feature = "logging")]
@@ -1900,18 +1901,21 @@ impl Bindings {
     }
 
     /// Gets the rustfmt path to rustfmt the generated bindings.
-    fn rustfmt_path<'a>(&'a self) -> io::Result<Cow<'a, PathBuf>> {
+    fn rustfmt_path<'a>(&'a self) -> io::Result<Option<Cow<'a, PathBuf>>> {
         debug_assert!(self.options.rustfmt_bindings);
         if let Some(ref p) = self.options.rustfmt_path {
-            return Ok(Cow::Borrowed(p));
+            return Ok(Some(Cow::Borrowed(p)));
         }
         if let Ok(rustfmt) = env::var("RUSTFMT") {
-            return Ok(Cow::Owned(rustfmt.into()));
+            return Ok(Some(Cow::Owned(rustfmt.into())));
         }
+        #[cfg(feature = "which-rustfmt")]
         match which::which("rustfmt") {
-            Ok(p) => Ok(Cow::Owned(p)),
+            Ok(p) => Ok(Some(Cow::Owned(p))),
             Err(e) => Err(io::Error::new(io::ErrorKind::Other, format!("{}", e))),
         }
+        #[cfg(not(feature = "which-rustfmt"))]
+        Ok(None)
     }
 
     /// Checks if rustfmt_bindings is set and runs rustfmt on the string
@@ -1926,7 +1930,11 @@ impl Bindings {
             return Ok(Cow::Borrowed(source));
         }
 
-        let rustfmt = self.rustfmt_path()?;
+        let rustfmt = if let Some(rustfmt) = self.rustfmt_path()? {
+            rustfmt
+        } else {
+            return Ok(Cow::Borrowed(source));
+        };
         let mut cmd = Command::new(&*rustfmt);
 
         cmd


### PR DESCRIPTION
This PR adds a new feature, enabled by default, called `which-rustfmt`. When enabled, this feature enables using the `which` crate to search for the `rustfmt` binary. `which` is now an optional dependency. Disabling this feature trims some dependencies in the case that bindings are generated at build time and never checked in.

This PR changes the API of `rustfmt_path` to return `Result<Option<Cow<PathBuf>>>`.

Ok(None) is returned in the case where `which` is disabled and no `rustfmt` command is
supplied explicitly either via configuration or env variable.

Downstream code checks for the presence of None to directly return the source without
emitting an error.

Fixes GH-1614.

I named the feature `which-rustfmt` instead of `which` because the feature is tied to the functionality, not the crate. If this functionality for some reason requires additional dependencies in the future, they can be added to this feature and excluded in a backwards compatible way. This is also the [suggested way to name features by the cargo documentation](https://doc.rust-lang.org/cargo/reference/manifest.html#the-features-section).

@emilio I have `rustfmt` enabled by default on save in my editor and there was quite a lot of diff to ignore to make this PR minimal. Can we either `rustfmt` bindgen and add a step to CI to enforce code is formatted or add a `rustfmt.toml` so the formatting is preserved?