### PR TITLE
Add support for MaybeUninit

### DIFF
--- a/src/features.rs
+++ b/src/features.rs
@@ -118,6 +118,9 @@ macro_rules! rust_target_base {
             /// Rust stable 1.33
             ///  * repr(packed(N)) ([PR](https://github.com/rust-lang/rust/pull/57049))
             => Stable_1_33 => 1.33;
+            /// Rust stable 1.36
+            ///  * `MaybeUninit` instead of `mem::uninitialized()` ([PR](https://github.com/rust-lang/rust/pull/60445))
+            => Stable_1_36 => 1.36;
             /// Nightly rust
             ///  * `thiscall` calling convention ([Tracking issue](https://github.com/rust-lang/rust/issues/42202))
             ///  * `non_exhaustive` enums/structs ([Tracking issue](https://github.com/rust-lang/rust/issues/44109))
@@ -130,7 +133,7 @@ rust_target_base!(rust_target_def);
 rust_target_base!(rust_target_values_def);
 
 /// Latest stable release of Rust
-pub const LATEST_STABLE_RUST: RustTarget = RustTarget::Stable_1_33;
+pub const LATEST_STABLE_RUST: RustTarget = RustTarget::Stable_1_36;
 
 /// Create RustFeatures struct definition, new(), and a getter for each field
 macro_rules! rust_feature_def {
@@ -212,6 +215,9 @@ rust_feature_def!(
     Stable_1_33 {
         => repr_packed_n;
     }
+    Stable_1_36 {
+        => maybe_uninit;
+    }
     Nightly {
         => thiscall_abi;
         => non_exhaustive;
@@ -256,6 +262,7 @@ mod test {
                 f_nightly.untagged_union &&
                 f_nightly.associated_const &&
                 f_nightly.builtin_clone_impls &&
+                f_nightly.maybe_uninit &&
                 f_nightly.repr_align &&
                 f_nightly.thiscall_abi
         );

--- a/tests/expectations/tests/constructor-tp.rs
+++ b/tests/expectations/tests/constructor-tp.rs
@@ -37,8 +37,8 @@ extern "C" {
 impl Bar {
     #[inline]
     pub unsafe fn new() -> Self {
-        let mut __bindgen_tmp = ::std::mem::uninitialized();
-        Bar_Bar(&mut __bindgen_tmp);
-        __bindgen_tmp
+        let mut __bindgen_tmp = ::std::mem::MaybeUninit::uninit();
+        Bar_Bar(__bindgen_tmp.as_mut_ptr());
+        __bindgen_tmp.assume_init()
     }
 }

--- a/tests/expectations/tests/constructors_1_33.rs
+++ b/tests/expectations/tests/constructors_1_33.rs
@@ -26,6 +26,7 @@ fn bindgen_test_layout_TestOverload() {
     );
 }
 extern "C" {
+    /// Calling this should use `mem::unintialized()` and not `MaybeUninit()` as only rust 1.36 includes that.
     #[link_name = "\u{1}_ZN12TestOverloadC1Ei"]
     pub fn TestOverload_TestOverload(
         this: *mut TestOverload,
@@ -33,21 +34,22 @@ extern "C" {
     );
 }
 extern "C" {
+    /// Calling this should use `mem::unintialized()` and not `MaybeUninit()` as only rust 1.36 includes that.
     #[link_name = "\u{1}_ZN12TestOverloadC1Ed"]
     pub fn TestOverload_TestOverload1(this: *mut TestOverload, arg1: f64);
 }
 impl TestOverload {
     #[inline]
     pub unsafe fn new(arg1: ::std::os::raw::c_int) -> Self {
-        let mut __bindgen_tmp = ::std::mem::MaybeUninit::uninit();
-        TestOverload_TestOverload(__bindgen_tmp.as_mut_ptr(), arg1);
-        __bindgen_tmp.assume_init()
+        let mut __bindgen_tmp = ::std::mem::uninitialized();
+        TestOverload_TestOverload(&mut __bindgen_tmp, arg1);
+        __bindgen_tmp
     }
     #[inline]
     pub unsafe fn new1(arg1: f64) -> Self {
-        let mut __bindgen_tmp = ::std::mem::MaybeUninit::uninit();
-        TestOverload_TestOverload1(__bindgen_tmp.as_mut_ptr(), arg1);
-        __bindgen_tmp.assume_init()
+        let mut __bindgen_tmp = ::std::mem::uninitialized();
+        TestOverload_TestOverload1(&mut __bindgen_tmp, arg1);
+        __bindgen_tmp
     }
 }
 #[repr(C)]
@@ -75,8 +77,8 @@ extern "C" {
 impl TestPublicNoArgs {
     #[inline]
     pub unsafe fn new() -> Self {
-        let mut __bindgen_tmp = ::std::mem::MaybeUninit::uninit();
-        TestPublicNoArgs_TestPublicNoArgs(__bindgen_tmp.as_mut_ptr());
-        __bindgen_tmp.assume_init()
+        let mut __bindgen_tmp = ::std::mem::uninitialized();
+        TestPublicNoArgs_TestPublicNoArgs(&mut __bindgen_tmp);
+        __bindgen_tmp
     }
 }

--- a/tests/expectations/tests/gen-constructors.rs
+++ b/tests/expectations/tests/gen-constructors.rs
@@ -32,8 +32,8 @@ extern "C" {
 impl Foo {
     #[inline]
     pub unsafe fn new(a: ::std::os::raw::c_int) -> Self {
-        let mut __bindgen_tmp = ::std::mem::uninitialized();
-        Foo_Foo(&mut __bindgen_tmp, a);
-        __bindgen_tmp
+        let mut __bindgen_tmp = ::std::mem::MaybeUninit::uninit();
+        Foo_Foo(__bindgen_tmp.as_mut_ptr(), a);
+        __bindgen_tmp.assume_init()
     }
 }

--- a/tests/expectations/tests/issue-447.rs
+++ b/tests/expectations/tests/issue-447.rs
@@ -67,9 +67,12 @@ pub mod root {
         pub unsafe fn new(
             arg1: root::mozilla::detail::GuardObjectNotifier,
         ) -> Self {
-            let mut __bindgen_tmp = ::std::mem::uninitialized();
-            JSAutoCompartment_JSAutoCompartment(&mut __bindgen_tmp, arg1);
-            __bindgen_tmp
+            let mut __bindgen_tmp = ::std::mem::MaybeUninit::uninit();
+            JSAutoCompartment_JSAutoCompartment(
+                __bindgen_tmp.as_mut_ptr(),
+                arg1,
+            );
+            __bindgen_tmp.assume_init()
         }
     }
 }

--- a/tests/expectations/tests/issue-807-opaque-types-methods-being-generated.rs
+++ b/tests/expectations/tests/issue-807-opaque-types-methods-being-generated.rs
@@ -95,9 +95,9 @@ impl Opaque {
     }
     #[inline]
     pub unsafe fn new(pup: Pupper) -> Self {
-        let mut __bindgen_tmp = ::std::mem::uninitialized();
-        Opaque_Opaque(&mut __bindgen_tmp, pup);
-        __bindgen_tmp
+        let mut __bindgen_tmp = ::std::mem::MaybeUninit::uninit();
+        Opaque_Opaque(__bindgen_tmp.as_mut_ptr(), pup);
+        __bindgen_tmp.assume_init()
     }
 }
 extern "C" {

--- a/tests/expectations/tests/libclang-3.8/partial-specialization-and-inheritance.rs
+++ b/tests/expectations/tests/libclang-3.8/partial-specialization-and-inheritance.rs
@@ -43,8 +43,8 @@ extern "C" {
 impl Usage {
     #[inline]
     pub unsafe fn new() -> Self {
-        let mut __bindgen_tmp = ::std::mem::uninitialized();
-        Usage_Usage(&mut __bindgen_tmp);
-        __bindgen_tmp
+        let mut __bindgen_tmp = ::std::mem::MaybeUninit::uninit();
+        Usage_Usage(__bindgen_tmp.as_mut_ptr());
+        __bindgen_tmp.assume_init()
     }
 }

--- a/tests/expectations/tests/var-tracing.rs
+++ b/tests/expectations/tests/var-tracing.rs
@@ -42,9 +42,9 @@ extern "C" {
 impl Bar {
     #[inline]
     pub unsafe fn new(baz: ::std::os::raw::c_int) -> Self {
-        let mut __bindgen_tmp = ::std::mem::uninitialized();
-        Bar_Bar(&mut __bindgen_tmp, baz);
-        __bindgen_tmp
+        let mut __bindgen_tmp = ::std::mem::MaybeUninit::uninit();
+        Bar_Bar(__bindgen_tmp.as_mut_ptr(), baz);
+        __bindgen_tmp.assume_init()
     }
 }
 #[repr(C)]

--- a/tests/headers/constructors_1_33.hpp
+++ b/tests/headers/constructors_1_33.hpp
@@ -1,0 +1,16 @@
+// bindgen-flags: --rust-target 1.33
+
+class TestOverload {
+  // This one shouldnt' be generated.
+  TestOverload();
+public:
+  /// Calling this should use `mem::unintialized()` and not `MaybeUninit()` as only rust 1.36 includes that.
+  TestOverload(int);
+  /// Calling this should use `mem::unintialized()` and not `MaybeUninit()` as only rust 1.36 includes that.
+  TestOverload(double);
+};
+
+class TestPublicNoArgs {
+public:
+  TestPublicNoArgs();
+};


### PR DESCRIPTION
Hi,
this solves #1660

I added a new rust_target 1.36 which will replace `mem::uninitialized()` with `MaybeUninit`.
should we use `mem::zeroed()` instead of uninitialized? this might be a little more safe in some small cases (i.e. scalar primitives and raw pointers only)