### PR TITLE
Replace transmute with `as` casting for pointers

### DIFF
--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -3970,13 +3970,13 @@ mod utils {
                 }
 
                 #[inline]
-                pub unsafe fn as_ptr(&self) -> *const T {
-                    ::#prefix::mem::transmute(self)
+                pub fn as_ptr(&self) -> *const T {
+                    self as *const _ as *const T
                 }
 
                 #[inline]
-                pub unsafe fn as_mut_ptr(&mut self) -> *mut T {
-                    ::#prefix::mem::transmute(self)
+                pub fn as_mut_ptr(&mut self) -> *mut T {
+                    self as *mut _ as *mut T
                 }
 
                 #[inline]

--- a/tests/expectations/tests/class.rs
+++ b/tests/expectations/tests/class.rs
@@ -16,12 +16,12 @@ impl<T> __IncompleteArrayField<T> {
         __IncompleteArrayField(::std::marker::PhantomData, [])
     }
     #[inline]
-    pub unsafe fn as_ptr(&self) -> *const T {
-        ::std::mem::transmute(self)
+    pub fn as_ptr(&self) -> *const T {
+        self as *const _ as *const T
     }
     #[inline]
-    pub unsafe fn as_mut_ptr(&mut self) -> *mut T {
-        ::std::mem::transmute(self)
+    pub fn as_mut_ptr(&mut self) -> *mut T {
+        self as *mut _ as *mut T
     }
     #[inline]
     pub unsafe fn as_slice(&self, len: usize) -> &[T] {

--- a/tests/expectations/tests/class_1_0.rs
+++ b/tests/expectations/tests/class_1_0.rs
@@ -16,12 +16,12 @@ impl<T> __IncompleteArrayField<T> {
         __IncompleteArrayField(::std::marker::PhantomData, [])
     }
     #[inline]
-    pub unsafe fn as_ptr(&self) -> *const T {
-        ::std::mem::transmute(self)
+    pub fn as_ptr(&self) -> *const T {
+        self as *const _ as *const T
     }
     #[inline]
-    pub unsafe fn as_mut_ptr(&mut self) -> *mut T {
-        ::std::mem::transmute(self)
+    pub fn as_mut_ptr(&mut self) -> *mut T {
+        self as *mut _ as *mut T
     }
     #[inline]
     pub unsafe fn as_slice(&self, len: usize) -> &[T] {

--- a/tests/expectations/tests/derive-hash-struct-with-incomplete-array.rs
+++ b/tests/expectations/tests/derive-hash-struct-with-incomplete-array.rs
@@ -16,12 +16,12 @@ impl<T> __IncompleteArrayField<T> {
         __IncompleteArrayField(::std::marker::PhantomData, [])
     }
     #[inline]
-    pub unsafe fn as_ptr(&self) -> *const T {
-        ::std::mem::transmute(self)
+    pub fn as_ptr(&self) -> *const T {
+        self as *const _ as *const T
     }
     #[inline]
-    pub unsafe fn as_mut_ptr(&mut self) -> *mut T {
-        ::std::mem::transmute(self)
+    pub fn as_mut_ptr(&mut self) -> *mut T {
+        self as *mut _ as *mut T
     }
     #[inline]
     pub unsafe fn as_slice(&self, len: usize) -> &[T] {

--- a/tests/expectations/tests/incomplete-array-padding.rs
+++ b/tests/expectations/tests/incomplete-array-padding.rs
@@ -103,12 +103,12 @@ impl<T> __IncompleteArrayField<T> {
         __IncompleteArrayField(::std::marker::PhantomData, [])
     }
     #[inline]
-    pub unsafe fn as_ptr(&self) -> *const T {
-        ::std::mem::transmute(self)
+    pub fn as_ptr(&self) -> *const T {
+        self as *const _ as *const T
     }
     #[inline]
-    pub unsafe fn as_mut_ptr(&mut self) -> *mut T {
-        ::std::mem::transmute(self)
+    pub fn as_mut_ptr(&mut self) -> *mut T {
+        self as *mut _ as *mut T
     }
     #[inline]
     pub unsafe fn as_slice(&self, len: usize) -> &[T] {

--- a/tests/expectations/tests/issue-643-inner-struct.rs
+++ b/tests/expectations/tests/issue-643-inner-struct.rs
@@ -16,12 +16,12 @@ impl<T> __IncompleteArrayField<T> {
         __IncompleteArrayField(::std::marker::PhantomData, [])
     }
     #[inline]
-    pub unsafe fn as_ptr(&self) -> *const T {
-        ::std::mem::transmute(self)
+    pub fn as_ptr(&self) -> *const T {
+        self as *const _ as *const T
     }
     #[inline]
-    pub unsafe fn as_mut_ptr(&mut self) -> *mut T {
-        ::std::mem::transmute(self)
+    pub fn as_mut_ptr(&mut self) -> *mut T {
+        self as *mut _ as *mut T
     }
     #[inline]
     pub unsafe fn as_slice(&self, len: usize) -> &[T] {

--- a/tests/expectations/tests/layout_align.rs
+++ b/tests/expectations/tests/layout_align.rs
@@ -103,12 +103,12 @@ impl<T> __IncompleteArrayField<T> {
         __IncompleteArrayField(::std::marker::PhantomData, [])
     }
     #[inline]
-    pub unsafe fn as_ptr(&self) -> *const T {
-        ::std::mem::transmute(self)
+    pub fn as_ptr(&self) -> *const T {
+        self as *const _ as *const T
     }
     #[inline]
-    pub unsafe fn as_mut_ptr(&mut self) -> *mut T {
-        ::std::mem::transmute(self)
+    pub fn as_mut_ptr(&mut self) -> *mut T {
+        self as *mut _ as *mut T
     }
     #[inline]
     pub unsafe fn as_slice(&self, len: usize) -> &[T] {

--- a/tests/expectations/tests/layout_large_align_field.rs
+++ b/tests/expectations/tests/layout_large_align_field.rs
@@ -16,12 +16,12 @@ impl<T> __IncompleteArrayField<T> {
         __IncompleteArrayField(::std::marker::PhantomData, [])
     }
     #[inline]
-    pub unsafe fn as_ptr(&self) -> *const T {
-        ::std::mem::transmute(self)
+    pub fn as_ptr(&self) -> *const T {
+        self as *const _ as *const T
     }
     #[inline]
-    pub unsafe fn as_mut_ptr(&mut self) -> *mut T {
-        ::std::mem::transmute(self)
+    pub fn as_mut_ptr(&mut self) -> *mut T {
+        self as *mut _ as *mut T
     }
     #[inline]
     pub unsafe fn as_slice(&self, len: usize) -> &[T] {

--- a/tests/expectations/tests/libclang-9/class.rs
+++ b/tests/expectations/tests/libclang-9/class.rs
@@ -16,12 +16,12 @@ impl<T> __IncompleteArrayField<T> {
         __IncompleteArrayField(::std::marker::PhantomData, [])
     }
     #[inline]
-    pub unsafe fn as_ptr(&self) -> *const T {
-        ::std::mem::transmute(self)
+    pub fn as_ptr(&self) -> *const T {
+        self as *const _ as *const T
     }
     #[inline]
-    pub unsafe fn as_mut_ptr(&mut self) -> *mut T {
-        ::std::mem::transmute(self)
+    pub fn as_mut_ptr(&mut self) -> *mut T {
+        self as *mut _ as *mut T
     }
     #[inline]
     pub unsafe fn as_slice(&self, len: usize) -> &[T] {
@@ -95,7 +95,10 @@ fn bindgen_test_layout_C_with_zero_length_array() {
         concat!("Alignment of ", stringify!(C_with_zero_length_array))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<C_with_zero_length_array>())).a as *const _ as usize },
+        unsafe {
+            &(*(::std::ptr::null::<C_with_zero_length_array>())).a as *const _
+                as usize
+        },
         0usize,
         concat!(
             "Offset of field: ",
@@ -106,7 +109,8 @@ fn bindgen_test_layout_C_with_zero_length_array() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<C_with_zero_length_array>())).big_array as *const _ as usize
+            &(*(::std::ptr::null::<C_with_zero_length_array>())).big_array
+                as *const _ as usize
         },
         4usize,
         concat!(
@@ -118,8 +122,8 @@ fn bindgen_test_layout_C_with_zero_length_array() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<C_with_zero_length_array>())).zero_length_array as *const _
-                as usize
+            &(*(::std::ptr::null::<C_with_zero_length_array>()))
+                .zero_length_array as *const _ as usize
         },
         37usize,
         concat!(
@@ -154,7 +158,10 @@ fn bindgen_test_layout_C_with_zero_length_array_2() {
         concat!("Alignment of ", stringify!(C_with_zero_length_array_2))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<C_with_zero_length_array_2>())).a as *const _ as usize },
+        unsafe {
+            &(*(::std::ptr::null::<C_with_zero_length_array_2>())).a as *const _
+                as usize
+        },
         0usize,
         concat!(
             "Offset of field: ",
@@ -165,8 +172,8 @@ fn bindgen_test_layout_C_with_zero_length_array_2() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<C_with_zero_length_array_2>())).zero_length_array as *const _
-                as usize
+            &(*(::std::ptr::null::<C_with_zero_length_array_2>()))
+                .zero_length_array as *const _ as usize
         },
         4usize,
         concat!(
@@ -196,7 +203,10 @@ fn bindgen_test_layout_C_with_incomplete_array() {
         concat!("Alignment of ", stringify!(C_with_incomplete_array))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<C_with_incomplete_array>())).a as *const _ as usize },
+        unsafe {
+            &(*(::std::ptr::null::<C_with_incomplete_array>())).a as *const _
+                as usize
+        },
         0usize,
         concat!(
             "Offset of field: ",
@@ -207,7 +217,8 @@ fn bindgen_test_layout_C_with_incomplete_array() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<C_with_incomplete_array>())).big_array as *const _ as usize
+            &(*(::std::ptr::null::<C_with_incomplete_array>())).big_array
+                as *const _ as usize
         },
         4usize,
         concat!(
@@ -219,8 +230,8 @@ fn bindgen_test_layout_C_with_incomplete_array() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<C_with_incomplete_array>())).incomplete_array as *const _
-                as usize
+            &(*(::std::ptr::null::<C_with_incomplete_array>())).incomplete_array
+                as *const _ as usize
         },
         37usize,
         concat!(
@@ -255,7 +266,10 @@ fn bindgen_test_layout_C_with_incomplete_array_2() {
         concat!("Alignment of ", stringify!(C_with_incomplete_array_2))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<C_with_incomplete_array_2>())).a as *const _ as usize },
+        unsafe {
+            &(*(::std::ptr::null::<C_with_incomplete_array_2>())).a as *const _
+                as usize
+        },
         0usize,
         concat!(
             "Offset of field: ",
@@ -266,8 +280,8 @@ fn bindgen_test_layout_C_with_incomplete_array_2() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<C_with_incomplete_array_2>())).incomplete_array as *const _
-                as usize
+            &(*(::std::ptr::null::<C_with_incomplete_array_2>()))
+                .incomplete_array as *const _ as usize
         },
         4usize,
         concat!(
@@ -305,8 +319,10 @@ fn bindgen_test_layout_C_with_zero_length_array_and_incomplete_array() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<C_with_zero_length_array_and_incomplete_array>())).a as *const _
-                as usize
+            &(*(::std::ptr::null::<
+                C_with_zero_length_array_and_incomplete_array,
+            >()))
+            .a as *const _ as usize
         },
         0usize,
         concat!(
@@ -318,8 +334,10 @@ fn bindgen_test_layout_C_with_zero_length_array_and_incomplete_array() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<C_with_zero_length_array_and_incomplete_array>())).big_array
-                as *const _ as usize
+            &(*(::std::ptr::null::<
+                C_with_zero_length_array_and_incomplete_array,
+            >()))
+            .big_array as *const _ as usize
         },
         4usize,
         concat!(
@@ -331,8 +349,10 @@ fn bindgen_test_layout_C_with_zero_length_array_and_incomplete_array() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<C_with_zero_length_array_and_incomplete_array>()))
-                .zero_length_array as *const _ as usize
+            &(*(::std::ptr::null::<
+                C_with_zero_length_array_and_incomplete_array,
+            >()))
+            .zero_length_array as *const _ as usize
         },
         37usize,
         concat!(
@@ -344,8 +364,10 @@ fn bindgen_test_layout_C_with_zero_length_array_and_incomplete_array() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<C_with_zero_length_array_and_incomplete_array>()))
-                .incomplete_array as *const _ as usize
+            &(*(::std::ptr::null::<
+                C_with_zero_length_array_and_incomplete_array,
+            >()))
+            .incomplete_array as *const _ as usize
         },
         37usize,
         concat!(
@@ -371,7 +393,8 @@ pub struct C_with_zero_length_array_and_incomplete_array_2 {
 #[test]
 fn bindgen_test_layout_C_with_zero_length_array_and_incomplete_array_2() {
     assert_eq!(
-        ::std::mem::size_of::<C_with_zero_length_array_and_incomplete_array_2>(),
+        ::std::mem::size_of::<C_with_zero_length_array_and_incomplete_array_2>(
+        ),
         4usize,
         concat!(
             "Size of: ",
@@ -379,7 +402,8 @@ fn bindgen_test_layout_C_with_zero_length_array_and_incomplete_array_2() {
         )
     );
     assert_eq!(
-        ::std::mem::align_of::<C_with_zero_length_array_and_incomplete_array_2>(),
+        ::std::mem::align_of::<C_with_zero_length_array_and_incomplete_array_2>(
+        ),
         4usize,
         concat!(
             "Alignment of ",
@@ -388,8 +412,10 @@ fn bindgen_test_layout_C_with_zero_length_array_and_incomplete_array_2() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<C_with_zero_length_array_and_incomplete_array_2>())).a
-                as *const _ as usize
+            &(*(::std::ptr::null::<
+                C_with_zero_length_array_and_incomplete_array_2,
+            >()))
+            .a as *const _ as usize
         },
         0usize,
         concat!(
@@ -401,8 +427,10 @@ fn bindgen_test_layout_C_with_zero_length_array_and_incomplete_array_2() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<C_with_zero_length_array_and_incomplete_array_2>()))
-                .zero_length_array as *const _ as usize
+            &(*(::std::ptr::null::<
+                C_with_zero_length_array_and_incomplete_array_2,
+            >()))
+            .zero_length_array as *const _ as usize
         },
         4usize,
         concat!(
@@ -414,8 +442,10 @@ fn bindgen_test_layout_C_with_zero_length_array_and_incomplete_array_2() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<C_with_zero_length_array_and_incomplete_array_2>()))
-                .incomplete_array as *const _ as usize
+            &(*(::std::ptr::null::<
+                C_with_zero_length_array_and_incomplete_array_2,
+            >()))
+            .incomplete_array as *const _ as usize
         },
         4usize,
         concat!(
@@ -473,7 +503,8 @@ fn bindgen_test_layout_IncompleteArrayNonCopiable() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<IncompleteArrayNonCopiable>())).whatever as *const _ as usize
+            &(*(::std::ptr::null::<IncompleteArrayNonCopiable>())).whatever
+                as *const _ as usize
         },
         0usize,
         concat!(
@@ -485,8 +516,8 @@ fn bindgen_test_layout_IncompleteArrayNonCopiable() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<IncompleteArrayNonCopiable>())).incomplete_array as *const _
-                as usize
+            &(*(::std::ptr::null::<IncompleteArrayNonCopiable>()))
+                .incomplete_array as *const _ as usize
         },
         8usize,
         concat!(
@@ -555,7 +586,9 @@ fn bindgen_test_layout_WithUnion() {
         concat!("Alignment of ", stringify!(WithUnion))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<WithUnion>())).data as *const _ as usize },
