### PR TITLE
Respect changes to BINDGEN_EXTRA_CLANG_ARGS

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -78,4 +78,5 @@ fn main() {
     println!("cargo:rerun-if-env-changed=LLVM_CONFIG_PATH");
     println!("cargo:rerun-if-env-changed=LIBCLANG_PATH");
     println!("cargo:rerun-if-env-changed=LIBCLANG_STATIC_PATH");
+    println!("cargo:rerun-if-env-changed=BINDGEN_EXTRA_CLANG_ARGS");
 }


### PR DESCRIPTION
This is a fix for a tiny edge case, in the spirit of #1766, to support the flag added in #1537.

I looked for other `env!` and `env::var` instances in `bindgen` itself and did not find anything else to change.