### PR TITLE
Rebuild bindgen and bindings when clang_sys environment changes

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -42,6 +42,13 @@ mod testgen {
 
         println!("cargo:rerun-if-changed=tests/headers");
 
+        // On behalf of clang_sys, rebuild ourselves if important configuration
+        // variables change, to ensure that bindings get rebuilt if the
+        // underlying libclang changes.
+        println!("cargo:rerun-if-env-changed=LLVM_CONFIG_PATH");
+        println!("cargo:rerun-if-env-changed=LIBCLANG_PATH");
+        println!("cargo:rerun-if-env-changed=LIBCLANG_STATIC_PATH");
+
         for entry in entries {
             match entry.path().extension().and_then(OsStr::to_str) {
                 Some("h") | Some("hpp") => {


### PR DESCRIPTION
Closes #1766.

Using a crate that uses `bindgen`([`lightning-sys`](https://github.com/Petelliott/lightning-sys)), I first confirmed that the following Bash script does not trigger any rebuilds after the first build finishes successfully.
```bash
cargo build
LIBCLANG_PATH="" cargo build
cargo build
```

Then I updated that crate's `Cargo.toml` to point `bindgen` to 18e2fbd6953f56cc5b9751691d596663a2029932 and ran the script again. As expected, the second build failed due to `clang_sys` not finding any libclang, and the third build succeeded like the first one, updating the `bindings.rs` file timestamp.