### PR TITLE
Update to latest version of bindgen

### DIFF
--- a/book/src/tutorial-1.md
+++ b/book/src/tutorial-1.md
@@ -4,12 +4,12 @@ First we need to declare a build-time dependency on `bindgen` by adding it to
 the `[build-dependencies]` section of our crate's `Cargo.toml` file.
 
 Please always use the latest version of `bindgen`, it has the most fixes and
-best compatibility. At the time of writing the latest bindgen is `0.51.1`, but
+best compatibility. At the time of writing the latest bindgen is `0.53.1`, but
 you can always check [the bindgen page of
 crates.io](https://crates.io/crates/bindgen) to verify the latest version if
 you're unsure.
 
 ```toml
 [build-dependencies]
-bindgen = "0.51.1"
+bindgen = "0.53.1"
 ```


### PR DESCRIPTION
using version 0.51.1 would trigger a build error like:
```
   |
   |         .parse_callbacks(Box::new(bindgen::CargoCallbacks))
   |                                            ^^^^^^^^^^^^^^ not found in `bindgen`
```

when using sample from tutorial.