### PR TITLE
codegen: Allow to not derive Debug on enums.

### DIFF
--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -2840,17 +2840,17 @@ impl CodeGenerator for Enum {
         }
 
         if !variation.is_const() {
-            let mut derives =
-                vec!["Debug", "Copy", "Clone", "PartialEq", "Eq", "Hash"];
-
-            if item.can_derive_partialord(ctx) {
-                derives.push("PartialOrd");
-            }
-
-            if item.can_derive_ord(ctx) {
-                derives.push("Ord");
-            }
-
+            let mut derives = derives_of_item(item, ctx);
+            // For backwards compat, enums always derive Clone/Eq/PartialEq/Hash, even
+            // if we don't generate those by default.
+            derives.insert(
+                DerivableTraits::CLONE |
+                    DerivableTraits::COPY |
+                    DerivableTraits::HASH |
+                    DerivableTraits::PARTIAL_EQ |
+                    DerivableTraits::EQ,
+            );
+            let derives: Vec<_> = derives.into();
             attrs.push(attributes::derives(&derives));
         }
 

--- a/tests/expectations/tests/anon_enum.rs
+++ b/tests/expectations/tests/anon_enum.rs
@@ -13,7 +13,7 @@ pub struct Test {
 }
 pub const Test_T_NONE: Test__bindgen_ty_1 = Test__bindgen_ty_1::T_NONE;
 #[repr(u32)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum Test__bindgen_ty_1 {
     T_NONE = 0,
 }
@@ -41,7 +41,7 @@ fn bindgen_test_layout_Test() {
     );
 }
 #[repr(u32)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum Baz {
     Foo = 0,
     Bar = 1,

--- a/tests/expectations/tests/anon_enum_trait.rs
+++ b/tests/expectations/tests/anon_enum_trait.rs
@@ -25,7 +25,7 @@ pub const DataType_fmt: DataType__bindgen_ty_1 =
 pub const DataType_type_: DataType__bindgen_ty_1 =
     DataType__bindgen_ty_1::generic_type;
 #[repr(i32)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum DataType__bindgen_ty_1 {
     generic_type = 0,
 }
@@ -37,7 +37,7 @@ pub struct Foo {
 pub const Foo_Bar: Foo__bindgen_ty_1 = Foo__bindgen_ty_1::Bar;
 pub const Foo_Baz: Foo__bindgen_ty_1 = Foo__bindgen_ty_1::Bar;
 #[repr(u32)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum Foo__bindgen_ty_1 {
     Bar = 0,
 }

--- a/tests/expectations/tests/anon_enum_whitelist.rs
+++ b/tests/expectations/tests/anon_enum_whitelist.rs
@@ -8,7 +8,7 @@
 pub const NODE_FLAG_FOO: _bindgen_ty_1 = _bindgen_ty_1::NODE_FLAG_FOO;
 pub const NODE_FLAG_BAR: _bindgen_ty_1 = _bindgen_ty_1::NODE_FLAG_BAR;
 #[repr(u32)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum _bindgen_ty_1 {
     NODE_FLAG_FOO = 0,
     NODE_FLAG_BAR = 1,

--- a/tests/expectations/tests/anon_union.rs
+++ b/tests/expectations/tests/anon_union.rs
@@ -17,7 +17,7 @@ impl TErrorResult_UnionState {
         TErrorResult_UnionState::HasMessage;
 }
 #[repr(i32)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum TErrorResult_UnionState {
     HasMessage = 0,
 }

--- a/tests/expectations/tests/anon_union_1_0.rs
+++ b/tests/expectations/tests/anon_union_1_0.rs
@@ -59,7 +59,7 @@ pub struct TErrorResult {
 pub const TErrorResult_UnionState_HasException: TErrorResult_UnionState =
     TErrorResult_UnionState::HasMessage;
 #[repr(i32)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum TErrorResult_UnionState {
     HasMessage = 0,
 }

--- a/tests/expectations/tests/bitfield-enum-basic.rs
+++ b/tests/expectations/tests/bitfield-enum-basic.rs
@@ -44,7 +44,7 @@ impl ::std::ops::BitAndAssign for Foo {
     }
 }
 #[repr(transparent)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct Foo(pub ::std::os::raw::c_int);
 impl Buz {
     pub const Bar: Buz = Buz(2);
@@ -85,7 +85,7 @@ impl ::std::ops::BitAndAssign for Buz {
     }
 }
 #[repr(transparent)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct Buz(pub ::std::os::raw::c_schar);
 pub const NS_FOO: _bindgen_ty_1 = _bindgen_ty_1(1);
 pub const NS_BAR: _bindgen_ty_1 = _bindgen_ty_1(2);
@@ -116,7 +116,7 @@ impl ::std::ops::BitAndAssign for _bindgen_ty_1 {
     }
 }
 #[repr(transparent)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct _bindgen_ty_1(pub ::std::os::raw::c_uint);
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
@@ -152,7 +152,7 @@ impl ::std::ops::BitAndAssign for Dummy__bindgen_ty_1 {
     }
 }
 #[repr(transparent)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct Dummy__bindgen_ty_1(pub ::std::os::raw::c_uint);
 #[test]
 fn bindgen_test_layout_Dummy() {

--- a/tests/expectations/tests/bitfield-enum-repr-c.rs
+++ b/tests/expectations/tests/bitfield-enum-repr-c.rs
@@ -44,5 +44,5 @@ impl ::std::ops::BitAndAssign for Foo {
     }
 }
 #[repr(C)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct Foo(pub ::std::os::raw::c_int);

