### PR TITLE
Add dynamic loading support

### DIFF
--- a/src/codegen/dyngen.rs
+++ b/src/codegen/dyngen.rs
@@ -1,0 +1,181 @@
+use crate::ir::function::Abi;
+use proc_macro2::Ident;
+
+/// Used to build the output tokens for dynamic bindings.
+pub struct DynamicItems {
+    /// Tracks the tokens that will appears inside the library struct -- e.g.:
+    /// ```ignore
+    /// struct Lib {
+    ///    __library: ::libloading::Library,
+    ///    x: Result<unsafe extern ..., ::libloading::Error>, // <- tracks these
+    ///    ...
+    /// }
+    /// ```
+    struct_members: Vec<proc_macro2::TokenStream>,
+
+    /// Tracks the tokens that will appear inside the library struct's implementation, e.g.:
+    ///
+    /// ```ignore
+    /// impl Lib {
+    ///     ...
+    ///     pub unsafe fn foo(&self, ...) { // <- tracks these
+    ///         ...
+    ///     }
+    /// }
+    /// ```
+    struct_implementation: Vec<proc_macro2::TokenStream>,
+
+    /// Tracks the tokens that will appear inside the struct used for checking if a symbol is
+    /// usable, e.g.:
+    /// ```ignore
+    /// pub fn f(&self) -> Result<(), &'a ::libloading::Error> { // <- tracks these
+    ///     self.__library.f.as_ref().map(|_| ())
+    /// }
+    /// ```
+    runtime_checks: Vec<proc_macro2::TokenStream>,
+
+    /// Tracks the initialization of the fields inside the `::new` constructor of the library
+    /// struct, e.g.:
+    /// ```ignore
+    /// impl Lib {
+    ///
+    ///     pub unsafe fn new<P>(path: P) -> Result<Self, ::libloading::Error>
+    ///     where
+    ///         P: AsRef<::std::ffi::OsStr>,
+    ///     {
+    ///         ...
+    ///         let foo = __library.get(...) ...; // <- tracks these
+    ///         ...
+    ///     }
+    ///
+    ///     ...
+    /// }
+    /// ```
+    constructor_inits: Vec<proc_macro2::TokenStream>,
+
+    /// Tracks the information that is passed to the library struct at the end of the `::new`
+    /// constructor, e.g.:
+    /// ```ignore
+    /// impl LibFoo {
+    ///     pub unsafe fn new<P>(path: P) -> Result<Self, ::libloading::Error>
+    ///     where
+    ///         P: AsRef<::std::ffi::OsStr>,
+    ///     {
+    ///         ...
+    ///         Ok(LibFoo {
+    ///             __library: __library,
+    ///             foo,
+    ///             bar, // <- tracks these
+    ///             ...
+    ///         })
+    ///     }
+    /// }
+    /// ```
+    init_fields: Vec<proc_macro2::TokenStream>,
+}
+
+impl Default for DynamicItems {
+    fn default() -> Self {
+        DynamicItems {
+            struct_members: vec![],
+            struct_implementation: vec![],
+            runtime_checks: vec![],
+            constructor_inits: vec![],
+            init_fields: vec![],
+        }
+    }
+}
+
+impl DynamicItems {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn get_tokens(
+        &self,
+        lib_ident: Ident,
+        check_struct_ident: Ident,
+    ) -> proc_macro2::TokenStream {
+        let struct_members = &self.struct_members;
+        let constructor_inits = &self.constructor_inits;
+        let init_fields = &self.init_fields;
+        let struct_implementation = &self.struct_implementation;
+        let runtime_checks = &self.runtime_checks;
+        quote! {
+            extern crate libloading;
+
+            pub struct #lib_ident {
+                __library: ::libloading::Library,
+                #(#struct_members)*
+            }
+
+            impl #lib_ident {
+                pub unsafe fn new<P>(
+                    path: P
+                ) -> Result<Self, ::libloading::Error>
+                where P: AsRef<::std::ffi::OsStr> {
+                    let __library = ::libloading::Library::new(path)?;
+                    #( #constructor_inits )*
+                    Ok(
+                        #lib_ident {
+                            __library: __library,
+                            #( #init_fields ),*
+                        }
+                    )
+                }
+
+                pub fn can_call(&self) -> #check_struct_ident {
+                    #check_struct_ident { __library: self }
+                }
+
+                #( #struct_implementation )*
+            }
+
+            pub struct #check_struct_ident<'a> {
+                __library: &'a #lib_ident,
+            }
+
+            impl<'a> #check_struct_ident<'a> {
+                #( #runtime_checks )*
+            }
+        }
+    }
+
+    pub fn add_function(
+        &mut self,
+        ident: Ident,
+        abi: Abi,
+        args: Vec<proc_macro2::TokenStream>,
+        args_identifiers: Vec<proc_macro2::TokenStream>,
+        ret: proc_macro2::TokenStream,
+        ret_ty: proc_macro2::TokenStream,
+    ) {
+        assert_eq!(args.len(), args_identifiers.len());
+
+        self.struct_members.push(quote!{
+            #ident: Result<unsafe extern #abi fn ( #( #args ),* ) #ret, ::libloading::Error>,
+        });
+
+        self.struct_implementation.push(quote! {
+            pub unsafe fn #ident ( &self, #( #args ),* ) -> #ret_ty {
+                let sym = self.#ident.as_ref().expect("Expected function, got error.");
+                (sym)(#( #args_identifiers ),*)
+            }
+        });
+
+        self.runtime_checks.push(quote! {
+            pub fn #ident (&self) -> Result<(), &'a::libloading::Error> {
+                self.__library.#ident.as_ref().map(|_| ())
+            }
+        });
+
+        let ident_str = ident.to_string();
+        self.constructor_inits.push(quote! {
+            let #ident = __library.get(#ident_str.as_bytes()).map(|sym| *sym);
+        });
+
+        self.init_fields.push(quote! {
+            #ident
+        });
+    }
+}

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -1,3 +1,4 @@
+mod dyngen;
 mod error;
 mod helpers;
 mod impl_debug;
