### PR TITLE
 Do not derive Clone/Copy/Eq*/Ord* for opaque types

### DIFF
--- a/src/codegen/impl_partialeq.rs
+++ b/src/codegen/impl_partialeq.rs
@@ -12,13 +12,13 @@ pub fn gen_partialeq_impl(
     item: &Item,
     ty_for_impl: &proc_macro2::TokenStream,
 ) -> Option<proc_macro2::TokenStream> {
+    debug_assert!(
+        !item.is_opaque(ctx, &()),
+        "You're not supposed to call this on an opaque type"
+    );
     let mut tokens = vec![];
 
-    if item.is_opaque(ctx, &()) {
-        tokens.push(quote! {
-            &self._bindgen_opaque_blob[..] == &other._bindgen_opaque_blob[..]
-        });
-    } else if comp_info.kind() == CompKind::Union {
+    if comp_info.kind() == CompKind::Union {
         assert!(!ctx.options().rust_features().untagged_union);
         tokens.push(quote! {
             &self.bindgen_union_field[..] == &other.bindgen_union_field[..]

--- a/tests/expectations/tests/annotation_hide.rs
+++ b/tests/expectations/tests/annotation_hide.rs
@@ -10,7 +10,7 @@
 /// <div rustbindgen opaque></div>
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Default)]
 pub struct D {
     pub _bindgen_opaque_blob: u32,
 }

--- a/tests/expectations/tests/bitfield_large_overflow.rs
+++ b/tests/expectations/tests/bitfield_large_overflow.rs
@@ -9,7 +9,7 @@
 
 #[repr(C)]
 #[repr(align(8))]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Default)]
 pub struct _bindgen_ty_1 {
     pub _bindgen_opaque_blob: [u64; 10usize],
 }

--- a/tests/expectations/tests/doggo-or-null.rs
+++ b/tests/expectations/tests/doggo-or-null.rs
@@ -56,7 +56,7 @@ fn bindgen_test_layout_Null() {
 /// this test to make sure that opaque unions don't derive and still compile.
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Copy, Clone)]
+#[derive(Default)]
 pub union DoggoOrNull {
     pub _bindgen_opaque_blob: u32,
 }
@@ -72,9 +72,4 @@ fn bindgen_test_layout_DoggoOrNull() {
         4usize,
         concat!("Alignment of ", stringify!(DoggoOrNull))
     );
-}
-impl Default for DoggoOrNull {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
 }

--- a/tests/expectations/tests/empty-union.rs
+++ b/tests/expectations/tests/empty-union.rs
@@ -8,12 +8,7 @@
 )]
 
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Default)]
 pub union a__bindgen_ty_1 {
     pub _address: u8,
-}
-impl Default for a__bindgen_ty_1 {
-    fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
-    }
 }

--- a/tests/expectations/tests/forward_declared_opaque.rs
+++ b/tests/expectations/tests/forward_declared_opaque.rs
@@ -8,12 +8,12 @@
 )]
 
 #[repr(C)]
-#[derive(Copy, Clone)]
+#[derive(Default)]
 pub struct a {
     _unused: [u8; 0],
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Default)]
 pub struct b {
     _unused: [u8; 0],
 }

--- a/tests/expectations/tests/issue-569-non-type-template-params-causing-layout-test-failures.rs
+++ b/tests/expectations/tests/issue-569-non-type-template-params-causing-layout-test-failures.rs
@@ -17,7 +17,6 @@ pub enum _bindgen_ty_1 {
 }
 pub type JS_Alias = u8;
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
 pub struct JS_Base {
     pub f: JS_Alias,
 }
@@ -27,7 +26,6 @@ impl Default for JS_Base {
     }
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone)]
 pub struct JS_AutoIdVector {
     pub _base: JS_Base,
 }

--- a/tests/expectations/tests/issue-573-layout-test-failures.rs
+++ b/tests/expectations/tests/issue-573-layout-test-failures.rs
@@ -8,12 +8,12 @@
 )]
 
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Default)]
 pub struct Outer {
     pub i: u8,
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Default)]
 pub struct AutoIdVector {
     pub ar: Outer,
 }

--- a/tests/expectations/tests/issue-674-1.rs
+++ b/tests/expectations/tests/issue-674-1.rs
@@ -15,14 +15,14 @@ pub mod root {
         #[allow(unused_imports)]
         use self::super::super::root;
         #[repr(C)]
-        #[derive(Debug, Default, Copy, Clone)]
+        #[derive(Default)]
         pub struct Maybe {
             pub _address: u8,
         }
         pub type Maybe_ValueType<T> = T;
     }
     #[repr(C)]
-    #[derive(Debug, Default, Copy, Clone)]
+    #[derive(Default)]
     pub struct CapturingContentInfo {
         pub a: u8,
     }

