### PR TITLE
Use c_void from core when --use-core is specified

### DIFF
--- a/src/codegen/helpers.rs
+++ b/src/codegen/helpers.rs
@@ -143,6 +143,27 @@ pub mod ast_ty {
     use proc_macro2::{self, TokenStream};
     use std::str::FromStr;
 
+    pub fn c_void(ctx: &BindgenContext) -> TokenStream {
+        // ctypes_prefix takes precedence
+        match ctx.options().ctypes_prefix {
+            Some(ref prefix) => {
+                let prefix = TokenStream::from_str(prefix.as_str()).unwrap();
+                quote! {
+                    #prefix::c_void
+                }
+            }
+            None => {
+                if ctx.options().use_core &&
+                    ctx.options().rust_features.core_ffi_c_void
+                {
+                    quote! { ::core::ffi::c_void }
+                } else {
+                    quote! { ::std::os::raw::c_void }
+                }
+            }
+        }
+    }
+
     pub fn raw_type(ctx: &BindgenContext, name: &str) -> TokenStream {
         let ident = ctx.rust_ident_raw(name);
         match ctx.options().ctypes_prefix {

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -861,7 +861,7 @@ impl<'a> CodeGenerator for Vtable<'a> {
         // For now, generate an empty struct, later we should generate function
         // pointers and whatnot.
         let name = ctx.rust_ident(&self.canonical_name(ctx));
-        let void = helpers::ast_ty::raw_type(ctx, "c_void");
+        let void = helpers::ast_ty::c_void(ctx);
         result.push(quote! {
             #[repr(C)]
             pub struct #name ( #void );
@@ -3076,10 +3076,10 @@ impl TryToRustTy for Type {
         use self::helpers::ast_ty::*;
 
         match *self.kind() {
-            TypeKind::Void => Ok(raw_type(ctx, "c_void")),
+            TypeKind::Void => Ok(c_void(ctx)),
             // TODO: we should do something smart with nullptr, or maybe *const
             // c_void is enough?
-            TypeKind::NullPtr => Ok(raw_type(ctx, "c_void").to_ptr(true)),
+            TypeKind::NullPtr => Ok(c_void(ctx).to_ptr(true)),
             TypeKind::Int(ik) => {
                 match ik {
                     IntKind::Bool => Ok(quote! { bool }),
@@ -3186,7 +3186,7 @@ impl TryToRustTy for Type {
             TypeKind::Alias(..) |
             TypeKind::BlockPointer(..) => {
                 if self.is_block_pointer() && !ctx.options().generate_block {
-                    let void = raw_type(ctx, "c_void");
+                    let void = c_void(ctx);
                     return Ok(void.to_ptr(/* is_const = */ false));
                 }
                 let template_params = item

--- a/src/features.rs
+++ b/src/features.rs
@@ -88,6 +88,8 @@ macro_rules! rust_target_base {
         $x_macro!(
             /// Rust stable 1.0
             => Stable_1_0 => 1.0;
+            /// Rust stable 1.1
+            => Stable_1_1 => 1.1;
             /// Rust stable 1.19
             => Stable_1_19 => 1.19;
             /// Rust stable 1.20
@@ -166,6 +168,10 @@ macro_rules! rust_feature_def {
 }
 
 rust_feature_def!(
+    Stable_1_1 {
+        /// [c_void available in core](https://doc.rust-lang.org/core/ffi/enum.c_void.html)
+        => core_ffi_c_void;
+    }
     Stable_1_19 {
         /// Untagged unions ([RFC 1444](https://github.com/rust-lang/rfcs/blob/master/text/1444-union.md))
         => untagged_union;
@@ -227,7 +233,8 @@ mod test {
     fn target_features() {
         let f_1_0 = RustFeatures::from(RustTarget::Stable_1_0);
         assert!(
-            !f_1_0.untagged_union &&
+            !f_1_0.core_ffi_c_void &&
+                !f_1_0.untagged_union &&
                 !f_1_0.associated_const &&
                 !f_1_0.builtin_clone_impls &&
                 !f_1_0.repr_align &&
@@ -235,7 +242,8 @@ mod test {
         );
         let f_1_21 = RustFeatures::from(RustTarget::Stable_1_21);
         assert!(
-            f_1_21.untagged_union &&
+            f_1_21.core_ffi_c_void &&
+                f_1_21.untagged_union &&
                 f_1_21.associated_const &&
                 f_1_21.builtin_clone_impls &&
                 !f_1_21.repr_align &&
@@ -243,7 +251,8 @@ mod test {
         );
         let f_nightly = RustFeatures::from(RustTarget::Nightly);
         assert!(
-            f_nightly.untagged_union &&
+            f_nightly.core_ffi_c_void &&
+                f_nightly.untagged_union &&
                 f_nightly.associated_const &&
                 f_nightly.builtin_clone_impls &&
                 f_nightly.repr_align &&

--- a/tests/expectations/tests/use-core.rs
+++ b/tests/expectations/tests/use-core.rs
@@ -14,7 +14,7 @@ extern crate core;
 pub struct foo {
     pub a: ::std::os::raw::c_int,
     pub b: ::std::os::raw::c_int,
-    pub bar: *mut ::std::os::raw::c_void,
+    pub bar: *mut ::core::ffi::c_void,
 }
 #[test]
 fn bindgen_test_layout_foo() {


### PR DESCRIPTION
`c_void` is available as `::std::os::raw::c_void` and
`::core::ffi::c_void`. If the "--use-core" option is specified (but no
--ctypes-prefix is provided), we should emit `::core::ffi::c_void`
rather than the `std` one.

Addresses #1584 