### PR TITLE
codegen: Do generate unnamed enums, as they can be referred to by members and others.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -144,6 +144,17 @@ Released YYYY/MM/DD
 
 --------------------------------------------------------------------------------
 
+# 0.55.1
+
+Released 2020/08/24.
+
+## Fixed
+
+ * Fixed a regression where anonymous enums referenced by members or such won't
+   generate valid Rust code. (#1882).
+
+--------------------------------------------------------------------------------
+
 # 0.55.0
 
 Released 2020/08/23.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,7 +27,7 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.55.0"
+version = "0.55.1"
 dependencies = [
  "bitflags 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "cexpr 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 repository = "https://github.com/rust-lang/rust-bindgen"
 documentation = "https://docs.rs/bindgen"
 homepage = "https://rust-lang.github.io/rust-bindgen/"
-version = "0.55.0"
+version = "0.55.1"
 edition = "2018"
 build = "build.rs"
 

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -2478,7 +2478,6 @@ impl<'a> EnumBuilder<'a> {
         repr: proc_macro2::TokenStream,
         enum_variation: EnumVariation,
         enum_codegen_depth: usize,
-        is_ty_named: bool,
     ) -> Self {
         let ident = Ident::new(name, Span::call_site());
 
@@ -2507,12 +2506,10 @@ impl<'a> EnumBuilder<'a> {
             EnumVariation::Consts => {
                 let mut variants = Vec::new();
 
-                if is_ty_named {
-                    variants.push(quote! {
-                        #( #attrs )*
-                        pub type #ident = #repr;
-                    });
-                }
+                variants.push(quote! {
+                    #( #attrs )*
+                    pub type #ident = #repr;
+                });
 
                 EnumBuilder::Consts {
                     repr,
@@ -2901,7 +2898,6 @@ impl CodeGenerator for Enum {
             repr,
             variation,
             item.codegen_depth(ctx),
-            enum_ty.name().is_some(),
         );
 
         // A map where we keep a value -> variant relation.

--- a/tests/expectations/tests/enum-default-bitfield.rs
+++ b/tests/expectations/tests/enum-default-bitfield.rs
@@ -5,6 +5,70 @@
     non_upper_case_globals
 )]
 
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct foo {
+    pub member: foo__bindgen_ty_1,
+}
+pub const foo_FOO_A: foo__bindgen_ty_1 = foo__bindgen_ty_1(0);
+pub const foo_FOO_B: foo__bindgen_ty_1 = foo__bindgen_ty_1(1);
+impl ::std::ops::BitOr<foo__bindgen_ty_1> for foo__bindgen_ty_1 {
+    type Output = Self;
+    #[inline]
+    fn bitor(self, other: Self) -> Self {
+        foo__bindgen_ty_1(self.0 | other.0)
+    }
+}
+impl ::std::ops::BitOrAssign for foo__bindgen_ty_1 {
+    #[inline]
+    fn bitor_assign(&mut self, rhs: foo__bindgen_ty_1) {
+        self.0 |= rhs.0;
+    }
+}
+impl ::std::ops::BitAnd<foo__bindgen_ty_1> for foo__bindgen_ty_1 {
+    type Output = Self;
+    #[inline]
+    fn bitand(self, other: Self) -> Self {
+        foo__bindgen_ty_1(self.0 & other.0)
+    }
+}
+impl ::std::ops::BitAndAssign for foo__bindgen_ty_1 {
+    #[inline]
+    fn bitand_assign(&mut self, rhs: foo__bindgen_ty_1) {
+        self.0 &= rhs.0;
+    }
+}
+#[repr(transparent)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub struct foo__bindgen_ty_1(pub ::std::os::raw::c_uint);
+#[test]
+fn bindgen_test_layout_foo() {
+    assert_eq!(
+        ::std::mem::size_of::<foo>(),
+        4usize,
+        concat!("Size of: ", stringify!(foo))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<foo>(),
+        4usize,
+        concat!("Alignment of ", stringify!(foo))
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<foo>())).member as *const _ as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(foo),
+            "::",
+            stringify!(member)
+        )
+    );
+}
+impl Default for foo {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
 impl Foo {
     pub const Bar: Foo = Foo(0);
 }

--- a/tests/expectations/tests/enum-default-consts.rs
+++ b/tests/expectations/tests/enum-default-consts.rs
@@ -5,6 +5,42 @@
     non_upper_case_globals
 )]
 
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct foo {
+    pub member: foo__bindgen_ty_1,
+}
+pub const foo_FOO_A: ::std::os::raw::c_uint = 0;
+pub const foo_FOO_B: ::std::os::raw::c_uint = 1;
+pub type foo__bindgen_ty_1 = ::std::os::raw::c_uint;
+#[test]
+fn bindgen_test_layout_foo() {
+    assert_eq!(
+        ::std::mem::size_of::<foo>(),
+        4usize,
+        concat!("Size of: ", stringify!(foo))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<foo>(),
+        4usize,
+        concat!("Alignment of ", stringify!(foo))
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<foo>())).member as *const _ as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(foo),
+            "::",
+            stringify!(member)
+        )
+    );
+}
+impl Default for foo {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
 pub const Foo_Bar: Foo = 0;
 pub const Foo_Qux: Foo = 1;
 pub type Foo = ::std::os::raw::c_uint;

--- a/tests/expectations/tests/enum-default-module.rs
+++ b/tests/expectations/tests/enum-default-module.rs
@@ -5,6 +5,44 @@
     non_upper_case_globals
 )]
 
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct foo {
+    pub member: foo__bindgen_ty_1::Type,
+}
+pub mod foo__bindgen_ty_1 {
+    pub type Type = ::std::os::raw::c_uint;
+    pub const FOO_A: Type = 0;
+    pub const FOO_B: Type = 1;
+}
+#[test]
+fn bindgen_test_layout_foo() {
+    assert_eq!(
+        ::std::mem::size_of::<foo>(),
+        4usize,
+        concat!("Size of: ", stringify!(foo))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<foo>(),
+        4usize,
+        concat!("Alignment of ", stringify!(foo))
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<foo>())).member as *const _ as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(foo),
+            "::",
+            stringify!(member)
+        )
+    );
+}
+impl Default for foo {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
 pub mod Foo {
     pub type Type = ::std::os::raw::c_uint;
     pub const Bar: Type = 0;

--- a/tests/expectations/tests/enum-default-rust.rs
+++ b/tests/expectations/tests/enum-default-rust.rs
@@ -5,6 +5,47 @@
     non_upper_case_globals
 )]
 
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct foo {
+    pub member: foo__bindgen_ty_1,
+}
+pub const foo_FOO_A: foo__bindgen_ty_1 = foo__bindgen_ty_1::FOO_A;
+pub const foo_FOO_B: foo__bindgen_ty_1 = foo__bindgen_ty_1::FOO_B;
+#[repr(u32)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub enum foo__bindgen_ty_1 {
+    FOO_A = 0,
+    FOO_B = 1,
+}
+#[test]
+fn bindgen_test_layout_foo() {
+    assert_eq!(
+        ::std::mem::size_of::<foo>(),
+        4usize,
+        concat!("Size of: ", stringify!(foo))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<foo>(),
+        4usize,
+        concat!("Alignment of ", stringify!(foo))
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<foo>())).member as *const _ as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(foo),
+            "::",
+            stringify!(member)
+        )
+    );
+}
+impl Default for foo {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum Foo {

--- a/tests/expectations/tests/enum.rs
+++ b/tests/expectations/tests/enum.rs
@@ -5,15 +5,45 @@
     non_upper_case_globals
 )]
 
