### PR TITLE
Allow only generating layout tests

### DIFF
--- a/src/options.rs
+++ b/src/options.rs
@@ -149,6 +149,11 @@ where
                 .takes_value(true)
                 .multiple(true)
                 .number_of_values(1),
+            Arg::with_name("only-layout-tests")
+                .long("only-layout-tests")
+                .help(
+                    "Only emit layout tests. Allows separating the tests from the bindings."
+                ),
             Arg::with_name("no-layout-tests")
                 .long("no-layout-tests")
                 .help("Avoid generating layout tests for any type."),


### PR DESCRIPTION
This is so that they can be placed in a separate file, or generated in CI and run against checked-in tests, etc.

I took the discussion in #1655 to mean that this is something that would probably be accepted (in some form -- I'm not married to the implementation I've PRed) if done acceptably. LMK if that's untrue.

Other than cleaning up whats there and addressing the thing's I've left open at the end, I'd also like make this prefix to slap onto the start of types in tests, e.g. a module path. This avoids the need to add `use crate::*;` or w/e to the test file (it also means we don't have to `include!` it for cases where that's undesirable).

(This also might make the testing easier? Not sure).

Anyway: Lots of of questions / thoughts for bits I'd like some guidance on.

#### Testing?

It works tested manually, but I don't really know how to extend the existing test setup to support it. I think ideally we'd verify the tests are the same?

I could also just slap the tests onto the end of files and make sure they run.

I'd appreciate guidance here.

#### C++ Namespaces?

Supporting this for types in modules mapped from C++ namespaces seems to make this vastly harder, I think. Since we need the fully qualified name? I don't know, I've never used C++ with bindgen.

I don't think this is an important use case really, but I'm not opposed to making it work if I get some guidance. Ideally I'd just report some sort of error saying it doesn't work, but this looks like it would be the first error of that sort so...

Anyway, essentially my issue here is: how can I ensure that the types referenced in the test are in scope?

At first I thought: "if there's a way to get the, current 'mod stack', that would be ideal -- It seems like the code already knows about this, but I could easily add tracking to `CodegenResult` if not"...

But then I read more docs and realized that I don't really know how this works (I guess types are emitted with names like (for example) std_vector and not `mod std { struct vector ... }`? Or it's based on a setting?)

Anyway yeah, advice please.