### PR TITLE
Add a callback for function-like macros

### DIFF
--- a/bindgen-integration/cpp/Test.h
+++ b/bindgen-integration/cpp/Test.h
@@ -7,6 +7,19 @@
 #define TESTMACRO_STRING_EXPANDED TESTMACRO_STRING
 #define TESTMACRO_CUSTOMINTKIND_PATH 123
 
+// The following two macros are parsed the same by cexpr, but are semantically
+// different.
+#define TESTMACRO_NONFUNCTIONAL (TESTMACRO_INTEGER)
+#define TESTMACRO_FUNCTIONAL_EMPTY(TESTMACRO_INTEGER)
+#define TESTMACRO_FUNCTIONAL_NONEMPTY(TESTMACRO_INTEGER)-TESTMACRO_INTEGER
+#define TESTMACRO_FUNCTIONAL_TOKENIZED(  a, b   ,c,d,e   ) a/b c    d ## e
+#define TESTMACRO_FUNCTIONAL_SPLIT(  a, \
+        b) b,\
+        a
+//#define TESTMACRO_INVALID("string") // A conforming preprocessor rejects this
+#define TESTMACRO_STRING_EXPR ("string")
+#define TESTMACRO_STRING_FUNC_NON_UTF8(x) (x "ÿÿ") /* invalid UTF-8 on purpose */
+
 #include <cwchar>
 
 enum {

--- a/src/callbacks.rs
+++ b/src/callbacks.rs
@@ -45,10 +45,8 @@ pub trait ParseCallbacks: fmt::Debug + UnwindSafe {
     ///
     /// The first parameter represents the name and argument list (including the
     /// parentheses) of the function-like macro. The second parameter represents
-    /// the expansion of the macro. It is not guaranteed that the whitespace of
-    /// the original is preserved, but it is guaranteed that tokenization will
-    /// not be changed.
-    fn func_macro(&self, _name: &str, _value: &str) {}
+    /// the expansion of the macro as a sequence of tokens.
+    fn func_macro(&self, _name: &str, _value: &[&[u8]]) {}
 
     /// This function should return whether, given an enum variant
     /// name, and value, this enum variant will forcibly be a constant.

--- a/src/callbacks.rs
+++ b/src/callbacks.rs
@@ -35,9 +35,20 @@ pub trait ParseCallbacks: fmt::Debug + UnwindSafe {
         None
     }
 
-    /// This will be run on every string macro. The callback can not influence the further
+    /// This will be run on every string macro. The callback cannot influence the further
     /// treatment of the macro, but may use the value to generate additional code or configuration.
     fn str_macro(&self, _name: &str, _value: &[u8]) {}
+
+    /// This will be run on every function-like macro. The callback cannot
+    /// influence the further treatment of the macro, but may use the value to
+    /// generate additional code or configuration.
+    ///
+    /// The first parameter represents the name and argument list (including the
+    /// parentheses) of the function-like macro. The second parameter represents
+    /// the expansion of the macro. It is not guaranteed that the whitespace of
+    /// the original is preserved, but it is guaranteed that tokenization will
+    /// not be changed.
+    fn func_macro(&self, _name: &str, _value: &str) {}
 
     /// This function should return whether, given an enum variant
     /// name, and value, this enum variant will forcibly be a constant.

--- a/src/clang.rs
+++ b/src/clang.rs
@@ -239,6 +239,17 @@ impl Cursor {
         }
     }
 
+    /// Is this Cursor pointing to a function-like macro definition?
+    /// Returns None if this cannot be determined with the available libclang
+    /// (it requires 3.9 or greater).
+    pub fn is_macro_function_like(&self) -> Option<bool> {
+        if clang_Cursor_isMacroFunctionLike::is_loaded() {
+            Some(unsafe { clang_Cursor_isMacroFunctionLike(self.x) != 0 })
+        } else {
+            None
+        }
+    }
+
     /// Get the kind of referent this cursor is pointing to.
     pub fn kind(&self) -> CXCursorKind {
         self.x.kind

--- a/src/clang.rs
+++ b/src/clang.rs
@@ -793,13 +793,16 @@ impl<'a> Drop for RawTokens<'a> {
     }
 }
 
-/// A raw clang token, that exposes only the kind and spelling. This is a
+/// A raw clang token, that exposes only kind, spelling, and extent. This is a
 /// slightly more convenient version of `CXToken` which owns the spelling
-/// string.
+/// string and extent.
 #[derive(Debug)]
 pub struct ClangToken {
     spelling: CXString,
-    /// The kind of token, this is the same as the relevant member from
+    /// The extent of the token. This is the same as the relevant member from
+    /// `CXToken`.
+    pub extent: CXSourceRange,
+    /// The kind of the token. This is the same as the relevant member from
     /// `CXToken`.
     pub kind: CXTokenKind,
 }
@@ -834,7 +837,12 @@ impl<'a> Iterator for ClangTokenIterator<'a> {
         unsafe {
             let kind = clang_getTokenKind(*raw);
             let spelling = clang_getTokenSpelling(self.tu, *raw);
-            Some(ClangToken { kind, spelling })
+            let extent = clang_getTokenExtent(self.tu, *raw);
+            Some(ClangToken {
+                kind,
+                extent,
+                spelling,
+            })
         }
     }
 }


### PR DESCRIPTION
Closes #1792.

Because whitespace information is not represented explicitly during parsing, it is non-trivial to reconstruct the exact textual form of the macro from the token list. I had previously inserted whitespace between tokens, which I still believe would be correct and acceptable, but it seems that spelling the tokens separately would be better.

Given this input :
```c
#define jit_get_note(n,u,v,w)	_jit_get_note(_jit,n,u,v,w)
```
and this callback :
```rust
fn func_macro(&self, name: &str, value: &[&[u8]]) {
    dbg!(name);
    dbg!(value);
}
```
this sort of output is achieved (pseudo-code) :
```rust
name = "jit_get_note(n,u,v,w)"
value = &[ "_jit_get_note", "(", "_jit", ",", "n", ",", "u", ",", "v", ",", "w", ")" ]
```