--- a/tests/expectations/tests/bitfield-enum-repr-transparent.rs
+++ b/tests/expectations/tests/bitfield-enum-repr-transparent.rs
@@ -44,5 +44,5 @@ impl ::std::ops::BitAndAssign for Foo {
     }
 }
 #[repr(transparent)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct Foo(pub ::std::os::raw::c_int);

--- a/tests/expectations/tests/bitfield_align_2.rs
+++ b/tests/expectations/tests/bitfield_align_2.rs
@@ -93,7 +93,7 @@ where
     }
 }
 #[repr(u32)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum MyEnum {
     ONE = 0,
     TWO = 1,

--- a/tests/expectations/tests/class_with_inner_struct.rs
+++ b/tests/expectations/tests/class_with_inner_struct.rs
@@ -229,7 +229,7 @@ fn bindgen_test_layout_B() {
     );
 }
 #[repr(i32)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum StepSyntax {
     Keyword = 0,
     FunctionalWithoutKeyword = 1,

--- a/tests/expectations/tests/class_with_inner_struct_1_0.rs
+++ b/tests/expectations/tests/class_with_inner_struct_1_0.rs
@@ -287,7 +287,7 @@ impl Clone for B {
     }
 }
 #[repr(i32)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum StepSyntax {
     Keyword = 0,
     FunctionalWithoutKeyword = 1,

--- a/tests/expectations/tests/const_enum_unnamed.rs
+++ b/tests/expectations/tests/const_enum_unnamed.rs
@@ -8,7 +8,7 @@
 pub const FOO_BAR: _bindgen_ty_1 = _bindgen_ty_1::FOO_BAR;
 pub const FOO_BAZ: _bindgen_ty_1 = _bindgen_ty_1::FOO_BAZ;
 #[repr(u32)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum _bindgen_ty_1 {
     FOO_BAR = 0,
     FOO_BAZ = 1,
@@ -20,7 +20,7 @@ pub struct Foo {
 }
 pub const Foo_FOO_BAR: Foo__bindgen_ty_1 = Foo__bindgen_ty_1::FOO_BAR;
 #[repr(u32)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum Foo__bindgen_ty_1 {
     FOO_BAR = 10,
 }

--- a/tests/expectations/tests/constify-enum.rs
+++ b/tests/expectations/tests/constify-enum.rs
@@ -13,7 +13,7 @@ impl nsCSSPropertyID {
         nsCSSPropertyID::eCSSPropertyAlias_aa;
 }
 #[repr(u32)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum nsCSSPropertyID {
     eCSSProperty_a = 0,
     eCSSProperty_b = 1,

--- a/tests/expectations/tests/dupe-enum-variant-in-namespace.rs
+++ b/tests/expectations/tests/dupe-enum-variant-in-namespace.rs
@@ -19,7 +19,7 @@ pub mod root {
             pub const Foo3: root::foo::Bar = Bar::Foo2;
         }
         #[repr(u32)]
-        #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+        #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
         pub enum Bar {
             Foo = 0,
             Foo2 = 1,

--- a/tests/expectations/tests/empty-enum.rs
+++ b/tests/expectations/tests/empty-enum.rs
@@ -7,7 +7,7 @@
 
 pub type EmptyConstified = ::std::os::raw::c_uint;
 #[repr(u32)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum EmptyRustified {
     __bindgen_cannot_repr_c_on_empty_enum = 0,
 }
@@ -15,7 +15,7 @@ pub mod EmptyModule {
     pub type Type = ::std::os::raw::c_uint;
 }
 #[repr(i8)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum EmptyClassRustified {
     __bindgen_cannot_repr_c_on_empty_enum = 0,
 }
@@ -24,7 +24,7 @@ pub mod EmptyClassModule {
     pub type Type = ::std::os::raw::c_char;
 }
 #[repr(i8)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum ForwardClassRustified {
     __bindgen_cannot_repr_c_on_empty_enum = 0,
 }

--- a/tests/expectations/tests/enum-default-bitfield.rs
+++ b/tests/expectations/tests/enum-default-bitfield.rs
@@ -39,7 +39,7 @@ impl ::std::ops::BitAndAssign for foo__bindgen_ty_1 {
     }
 }
 #[repr(transparent)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct foo__bindgen_ty_1(pub ::std::os::raw::c_uint);
 #[test]
 fn bindgen_test_layout_foo() {
@@ -102,10 +102,46 @@ impl ::std::ops::BitAndAssign for Foo {
     }
 }
 #[repr(transparent)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct Foo(pub ::std::os::raw::c_uint);
 pub mod Neg {
     pub type Type = ::std::os::raw::c_int;
     pub const MinusOne: Type = -1;
     pub const One: Type = 1;
 }