@@ -10,6 +11,7 @@ pub(crate) mod bitfield_unit;
 #[cfg(all(test, target_endian = "little"))]
 mod bitfield_unit_tests;
 
+use self::dyngen::DynamicItems;
 use self::helpers::attributes;
 use self::struct_layout::StructLayoutTracker;
 
@@ -184,6 +186,7 @@ impl From<DerivableTraits> for Vec<&'static str> {
 
 struct CodegenResult<'a> {
     items: Vec<proc_macro2::TokenStream>,
+    dynamic_items: DynamicItems,
 
     /// A monotonic counter used to add stable unique id's to stuff that doesn't
     /// need to be referenced by anything.
@@ -234,6 +237,7 @@ impl<'a> CodegenResult<'a> {
     fn new(codegen_id: &'a Cell<usize>) -> Self {
         CodegenResult {
             items: vec![],
+            dynamic_items: DynamicItems::new(),
             saw_bindgen_union: false,
             saw_incomplete_array: false,
             saw_objc: false,
@@ -245,6 +249,10 @@ impl<'a> CodegenResult<'a> {
             vars_seen: Default::default(),
             overload_counters: Default::default(),
         }
+    }
+
+    fn dynamic_items(&mut self) -> &mut DynamicItems {
+        &mut self.dynamic_items
     }
 
     fn saw_bindgen_union(&mut self) {
@@ -3704,7 +3712,29 @@ impl CodeGenerator for Function {
                 pub fn #ident ( #( #args ),* ) #ret;
             }
         };
-        result.push(tokens);
+
+        // If we're doing dynamic binding generation, add to the dynamic items.
+        if ctx.options().dynamic_library_name.is_some() &&
+            self.kind() == FunctionKind::Function
+        {
+            let args_identifiers =
+                utils::fnsig_argument_identifiers(ctx, signature);
+            let return_item = ctx.resolve_item(signature.return_type());
+            let ret_ty = match *return_item.kind().expect_type().kind() {
+                TypeKind::Void => quote! {()},
+                _ => return_item.to_rust_ty_or_opaque(ctx, &()),
+            };
+            result.dynamic_items().add_function(
+                ident,
+                abi,
+                args,
+                args_identifiers,
+                ret,
+                ret_ty,
+            );
+        } else {
+            result.push(tokens);
+        }
     }
 }
 
@@ -3948,11 +3978,28 @@ pub(crate) fn codegen(
             &(),
         );
 
