### PR TITLE
Fix regex to be marked opaque

### DIFF
--- a/book/src/cpp.md
+++ b/book/src/cpp.md
@@ -12,10 +12,10 @@ force C++ mode. You probably also want to use `-std=c++14` or similar clang args
 as well.
 
 You pretty much **must** use [whitelisting](./whitelisting.md) when working
-with C++ to avoid pulling in all of the `std::*` types, many of which `bindgen`
+with C++ to avoid pulling in all of the `std::.*` types, many of which `bindgen`
 cannot handle. Additionally, you may want to mark other types as
 [opaque](./opaque.md) that `bindgen` stumbles on. It is recommended to mark
-all of `std::*` opaque, and to whitelist only precisely the functions and types
+all of `std::.*` opaque, and to whitelist only precisely the functions and types
 you intend to use.
 
 You should read up on the [FAQs](./faq.md) as well.


### PR DESCRIPTION
While `std::*` makes informal sense, the user may be mislead into calling `opaque_type("std::*")` instead of the correct `opaque_type("std::.*")` (as I was).