### PR TITLE
Add --default-macro-constant-type

### DIFF
--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -3048,6 +3048,50 @@ impl CodeGenerator for Enum {
     }
 }
 
+/// Enum for the default type of macro constants.
+#[derive(Copy, Clone, PartialEq, Debug)]
+pub enum MacroTypeVariation {
+    /// Use i32 or i64
+    Signed,
+    /// Use u32 or u64
+    Unsigned,
+}
+
+impl MacroTypeVariation {
+    /// Convert a `MacroTypeVariation` to its str representation.
+    pub fn as_str(&self) -> &str {
+        match self {
+            MacroTypeVariation::Signed => "signed",
+            MacroTypeVariation::Unsigned => "unsigned",
+        }
+    }
+}
+
+impl Default for MacroTypeVariation {
+    fn default() -> MacroTypeVariation {
+        MacroTypeVariation::Unsigned
+    }
+}
+
+impl std::str::FromStr for MacroTypeVariation {
+    type Err = std::io::Error;
+
+    /// Create a `MacroTypeVariation` from a string.
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "signed" => Ok(MacroTypeVariation::Signed),
+            "unsigned" => Ok(MacroTypeVariation::Unsigned),
+            _ => Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                concat!(
+                    "Got an invalid MacroTypeVariation. Accepted values ",
+                    "are 'signed' and 'unsigned'"
+                ),
+            )),
+        }
+    }
+}
+
 /// Enum for how aliases should be translated.
 #[derive(Copy, Clone, PartialEq, Debug)]
 pub enum AliasVariation {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,7 +72,7 @@ doc_mod!(ir, ir_docs);
 doc_mod!(parse, parse_docs);
 doc_mod!(regex_set, regex_set_docs);
 
-pub use crate::codegen::{AliasVariation, EnumVariation};
+pub use crate::codegen::{AliasVariation, EnumVariation, MacroTypeVariation};
 use crate::features::RustFeatures;
 pub use crate::features::{
     RustTarget, LATEST_STABLE_RUST, RUST_TARGET_STRINGS,
@@ -265,6 +265,12 @@ impl Builder {
                 }
                 .into(),
             )
+        }
+
+        if self.options.default_macro_constant_type != Default::default() {
+            output_vector.push("--default-macro-constant-type".into());
+            output_vector
+                .push(self.options.default_macro_constant_type.as_str().into());
         }
 
         if self.options.default_alias_style != Default::default() {
@@ -869,6 +875,15 @@ impl Builder {
     /// just constants. Regular expressions are supported.
     pub fn constified_enum_module<T: AsRef<str>>(mut self, arg: T) -> Builder {
         self.options.constified_enum_modules.insert(arg);
+        self
+    }
+
+    /// Set the default type for macro constants
+    pub fn default_macro_constant_type(
+        mut self,
+        arg: codegen::MacroTypeVariation,
+    ) -> Builder {
+        self.options.default_macro_constant_type = arg;
         self
     }
 
@@ -1513,6 +1528,9 @@ struct BindgenOptions {
     /// The enum patterns to mark an enum as a set of constants.
     constified_enums: RegexSet,
 
+    /// The default type for C macro constants.
+    default_macro_constant_type: codegen::MacroTypeVariation,
+
     /// The default style of code to generate for typedefs.
     default_alias_style: codegen::AliasVariation,
 
@@ -1800,6 +1818,7 @@ impl Default for BindgenOptions {
             rustified_non_exhaustive_enums: Default::default(),
             constified_enums: Default::default(),
             constified_enum_modules: Default::default(),
+            default_macro_constant_type: Default::default(),
             default_alias_style: Default::default(),
             type_alias: Default::default(),
             new_type_alias: Default::default(),

--- a/src/options.rs
+++ b/src/options.rs
@@ -1,6 +1,7 @@
 use bindgen::{
-    builder, AliasVariation, Builder, CodegenConfig, EnumVariation, RustTarget,
-    DEFAULT_ANON_FIELDS_PREFIX, RUST_TARGET_STRINGS,
+    builder, AliasVariation, Builder, CodegenConfig, EnumVariation,
+    MacroTypeVariation, RustTarget, DEFAULT_ANON_FIELDS_PREFIX,
+    RUST_TARGET_STRINGS,
 };
 use clap::{App, Arg};
 use std::fs::File;
@@ -87,6 +88,13 @@ where
                 .takes_value(true)
                 .multiple(true)
                 .number_of_values(1),
+            Arg::with_name("default-macro-constant-type")
+                .long("default-macro-constant-type")
+                .help("The default signed/unsigned type for C macro constants.")
+                .value_name("variant")
+                .default_value("unsigned")
+                .possible_values(&["signed", "unsigned"])
+                .multiple(false),
             Arg::with_name("default-alias-style")
                 .long("default-alias-style")
                 .help("The default style of code used to generate typedefs.")
@@ -520,6 +528,11 @@ where
         for regex in constified_mods {
             builder = builder.constified_enum_module(regex);
         }
+    }
+
+    if let Some(variant) = matches.value_of("default-macro-constant-type") {
+        builder = builder
+            .default_macro_constant_type(MacroTypeVariation::from_str(variant)?)
     }
 
     if let Some(variant) = matches.value_of("default-alias-style") {

--- a/tests/expectations/tests/default-macro-constant-type-signed.rs
+++ b/tests/expectations/tests/default-macro-constant-type-signed.rs
@@ -1,0 +1,42 @@
+#![allow(
+    dead_code,
+    non_snake_case,
+    non_camel_case_types,
+    non_upper_case_globals
+)]
+
+pub const N0: i32 = 0;
+pub const N1: i32 = 1;
+pub const N2: i32 = 2;
+pub const N_1: i32 = -1;
+pub const N_2: i32 = -2;
+pub const MAX_U32: i64 = 4294967295;
+pub const MAX_I32: i32 = 2147483647;
+pub const MAX_I32_Plus1: i64 = 2147483648;
+pub const MAX_U32_Plus1: i64 = 4294967296;
+pub const MAX_I32_Minus1: i32 = 2147483646;
+pub const MAX_U32_Minus1: i64 = 4294967294;
+pub const MIN_U32: i32 = 0;
+pub const MIN_I32: i32 = -2147483648;
+pub const MIN_U32_Plus1: i32 = 1;
+pub const MIN_I32_Plus1: i32 = -2147483647;
+pub const MIN_U32_Minus1: i32 = -1;
+pub const MIN_I32_Minus1: i64 = -2147483649;
+pub const LONG12: i64 = 123456789012;
+pub const LONG_12: i64 = -123456789012;
+extern "C" {
+    pub fn foo(
+        arg1: ::std::os::raw::c_int,
+        arg2: ::std::os::raw::c_int,
+        arg3: ::std::os::raw::c_uint,
+        arg4: ::std::os::raw::c_char,
+        arg5: ::std::os::raw::c_uchar,
+        arg6: ::std::os::raw::c_schar,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    pub fn bar(
+        arg1: ::std::os::raw::c_long,
+        arg2: ::std::os::raw::c_longlong,
+    ) -> ::std::os::raw::c_long;
+}

--- a/tests/expectations/tests/default-macro-constant-type-unsigned.rs
+++ b/tests/expectations/tests/default-macro-constant-type-unsigned.rs
@@ -1,0 +1,42 @@
+#![allow(
+    dead_code,
+    non_snake_case,
+    non_camel_case_types,
+    non_upper_case_globals
+)]
+
+pub const N0: u32 = 0;
+pub const N1: u32 = 1;
+pub const N2: u32 = 2;
+pub const N_1: i32 = -1;
+pub const N_2: i32 = -2;
+pub const MAX_U32: u32 = 4294967295;
+pub const MAX_I32: u32 = 2147483647;
+pub const MAX_I32_Plus1: u32 = 2147483648;
+pub const MAX_U32_Plus1: u64 = 4294967296;
+pub const MAX_I32_Minus1: u32 = 2147483646;
+pub const MAX_U32_Minus1: u32 = 4294967294;
+pub const MIN_U32: u32 = 0;
+pub const MIN_I32: i32 = -2147483648;
+pub const MIN_U32_Plus1: u32 = 1;
+pub const MIN_I32_Plus1: i32 = -2147483647;
+pub const MIN_U32_Minus1: i32 = -1;
+pub const MIN_I32_Minus1: i64 = -2147483649;
+pub const LONG12: u64 = 123456789012;
+pub const LONG_12: i64 = -123456789012;
+extern "C" {
+    pub fn foo(
+        arg1: ::std::os::raw::c_int,
+        arg2: ::std::os::raw::c_int,
+        arg3: ::std::os::raw::c_uint,
+        arg4: ::std::os::raw::c_char,
+        arg5: ::std::os::raw::c_uchar,
+        arg6: ::std::os::raw::c_schar,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    pub fn bar(
+        arg1: ::std::os::raw::c_long,
+        arg2: ::std::os::raw::c_longlong,
+    ) -> ::std::os::raw::c_long;
+}

--- a/tests/expectations/tests/default-macro-constant-type.rs
+++ b/tests/expectations/tests/default-macro-constant-type.rs
@@ -1,0 +1,42 @@
+#![allow(
+    dead_code,
+    non_snake_case,
+    non_camel_case_types,
+    non_upper_case_globals
+)]
+
+pub const N0: u32 = 0;
+pub const N1: u32 = 1;
+pub const N2: u32 = 2;
+pub const N_1: i32 = -1;
+pub const N_2: i32 = -2;
+pub const MAX_U32: u32 = 4294967295;
+pub const MAX_I32: u32 = 2147483647;
+pub const MAX_I32_Plus1: u32 = 2147483648;
+pub const MAX_U32_Plus1: u64 = 4294967296;
+pub const MAX_I32_Minus1: u32 = 2147483646;
+pub const MAX_U32_Minus1: u32 = 4294967294;
+pub const MIN_U32: u32 = 0;
+pub const MIN_I32: i32 = -2147483648;
+pub const MIN_U32_Plus1: u32 = 1;
+pub const MIN_I32_Plus1: i32 = -2147483647;
+pub const MIN_U32_Minus1: i32 = -1;
+pub const MIN_I32_Minus1: i64 = -2147483649;
+pub const LONG12: u64 = 123456789012;
+pub const LONG_12: i64 = -123456789012;
+extern "C" {
+    pub fn foo(
+        arg1: ::std::os::raw::c_int,
+        arg2: ::std::os::raw::c_int,
+        arg3: ::std::os::raw::c_uint,
+        arg4: ::std::os::raw::c_char,
+        arg5: ::std::os::raw::c_uchar,
+        arg6: ::std::os::raw::c_schar,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    pub fn bar(
+        arg1: ::std::os::raw::c_long,
+        arg2: ::std::os::raw::c_longlong,
+    ) -> ::std::os::raw::c_long;
+}

--- a/tests/headers/default-macro-constant-type-signed.h
+++ b/tests/headers/default-macro-constant-type-signed.h
@@ -1,0 +1,3 @@
+// bindgen-flags: --default-macro-constant-type signed
+// All values are i32 if they fit; otherwise i64.
+#include "default-macro-constant-type.h"

--- a/tests/headers/default-macro-constant-type-unsigned.h
+++ b/tests/headers/default-macro-constant-type-unsigned.h
@@ -1,0 +1,3 @@
+// bindgen-flags: --default-macro-constant-type unsigned
+// Negative values are i32 or i64; others are u32 or u64.
+#include "default-macro-constant-type.h"

--- a/tests/headers/default-macro-constant-type.h
+++ b/tests/headers/default-macro-constant-type.h
@@ -1,0 +1,34 @@
+// Test default of --default-macro-constant-type
+// Negative values are i32 or i64; others are u32 or u64.
+
+#define N0 0
+#define N1 1ULL
+#define N2 2ULL
+
+#define N_1 (-1LL)
+#define N_2 (-2LL)
+
+#define MAX_U32  0xFFFFFFFFULL
+#define MAX_I32 (0x80000000ULL - 1)
+
+#define MAX_I32_Plus1 (MAX_I32 + 1)
+#define MAX_U32_Plus1 (MAX_U32 + 1)
+
+#define MAX_I32_Minus1 (MAX_I32 - 1)
+#define MAX_U32_Minus1 (MAX_U32 - 1)
+
+#define MIN_U32 0
+#define MIN_I32 (- (1ULL<<31))
+
+#define MIN_U32_Plus1 (MIN_U32 + 1)
+#define MIN_I32_Plus1 (MIN_I32 + 1)
+
+#define MIN_U32_Minus1 (MIN_U32 - 1)
+#define MIN_I32_Minus1 (MIN_I32 - 1)
+
+#define LONG12    123456789012ULL
+#define LONG_12 (- 123456789012ULL)
+
+// Function parameter and return types are not affected.
+int foo(int, signed, unsigned, char, unsigned char, signed char);
+long bar(long, long long);


### PR DESCRIPTION
* --default-macro-constant-type could be 'signed' or 'unsigned'
  * Its default value is 'unsigned' to use u32/u64
    for C macro constants that fit into the u32/u64 ranges.
  * For old C libraries that use macros as int/long parameter
    and/or return value types, their macros are better declared
    as i32/i64 if the values fit the i32/i64 ranges,
    to be compatible with c_int/c_long types.
    They can use "--default-macro-constant-type signed"