+        unsafe {
+            &(*(::std::ptr::null::<WithUnion>())).data as *const _ as usize
+        },
         0usize,
         concat!(
             "Offset of field: ",
@@ -593,11 +626,15 @@ fn bindgen_test_layout_RealAbstractionWithTonsOfMethods() {
 }
 extern "C" {
     #[link_name = "\u{1}_ZNK32RealAbstractionWithTonsOfMethods3barEv"]
-    pub fn RealAbstractionWithTonsOfMethods_bar(this: *const RealAbstractionWithTonsOfMethods);
+    pub fn RealAbstractionWithTonsOfMethods_bar(
+        this: *const RealAbstractionWithTonsOfMethods,
+    );
 }
 extern "C" {
     #[link_name = "\u{1}_ZN32RealAbstractionWithTonsOfMethods3barEv"]
-    pub fn RealAbstractionWithTonsOfMethods_bar1(this: *mut RealAbstractionWithTonsOfMethods);
+    pub fn RealAbstractionWithTonsOfMethods_bar1(
+        this: *mut RealAbstractionWithTonsOfMethods,
+    );
 }
 extern "C" {
     #[link_name = "\u{1}_ZN32RealAbstractionWithTonsOfMethods3barEi"]

--- a/tests/expectations/tests/libclang-9/class_1_0.rs
+++ b/tests/expectations/tests/libclang-9/class_1_0.rs
@@ -16,12 +16,12 @@ impl<T> __IncompleteArrayField<T> {
         __IncompleteArrayField(::std::marker::PhantomData, [])
     }
     #[inline]
-    pub unsafe fn as_ptr(&self) -> *const T {
-        ::std::mem::transmute(self)
+    pub fn as_ptr(&self) -> *const T {
+        self as *const _ as *const T
     }
     #[inline]
-    pub unsafe fn as_mut_ptr(&mut self) -> *mut T {
-        ::std::mem::transmute(self)
+    pub fn as_mut_ptr(&mut self) -> *mut T {
+        self as *mut _ as *mut T
     }
     #[inline]
     pub unsafe fn as_slice(&self, len: usize) -> &[T] {
@@ -148,7 +148,10 @@ fn bindgen_test_layout_C_with_zero_length_array() {
         concat!("Alignment of ", stringify!(C_with_zero_length_array))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<C_with_zero_length_array>())).a as *const _ as usize },
+        unsafe {
+            &(*(::std::ptr::null::<C_with_zero_length_array>())).a as *const _
+                as usize
+        },
         0usize,
         concat!(
             "Offset of field: ",
@@ -159,7 +162,8 @@ fn bindgen_test_layout_C_with_zero_length_array() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<C_with_zero_length_array>())).big_array as *const _ as usize
+            &(*(::std::ptr::null::<C_with_zero_length_array>())).big_array
+                as *const _ as usize
         },
         4usize,
         concat!(
@@ -171,8 +175,8 @@ fn bindgen_test_layout_C_with_zero_length_array() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<C_with_zero_length_array>())).zero_length_array as *const _
-                as usize
+            &(*(::std::ptr::null::<C_with_zero_length_array>()))
+                .zero_length_array as *const _ as usize
         },
         37usize,
         concat!(
@@ -207,7 +211,10 @@ fn bindgen_test_layout_C_with_zero_length_array_2() {
         concat!("Alignment of ", stringify!(C_with_zero_length_array_2))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<C_with_zero_length_array_2>())).a as *const _ as usize },
