### PR TITLE
Allow non-operator functions whose names start with `operator`

### DIFF
--- a/src/ir/function.rs
+++ b/src/ir/function.rs
@@ -377,9 +377,14 @@ impl FunctionSig {
             return Err(ParseError::Continue);
         }
 
-        // Don't parse operatorxx functions in C++
         let spelling = cursor.spelling();
-        if spelling.starts_with("operator") {
+
+        // Don't parse operatorxx functions in C++
+        let is_operator = |spelling: &str| {
+            spelling.starts_with("operator") &&
+                !clang::is_valid_identifier(spelling)
+        };
+        if is_operator(&spelling) {
             return Err(ParseError::Continue);
         }
 

--- a/tests/expectations/tests/operator.rs
+++ b/tests/expectations/tests/operator.rs
@@ -1,0 +1,16 @@
+#![allow(
+    dead_code,
+    non_snake_case,
+    non_camel_case_types,
+    non_upper_case_globals
+)]
+
+extern "C" {
+    #[link_name = "\u{1}_Z20operator_informationv"]
+    pub fn operator_information() -> ::std::os::raw::c_int;
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct Foo {
+    _unused: [u8; 0],
+}

--- a/tests/headers/operator.hpp
+++ b/tests/headers/operator.hpp
@@ -1,0 +1,5 @@
+int operator_information(void);
+
+class Foo;
+int operator<<(const Foo&, int);
+


### PR DESCRIPTION
This PR closes #1292 and replaces it, if desired.