### PR TITLE
Fix warning on rustdoc

### DIFF
--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -2279,7 +2279,7 @@ impl MethodCodegen for Method {
 pub enum EnumVariation {
     /// The code for this enum will use a Rust enum
     Rust {
-        /// Indicates whether the generated struct should be #[non_exhaustive]
+        /// Indicates whether the generated struct should be `#[non_exhaustive]`
         non_exhaustive: bool,
     },
     /// The code for this enum will use a newtype

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -909,7 +909,7 @@ impl Builder {
     }
 
     /// Mark the given enum (or set of enums, if using a pattern) as a Rust
-    /// enum with the #[non_exhaustive] attribute.
+    /// enum with the `#[non_exhaustive]` attribute.
     ///
     /// This makes bindgen generate enums instead of constants. Regular
     /// expressions are supported.


### PR DESCRIPTION
Rustdoc was treating doc comments containing `#[non_exhaustive]`
as links and warning, so escape it.

Cargo doc builds without warnings after this change.