### PR TITLE
Don't always output translation_unit timer.

### DIFF
--- a/src/ir/context.rs
+++ b/src/ir/context.rs
@@ -553,7 +553,8 @@ impl BindgenContext {
             clang_sys::CXTranslationUnit_DetailedPreprocessingRecord;
 
         let translation_unit = {
-            let _t = Timer::new("translation_unit");
+            let _t = Timer::new("translation_unit")
+                .with_output(options.time_phases);
             let clang_args = if explicit_target {
                 Cow::Borrowed(&options.clang_args)
             } else {


### PR DESCRIPTION
Oops.