+        unsafe {
+            &(*(::std::ptr::null::<C_with_zero_length_array_2>())).a as *const _
+                as usize
+        },
         0usize,
         concat!(
             "Offset of field: ",
@@ -218,8 +225,8 @@ fn bindgen_test_layout_C_with_zero_length_array_2() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<C_with_zero_length_array_2>())).zero_length_array as *const _
-                as usize
+            &(*(::std::ptr::null::<C_with_zero_length_array_2>()))
+                .zero_length_array as *const _ as usize
         },
         4usize,
         concat!(
@@ -249,7 +256,10 @@ fn bindgen_test_layout_C_with_incomplete_array() {
         concat!("Alignment of ", stringify!(C_with_incomplete_array))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<C_with_incomplete_array>())).a as *const _ as usize },
+        unsafe {
+            &(*(::std::ptr::null::<C_with_incomplete_array>())).a as *const _
+                as usize
+        },
         0usize,
         concat!(
             "Offset of field: ",
@@ -260,7 +270,8 @@ fn bindgen_test_layout_C_with_incomplete_array() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<C_with_incomplete_array>())).big_array as *const _ as usize
+            &(*(::std::ptr::null::<C_with_incomplete_array>())).big_array
+                as *const _ as usize
         },
         4usize,
         concat!(
@@ -272,8 +283,8 @@ fn bindgen_test_layout_C_with_incomplete_array() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<C_with_incomplete_array>())).incomplete_array as *const _
-                as usize
+            &(*(::std::ptr::null::<C_with_incomplete_array>())).incomplete_array
+                as *const _ as usize
         },
         37usize,
         concat!(
@@ -308,7 +319,10 @@ fn bindgen_test_layout_C_with_incomplete_array_2() {
         concat!("Alignment of ", stringify!(C_with_incomplete_array_2))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<C_with_incomplete_array_2>())).a as *const _ as usize },
