### PR TITLE
Update to clang-sys 1.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,7 +32,7 @@ dependencies = [
  "bitflags 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cexpr 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "clang-sys 0.29.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clang-sys 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "diff 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -59,11 +59,6 @@ version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "cc"
-version = "1.0.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "cexpr"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -78,12 +73,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "clang-sys"
-version = "0.29.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "glob 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
- "libloading 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libloading 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -147,10 +142,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libloading"
-version = "0.5.2"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cc 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -330,10 +324,9 @@ dependencies = [
 "checksum atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)" = "1803c647a3ec87095e7ae7acfca019e98de5ec9a7d01343f611cf3152ed71a90"
 "checksum bitflags 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8a606a02debe2813760609f57a64a2ffd27d9fdf5b2f133eaca0b248dd92cdd2"
 "checksum byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a7c3dd8985a7111efc5c80b44e23ecdd8c007de8ade3b96595387e812b957cf5"
-"checksum cc 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)" = "4fc9a35e1f4290eb9e5fc54ba6cf40671ed2a2514c3eeb2b2a908dda2ea5a1be"
 "checksum cexpr 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f4aedb84272dbe89af497cf81375129abda4fc0a9e7c5d317498c15cc30c0d27"
 "checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
-"checksum clang-sys 0.29.0 (registry+https://github.com/rust-lang/crates.io-index)" = "03542fa2ed0accba4a5c84ec031f09a20b725e7ba1b1c9b79f1feb4aa17d0c07"
+"checksum clang-sys 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9da1484c6a890e374ca5086062d4847e0a2c1e5eba9afa5d48c09e8eb39b2519"
 "checksum clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
 "checksum diff 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "3c2b69f912779fbb121ceb775d74d51e915af17aaebc38d28a592843a2dd0a3a"
 "checksum env_logger 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "39ecdb7dd54465526f0a56d666e3b2dd5f3a218665a030b6e4ad9e70fa95d8fa"
@@ -342,7 +335,7 @@ dependencies = [
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 "checksum lazycell 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b294d6fa9ee409a054354afc4352b0b9ef7ca222c69b8812cbea9e7d2bf3783f"
 "checksum libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)" = "d515b1f41455adea1313a4a2ac8a8a477634fbae63cc6100e3aebb207ce61558"
-"checksum libloading 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f2b111a074963af1d37a139918ac6d49ad1d0d5e47f72fd55388619691a7d753"
+"checksum libloading 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2cadb8e769f070c45df05c78c7520eb4cd17061d4ab262e43cfc68b4d00ac71c"
 "checksum log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
 "checksum memchr 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "88579771288728879b57485cc7d6b07d648c9f0141eb955f8ab7f9d45394468e"
 "checksum nom 5.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0b471253da97532da4b61552249c521e01e736071f71c1a4f7ebbfbf0a06aad6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ cexpr = "0.4"
 cfg-if = "0.1.0"
 # This kinda sucks: https://github.com/rust-lang/cargo/issues/1982
 clap = { version = "2", optional = true }
-clang-sys = { version = "0.29", features = ["clang_6_0"] }
+clang-sys = { version = "1", features = ["clang_6_0"] }
 lazycell = "1"
 lazy_static = "1"
 peeking_take_while = "0.1.2"

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ extern "C" {
 
 ## MSRV
 
-The minimum supported Rust version is **1.34**.
+The minimum supported Rust version is **1.40**.
 
 No MSRV bump policy has been established yet, so MSRV may increase in any release.
 

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -31,8 +31,8 @@ case "$BINDGEN_JOB" in
         # This test should not use Cargo.lock as it's ignored for library builds
         rm Cargo.lock
         # The MSRV below is also documented in README.md, please keep in sync
-        rustup install 1.34.0
-        cargo +1.34.0 build --lib $NO_DEFAULT_FEATURES --features "$BINDGEN_FEATURES"
+        rustup install 1.40.0
+        cargo +1.40.0 build --lib $NO_DEFAULT_FEATURES --features "$BINDGEN_FEATURES"
         ;;
 
     "integration")


### PR DESCRIPTION
~~First, an update:~~

~~Due to issues where incompatible versions of `clang-sys` pulled in by different versions of `bindgen` would be rejected by Cargo due to duplicate [`package.links` Cargo manifest keys](https://doc.rust-lang.org/cargo/reference/build-scripts.html#the-links-manifest-key), I have today published the following patch releases for previous minor versions of `clang-sys` so that they can co-exist peacefully (for more info, see [this issue](https://github.com/KyleMayes/clang-sys/issues/96)):~~

* ~~`v0.29.4`~~
* ~~`v0.28.2`~~
* ~~`v0.27.1`~~

~~However, this was accomplished with a hack, essentially republishing `clang-sys` under a different name (`clang-sys-linkage`) as `v1.0.0` and then re-exporting that crate from the above patch versions.~~

**EDIT:** Unfortunately the above strategy did not work due to API incompatibilities I was not aware of.

Going forward, `clang-sys` has been published as `v1.0.0` so that future additions to the API can be added in a backwards-compatible way (since `1.0.0` and `1.1.0` are compatible but `v0.29.0` and `v0.30.0` are not) so that users will eventually not ever have multiple versions of `clang-sys` in their dependency tree.

The bump to `v1.0.0` also includes these changes:

* warnings from the `clang-sys` build script about `llvm-config` failing to execute are no longer printed unless the build script fails to find an instance of `libclang`
* update `libloading` version to `0.6.0` since `0.5.0` was causing some people problems
* Clang 10 support (which is almost entirely new OpenMP enum values, not very exciting)