+        if context.options().dynamic_library_name.is_some() {
+            let lib_ident = context.rust_ident(
+                context.options().dynamic_library_name.as_ref().unwrap(),
+            );
+            let check_struct_ident = context.rust_ident(
+                [
+                    "Check",
+                    context.options().dynamic_library_name.as_ref().unwrap(),
+                ]
+                .join(""),
+            );
+            let dynamic_items_tokens = result
+                .dynamic_items()
+                .get_tokens(lib_ident, check_struct_ident);
+            result.push(dynamic_items_tokens);
+        }
+
         result.items
     })
 }
 
-mod utils {
+pub mod utils {
     use super::{error, ToRustTyOrOpaque};
     use crate::ir::context::BindgenContext;
     use crate::ir::function::{Abi, FunctionSig};
@@ -4352,6 +4399,35 @@ mod utils {
         if sig.is_variadic() {
             args.push(quote! { ... })
         }
+
+        args
+    }
+
+    pub fn fnsig_argument_identifiers(
+        ctx: &BindgenContext,
+        sig: &FunctionSig,
+    ) -> Vec<proc_macro2::TokenStream> {
+        let mut unnamed_arguments = 0;
+        let args = sig
+            .argument_types()
+            .iter()
+            .map(|&(ref name, _ty)| {
+                let arg_name = match *name {
+                    Some(ref name) => ctx.rust_mangle(name).into_owned(),
+                    None => {
+                        unnamed_arguments += 1;
+                        format!("arg{}", unnamed_arguments)
+                    }
+                };
+
+                assert!(!arg_name.is_empty());
+                let arg_name = ctx.rust_ident(arg_name);
+
+                quote! {
+                    #arg_name
+                }
+            })
+            .collect::<Vec<_>>();
 
         args
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -503,6 +503,12 @@ impl Builder {
             output_vector.push(path.into());
         }
 
+        if self.options.dynamic_library_name.is_some() {
+            let libname = self.options.dynamic_library_name.as_ref().unwrap();
+            output_vector.push("--dynamic-loading".into());
+            output_vector.push(libname.clone());
+        }
+
         // Add clang arguments
 
         output_vector.push("--".into());
@@ -1431,6 +1437,15 @@ impl Builder {
         self.options.wasm_import_module_name = Some(import_name.into());
         self
     }
+
+    /// Specify the dynamic library name if we are generating bindings for a shared library.
+    pub fn dynamic_library_name<T: Into<String>>(
+        mut self,
+        dynamic_library_name: T,
+    ) -> Self {
+        self.options.dynamic_library_name = Some(dynamic_library_name.into());
+        self
+    }
 }
 
 /// Configuration options for generated bindings.
@@ -1699,6 +1714,10 @@ struct BindgenOptions {
 
     /// Wasm import module name.
     wasm_import_module_name: Option<String>,
+
+    /// The name of the dynamic library (if we are generating bindings for a shared library). If
+    /// this is None, no dynamic bindings are created.
+    dynamic_library_name: Option<String>,
 }
 
 /// TODO(emilio): This is sort of a lie (see the error message that results from
@@ -1827,6 +1846,7 @@ impl Default for BindgenOptions {
             no_hash_types: Default::default(),
             array_pointers_in_arguments: false,
             wasm_import_module_name: None,
+            dynamic_library_name: None,
         }
     }
 }

--- a/src/options.rs
+++ b/src/options.rs
@@ -450,7 +450,11 @@ where
                 .long("wasm-import-module-name")
                 .value_name("name")
                 .takes_value(true)
-                .help("The name to be used in a #[link(wasm_import_module = ...)] statement")
+                .help("The name to be used in a #[link(wasm_import_module = ...)] statement"),
+            Arg::with_name("dynamic-loading")
+                .long("dynamic-loading")
+                .takes_value(true)
+                .help("Use dynamic loading mode with the given library name."),
         ]) // .args()
         .get_matches_from(args);
 
@@ -835,6 +839,10 @@ where
         for regex in no_hash {
             builder = builder.no_hash(regex);
         }
+    }
+
+    if let Some(dynamic_library_name) = matches.value_of("dynamic-loading") {
+        builder = builder.dynamic_library_name(dynamic_library_name);
     }
 
     let verbose = matches.is_present("verbose");

