### PR TITLE
Move warnings check on the CI

### DIFF
--- a/ci/assert-warnings.sh
+++ b/ci/assert-warnings.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -xeu
+cd "$(dirname "$0")/.."
+
+cargo rustc --lib --features "$BINDGEN_FEATURES" -- -Dwarnings

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -38,6 +38,7 @@ case "$BINDGEN_JOB" in
 
     "misc")
         ./ci/assert-docs.sh
+        ./ci/assert-warnings.sh
         ./ci/test-book.sh
         ./ci/no-includes.sh
         ./ci/assert-rustfmt.sh

--- a/src/features.rs
+++ b/src/features.rs
@@ -1,7 +1,6 @@
 //! Contains code for selecting features
 
 #![deny(missing_docs)]
-#![deny(warnings)]
 #![deny(unused_extern_crates)]
 
 use std::io;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,6 @@
 //! See the [Users Guide](https://rust-lang.github.io/rust-bindgen/) for
 //! additional documentation.
 #![deny(missing_docs)]
-#![deny(warnings)]
 #![deny(unused_extern_crates)]
 // To avoid rather annoying warnings when matching with CXCursor_xxx as a
 // constant.


### PR DESCRIPTION
Always building with `deny(warnings)` leads to messups such as
https://docs.rs/crate/bindgen/0.52.0/builds/199624