+        unsafe {
+            &(*(::std::ptr::null::<C_with_incomplete_array_2>())).a as *const _
+                as usize
+        },
         0usize,
         concat!(
             "Offset of field: ",
@@ -319,8 +333,8 @@ fn bindgen_test_layout_C_with_incomplete_array_2() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<C_with_incomplete_array_2>())).incomplete_array as *const _
-                as usize
+            &(*(::std::ptr::null::<C_with_incomplete_array_2>()))
+                .incomplete_array as *const _ as usize
         },
         4usize,
         concat!(
@@ -358,8 +372,10 @@ fn bindgen_test_layout_C_with_zero_length_array_and_incomplete_array() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<C_with_zero_length_array_and_incomplete_array>())).a as *const _
-                as usize
+            &(*(::std::ptr::null::<
+                C_with_zero_length_array_and_incomplete_array,
+            >()))
+            .a as *const _ as usize
         },
         0usize,
         concat!(
@@ -371,8 +387,10 @@ fn bindgen_test_layout_C_with_zero_length_array_and_incomplete_array() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<C_with_zero_length_array_and_incomplete_array>())).big_array
-                as *const _ as usize
+            &(*(::std::ptr::null::<
+                C_with_zero_length_array_and_incomplete_array,
+            >()))
+            .big_array as *const _ as usize
         },
         4usize,
         concat!(
@@ -384,8 +402,10 @@ fn bindgen_test_layout_C_with_zero_length_array_and_incomplete_array() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<C_with_zero_length_array_and_incomplete_array>()))
-                .zero_length_array as *const _ as usize
+            &(*(::std::ptr::null::<
+                C_with_zero_length_array_and_incomplete_array,
+            >()))
+            .zero_length_array as *const _ as usize
         },
         37usize,
         concat!(
@@ -397,8 +417,10 @@ fn bindgen_test_layout_C_with_zero_length_array_and_incomplete_array() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<C_with_zero_length_array_and_incomplete_array>()))
-                .incomplete_array as *const _ as usize
+            &(*(::std::ptr::null::<
+                C_with_zero_length_array_and_incomplete_array,
+            >()))
+            .incomplete_array as *const _ as usize
         },
         37usize,
         concat!(
@@ -424,7 +446,8 @@ pub struct C_with_zero_length_array_and_incomplete_array_2 {
 #[test]
 fn bindgen_test_layout_C_with_zero_length_array_and_incomplete_array_2() {
     assert_eq!(
-        ::std::mem::size_of::<C_with_zero_length_array_and_incomplete_array_2>(),
+        ::std::mem::size_of::<C_with_zero_length_array_and_incomplete_array_2>(
+        ),
         4usize,
         concat!(
             "Size of: ",
@@ -432,7 +455,8 @@ fn bindgen_test_layout_C_with_zero_length_array_and_incomplete_array_2() {
         )
     );
     assert_eq!(
-        ::std::mem::align_of::<C_with_zero_length_array_and_incomplete_array_2>(),
+        ::std::mem::align_of::<C_with_zero_length_array_and_incomplete_array_2>(
+        ),
         4usize,
         concat!(
             "Alignment of ",
@@ -441,8 +465,10 @@ fn bindgen_test_layout_C_with_zero_length_array_and_incomplete_array_2() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<C_with_zero_length_array_and_incomplete_array_2>())).a
-                as *const _ as usize
+            &(*(::std::ptr::null::<
+                C_with_zero_length_array_and_incomplete_array_2,
+            >()))
+            .a as *const _ as usize
         },
         0usize,
         concat!(
@@ -454,8 +480,10 @@ fn bindgen_test_layout_C_with_zero_length_array_and_incomplete_array_2() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<C_with_zero_length_array_and_incomplete_array_2>()))
-                .zero_length_array as *const _ as usize
+            &(*(::std::ptr::null::<
+                C_with_zero_length_array_and_incomplete_array_2,
+            >()))
+            .zero_length_array as *const _ as usize
         },
         4usize,
         concat!(
@@ -467,8 +495,10 @@ fn bindgen_test_layout_C_with_zero_length_array_and_incomplete_array_2() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<C_with_zero_length_array_and_incomplete_array_2>()))
-                .incomplete_array as *const _ as usize
+            &(*(::std::ptr::null::<
+                C_with_zero_length_array_and_incomplete_array_2,
+            >()))
+            .incomplete_array as *const _ as usize
         },
         4usize,
         concat!(
@@ -526,7 +556,8 @@ fn bindgen_test_layout_IncompleteArrayNonCopiable() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<IncompleteArrayNonCopiable>())).whatever as *const _ as usize
+            &(*(::std::ptr::null::<IncompleteArrayNonCopiable>())).whatever
+                as *const _ as usize
         },
         0usize,
         concat!(
@@ -538,8 +569,8 @@ fn bindgen_test_layout_IncompleteArrayNonCopiable() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<IncompleteArrayNonCopiable>())).incomplete_array as *const _
-                as usize
+            &(*(::std::ptr::null::<IncompleteArrayNonCopiable>()))
+                .incomplete_array as *const _ as usize
         },
         8usize,
         concat!(
@@ -608,7 +639,9 @@ fn bindgen_test_layout_WithUnion() {
         concat!("Alignment of ", stringify!(WithUnion))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<WithUnion>())).data as *const _ as usize },