--- a/tests/expectations/tests/issue-674-2.rs
+++ b/tests/expectations/tests/issue-674-2.rs
@@ -15,14 +15,14 @@ pub mod root {
         #[allow(unused_imports)]
         use self::super::super::root;
         #[repr(C)]
-        #[derive(Debug, Default, Copy, Clone)]
+        #[derive(Default)]
         pub struct Rooted {
             pub _address: u8,
         }
         pub type Rooted_ElementType<T> = T;
     }
     #[repr(C)]
-    #[derive(Debug, Default, Copy, Clone)]
+    #[derive(Default)]
     pub struct c {
         pub b: u8,
     }
@@ -45,7 +45,7 @@ pub mod root {
         );
     }
     #[repr(C)]
-    #[derive(Debug, Default, Copy, Clone)]
+    #[derive(Default)]
     pub struct B {
         pub a: root::c,
     }

--- a/tests/expectations/tests/issue-674-3.rs
+++ b/tests/expectations/tests/issue-674-3.rs
@@ -12,13 +12,13 @@ pub mod root {
     #[allow(unused_imports)]
     use self::super::root;
     #[repr(C)]
-    #[derive(Debug, Default, Copy, Clone)]
+    #[derive(Default)]
     pub struct nsRefPtrHashtable {
         pub _address: u8,
     }
     pub type nsRefPtrHashtable_UserDataType<PtrType> = *mut PtrType;
     #[repr(C)]
-    #[derive(Debug, Default, Copy, Clone)]
+    #[derive(Default)]
     pub struct a {
         pub b: u8,
     }
@@ -41,7 +41,7 @@ pub mod root {
         );
     }
     #[repr(C)]
-    #[derive(Debug, Default, Copy, Clone)]
+    #[derive(Default)]
     pub struct nsCSSValue {
         pub c: root::a,
     }

--- a/tests/expectations/tests/issue-801-opaque-sloppiness.rs
+++ b/tests/expectations/tests/issue-801-opaque-sloppiness.rs
@@ -14,7 +14,7 @@ pub struct A {
 }
 #[repr(C)]
 #[repr(align(1))]
-#[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Default)]
 pub struct B {
     pub _bindgen_opaque_blob: u8,
 }
@@ -36,7 +36,7 @@ extern "C" {
     pub static mut B_a: A;
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Default)]
 pub struct C {
     pub b: B,
 }

--- a/tests/expectations/tests/issue-807-opaque-types-methods-being-generated.rs
+++ b/tests/expectations/tests/issue-807-opaque-types-methods-being-generated.rs
@@ -63,7 +63,7 @@ fn bindgen_test_layout_SuchWow() {
 }
 #[repr(C)]
 #[repr(align(1))]
-#[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Default)]
 pub struct Opaque {
     pub _bindgen_opaque_blob: u8,
 }
@@ -105,7 +105,7 @@ extern "C" {
     pub static mut Opaque_MAJESTIC_AF: Doggo;
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Default)]
 pub struct Whitelisted {
     pub some_member: Opaque,
 }

--- a/tests/expectations/tests/no-hash-opaque.rs
+++ b/tests/expectations/tests/no-hash-opaque.rs
@@ -9,7 +9,7 @@
 
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Default)]
 pub struct NoHash {
     pub _bindgen_opaque_blob: u32,
 }

--- a/tests/expectations/tests/no-partialeq-opaque.rs
+++ b/tests/expectations/tests/no-partialeq-opaque.rs
@@ -9,7 +9,7 @@
 
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Default)]
 pub struct NoPartialEq {
     pub _bindgen_opaque_blob: u32,
 }

--- a/tests/expectations/tests/no_copy_opaque.rs
+++ b/tests/expectations/tests/no_copy_opaque.rs
@@ -9,7 +9,7 @@
 
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Debug, Default)]
+#[derive(Default)]
 pub struct NoCopy {
     pub _bindgen_opaque_blob: u32,
 }

--- a/tests/expectations/tests/non-type-params.rs
+++ b/tests/expectations/tests/non-type-params.rs
@@ -10,7 +10,7 @@
 pub type Array16 = u8;
 pub type ArrayInt4 = [u32; 4usize];
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Default)]
 pub struct UsesArray {
     pub array_char_16: [u8; 16usize],
     pub array_bool_8: [u8; 8usize],

--- a/tests/expectations/tests/opaque-template-inst-member-2.rs
+++ b/tests/expectations/tests/opaque-template-inst-member-2.rs
@@ -10,13 +10,13 @@
 /// This is like `opaque-template-inst-member.hpp` except exercising the cases
 /// where we are OK to derive Debug/Hash/PartialEq.
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Default)]
 pub struct OpaqueTemplate {
     pub _address: u8,
 }
 /// Should derive Debug/Hash/PartialEq.
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Default)]
 pub struct ContainsOpaqueTemplate {
     pub mBlah: u32,
     pub mBaz: ::std::os::raw::c_int,
@@ -62,7 +62,6 @@ fn bindgen_test_layout_ContainsOpaqueTemplate() {
 }
 /// Should also derive Debug/Hash/PartialEq.
 #[repr(C)]
-#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct InheritsOpaqueTemplate {
     pub _base: u8,
     pub wow: *mut ::std::os::raw::c_char,

--- a/tests/expectations/tests/opaque-template-inst-member.rs
+++ b/tests/expectations/tests/opaque-template-inst-member.rs
@@ -8,7 +8,7 @@
 )]
 
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Default)]
 pub struct OpaqueTemplate {
     pub _address: u8,
 }
