### PR TITLE
Handle multiple headers for command_line_flags()

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -654,11 +654,13 @@ impl Builder {
         }
 
         if self.input_headers.len() > 1 {
-            output_vector.extend(
-                self.input_headers[..self.input_headers.len() - 1]
-                    .iter()
-                    .cloned(),
-            );
+            // To pass more than one header, we need to pass all but the last
+            // header via the `-include` clang arg
+            output_vector.reserve(2 * self.input_headers.len() - 2);
+            for header in &self.input_headers[..self.input_headers.len() - 1] {
+                output_vector.push("-include".to_string());
+                output_vector.push(header.clone());
+            }
         }
 
         output_vector

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -656,7 +656,6 @@ impl Builder {
         if self.input_headers.len() > 1 {
             // To pass more than one header, we need to pass all but the last
             // header via the `-include` clang arg
-            output_vector.reserve(2 * self.input_headers.len() - 2);
             for header in &self.input_headers[..self.input_headers.len() - 1] {
                 output_vector.push("-include".to_string());
                 output_vector.push(header.clone());

--- a/src/main.rs
+++ b/src/main.rs
@@ -102,25 +102,14 @@ mod test {
         let flags_str = flags_quoted.join(" ");
         println!("{}", flags_str);
 
-        crate::options::builder_from_flags(command_line_flags.into_iter())
-            .unwrap();
+        let (builder, _output, _verbose) =
+            crate::options::builder_from_flags(command_line_flags.into_iter())
+                .unwrap();
+        builder.generate().expect("failed to generate bindings");
     }
 
     #[test]
-    fn commandline_flag_roundtrip() {
-        // test1: various options
-        let bindings = bindgen::Builder::default()
-            .header("tests/headers/char.h")
-            .record_matches(false)
-            .size_t_is_usize(true)
-            .rustfmt_bindings(false)
-            .rustfmt_configuration_file(Some(PathBuf::from("/dev/null")))
-            .no_partialeq(".")
-            .no_copy(".")
-            .no_hash(".");
-        build_flags_output_helper(&bindings);
-
-        // test2: multiple headers
+    fn commandline_multiple_headers() {
         let bindings = bindgen::Builder::default()
             .header("tests/headers/char.h")
             .header("tests/headers/func_ptr.h")

--- a/src/main.rs
+++ b/src/main.rs
@@ -97,7 +97,7 @@ mod test {
 
         let flags_quoted: Vec<String> = command_line_flags
             .iter()
-            .map(|x| format!("'{}'", x))
+            .map(|x| format!("{}", shlex::quote(x)))
             .collect();
         let flags_str = flags_quoted.join(" ");
         println!("{}", flags_str);

--- a/src/main.rs
+++ b/src/main.rs
@@ -86,3 +86,45 @@ fn print_verbose_err() {
          https://github.com/rust-lang/rust-bindgen/issues/new"
     );
 }
+
+#[cfg(test)]
+mod test {
+    use std::path::PathBuf;
+
+    fn build_flags_output_helper(builder: &bindgen::Builder) {
+        let mut command_line_flags = builder.command_line_flags();
+        command_line_flags.insert(0, "bindgen".to_string());
+
+        let flags_quoted: Vec<String> = command_line_flags
+            .iter()
+            .map(|x| format!("'{}'", x))
+            .collect();
+        let flags_str = flags_quoted.join(" ");
+        println!("{}", flags_str);
+
+        crate::options::builder_from_flags(command_line_flags.into_iter())
+            .unwrap();
+    }
+
+    #[test]
+    fn commandline_flag_roundtrip() {
+        // test1: various options
+        let bindings = bindgen::Builder::default()
+            .header("tests/headers/char.h")
+            .record_matches(false)
+            .size_t_is_usize(true)
+            .rustfmt_bindings(false)
+            .rustfmt_configuration_file(Some(PathBuf::from("/dev/null")))
+            .no_partialeq(".")
+            .no_copy(".")
+            .no_hash(".");
+        build_flags_output_helper(&bindings);
+
+        // test2: multiple headers
+        let bindings = bindgen::Builder::default()
+            .header("tests/headers/char.h")
+            .header("tests/headers/func_ptr.h")
+            .header("tests/headers/16-byte-alignment.h");
+        build_flags_output_helper(&bindings);
+    }
+}


### PR DESCRIPTION
Output from Builder::command_line_flags() would fail if more than one
header were provided. This adds extra headers via the '-include' clang
option.