### PR TITLE
ci: Explicitly use Ubuntu 16.04

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: rust
 
+dist: xenial
+
 os:
   - linux
 

--- a/ci/before_install.sh
+++ b/ci/before_install.sh
@@ -9,7 +9,7 @@ set -x
 set -o pipefail
 
 function llvm_linux_target_triple() {
-    echo "x86_64-linux-gnu-ubuntu-14.04"
+    echo "x86_64-linux-gnu-ubuntu-16.04"
 }
 
 function llvm_macos_target_triple() {

--- a/ci/before_install.sh
+++ b/ci/before_install.sh
@@ -49,8 +49,6 @@ function llvm_download() {
     export LLVM=clang+llvm-${LLVM_VERSION_TRIPLE}-$arch
     export LLVM_DIRECTORY="$HOME/.llvm/${LLVM}"
 
-    local base_url
-
     if [ -d "${LLVM_DIRECTORY}" ]; then
         echo "Using cached LLVM download for ${LLVM}..."
     else

--- a/ci/before_install.sh
+++ b/ci/before_install.sh
@@ -9,10 +9,7 @@ set -x
 set -o pipefail
 
 function llvm_linux_target_triple() {
-    case "$1" in
-        5.*)                echo "linux-x86_64-ubuntu14.04" ;;
-        *)                  echo "x86_64-linux-gnu-ubuntu-14.04" ;;
-    esac
+    echo "x86_64-linux-gnu-ubuntu-14.04"
 }
 
 function llvm_macos_target_triple() {
@@ -29,6 +26,7 @@ function llvm_version_triple() {
         3.6) echo "3.6.2" ;;
         3.7) echo "3.7.1" ;;
         3.8) echo "3.8.1" ;;
+        5.0) echo "5.0.1" ;;
         # By default, take the .0 patch release
         *)   echo "$1.0"  ;;
     esac

--- a/ci/before_install.sh
+++ b/ci/before_install.sh
@@ -22,10 +22,6 @@ function llvm_macos_target_triple() {
 
 function llvm_version_triple() {
     case "$1" in
-        3.5) echo "3.5.2" ;;
-        3.6) echo "3.6.2" ;;
-        3.7) echo "3.7.1" ;;
-        3.8) echo "3.8.1" ;;
         5.0) echo "5.0.1" ;;
         # By default, take the .0 patch release
         *)   echo "$1.0"  ;;


### PR DESCRIPTION
Since Ubuntu 16.04 LTS builds of LLVM are available for each major `libclang` version supported by `bindgen`, it could be worthwhile to point to those instead of Ubuntu 14.04 as before.

For LLVM 10.0.0, Ubuntu builds are available for only 18.04, so the current PR might help to prepare for that transition later.

Using LLVM 5.0.1 instead of 5.0.0 avoids the target-triple mixup that needed a special case for 5.0.0.