### PR TITLE
Fix CI for Rust 1.45.0

### DIFF
--- a/src/ir/comp.rs
+++ b/src/ir/comp.rs
@@ -748,16 +748,13 @@ impl CompFields {
 
         match result {
             Ok((fields, has_bitfield_units)) => {
-                mem::replace(
-                    self,
-                    CompFields::AfterComputingBitfieldUnits {
-                        fields,
-                        has_bitfield_units,
-                    },
-                );
+                *self = CompFields::AfterComputingBitfieldUnits {
+                    fields,
+                    has_bitfield_units,
+                };
             }
             Err(()) => {
-                mem::replace(self, CompFields::ErrorComputingBitfieldUnits);
+                *self = CompFields::ErrorComputingBitfieldUnits;
             }
         }
     }


### PR DESCRIPTION
In [Rust 1.45.0](https://blog.rust-lang.org/2020/07/16/Rust-1.45.0.html), [`std::mem::replace` has the `#[must_use]` attribute](https://doc.rust-lang.org/1.45.0/std/mem/fn.replace.html) (which was [not present in Rust 1.44.1](https://doc.rust-lang.org/1.44.1/std/mem/fn.replace.html)), causing a new diagnostic for some `bindgen` code :

    error: unused return value of `std::mem::replace` that must be used
       --> src/ir/comp.rs:751:17
        |
    751 | /                 mem::replace(
    752 | |                     self,
    753 | |                     CompFields::AfterComputingBitfieldUnits {
    754 | |                         fields,
    755 | |                         has_bitfield_units,
    756 | |                     },
    757 | |                 );
        | |__________________^
        |
        = note: `-D unused-must-use` implied by `-D warnings`
        = note: if you don't need the old value, you can just assign the new value directly

    error: unused return value of `std::mem::replace` that must be used
       --> src/ir/comp.rs:760:17
        |
    760 |                 mem::replace(self, CompFields::ErrorComputingBitfieldUnits);
        |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        |
        = note: if you don't need the old value, you can just assign the new value directly

    error: aborting due to 2 previous errors

[A Travis job](https://travis-ci.com/github/rust-lang/rust-bindgen/jobs/362197917) found this error on an unrelated pull request. I thought it best to separate this change into its own pull request.