+        unsafe {
+            &(*(::std::ptr::null::<WithUnion>())).data as *const _ as usize
+        },
         0usize,
         concat!(
             "Offset of field: ",
@@ -646,11 +679,15 @@ fn bindgen_test_layout_RealAbstractionWithTonsOfMethods() {
 }
 extern "C" {
     #[link_name = "\u{1}_ZNK32RealAbstractionWithTonsOfMethods3barEv"]
-    pub fn RealAbstractionWithTonsOfMethods_bar(this: *const RealAbstractionWithTonsOfMethods);
+    pub fn RealAbstractionWithTonsOfMethods_bar(
+        this: *const RealAbstractionWithTonsOfMethods,
+    );
 }
 extern "C" {
     #[link_name = "\u{1}_ZN32RealAbstractionWithTonsOfMethods3barEv"]
-    pub fn RealAbstractionWithTonsOfMethods_bar1(this: *mut RealAbstractionWithTonsOfMethods);
+    pub fn RealAbstractionWithTonsOfMethods_bar1(
+        this: *mut RealAbstractionWithTonsOfMethods,
+    );
 }
 extern "C" {
     #[link_name = "\u{1}_ZN32RealAbstractionWithTonsOfMethods3barEi"]

--- a/tests/expectations/tests/libclang-9/derive-hash-struct-with-incomplete-array.rs
+++ b/tests/expectations/tests/libclang-9/derive-hash-struct-with-incomplete-array.rs
@@ -16,12 +16,12 @@ impl<T> __IncompleteArrayField<T> {
         __IncompleteArrayField(::std::marker::PhantomData, [])
     }
     #[inline]
-    pub unsafe fn as_ptr(&self) -> *const T {
-        ::std::mem::transmute(self)
+    pub fn as_ptr(&self) -> *const T {
+        self as *const _ as *const T
     }
     #[inline]
-    pub unsafe fn as_mut_ptr(&mut self) -> *mut T {
-        ::std::mem::transmute(self)
+    pub fn as_mut_ptr(&mut self) -> *mut T {
+        self as *mut _ as *mut T
     }
     #[inline]
     pub unsafe fn as_slice(&self, len: usize) -> &[T] {
@@ -61,7 +61,10 @@ fn bindgen_test_layout_test() {
         concat!("Offset of field: ", stringify!(test), "::", stringify!(a))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<test>())).zero_length_array as *const _ as usize },
+        unsafe {
+            &(*(::std::ptr::null::<test>())).zero_length_array as *const _
+                as usize
+        },
         4usize,
         concat!(
             "Offset of field: ",
@@ -95,7 +98,10 @@ fn bindgen_test_layout_test2() {
         concat!("Offset of field: ", stringify!(test2), "::", stringify!(a))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<test2>())).incomplete_array as *const _ as usize },
+        unsafe {
+            &(*(::std::ptr::null::<test2>())).incomplete_array as *const _
+                as usize
+        },
         4usize,
         concat!(
             "Offset of field: ",
@@ -130,7 +136,10 @@ fn bindgen_test_layout_test3() {
         concat!("Offset of field: ", stringify!(test3), "::", stringify!(a))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<test3>())).zero_length_array as *const _ as usize },
+        unsafe {
+            &(*(::std::ptr::null::<test3>())).zero_length_array as *const _
+                as usize
+        },
         4usize,
         concat!(
             "Offset of field: ",
@@ -140,7 +149,10 @@ fn bindgen_test_layout_test3() {
         )
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<test3>())).incomplete_array as *const _ as usize },
+        unsafe {
+            &(*(::std::ptr::null::<test3>())).incomplete_array as *const _
+                as usize
+        },
         4usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/libclang-9/incomplete-array-padding.rs
