### PR TITLE
Update latest stable rust to 1.40 and give non_exhaustive feature

### DIFF
--- a/src/features.rs
+++ b/src/features.rs
@@ -120,9 +120,11 @@ macro_rules! rust_target_base {
             /// Rust stable 1.36
             ///  * `MaybeUninit` instead of `mem::uninitialized()` ([PR](https://github.com/rust-lang/rust/pull/60445))
             => Stable_1_36 => 1.36;
+            /// Rust stable 1.40
+            /// * `non_exhaustive` enums/structs ([Tracking issue](https://github.com/rust-lang/rust/issues/44109))
+            => Stable_1_40 => 1.40;
             /// Nightly rust
             ///  * `thiscall` calling convention ([Tracking issue](https://github.com/rust-lang/rust/issues/42202))
-            ///  * `non_exhaustive` enums/structs ([Tracking issue](https://github.com/rust-lang/rust/issues/44109))
             => Nightly => nightly;
         );
     }
@@ -132,7 +134,7 @@ rust_target_base!(rust_target_def);
 rust_target_base!(rust_target_values_def);
 
 /// Latest stable release of Rust
-pub const LATEST_STABLE_RUST: RustTarget = RustTarget::Stable_1_36;
+pub const LATEST_STABLE_RUST: RustTarget = RustTarget::Stable_1_40;
 
 /// Create RustFeatures struct definition, new(), and a getter for each field
 macro_rules! rust_feature_def {
@@ -217,9 +219,11 @@ rust_feature_def!(
     Stable_1_36 {
         => maybe_uninit;
     }
+    Stable_1_40 {
+        => non_exhaustive;
+    }
     Nightly {
         => thiscall_abi;
-        => non_exhaustive;
     }
 );
 


### PR DESCRIPTION
Now that rust 1.40 is out non_exhaustive is supported in stable. This makes the latest stable rust 1.40 and gives it the non_exhaustive feature