### PR TITLE
Recusrse through type references to find argument names in some cases.

### DIFF
--- a/tests/expectations/tests/function-typedef-stdcall.rs
+++ b/tests/expectations/tests/function-typedef-stdcall.rs
@@ -9,11 +9,11 @@
 
 pub type PFN_VIGEM_X360_NOTIFICATION = ::std::option::Option<
     unsafe extern "C" fn(
-        arg1: *mut ::std::os::raw::c_void,
-        arg2: *mut ::std::os::raw::c_void,
-        arg3: ::std::os::raw::c_uchar,
-        arg4: ::std::os::raw::c_uchar,
-        arg5: ::std::os::raw::c_uchar,
-        arg6: *mut ::std::os::raw::c_void,
+        Client: *mut ::std::os::raw::c_void,
+        Target: *mut ::std::os::raw::c_void,
+        LargeMotor: ::std::os::raw::c_uchar,
+        SmallMotor: ::std::os::raw::c_uchar,
+        LedNumber: ::std::os::raw::c_uchar,
+        UserData: *mut ::std::os::raw::c_void,
     ),
 >;


### PR DESCRIPTION
This fixes the names in function-typedef-stdcall.h

We still keep the fallback introduced in the previous patch because the
objective-c test that it fixed is not fixed by this (the cursors aren't
even there).