+++ b/tests/expectations/tests/libclang-9/incomplete-array-padding.rs
@@ -57,7 +57,10 @@ where
     pub fn get(&self, bit_offset: usize, bit_width: u8) -> u64 {
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < self.storage.as_ref().len());
-        debug_assert!((bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len());
+        debug_assert!(
+            (bit_offset + (bit_width as usize)) / 8 <=
+                self.storage.as_ref().len()
+        );
         let mut val = 0;
         for i in 0..(bit_width as usize) {
             if self.get_bit(i + bit_offset) {
@@ -75,7 +78,10 @@ where
     pub fn set(&mut self, bit_offset: usize, bit_width: u8, val: u64) {
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < self.storage.as_ref().len());
-        debug_assert!((bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len());
+        debug_assert!(
+            (bit_offset + (bit_width as usize)) / 8 <=
+                self.storage.as_ref().len()
+        );
         for i in 0..(bit_width as usize) {
             let mask = 1 << i;
             let val_bit_is_set = val & mask == mask;
@@ -97,12 +103,12 @@ impl<T> __IncompleteArrayField<T> {
         __IncompleteArrayField(::std::marker::PhantomData, [])
     }
     #[inline]
-    pub unsafe fn as_ptr(&self) -> *const T {
-        ::std::mem::transmute(self)
+    pub fn as_ptr(&self) -> *const T {
+        self as *const _ as *const T
     }
     #[inline]
-    pub unsafe fn as_mut_ptr(&mut self) -> *mut T {
-        ::std::mem::transmute(self)
+    pub fn as_mut_ptr(&mut self) -> *mut T {
+        self as *mut _ as *mut T
     }
     #[inline]
     pub unsafe fn as_slice(&self, len: usize) -> &[T] {
@@ -150,7 +156,9 @@ impl Default for foo {
 impl foo {
     #[inline]
     pub fn a(&self) -> ::std::os::raw::c_char {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u8) }
+        unsafe {
+            ::std::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u8)
+        }
     }
     #[inline]
     pub fn set_a(&mut self, val: ::std::os::raw::c_char) {
@@ -160,9 +168,13 @@ impl foo {
         }
     }
     #[inline]
-    pub fn new_bitfield_1(a: ::std::os::raw::c_char) -> __BindgenBitfieldUnit<[u8; 1usize], u8> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 1usize], u8> =
-            Default::default();
+    pub fn new_bitfield_1(
+        a: ::std::os::raw::c_char,
+    ) -> __BindgenBitfieldUnit<[u8; 1usize], u8> {
+        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<
+            [u8; 1usize],
+            u8,
+        > = Default::default();
         __bindgen_bitfield_unit.set(0usize, 1u8, {
             let a: u8 = unsafe { ::std::mem::transmute(a) };
             a as u64

--- a/tests/expectations/tests/libclang-9/issue-643-inner-struct.rs
+++ b/tests/expectations/tests/libclang-9/issue-643-inner-struct.rs
@@ -16,12 +16,12 @@ impl<T> __IncompleteArrayField<T> {
         __IncompleteArrayField(::std::marker::PhantomData, [])
     }
     #[inline]
-    pub unsafe fn as_ptr(&self) -> *const T {
-        ::std::mem::transmute(self)
+    pub fn as_ptr(&self) -> *const T {
+        self as *const _ as *const T
     }
     #[inline]
-    pub unsafe fn as_mut_ptr(&mut self) -> *mut T {
-        ::std::mem::transmute(self)
+    pub fn as_mut_ptr(&mut self) -> *mut T {
+        self as *mut _ as *mut T
     }
     #[inline]
     pub unsafe fn as_slice(&self, len: usize) -> &[T] {
@@ -63,7 +63,10 @@ fn bindgen_test_layout_rte_ring_prod() {
         concat!("Alignment of ", stringify!(rte_ring_prod))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<rte_ring_prod>())).watermark as *const _ as usize },
+        unsafe {
+            &(*(::std::ptr::null::<rte_ring_prod>())).watermark as *const _
+                as usize
+        },
         0usize,
         concat!(
             "Offset of field: ",
@@ -91,7 +94,10 @@ fn bindgen_test_layout_rte_ring_cons() {
         concat!("Alignment of ", stringify!(rte_ring_cons))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<rte_ring_cons>())).sc_dequeue as *const _ as usize },
+        unsafe {
+            &(*(::std::ptr::null::<rte_ring_cons>())).sc_dequeue as *const _
+                as usize
+        },
         0usize,
         concat!(
             "Offset of field: ",
@@ -114,7 +120,9 @@ fn bindgen_test_layout_rte_ring() {
         concat!("Alignment of ", stringify!(rte_ring))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<rte_ring>())).memzone as *const _ as usize },
+        unsafe {
+            &(*(::std::ptr::null::<rte_ring>())).memzone as *const _ as usize
+        },
         0usize,
         concat!(
             "Offset of field: ",
@@ -124,7 +132,9 @@ fn bindgen_test_layout_rte_ring() {
         )
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<rte_ring>())).prod as *const _ as usize },
+        unsafe {
+            &(*(::std::ptr::null::<rte_ring>())).prod as *const _ as usize
+        },
         8usize,
         concat!(
             "Offset of field: ",
@@ -134,7 +144,9 @@ fn bindgen_test_layout_rte_ring() {
         )
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<rte_ring>())).cons as *const _ as usize },
+        unsafe {
+            &(*(::std::ptr::null::<rte_ring>())).cons as *const _ as usize
+        },
         12usize,
         concat!(
             "Offset of field: ",
@@ -144,7 +156,9 @@ fn bindgen_test_layout_rte_ring() {
         )
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<rte_ring>())).ring as *const _ as usize },
+        unsafe {
+            &(*(::std::ptr::null::<rte_ring>())).ring as *const _ as usize
+        },
         16usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/libclang-9/layout_align.rs
+++ b/tests/expectations/tests/libclang-9/layout_align.rs
@@ -57,7 +57,10 @@ where
     pub fn get(&self, bit_offset: usize, bit_width: u8) -> u64 {
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < self.storage.as_ref().len());
-        debug_assert!((bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len());
+        debug_assert!(
+            (bit_offset + (bit_width as usize)) / 8 <=
+                self.storage.as_ref().len()
+        );
         let mut val = 0;
         for i in 0..(bit_width as usize) {
             if self.get_bit(i + bit_offset) {
@@ -75,7 +78,10 @@ where
     pub fn set(&mut self, bit_offset: usize, bit_width: u8, val: u64) {
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < self.storage.as_ref().len());
-        debug_assert!((bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len());
+        debug_assert!(
+            (bit_offset + (bit_width as usize)) / 8 <=
+                self.storage.as_ref().len()
+        );
         for i in 0..(bit_width as usize) {
             let mask = 1 << i;
             let val_bit_is_set = val & mask == mask;
@@ -97,12 +103,12 @@ impl<T> __IncompleteArrayField<T> {
         __IncompleteArrayField(::std::marker::PhantomData, [])
     }
     #[inline]
-    pub unsafe fn as_ptr(&self) -> *const T {
-        ::std::mem::transmute(self)
+    pub fn as_ptr(&self) -> *const T {
+        self as *const _ as *const T
     }
     #[inline]
-    pub unsafe fn as_mut_ptr(&mut self) -> *mut T {
-        ::std::mem::transmute(self)
+    pub fn as_mut_ptr(&mut self) -> *mut T {
+        self as *mut _ as *mut T
     }
     #[inline]
     pub unsafe fn as_slice(&self, len: usize) -> &[T] {
@@ -145,7 +151,9 @@ fn bindgen_test_layout_rte_kni_fifo() {
         concat!("Alignment of ", stringify!(rte_kni_fifo))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<rte_kni_fifo>())).write as *const _ as usize },
+        unsafe {
+            &(*(::std::ptr::null::<rte_kni_fifo>())).write as *const _ as usize
+        },
         0usize,
         concat!(
             "Offset of field: ",
@@ -155,7 +163,9 @@ fn bindgen_test_layout_rte_kni_fifo() {
         )
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<rte_kni_fifo>())).read as *const _ as usize },
+        unsafe {
+            &(*(::std::ptr::null::<rte_kni_fifo>())).read as *const _ as usize
+        },
         4usize,
         concat!(
             "Offset of field: ",
@@ -165,7 +175,9 @@ fn bindgen_test_layout_rte_kni_fifo() {
         )
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<rte_kni_fifo>())).len as *const _ as usize },
+        unsafe {
+            &(*(::std::ptr::null::<rte_kni_fifo>())).len as *const _ as usize
+        },
         8usize,
         concat!(
             "Offset of field: ",
@@ -175,7 +187,10 @@ fn bindgen_test_layout_rte_kni_fifo() {
         )
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<rte_kni_fifo>())).elem_size as *const _ as usize },
+        unsafe {
+            &(*(::std::ptr::null::<rte_kni_fifo>())).elem_size as *const _
+                as usize
+        },
         12usize,
         concat!(
             "Offset of field: ",
@@ -185,7 +200,9 @@ fn bindgen_test_layout_rte_kni_fifo() {
         )
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<rte_kni_fifo>())).buffer as *const _ as usize },
+        unsafe {
+            &(*(::std::ptr::null::<rte_kni_fifo>())).buffer as *const _ as usize
+        },
         16usize,
         concat!(
             "Offset of field: ",
@@ -222,7 +239,10 @@ fn bindgen_test_layout_rte_eth_link() {
         concat!("Alignment of ", stringify!(rte_eth_link))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<rte_eth_link>())).link_speed as *const _ as usize },
