### PR TITLE
Higher level objective-c support.

### DIFF
--- a/src/ir/objc.rs
+++ b/src/ir/objc.rs
@@ -31,7 +31,8 @@ pub struct ObjCInterface {
     /// The list of template names almost always, ObjectType or KeyType
     pub template_names: Vec<String>,
 
-    conforms_to: Vec<ItemId>,
+    /// The list of protocols that this interface conforms to.
+    pub conforms_to: Vec<ItemId>,
 
     /// List of the methods defined in this interfae
     methods: Vec<ObjCMethod>,
@@ -77,15 +78,15 @@ impl ObjCInterface {
 
     /// Formats the name for rust
     /// Can be like NSObject, but with categories might be like NSObject_NSCoderMethods
-    /// and protocols are like protocol_NSObject
+    /// and protocols are like PNSObject
     pub fn rust_name(&self) -> String {
         if let Some(ref cat) = self.category {
             format!("{}_{}", self.name(), cat)
         } else {
             if self.is_protocol {
-                format!("protocol_{}", self.name())
+                format!("P{}", self.name())
             } else {
-                self.name().to_owned()
+                format!("I{}", self.name().to_owned())
             }
         }
     }
@@ -98,6 +99,16 @@ impl ObjCInterface {
     /// List of the methods defined in this interface
     pub fn methods(&self) -> &Vec<ObjCMethod> {
         &self.methods
+    }
+
+    /// Is this a protocol?
+    pub fn is_protocol(&self) -> bool {
+        self.is_protocol
+    }
+
+    /// Is this a category?
+    pub fn is_category(&self) -> bool {
+        self.category.is_some()
     }
 
     /// List of the class methods defined in this interface
@@ -129,7 +140,7 @@ impl ObjCInterface {
                 }
                 CXCursor_ObjCProtocolRef => {
                     // Gather protocols this interface conforms to
-                    let needle = format!("protocol_{}", c.spelling());
+                    let needle = format!("P{}", c.spelling());
                     let items_map = ctx.items();
                     debug!("Interface {} conforms to {}, find the item", interface.name, needle);
 

--- a/tests/expectations/tests/libclang-3.8/objc_template.rs
+++ b/tests/expectations/tests/libclang-3.8/objc_template.rs
@@ -8,21 +8,56 @@
 extern crate objc;
 #[allow(non_camel_case_types)]
 pub type id = *mut objc::runtime::Object;
-pub trait Foo<ObjectType> {
-    unsafe fn get(self) -> id;
+#[repr(transparent)]
+#[derive(Clone, Copy)]
+pub struct Foo(pub id);
+impl std::ops::Deref for Foo {
+    type Target = objc::runtime::Object;
+    fn deref(&self) -> &Self::Target {
+        unsafe { &*self.0 }
+    }
 }
-impl<ObjectType: 'static> Foo<ObjectType> for id {
-    unsafe fn get(self) -> id {
+unsafe impl objc::Message for Foo {}
+impl Foo {
+    pub fn alloc() -> Self {
+        Self(unsafe { msg_send!(objc::class!(Foo), alloc) })
+    }
+}
+impl<ObjectType: 'static> IFoo<ObjectType> for Foo {}
+pub trait IFoo<ObjectType>: Sized + std::ops::Deref {
+    unsafe fn get(self) -> id
+    where
+        <Self as std::ops::Deref>::Target: objc::Message + Sized,
+    {
         msg_send!(self, get)
     }
 }
-pub trait FooMultiGeneric<KeyType, ObjectType> {
-    unsafe fn objectForKey_(self, key: id) -> id;
+#[repr(transparent)]
+#[derive(Clone, Copy)]
+pub struct FooMultiGeneric(pub id);
+impl std::ops::Deref for FooMultiGeneric {
+    type Target = objc::runtime::Object;
+    fn deref(&self) -> &Self::Target {
+        unsafe { &*self.0 }
+    }
 }
-impl<KeyType: 'static, ObjectType: 'static> FooMultiGeneric<KeyType, ObjectType>
-    for id
+unsafe impl objc::Message for FooMultiGeneric {}
+impl FooMultiGeneric {
+    pub fn alloc() -> Self {
+        Self(unsafe { msg_send!(objc::class!(FooMultiGeneric), alloc) })
+    }
+}
+impl<KeyType: 'static, ObjectType: 'static>
+    IFooMultiGeneric<KeyType, ObjectType> for FooMultiGeneric
 {
-    unsafe fn objectForKey_(self, key: id) -> id {
+}
+pub trait IFooMultiGeneric<KeyType, ObjectType>:
+    Sized + std::ops::Deref
+{
+    unsafe fn objectForKey_(self, key: id) -> id
+    where
+        <Self as std::ops::Deref>::Target: objc::Message + Sized,
+    {
         msg_send!(self, objectForKey: key)
     }
 }

--- a/tests/expectations/tests/libclang-3.9/objc_template.rs
+++ b/tests/expectations/tests/libclang-3.9/objc_template.rs
@@ -8,21 +8,56 @@
 extern crate objc;
 #[allow(non_camel_case_types)]
 pub type id = *mut objc::runtime::Object;
-pub trait Foo<ObjectType> {
-    unsafe fn get(self) -> id;
+#[repr(transparent)]
+#[derive(Clone, Copy)]
+pub struct Foo(pub id);
+impl std::ops::Deref for Foo {
+    type Target = objc::runtime::Object;
+    fn deref(&self) -> &Self::Target {
+        unsafe { &*self.0 }
+    }
 }
-impl<ObjectType: 'static> Foo<ObjectType> for id {
-    unsafe fn get(self) -> id {
+unsafe impl objc::Message for Foo {}
+impl Foo {
+    pub fn alloc() -> Self {
+        Self(unsafe { msg_send!(objc::class!(Foo), alloc) })
+    }
+}
+impl<ObjectType: 'static> IFoo<ObjectType> for Foo {}
+pub trait IFoo<ObjectType>: Sized + std::ops::Deref {
+    unsafe fn get(self) -> id
+    where
+        <Self as std::ops::Deref>::Target: objc::Message + Sized,
+    {
         msg_send!(self, get)
     }
 }
-pub trait FooMultiGeneric<KeyType, ObjectType> {
-    unsafe fn objectForKey_(self, key: id) -> id;
+#[repr(transparent)]
+#[derive(Clone, Copy)]
+pub struct FooMultiGeneric(pub id);
+impl std::ops::Deref for FooMultiGeneric {
+    type Target = objc::runtime::Object;
+    fn deref(&self) -> &Self::Target {
+        unsafe { &*self.0 }
+    }
 }
-impl<KeyType: 'static, ObjectType: 'static> FooMultiGeneric<KeyType, ObjectType>
-    for id
+unsafe impl objc::Message for FooMultiGeneric {}
+impl FooMultiGeneric {
+    pub fn alloc() -> Self {
+        Self(unsafe { msg_send!(objc::class!(FooMultiGeneric), alloc) })
+    }
+}
+impl<KeyType: 'static, ObjectType: 'static>
+    IFooMultiGeneric<KeyType, ObjectType> for FooMultiGeneric
 {
-    unsafe fn objectForKey_(self, key: id) -> id {
+}
+pub trait IFooMultiGeneric<KeyType, ObjectType>:
+    Sized + std::ops::Deref
+{
+    unsafe fn objectForKey_(self, key: id) -> id
+    where
+        <Self as std::ops::Deref>::Target: objc::Message + Sized,
+    {
         msg_send!(self, objectForKey: key)
     }
 }

--- a/tests/expectations/tests/libclang-4/objc_template.rs
+++ b/tests/expectations/tests/libclang-4/objc_template.rs
@@ -9,20 +9,56 @@
 extern crate objc;
 #[allow(non_camel_case_types)]
 pub type id = *mut objc::runtime::Object;
-pub trait Foo<ObjectType> {
-    unsafe fn get(self)
-    -> *mut ObjectType;
+#[repr(transparent)]
+#[derive(Clone, Copy)]
+pub struct Foo(pub id);
+impl std::ops::Deref for Foo {
+    type Target = objc::runtime::Object;
+    fn deref(&self) -> &Self::Target {
+        unsafe { &*self.0 }
+    }
 }
-impl<ObjectType: 'static> Foo<ObjectType> for id {
-    unsafe fn get(self) -> *mut ObjectType { msg_send!(self , get) }
+unsafe impl objc::Message for Foo {}
+impl Foo {
+    pub fn alloc() -> Self {
+        Self(unsafe { msg_send!(objc::class!(Foo), alloc) })
+    }
 }
-pub trait FooMultiGeneric<KeyType, ObjectType> {
-    unsafe fn objectForKey_(self, key: *mut KeyType) -> *mut ObjectType;
+impl<ObjectType: 'static> IFoo<ObjectType> for Foo {}
+pub trait IFoo<ObjectType>: Sized + std::ops::Deref {
+    unsafe fn get(self) -> *mut ObjectType
+    where
+        <Self as std::ops::Deref>::Target: objc::Message + Sized,
+    {
+        msg_send!(self , get)
+    }
 }
-impl<KeyType: 'static, ObjectType: 'static> FooMultiGeneric<KeyType, ObjectType>
-    for id
+#[repr(transparent)]
+#[derive(Clone, Copy)]
+pub struct FooMultiGeneric(pub id);
+impl std::ops::Deref for FooMultiGeneric {
+    type Target = objc::runtime::Object;
+    fn deref(&self) -> &Self::Target {
+        unsafe { &*self.0 }
+    }
+}
+unsafe impl objc::Message for FooMultiGeneric {}
+impl FooMultiGeneric {
+    pub fn alloc() -> Self {
+        Self(unsafe { msg_send!(objc::class!(FooMultiGeneric), alloc) })
+    }
+}
+impl<KeyType: 'static, ObjectType: 'static>
+    IFooMultiGeneric<KeyType, ObjectType> for FooMultiGeneric
 {
-    unsafe fn objectForKey_(self, key: *mut KeyType) -> *mut ObjectType {
+}
+pub trait IFooMultiGeneric<KeyType, ObjectType>:
+    Sized + std::ops::Deref
+{
+    unsafe fn objectForKey_(self, key: *mut KeyType) -> *mut ObjectType
+    where
+        <Self as std::ops::Deref>::Target: objc::Message + Sized,
+    {
         msg_send!(self, objectForKey: key)
     }
 }

--- a/tests/expectations/tests/libclang-5/objc_template.rs
+++ b/tests/expectations/tests/libclang-5/objc_template.rs
@@ -12,21 +12,56 @@
 extern crate objc;
 #[allow(non_camel_case_types)]
 pub type id = *mut objc::runtime::Object;
-pub trait Foo<ObjectType> {
-    unsafe fn get(self) -> *mut ObjectType;
+#[repr(transparent)]
+#[derive(Clone, Copy)]
+pub struct Foo(pub id);
+impl std::ops::Deref for Foo {
+    type Target = objc::runtime::Object;
+    fn deref(&self) -> &Self::Target {
+        unsafe { &*self.0 }
+    }
 }
-impl<ObjectType: 'static> Foo<ObjectType> for id {
-    unsafe fn get(self) -> *mut ObjectType {
+unsafe impl objc::Message for Foo {}
+impl Foo {
+    pub fn alloc() -> Self {
+        Self(unsafe { msg_send!(objc::class!(Foo), alloc) })
+    }
+}
+impl<ObjectType: 'static> IFoo<ObjectType> for Foo {}
+pub trait IFoo<ObjectType>: Sized + std::ops::Deref {
+    unsafe fn get(self) -> *mut ObjectType
+    where
+        <Self as std::ops::Deref>::Target: objc::Message + Sized,
+    {
         msg_send!(self, get)
     }
 }
-pub trait FooMultiGeneric<KeyType, ObjectType> {
-    unsafe fn objectForKey_(self, key: *mut KeyType) -> *mut ObjectType;
+#[repr(transparent)]
+#[derive(Clone, Copy)]
+pub struct FooMultiGeneric(pub id);
+impl std::ops::Deref for FooMultiGeneric {
+    type Target = objc::runtime::Object;
+    fn deref(&self) -> &Self::Target {
+        unsafe { &*self.0 }
+    }
 }
-impl<KeyType: 'static, ObjectType: 'static> FooMultiGeneric<KeyType, ObjectType>
-    for id
+unsafe impl objc::Message for FooMultiGeneric {}
+impl FooMultiGeneric {
+    pub fn alloc() -> Self {
+        Self(unsafe { msg_send!(objc::class!(FooMultiGeneric), alloc) })
+    }
+}
+impl<KeyType: 'static, ObjectType: 'static>
+    IFooMultiGeneric<KeyType, ObjectType> for FooMultiGeneric
 {
-    unsafe fn objectForKey_(self, key: *mut KeyType) -> *mut ObjectType {
+}
+pub trait IFooMultiGeneric<KeyType, ObjectType>:
+    Sized + std::ops::Deref
+{
+    unsafe fn objectForKey_(self, key: *mut KeyType) -> *mut ObjectType
+    where
+        <Self as std::ops::Deref>::Target: objc::Message + Sized,
+    {
         msg_send!(self, objectForKey: key)
     }
 }

--- a/tests/expectations/tests/libclang-9/objc_template.rs
+++ b/tests/expectations/tests/libclang-9/objc_template.rs
@@ -12,21 +12,56 @@
 extern crate objc;
 #[allow(non_camel_case_types)]
 pub type id = *mut objc::runtime::Object;
-pub trait Foo<ObjectType> {
-    unsafe fn get(self) -> u64;
+#[repr(transparent)]
+#[derive(Clone, Copy)]
+pub struct Foo(pub id);
+impl std::ops::Deref for Foo {
+    type Target = objc::runtime::Object;
+    fn deref(&self) -> &Self::Target {
+        unsafe { &*self.0 }
+    }
 }
-impl<ObjectType: 'static> Foo<ObjectType> for id {
-    unsafe fn get(self) -> u64 {
+unsafe impl objc::Message for Foo {}
+impl Foo {
+    pub fn alloc() -> Self {
+        Self(unsafe { msg_send!(objc::class!(Foo), alloc) })
+    }
+}
+impl<ObjectType: 'static> IFoo<ObjectType> for Foo {}
+pub trait IFoo<ObjectType>: Sized + std::ops::Deref {
+    unsafe fn get(self) -> u64
+    where
+        <Self as std::ops::Deref>::Target: objc::Message + Sized,
+    {
         msg_send!(self, get)
     }
 }
-pub trait FooMultiGeneric<KeyType, ObjectType> {
-    unsafe fn objectForKey_(self, key: u64) -> u64;
+#[repr(transparent)]
+#[derive(Clone, Copy)]
+pub struct FooMultiGeneric(pub id);
+impl std::ops::Deref for FooMultiGeneric {
+    type Target = objc::runtime::Object;
+    fn deref(&self) -> &Self::Target {
+        unsafe { &*self.0 }
+    }
 }
-impl<KeyType: 'static, ObjectType: 'static> FooMultiGeneric<KeyType, ObjectType>
-    for id
+unsafe impl objc::Message for FooMultiGeneric {}
+impl FooMultiGeneric {
+    pub fn alloc() -> Self {
+        Self(unsafe { msg_send!(objc::class!(FooMultiGeneric), alloc) })
+    }
+}
+impl<KeyType: 'static, ObjectType: 'static>
+    IFooMultiGeneric<KeyType, ObjectType> for FooMultiGeneric
 {
-    unsafe fn objectForKey_(self, key: u64) -> u64 {
+}
+pub trait IFooMultiGeneric<KeyType, ObjectType>:
+    Sized + std::ops::Deref
+{
+    unsafe fn objectForKey_(self, key: u64) -> u64
+    where
+        <Self as std::ops::Deref>::Target: objc::Message + Sized,
+    {
         msg_send!(self, objectForKey: key)
     }
 }

--- a/tests/expectations/tests/objc_category.rs
+++ b/tests/expectations/tests/objc_category.rs
@@ -12,19 +12,36 @@
 extern crate objc;
 #[allow(non_camel_case_types)]
 pub type id = *mut objc::runtime::Object;
-pub trait Foo {
-    unsafe fn method(self);
+#[repr(transparent)]
+#[derive(Clone, Copy)]
+pub struct Foo(pub id);
+impl std::ops::Deref for Foo {
+    type Target = objc::runtime::Object;
+    fn deref(&self) -> &Self::Target {
+        unsafe { &*self.0 }
+    }
 }
-impl Foo for id {
-    unsafe fn method(self) {
+unsafe impl objc::Message for Foo {}
+impl Foo {
+    pub fn alloc() -> Self {
+        Self(unsafe { msg_send!(objc::class!(Foo), alloc) })
+    }
+}
+impl IFoo for Foo {}
+pub trait IFoo: Sized + std::ops::Deref {
+    unsafe fn method(self)
+    where
+        <Self as std::ops::Deref>::Target: objc::Message + Sized,
+    {
         msg_send!(self, method)
     }
 }
-pub trait Foo_BarCategory {
-    unsafe fn categoryMethod(self);
-}
-impl Foo_BarCategory for id {
-    unsafe fn categoryMethod(self) {
+impl Foo_BarCategory for Foo {}
+pub trait Foo_BarCategory: Sized + std::ops::Deref {
+    unsafe fn categoryMethod(self)
+    where
+        <Self as std::ops::Deref>::Target: objc::Message + Sized,
+    {
         msg_send!(self, categoryMethod)
     }
 }

--- a/tests/expectations/tests/objc_class_method.rs
+++ b/tests/expectations/tests/objc_class_method.rs
@@ -12,54 +12,60 @@
 extern crate objc;
 #[allow(non_camel_case_types)]
 pub type id = *mut objc::runtime::Object;
-pub trait Foo {
-    unsafe fn method();
-    unsafe fn methodWithInt_(foo: ::std::os::raw::c_int);
-    unsafe fn methodWithFoo_(foo: id);
-    unsafe fn methodReturningInt() -> ::std::os::raw::c_int;
-    unsafe fn methodReturningFoo() -> *mut id;
-    unsafe fn methodWithArg1_andArg2_andArg3_(
-        intvalue: ::std::os::raw::c_int,
-        ptr: *mut ::std::os::raw::c_char,
-        floatvalue: f32,
-    );
+#[repr(transparent)]
+#[derive(Clone, Copy)]
+pub struct Foo(pub id);
+impl std::ops::Deref for Foo {
+    type Target = objc::runtime::Object;
+    fn deref(&self) -> &Self::Target {
+        unsafe { &*self.0 }
+    }
 }
-impl Foo for id {
-    unsafe fn method() {
-        msg_send!(
-            objc::runtime::Class::get("Foo").expect("Couldn't find Foo"),
-            method
-        )
+unsafe impl objc::Message for Foo {}
+impl Foo {
+    pub fn alloc() -> Self {
+        Self(unsafe { msg_send!(objc::class!(Foo), alloc) })
     }
-    unsafe fn methodWithInt_(foo: ::std::os::raw::c_int) {
-        msg_send!(
-            objc::runtime::Class::get("Foo").expect("Couldn't find Foo"),
-            methodWithInt: foo
-        )
+}
+impl IFoo for Foo {}
+pub trait IFoo: Sized + std::ops::Deref {
+    unsafe fn method()
+    where
+        <Self as std::ops::Deref>::Target: objc::Message + Sized,
+    {
+        msg_send!(class!(Foo), method)
     }
-    unsafe fn methodWithFoo_(foo: id) {
-        msg_send!(
-            objc::runtime::Class::get("Foo").expect("Couldn't find Foo"),
-            methodWithFoo: foo
-        )
+    unsafe fn methodWithInt_(foo: ::std::os::raw::c_int)
+    where
+        <Self as std::ops::Deref>::Target: objc::Message + Sized,
+    {
+        msg_send!(class!(Foo), methodWithInt: foo)
     }
-    unsafe fn methodReturningInt() -> ::std::os::raw::c_int {
-        msg_send!(
-            objc::runtime::Class::get("Foo").expect("Couldn't find Foo"),
-            methodReturningInt
-        )
+    unsafe fn methodWithFoo_(foo: id)
+    where
+        <Self as std::ops::Deref>::Target: objc::Message + Sized,
+    {
+        msg_send!(class!(Foo), methodWithFoo: foo)
     }
-    unsafe fn methodReturningFoo() -> *mut id {
-        msg_send!(
-            objc::runtime::Class::get("Foo").expect("Couldn't find Foo"),
-            methodReturningFoo
-        )
+    unsafe fn methodReturningInt() -> ::std::os::raw::c_int
+    where
+        <Self as std::ops::Deref>::Target: objc::Message + Sized,
+    {
+        msg_send!(class!(Foo), methodReturningInt)
+    }
+    unsafe fn methodReturningFoo() -> *mut objc::runtime::Object
+    where
+        <Self as std::ops::Deref>::Target: objc::Message + Sized,
+    {
+        msg_send!(class!(Foo), methodReturningFoo)
     }
     unsafe fn methodWithArg1_andArg2_andArg3_(
         intvalue: ::std::os::raw::c_int,
         ptr: *mut ::std::os::raw::c_char,
         floatvalue: f32,
-    ) {
-        msg_send ! ( objc :: runtime :: Class :: get ( "Foo" ) . expect ( "Couldn't find Foo" ) , methodWithArg1 : intvalue andArg2 : ptr andArg3 : floatvalue )
+    ) where
+        <Self as std::ops::Deref>::Target: objc::Message + Sized,
+    {
+        msg_send ! ( class ! ( Foo ) , methodWithArg1 : intvalue andArg2 : ptr andArg3 : floatvalue )
     }
 }

--- a/tests/expectations/tests/objc_interface.rs
+++ b/tests/expectations/tests/objc_interface.rs
@@ -12,7 +12,21 @@
 extern crate objc;
 #[allow(non_camel_case_types)]
 pub type id = *mut objc::runtime::Object;
-pub trait Foo {}
-impl Foo for id {}
-pub trait protocol_bar {}
-impl protocol_bar for id {}
+#[repr(transparent)]
+#[derive(Clone, Copy)]
+pub struct Foo(pub id);
+impl std::ops::Deref for Foo {
+    type Target = objc::runtime::Object;
+    fn deref(&self) -> &Self::Target {
+        unsafe { &*self.0 }
+    }
+}
+unsafe impl objc::Message for Foo {}
+impl Foo {
+    pub fn alloc() -> Self {
+        Self(unsafe { msg_send!(objc::class!(Foo), alloc) })
+    }
+}
+impl IFoo for Foo {}
+pub trait IFoo: Sized + std::ops::Deref {}
+pub trait Pbar: Sized + std::ops::Deref {}

--- a/tests/expectations/tests/objc_method.rs
+++ b/tests/expectations/tests/objc_method.rs
@@ -12,40 +12,51 @@
 extern crate objc;
 #[allow(non_camel_case_types)]
 pub type id = *mut objc::runtime::Object;
-pub trait Foo {
-    unsafe fn method(self);
-    unsafe fn methodWithInt_(self, foo: ::std::os::raw::c_int);
-    unsafe fn methodWithFoo_(self, foo: id);
-    unsafe fn methodReturningInt(self) -> ::std::os::raw::c_int;
-    unsafe fn methodReturningFoo(self) -> *mut id;
-    unsafe fn methodWithArg1_andArg2_andArg3_(
-        self,
-        intvalue: ::std::os::raw::c_int,
-        ptr: *mut ::std::os::raw::c_char,
-        floatvalue: f32,
-    );
-    unsafe fn methodWithAndWithoutKeywords_arg2Name__arg4Name_(
-        self,
-        arg1: ::std::os::raw::c_int,
-        arg2: f32,
-        arg3: f32,
-        arg4: ::std::os::raw::c_int,
-    ) -> instancetype;
+#[repr(transparent)]
+#[derive(Clone, Copy)]
+pub struct Foo(pub id);
+impl std::ops::Deref for Foo {
+    type Target = objc::runtime::Object;
+    fn deref(&self) -> &Self::Target {
+        unsafe { &*self.0 }
+    }
 }
-impl Foo for id {
-    unsafe fn method(self) {
+unsafe impl objc::Message for Foo {}
+impl Foo {
+    pub fn alloc() -> Self {
+        Self(unsafe { msg_send!(objc::class!(Foo), alloc) })
+    }
+}
+impl IFoo for Foo {}
+pub trait IFoo: Sized + std::ops::Deref {
+    unsafe fn method(self)
+    where
+        <Self as std::ops::Deref>::Target: objc::Message + Sized,
+    {
         msg_send!(self, method)
     }
-    unsafe fn methodWithInt_(self, foo: ::std::os::raw::c_int) {
+    unsafe fn methodWithInt_(self, foo: ::std::os::raw::c_int)
+    where
+        <Self as std::ops::Deref>::Target: objc::Message + Sized,
+    {
         msg_send!(self, methodWithInt: foo)
     }
-    unsafe fn methodWithFoo_(self, foo: id) {
+    unsafe fn methodWithFoo_(self, foo: id)
+    where
+        <Self as std::ops::Deref>::Target: objc::Message + Sized,
+    {
         msg_send!(self, methodWithFoo: foo)
     }
-    unsafe fn methodReturningInt(self) -> ::std::os::raw::c_int {
+    unsafe fn methodReturningInt(self) -> ::std::os::raw::c_int
+    where
+        <Self as std::ops::Deref>::Target: objc::Message + Sized,
+    {
         msg_send!(self, methodReturningInt)
     }
-    unsafe fn methodReturningFoo(self) -> *mut id {
+    unsafe fn methodReturningFoo(self) -> *mut objc::runtime::Object
+    where
+        <Self as std::ops::Deref>::Target: objc::Message + Sized,
+    {
         msg_send!(self, methodReturningFoo)
     }
     unsafe fn methodWithArg1_andArg2_andArg3_(
@@ -53,7 +64,9 @@ impl Foo for id {
         intvalue: ::std::os::raw::c_int,
         ptr: *mut ::std::os::raw::c_char,
         floatvalue: f32,
-    ) {
+    ) where
+        <Self as std::ops::Deref>::Target: objc::Message + Sized,
+    {
         msg_send ! ( self , methodWithArg1 : intvalue andArg2 : ptr andArg3 : floatvalue )
     }
     unsafe fn methodWithAndWithoutKeywords_arg2Name__arg4Name_(
@@ -62,7 +75,10 @@ impl Foo for id {
         arg2: f32,
         arg3: f32,
         arg4: ::std::os::raw::c_int,
-    ) -> instancetype {
+    ) -> instancetype
+    where
+        <Self as std::ops::Deref>::Target: objc::Message + Sized,
+    {
         msg_send ! ( self , methodWithAndWithoutKeywords : arg1 arg2Name : arg2 arg3 : arg3 arg4Name : arg4 )
     }
 }

--- a/tests/expectations/tests/objc_property_fnptr.rs
+++ b/tests/expectations/tests/objc_property_fnptr.rs
@@ -12,24 +12,23 @@
 extern crate objc;
 #[allow(non_camel_case_types)]
 pub type id = *mut objc::runtime::Object;
-pub trait Foo {
-    unsafe fn func(
-        self,
-    ) -> ::std::option::Option<
-        unsafe extern "C" fn(
-            arg1: ::std::os::raw::c_char,
-            arg2: ::std::os::raw::c_short,
-            arg3: f32,
-        ) -> ::std::os::raw::c_int,
-    >;
-    unsafe fn setFunc_(
-        self,
-        func: ::std::option::Option<
-            unsafe extern "C" fn() -> ::std::os::raw::c_int,
-        >,
-    );
+#[repr(transparent)]
+#[derive(Clone, Copy)]
+pub struct Foo(pub id);
+impl std::ops::Deref for Foo {
+    type Target = objc::runtime::Object;
+    fn deref(&self) -> &Self::Target {
+        unsafe { &*self.0 }
+    }
 }
-impl Foo for id {
+unsafe impl objc::Message for Foo {}
+impl Foo {
+    pub fn alloc() -> Self {
+        Self(unsafe { msg_send!(objc::class!(Foo), alloc) })
+    }
+}
+impl IFoo for Foo {}
+pub trait IFoo: Sized + std::ops::Deref {
     unsafe fn func(
         self,
     ) -> ::std::option::Option<
@@ -38,7 +37,10 @@ impl Foo for id {
             arg2: ::std::os::raw::c_short,
             arg3: f32,
         ) -> ::std::os::raw::c_int,
-    > {
+    >
+    where
+        <Self as std::ops::Deref>::Target: objc::Message + Sized,
+    {
         msg_send!(self, func)
     }
     unsafe fn setFunc_(
@@ -46,7 +48,9 @@ impl Foo for id {
         func: ::std::option::Option<
             unsafe extern "C" fn() -> ::std::os::raw::c_int,
         >,
-    ) {
+    ) where
+        <Self as std::ops::Deref>::Target: objc::Message + Sized,
+    {
         msg_send!(self, setFunc: func)
     }
 }

--- a/tests/expectations/tests/objc_protocol.rs
+++ b/tests/expectations/tests/objc_protocol.rs
@@ -12,7 +12,22 @@
 extern crate objc;
 #[allow(non_camel_case_types)]
 pub type id = *mut objc::runtime::Object;
-pub trait protocol_Foo {}
-impl protocol_Foo for id {}
-pub trait Foo {}
-impl Foo for id {}
+pub trait PFoo: Sized + std::ops::Deref {}
+#[repr(transparent)]
+#[derive(Clone, Copy)]
+pub struct Foo(pub id);
+impl std::ops::Deref for Foo {
+    type Target = objc::runtime::Object;
+    fn deref(&self) -> &Self::Target {
+        unsafe { &*self.0 }
+    }
+}
+unsafe impl objc::Message for Foo {}
+impl Foo {
+    pub fn alloc() -> Self {
+        Self(unsafe { msg_send!(objc::class!(Foo), alloc) })
+    }
+}
+impl PFoo for Foo {}
+impl IFoo for Foo {}
+pub trait IFoo: Sized + std::ops::Deref {}

--- a/tests/expectations/tests/objc_whitelist.rs
+++ b/tests/expectations/tests/objc_whitelist.rs
@@ -12,37 +12,5 @@
 extern crate objc;
 #[allow(non_camel_case_types)]
 pub type id = *mut objc::runtime::Object;
-pub trait protocol_SomeProtocol {
-    unsafe fn protocolMethod(self);
-    unsafe fn protocolClassMethod();
-}
-impl protocol_SomeProtocol for id {
-    unsafe fn protocolMethod(self) {
-        msg_send!(self, protocolMethod)
-    }
-    unsafe fn protocolClassMethod() {
-        msg_send!(
-            objc::runtime::Class::get("SomeProtocol")
-                .expect("Couldn't find SomeProtocol"),
-            protocolClassMethod
-        )
-    }
-}
-pub trait WhitelistMe {
-    unsafe fn method(self);
-    unsafe fn classMethod();
-}
-impl WhitelistMe for id {
-    unsafe fn method(self) {
-        msg_send!(self, method)
-    }
-    unsafe fn classMethod() {
-        msg_send!(
-            objc::runtime::Class::get("WhitelistMe")
-                .expect("Couldn't find WhitelistMe"),
-            classMethod
-        )
-    }
-}
-pub trait WhitelistMe_InterestingCategory {}
-impl WhitelistMe_InterestingCategory for id {}
+impl WhitelistMe_InterestingCategory for WhitelistMe {}
+pub trait WhitelistMe_InterestingCategory: Sized + std::ops::Deref {}


### PR DESCRIPTION
I took a whack at doing a bit of #109. There hasn't been much movement on the issue so I wanted some feedback on some of the trait constraints generated.

Here's a summary of the changes:
* Each objective-c interface `Foo` now has a `struct_Foo` which wraps the `id` as mentioned in #109. 
* I removed `impl interface_Foo for id { all_the_trait_fns }` and replaced it with `pub trait interface_Foo { all_the_trait_fns }`, and added `impl interface_Foo for struct_Foo { }`. This allows some of the simple inheritance.
* I added trait constraints of `Sized + std::ops::Deref + objc::Message`, to mimic the [objc-foundation crate](https://github.com/SSheldon/rust-objc-foundation/blob/15f9ebec1190889e48a4bc2d36601e61d303071f/src/object.rs#L10).
* Added an `impl struct_Foo { fn alloc() {...}}` for creation of methods.

~I still need to add an `impl struct_Foo { fn alloc() {...}}` for the structs as a convenience method.~

Also, I think it might be useful to have things that return a different type from a given function to be of that wrapped type So, when a `interface_Foo` trait has a property of type `Bar`, it'd return `Bar(id)`. Thoughts?

I've tested this out with generating bindings for a [uikit-sys crate](https://github.com/simlay/uikit-sys) I've been working on and it compiles. That being said, it's still a WIP.