### PR TITLE
propose adding host v. target architecture mismatch to problem list

### DIFF
--- a/src/ir/context.rs
+++ b/src/ir/context.rs
@@ -575,6 +575,7 @@ impl BindgenContext {
 - Unrecognized flags
 - Invalid flag arguments
 - File I/O errors
+- Host vs. target architecture mismatch
 If you encounter an error missing from this list, please file an issue or a PR!")
         };
 


### PR DESCRIPTION
I spent an afternoon scratching my head on this one before I ran
into https://github.com/rust-lang/rust-bindgen/issues/1728.

Since the error message welcomes PRs...maybe this will help save other people time by adding this to the list of things to check?
