### PR TITLE
Sanitize RegexSet input so alternation is properly handled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,6 +151,9 @@
 
 ## Changed
 
+ * Regex inputs are sanitized so alternation (`a|b`) is handled correctly but
+   wildcard patterns (`*`) are now considered invalid.
+
 ## Removed
 
 ## Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,7 +48,7 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "bindgen"
-version = "0.61.0"
+version = "0.62.0"
 dependencies = [
  "bitflags",
  "cexpr",
@@ -68,7 +68,7 @@ dependencies = [
 
 [[package]]
 name = "bindgen-cli"
-version = "0.61.0"
+version = "0.62.0"
 dependencies = [
  "bindgen",
  "clap 3.2.12",

--- a/bindgen-cli/Cargo.toml
+++ b/bindgen-cli/Cargo.toml
@@ -11,7 +11,7 @@ readme = "../README.md"
 repository = "https://github.com/rust-lang/rust-bindgen"
 documentation = "https://docs.rs/bindgen"
 homepage = "https://rust-lang.github.io/rust-bindgen/"
-version = "0.61.0"
+version = "0.62.0"
 edition = "2018"
 # If you change this, also update README.md and msrv in .github/workflows/bindgen.yml
 rust-version = "1.57.0"

--- a/bindgen-tests/tests/expectations/tests/whitelist-alternates.rs
+++ b/bindgen-tests/tests/expectations/tests/whitelist-alternates.rs
@@ -1,0 +1,39 @@
+#![allow(
+    dead_code,
+    non_snake_case,
+    non_camel_case_types,
+    non_upper_case_globals
+)]
+
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct WhitelistedType {}
+#[test]
+fn bindgen_test_layout_WhitelistedType() {
+    assert_eq!(
+        ::std::mem::size_of::<WhitelistedType>(),
+        0usize,
+        concat!("Size of: ", stringify!(WhitelistedType))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<WhitelistedType>(),
+        1usize,
+        concat!("Alignment of ", stringify!(WhitelistedType))
+    );
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct AllowType {}
+#[test]
+fn bindgen_test_layout_AllowType() {
+    assert_eq!(
+        ::std::mem::size_of::<AllowType>(),
+        0usize,
+        concat!("Size of: ", stringify!(AllowType))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<AllowType>(),
+        1usize,
+        concat!("Alignment of ", stringify!(AllowType))
+    );
+}

--- a/bindgen-tests/tests/headers/empty-union.hpp
+++ b/bindgen-tests/tests/headers/empty-union.hpp
@@ -1,4 +1,4 @@
-// bindgen-flags: --opaque-type "*"
+// bindgen-flags: --opaque-type ".*"
 
 template <int> class a {
   union {};

--- a/bindgen-tests/tests/headers/forward_declared_opaque.h
+++ b/bindgen-tests/tests/headers/forward_declared_opaque.h
@@ -1,4 +1,4 @@
-// bindgen-flags: --opaque-type "*"
+// bindgen-flags: --opaque-type ".*"
 
 union a;
 struct b;

--- a/bindgen-tests/tests/headers/ord-enum.h
+++ b/bindgen-tests/tests/headers/ord-enum.h
@@ -1,4 +1,4 @@
-// bindgen-flags: --rustified-enum * --with-derive-ord
+// bindgen-flags: --rustified-enum ".*" --with-derive-ord
 
 enum A {
 	A0 = 0,

--- a/bindgen-tests/tests/headers/whitelist-alternates.h
+++ b/bindgen-tests/tests/headers/whitelist-alternates.h
@@ -1,0 +1,8 @@
+// bindgen-flags: --whitelist-type 'Whitelisted.*|Allow.*'
+// Test for changes introduced in #1756
+
+struct WhitelistedType {};
+struct AllowType {};
+// this would have been accepted because the start anchor
+// wouldn't be applied to the second alternative:
+struct NoAllowType {};

--- a/bindgen/Cargo.toml
+++ b/bindgen/Cargo.toml
@@ -14,7 +14,7 @@ readme = "../README.md"
 repository = "https://github.com/rust-lang/rust-bindgen"
 documentation = "https://docs.rs/bindgen"
 homepage = "https://rust-lang.github.io/rust-bindgen/"
-version = "0.61.0"
+version = "0.62.0"
 edition = "2018"
 build = "build.rs"
 # If you change this, also update README.md and msrv in .github/workflows/bindgen.yml

--- a/bindgen/regex_set.rs
+++ b/bindgen/regex_set.rs
@@ -53,7 +53,7 @@ impl RegexSet {
     /// Must be called before calling `matches()`, or it will always return
     /// false.
     pub fn build(&mut self, record_matches: bool) {
-        let items = self.items.iter().map(|item| format!("^{}$", item));
+        let items = self.items.iter().map(|item| format!("^({})$", item));
         self.record_matches = record_matches;
         self.set = match RxSet::new(items) {
             Ok(x) => Some(x),

--- a/bindgen/regex_set.rs
+++ b/bindgen/regex_set.rs
@@ -26,7 +26,11 @@ impl RegexSet {
     where
         S: AsRef<str>,
     {
-        self.items.push(string.as_ref().to_owned());
+        let string = string.as_ref().to_owned();
+        if string == "*" {
+            warn!("using wildcard patterns (`*`) is no longer considered valid. Use `.*` instead");
+        }
+        self.items.push(string);
         self.matched.push(Cell::new(false));
         self.set = None;
     }


### PR DESCRIPTION
Resolves #1755 by wrapping the regexes provided to a `RegexSet` in a capture group, so the added anchors work properly with alternation.

This doesn't resolve the issue of implicit/hidden regex modifications performed by this crate, which should still be properly documented.