--- a/tests/expectations/Cargo.toml
+++ b/tests/expectations/Cargo.toml
@@ -11,3 +11,4 @@ authors = [
 [dependencies]
 objc = "0.2"
 block = "0.1"
+libloading = "0.6.2"

--- a/tests/expectations/tests/dynamic_loading_simple.rs
+++ b/tests/expectations/tests/dynamic_loading_simple.rs
@@ -1,0 +1,81 @@
+#![allow(
+    dead_code,
+    non_snake_case,
+    non_camel_case_types,
+    non_upper_case_globals
+)]
+
+extern crate libloading;
+pub struct TestLib {
+    __library: ::libloading::Library,
+    foo: Result<
+        unsafe extern "C" fn(
+            x: ::std::os::raw::c_int,
+            y: ::std::os::raw::c_int,
+        ) -> ::std::os::raw::c_int,
+        ::libloading::Error,
+    >,
+    bar: Result<
+        unsafe extern "C" fn(
+            x: *mut ::std::os::raw::c_void,
+        ) -> ::std::os::raw::c_int,
+        ::libloading::Error,
+    >,
+    baz: Result<
+        unsafe extern "C" fn() -> ::std::os::raw::c_int,
+        ::libloading::Error,
+    >,
+}
+impl TestLib {
+    pub unsafe fn new<P>(path: P) -> Result<Self, ::libloading::Error>
+    where
+        P: AsRef<::std::ffi::OsStr>,
+    {
+        let __library = ::libloading::Library::new(path)?;
+        let foo = __library.get("foo".as_bytes()).map(|sym| *sym);
+        let bar = __library.get("bar".as_bytes()).map(|sym| *sym);
+        let baz = __library.get("baz".as_bytes()).map(|sym| *sym);
+        Ok(TestLib {
+            __library: __library,
+            foo,
+            bar,
+            baz,
+        })
+    }
+    pub fn can_call(&self) -> CheckTestLib {
+        CheckTestLib { __library: self }
+    }
+    pub unsafe fn foo(
+        &self,
+        x: ::std::os::raw::c_int,
+        y: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int {
+        let sym = self.foo.as_ref().expect("Expected function, got error.");
+        (sym)(x, y)
+    }
+    pub unsafe fn bar(
+        &self,
+        x: *mut ::std::os::raw::c_void,
+    ) -> ::std::os::raw::c_int {
+        let sym = self.bar.as_ref().expect("Expected function, got error.");
+        (sym)(x)
+    }
+    pub unsafe fn baz(&self) -> ::std::os::raw::c_int {
+        let sym = self.baz.as_ref().expect("Expected function, got error.");
+        (sym)()
+    }
+}
+pub struct CheckTestLib<'a> {
+    __library: &'a TestLib,
+}
+impl<'a> CheckTestLib<'a> {
+    pub fn foo(&self) -> Result<(), &'a ::libloading::Error> {
+        self.__library.foo.as_ref().map(|_| ())
+    }
+    pub fn bar(&self) -> Result<(), &'a ::libloading::Error> {
+        self.__library.bar.as_ref().map(|_| ())
+    }
+    pub fn baz(&self) -> Result<(), &'a ::libloading::Error> {
+        self.__library.baz.as_ref().map(|_| ())
+    }
+}

--- a/tests/expectations/tests/dynamic_loading_template.rs
+++ b/tests/expectations/tests/dynamic_loading_template.rs
@@ -1,0 +1,56 @@
+#![allow(
+    dead_code,
+    non_snake_case,
+    non_camel_case_types,
+    non_upper_case_globals
+)]
+
+extern crate libloading;
+pub struct TestLib {
+    __library: ::libloading::Library,
+    foo: Result<
+        unsafe extern "C" fn(x: ::std::os::raw::c_int) -> ::std::os::raw::c_int,
+        ::libloading::Error,
+    >,
+    foo1: Result<unsafe extern "C" fn(x: f32) -> f32, ::libloading::Error>,
+}
+impl TestLib {
+    pub unsafe fn new<P>(path: P) -> Result<Self, ::libloading::Error>
+    where
+        P: AsRef<::std::ffi::OsStr>,
+    {
+        let __library = ::libloading::Library::new(path)?;
+        let foo = __library.get("foo".as_bytes()).map(|sym| *sym);
+        let foo1 = __library.get("foo1".as_bytes()).map(|sym| *sym);
+        Ok(TestLib {
+            __library: __library,
+            foo,
+            foo1,
+        })
+    }
+    pub fn can_call(&self) -> CheckTestLib {
+        CheckTestLib { __library: self }
+    }
+    pub unsafe fn foo(
+        &self,
+        x: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int {
+        let sym = self.foo.as_ref().expect("Expected function, got error.");
+        (sym)(x)
+    }
+    pub unsafe fn foo1(&self, x: f32) -> f32 {
+        let sym = self.foo1.as_ref().expect("Expected function, got error.");
+        (sym)(x)
+    }
+}
+pub struct CheckTestLib<'a> {
+    __library: &'a TestLib,
+}
+impl<'a> CheckTestLib<'a> {
+    pub fn foo(&self) -> Result<(), &'a ::libloading::Error> {
+        self.__library.foo.as_ref().map(|_| ())
+    }
+    pub fn foo1(&self) -> Result<(), &'a ::libloading::Error> {
+        self.__library.foo1.as_ref().map(|_| ())
+    }
+}

