### PR TITLE
Change non-fatal errors to warnings

### DIFF
--- a/src/clang.rs
+++ b/src/clang.rs
@@ -796,7 +796,7 @@ impl ClangToken {
             // expressions, so we strip them down here.
             CXToken_Comment => return None,
             _ => {
-                error!("Found unexpected token kind: {:?}", self);
+                warn!("Found unexpected token kind: {:?}", self);
                 return None;
             }
         };

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -449,7 +449,7 @@ impl CodeGenerator for Item {
             // TODO(emilio, #453): Figure out what to do when this happens
             // legitimately, we could track the opaque stuff and disable the
             // assertion there I guess.
-            error!("Found non-whitelisted item in code generation: {:?}", self);
+            warn!("Found non-whitelisted item in code generation: {:?}", self);
         }
 
         result.set_seen(self.id());
@@ -3938,7 +3938,7 @@ pub(crate) fn codegen(
                     "Your dot file was generated successfully into: {}",
                     path
                 ),
-                Err(e) => error!("{}", e),
+                Err(e) => warn!("{}", e),
             }
         }
 

--- a/src/codegen/struct_layout.rs
+++ b/src/codegen/struct_layout.rs
@@ -248,7 +248,7 @@ impl<'a> StructLayoutTracker<'a> {
         );
 
         if layout.size < self.latest_offset {
-            error!(
+            warn!(
                 "Calculated wrong layout for {}, too more {} bytes",
                 self.name,
                 self.latest_offset - layout.size

--- a/src/ir/context.rs
+++ b/src/ir/context.rs
@@ -2400,15 +2400,15 @@ If you encounter an error missing from this list, please file an issue or a PR!"
         self.codegen_items = Some(codegen_items);
 
         for item in self.options().whitelisted_functions.unmatched_items() {
-            error!("unused option: --whitelist-function {}", item);
+            warn!("unused option: --whitelist-function {}", item);
         }
 
         for item in self.options().whitelisted_vars.unmatched_items() {
-            error!("unused option: --whitelist-var {}", item);
+            warn!("unused option: --whitelist-var {}", item);
         }
 
         for item in self.options().whitelisted_types.unmatched_items() {
-            error!("unused option: --whitelist-type {}", item);
+            warn!("unused option: --whitelist-type {}", item);
         }
     }
 

--- a/src/ir/item.rs
+++ b/src/ir/item.rs
@@ -1428,7 +1428,7 @@ impl ClangItemParser for Item {
                     // ignore toplevel operator overloads
                     let spelling = cursor.spelling();
                     if !spelling.starts_with("operator") {
-                        error!(
+                        warn!(
                             "Unhandled cursor kind {:?}: {:?}",
                             cursor.kind(),
                             cursor

--- a/src/ir/ty.rs
+++ b/src/ir/ty.rs
@@ -973,7 +973,7 @@ impl Type {
                                 let inner_type = match inner {
                                     Ok(inner) => inner,
                                     Err(..) => {
-                                        error!(
+                                        warn!(
                                             "Failed to parse template alias \
                                              {:?}",
                                             location
@@ -1196,7 +1196,7 @@ impl Type {
                     return Err(ParseError::Continue);
                 }
                 _ => {
-                    error!(
+                    warn!(
                         "unsupported type: kind = {:?}; ty = {:?}; at {:?}",
                         ty.kind(),
                         ty,

--- a/src/regex_set.rs
+++ b/src/regex_set.rs
@@ -58,7 +58,7 @@ impl RegexSet {
         self.set = match RxSet::new(items) {
             Ok(x) => Some(x),
             Err(e) => {
-                error!("Invalid regex in {:?}: {:?}", self.items, e);
+                warn!("Invalid regex in {:?}: {:?}", self.items, e);
                 None
             }
         }


### PR DESCRIPTION
This was suggested all the way back in https://github.com/rust-lang/rust-bindgen/issues/363#issuecomment-269513599, but was never implemented. This can be pretty confusing if you're trying to bind to C++, as almost every STL header triggers some of these non-fatal "errors."