-#[repr(u32)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub enum Foo {
-    Bar = 0,
-    Qux = 1,
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct foo {
+    pub member: foo__bindgen_ty_1,
 }
-#[repr(i32)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub enum Neg {
-    MinusOne = -1,
-    One = 1,
+pub const foo_FOO_A: ::std::os::raw::c_uint = 0;
+pub const foo_FOO_B: ::std::os::raw::c_uint = 1;
+pub type foo__bindgen_ty_1 = ::std::os::raw::c_uint;
+#[test]
+fn bindgen_test_layout_foo() {
+    assert_eq!(
+        ::std::mem::size_of::<foo>(),
+        4usize,
+        concat!("Size of: ", stringify!(foo))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<foo>(),
+        4usize,
+        concat!("Alignment of ", stringify!(foo))
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<foo>())).member as *const _ as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(foo),
+            "::",
+            stringify!(member)
+        )
+    );
 }
+impl Default for foo {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+pub const Foo_Bar: Foo = 0;
+pub const Foo_Qux: Foo = 1;
+pub type Foo = ::std::os::raw::c_uint;
+pub const Neg_MinusOne: Neg = -1;
+pub const Neg_One: Neg = 1;
+pub type Neg = ::std::os::raw::c_int;

--- a/tests/expectations/tests/enum_explicit_type_constants.rs
+++ b/tests/expectations/tests/enum_explicit_type_constants.rs
@@ -27,3 +27,4 @@ pub const BoolEnumsAreFun2_Value2: BoolEnumsAreFun2 = true;
 pub type BoolEnumsAreFun2 = MyType;
 pub const AnonymousVariantOne: ::std::os::raw::c_uchar = 0;
 pub const AnonymousVariantTwo: ::std::os::raw::c_uchar = 1;
+pub type _bindgen_ty_1 = ::std::os::raw::c_uchar;

--- a/tests/expectations/tests/issue-1025-unknown-enum-repr.rs
+++ b/tests/expectations/tests/issue-1025-unknown-enum-repr.rs
@@ -10,3 +10,4 @@
 pub struct a {
     pub _address: u8,
 }
+pub type a__bindgen_ty_1 = i32;

--- a/tests/headers/enum-default-bitfield.h
+++ b/tests/headers/enum-default-bitfield.h
@@ -1,11 +1,3 @@
 // bindgen-flags: --default-enum-style=bitfield --constified-enum-module=Neg
 
-enum Foo {
-    Bar = 0,
-    Qux
-};
-
-enum Neg {
-    MinusOne = -1,
-    One = 1,
-};
+#include "enum.h"

--- a/tests/headers/enum-default-consts.h
+++ b/tests/headers/enum-default-consts.h
@@ -1,11 +1,3 @@
 // bindgen-flags: --default-enum-style=consts --constified-enum-module=Neg
 
-enum Foo {
-    Bar = 0,
-    Qux
-};
-
-enum Neg {
-    MinusOne = -1,
-    One = 1,
-};
+#include "enum.h"

--- a/tests/headers/enum-default-module.h
+++ b/tests/headers/enum-default-module.h
@@ -1,11 +1,3 @@
 // bindgen-flags: --default-enum-style=moduleconsts --constified-enum-module=Neg
 
-enum Foo {
-    Bar = 0,
-    Qux
-};
-
-enum Neg {
-    MinusOne = -1,
-    One = 1,
-};
+#include "enum.h"

--- a/tests/headers/enum-default-rust.h
+++ b/tests/headers/enum-default-rust.h
@@ -1,11 +1,3 @@
 // bindgen-flags: --default-enum-style=rust --constified-enum-module=Neg
 
-enum Foo {
-    Bar = 0,
-    Qux
-};
-
-enum Neg {
-    MinusOne = -1,
-    One = 1,
-};
+#include "enum.h"

--- a/tests/headers/enum.h
+++ b/tests/headers/enum.h
@@ -1,4 +1,12 @@
-// bindgen-flags: --rustified-enum ".*"
+// A few tests for enum-related issues that should be tested with all the enum
+// representations.
+
+struct foo {
+  enum {
+    FOO_A,
+    FOO_B,
+  } member;
+};
 
 enum Foo {
     Bar = 0,


### PR DESCRIPTION
Fixes #1880 