### PR TITLE
[Objc] Add From<ChildClass>, TryFrom<ParentClass>, function ownership updates and Protocol inheritance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,11 +120,11 @@ Released YYYY/MM/DD
 
 ## Added
 
-* TODO (or remove section if none)
+* Objective-c bindings generate `From<ChildClass> for ParentClass` as well as `TryFrom<ParentClass> for ChildClass` ([#1883][]).
 
 ## Changed
 
-* TODO (or remove section if none)
+* Objective-c bindings borrow self rather than take ownership ([#1883][]).
 
 ## Deprecated
 
@@ -136,11 +136,14 @@ Released YYYY/MM/DD
 
 ## Fixed
 
-* TODO (or remove section if none)
+* Fixed objective-c protocol impl blocks for parent classes's protocols ([#1883][]).
 
 ## Security
 
 * TODO (or remove section if none)
+
+
+[#1883]: https://github.com/rust-lang/rust-bindgen/issues/1883
 
 --------------------------------------------------------------------------------
 

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -3992,7 +3992,10 @@ impl CodeGenerator for ObjCInterface {
                         };
                         result.push(from_block);
 
-                        let error_msg = format!("This {} cannot be downcasted to {}", parent_struct_name, child_struct_name);
+                        let error_msg = format!(
+                            "This {} cannot be downcasted to {}",
+                            parent_struct_name, child_struct_name
+                        );
                         let try_into_block = quote! {
                             impl std::convert::TryFrom<#parent_struct> for #class_name {
                                 type Error = &'static str;

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -3926,13 +3926,14 @@ impl CodeGenerator for ObjCInterface {
                 }
             };
             result.push(struct_block);
-            let mut protocol_set : CollectionHashSet<ItemId> = CollectionHashSet::new();
+            let mut protocol_set: CollectionHashSet<ItemId> =
+                CollectionHashSet::new();
             for protocol_id in self.conforms_to.iter() {
                 protocol_set.insert(*protocol_id);
                 let protocol_name = ctx.rust_ident(
                     ctx.resolve_type(protocol_id.expect_type_id(ctx))
-                    .name()
-                    .unwrap(),
+                        .name()
+                        .unwrap(),
                 );
                 let impl_trait = quote! {
                     impl #protocol_name for #class_name { }
@@ -3971,10 +3972,11 @@ impl CodeGenerator for ObjCInterface {
                     result.push(impl_trait);
                     for protocol_id in parent.conforms_to.iter() {
                         if !protocol_set.contains(protocol_id) {
-
                             protocol_set.insert(*protocol_id);
                             let protocol_name = ctx.rust_ident(
-                                ctx.resolve_type(protocol_id.expect_type_id(ctx))
+                                ctx.resolve_type(
+                                    protocol_id.expect_type_id(ctx),
+                                )
                                 .name()
                                 .unwrap(),
                             );

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -3810,7 +3810,7 @@ fn objc_method_codegen(
         }
     } else {
         let fn_args = fn_args.clone();
-        let args = iter::once(quote! { self }).chain(fn_args.into_iter());
+        let args = iter::once(quote! { &self }).chain(fn_args.into_iter());
         quote! {
             ( #( #args ),* ) #fn_ret
         }
@@ -3829,7 +3829,7 @@ fn objc_method_codegen(
         }
     } else {
         quote! {
-            msg_send!(self, #methods_and_args)
+            msg_send!(*self, #methods_and_args)
         }
     };
 
@@ -3905,7 +3905,7 @@ impl CodeGenerator for ObjCInterface {
         if !self.is_category() && !self.is_protocol() {
             let struct_block = quote! {
                 #[repr(transparent)]
-                #[derive(Clone, Copy)]
+                #[derive(Clone)]
                 pub struct #class_name(pub id);
                 impl std::ops::Deref for #class_name {
                     type Target = objc::runtime::Object;
@@ -3966,6 +3966,17 @@ impl CodeGenerator for ObjCInterface {
                         }
                     };
                     result.push(impl_trait);
+                    if !parent.is_template() {
+                        let parent_struct_name = ctx.rust_ident(parent.name());
+                        let from_block = quote! {
+                            impl From<#class_name> for #parent_struct_name {
+                                fn from(child: #class_name) -> #parent_struct_name {
+                                    #parent_struct_name(child.0)
+                                }
+                            }
+                        };
+                        result.push(from_block);
+                    }
                     parent.parent_class
                 } else {
                     None

--- a/tests/expectations/tests/libclang-3.9/objc_inheritance.rs
+++ b/tests/expectations/tests/libclang-3.9/objc_inheritance.rs
@@ -11,7 +11,7 @@ extern crate objc;
 #[allow(non_camel_case_types)]
 pub type id = *mut objc::runtime::Object;
 #[repr(transparent)]
-#[derive(Clone, Copy)]
+#[derive(Clone)]
 pub struct Foo(pub id);
 impl std::ops::Deref for Foo {
     type Target = objc::runtime::Object;
@@ -28,7 +28,7 @@ impl Foo {
 impl IFoo for Foo {}
 pub trait IFoo: Sized + std::ops::Deref {}
 #[repr(transparent)]
-#[derive(Clone, Copy)]
+#[derive(Clone)]
 pub struct Bar(pub id);
 impl std::ops::Deref for Bar {
     type Target = objc::runtime::Object;
@@ -43,10 +43,78 @@ impl Bar {
     }
 }
 impl IFoo for Bar {}
+
+mpl From<Bar> for Foo {
+
++    fn from(child: Bar) -> Foo {
+
++        Foo(child.0)
+
++    }
+
++}
+
+impl std::convert::TryFrom<Foo> for Bar {
+    type Error = String;
+    fn try_from(parent: Foo) -> Result<Bar, Self::Error> {
+        let is_kind_of: bool =
+            unsafe { msg_send!(parent, isKindOfClass: class!(Bar)) };
+        if is_kind_of {
+            Ok(Bar(parent.0))
+        } else {
+            Err(format!(
+                "This {} is not an cannot be downcasted to {}",
+                "Foo", "Bar"
+            ))
+        }
+    }
+}
 impl IBar for Bar {}
+impl From<Baz> for Bar {
+    fn from(child: Baz) -> Bar {
+        Bar(child.0)
+    }
+}
+
+impl std::convert::TryFrom<Bar> for Baz {
+    type Error = String;
+    fn try_from(parent: Bar) -> Result<Baz, Self::Error> {
+        let is_kind_of: bool =
+            unsafe { msg_send!(parent, isKindOfClass: class!(Baz)) };
+        if is_kind_of {
+            Ok(Baz(parent.0))
+        } else {
+            Err(format!(
+                "This {} is not an cannot be downcasted to {}",
+                "Bar", "Baz"
+            ))
+        }
+    }
+}
+impl IFoo for Baz {}
+impl From<Baz> for Foo {
+    fn from(child: Baz) -> Foo {
+        Foo(child.0)
+    }
+}
+impl std::convert::TryFrom<Foo> for Baz {
+    type Error = String;
+    fn try_from(parent: Foo) -> Result<Baz, Self::Error> {
+        let is_kind_of: bool =
+            unsafe { msg_send!(parent, isKindOfClass: class!(Baz)) };
+        if is_kind_of {
+            Ok(Baz(parent.0))
+        } else {
+            Err(format!(
+                "This {} is not an cannot be downcasted to {}",
+                "Foo", "Baz"
+            ))
+        }
+    }
+}
 pub trait IBar: Sized + std::ops::Deref {}
 #[repr(transparent)]
-#[derive(Clone, Copy)]
+#[derive(Clone)]
 pub struct Baz(pub id);
 impl std::ops::Deref for Baz {
     type Target = objc::runtime::Object;
@@ -60,7 +128,5 @@ impl Baz {
         Self(unsafe { msg_send!(objc::class!(Baz), alloc) })
     }
 }
-impl IBar for Baz {}
-impl IFoo for Baz {}
 impl IBaz for Baz {}
 pub trait IBaz: Sized + std::ops::Deref {}

--- a/tests/expectations/tests/libclang-3.9/objc_inheritance.rs
+++ b/tests/expectations/tests/libclang-3.9/objc_inheritance.rs
@@ -77,6 +77,7 @@ impl Baz {
         Self(unsafe { msg_send!(objc::class!(Baz), alloc) })
     }
 }
+impl IBar for Baz {}
 impl From<Baz> for Bar {
     fn from(child: Baz) -> Bar {
         Bar(child.0)

--- a/tests/expectations/tests/libclang-3.9/objc_inheritance.rs
+++ b/tests/expectations/tests/libclang-3.9/objc_inheritance.rs
@@ -50,17 +50,14 @@ impl From<Bar> for Foo {
     }
 }
 impl std::convert::TryFrom<Foo> for Bar {
-    type Error = String;
+    type Error = &'static str;
     fn try_from(parent: Foo) -> Result<Bar, Self::Error> {
         let is_kind_of: bool =
             unsafe { msg_send!(parent, isKindOfClass: class!(Bar)) };
         if is_kind_of {
             Ok(Bar(parent.0))
         } else {
-            Err(format!(
-                "This {} is not an cannot be downcasted to {}",
-                "Foo", "Bar"
-            ))
+            Err("This Foo cannot be downcasted to Bar")
         }
     }
 }
@@ -70,19 +67,15 @@ impl From<Baz> for Bar {
         Bar(child.0)
     }
 }
-
 impl std::convert::TryFrom<Bar> for Baz {
-    type Error = String;
+    type Error = &'static str;
     fn try_from(parent: Bar) -> Result<Baz, Self::Error> {
         let is_kind_of: bool =
             unsafe { msg_send!(parent, isKindOfClass: class!(Baz)) };
         if is_kind_of {
             Ok(Baz(parent.0))
         } else {
-            Err(format!(
-                "This {} is not an cannot be downcasted to {}",
-                "Bar", "Baz"
-            ))
+            Err("This Bar cannot be downcasted to Baz")
         }
     }
 }
@@ -93,17 +86,14 @@ impl From<Baz> for Foo {
     }
 }
 impl std::convert::TryFrom<Foo> for Baz {
-    type Error = String;
+    type Error = &'static str;
     fn try_from(parent: Foo) -> Result<Baz, Self::Error> {
         let is_kind_of: bool =
             unsafe { msg_send!(parent, isKindOfClass: class!(Baz)) };
         if is_kind_of {
             Ok(Baz(parent.0))
         } else {
-            Err(format!(
-                "This {} is not an cannot be downcasted to {}",
-                "Foo", "Baz"
-            ))
+            Err("This Foo cannot be downcasted to Baz")
         }
     }
 }

--- a/tests/expectations/tests/libclang-3.9/objc_inheritance.rs
+++ b/tests/expectations/tests/libclang-3.9/objc_inheritance.rs
@@ -43,7 +43,6 @@ impl Bar {
     }
 }
 impl IFoo for Bar {}
-
 impl From<Bar> for Foo {
     fn from(child: Bar) -> Foo {
         Foo(child.0)
@@ -62,6 +61,22 @@ impl std::convert::TryFrom<Foo> for Bar {
     }
 }
 impl IBar for Bar {}
+pub trait IBar: Sized + std::ops::Deref {}
+#[repr(transparent)]
+#[derive(Clone)]
+pub struct Baz(pub id);
+impl std::ops::Deref for Baz {
+    type Target = objc::runtime::Object;
+    fn deref(&self) -> &Self::Target {
+        unsafe { &*self.0 }
+    }
+}
+unsafe impl objc::Message for Baz {}
+impl Baz {
+    pub fn alloc() -> Self {
+        Self(unsafe { msg_send!(objc::class!(Baz), alloc) })
+    }
+}
 impl From<Baz> for Bar {
     fn from(child: Baz) -> Bar {
         Bar(child.0)
@@ -95,22 +110,6 @@ impl std::convert::TryFrom<Foo> for Baz {
         } else {
             Err("This Foo cannot be downcasted to Baz")
         }
-    }
-}
-pub trait IBar: Sized + std::ops::Deref {}
-#[repr(transparent)]
-#[derive(Clone)]
-pub struct Baz(pub id);
-impl std::ops::Deref for Baz {
-    type Target = objc::runtime::Object;
-    fn deref(&self) -> &Self::Target {
-        unsafe { &*self.0 }
-    }
-}
-unsafe impl objc::Message for Baz {}
-impl Baz {
-    pub fn alloc() -> Self {
-        Self(unsafe { msg_send!(objc::class!(Baz), alloc) })
     }
 }
 impl IBaz for Baz {}

--- a/tests/expectations/tests/libclang-3.9/objc_inheritance.rs
+++ b/tests/expectations/tests/libclang-3.9/objc_inheritance.rs
@@ -44,16 +44,11 @@ impl Bar {
 }
 impl IFoo for Bar {}
 
-mpl From<Bar> for Foo {
-
-+    fn from(child: Bar) -> Foo {
-
-+        Foo(child.0)
-
-+    }
-
-+}
-
+impl From<Bar> for Foo {
+    fn from(child: Bar) -> Foo {
+        Foo(child.0)
+    }
+}
 impl std::convert::TryFrom<Foo> for Bar {
     type Error = String;
     fn try_from(parent: Foo) -> Result<Bar, Self::Error> {

--- a/tests/expectations/tests/libclang-3.9/objc_template.rs
+++ b/tests/expectations/tests/libclang-3.9/objc_template.rs
@@ -11,7 +11,7 @@ extern crate objc;
 #[allow(non_camel_case_types)]
 pub type id = *mut objc::runtime::Object;
 #[repr(transparent)]
-#[derive(Clone, Copy)]
+#[derive(Clone)]
 pub struct Foo(pub id);
 impl std::ops::Deref for Foo {
     type Target = objc::runtime::Object;
@@ -27,15 +27,15 @@ impl Foo {
 }
 impl<ObjectType: 'static> IFoo<ObjectType> for Foo {}
 pub trait IFoo<ObjectType>: Sized + std::ops::Deref {
-    unsafe fn get(self) -> id
+    unsafe fn get(&self) -> id
     where
         <Self as std::ops::Deref>::Target: objc::Message + Sized,
     {
-        msg_send!(self, get)
+        msg_send!(*self, get)
     }
 }
 #[repr(transparent)]
-#[derive(Clone, Copy)]
+#[derive(Clone)]
 pub struct FooMultiGeneric(pub id);
 impl std::ops::Deref for FooMultiGeneric {
     type Target = objc::runtime::Object;
@@ -56,10 +56,10 @@ impl<KeyType: 'static, ObjectType: 'static>
 pub trait IFooMultiGeneric<KeyType, ObjectType>:
     Sized + std::ops::Deref
 {
-    unsafe fn objectForKey_(self, key: id) -> id
+    unsafe fn objectForKey_(&self, key: id) -> id
     where
         <Self as std::ops::Deref>::Target: objc::Message + Sized,
     {
-        msg_send!(self, objectForKey: key)
+        msg_send!(*self, objectForKey: key)
     }
 }

--- a/tests/expectations/tests/libclang-4/objc_inheritance.rs
+++ b/tests/expectations/tests/libclang-4/objc_inheritance.rs
@@ -11,7 +11,7 @@ extern crate objc;
 #[allow(non_camel_case_types)]
 pub type id = *mut objc::runtime::Object;
 #[repr(transparent)]
-#[derive(Clone, Copy)]
+#[derive(Clone)]
 pub struct Foo(pub id);
 impl std::ops::Deref for Foo {
     type Target = objc::runtime::Object;
@@ -28,7 +28,7 @@ impl Foo {
 impl IFoo for Foo {}
 pub trait IFoo: Sized + std::ops::Deref {}
 #[repr(transparent)]
-#[derive(Clone, Copy)]
+#[derive(Clone)]
 pub struct Bar(pub id);
 impl std::ops::Deref for Bar {
     type Target = objc::runtime::Object;
@@ -43,10 +43,30 @@ impl Bar {
     }
 }
 impl IFoo for Bar {}
+impl From<Bar> for Foo {
+    fn from(child: Bar) -> Foo {
+        Foo(child.0)
+    }
+}
+impl std::convert::TryFrom<Foo> for Bar {
+    type Error = String;
+    fn try_from(parent: Foo) -> Result<Bar, Self::Error> {
+        let is_kind_of: bool =
+            unsafe { msg_send!(parent, isKindOfClass: class!(Bar)) };
+        if is_kind_of {
+            Ok(Bar(parent.0))
+        } else {
+            Err(format!(
+                "This {} is not an cannot be downcasted to {}",
+                "Foo", "Bar"
+            ))
+        }
+    }
+}
 impl IBar for Bar {}
 pub trait IBar: Sized + std::ops::Deref {}
 #[repr(transparent)]
-#[derive(Clone, Copy)]
+#[derive(Clone)]
 pub struct Baz(pub id);
 impl std::ops::Deref for Baz {
     type Target = objc::runtime::Object;
@@ -61,6 +81,46 @@ impl Baz {
     }
 }
 impl IBar for Baz {}
+impl From<Baz> for Bar {
+    fn from(child: Baz) -> Bar {
+        Bar(child.0)
+    }
+}
+impl std::convert::TryFrom<Bar> for Baz {
+    type Error = String;
+    fn try_from(parent: Bar) -> Result<Baz, Self::Error> {
+        let is_kind_of: bool =
+            unsafe { msg_send!(parent, isKindOfClass: class!(Baz)) };
+        if is_kind_of {
+            Ok(Baz(parent.0))
+        } else {
+            Err(format!(
+                "This {} is not an cannot be downcasted to {}",
+                "Bar", "Baz"
+            ))
+        }
+    }
+}
 impl IFoo for Baz {}
+impl From<Baz> for Foo {
+    fn from(child: Baz) -> Foo {
+        Foo(child.0)
+    }
+}
+impl std::convert::TryFrom<Foo> for Baz {
+    type Error = String;
+    fn try_from(parent: Foo) -> Result<Baz, Self::Error> {
+        let is_kind_of: bool =
+            unsafe { msg_send!(parent, isKindOfClass: class!(Baz)) };
+        if is_kind_of {
+            Ok(Baz(parent.0))
+        } else {
+            Err(format!(
+                "This {} is not an cannot be downcasted to {}",
+                "Foo", "Baz"
+            ))
+        }
+    }
+}
 impl IBaz for Baz {}
 pub trait IBaz: Sized + std::ops::Deref {}

--- a/tests/expectations/tests/libclang-4/objc_inheritance.rs
+++ b/tests/expectations/tests/libclang-4/objc_inheritance.rs
@@ -49,17 +49,14 @@ impl From<Bar> for Foo {
     }
 }
 impl std::convert::TryFrom<Foo> for Bar {
-    type Error = String;
+    type Error = &'static str;
     fn try_from(parent: Foo) -> Result<Bar, Self::Error> {
         let is_kind_of: bool =
             unsafe { msg_send!(parent, isKindOfClass: class!(Bar)) };
         if is_kind_of {
             Ok(Bar(parent.0))
         } else {
-            Err(format!(
-                "This {} is not an cannot be downcasted to {}",
-                "Foo", "Bar"
-            ))
+            Err("This Foo cannot be downcasted to Bar")
         }
     }
 }
@@ -87,17 +84,14 @@ impl From<Baz> for Bar {
     }
 }
 impl std::convert::TryFrom<Bar> for Baz {
-    type Error = String;
+    type Error = &'static str;
     fn try_from(parent: Bar) -> Result<Baz, Self::Error> {
         let is_kind_of: bool =
             unsafe { msg_send!(parent, isKindOfClass: class!(Baz)) };
         if is_kind_of {
             Ok(Baz(parent.0))
         } else {
-            Err(format!(
-                "This {} is not an cannot be downcasted to {}",
-                "Bar", "Baz"
-            ))
+            Err("This Bar cannot be downcasted to Baz")
         }
     }
 }
@@ -108,17 +102,14 @@ impl From<Baz> for Foo {
     }
 }
 impl std::convert::TryFrom<Foo> for Baz {
-    type Error = String;
+    type Error = &'static str;
     fn try_from(parent: Foo) -> Result<Baz, Self::Error> {
         let is_kind_of: bool =
             unsafe { msg_send!(parent, isKindOfClass: class!(Baz)) };
         if is_kind_of {
             Ok(Baz(parent.0))
         } else {
-            Err(format!(
-                "This {} is not an cannot be downcasted to {}",
-                "Foo", "Baz"
-            ))
+            Err("This Foo cannot be downcasted to Baz")
         }
     }
 }

--- a/tests/expectations/tests/libclang-4/objc_template.rs
+++ b/tests/expectations/tests/libclang-4/objc_template.rs
@@ -11,7 +11,7 @@ extern crate objc;
 #[allow(non_camel_case_types)]
 pub type id = *mut objc::runtime::Object;
 #[repr(transparent)]
-#[derive(Clone, Copy)]
+#[derive(Clone)]
 pub struct Foo(pub id);
 impl std::ops::Deref for Foo {
     type Target = objc::runtime::Object;
@@ -27,15 +27,15 @@ impl Foo {
 }
 impl<ObjectType: 'static> IFoo<ObjectType> for Foo {}
 pub trait IFoo<ObjectType>: Sized + std::ops::Deref {
-    unsafe fn get(self) -> *mut ObjectType
+    unsafe fn get(&self) -> *mut ObjectType
     where
         <Self as std::ops::Deref>::Target: objc::Message + Sized,
     {
-        msg_send!(self, get)
+        msg_send!(*self, get)
     }
 }
 #[repr(transparent)]
-#[derive(Clone, Copy)]
+#[derive(Clone)]
 pub struct FooMultiGeneric(pub id);
 impl std::ops::Deref for FooMultiGeneric {
     type Target = objc::runtime::Object;
@@ -56,10 +56,10 @@ impl<KeyType: 'static, ObjectType: 'static>
 pub trait IFooMultiGeneric<KeyType, ObjectType>:
     Sized + std::ops::Deref
 {
-    unsafe fn objectForKey_(self, key: *mut KeyType) -> *mut ObjectType
+    unsafe fn objectForKey_(&self, key: *mut KeyType) -> *mut ObjectType
     where
         <Self as std::ops::Deref>::Target: objc::Message + Sized,
     {
-        msg_send!(self, objectForKey: key)
+        msg_send!(*self, objectForKey: key)
     }
 }

--- a/tests/expectations/tests/libclang-5/objc_inheritance.rs
+++ b/tests/expectations/tests/libclang-5/objc_inheritance.rs
@@ -11,7 +11,7 @@ extern crate objc;
 #[allow(non_camel_case_types)]
 pub type id = *mut objc::runtime::Object;
 #[repr(transparent)]
-#[derive(Clone, Copy)]
+#[derive(Clone)]
 pub struct Foo(pub id);
 impl std::ops::Deref for Foo {
     type Target = objc::runtime::Object;
@@ -28,7 +28,7 @@ impl Foo {
 impl IFoo for Foo {}
 pub trait IFoo: Sized + std::ops::Deref {}
 #[repr(transparent)]
-#[derive(Clone, Copy)]
+#[derive(Clone)]
 pub struct Bar(pub id);
 impl std::ops::Deref for Bar {
     type Target = objc::runtime::Object;
@@ -43,10 +43,30 @@ impl Bar {
     }
 }
 impl IFoo for Bar {}
+impl From<Bar> for Foo {
+    fn from(child: Bar) -> Foo {
+        Foo(child.0)
+    }
+}
+impl std::convert::TryFrom<Foo> for Bar {
+    type Error = String;
+    fn try_from(parent: Foo) -> Result<Bar, Self::Error> {
+        let is_kind_of: bool =
+            unsafe { msg_send!(parent, isKindOfClass: class!(Bar)) };
+        if is_kind_of {
+            Ok(Bar(parent.0))
+        } else {
+            Err(format!(
+                "This {} is not an cannot be downcasted to {}",
+                "Foo", "Bar"
+            ))
+        }
+    }
+}
 impl IBar for Bar {}
 pub trait IBar: Sized + std::ops::Deref {}
 #[repr(transparent)]
-#[derive(Clone, Copy)]
+#[derive(Clone)]
 pub struct Baz(pub id);
 impl std::ops::Deref for Baz {
     type Target = objc::runtime::Object;
@@ -61,6 +81,46 @@ impl Baz {
     }
 }
 impl IBar for Baz {}
+impl From<Baz> for Bar {
+    fn from(child: Baz) -> Bar {
+        Bar(child.0)
+    }
+}
+impl std::convert::TryFrom<Bar> for Baz {
+    type Error = String;
+    fn try_from(parent: Bar) -> Result<Baz, Self::Error> {
+        let is_kind_of: bool =
+            unsafe { msg_send!(parent, isKindOfClass: class!(Baz)) };
+        if is_kind_of {
+            Ok(Baz(parent.0))
+        } else {
+            Err(format!(
+                "This {} is not an cannot be downcasted to {}",
+                "Bar", "Baz"
+            ))
+        }
+    }
+}
 impl IFoo for Baz {}
+impl From<Baz> for Foo {
+    fn from(child: Baz) -> Foo {
+        Foo(child.0)
+    }
+}
+impl std::convert::TryFrom<Foo> for Baz {
+    type Error = String;
+    fn try_from(parent: Foo) -> Result<Baz, Self::Error> {
+        let is_kind_of: bool =
+            unsafe { msg_send!(parent, isKindOfClass: class!(Baz)) };
+        if is_kind_of {
+            Ok(Baz(parent.0))
+        } else {
+            Err(format!(
+                "This {} is not an cannot be downcasted to {}",
+                "Foo", "Baz"
+            ))
+        }
+    }
+}
 impl IBaz for Baz {}
 pub trait IBaz: Sized + std::ops::Deref {}

--- a/tests/expectations/tests/libclang-5/objc_inheritance.rs
+++ b/tests/expectations/tests/libclang-5/objc_inheritance.rs
@@ -49,7 +49,7 @@ impl From<Bar> for Foo {
     }
 }
 impl std::convert::TryFrom<Foo> for Bar {
-    type Error = String;
+    type Error = &'static str;
     fn try_from(parent: Foo) -> Result<Bar, Self::Error> {
         let is_kind_of: bool =
             unsafe { msg_send!(parent, isKindOfClass: class!(Bar)) };

--- a/tests/expectations/tests/libclang-5/objc_inheritance.rs
+++ b/tests/expectations/tests/libclang-5/objc_inheritance.rs
@@ -56,10 +56,7 @@ impl std::convert::TryFrom<Foo> for Bar {
         if is_kind_of {
             Ok(Bar(parent.0))
         } else {
-            Err(format!(
-                "This {} is not an cannot be downcasted to {}",
-                "Foo", "Bar"
-            ))
+            Err("This Foo cannot be downcasted to Bar")
         }
     }
 }
@@ -87,17 +84,14 @@ impl From<Baz> for Bar {
     }
 }
 impl std::convert::TryFrom<Bar> for Baz {
-    type Error = String;
+    type Error = &'static str;
     fn try_from(parent: Bar) -> Result<Baz, Self::Error> {
         let is_kind_of: bool =
             unsafe { msg_send!(parent, isKindOfClass: class!(Baz)) };
         if is_kind_of {
             Ok(Baz(parent.0))
         } else {
-            Err(format!(
-                "This {} is not an cannot be downcasted to {}",
-                "Bar", "Baz"
-            ))
+            Err("This Bar cannot be downcasted to Baz")
         }
     }
 }
@@ -108,17 +102,14 @@ impl From<Baz> for Foo {
     }
 }
 impl std::convert::TryFrom<Foo> for Baz {
-    type Error = String;
+    type Error = &'static str;
     fn try_from(parent: Foo) -> Result<Baz, Self::Error> {
         let is_kind_of: bool =
             unsafe { msg_send!(parent, isKindOfClass: class!(Baz)) };
         if is_kind_of {
             Ok(Baz(parent.0))
         } else {
-            Err(format!(
-                "This {} is not an cannot be downcasted to {}",
-                "Foo", "Baz"
-            ))
+            Err("This Foo cannot be downcasted to Baz")
         }
     }
 }

--- a/tests/expectations/tests/libclang-5/objc_template.rs
+++ b/tests/expectations/tests/libclang-5/objc_template.rs
@@ -11,7 +11,7 @@ extern crate objc;
 #[allow(non_camel_case_types)]
 pub type id = *mut objc::runtime::Object;
 #[repr(transparent)]
-#[derive(Clone, Copy)]
+#[derive(Clone)]
 pub struct Foo(pub id);
 impl std::ops::Deref for Foo {
     type Target = objc::runtime::Object;
@@ -27,15 +27,15 @@ impl Foo {
 }
 impl<ObjectType: 'static> IFoo<ObjectType> for Foo {}
 pub trait IFoo<ObjectType>: Sized + std::ops::Deref {
-    unsafe fn get(self) -> *mut ObjectType
+    unsafe fn get(&self) -> *mut ObjectType
     where
         <Self as std::ops::Deref>::Target: objc::Message + Sized,
     {
-        msg_send!(self, get)
+        msg_send!(*self, get)
     }
 }
 #[repr(transparent)]
-#[derive(Clone, Copy)]
+#[derive(Clone)]
 pub struct FooMultiGeneric(pub id);
 impl std::ops::Deref for FooMultiGeneric {
     type Target = objc::runtime::Object;
@@ -56,10 +56,10 @@ impl<KeyType: 'static, ObjectType: 'static>
 pub trait IFooMultiGeneric<KeyType, ObjectType>:
     Sized + std::ops::Deref
 {
-    unsafe fn objectForKey_(self, key: *mut KeyType) -> *mut ObjectType
+    unsafe fn objectForKey_(&self, key: *mut KeyType) -> *mut ObjectType
     where
         <Self as std::ops::Deref>::Target: objc::Message + Sized,
     {
-        msg_send!(self, objectForKey: key)
+        msg_send!(*self, objectForKey: key)
     }
 }

--- a/tests/expectations/tests/libclang-9/objc_inheritance.rs
+++ b/tests/expectations/tests/libclang-9/objc_inheritance.rs
@@ -11,7 +11,7 @@ extern crate objc;
 #[allow(non_camel_case_types)]
 pub type id = *mut objc::runtime::Object;
 #[repr(transparent)]
-#[derive(Clone, Copy)]
+#[derive(Clone)]
 pub struct Foo(pub id);
 impl std::ops::Deref for Foo {
     type Target = objc::runtime::Object;
@@ -28,7 +28,7 @@ impl Foo {
 impl IFoo for Foo {}
 pub trait IFoo: Sized + std::ops::Deref {}
 #[repr(transparent)]
-#[derive(Clone, Copy)]
+#[derive(Clone)]
 pub struct Bar(pub id);
 impl std::ops::Deref for Bar {
     type Target = objc::runtime::Object;
@@ -43,10 +43,15 @@ impl Bar {
     }
 }
 impl IFoo for Bar {}
+impl From<Bar> for Foo {
+    fn from(child: Bar) -> Foo {
+        Foo(child.0)
+    }
+}
 impl IBar for Bar {}
 pub trait IBar: Sized + std::ops::Deref {}
 #[repr(transparent)]
-#[derive(Clone, Copy)]
+#[derive(Clone)]
 pub struct Baz(pub id);
 impl std::ops::Deref for Baz {
     type Target = objc::runtime::Object;
@@ -61,6 +66,16 @@ impl Baz {
     }
 }
 impl IBar for Baz {}
+impl From<Baz> for Bar {
+    fn from(child: Baz) -> Bar {
+        Bar(child.0)
+    }
+}
 impl IFoo for Baz {}
+impl From<Baz> for Foo {
+    fn from(child: Baz) -> Foo {
+        Foo(child.0)
+    }
+}
 impl IBaz for Baz {}
 pub trait IBaz: Sized + std::ops::Deref {}

--- a/tests/expectations/tests/libclang-9/objc_inheritance.rs
+++ b/tests/expectations/tests/libclang-9/objc_inheritance.rs
@@ -49,17 +49,14 @@ impl From<Bar> for Foo {
     }
 }
 impl std::convert::TryFrom<Foo> for Bar {
-    type Error = String;
+    type Error = &'static str;
     fn try_from(parent: Foo) -> Result<Bar, Self::Error> {
         let is_kind_of: bool =
             unsafe { msg_send!(parent, isKindOfClass: class!(Bar)) };
         if is_kind_of {
             Ok(Bar(parent.0))
         } else {
-            Err(format!(
-                "This {} is not an cannot be downcasted to {}",
-                "Foo", "Bar"
-            ))
+            Err("This Foo cannot be downcasted to Bar")
         }
     }
 }
@@ -87,17 +84,14 @@ impl From<Baz> for Bar {
     }
 }
 impl std::convert::TryFrom<Bar> for Baz {
-    type Error = String;
+    type Error = &'static str;
     fn try_from(parent: Bar) -> Result<Baz, Self::Error> {
         let is_kind_of: bool =
             unsafe { msg_send!(parent, isKindOfClass: class!(Baz)) };
         if is_kind_of {
             Ok(Baz(parent.0))
         } else {
-            Err(format!(
-                "This {} is not an cannot be downcasted to {}",
-                "Bar", "Baz"
-            ))
+            Err("This Bar cannot be downcasted to Baz")
         }
     }
 }
@@ -108,17 +102,14 @@ impl From<Baz> for Foo {
     }
 }
 impl std::convert::TryFrom<Foo> for Baz {
-    type Error = String;
+    type Error = &'static str;
     fn try_from(parent: Foo) -> Result<Baz, Self::Error> {
         let is_kind_of: bool =
             unsafe { msg_send!(parent, isKindOfClass: class!(Baz)) };
         if is_kind_of {
             Ok(Baz(parent.0))
         } else {
-            Err(format!(
-                "This {} is not an cannot be downcasted to {}",
-                "Foo", "Baz"
-            ))
+            Err("This Foo cannot be downcasted to Baz")
         }
     }
 }

--- a/tests/expectations/tests/libclang-9/objc_template.rs
+++ b/tests/expectations/tests/libclang-9/objc_template.rs
@@ -11,7 +11,7 @@ extern crate objc;
 #[allow(non_camel_case_types)]
 pub type id = *mut objc::runtime::Object;
 #[repr(transparent)]
-#[derive(Clone, Copy)]
+#[derive(Clone)]
 pub struct Foo(pub id);
 impl std::ops::Deref for Foo {
     type Target = objc::runtime::Object;
@@ -27,15 +27,15 @@ impl Foo {
 }
 impl<ObjectType: 'static> IFoo<ObjectType> for Foo {}
 pub trait IFoo<ObjectType>: Sized + std::ops::Deref {
-    unsafe fn get(self) -> u64
+    unsafe fn get(&self) -> u64
     where
         <Self as std::ops::Deref>::Target: objc::Message + Sized,
     {
-        msg_send!(self, get)
+        msg_send!(*self, get)
     }
 }
 #[repr(transparent)]
-#[derive(Clone, Copy)]
+#[derive(Clone)]
 pub struct FooMultiGeneric(pub id);
 impl std::ops::Deref for FooMultiGeneric {
     type Target = objc::runtime::Object;
@@ -56,10 +56,10 @@ impl<KeyType: 'static, ObjectType: 'static>
 pub trait IFooMultiGeneric<KeyType, ObjectType>:
     Sized + std::ops::Deref
 {
-    unsafe fn objectForKey_(self, key: u64) -> u64
+    unsafe fn objectForKey_(&self, key: u64) -> u64
     where
         <Self as std::ops::Deref>::Target: objc::Message + Sized,
     {
-        msg_send!(self, objectForKey: key)
+        msg_send!(*self, objectForKey: key)
     }
 }

--- a/tests/expectations/tests/objc_category.rs
+++ b/tests/expectations/tests/objc_category.rs
@@ -11,7 +11,7 @@ extern crate objc;
 #[allow(non_camel_case_types)]
 pub type id = *mut objc::runtime::Object;
 #[repr(transparent)]
-#[derive(Clone, Copy)]
+#[derive(Clone)]
 pub struct Foo(pub id);
 impl std::ops::Deref for Foo {
     type Target = objc::runtime::Object;
@@ -27,19 +27,19 @@ impl Foo {
 }
 impl IFoo for Foo {}
 pub trait IFoo: Sized + std::ops::Deref {
-    unsafe fn method(self)
+    unsafe fn method(&self)
     where
         <Self as std::ops::Deref>::Target: objc::Message + Sized,
     {
-        msg_send!(self, method)
+        msg_send!(*self, method)
     }
 }
 impl Foo_BarCategory for Foo {}
 pub trait Foo_BarCategory: Sized + std::ops::Deref {
-    unsafe fn categoryMethod(self)
+    unsafe fn categoryMethod(&self)
     where
         <Self as std::ops::Deref>::Target: objc::Message + Sized,
     {
-        msg_send!(self, categoryMethod)
+        msg_send!(*self, categoryMethod)
     }
 }

--- a/tests/expectations/tests/objc_class.rs
+++ b/tests/expectations/tests/objc_class.rs
@@ -14,7 +14,7 @@ extern "C" {
     pub static mut fooVar: Foo;
 }
 #[repr(transparent)]
-#[derive(Clone, Copy)]
+#[derive(Clone)]
 pub struct Foo(pub id);
 impl std::ops::Deref for Foo {
     type Target = objc::runtime::Object;
@@ -30,10 +30,10 @@ impl Foo {
 }
 impl IFoo for Foo {}
 pub trait IFoo: Sized + std::ops::Deref {
-    unsafe fn method(self)
+    unsafe fn method(&self)
     where
         <Self as std::ops::Deref>::Target: objc::Message + Sized,
     {
-        msg_send!(self, method)
+        msg_send!(*self, method)
     }
 }

--- a/tests/expectations/tests/objc_class_method.rs
+++ b/tests/expectations/tests/objc_class_method.rs
@@ -11,7 +11,7 @@ extern crate objc;
 #[allow(non_camel_case_types)]
 pub type id = *mut objc::runtime::Object;
 #[repr(transparent)]
-#[derive(Clone, Copy)]
+#[derive(Clone)]
 pub struct Foo(pub id);
 impl std::ops::Deref for Foo {
     type Target = objc::runtime::Object;

--- a/tests/expectations/tests/objc_interface.rs
+++ b/tests/expectations/tests/objc_interface.rs
@@ -11,7 +11,7 @@ extern crate objc;
 #[allow(non_camel_case_types)]
 pub type id = *mut objc::runtime::Object;
 #[repr(transparent)]
-#[derive(Clone, Copy)]
+#[derive(Clone)]
 pub struct Foo(pub id);
 impl std::ops::Deref for Foo {
     type Target = objc::runtime::Object;

--- a/tests/expectations/tests/objc_interface_type.rs
+++ b/tests/expectations/tests/objc_interface_type.rs
@@ -11,7 +11,7 @@ extern crate objc;
 #[allow(non_camel_case_types)]
 pub type id = *mut objc::runtime::Object;
 #[repr(transparent)]
-#[derive(Clone, Copy)]
+#[derive(Clone)]
 pub struct Foo(pub id);
 impl std::ops::Deref for Foo {
     type Target = objc::runtime::Object;

--- a/tests/expectations/tests/objc_method.rs
+++ b/tests/expectations/tests/objc_method.rs
@@ -11,7 +11,7 @@ extern crate objc;
 #[allow(non_camel_case_types)]
 pub type id = *mut objc::runtime::Object;
 #[repr(transparent)]
-#[derive(Clone, Copy)]
+#[derive(Clone)]
 pub struct Foo(pub id);
 impl std::ops::Deref for Foo {
     type Target = objc::runtime::Object;
@@ -27,48 +27,48 @@ impl Foo {
 }
 impl IFoo for Foo {}
 pub trait IFoo: Sized + std::ops::Deref {
-    unsafe fn method(self)
+    unsafe fn method(&self)
     where
         <Self as std::ops::Deref>::Target: objc::Message + Sized,
     {
-        msg_send!(self, method)
+        msg_send!(*self, method)
     }
-    unsafe fn methodWithInt_(self, foo: ::std::os::raw::c_int)
+    unsafe fn methodWithInt_(&self, foo: ::std::os::raw::c_int)
     where
         <Self as std::ops::Deref>::Target: objc::Message + Sized,
     {
-        msg_send!(self, methodWithInt: foo)
+        msg_send!(*self, methodWithInt: foo)
     }
-    unsafe fn methodWithFoo_(self, foo: Foo)
+    unsafe fn methodWithFoo_(&self, foo: Foo)
     where
         <Self as std::ops::Deref>::Target: objc::Message + Sized,
     {
-        msg_send!(self, methodWithFoo: foo)
+        msg_send!(*self, methodWithFoo: foo)
     }
-    unsafe fn methodReturningInt(self) -> ::std::os::raw::c_int
+    unsafe fn methodReturningInt(&self) -> ::std::os::raw::c_int
     where
         <Self as std::ops::Deref>::Target: objc::Message + Sized,
     {
-        msg_send!(self, methodReturningInt)
+        msg_send!(*self, methodReturningInt)
     }
-    unsafe fn methodReturningFoo(self) -> Foo
+    unsafe fn methodReturningFoo(&self) -> Foo
     where
         <Self as std::ops::Deref>::Target: objc::Message + Sized,
     {
-        msg_send!(self, methodReturningFoo)
+        msg_send!(*self, methodReturningFoo)
     }
     unsafe fn methodWithArg1_andArg2_andArg3_(
-        self,
+        &self,
         intvalue: ::std::os::raw::c_int,
         ptr: *mut ::std::os::raw::c_char,
         floatvalue: f32,
     ) where
         <Self as std::ops::Deref>::Target: objc::Message + Sized,
     {
-        msg_send ! ( self , methodWithArg1 : intvalue andArg2 : ptr andArg3 : floatvalue )
+        msg_send ! ( * self , methodWithArg1 : intvalue andArg2 : ptr andArg3 : floatvalue )
     }
     unsafe fn methodWithAndWithoutKeywords_arg2Name__arg4Name_(
-        self,
+        &self,
         arg1: ::std::os::raw::c_int,
         arg2: f32,
         arg3: f32,
@@ -77,7 +77,7 @@ pub trait IFoo: Sized + std::ops::Deref {
     where
         <Self as std::ops::Deref>::Target: objc::Message + Sized,
     {
-        msg_send ! ( self , methodWithAndWithoutKeywords : arg1 arg2Name : arg2 arg3 : arg3 arg4Name : arg4 )
+        msg_send ! ( * self , methodWithAndWithoutKeywords : arg1 arg2Name : arg2 arg3 : arg3 arg4Name : arg4 )
     }
 }
 pub type instancetype = id;

--- a/tests/expectations/tests/objc_method_clash.rs
+++ b/tests/expectations/tests/objc_method_clash.rs
@@ -11,7 +11,7 @@ extern crate objc;
 #[allow(non_camel_case_types)]
 pub type id = *mut objc::runtime::Object;
 #[repr(transparent)]
-#[derive(Clone, Copy)]
+#[derive(Clone)]
 pub struct Foo(pub id);
 impl std::ops::Deref for Foo {
     type Target = objc::runtime::Object;
@@ -27,11 +27,11 @@ impl Foo {
 }
 impl IFoo for Foo {}
 pub trait IFoo: Sized + std::ops::Deref {
-    unsafe fn foo(self)
+    unsafe fn foo(&self)
     where
         <Self as std::ops::Deref>::Target: objc::Message + Sized,
     {
-        msg_send!(self, foo)
+        msg_send!(*self, foo)
     }
     unsafe fn class_foo()
     where

--- a/tests/expectations/tests/objc_pointer_return_types.rs
+++ b/tests/expectations/tests/objc_pointer_return_types.rs
@@ -11,7 +11,7 @@ extern crate objc;
 #[allow(non_camel_case_types)]
 pub type id = *mut objc::runtime::Object;
 #[repr(transparent)]
-#[derive(Clone, Copy)]
+#[derive(Clone)]
 pub struct Bar(pub id);
 impl std::ops::Deref for Bar {
     type Target = objc::runtime::Object;
@@ -28,7 +28,7 @@ impl Bar {
 impl IBar for Bar {}
 pub trait IBar: Sized + std::ops::Deref {}
 #[repr(transparent)]
-#[derive(Clone, Copy)]
+#[derive(Clone)]
 pub struct Foo(pub id);
 impl std::ops::Deref for Foo {
     type Target = objc::runtime::Object;
@@ -44,11 +44,11 @@ impl Foo {
 }
 impl IFoo for Foo {}
 pub trait IFoo: Sized + std::ops::Deref {
-    unsafe fn methodUsingBar_(self, my_bar: Bar)
+    unsafe fn methodUsingBar_(&self, my_bar: Bar)
     where
         <Self as std::ops::Deref>::Target: objc::Message + Sized,
     {
-        msg_send!(self, methodUsingBar: my_bar)
+        msg_send!(*self, methodUsingBar: my_bar)
     }
     unsafe fn methodReturningBar() -> Bar
     where

--- a/tests/expectations/tests/objc_property_fnptr.rs
+++ b/tests/expectations/tests/objc_property_fnptr.rs
@@ -11,7 +11,7 @@ extern crate objc;
 #[allow(non_camel_case_types)]
 pub type id = *mut objc::runtime::Object;
 #[repr(transparent)]
-#[derive(Clone, Copy)]
+#[derive(Clone)]
 pub struct Foo(pub id);
 impl std::ops::Deref for Foo {
     type Target = objc::runtime::Object;
@@ -28,7 +28,7 @@ impl Foo {
 impl IFoo for Foo {}
 pub trait IFoo: Sized + std::ops::Deref {
     unsafe fn func(
-        self,
+        &self,
     ) -> ::std::option::Option<
         unsafe extern "C" fn(
             arg1: ::std::os::raw::c_char,
@@ -39,10 +39,10 @@ pub trait IFoo: Sized + std::ops::Deref {
     where
         <Self as std::ops::Deref>::Target: objc::Message + Sized,
     {
-        msg_send!(self, func)
+        msg_send!(*self, func)
     }
     unsafe fn setFunc_(
-        self,
+        &self,
         func: ::std::option::Option<
             unsafe extern "C" fn(
                 arg1: ::std::os::raw::c_char,
@@ -53,6 +53,6 @@ pub trait IFoo: Sized + std::ops::Deref {
     ) where
         <Self as std::ops::Deref>::Target: objc::Message + Sized,
     {
-        msg_send!(self, setFunc: func)
+        msg_send!(*self, setFunc: func)
     }
 }

--- a/tests/expectations/tests/objc_protocol.rs
+++ b/tests/expectations/tests/objc_protocol.rs
@@ -12,7 +12,7 @@ extern crate objc;
 pub type id = *mut objc::runtime::Object;
 pub trait PFoo: Sized + std::ops::Deref {}
 #[repr(transparent)]
-#[derive(Clone, Copy)]
+#[derive(Clone)]
 pub struct Foo(pub id);
 impl std::ops::Deref for Foo {
     type Target = objc::runtime::Object;

--- a/tests/expectations/tests/objc_protocol_inheritance.rs
+++ b/tests/expectations/tests/objc_protocol_inheritance.rs
@@ -52,17 +52,14 @@ impl From<Bar> for Foo {
     }
 }
 impl std::convert::TryFrom<Foo> for Bar {
-    type Error = String;
+    type Error = &'static str;
     fn try_from(parent: Foo) -> Result<Bar, Self::Error> {
         let is_kind_of: bool =
             unsafe { msg_send!(parent, isKindOfClass: class!(Bar)) };
         if is_kind_of {
             Ok(Bar(parent.0))
         } else {
-            Err(format!(
-                "This {} is not an cannot be downcasted to {}",
-                "Foo", "Bar"
-            ))
+            Err("This Foo cannot be downcasted to Bar")
         }
     }
 }

--- a/tests/headers/objc_protocol_inheritance.h
+++ b/tests/headers/objc_protocol_inheritance.h
@@ -1,0 +1,11 @@
+// bindgen-flags: --objc-extern-crate -- -x objective-c
+// bindgen-osx-only
+
+@protocol Foo
+@end
+
+@interface Foo <Foo>
+@end
+
+@interface Bar : Foo
+@end


### PR DESCRIPTION
First off, I don't wanna spend forever trying to build the perfect objective-c bindings because I think that might never end. I think this PR adds a bit to the ergonomics to the generated bindings.

In this PR, we add

* `impl From<Bar> for Foo` where `Bar` is a subclass of `Foo` in the objective-c. This will be done for all super classes of `Baz`. The reason why this will be nice is that whatever uses these bindings will want to deal with the generics of stuff. In my case, I plan to create UIKit views using specific types (`UILabel`, `UIButton`, `UITextInput`, etc.) and then turn them into a `UIView`. If there's strong push back against this feature, I suppose using a `Box<dyn UIView>` will have to work.
* Changing `unsafe fn methodWithFoo_(self, foo: Foo)` to `unsafe fn methodWithFoo_(&self, foo: Foo)` and removing the `Copy` as a derived trait. One aspect of this that I've got mixed feelings about is that the existence of `&self` implies that there should be a `&mut self` and that's just not something that's all that feasible across the board. With `getters/setters` it's probably possible to have `&self` and `&mut self` respectively. With things like [`addSubview_`](https://developer.apple.com/documentation/uikit/uiview/1622616-addsubview?language=objc), it modifies the instance of the `UIView`.

I'm also temped to try and move to `unsafe fn methodWithFoo_(&self, foo: &Foo)` but I'm less interested in that is because those things are commonly actually taking ownership. For example, `root_view.setBackgroundColor_(UIColor::redColor())`. You don't really need the color after this (though you may need to deallocate it). But as a counter point `root_view.addSubview_(my_button)`, you want to keep track of `my_button` because you're going to need to run `[removeFromSuperview_`](https://developer.apple.com/documentation/uikit/uiview/1622421-removefromsuperview?language=objc) and then free the memory (or not depending on your use case).

@scoopr I think you might have some opinions on this.