--- a/tests/expectations/tests/dynamic_loading_with_blacklist.rs
+++ b/tests/expectations/tests/dynamic_loading_with_blacklist.rs
@@ -1,0 +1,117 @@
+#![allow(
+    dead_code,
+    non_snake_case,
+    non_camel_case_types,
+    non_upper_case_globals
+)]
+
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct X {
+    pub _x: ::std::os::raw::c_int,
+}
+#[test]
+fn bindgen_test_layout_X() {
+    assert_eq!(
+        ::std::mem::size_of::<X>(),
+        4usize,
+        concat!("Size of: ", stringify!(X))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<X>(),
+        4usize,
+        concat!("Alignment of ", stringify!(X))
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<X>()))._x as *const _ as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(X), "::", stringify!(_x))
+    );
+}
+extern "C" {
+    #[link_name = "\u{1}_ZN1X13some_functionEv"]
+    pub fn X_some_function(this: *mut X);
+}
+extern "C" {
+    #[link_name = "\u{1}_ZN1X19some_other_functionEv"]
+    pub fn X_some_other_function(this: *mut X);
+}
+extern "C" {
+    #[link_name = "\u{1}_ZN1XC1Ei"]
+    pub fn X_X(this: *mut X, x: ::std::os::raw::c_int);
+}
+impl X {
+    #[inline]
+    pub unsafe fn some_function(&mut self) {
+        X_some_function(self)
+    }
+    #[inline]
+    pub unsafe fn some_other_function(&mut self) {
+        X_some_other_function(self)
+    }
+    #[inline]
+    pub unsafe fn new(x: ::std::os::raw::c_int) -> Self {
+        let mut __bindgen_tmp = ::std::mem::MaybeUninit::uninit();
+        X_X(__bindgen_tmp.as_mut_ptr(), x);
+        __bindgen_tmp.assume_init()
+    }
+}
+extern crate libloading;
+pub struct TestLib {
+    __library: ::libloading::Library,
+    foo: Result<
+        unsafe extern "C" fn(
+            x: *mut ::std::os::raw::c_void,
+        ) -> ::std::os::raw::c_int,
+        ::libloading::Error,
+    >,
+    bar: Result<
+        unsafe extern "C" fn(
+            x: *mut ::std::os::raw::c_void,
+        ) -> ::std::os::raw::c_int,
+        ::libloading::Error,
+    >,
+}
+impl TestLib {
+    pub unsafe fn new<P>(path: P) -> Result<Self, ::libloading::Error>
+    where
+        P: AsRef<::std::ffi::OsStr>,
+    {
+        let __library = ::libloading::Library::new(path)?;
+        let foo = __library.get("foo".as_bytes()).map(|sym| *sym);
+        let bar = __library.get("bar".as_bytes()).map(|sym| *sym);
+        Ok(TestLib {
+            __library: __library,
+            foo,
+            bar,
+        })
+    }
+    pub fn can_call(&self) -> CheckTestLib {
+        CheckTestLib { __library: self }
+    }
+    pub unsafe fn foo(
+        &self,
+        x: *mut ::std::os::raw::c_void,
+    ) -> ::std::os::raw::c_int {
+        let sym = self.foo.as_ref().expect("Expected function, got error.");
+        (sym)(x)
+    }
+    pub unsafe fn bar(
+        &self,
+        x: *mut ::std::os::raw::c_void,
+    ) -> ::std::os::raw::c_int {
+        let sym = self.bar.as_ref().expect("Expected function, got error.");
+        (sym)(x)
+    }
+}
+pub struct CheckTestLib<'a> {
+    __library: &'a TestLib,
+}
+impl<'a> CheckTestLib<'a> {
+    pub fn foo(&self) -> Result<(), &'a ::libloading::Error> {
+        self.__library.foo.as_ref().map(|_| ())
+    }
+    pub fn bar(&self) -> Result<(), &'a ::libloading::Error> {
+        self.__library.bar.as_ref().map(|_| ())
+    }
+}

