### PR TITLE
Added non-keyword support to objective-c methods for 1703

### DIFF
--- a/tests/expectations/tests/objc_method.rs
+++ b/tests/expectations/tests/objc_method.rs
@@ -24,6 +24,13 @@ pub trait Foo {
         ptr: *mut ::std::os::raw::c_char,
         floatvalue: f32,
     );
+    unsafe fn methodWithAndWithoutKeywords_arg2Name__arg4Name_(
+        self,
+        arg1: ::std::os::raw::c_int,
+        arg2: f32,
+        arg3: f32,
+        arg4: ::std::os::raw::c_int,
+    ) -> instancetype;
 }
 impl Foo for id {
     unsafe fn method(self) {
@@ -49,4 +56,14 @@ impl Foo for id {
     ) {
         msg_send ! ( self , methodWithArg1 : intvalue andArg2 : ptr andArg3 : floatvalue )
     }
+    unsafe fn methodWithAndWithoutKeywords_arg2Name__arg4Name_(
+        self,
+        arg1: ::std::os::raw::c_int,
+        arg2: f32,
+        arg3: f32,
+        arg4: ::std::os::raw::c_int,
+    ) -> instancetype {
+        msg_send ! ( self , methodWithAndWithoutKeywords : arg1 arg2Name : arg2 arg3 : arg3 arg4Name : arg4 )
+    }
 }
+pub type instancetype = id;

--- a/tests/headers/objc_method.h
+++ b/tests/headers/objc_method.h
@@ -8,4 +8,8 @@
 - (int)methodReturningInt;
 - (Foo*)methodReturningFoo;
 - (void)methodWithArg1:(int)intvalue andArg2:(char*)ptr andArg3:(float)floatvalue;
+- (instancetype)methodWithAndWithoutKeywords:(int)arg1
+                                    arg2Name:(float)arg2
+                                            :(float)arg3
+                                    arg4Name:(int)arg4;
 @end


### PR DESCRIPTION
This closes #1703 and adds the rare needed feature of non-keyword methods from objective-c method declarations.