### PR TITLE
Add ParseCallbacks handler for included files

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ cexpr = "0.3.3"
 cfg-if = "0.1.0"
 # This kinda sucks: https://github.com/rust-lang/cargo/issues/1982
 clap = { version = "2", optional = true }
-clang-sys = { version = "0.28.0", features = ["runtime", "clang_7_0"] }
+clang-sys = { version = "0.28.0", features = ["runtime", "clang_6_0"] }
 lazy_static = "1"
 peeking_take_while = "0.1.2"
 quote = { version = "1", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ cexpr = "0.3.3"
 cfg-if = "0.1.0"
 # This kinda sucks: https://github.com/rust-lang/cargo/issues/1982
 clap = { version = "2", optional = true }
-clang-sys = { version = "0.28.0", features = ["runtime", "clang_6_0"] }
+clang-sys = { version = "0.28.0", features = ["runtime", "clang_7_0"] }
 lazy_static = "1"
 peeking_take_while = "0.1.2"
 quote = { version = "1", default-features = false }

--- a/book/src/tutorial-3.md
+++ b/book/src/tutorial-3.md
@@ -18,6 +18,9 @@ fn main() {
     // shared library.
     println!("cargo:rustc-link-lib=bz2");
 
+    // Tell cargo to invalidate the built crate whenever the wrapper changes
+    println!("cargo:rerun-if-changed=wrapper.h");
+
     // The bindgen::Builder is the main entry point
     // to bindgen, and lets you build up options for
     // the resulting bindings.
@@ -25,6 +28,9 @@ fn main() {
         // The input header we would like to generate
         // bindings for.
         .header("wrapper.h")
+        // Tell cargo to invalidate the built crate whenever any of the
+        // included header files changed.
+        .parse_callbacks(Box::new(bindgen::CargoCallbacks()))
         // Finish the builder and generate the bindings.
         .generate()
         // Unwrap the Result and panic on failure.

--- a/book/src/tutorial-3.md
+++ b/book/src/tutorial-3.md
@@ -30,7 +30,7 @@ fn main() {
         .header("wrapper.h")
         // Tell cargo to invalidate the built crate whenever any of the
         // included header files changed.
-        .parse_callbacks(Box::new(bindgen::CargoCallbacks()))
+        .parse_callbacks(Box::new(bindgen::CargoCallbacks))
         // Finish the builder and generate the bindings.
         .generate()
         // Unwrap the Result and panic on failure.

--- a/src/callbacks.rs
+++ b/src/callbacks.rs
@@ -64,4 +64,24 @@ pub trait ParseCallbacks: fmt::Debug + UnwindSafe {
     fn item_name(&self, _original_item_name: &str) -> Option<String> {
         None
     }
+
+    /// This will be called on every file inclusion, with the full path of the included file.
+    fn include_file(&self, _filename: &str) {}
+}
+
+/// A ParseCallbacks implementation that will act on file includes by echoing a rerun-if-changed
+/// line
+///
+/// When running in side a `build.rs` script, this can be used to make cargo re-run the binding
+/// generation whenever any of the included header files change:
+/// ```
+/// builder.parse_callbacks(Box::new(bindgen::callbacks::CargoCallbacks()));
+/// ```
+#[derive(Debug)]
+pub struct CargoCallbacks();
+
+impl ParseCallbacks for CargoCallbacks {
+    fn include_file(&self, filename: &str) {
+        println!("cargo:rerun-if-changed={}", filename);
+    }
 }

--- a/src/callbacks.rs
+++ b/src/callbacks.rs
@@ -75,7 +75,11 @@ pub trait ParseCallbacks: fmt::Debug + UnwindSafe {
 /// When running in side a `build.rs` script, this can be used to make cargo re-run the binding
 /// generation whenever any of the included header files change:
 /// ```
-/// builder.parse_callbacks(Box::new(bindgen::callbacks::CargoCallbacks()));
+/// use bindgen::builder;
+/// let bindings = builder()
+///     .header("path/to/input/header")
+///     .parse_callbacks(Box::new(bindgen::callbacks::CargoCallbacks()))
+///     .generate();
 /// ```
 #[derive(Debug)]
 pub struct CargoCallbacks();

--- a/src/callbacks.rs
+++ b/src/callbacks.rs
@@ -68,24 +68,3 @@ pub trait ParseCallbacks: fmt::Debug + UnwindSafe {
     /// This will be called on every file inclusion, with the full path of the included file.
     fn include_file(&self, _filename: &str) {}
 }
-
-/// A ParseCallbacks implementation that will act on file includes by echoing a rerun-if-changed
-/// line
-///
-/// When running in side a `build.rs` script, this can be used to make cargo re-run the binding
-/// generation whenever any of the included header files change:
-/// ```
-/// use bindgen::builder;
-/// let bindings = builder()
-///     .header("path/to/input/header")
-///     .parse_callbacks(Box::new(bindgen::callbacks::CargoCallbacks()))
-///     .generate();
-/// ```
-#[derive(Debug)]
-pub struct CargoCallbacks();
-
-impl ParseCallbacks for CargoCallbacks {
-    fn include_file(&self, filename: &str) {
-        println!("cargo:rerun-if-changed={}", filename);
-    }
-}

--- a/src/clang.rs
+++ b/src/clang.rs
@@ -717,6 +717,19 @@ impl Cursor {
             })
             .collect()
     }
+
+    /// Obtain the real path name of a cursor of InclusionDirective kind.
+    ///
+    /// Returns None if the cursor does not include a file, or if no real path name can be obtained
+    /// for the file.
+    pub fn get_included_file_name(&self) -> Option<String> {
+        let file = unsafe { clang_sys::clang_getIncludedFile(self.x) };
+        if file.is_null() {
+            None
+        } else {
+            Some(unsafe { cxstring_into_string(clang_sys::clang_File_tryGetRealPathName(file)) })
+        }
+    }
 }
 
 /// A struct that owns the tokenizer result from a given cursor.

--- a/src/clang.rs
+++ b/src/clang.rs
@@ -720,14 +720,13 @@ impl Cursor {
 
     /// Obtain the real path name of a cursor of InclusionDirective kind.
     ///
-    /// Returns None if the cursor does not include a file, or if no real path name can be obtained
-    /// for the file.
+    /// Returns None if the cursor does not include a file, otherwise the file's full name
     pub fn get_included_file_name(&self) -> Option<String> {
         let file = unsafe { clang_sys::clang_getIncludedFile(self.x) };
         if file.is_null() {
             None
         } else {
-            Some(unsafe { cxstring_into_string(clang_sys::clang_File_tryGetRealPathName(file)) })
+            Some(unsafe { cxstring_into_string(clang_sys::clang_getFileName(file)) })
         }
     }
 }

--- a/src/ir/item.rs
+++ b/src/ir/item.rs
@@ -1357,13 +1357,28 @@ impl ClangItemParser for Item {
                 CXCursor_UsingDeclaration |
                 CXCursor_UsingDirective |
                 CXCursor_StaticAssert |
-                CXCursor_InclusionDirective |
                 CXCursor_FunctionTemplate => {
                     debug!(
                         "Unhandled cursor kind {:?}: {:?}",
                         cursor.kind(),
                         cursor
                     );
+                }
+                CXCursor_InclusionDirective => {
+                    let file = cursor.get_included_file_name();
+                    match file {
+                        None => {
+                            warn!(
+                                "Inclusion of a nameless file in {:?}",
+                                cursor
+                            );
+                        }
+                        Some(filename) => {
+                            if let Some(cb) = ctx.parse_callbacks() {
+                                cb.include_file(&filename)
+                            }
+                        }
+                    }
                 }
                 _ => {
                     // ignore toplevel operator overloads

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2151,8 +2151,8 @@ pub fn clang_version() -> ClangVersion {
 /// A ParseCallbacks implementation that will act on file includes by echoing a rerun-if-changed
 /// line
 ///
-/// When running in side a `build.rs` script, this can be used to make cargo re-run the binding
-/// generation whenever any of the included header files change:
+/// When running in side a `build.rs` script, this can be used to make cargo invalidate the
+/// generated bindings whenever any of the files included from the header change:
 /// ```
 /// use bindgen::builder;
 /// let bindings = builder()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2157,11 +2157,11 @@ pub fn clang_version() -> ClangVersion {
 /// use bindgen::builder;
 /// let bindings = builder()
 ///     .header("path/to/input/header")
-///     .parse_callbacks(Box::new(bindgen::CargoCallbacks()))
+///     .parse_callbacks(Box::new(bindgen::CargoCallbacks))
 ///     .generate();
 /// ```
 #[derive(Debug)]
-pub struct CargoCallbacks();
+pub struct CargoCallbacks;
 
 impl callbacks::ParseCallbacks for CargoCallbacks {
     fn include_file(&self, filename: &str) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2148,6 +2148,27 @@ pub fn clang_version() -> ClangVersion {
     }
 }
 
+/// A ParseCallbacks implementation that will act on file includes by echoing a rerun-if-changed
+/// line
+///
+/// When running in side a `build.rs` script, this can be used to make cargo re-run the binding
+/// generation whenever any of the included header files change:
+/// ```
+/// use bindgen::builder;
+/// let bindings = builder()
+///     .header("path/to/input/header")
+///     .parse_callbacks(Box::new(bindgen::CargoCallbacks()))
+///     .generate();
+/// ```
+#[derive(Debug)]
+pub struct CargoCallbacks();
+
+impl callbacks::ParseCallbacks for CargoCallbacks {
+    fn include_file(&self, filename: &str) {
+        println!("cargo:rerun-if-changed={}", filename);
+    }
+}
+
 /// Test command_line_flag function.
 #[test]
 fn commandline_flag_unit_test_function() {


### PR DESCRIPTION
This does not make bindgen emit the rerun-if-changed statements requested in #1635 (which it closes)  unconditionally (as, to the best of my knowledge, bindgen never really knows if it's called in a Cargo context). Instead, as suggested, it adds an `include_file` parse callback. In addition, a simple implementation of ParseCallbacks is provided that emits the adaequate rerun-if-changed lines.

As the `clang_File_tryGetRealPathName` function is only exposed by clang_sys for clang >= 7.0, this raises the clang dependency – I suppose this will be the most controversial aspect of this PR.