--- a/tests/expectations/tests/dynamic_loading_with_class.rs
+++ b/tests/expectations/tests/dynamic_loading_with_class.rs
@@ -1,0 +1,109 @@
+#![allow(
+    dead_code,
+    non_snake_case,
+    non_camel_case_types,
+    non_upper_case_globals
+)]
+
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct A {
+    pub _x: ::std::os::raw::c_int,
+}
+#[test]
+fn bindgen_test_layout_A() {
+    assert_eq!(
+        ::std::mem::size_of::<A>(),
+        4usize,
+        concat!("Size of: ", stringify!(A))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<A>(),
+        4usize,
+        concat!("Alignment of ", stringify!(A))
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<A>()))._x as *const _ as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(A), "::", stringify!(_x))
+    );
+}
+extern "C" {
+    #[link_name = "\u{1}_ZN1A13some_functionEv"]
+    pub fn A_some_function(this: *mut A);
+}
+extern "C" {
+    #[link_name = "\u{1}_ZN1A19some_other_functionEv"]
+    pub fn A_some_other_function(this: *mut A);
+}
+extern "C" {
+    #[link_name = "\u{1}_ZN1AC1Ei"]
+    pub fn A_A(this: *mut A, x: ::std::os::raw::c_int);
+}
+impl A {
+    #[inline]
+    pub unsafe fn some_function(&mut self) {
+        A_some_function(self)
+    }
+    #[inline]
+    pub unsafe fn some_other_function(&mut self) {
+        A_some_other_function(self)
+    }
+    #[inline]
+    pub unsafe fn new(x: ::std::os::raw::c_int) -> Self {
+        let mut __bindgen_tmp = ::std::mem::MaybeUninit::uninit();
+        A_A(__bindgen_tmp.as_mut_ptr(), x);
+        __bindgen_tmp.assume_init()
+    }
+}
+extern crate libloading;
+pub struct TestLib {
+    __library: ::libloading::Library,
+    foo: Result<
+        unsafe extern "C" fn(
+            x: *mut ::std::os::raw::c_void,
+        ) -> ::std::os::raw::c_int,
+        ::libloading::Error,
+    >,
+    bar: Result<unsafe extern "C" fn(), ::libloading::Error>,
+}
+impl TestLib {
+    pub unsafe fn new<P>(path: P) -> Result<Self, ::libloading::Error>
+    where
+        P: AsRef<::std::ffi::OsStr>,
+    {
+        let __library = ::libloading::Library::new(path)?;
+        let foo = __library.get("foo".as_bytes()).map(|sym| *sym);
+        let bar = __library.get("bar".as_bytes()).map(|sym| *sym);
+        Ok(TestLib {
+            __library: __library,
+            foo,
+            bar,
+        })
+    }
+    pub fn can_call(&self) -> CheckTestLib {
+        CheckTestLib { __library: self }
+    }
+    pub unsafe fn foo(
+        &self,
+        x: *mut ::std::os::raw::c_void,
+    ) -> ::std::os::raw::c_int {
+        let sym = self.foo.as_ref().expect("Expected function, got error.");
+        (sym)(x)
+    }
+    pub unsafe fn bar(&self) -> () {
+        let sym = self.bar.as_ref().expect("Expected function, got error.");
+        (sym)()
+    }
+}
+pub struct CheckTestLib<'a> {
+    __library: &'a TestLib,
+}
+impl<'a> CheckTestLib<'a> {
+    pub fn foo(&self) -> Result<(), &'a ::libloading::Error> {
+        self.__library.foo.as_ref().map(|_| ())
+    }
+    pub fn bar(&self) -> Result<(), &'a ::libloading::Error> {
+        self.__library.bar.as_ref().map(|_| ())
+    }
+}