+impl NoDebug {
+    pub const NoDebug1: NoDebug = NoDebug(0);
+}
+impl NoDebug {
+    pub const NoDebug2: NoDebug = NoDebug(1);
+}
+impl ::std::ops::BitOr<NoDebug> for NoDebug {
+    type Output = Self;
+    #[inline]
+    fn bitor(self, other: Self) -> Self {
+        NoDebug(self.0 | other.0)
+    }
+}
+impl ::std::ops::BitOrAssign for NoDebug {
+    #[inline]
+    fn bitor_assign(&mut self, rhs: NoDebug) {
+        self.0 |= rhs.0;
+    }
+}
+impl ::std::ops::BitAnd<NoDebug> for NoDebug {
+    type Output = Self;
+    #[inline]
+    fn bitand(self, other: Self) -> Self {
+        NoDebug(self.0 & other.0)
+    }
+}
+impl ::std::ops::BitAndAssign for NoDebug {
+    #[inline]
+    fn bitand_assign(&mut self, rhs: NoDebug) {
+        self.0 &= rhs.0;
+    }
+}
+#[repr(transparent)]
+/// <div rustbindgen nodebug></div>
+#[derive(Copy, Clone, Hash, PartialEq, Eq)]
+pub struct NoDebug(pub ::std::os::raw::c_uint);

--- a/tests/expectations/tests/enum-default-consts.rs
+++ b/tests/expectations/tests/enum-default-consts.rs
@@ -49,3 +49,7 @@ pub mod Neg {
     pub const MinusOne: Type = -1;
     pub const One: Type = 1;
 }
+pub const NoDebug_NoDebug1: NoDebug = 0;
+pub const NoDebug_NoDebug2: NoDebug = 1;
+/// <div rustbindgen nodebug></div>
+pub type NoDebug = ::std::os::raw::c_uint;

--- a/tests/expectations/tests/enum-default-module.rs
+++ b/tests/expectations/tests/enum-default-module.rs
@@ -53,3 +53,9 @@ pub mod Neg {
     pub const MinusOne: Type = -1;
     pub const One: Type = 1;
 }
+pub mod NoDebug {
+    /// <div rustbindgen nodebug></div>
+    pub type Type = ::std::os::raw::c_uint;
+    pub const NoDebug1: Type = 0;
+    pub const NoDebug2: Type = 1;
+}

--- a/tests/expectations/tests/enum-default-rust.rs
+++ b/tests/expectations/tests/enum-default-rust.rs
@@ -13,7 +13,7 @@ pub struct foo {
 pub const foo_FOO_A: foo__bindgen_ty_1 = foo__bindgen_ty_1::FOO_A;
 pub const foo_FOO_B: foo__bindgen_ty_1 = foo__bindgen_ty_1::FOO_B;
 #[repr(u32)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum foo__bindgen_ty_1 {
     FOO_A = 0,
     FOO_B = 1,
@@ -47,7 +47,7 @@ impl Default for foo {
     }
 }
 #[repr(u32)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum Foo {
     Bar = 0,
     Qux = 1,
@@ -56,4 +56,11 @@ pub mod Neg {
     pub type Type = ::std::os::raw::c_int;
     pub const MinusOne: Type = -1;
     pub const One: Type = 1;
+}
+#[repr(u32)]
+/// <div rustbindgen nodebug></div>
+#[derive(Copy, Clone, Hash, PartialEq, Eq)]
+pub enum NoDebug {
+    NoDebug1 = 0,
+    NoDebug2 = 1,
 }

--- a/tests/expectations/tests/enum-doc-bitfield.rs
+++ b/tests/expectations/tests/enum-doc-bitfield.rs
@@ -60,5 +60,5 @@ impl ::std::ops::BitAndAssign for B {
 }
 #[repr(transparent)]
 /// Document enum
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct B(pub ::std::os::raw::c_uint);

--- a/tests/expectations/tests/enum-doc-rusty.rs
+++ b/tests/expectations/tests/enum-doc-rusty.rs
@@ -7,7 +7,7 @@
 
 #[repr(u32)]
 /// Document enum
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum B {
     /// Document field with three slashes
     VAR_A = 0,

--- a/tests/expectations/tests/enum-undefault.rs
+++ b/tests/expectations/tests/enum-undefault.rs
@@ -6,7 +6,7 @@
 )]
 
 #[repr(u32)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum Foo {
     Bar = 0,
     Qux = 1,

--- a/tests/expectations/tests/enum.rs
+++ b/tests/expectations/tests/enum.rs
@@ -47,3 +47,7 @@ pub type Foo = ::std::os::raw::c_uint;
 pub const Neg_MinusOne: Neg = -1;
 pub const Neg_One: Neg = 1;
 pub type Neg = ::std::os::raw::c_int;
+pub const NoDebug_NoDebug1: NoDebug = 0;
+pub const NoDebug_NoDebug2: NoDebug = 1;
+/// <div rustbindgen nodebug></div>
+pub type NoDebug = ::std::os::raw::c_uint;

--- a/tests/expectations/tests/enum_alias.rs
+++ b/tests/expectations/tests/enum_alias.rs
@@ -6,7 +6,7 @@
 )]
 
 #[repr(u8)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum Bar {
     VAL = 0,
 }