+        unsafe {
+            &(*(::std::ptr::null::<rte_eth_link>())).link_speed as *const _
+                as usize
+        },
         0usize,
         concat!(
             "Offset of field: ",
@@ -235,7 +255,9 @@ fn bindgen_test_layout_rte_eth_link() {
 impl rte_eth_link {
     #[inline]
     pub fn link_duplex(&self) -> u16 {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u16) }
+        unsafe {
+            ::std::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u16)
+        }
     }
     #[inline]
     pub fn set_link_duplex(&mut self, val: u16) {
@@ -246,7 +268,9 @@ impl rte_eth_link {
     }
     #[inline]
     pub fn link_autoneg(&self) -> u16 {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u16) }
+        unsafe {
+            ::std::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u16)
+        }
     }
     #[inline]
     pub fn set_link_autoneg(&mut self, val: u16) {
@@ -257,7 +281,9 @@ impl rte_eth_link {
     }
     #[inline]
     pub fn link_status(&self) -> u16 {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(2usize, 1u8) as u16) }
+        unsafe {
+            ::std::mem::transmute(self._bitfield_1.get(2usize, 1u8) as u16)
+        }
     }
     #[inline]
     pub fn set_link_status(&mut self, val: u16) {
@@ -272,18 +298,23 @@ impl rte_eth_link {
         link_autoneg: u16,
         link_status: u16,
     ) -> __BindgenBitfieldUnit<[u8; 1usize], u8> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 1usize], u8> =