--- a/tests/expectations/tests/dynamic_loading_with_whitelist.rs
+++ b/tests/expectations/tests/dynamic_loading_with_whitelist.rs
@@ -1,0 +1,66 @@
+#![allow(
+    dead_code,
+    non_snake_case,
+    non_camel_case_types,
+    non_upper_case_globals
+)]
+
+extern crate libloading;
+pub struct TestLib {
+    __library: ::libloading::Library,
+    foo: Result<
+        unsafe extern "C" fn(
+            x: *mut ::std::os::raw::c_void,
+        ) -> ::std::os::raw::c_int,
+        ::libloading::Error,
+    >,
+    baz: Result<
+        unsafe extern "C" fn(
+            x: *mut ::std::os::raw::c_void,
+        ) -> ::std::os::raw::c_int,
+        ::libloading::Error,
+    >,
+}
+impl TestLib {
+    pub unsafe fn new<P>(path: P) -> Result<Self, ::libloading::Error>
+    where
+        P: AsRef<::std::ffi::OsStr>,
+    {
+        let __library = ::libloading::Library::new(path)?;
+        let foo = __library.get("foo".as_bytes()).map(|sym| *sym);
+        let baz = __library.get("baz".as_bytes()).map(|sym| *sym);
+        Ok(TestLib {
+            __library: __library,
+            foo,
+            baz,
+        })
+    }
+    pub fn can_call(&self) -> CheckTestLib {
+        CheckTestLib { __library: self }
+    }
+    pub unsafe fn foo(
+        &self,
+        x: *mut ::std::os::raw::c_void,
+    ) -> ::std::os::raw::c_int {
+        let sym = self.foo.as_ref().expect("Expected function, got error.");
+        (sym)(x)
+    }
+    pub unsafe fn baz(
+        &self,
+        x: *mut ::std::os::raw::c_void,
+    ) -> ::std::os::raw::c_int {
+        let sym = self.baz.as_ref().expect("Expected function, got error.");
+        (sym)(x)
+    }
+}
+pub struct CheckTestLib<'a> {
+    __library: &'a TestLib,
+}
+impl<'a> CheckTestLib<'a> {
+    pub fn foo(&self) -> Result<(), &'a ::libloading::Error> {
+        self.__library.foo.as_ref().map(|_| ())
+    }
+    pub fn baz(&self) -> Result<(), &'a ::libloading::Error> {
+        self.__library.baz.as_ref().map(|_| ())
+    }
+}

--- a/tests/headers/dynamic_loading_simple.h
+++ b/tests/headers/dynamic_loading_simple.h
@@ -1,0 +1,5 @@
+// bindgen-flags: --dynamic-loading TestLib
+
+int foo(int x, int y);
+int bar(void *x);
+int baz();

--- a/tests/headers/dynamic_loading_template.hpp
+++ b/tests/headers/dynamic_loading_template.hpp
@@ -1,0 +1,10 @@
+// bindgen-flags: --dynamic-loading TestLib
+
+template<typename T>
+T foo(T x);
+
+template<>
+int foo(int x);
+
+template<>
+float foo(float x);

--- a/tests/headers/dynamic_loading_with_blacklist.hpp
+++ b/tests/headers/dynamic_loading_with_blacklist.hpp
@@ -1,0 +1,15 @@
+// bindgen-flags: --dynamic-loading TestLib --blacklist-function baz
+
+class X {
+  int _x;
+
+ public:
+  X(int x);
+
+  void some_function();
+  void some_other_function();
+};
+
+int foo(void *x);
+int bar(void *x);
+int baz(void *x);

--- a/tests/headers/dynamic_loading_with_class.hpp
+++ b/tests/headers/dynamic_loading_with_class.hpp
@@ -1,0 +1,15 @@
+// bindgen-flags: --dynamic-loading TestLib
+
+int foo(void *x);
+
+class A {
+  int _x;
+
+ public:
+  A(int x);
+
+  void some_function();
+  void some_other_function();
+};
+
+void bar();