@@ -63,11 +63,6 @@ impl Default for ContainsOpaqueTemplate {
         unsafe { ::std::mem::zeroed() }
     }
 }
-impl ::std::cmp::PartialEq for ContainsOpaqueTemplate {
-    fn eq(&self, other: &ContainsOpaqueTemplate) -> bool {
-        &self.mBlah[..] == &other.mBlah[..] && self.mBaz == other.mBaz
-    }
-}
 /// This should not end up deriving Debug/Hash either, for similar reasons, although
 /// we're exercising base member edges now.
 #[repr(C)]
@@ -104,10 +99,5 @@ fn bindgen_test_layout_InheritsOpaqueTemplate() {
 impl Default for InheritsOpaqueTemplate {
     fn default() -> Self {
         unsafe { ::std::mem::zeroed() }
-    }
-}
-impl ::std::cmp::PartialEq for InheritsOpaqueTemplate {
-    fn eq(&self, other: &InheritsOpaqueTemplate) -> bool {
-        &self._base[..] == &other._base[..] && self.wow == other.wow
     }
 }

--- a/tests/expectations/tests/opaque-template-instantiation-namespaced.rs
+++ b/tests/expectations/tests/opaque-template-instantiation-namespaced.rs
@@ -123,7 +123,7 @@ pub mod root {
             }
         }
         #[repr(C)]
-        #[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+        #[derive(Default)]
         pub struct ContainsOpaqueInstantiation {
             pub opaque: u32,
         }

--- a/tests/expectations/tests/opaque-template-instantiation.rs
+++ b/tests/expectations/tests/opaque-template-instantiation.rs
@@ -55,7 +55,7 @@ impl Default for ContainsInstantiation {
     }
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Default)]
 pub struct ContainsOpaqueInstantiation {
     pub opaque: u32,
 }

--- a/tests/expectations/tests/opaque-tracing.rs
+++ b/tests/expectations/tests/opaque-tracing.rs
@@ -13,7 +13,7 @@ extern "C" {
 }
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Default)]
 pub struct Container {
     pub _bindgen_opaque_blob: [u32; 2usize],
 }

--- a/tests/expectations/tests/opaque_in_struct.rs
+++ b/tests/expectations/tests/opaque_in_struct.rs
@@ -10,7 +10,7 @@
 /// <div rustbindgen opaque>
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Default)]
 pub struct opaque {
     pub _bindgen_opaque_blob: u32,
 }
@@ -28,7 +28,7 @@ fn bindgen_test_layout_opaque() {
     );
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Default)]
 pub struct container {
     pub contained: opaque,
 }

--- a/tests/expectations/tests/opaque_pointer.rs
+++ b/tests/expectations/tests/opaque_pointer.rs
@@ -10,7 +10,7 @@
 /// <div rustbindgen opaque></div>
 #[repr(C)]
 #[repr(align(4))]
-#[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Default)]
 pub struct OtherOpaque {
     pub _bindgen_opaque_blob: u32,
 }
@@ -29,12 +29,11 @@ fn bindgen_test_layout_OtherOpaque() {
 }
 /// <div rustbindgen opaque></div>
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Default)]
 pub struct Opaque {
     pub _address: u8,
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone, Hash, PartialEq)]
 pub struct WithOpaquePtr {
     pub whatever: *mut u8,
     pub other: u32,

--- a/tests/expectations/tests/size_t_template.rs
+++ b/tests/expectations/tests/size_t_template.rs
@@ -8,7 +8,7 @@
 )]
 
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Default)]
 pub struct C {
     pub arr: [u32; 3usize],
 }

--- a/tests/expectations/tests/template.rs
+++ b/tests/expectations/tests/template.rs
@@ -358,12 +358,12 @@ impl Default for PODButContainsDtor {
 }
 /// <div rustbindgen opaque>
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Default)]
 pub struct Opaque {
     pub _address: u8,
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Default)]
 pub struct POD {
     pub opaque_member: u32,
 }

--- a/tests/expectations/tests/templatized-bitfield.rs
+++ b/tests/expectations/tests/templatized-bitfield.rs
@@ -11,7 +11,7 @@
 /// be, so we cannot allocate bitfield units. The best thing we can do is make
 /// the struct opaque.
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Default)]
 pub struct TemplatizedBitfield {
     pub _address: u8,
 }


### PR DESCRIPTION
Hi,
This is an attempt to solve #1656
I'm not sure if the `IsOpaque` trait is defined only on actually opaque types. but I used that to check and not impl anything except Debug/Default