-            Default::default();
+        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<
+            [u8; 1usize],
+            u8,
+        > = Default::default();
         __bindgen_bitfield_unit.set(0usize, 1u8, {
-            let link_duplex: u16 = unsafe { ::std::mem::transmute(link_duplex) };
+            let link_duplex: u16 =
+                unsafe { ::std::mem::transmute(link_duplex) };
             link_duplex as u64
         });
         __bindgen_bitfield_unit.set(1usize, 1u8, {
-            let link_autoneg: u16 = unsafe { ::std::mem::transmute(link_autoneg) };
+            let link_autoneg: u16 =
+                unsafe { ::std::mem::transmute(link_autoneg) };
             link_autoneg as u64
         });
         __bindgen_bitfield_unit.set(2usize, 1u8, {
-            let link_status: u16 = unsafe { ::std::mem::transmute(link_status) };
+            let link_status: u16 =
+                unsafe { ::std::mem::transmute(link_status) };
             link_status as u64
         });
         __bindgen_bitfield_unit

--- a/tests/expectations/tests/libclang-9/zero-sized-array.rs
+++ b/tests/expectations/tests/libclang-9/zero-sized-array.rs
@@ -16,12 +16,12 @@ impl<T> __IncompleteArrayField<T> {
         __IncompleteArrayField(::std::marker::PhantomData, [])
     }
     #[inline]
-    pub unsafe fn as_ptr(&self) -> *const T {
-        ::std::mem::transmute(self)
+    pub fn as_ptr(&self) -> *const T {
+        self as *const _ as *const T
     }
     #[inline]
-    pub unsafe fn as_mut_ptr(&mut self) -> *mut T {
-        ::std::mem::transmute(self)
+    pub fn as_mut_ptr(&mut self) -> *mut T {
+        self as *mut _ as *mut T
     }
     #[inline]
     pub unsafe fn as_slice(&self, len: usize) -> &[T] {
@@ -56,7 +56,9 @@ fn bindgen_test_layout_ZeroSizedArray() {
         concat!("Alignment of ", stringify!(ZeroSizedArray))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<ZeroSizedArray>())).arr as *const _ as usize },
+        unsafe {
+            &(*(::std::ptr::null::<ZeroSizedArray>())).arr as *const _ as usize
+        },
         0usize,
         concat!(
             "Offset of field: ",
@@ -85,7 +87,10 @@ fn bindgen_test_layout_ContainsZeroSizedArray() {
         concat!("Alignment of ", stringify!(ContainsZeroSizedArray))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<ContainsZeroSizedArray>())).zsa as *const _ as usize },
+        unsafe {
+            &(*(::std::ptr::null::<ContainsZeroSizedArray>())).zsa as *const _
+                as usize
+        },
         0usize,
         concat!(
             "Offset of field: ",
@@ -134,7 +139,10 @@ fn bindgen_test_layout_DynamicallySizedArray() {
         concat!("Alignment of ", stringify!(DynamicallySizedArray))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<DynamicallySizedArray>())).arr as *const _ as usize },
+        unsafe {
+            &(*(::std::ptr::null::<DynamicallySizedArray>())).arr as *const _
+                as usize
+        },
         0usize,
         concat!(
             "Offset of field: ",
@@ -164,7 +172,8 @@ fn bindgen_test_layout_ContainsDynamicallySizedArray() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<ContainsDynamicallySizedArray>())).dsa as *const _ as usize
+            &(*(::std::ptr::null::<ContainsDynamicallySizedArray>())).dsa
+                as *const _ as usize
         },
         0usize,
         concat!(

--- a/tests/expectations/tests/zero-size-array-align.rs
+++ b/tests/expectations/tests/zero-size-array-align.rs
@@ -16,12 +16,12 @@ impl<T> __IncompleteArrayField<T> {
         __IncompleteArrayField(::std::marker::PhantomData, [])
     }
     #[inline]
-    pub unsafe fn as_ptr(&self) -> *const T {
-        ::std::mem::transmute(self)
+    pub fn as_ptr(&self) -> *const T {
+        self as *const _ as *const T
     }
     #[inline]
-    pub unsafe fn as_mut_ptr(&mut self) -> *mut T {
-        ::std::mem::transmute(self)
+    pub fn as_mut_ptr(&mut self) -> *mut T {
+        self as *mut _ as *mut T
     }
     #[inline]
     pub unsafe fn as_slice(&self, len: usize) -> &[T] {

--- a/tests/expectations/tests/zero-sized-array.rs
+++ b/tests/expectations/tests/zero-sized-array.rs
@@ -16,12 +16,12 @@ impl<T> __IncompleteArrayField<T> {
         __IncompleteArrayField(::std::marker::PhantomData, [])
     }
     #[inline]
-    pub unsafe fn as_ptr(&self) -> *const T {
-        ::std::mem::transmute(self)
+    pub fn as_ptr(&self) -> *const T {
+        self as *const _ as *const T
     }
     #[inline]
-    pub unsafe fn as_mut_ptr(&mut self) -> *mut T {
-        ::std::mem::transmute(self)
+    pub fn as_mut_ptr(&mut self) -> *mut T {
+        self as *mut _ as *mut T
     }
     #[inline]
     pub unsafe fn as_slice(&self, len: usize) -> &[T] {


### PR DESCRIPTION
Closes #1670 
this way the `as_*ptr()` functions are no longer unsafe and don't use transmute.
(and as a bonus one less clippy warning :) )

(seems like changes in `rustfmt` affected this PR)