--- a/tests/expectations/tests/enum_and_vtable_mangling.rs
+++ b/tests/expectations/tests/enum_and_vtable_mangling.rs
@@ -8,7 +8,7 @@
 pub const match_: _bindgen_ty_1 = _bindgen_ty_1::match_;
 pub const whatever_else: _bindgen_ty_1 = _bindgen_ty_1::whatever_else;
 #[repr(u32)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum _bindgen_ty_1 {
     match_ = 0,
     whatever_else = 1,

--- a/tests/expectations/tests/enum_dupe.rs
+++ b/tests/expectations/tests/enum_dupe.rs
@@ -9,7 +9,7 @@ impl Foo {
     pub const Dupe: Foo = Foo::Bar;
 }
 #[repr(u32)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum Foo {
     Bar = 1,
 }

--- a/tests/expectations/tests/enum_explicit_type.rs
+++ b/tests/expectations/tests/enum_explicit_type.rs
@@ -6,46 +6,46 @@
 )]
 
 #[repr(u8)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum Foo {
     Bar = 0,
     Qux = 1,
 }
 #[repr(i8)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum Neg {
     MinusOne = -1,
     One = 1,
 }
 #[repr(u16)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum Bigger {
     Much = 255,
     Larger = 256,
 }
 #[repr(i64)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum MuchLong {
     MuchLow = -4294967296,
 }
 #[repr(i64)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum MuchLongLong {
     I64_MIN = -9223372036854775808,
 }
 #[repr(u64)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum MuchULongLong {
     MuchHigh = 4294967296,
 }
 #[repr(u8)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum BoolEnumsAreFun {
     Value = 1,
 }
 pub type MyType = bool;
 #[repr(u8)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum BoolEnumsAreFun2 {
     Value2 = 1,
 }
@@ -54,7 +54,7 @@ pub const AnonymousVariantOne: _bindgen_ty_1 =
 pub const AnonymousVariantTwo: _bindgen_ty_1 =
     _bindgen_ty_1::AnonymousVariantTwo;
 #[repr(u8)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum _bindgen_ty_1 {
     AnonymousVariantOne = 0,
     AnonymousVariantTwo = 1,

--- a/tests/expectations/tests/enum_in_template_with_typedef.rs
+++ b/tests/expectations/tests/enum_in_template_with_typedef.rs
@@ -15,7 +15,7 @@ impl std_fbstring_core_Category {
     pub const Bar: std_fbstring_core_Category = std_fbstring_core_Category::Foo;
 }
 #[repr(u8)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum std_fbstring_core_Category {
     Foo = 0,
 }

--- a/tests/expectations/tests/enum_negative.rs
+++ b/tests/expectations/tests/enum_negative.rs
@@ -6,7 +6,7 @@
 )]
 
 #[repr(i32)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum Foo {
     Bar = -2,
     Qux = 1,

--- a/tests/expectations/tests/enum_packed.rs
+++ b/tests/expectations/tests/enum_packed.rs
@@ -6,19 +6,19 @@
 )]
 
 #[repr(u8)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum Foo {
     Bar = 0,
     Qux = 1,
 }
 #[repr(i8)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum Neg {
     MinusOne = -1,
     One = 1,
 }
 #[repr(u16)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum Bigger {
     Much = 255,
     Larger = 256,

--- a/tests/expectations/tests/forward-enum-decl.rs
+++ b/tests/expectations/tests/forward-enum-decl.rs
@@ -6,7 +6,7 @@
 )]
 
 #[repr(i32)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum CSSPseudoClassType {
     empty = 0,
     link = 1,

--- a/tests/expectations/tests/func_ptr_in_struct.rs
+++ b/tests/expectations/tests/func_ptr_in_struct.rs
@@ -6,7 +6,7 @@
 )]
 
 #[repr(i32)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum baz {
     __bindgen_cannot_repr_c_on_empty_enum = 0,
 }

--- a/tests/expectations/tests/issue-1198-alias-rust-bitfield-enum.rs
+++ b/tests/expectations/tests/issue-1198-alias-rust-bitfield-enum.rs
@@ -41,7 +41,7 @@ impl ::std::ops::BitAndAssign for MyDupeEnum {
     }
 }
 #[repr(transparent)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct MyDupeEnum(pub ::std::os::raw::c_uint);
 impl MyOtherDupeEnum {
     pub const C: MyOtherDupeEnum = MyOtherDupeEnum(0);
@@ -79,5 +79,5 @@ impl ::std::ops::BitAndAssign for MyOtherDupeEnum {
     }
 }
 #[repr(transparent)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct MyOtherDupeEnum(pub ::std::os::raw::c_uint);

--- a/tests/expectations/tests/issue-1198-alias-rust-enum.rs
+++ b/tests/expectations/tests/issue-1198-alias-rust-enum.rs
@@ -9,7 +9,7 @@ impl MyDupeEnum {
     pub const A_alias: MyDupeEnum = MyDupeEnum::A;
 }
 #[repr(u32)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum MyDupeEnum {
     A = 0,
     B = 1,
@@ -18,7 +18,7 @@ impl MyOtherDupeEnum {
     pub const C_alias: MyOtherDupeEnum = MyOtherDupeEnum::C;
 }
 #[repr(u32)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum MyOtherDupeEnum {
     C = 0,
     D = 1,

