### PR TITLE
Update clang-sys dependency (for macOS Big Sur 11.0 compatibility)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,9 +81,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clang-sys"
-version = "1.0.1"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa785e9017cb8e8c8045e3f096b7d1ebc4d7337cceccdca8d678a27f788ac133"
+checksum = "0659001ab56b791be01d4b729c44376edc6718cf389a502e579b77b758f3296c"
 dependencies = [
  "glob",
  "libc",


### PR DESCRIPTION
Version 1.0.3 of clang-sys fixes an issue that was causing upstream builds on macOS 11.0 to fail when it couldn't find LLVM configs properly.

https://github.com/KyleMayes/clang-sys/blob/master/CHANGELOG.md#102---2020-11-17
https://github.com/KyleMayes/clang-sys/pull/118