### PR TITLE
ir: Make Ord and PartialOrd implementations agree.

### DIFF
--- a/src/ir/analysis/has_vtable.rs
+++ b/src/ir/analysis/has_vtable.rs
@@ -9,37 +9,22 @@ use std::ops;
 use {Entry, HashMap};
 
 /// The result of the `HasVtableAnalysis` for an individual item.
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Ord)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub enum HasVtableResult {
-    /// The item has a vtable, but the actual vtable pointer is in a base
-    /// member.
-    BaseHasVtable,
+    /// The item does not have a vtable pointer.
+    No,
 
     /// The item has a vtable and the actual vtable pointer is within this item.
     SelfHasVtable,
 
-    /// The item does not have a vtable pointer.
-    No,
+    /// The item has a vtable, but the actual vtable pointer is in a base
+    /// member.
+    BaseHasVtable,
 }
 
 impl Default for HasVtableResult {
     fn default() -> Self {
         HasVtableResult::No
-    }
-}
-
-impl cmp::PartialOrd for HasVtableResult {
-    fn partial_cmp(&self, rhs: &Self) -> Option<cmp::Ordering> {
-        use self::HasVtableResult::*;
-
-        match (*self, *rhs) {
-            (x, y) if x == y => Some(cmp::Ordering::Equal),
-            (BaseHasVtable, _) => Some(cmp::Ordering::Greater),
-            (_, BaseHasVtable) => Some(cmp::Ordering::Less),
-            (SelfHasVtable, _) => Some(cmp::Ordering::Greater),
-            (_, SelfHasVtable) => Some(cmp::Ordering::Less),
-            _ => unreachable!(),
-        }
     }
 }
 

--- a/src/ir/analysis/sizedness.rs
+++ b/src/ir/analysis/sizedness.rs
@@ -24,13 +24,14 @@ use {Entry, HashMap};
 ///
 /// We initially assume that all types are `ZeroSized` and then update our
 /// understanding as we learn more about each type.
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Ord)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub enum SizednessResult {
-    /// Has some size that is known to be greater than zero. That doesn't mean
-    /// it has a static size, but it is not zero sized for sure. In other words,
-    /// it might contain an incomplete array or some other dynamically sized
-    /// type.
-    NonZeroSized,
+    /// The type is zero-sized.
+    ///
+    /// This means that if it is a C++ type, and is not being used as a base
+    /// member, then we must add an `_address` byte to enforce the
+    /// unique-address-per-distinct-object-instance rule.
+    ZeroSized,
 
     /// Whether this type is zero-sized or not depends on whether a type
     /// parameter is zero-sized or not.
@@ -54,32 +55,16 @@ pub enum SizednessResult {
     /// https://github.com/rust-lang/rust-bindgen/issues/586
     DependsOnTypeParam,
 
-    /// The type is zero-sized.
-    ///
-    /// This means that if it is a C++ type, and is not being used as a base
-    /// member, then we must add an `_address` byte to enforce the
-    /// unique-address-per-distinct-object-instance rule.
-    ZeroSized,
+    /// Has some size that is known to be greater than zero. That doesn't mean
+    /// it has a static size, but it is not zero sized for sure. In other words,
+    /// it might contain an incomplete array or some other dynamically sized
+    /// type.
+    NonZeroSized,
 }
 
 impl Default for SizednessResult {
     fn default() -> Self {
         SizednessResult::ZeroSized
-    }
-}
-
-impl cmp::PartialOrd for SizednessResult {
-    fn partial_cmp(&self, rhs: &Self) -> Option<cmp::Ordering> {
-        use self::SizednessResult::*;
-
-        match (*self, *rhs) {
-            (x, y) if x == y => Some(cmp::Ordering::Equal),
-            (NonZeroSized, _) => Some(cmp::Ordering::Greater),
-            (_, NonZeroSized) => Some(cmp::Ordering::Less),
-            (DependsOnTypeParam, _) => Some(cmp::Ordering::Greater),
-            (_, DependsOnTypeParam) => Some(cmp::Ordering::Less),
-            _ => unreachable!(),
-        }
     }
 }
 

--- a/src/ir/derive.rs
+++ b/src/ir/derive.rs
@@ -92,10 +92,10 @@ pub trait CanDeriveOrd {
 ///
 /// Initially we assume that we can derive trait for all types and then
 /// update our understanding as we learn more about each type.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Ord)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum CanDerive {
-    /// No, we cannot.
-    No,
+    /// Yes, we can derive automatically.
+    Yes,
 
     /// The only thing that stops us from automatically deriving is that
     /// array with more than maximum number of elements is used.
@@ -103,29 +103,13 @@ pub enum CanDerive {
     /// This means we probably can "manually" implement such trait.
     Manually,
 
-    /// Yes, we can derive automatically.
-    Yes,
+    /// No, we cannot.
+    No,
 }
 
 impl Default for CanDerive {
     fn default() -> CanDerive {
         CanDerive::Yes
-    }
-}
-
-impl cmp::PartialOrd for CanDerive {
-    fn partial_cmp(&self, rhs: &Self) -> Option<cmp::Ordering> {
-        use self::CanDerive::*;
-
-        let ordering = match (*self, *rhs) {
-            (x, y) if x == y => cmp::Ordering::Equal,
-            (No, _) => cmp::Ordering::Greater,
-            (_, No) => cmp::Ordering::Less,
-            (Manually, _) => cmp::Ordering::Greater,
-            (_, Manually) => cmp::Ordering::Less,
-            _ => unreachable!(),
-        };
-        Some(ordering)
     }
 }
 


### PR DESCRIPTION
See https://github.com/rust-lang/rust/issues/64710.

Bogus implementations were introduced in 230545e7c, d3e39dc62, and 379bb1663.