### PR TITLE
Do not emit Rust method wrapper for blacklisted functions

### DIFF
--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -2146,6 +2146,10 @@ impl MethodCodegen for Method {
 
         // First of all, output the actual function.
         let function_item = ctx.resolve_item(self.signature());
+        if function_item.is_blacklisted(ctx) {
+            // We shouldn't emit a method declaration if the function is blacklisted
+            return;
+        }
         function_item.codegen(ctx, result, &());
 
         let function = function_item.expect_function();

--- a/tests/expectations/tests/blacklist-function.rs
+++ b/tests/expectations/tests/blacklist-function.rs
@@ -23,4 +23,22 @@ pub mod root {
             pub fn NamespacedFunction();
         }
     }
+    #[repr(C)]
+    #[derive(Debug, Default, Copy, Clone)]
+    pub struct C {
+        pub _address: u8,
+    }
+    #[test]
+    fn bindgen_test_layout_C() {
+        assert_eq!(
+            ::std::mem::size_of::<C>(),
+            1usize,
+            concat!("Size of: ", stringify!(C))
+        );
+        assert_eq!(
+            ::std::mem::align_of::<C>(),
+            1usize,
+            concat!("Alignment of ", stringify!(C))
+        );
+    }
 }

--- a/tests/headers/blacklist-function.hpp
+++ b/tests/headers/blacklist-function.hpp
@@ -1,4 +1,4 @@
-// bindgen-flags: --blacklist-function "ExternFunction" --blacklist-function "foo::NamespacedFunction" --enable-cxx-namespaces
+// bindgen-flags: --blacklist-function "ExternFunction" --blacklist-function "foo::NamespacedFunction" --blacklist-function "C_ClassMethod" --enable-cxx-namespaces
 
 extern "C" void ExternFunction();
 
@@ -9,3 +9,8 @@ namespace foo {
 namespace bar {
   void NamespacedFunction();
 }
+
+class C {
+public:
+  void ClassMethod();
+};


### PR DESCRIPTION
We should not emit Rust struct methods corresponding to a C++ method
unless we are actually emitting a binding for that method.

Resolves #1774