--- a/tests/expectations/tests/issue-1488-enum-new-type.rs
+++ b/tests/expectations/tests/issue-1488-enum-new-type.rs
@@ -20,7 +20,7 @@ pub mod Bar {
 #[derive(Debug, Copy, Clone)]
 pub struct BarAlias(pub Bar::Type);
 #[repr(u32)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum Qux {
     E = 0,
     F = 1,

--- a/tests/expectations/tests/issue-1554.rs
+++ b/tests/expectations/tests/issue-1554.rs
@@ -9,7 +9,7 @@
 
 #[repr(u32)]
 #[non_exhaustive]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum Planet {
     earth = 0,
     mars = 1,

--- a/tests/expectations/tests/issue-372.rs
+++ b/tests/expectations/tests/issue-372.rs
@@ -78,7 +78,7 @@ pub mod root {
         }
     }
     #[repr(u32)]
-    #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+    #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
     pub enum n {
         o = 0,
         p = 1,

--- a/tests/expectations/tests/issue-410.rs
+++ b/tests/expectations/tests/issue-410.rs
@@ -42,7 +42,7 @@ pub mod root {
         }
     }
     #[repr(u32)]
-    #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+    #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
     pub enum JSWhyMagic {
         __bindgen_cannot_repr_c_on_empty_enum = 0,
     }

--- a/tests/expectations/tests/issue-493.rs
+++ b/tests/expectations/tests/issue-493.rs
@@ -71,7 +71,7 @@ impl Default for basic_string___long {
 pub const basic_string___min_cap: basic_string__bindgen_ty_1 =
     basic_string__bindgen_ty_1::__min_cap;
 #[repr(i32)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum basic_string__bindgen_ty_1 {
     __min_cap = 0,
 }
@@ -110,7 +110,7 @@ impl Default for basic_string___ulx {
 pub const basic_string___n_words: basic_string__bindgen_ty_2 =
     basic_string__bindgen_ty_2::__n_words;
 #[repr(i32)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum basic_string__bindgen_ty_2 {
     __n_words = 0,
 }

--- a/tests/expectations/tests/issue-493_1_0.rs
+++ b/tests/expectations/tests/issue-493_1_0.rs
@@ -71,7 +71,7 @@ impl Default for basic_string___long {
 pub const basic_string___min_cap: basic_string__bindgen_ty_1 =
     basic_string__bindgen_ty_1::__min_cap;
 #[repr(i32)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum basic_string__bindgen_ty_1 {
     __min_cap = 0,
 }
@@ -103,7 +103,7 @@ pub struct basic_string___ulx {
 pub const basic_string___n_words: basic_string__bindgen_ty_2 =
     basic_string__bindgen_ty_2::__n_words;
 #[repr(i32)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum basic_string__bindgen_ty_2 {
     __n_words = 0,
 }

--- a/tests/expectations/tests/issue-569-non-type-template-params-causing-layout-test-failures.rs
+++ b/tests/expectations/tests/issue-569-non-type-template-params-causing-layout-test-failures.rs
@@ -8,7 +8,7 @@
 pub const ENUM_VARIANT_1: _bindgen_ty_1 = _bindgen_ty_1::ENUM_VARIANT_1;
 pub const ENUM_VARIANT_2: _bindgen_ty_1 = _bindgen_ty_1::ENUM_VARIANT_2;
 #[repr(u32)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum _bindgen_ty_1 {
     ENUM_VARIANT_1 = 0,
     ENUM_VARIANT_2 = 1,

--- a/tests/expectations/tests/issue-888-enum-var-decl-jump.rs
+++ b/tests/expectations/tests/issue-888-enum-var-decl-jump.rs
@@ -36,7 +36,7 @@ pub mod root {
         }
     }
     #[repr(u32)]
-    #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+    #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
     pub enum a {
         __bindgen_cannot_repr_c_on_empty_enum = 0,
     }

--- a/tests/expectations/tests/jsval_layout_opaque.rs
+++ b/tests/expectations/tests/jsval_layout_opaque.rs
@@ -97,7 +97,7 @@ pub const JSVAL_PAYLOAD_MASK: u64 = 140737488355327;
 pub const JSVAL_TAG_MASK: i64 = -140737488355328;
 pub type size_t = ::std::os::raw::c_ulonglong;
 #[repr(u8)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum JSValueType {
     JSVAL_TYPE_DOUBLE = 0,
     JSVAL_TYPE_INT32 = 1,
@@ -112,7 +112,7 @@ pub enum JSValueType {
     JSVAL_TYPE_MISSING = 33,
 }
 #[repr(u32)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum JSValueTag {
     JSVAL_TAG_MAX_DOUBLE = 131056,
     JSVAL_TAG_INT32 = 131057,
@@ -125,7 +125,7 @@ pub enum JSValueTag {
     JSVAL_TAG_OBJECT = 131064,
 }
 #[repr(u64)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum JSValueShiftedTag {
     JSVAL_SHIFTED_TAG_MAX_DOUBLE = 18444492278190833663,
     JSVAL_SHIFTED_TAG_INT32 = 18444633011384221696,
@@ -138,7 +138,7 @@ pub enum JSValueShiftedTag {
     JSVAL_SHIFTED_TAG_OBJECT = 18445618173802708992,
 }
 #[repr(u32)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum JSWhyMagic {
     /// a hole in a native object's elements
     JS_ELEMENTS_HOLE = 0,

