### PR TITLE
Cache the result of Item::path_for_whitelisting.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,6 +37,7 @@ dependencies = [
  "diff 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazycell 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "peeking_take_while 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -132,6 +133,11 @@ dependencies = [
 [[package]]
 name = "lazy_static"
 version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "lazycell"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -334,6 +340,7 @@ dependencies = [
 "checksum glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 "checksum humantime 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+"checksum lazycell 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b294d6fa9ee409a054354afc4352b0b9ef7ca222c69b8812cbea9e7d2bf3783f"
 "checksum libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)" = "34fcd2c08d2f832f376f4173a231990fa5aef4e99fb569867318a227ef4c06ba"
 "checksum libloading 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f2b111a074963af1d37a139918ac6d49ad1d0d5e47f72fd55388619691a7d753"
 "checksum log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ cfg-if = "0.1.0"
 # This kinda sucks: https://github.com/rust-lang/cargo/issues/1982
 clap = { version = "2", optional = true }
 clang-sys = { version = "0.28.0", features = ["runtime", "clang_6_0"] }
+lazycell = "1"
 lazy_static = "1"
 peeking_take_while = "0.1.2"
 quote = { version = "1", default-features = false }

--- a/src/ir/context.rs
+++ b/src/ir/context.rs
@@ -2326,7 +2326,7 @@ If you encounter an error missing from this list, please file an issue or a PR!"
                             }
 
                             let mut prefix_path =
-                                parent.path_for_whitelisting(self);
+                                parent.path_for_whitelisting(self).clone();
                             enum_.variants().iter().any(|variant| {
                                 prefix_path.push(variant.name().into());
                                 let name = prefix_path[1..].join("::");

--- a/src/ir/item.rs
+++ b/src/ir/item.rs
@@ -397,7 +397,7 @@ pub struct Item {
     ///
     /// This is a fairly used operation during codegen so this makes bindgen
     /// considerably faster in those cases.
-    canonical_name_cache: LazyCell<String>,
+    canonical_name: LazyCell<String>,
 
     /// The path to use for whitelisting and other name-based checks, as
     /// returned by `path_for_whitelisting`, lazily constructed.
@@ -438,7 +438,7 @@ impl Item {
             id: id,
             local_id: LazyCell::new(),
             next_child_local_id: Cell::new(1),
-            canonical_name_cache: LazyCell::new(),
+            canonical_name: LazyCell::new(),
             path_for_whitelisting: LazyCell::new(),
             parent_id: parent_id,
             comment: comment,
@@ -1819,7 +1819,7 @@ impl ItemCanonicalName for Item {
             ctx.in_codegen_phase(),
             "You're not supposed to call this yet"
         );
-        self.canonical_name_cache
+        self.canonical_name
             .borrow_with(|| {
                 let in_namespace = ctx.options().enable_cxx_namespaces ||
                     ctx.options().disable_name_namespacing;

--- a/src/ir/item.rs
+++ b/src/ir/item.rs
@@ -23,7 +23,7 @@ use clang_sys;
 use lazycell::LazyCell;
 use parse::{ClangItemParser, ClangSubItemParser, ParseError, ParseResult};
 use regex;
-use std::cell::{Cell, RefCell};
+use std::cell::Cell;
 use std::collections::BTreeSet;
 use std::fmt::Write;
 use std::io;
@@ -388,7 +388,7 @@ pub struct Item {
     ///
     /// Note that only structs, unions, and enums get a local type id. In any
     /// case this is an implementation detail.
-    local_id: Cell<Option<usize>>,
+    local_id: LazyCell<usize>,
 
     /// The next local id to use for a child or template instantiation.
     next_child_local_id: Cell<usize>,
@@ -397,7 +397,7 @@ pub struct Item {
     ///
     /// This is a fairly used operation during codegen so this makes bindgen
     /// considerably faster in those cases.
-    canonical_name_cache: RefCell<Option<String>>,
+    canonical_name_cache: LazyCell<String>,
 
     /// The path to use for whitelisting and other name-based checks, as
     /// returned by `path_for_whitelisting`, lazily constructed.
@@ -436,9 +436,9 @@ impl Item {
         debug_assert!(id != parent_id || kind.is_module());
         Item {
             id: id,
-            local_id: Cell::new(None),
+            local_id: LazyCell::new(),
             next_child_local_id: Cell::new(1),
-            canonical_name_cache: RefCell::new(None),
+            canonical_name_cache: LazyCell::new(),
             path_for_whitelisting: LazyCell::new(),
             parent_id: parent_id,
             comment: comment,
@@ -526,11 +526,11 @@ impl Item {
     /// below this item's lexical scope, meaning that this can be useful for
     /// generating relatively stable identifiers within a scope.
     pub fn local_id(&self, ctx: &BindgenContext) -> usize {
-        if self.local_id.get().is_none() {
-            let parent = ctx.resolve_item(self.parent_id);
-            self.local_id.set(Some(parent.next_child_local_id()));
-        }
-        self.local_id.get().unwrap()
+        *self.local_id
+            .borrow_with(|| {
+                let parent = ctx.resolve_item(self.parent_id);
+                parent.next_child_local_id()
+            })
     }
 
     /// Get an identifier that differentiates a child of this item of other
@@ -1819,17 +1819,18 @@ impl ItemCanonicalName for Item {
             ctx.in_codegen_phase(),
             "You're not supposed to call this yet"
         );
-        if self.canonical_name_cache.borrow().is_none() {
-            let in_namespace = ctx.options().enable_cxx_namespaces ||
-                ctx.options().disable_name_namespacing;
+        self.canonical_name_cache
+            .borrow_with(|| {
+                let in_namespace = ctx.options().enable_cxx_namespaces ||
+                    ctx.options().disable_name_namespacing;
 
-            *self.canonical_name_cache.borrow_mut() = if in_namespace {
-                Some(self.name(ctx).within_namespaces().get())
-            } else {
-                Some(self.name(ctx).get())
-            };
-        }
-        return self.canonical_name_cache.borrow().as_ref().unwrap().clone();
+                if in_namespace {
+                    self.name(ctx).within_namespaces().get()
+                } else {
+                    self.name(ctx).get()
+                }
+            })
+            .clone()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,7 @@ extern crate cexpr;
 extern crate cfg_if;
 extern crate clang_sys;
 extern crate rustc_hash;
+extern crate lazycell;
 #[macro_use]
 extern crate lazy_static;
 extern crate peeking_take_while;


### PR DESCRIPTION
In an opt build this doesn't make much difference, but in a debug build it brings down the runtime for bindgen on Gecko from 30 seconds to 20 seconds.  Ideally we'd build the style crate build script with optimizations, but for now this is useful.