### PR TITLE
Delay invoking clang version checks until a functional path is taken

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -17,12 +17,7 @@ mod log_stubs;
 mod options;
 use options::builder_from_flags;
 
-pub fn main() {
-    #[cfg(feature = "logging")]
-    env_logger::init();
-
-    let bind_args: Vec<_> = env::args().collect();
-
+fn clang_version_check() {
     let version = clang_version();
     let expected_version = if cfg!(feature = "testing_only_libclang_9") {
         Some((9, 0))
@@ -46,9 +41,17 @@ pub fn main() {
     if expected_version.is_some() {
         assert_eq!(version.parsed, version.parsed);
     }
+}
+
+pub fn main() {
+    #[cfg(feature = "logging")]
+    env_logger::init();
+
+    let bind_args: Vec<_> = env::args().collect();
 
     match builder_from_flags(bind_args.into_iter()) {
         Ok((builder, output, verbose)) => {
+            clang_version_check();
             let builder_result = panic::catch_unwind(|| {
                 builder.generate().expect("Unable to generate bindings")
             });


### PR DESCRIPTION
This allows avoiding large numbers of system calls to dynaload clang
to determine its version, when no action is performed, for example:

- When calling `--version` / `-V`
- When calling `--help`

This improves the raw responsiveness from:

  Before:
```
    time bindgen --help # 0.593s
    strace -cf bindgen --help # 83k syscalls, 64k to statx
```
  After:
```
    time bindgen --help # 0.004s
    strace -cf bindgen --help # 90 syscalls
```
However, it does mean that you can no longer obtain the discovered
clang version with:
```bash
RUST_LOG=info bindgen -V
```
But this may be remedied in a future commit.

Closes: https://github.com/rust-lang/rust-bindgen/issues/1736