### PR TITLE
Indicate possible undefined behaviour in rustified enum docs and point to alternative

### DIFF
--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -2285,7 +2285,9 @@ impl MethodCodegen for Method {
 /// A helper type that represents different enum variations.
 #[derive(Copy, Clone, PartialEq, Debug)]
 pub enum EnumVariation {
-    /// The code for this enum will use a Rust enum
+    /// The code for this enum will use a Rust enum. Note that creating this in unsafe code
+    /// (including FFI) with an invalid value will invoke undefined behaviour, whether or not
+    /// its marked as non_exhaustive.
     Rust {
         /// Indicates whether the generated struct should be `#[non_exhaustive]`
         non_exhaustive: bool,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -939,9 +939,9 @@ impl Builder {
     /// This makes bindgen generate enums instead of constants. Regular
     /// expressions are supported.
     ///
-    /// **Use this with caution,** you probably want to use the non_exhaustive
-    /// flavor of rust enums instead of this one. Take a look at
-    /// https://github.com/rust-lang/rust/issues/36927 for more information.
+    /// **Use this with caution**, creating this in unsafe code
+    /// (including FFI) with an invalid value will invoke undefined behaviour.
+    /// You may want to use the newtype enum style instead.
     pub fn rustified_enum<T: AsRef<str>>(mut self, arg: T) -> Builder {
         self.options.rustified_enums.insert(arg);
         self
@@ -952,6 +952,10 @@ impl Builder {
     ///
     /// This makes bindgen generate enums instead of constants. Regular
     /// expressions are supported.
+    ///
+    /// **Use this with caution**, creating this in unsafe code
+    /// (including FFI) with an invalid value will invoke undefined behaviour.
+    /// You may want to use the newtype enum style instead.
     pub fn rustified_non_exhaustive_enum<T: AsRef<str>>(
         mut self,
         arg: T,


### PR DESCRIPTION
As talked about in #1554, this intends to make it clear that non_exhaustive doesn't solve the UB problem and recommends using the newtype enum style instead of both types of rustified enum.