### PR TITLE
Add --anon-fields-prefix option

### DIFF
--- a/src/ir/comp.rs
+++ b/src/ir/comp.rs
@@ -825,9 +825,15 @@ impl CompFields {
                     }
 
                     anon_field_counter += 1;
-                    let generated_name =
-                        format!("__bindgen_anon_{}", anon_field_counter);
-                    *name = Some(generated_name);
+                    if let Some(ref prefix) = ctx.options().anon_fields_prefix {
+                        *name =
+                            Some(format!("{}{}", prefix, anon_field_counter));
+                    } else {
+                        *name = Some(format!(
+                            "__bindgen_anon_{}",
+                            anon_field_counter
+                        ));
+                    }
                 }
                 Field::Bitfields(ref mut bu) => {
                     for bitfield in &mut bu.bitfields {

--- a/src/ir/comp.rs
+++ b/src/ir/comp.rs
@@ -825,15 +825,11 @@ impl CompFields {
                     }
 
                     anon_field_counter += 1;
-                    if let Some(ref prefix) = ctx.options().anon_fields_prefix {
-                        *name =
-                            Some(format!("{}{}", prefix, anon_field_counter));
-                    } else {
-                        *name = Some(format!(
-                            "__bindgen_anon_{}",
-                            anon_field_counter
-                        ));
-                    }
+                    *name = Some(format!(
+                        "{}{}",
+                        ctx.options().anon_fields_prefix,
+                        anon_field_counter
+                    ));
                 }
                 Field::Bitfields(ref mut bu) => {
                     for bitfield in &mut bu.bitfields {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -385,10 +385,8 @@ impl Builder {
             output_vector.push(prefix.clone());
         }
 
-        if let prefix = &self.options.anon_fields_prefix {
-            output_vector.push("--anon-fields-prefix".into());
-            output_vector.push(prefix.clone());
-        }
+        output_vector.push("--anon-fields-prefix".into());
+        output_vector.push(self.options.anon_fields_prefix.clone());
 
         if self.options.emit_ast {
             output_vector.push("--emit-clang-ast".into());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -385,6 +385,11 @@ impl Builder {
             output_vector.push(prefix.clone());
         }
 
+        if let Some(ref prefix) = self.options.anon_fields_prefix {
+            output_vector.push("--anon-fields-prefix".into());
+            output_vector.push(prefix.clone());
+        }
+
         if self.options.emit_ast {
             output_vector.push("--emit-clang-ast".into());
         }
@@ -1212,6 +1217,12 @@ impl Builder {
         self
     }
 
+    /// Use the given prefix for the anon fields instead of `__bindgen_anon_`.
+    pub fn anon_fields_prefix<T: Into<String>>(mut self, prefix: T) -> Builder {
+        self.options.anon_fields_prefix = Some(prefix.into());
+        self
+    }
+
     /// Allows configuring types in different situations, see the
     /// [`ParseCallbacks`](./callbacks/trait.ParseCallbacks.html) documentation.
     pub fn parse_callbacks(
@@ -1590,6 +1601,9 @@ struct BindgenOptions {
     /// An optional prefix for the "raw" types, like `c_int`, `c_void`...
     ctypes_prefix: Option<String>,
 
+    /// An optional prefix for the anon fields instead of `__bindgen_anon_`.
+    anon_fields_prefix: Option<String>,
+
     /// Whether to time the bindgen phases.
     time_phases: bool,
 
@@ -1809,6 +1823,7 @@ impl Default for BindgenOptions {
             disable_header_comment: false,
             use_core: false,
             ctypes_prefix: None,
+            anon_fields_prefix: None,
             namespaced_constants: true,
             msvc_mangling: false,
             convert_floats: true,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -385,7 +385,7 @@ impl Builder {
             output_vector.push(prefix.clone());
         }
 
-        if let Some(ref prefix) = self.options.anon_fields_prefix {
+        if let prefix = &self.options.anon_fields_prefix {
             output_vector.push("--anon-fields-prefix".into());
             output_vector.push(prefix.clone());
         }
@@ -1217,9 +1217,9 @@ impl Builder {
         self
     }
 
-    /// Use the given prefix for the anon fields instead of `__bindgen_anon_`.
+    /// Use the given prefix for the anon fields.
     pub fn anon_fields_prefix<T: Into<String>>(mut self, prefix: T) -> Builder {
-        self.options.anon_fields_prefix = Some(prefix.into());
+        self.options.anon_fields_prefix = prefix.into();
         self
     }
 
@@ -1601,8 +1601,8 @@ struct BindgenOptions {
     /// An optional prefix for the "raw" types, like `c_int`, `c_void`...
     ctypes_prefix: Option<String>,
 
-    /// An optional prefix for the anon fields instead of `__bindgen_anon_`.
-    anon_fields_prefix: Option<String>,
+    /// The prefix for the anon fields.
+    anon_fields_prefix: String,
 
     /// Whether to time the bindgen phases.
     time_phases: bool,
@@ -1823,7 +1823,7 @@ impl Default for BindgenOptions {
             disable_header_comment: false,
             use_core: false,
             ctypes_prefix: None,
-            anon_fields_prefix: None,
+            anon_fields_prefix: "__bindgen_anon_".into(),
             namespaced_constants: true,
             msvc_mangling: false,
             convert_floats: true,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,6 +94,9 @@ type HashMap<K, V> = ::rustc_hash::FxHashMap<K, V>;
 type HashSet<K> = ::rustc_hash::FxHashSet<K>;
 pub(crate) use std::collections::hash_map::Entry;
 
+/// Default prefix for the anon fields.
+pub const DEFAULT_ANON_FIELDS_PREFIX: &'static str = "__bindgen_anon_";
+
 fn args_are_cpp(clang_args: &[String]) -> bool {
     return clang_args
         .windows(2)
@@ -385,8 +388,10 @@ impl Builder {
             output_vector.push(prefix.clone());
         }
 
-        output_vector.push("--anon-fields-prefix".into());
-        output_vector.push(self.options.anon_fields_prefix.clone());
+        if self.options.anon_fields_prefix != DEFAULT_ANON_FIELDS_PREFIX {
+            output_vector.push("--anon-fields-prefix".into());
+            output_vector.push(self.options.anon_fields_prefix.clone());
+        }
 
         if self.options.emit_ast {
             output_vector.push("--emit-clang-ast".into());
@@ -1821,7 +1826,7 @@ impl Default for BindgenOptions {
             disable_header_comment: false,
             use_core: false,
             ctypes_prefix: None,
-            anon_fields_prefix: "__bindgen_anon_".into(),
+            anon_fields_prefix: DEFAULT_ANON_FIELDS_PREFIX.into(),
             namespaced_constants: true,
             msvc_mangling: false,
             convert_floats: true,

--- a/src/options.rs
+++ b/src/options.rs
@@ -236,11 +236,9 @@ where
                 .takes_value(true),
             Arg::with_name("anon-fields-prefix")
                 .long("anon-fields-prefix")
-                .help(
-                    "Use the given prefix for the anon fields instead of \
-                     __bindgen_anon_.",
-                )
+                .help("Use the given prefix for the anon fields.")
                 .value_name("prefix")
+                .default_value("__bindgen_anon_")
                 .takes_value(true),
             Arg::with_name("time-phases")
                 .long("time-phases")

--- a/src/options.rs
+++ b/src/options.rs
@@ -1,6 +1,6 @@
 use bindgen::{
     builder, AliasVariation, Builder, CodegenConfig, EnumVariation, RustTarget,
-    RUST_TARGET_STRINGS,
+    DEFAULT_ANON_FIELDS_PREFIX, RUST_TARGET_STRINGS,
 };
 use clap::{App, Arg};
 use std::fs::File;
@@ -238,7 +238,7 @@ where
                 .long("anon-fields-prefix")
                 .help("Use the given prefix for the anon fields.")
                 .value_name("prefix")
-                .default_value("__bindgen_anon_")
+                .default_value(DEFAULT_ANON_FIELDS_PREFIX)
                 .takes_value(true),
             Arg::with_name("time-phases")
                 .long("time-phases")

--- a/src/options.rs
+++ b/src/options.rs
@@ -234,6 +234,14 @@ where
                 )
                 .value_name("prefix")
                 .takes_value(true),
+            Arg::with_name("anon-fields-prefix")
+                .long("anon-fields-prefix")
+                .help(
+                    "Use the given prefix for the anon fields instead of \
+                     __bindgen_anon_.",
+                )
+                .value_name("prefix")
+                .takes_value(true),
             Arg::with_name("time-phases")
                 .long("time-phases")
                 .help("Time the different bindgen phases and print to stderr"),
@@ -632,6 +640,10 @@ where
 
     if let Some(prefix) = matches.value_of("ctypes-prefix") {
         builder = builder.ctypes_prefix(prefix);
+    }
+
+    if let Some(prefix) = matches.value_of("anon-fields-prefix") {
+        builder = builder.anon_fields_prefix(prefix);
     }
 
     if let Some(what_to_generate) = matches.value_of("generate") {

--- a/tests/expectations/tests/anon-fields-prefix.rs
+++ b/tests/expectations/tests/anon-fields-prefix.rs
@@ -1,0 +1,156 @@
+#![allow(
+    dead_code,
+    non_snake_case,
+    non_camel_case_types,
+    non_upper_case_globals
+)]
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union color {
+    pub u1: color__bindgen_ty_1,
+    pub u2: color__bindgen_ty_2,
+    pub v3: [::std::os::raw::c_uchar; 3usize],
+    _bindgen_union_align: [u8; 3usize],
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct color__bindgen_ty_1 {
+    pub r: ::std::os::raw::c_uchar,
+    pub g: ::std::os::raw::c_uchar,
+    pub b: ::std::os::raw::c_uchar,
+}
+#[test]
+fn bindgen_test_layout_color__bindgen_ty_1() {
+    assert_eq!(
+        ::std::mem::size_of::<color__bindgen_ty_1>(),
+        3usize,
+        concat!("Size of: ", stringify!(color__bindgen_ty_1))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<color__bindgen_ty_1>(),
+        1usize,
+        concat!("Alignment of ", stringify!(color__bindgen_ty_1))
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<color__bindgen_ty_1>())).r as *const _
+                as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(color__bindgen_ty_1),
+            "::",
+            stringify!(r)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<color__bindgen_ty_1>())).g as *const _
+                as usize
+        },
+        1usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(color__bindgen_ty_1),
+            "::",
+            stringify!(g)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<color__bindgen_ty_1>())).b as *const _
+                as usize
+        },
+        2usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(color__bindgen_ty_1),
+            "::",
+            stringify!(b)
+        )
+    );
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct color__bindgen_ty_2 {
+    pub y: ::std::os::raw::c_uchar,
+    pub u: ::std::os::raw::c_uchar,
+    pub v: ::std::os::raw::c_uchar,
+}
+#[test]
+fn bindgen_test_layout_color__bindgen_ty_2() {
+    assert_eq!(
+        ::std::mem::size_of::<color__bindgen_ty_2>(),
+        3usize,
+        concat!("Size of: ", stringify!(color__bindgen_ty_2))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<color__bindgen_ty_2>(),
+        1usize,
+        concat!("Alignment of ", stringify!(color__bindgen_ty_2))
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<color__bindgen_ty_2>())).y as *const _
+                as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(color__bindgen_ty_2),
+            "::",
+            stringify!(y)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<color__bindgen_ty_2>())).u as *const _
+                as usize
+        },
+        1usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(color__bindgen_ty_2),
+            "::",
+            stringify!(u)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<color__bindgen_ty_2>())).v as *const _
+                as usize
+        },
+        2usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(color__bindgen_ty_2),
+            "::",
+            stringify!(v)
+        )
+    );
+}
+#[test]
+fn bindgen_test_layout_color() {
+    assert_eq!(
+        ::std::mem::size_of::<color>(),
+        3usize,
+        concat!("Size of: ", stringify!(color))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<color>(),
+        1usize,
+        concat!("Alignment of ", stringify!(color))
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<color>())).v3 as *const _ as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(color), "::", stringify!(v3))
+    );
+}
+impl Default for color {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}

--- a/tests/headers/anon-fields-prefix.h
+++ b/tests/headers/anon-fields-prefix.h
@@ -1,0 +1,15 @@
+// bindgen-flags: --anon-fields-prefix "u"
+
+union color {
+  struct {
+    unsigned char r;
+    unsigned char g;
+    unsigned char b;
+  };
+  struct {
+    unsigned char y;
+    unsigned char u;
+    unsigned char v;
+  };
+  unsigned char v3[3];
+};


### PR DESCRIPTION
Allow to use the given prefix for the anon fields instead of `__bindgen_anon_`.