### PR TITLE
Readme/CI: mention and test the MSRV

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,6 +65,7 @@ env:
     # Miscellaneous tests.
     - LLVM_VERSION="9.0" BINDGEN_JOB="misc"
     - LLVM_VERSION="9.0" BINDGEN_JOB="quickchecking"
+    - LLVM_VERSION="9.0" BINDGEN_JOB="msrv"
 
 matrix:
   fast_finish: true

--- a/README.md
+++ b/README.md
@@ -37,6 +37,12 @@ extern "C" {
 
 [📚 Read the `bindgen` users guide here! 📚](https://rust-lang.github.io/rust-bindgen)
 
+## MSRV
+
+The minimum supported Rust version is **1.34**.
+
+No MSRV bump policy has been established yet, so MSRV may increase in any release.
+
 ## API Reference
 
 [API reference documentation is on docs.rs](https://docs.rs/bindgen)

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -26,6 +26,15 @@ case "$BINDGEN_JOB" in
         ./ci/assert-no-diff.sh
         ;;
 
+    "msrv")
+        # Test that the bindgen library can be built with the minimum supported Rust version
+        # This test should not use Cargo.lock as it's ignored for library builds
+        rm Cargo.lock
+        # The MSRV below is also documented in README.md, please keep in sync
+        rustup install 1.34.0
+        cargo +1.34.0 build --lib $NO_DEFAULT_FEATURES --features "$BINDGEN_FEATURES"
+        ;;
+
     "integration")
         cd ./bindgen-integration
         cargo test "$BINDGEN_PROFILE" $NO_DEFAULT_FEATURES --features "$BINDGEN_FEATURES"


### PR DESCRIPTION
Write down the minimal supported Rust version in the README.md and add a CI test that ensures MSRV bumps cannot happen accidentally. No promises about MSRV bumps in minor versions are given.

The test intentionally removes `Cargo.lock` as the MSRV problem becomes most important when `bindgen` is used as a library dependency, and `Cargo.lock` is not used in that case anyway.

Fixes #1758.