--- a/tests/headers/dynamic_loading_with_whitelist.hpp
+++ b/tests/headers/dynamic_loading_with_whitelist.hpp
@@ -1,0 +1,15 @@
+// bindgen-flags: --dynamic-loading TestLib --whitelist-function baz --whitelist-function foo
+
+class X {
+  int _x;
+
+ public:
+  X(int x);
+
+  void some_function();
+  void some_other_function();
+};
+
+int foo(void *x);
+int bar(void *x);
+int baz(void *x);


### PR DESCRIPTION
Hi guys,

Following on from [issue 1541](https://github.com/rust-lang/rust-bindgen/issues/1541), here's an implementation for libloading support in bindgen. I'd still consider this a prototype at the minute, so any comments are welcome and appreciated.

# Implementation

- The existing functionality is maintained if dynamic loading mode is not specified.
- We introduce two new flags -- `--dynamic-loading` and `--dynamic-library-name` -- which enable dynamic loading mode and specify a name for the shared library respectively. The 'name' of the shared library is what you want the struct containing the bindings to be called. For example, you could call it `BZip2` -- then you'd instantiate the dynamically loaded library with `let lib = BZip2::new();`. If `--dynamic-library-name` is not specified it'll just default to `Lib`.
- If dynamic loading mode is specified, the bindings are created inside a library struct alongside some libloading boilerplate.

# Example

Given the following `header.h`:

```
int foo(int x);
void bar(double x);
```

And the following code inside our `build.rs`:

```
let bindings = bindgen::Builder::default()
    .header("header.h")
    // Use dynamic loading
    .dynamic_loading(true)
    .dynamic_library_name("MyLibrary")
    // ...
    .generate()
    .expect("Unable to generate bindings");
```

We generate the following bindings:

```
/* automatically generated by rust-bindgen 0.54.1 */

pub struct MyLibrary<'a> {
    foo: libloading::Symbol<
        'a,
        unsafe extern "C" fn(x: ::std::os::raw::c_int) -> ::std::os::raw::c_int,
    >,
    bar: libloading::Symbol<'a, unsafe extern "C" fn(x: f64)>,
}
impl<'a> MyLibrary<'a> {
    pub fn new(lib: &libloading::Library) -> MyLibrary {
        unsafe {
            MyLibrary {
                foo: lib.get("foo".as_bytes()).unwrap(),
                bar: lib.get("bar".as_bytes()).unwrap(),
            }
        }
    }
}
```

Which we can then use in our code with the following:

```
#![allow(non_upper_case_globals)]
#![allow(non_camel_case_types)]
#![allow(non_snake_case)]
include!(concat!(env!("OUT_DIR"), "/bindings.rs"));

extern crate libloading;

pub fn main() {
    let lib = libloading::Library::new("/path/to/shared/lib.so").unwrap();
    let library_wrapper = MyLibrary::new(&lib);
    unsafe { (library_wrapper.bar)(123.0) };
}
```

## Multiple Dynamically Loaded Libraries

If you want to use multiple dynamically loaded libraries, the correct approach would be to do this in your `build.rs`:

```
let bindings_x = bindgen::Builder::default()
    .header("header_x.h")
    // Use dynamic loading
    .dynamic_loading(true)
    .dynamic_library_name("LibraryX")
    // ...
    .generate()
    .expect("Unable to generate bindings");

let bindings_y = bindgen::Builder::default()
    .header("header_y.h")
    // Use dynamic loading
    .dynamic_loading(true)
    .dynamic_library_name("LibraryY")
    // ...
    .generate()
    .expect("Unable to generate bindings");

let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
lib1_bindings
    .write_to_file(out_path.join("libx_bindings.rs"))
    .expect("Couldn't write bindings!");
lib2_bindings
    .write_to_file(out_path.join("liby_bindings.rs"))
    .expect("Couldn't write bindings!");
```

Then do the following in your code:

```
extern crate libloading;

mod libx {
    include!(concat!(env!("OUT_DIR"), "/libx_bindings.rs"));
}
mod liby {
    include!(concat!(env!("OUT_DIR"), "/liby_bindings.rs"));
}
pub use lib1::LibraryX;
pub use lib2::LibraryY;
```

(the `mod libx { ... }` is to prevent namespace collisions if `LibraryX` and `LibraryY` have common includes -- e.g. if they both have `#include <stdint.h>`)

---

Comments and criticisms absolutely welcome! If this seems like a suitable approach I can update the docs in a separate PR. Cheers! 🍻 