--- a/tests/expectations/tests/jsval_layout_opaque_1_0.rs
+++ b/tests/expectations/tests/jsval_layout_opaque_1_0.rs
@@ -140,7 +140,7 @@ pub const JSVAL_PAYLOAD_MASK: u64 = 140737488355327;
 pub const JSVAL_TAG_MASK: i64 = -140737488355328;
 pub type size_t = ::std::os::raw::c_ulonglong;
 #[repr(u8)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum JSValueType {
     JSVAL_TYPE_DOUBLE = 0,
     JSVAL_TYPE_INT32 = 1,
@@ -155,7 +155,7 @@ pub enum JSValueType {
     JSVAL_TYPE_MISSING = 33,
 }
 #[repr(u32)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum JSValueTag {
     JSVAL_TAG_MAX_DOUBLE = 131056,
     JSVAL_TAG_INT32 = 131057,
@@ -168,7 +168,7 @@ pub enum JSValueTag {
     JSVAL_TAG_OBJECT = 131064,
 }
 #[repr(u64)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum JSValueShiftedTag {
     JSVAL_SHIFTED_TAG_MAX_DOUBLE = 18444492278190833663,
     JSVAL_SHIFTED_TAG_INT32 = 18444633011384221696,
@@ -181,7 +181,7 @@ pub enum JSValueShiftedTag {
     JSVAL_SHIFTED_TAG_OBJECT = 18445618173802708992,
 }
 #[repr(u32)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum JSWhyMagic {
     /// a hole in a native object's elements
     JS_ELEMENTS_HOLE = 0,

--- a/tests/expectations/tests/layout_array_too_long.rs
+++ b/tests/expectations/tests/layout_array_too_long.rs
@@ -12,7 +12,7 @@ pub const IP_FIRST_FRAG_IDX: _bindgen_ty_1 = _bindgen_ty_1::IP_FIRST_FRAG_IDX;
 pub const IP_MIN_FRAG_NUM: _bindgen_ty_1 = _bindgen_ty_1::IP_MIN_FRAG_NUM;
 pub const IP_MAX_FRAG_NUM: _bindgen_ty_1 = _bindgen_ty_1::IP_MAX_FRAG_NUM;
 #[repr(u32)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum _bindgen_ty_1 {
     ///< index of last fragment
     IP_LAST_FRAG_IDX = 0,

--- a/tests/expectations/tests/layout_cmdline_token.rs
+++ b/tests/expectations/tests/layout_cmdline_token.rs
@@ -177,7 +177,7 @@ fn bindgen_test_layout_cmdline_token_ops() {
     );
 }
 #[repr(u32)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum cmdline_numtype {
     UINT8 = 0,
     UINT16 = 1,

--- a/tests/expectations/tests/layout_eth_conf.rs
+++ b/tests/expectations/tests/layout_eth_conf.rs
@@ -127,7 +127,7 @@ pub const RTE_ETH_FLOW_MAX: u32 = 22;
 #[repr(u32)]
 ///  A set of values to identify what method is to be used to route
 ///  packets to multiple queues.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum rte_eth_rx_mq_mode {
     /// None of DCB,RSS or VMDQ mode
     ETH_MQ_RX_NONE = 0,
