### PR TITLE
Avoid unnecessary padding in some cases.

### DIFF
--- a/tests/expectations/tests/issue-1291.rs
+++ b/tests/expectations/tests/issue-1291.rs
@@ -26,7 +26,6 @@ pub struct RTCRay {
     pub geomID: ::std::os::raw::c_uint,
     pub primID: ::std::os::raw::c_uint,
     pub instID: ::std::os::raw::c_uint,
-    pub __bindgen_padding_0: [u32; 3usize],
 }
 #[test]
 fn bindgen_test_layout_RTCRay() {

--- a/tests/expectations/tests/issue-648-derive-debug-with-padding.rs
+++ b/tests/expectations/tests/issue-648-derive-debug-with-padding.rs
@@ -16,7 +16,6 @@
 #[derive(Copy, Clone)]
 pub struct NoDebug {
     pub c: ::std::os::raw::c_char,
-    pub __bindgen_padding_0: [u8; 63usize],
 }
 #[test]
 fn bindgen_test_layout_NoDebug() {
@@ -61,7 +60,6 @@ impl ::std::cmp::PartialEq for NoDebug {
 pub struct ShouldDeriveDebugButDoesNot {
     pub c: [::std::os::raw::c_char; 32usize],
     pub d: ::std::os::raw::c_char,
-    pub __bindgen_padding_0: [u8; 31usize],
 }
 #[test]
 fn bindgen_test_layout_ShouldDeriveDebugButDoesNot() {

--- a/tests/expectations/tests/layout_array.rs
+++ b/tests/expectations/tests/layout_array.rs
@@ -68,7 +68,6 @@ pub struct rte_mempool_ops {
     pub dequeue: rte_mempool_dequeue_t,
     ///< Get qty of available objs.
     pub get_count: rte_mempool_get_count,
-    pub __bindgen_padding_0: [u64; 7usize],
 }
 #[test]
 fn bindgen_test_layout_rte_mempool_ops() {

--- a/tests/expectations/tests/layout_array_too_long.rs
+++ b/tests/expectations/tests/layout_array_too_long.rs
@@ -163,7 +163,6 @@ pub struct ip_frag_pkt {
     pub last_idx: u32,
     ///< fragments
     pub frags: [ip_frag; 4usize],
-    pub __bindgen_padding_0: [u64; 6usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]

--- a/tests/expectations/tests/layout_kni_mbuf.rs
+++ b/tests/expectations/tests/layout_kni_mbuf.rs
@@ -33,7 +33,6 @@ pub struct rte_kni_mbuf {
     pub pad3: [::std::os::raw::c_char; 8usize],
     pub pool: *mut ::std::os::raw::c_void,
     pub next: *mut ::std::os::raw::c_void,
-    pub __bindgen_padding_1: [u64; 5usize],
 }
 #[test]
 fn bindgen_test_layout_rte_kni_mbuf() {

--- a/tests/expectations/tests/layout_large_align_field.rs
+++ b/tests/expectations/tests/layout_large_align_field.rs
@@ -193,7 +193,6 @@ pub struct ip_frag_pkt {
     pub last_idx: u32,
     ///< fragments
     pub frags: [ip_frag; 4usize],
-    pub __bindgen_padding_0: [u64; 6usize],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -417,7 +416,6 @@ pub struct ip_frag_tbl_stat {
     pub fail_total: u64,
     ///< # of 'no space' add failures.
     pub fail_nospace: u64,
-    pub __bindgen_padding_0: [u64; 2usize],
 }
 #[test]
 fn bindgen_test_layout_ip_frag_tbl_stat() {

--- a/tests/expectations/tests/layout_mbuf.rs
+++ b/tests/expectations/tests/layout_mbuf.rs
@@ -178,7 +178,6 @@ pub struct rte_mbuf {
     pub priv_size: u16,
     /// Timesync flags for use with IEEE1588.
     pub timesync: u16,
-    pub __bindgen_padding_0: [u32; 7usize],
 }
 /// 16-bit Reference counter.
 /// It should only be accessed using the following functions:

--- a/tests/expectations/tests/libclang-5/call-conv-field.rs
+++ b/tests/expectations/tests/libclang-5/call-conv-field.rs
@@ -14,7 +14,6 @@ pub struct JNINativeInterface_ {
     pub GetVersion: ::std::option::Option<
         unsafe extern "stdcall" fn(env: *mut ::std::os::raw::c_void) -> ::std::os::raw::c_int,
     >,
-    pub __bindgen_padding_0: u32,
     pub __hack: ::std::os::raw::c_ulonglong,
 }
 #[test]

--- a/tests/expectations/tests/libclang-9/call-conv-field.rs
+++ b/tests/expectations/tests/libclang-9/call-conv-field.rs
@@ -12,9 +12,10 @@
 #[derive(Default, Copy, Clone)]
 pub struct JNINativeInterface_ {
     pub GetVersion: ::std::option::Option<
-        unsafe extern "stdcall" fn(env: *mut ::std::os::raw::c_void) -> ::std::os::raw::c_int,
+        unsafe extern "stdcall" fn(
+            env: *mut ::std::os::raw::c_void,
+        ) -> ::std::os::raw::c_int,
     >,
-    pub __bindgen_padding_0: u32,
     pub __hack: ::std::os::raw::c_ulonglong,
 }
 #[test]
@@ -30,7 +31,10 @@ fn bindgen_test_layout_JNINativeInterface_() {
         concat!("Alignment of ", stringify!(JNINativeInterface_))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<JNINativeInterface_>())).GetVersion as *const _ as usize },
+        unsafe {
+            &(*(::std::ptr::null::<JNINativeInterface_>())).GetVersion
+                as *const _ as usize
+        },
         0usize,
         concat!(
             "Offset of field: ",
@@ -40,7 +44,10 @@ fn bindgen_test_layout_JNINativeInterface_() {
         )
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<JNINativeInterface_>())).__hack as *const _ as usize },
+        unsafe {
+            &(*(::std::ptr::null::<JNINativeInterface_>())).__hack as *const _
+                as usize
+        },
         8usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/unknown_attr.rs
+++ b/tests/expectations/tests/unknown_attr.rs
@@ -14,7 +14,6 @@ pub struct max_align_t {
     pub __clang_max_align_nonce1: ::std::os::raw::c_longlong,
     pub __bindgen_padding_0: u64,
     pub __clang_max_align_nonce2: ::std::os::raw::c_longlong,
-    pub __bindgen_padding_1: u64,
 }
 #[test]
 fn bindgen_test_layout_max_align_t() {


### PR DESCRIPTION
See individual commits for details.

Fixes #1709.