### PR TITLE
Add ParseCallbacks handler for generated TokenStreams

### DIFF
--- a/src/callbacks.rs
+++ b/src/callbacks.rs
@@ -2,7 +2,6 @@
 
 pub use ir::enum_ty::{EnumVariantCustomBehavior, EnumVariantValue};
 pub use ir::int::IntKind;
-
 use std::fmt;
 use std::panic::UnwindSafe;
 

--- a/src/callbacks.rs
+++ b/src/callbacks.rs
@@ -2,6 +2,9 @@
 
 pub use ir::enum_ty::{EnumVariantCustomBehavior, EnumVariantValue};
 pub use ir::int::IntKind;
+
+use proc_macro2::TokenStream;
+
 use std::fmt;
 use std::panic::UnwindSafe;
 
@@ -64,4 +67,7 @@ pub trait ParseCallbacks: fmt::Debug + UnwindSafe {
     fn item_name(&self, _original_item_name: &str) -> Option<String> {
         None
     }
+
+    /// Allows to modify the generated code items as tokenstreams. 
+    fn items(&self, _items: &mut Vec<TokenStream>) {}
 }

--- a/src/callbacks.rs
+++ b/src/callbacks.rs
@@ -3,8 +3,6 @@
 pub use ir::enum_ty::{EnumVariantCustomBehavior, EnumVariantValue};
 pub use ir::int::IntKind;
 
-use proc_macro2::TokenStream;
-
 use std::fmt;
 use std::panic::UnwindSafe;
 
@@ -68,6 +66,8 @@ pub trait ParseCallbacks: fmt::Debug + UnwindSafe {
         None
     }
 
-    /// Allows to modify the generated code items as tokenstreams. 
-    fn items(&self, _items: &mut Vec<TokenStream>) {}
+    /// Allows to modify the generated bindings before they are formatted and written.
+    fn bindings(&self, _bindings: &str) -> Option<String> {
+        None
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1881,11 +1881,7 @@ impl Bindings {
             parse(&mut context)?;
         }
 
-        let (mut items, options) = codegen::codegen(context);
-
-        if let Some(ref callbacks) = options.parse_callbacks {
-            callbacks.items(&mut items)
-        }
+        let (items, options) = codegen::codegen(context);
 
         Ok(Bindings {
             options: options,
@@ -1931,6 +1927,10 @@ impl Bindings {
         }
 
         let bindings = self.module.to_string();
+
+        let bindings = self.options.parse_callbacks.as_ref()
+            .and_then(|callbacks| callbacks.bindings(&bindings))
+            .unwrap_or(bindings);
 
         match self.rustfmt_generated_string(&bindings) {
             Ok(rustfmt_bindings) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1881,7 +1881,11 @@ impl Bindings {
             parse(&mut context)?;
         }
 
-        let (items, options) = codegen::codegen(context);
+        let (mut items, options) = codegen::codegen(context);
+
+        if let Some(ref callbacks) = options.parse_callbacks {
+            callbacks.items(&mut items)
+        }
 
         Ok(Bindings {
             options: options,


### PR DESCRIPTION
This small feature enables advances users to modify the generated code before it gets converted to a string representation.