### PR TITLE
Reintroduce some macOS builds to Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,6 +65,18 @@ env:
 matrix:
   fast_finish: true
 
+  # Include a few jobs for spot-checking different configurations without
+  # invoking combinatoric explosion of Travis jobs.
+  include:
+    - os: osx
+      env: LLVM_VERSION="9.0" BINDGEN_JOB="test"         BINDGEN_PROFILE=
+    - os: osx
+      env: LLVM_VERSION="9.0" BINDGEN_JOB="test"         BINDGEN_PROFILE="--release"
+    - os: osx
+      env: LLVM_VERSION="9.0" BINDGEN_JOB="integration"  BINDGEN_PROFILE=
+    - os: osx
+      env: LLVM_VERSION="9.0" BINDGEN_JOB="integration"  BINDGEN_PROFILE="--release"
+
 cache:
   directories:
     - $HOME/.cargo

--- a/ci/before_install.sh
+++ b/ci/before_install.sh
@@ -1,63 +1,85 @@
-set -ex
-pushd ~
-
-# Workaround for Travis CI macOS bug (https://github.com/travis-ci/travis-ci/issues/6307)
-if [ "${TRAVIS_OS_NAME}" == "osx" ]; then
-    rvm get head || true
-fi
+#!/usr/bin/env bash
+# Bail on first error
+set -e
+# Bail if an unset variable is encountered
+set -u
+# Enable debugging output
+set -x
+# Give a pipeline a non-zero exit code if one of its constituents fails
+set -o pipefail
 
 function llvm_linux_target_triple() {
-    if [ "$1" == "5.0" ]; then
-        echo "linux-x86_64-ubuntu14.04"
-    else
-        echo "x86_64-linux-gnu-ubuntu-14.04"
-    fi
+    case "$1" in
+        5.*)                echo "linux-x86_64-ubuntu14.04" ;;
+        *)                  echo "x86_64-linux-gnu-ubuntu-14.04" ;;
+    esac
+}
+
+function llvm_macos_target_triple() {
+    case "$1" in
+        [0-8].* | 9.0.0)    echo "x86_64-darwin-apple" ;;
+        # Starting with 9.0.1, triple swapped ordering
+        *)                  echo "x86_64-apple-darwin" ;;
+    esac
 }
 
 function llvm_version_triple() {
-    if [ "$1" == "3.5" ]; then
-        echo "3.5.2"
-    elif [ "$1" == "3.6" ]; then
-        echo "3.6.2"
-    elif [ "$1" == "3.7" ]; then
-        echo "3.7.1"
-    elif [ "$1" == "3.8" ]; then
-        echo "3.8.1"
-    elif [ "$1" == "3.9" ]; then
-        echo "3.9.0"
-    elif [ "$1" == "4.0" ]; then
-        echo "4.0.0"
-    elif [ "$1" == "5.0" ]; then
-        echo "5.0.0"
-    elif [ "$1" == "9.0" ]; then
-        echo "9.0.0"
-    fi
+    case "$1" in
+        3.5) echo "3.5.2" ;;
+        3.6) echo "3.6.2" ;;
+        3.7) echo "3.7.1" ;;
+        3.8) echo "3.8.1" ;;
+        # By default, take the .0 patch release
+        *)   echo "$1.0"  ;;
+    esac
+}
+
+function llvm_base_url() {
+    local llvm_version_triple=$1
+
+    case "$llvm_version_triple" in
+        [0-8].* | 9.0.0)
+            echo "http://releases.llvm.org/$llvm_version_triple"
+            ;;
+        # Starting with 9.0.1, releases are hosted on github
+        *)
+            echo "https://github.com/llvm/llvm-project/releases/download/llvmorg-$llvm_version_triple"
+            ;;
+    esac
 }
 
 function llvm_download() {
-    export LLVM_VERSION_TRIPLE=`llvm_version_triple ${LLVM_VERSION}`
-    export LLVM=clang+llvm-${LLVM_VERSION_TRIPLE}-$1
+    local base_url=$1
+    local arch=$2
+
+    export LLVM=clang+llvm-${LLVM_VERSION_TRIPLE}-$arch
     export LLVM_DIRECTORY="$HOME/.llvm/${LLVM}"
+
+    local base_url
 
     if [ -d "${LLVM_DIRECTORY}" ]; then
         echo "Using cached LLVM download for ${LLVM}..."
     else
-        wget http://releases.llvm.org/${LLVM_VERSION_TRIPLE}/${LLVM}.tar.xz
+        wget $base_url/${LLVM}.tar.xz
         mkdir -p "${LLVM_DIRECTORY}"
         tar xf ${LLVM}.tar.xz -C "${LLVM_DIRECTORY}" --strip-components=1
     fi
 
+    export LIBCLANG_PATH="${LLVM_DIRECTORY}/lib"
     export LLVM_CONFIG_PATH="${LLVM_DIRECTORY}/bin/llvm-config"
 }
 
+export LLVM_VERSION_TRIPLE=`llvm_version_triple ${LLVM_VERSION}`
+
+base_url=`llvm_base_url ${LLVM_VERSION_TRIPLE}`
+
 if [ "${TRAVIS_OS_NAME}" == "linux" ]; then
-    llvm_download `llvm_linux_target_triple ${LLVM_VERSION}`
-    export LD_LIBRARY_PATH="${LLVM_DIRECTORY}/lib":$LD_LIBRARY_PATH
+    llvm_download $base_url `llvm_linux_target_triple ${LLVM_VERSION_TRIPLE}`
+    export LD_LIBRARY_PATH="${LLVM_DIRECTORY}/lib":${LD_LIBRARY_PATH:-}
 else
-    llvm_download x86_64-apple-darwin
-    cp "${LLVM_DIRECTORY}/lib/libclang.dylib" /usr/local/lib/libclang.dylib
-    export DYLD_LIBRARY_PATH="${LLVM_DIRECTORY}/lib":$DYLD_LIBRARY_PATH
+    llvm_download $base_url `llvm_macos_target_triple ${LLVM_VERSION_TRIPLE}`
+    export DYLD_LIBRARY_PATH="${LLVM_DIRECTORY}/lib":${DYLD_LIBRARY_PATH:-}
 fi
 
-popd
-set +e
+# Subsequent scripts can see the state of `set -eu`, so unset it again.
+set +eu


### PR DESCRIPTION
Closes #1072 by running a few critical jobs on macOS, but not the whole matrix.

In my experience with Travis in general in the last few years, there has not been a lack of macOS builders as was the case when https://github.com/rust-lang/rust-bindgen/issues/1072#issuecomment-335859660 was written.

**This PR would increase the number of Travis jobs by four, from ~~37 to 41~~ 31 to 35.**

Along the way I refactored `ci/before_install.sh`, making it capable of handling LLVM 9.0.1+ (including 10.0.0). Some of the changes there are not strictly necessary to get macOS builds working again, so let me know if I should pare down the list of changes.

The most significant change here was to set `LIBCLANG_PATH` instead of only `DYLD_LIBRARY_PATH`-plus-a-copy. Perhaps it would be better not to set `LIBCLANG_PATH` if we could avoid it.