### PR TITLE
Fix constness of multidimensional arrays

### DIFF
--- a/src/ir/ty.rs
+++ b/src/ir/ty.rs
@@ -1209,7 +1209,10 @@ impl Type {
 
         let name = if name.is_empty() { None } else { Some(name) };
 
-        let is_const = ty.is_const();
+        let is_const = ty.is_const() ||
+            (ty.kind() == CXType_ConstantArray &&
+                ty.elem_type()
+                    .map_or(false, |element| element.is_const()));
 
         let ty = Type::new(name, layout, kind, is_const);
         // TODO: maybe declaration.canonical()?

--- a/tests/expectations/tests/const_multidim_array_fn_arg.rs
+++ b/tests/expectations/tests/const_multidim_array_fn_arg.rs
@@ -1,0 +1,10 @@
+#![allow(
+    dead_code,
+    non_snake_case,
+    non_camel_case_types,
+    non_upper_case_globals
+)]
+
+extern "C" {
+    pub fn f(a: *const [::std::os::raw::c_int; 1usize]);
+}

--- a/tests/headers/const_multidim_array_fn_arg.h
+++ b/tests/headers/const_multidim_array_fn_arg.h
@@ -1,0 +1,1 @@
+void f(const int a[1][1]);


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust-bindgen/issues/1849 by making sure that multidimensional arrays are properly marked as being `const`