@@ -399,7 +399,7 @@ impl rte_eth_rxmode {
 #[repr(u32)]
 /// A set of values to identify what method is to be used to transmit
 /// packets using multi-TCs.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum rte_eth_tx_mq_mode {
     ///< It is in neither DCB nor VT mode.
     ETH_MQ_TX_NONE = 0,
@@ -616,7 +616,7 @@ impl Default for rte_eth_rss_conf {
 #[repr(u32)]
 /// This enum indicates the possible number of traffic classes
 /// in DCB configratioins
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum rte_eth_nb_tcs {
     ///< 4 TCs with DCB.
     ETH_4_TCS = 4,
@@ -626,7 +626,7 @@ pub enum rte_eth_nb_tcs {
 #[repr(u32)]
 /// This enum indicates the possible number of queue pools
 /// in VMDQ configurations.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum rte_eth_nb_pools {
     ///< 8 VMDq pools.
     ETH_8_POOLS = 8,
@@ -1179,7 +1179,7 @@ impl Default for rte_eth_vmdq_rx_conf {
 }
 #[repr(u32)]
 ///  Flow Director setting modes: none, signature or perfect.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum rte_fdir_mode {
     ///< Disable FDIR support.
     RTE_FDIR_MODE_NONE = 0,
@@ -1195,7 +1195,7 @@ pub enum rte_fdir_mode {
 #[repr(u32)]
 ///  Memory space that can be configured to store Flow Director filters
 ///  in the board memory.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum rte_fdir_pballoc_type {
     ///< 64k.
     RTE_FDIR_PBALLOC_64K = 0,
@@ -1206,7 +1206,7 @@ pub enum rte_fdir_pballoc_type {
 }
 #[repr(u32)]
 ///  Select report mode of FDIR hash information in RX descriptors.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum rte_fdir_status_mode {
     ///< Never report FDIR hash.
     RTE_FDIR_NO_REPORT_STATUS = 0,
@@ -1544,7 +1544,7 @@ fn bindgen_test_layout_rte_eth_fdir_masks() {
 }
 #[repr(u32)]
 /// Payload type
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum rte_eth_payload_type {
     RTE_ETH_PAYLOAD_UNKNOWN = 0,
     RTE_ETH_RAW_PAYLOAD = 1,

--- a/tests/expectations/tests/layout_eth_conf_1_0.rs
+++ b/tests/expectations/tests/layout_eth_conf_1_0.rs
@@ -170,7 +170,7 @@ pub const RTE_ETH_FLOW_MAX: u32 = 22;
 #[repr(u32)]
 ///  A set of values to identify what method is to be used to route
 ///  packets to multiple queues.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum rte_eth_rx_mq_mode {
     /// None of DCB,RSS or VMDQ mode
     ETH_MQ_RX_NONE = 0,
@@ -447,7 +447,7 @@ impl rte_eth_rxmode {
 #[repr(u32)]
 /// A set of values to identify what method is to be used to transmit
 /// packets using multi-TCs.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum rte_eth_tx_mq_mode {
     ///< It is in neither DCB nor VT mode.
     ETH_MQ_TX_NONE = 0,
@@ -674,7 +674,7 @@ impl Default for rte_eth_rss_conf {
 #[repr(u32)]
 /// This enum indicates the possible number of traffic classes
 /// in DCB configratioins
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum rte_eth_nb_tcs {
     ///< 4 TCs with DCB.
     ETH_4_TCS = 4,
@@ -684,7 +684,7 @@ pub enum rte_eth_nb_tcs {
 #[repr(u32)]
 /// This enum indicates the possible number of queue pools
 /// in VMDQ configurations.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum rte_eth_nb_pools {
     ///< 8 VMDq pools.
     ETH_8_POOLS = 8,
@@ -1277,7 +1277,7 @@ impl Default for rte_eth_vmdq_rx_conf {
 }
 #[repr(u32)]
 ///  Flow Director setting modes: none, signature or perfect.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum rte_fdir_mode {
     ///< Disable FDIR support.
     RTE_FDIR_MODE_NONE = 0,
@@ -1293,7 +1293,7 @@ pub enum rte_fdir_mode {
 #[repr(u32)]
 ///  Memory space that can be configured to store Flow Director filters
 ///  in the board memory.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum rte_fdir_pballoc_type {
     ///< 64k.
     RTE_FDIR_PBALLOC_64K = 0,
@@ -1304,7 +1304,7 @@ pub enum rte_fdir_pballoc_type {
 }
 #[repr(u32)]
 ///  Select report mode of FDIR hash information in RX descriptors.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum rte_fdir_status_mode {
     ///< Never report FDIR hash.
     RTE_FDIR_NO_REPORT_STATUS = 0,
@@ -1657,7 +1657,7 @@ impl Clone for rte_eth_fdir_masks {
 }
 #[repr(u32)]
 /// Payload type
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum rte_eth_payload_type {
     RTE_ETH_PAYLOAD_UNKNOWN = 0,
     RTE_ETH_RAW_PAYLOAD = 1,

--- a/tests/expectations/tests/layout_large_align_field.rs
+++ b/tests/expectations/tests/layout_large_align_field.rs
@@ -42,7 +42,7 @@ pub const IP_FIRST_FRAG_IDX: _bindgen_ty_1 = _bindgen_ty_1::IP_FIRST_FRAG_IDX;
 pub const IP_MIN_FRAG_NUM: _bindgen_ty_1 = _bindgen_ty_1::IP_MIN_FRAG_NUM;
 pub const IP_MAX_FRAG_NUM: _bindgen_ty_1 = _bindgen_ty_1::IP_MAX_FRAG_NUM;
 #[repr(u32)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum _bindgen_ty_1 {
     ///< index of last fragment
     IP_LAST_FRAG_IDX = 0,

--- a/tests/expectations/tests/libclang-3.9/constant-evaluate.rs
+++ b/tests/expectations/tests/libclang-3.9/constant-evaluate.rs
@@ -8,7 +8,7 @@
 pub const foo: _bindgen_ty_1 = _bindgen_ty_1::foo;
 pub const bar: _bindgen_ty_1 = _bindgen_ty_1::bar;
 #[repr(u32)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum _bindgen_ty_1 {
     foo = 4,
     bar = 8,

--- a/tests/expectations/tests/libclang-4/constant-evaluate.rs
+++ b/tests/expectations/tests/libclang-4/constant-evaluate.rs
@@ -8,7 +8,7 @@
 pub const foo: _bindgen_ty_1 = _bindgen_ty_1::foo;
 pub const bar: _bindgen_ty_1 = _bindgen_ty_1::bar;
 #[repr(u32)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum _bindgen_ty_1 {
     foo = 4,
     bar = 8,

--- a/tests/expectations/tests/libclang-5/constant-evaluate.rs
+++ b/tests/expectations/tests/libclang-5/constant-evaluate.rs
@@ -8,7 +8,7 @@
 pub const foo: _bindgen_ty_1 = _bindgen_ty_1::foo;
 pub const bar: _bindgen_ty_1 = _bindgen_ty_1::bar;
 #[repr(u32)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum _bindgen_ty_1 {
     foo = 4,
     bar = 8,

--- a/tests/expectations/tests/libclang-9/constant-evaluate.rs
+++ b/tests/expectations/tests/libclang-9/constant-evaluate.rs
@@ -8,7 +8,7 @@
 pub const foo: _bindgen_ty_1 = _bindgen_ty_1::foo;
 pub const bar: _bindgen_ty_1 = _bindgen_ty_1::bar;
 #[repr(u32)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum _bindgen_ty_1 {
     foo = 4,
     bar = 8,

--- a/tests/expectations/tests/newtype-enum.rs
+++ b/tests/expectations/tests/newtype-enum.rs
@@ -18,5 +18,5 @@ impl Foo {
     pub const Negative: Foo = Foo(-3);
 }
 #[repr(transparent)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct Foo(pub ::std::os::raw::c_int);

--- a/tests/expectations/tests/nsStyleAutoArray.rs
+++ b/tests/expectations/tests/nsStyleAutoArray.rs
@@ -24,7 +24,7 @@ pub struct nsStyleAutoArray<T> {
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
 }
 #[repr(i32)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum nsStyleAutoArray_WithSingleInitialElement {
     WITH_SINGLE_INITIAL_ELEMENT = 0,
 }

--- a/tests/expectations/tests/ord-enum.rs
+++ b/tests/expectations/tests/ord-enum.rs
@@ -6,7 +6,7 @@
 )]
 
 #[repr(i32)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum A {
     A0 = 0,
     A1 = 1,
@@ -14,7 +14,7 @@ pub enum A {
     A3 = -1,
 }
 #[repr(i32)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum B {
     B0 = 1,
     B1 = 4,

--- a/tests/expectations/tests/overflowed_enum.rs
+++ b/tests/expectations/tests/overflowed_enum.rs
@@ -6,14 +6,14 @@
 )]
 
 #[repr(u32)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum Foo {
     BAP_ARM = 9698489,
     BAP_X86 = 11960045,
     BAP_X86_64 = 3128633167,
 }
 #[repr(u16)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum Bar {
     One = 1,
     Big = 2,

--- a/tests/expectations/tests/prepend-enum-constified-variant.rs
+++ b/tests/expectations/tests/prepend-enum-constified-variant.rs
@@ -9,7 +9,7 @@ impl AVCodecID {
     pub const AV_CODEC_ID_TTF: AVCodecID = AVCodecID::AV_CODEC_ID_FIRST_UNKNOWN;
 }
 #[repr(u32)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum AVCodecID {
     AV_CODEC_ID_FIRST_UNKNOWN = 98304,
 }

--- a/tests/expectations/tests/short-enums.rs
+++ b/tests/expectations/tests/short-enums.rs
@@ -6,17 +6,17 @@
 )]
 
 #[repr(u8)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum one_byte_t {
     SOME_VALUE = 1,
 }
 #[repr(u16)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum two_byte_t {
     SOME_OTHER_VALUE = 256,
 }
 #[repr(u32)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum four_byte_t {
     SOME_BIGGER_VALUE = 16777216,
 }

--- a/tests/expectations/tests/struct_typedef.rs
+++ b/tests/expectations/tests/struct_typedef.rs
@@ -75,13 +75,13 @@ impl Default for _bindgen_ty_1 {
 pub type struct_ptr_t = *mut _bindgen_ty_1;
 pub type struct_ptr_ptr_t = *mut *mut _bindgen_ty_1;
 #[repr(u32)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum typedef_named_enum {
     ENUM_HAS_NAME = 1,
 }
 pub const ENUM_IS_ANON: _bindgen_ty_2 = _bindgen_ty_2::ENUM_IS_ANON;
 #[repr(u32)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum _bindgen_ty_2 {
     ENUM_IS_ANON = 0,
 }

--- a/tests/expectations/tests/struct_typedef_ns.rs
+++ b/tests/expectations/tests/struct_typedef_ns.rs
@@ -44,7 +44,7 @@ pub mod root {
             );
         }
         #[repr(u32)]
-        #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+        #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
         pub enum typedef_enum {
             BAR = 1,
         }
@@ -87,7 +87,7 @@ pub mod root {
         pub const _bindgen_mod_id_12_BAR:
             root::_bindgen_mod_id_12::_bindgen_ty_2 = _bindgen_ty_2::BAR;
         #[repr(u32)]
-        #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+        #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
         pub enum _bindgen_ty_2 {
             BAR = 1,
         }

--- a/tests/expectations/tests/weird_bitfields.rs
+++ b/tests/expectations/tests/weird_bitfields.rs
@@ -93,7 +93,7 @@ where
     }
 }
 #[repr(u32)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum nsStyleSVGOpacitySource {
     eStyleSVGOpacitySource_Normal = 0,
     eStyleSVGOpacitySource_ContextFillOpacity = 1,

--- a/tests/headers/enum.h
+++ b/tests/headers/enum.h
@@ -17,3 +17,9 @@ enum Neg {
     MinusOne = -1,
     One = 1,
 };
+
+/** <div rustbindgen nodebug></div> */
+enum NoDebug {
+    NoDebug1,
+    NoDebug2,
+};


### PR DESCRIPTION
Fixes #1899.

This code predated all the derive machinery, and always hardcoded its
derives.

We could avoid hard-coding the other traits, but those seem
usually-useful, so leave them there for backwards compat for now.