### PR TITLE
dyngen: Handle variadic functions.

### DIFF
--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -3808,6 +3808,7 @@ impl CodeGenerator for Function {
             result.dynamic_items().push(
                 ident,
                 abi,
+                signature.is_variadic(),
                 args,
                 args_identifiers,
                 ret,
@@ -4107,11 +4108,8 @@ pub(crate) fn codegen(
 
         if let Some(ref lib_name) = context.options().dynamic_library_name {
             let lib_ident = context.rust_ident(lib_name);
-            let check_struct_ident =
-                context.rust_ident(format!("Check{}", lib_name));
-            let dynamic_items_tokens = result
-                .dynamic_items()
-                .get_tokens(lib_ident, check_struct_ident);
+            let dynamic_items_tokens =
+                result.dynamic_items().get_tokens(lib_ident);
             result.push(dynamic_items_tokens);
         }
 

--- a/tests/expectations/tests/dynamic_loading_simple.rs
+++ b/tests/expectations/tests/dynamic_loading_simple.rs
@@ -8,20 +8,20 @@
 extern crate libloading;
 pub struct TestLib {
     __library: ::libloading::Library,
-    foo: Result<
+    pub foo: Result<
         unsafe extern "C" fn(
             x: ::std::os::raw::c_int,
             y: ::std::os::raw::c_int,
         ) -> ::std::os::raw::c_int,
         ::libloading::Error,
     >,
-    bar: Result<
+    pub bar: Result<
         unsafe extern "C" fn(
             x: *mut ::std::os::raw::c_void,
         ) -> ::std::os::raw::c_int,
         ::libloading::Error,
     >,
-    baz: Result<
+    pub baz: Result<
         unsafe extern "C" fn() -> ::std::os::raw::c_int,
         ::libloading::Error,
     >,
@@ -36,14 +36,11 @@ impl TestLib {
         let bar = __library.get("bar".as_bytes()).map(|sym| *sym);
         let baz = __library.get("baz".as_bytes()).map(|sym| *sym);
         Ok(TestLib {
-            __library: __library,
+            __library,
             foo,
             bar,
             baz,
         })
-    }
-    pub fn can_call(&self) -> CheckTestLib {
-        CheckTestLib { __library: self }
     }
     pub unsafe fn foo(
         &self,
@@ -63,19 +60,5 @@ impl TestLib {
     pub unsafe fn baz(&self) -> ::std::os::raw::c_int {
         let sym = self.baz.as_ref().expect("Expected function, got error.");
         (sym)()
-    }
-}
-pub struct CheckTestLib<'a> {
-    __library: &'a TestLib,
-}
-impl<'a> CheckTestLib<'a> {
-    pub fn foo(&self) -> Result<(), &'a ::libloading::Error> {
-        self.__library.foo.as_ref().map(|_| ())
-    }
-    pub fn bar(&self) -> Result<(), &'a ::libloading::Error> {
-        self.__library.bar.as_ref().map(|_| ())
-    }
-    pub fn baz(&self) -> Result<(), &'a ::libloading::Error> {
-        self.__library.baz.as_ref().map(|_| ())
     }
 }

--- a/tests/expectations/tests/dynamic_loading_template.rs
+++ b/tests/expectations/tests/dynamic_loading_template.rs
@@ -8,11 +8,11 @@
 extern crate libloading;
 pub struct TestLib {
     __library: ::libloading::Library,
-    foo: Result<
+    pub foo: Result<
         unsafe extern "C" fn(x: ::std::os::raw::c_int) -> ::std::os::raw::c_int,
         ::libloading::Error,
     >,
-    foo1: Result<unsafe extern "C" fn(x: f32) -> f32, ::libloading::Error>,
+    pub foo1: Result<unsafe extern "C" fn(x: f32) -> f32, ::libloading::Error>,
 }
 impl TestLib {
     pub unsafe fn new<P>(path: P) -> Result<Self, ::libloading::Error>
@@ -23,13 +23,10 @@ impl TestLib {
         let foo = __library.get("foo".as_bytes()).map(|sym| *sym);
         let foo1 = __library.get("foo1".as_bytes()).map(|sym| *sym);
         Ok(TestLib {
-            __library: __library,
+            __library,
             foo,
             foo1,
         })
-    }
-    pub fn can_call(&self) -> CheckTestLib {
-        CheckTestLib { __library: self }
     }
     pub unsafe fn foo(
         &self,
@@ -41,16 +38,5 @@ impl TestLib {
     pub unsafe fn foo1(&self, x: f32) -> f32 {
         let sym = self.foo1.as_ref().expect("Expected function, got error.");
         (sym)(x)
-    }
-}
-pub struct CheckTestLib<'a> {
-    __library: &'a TestLib,
-}
-impl<'a> CheckTestLib<'a> {
-    pub fn foo(&self) -> Result<(), &'a ::libloading::Error> {
-        self.__library.foo.as_ref().map(|_| ())
-    }
-    pub fn foo1(&self) -> Result<(), &'a ::libloading::Error> {
-        self.__library.foo1.as_ref().map(|_| ())
     }
 }

--- a/tests/expectations/tests/dynamic_loading_with_blacklist.rs
+++ b/tests/expectations/tests/dynamic_loading_with_blacklist.rs
@@ -59,13 +59,13 @@ impl X {
 extern crate libloading;
 pub struct TestLib {
     __library: ::libloading::Library,
-    foo: Result<
+    pub foo: Result<
         unsafe extern "C" fn(
             x: *mut ::std::os::raw::c_void,
         ) -> ::std::os::raw::c_int,
         ::libloading::Error,
     >,
-    bar: Result<
+    pub bar: Result<
         unsafe extern "C" fn(
             x: *mut ::std::os::raw::c_void,
         ) -> ::std::os::raw::c_int,
@@ -81,13 +81,10 @@ impl TestLib {
         let foo = __library.get("foo".as_bytes()).map(|sym| *sym);
         let bar = __library.get("bar".as_bytes()).map(|sym| *sym);
         Ok(TestLib {
-            __library: __library,
+            __library,
             foo,
             bar,
         })
-    }
-    pub fn can_call(&self) -> CheckTestLib {
-        CheckTestLib { __library: self }
     }
     pub unsafe fn foo(
         &self,
@@ -102,16 +99,5 @@ impl TestLib {
     ) -> ::std::os::raw::c_int {
         let sym = self.bar.as_ref().expect("Expected function, got error.");
         (sym)(x)
-    }
-}
-pub struct CheckTestLib<'a> {
-    __library: &'a TestLib,
-}
-impl<'a> CheckTestLib<'a> {
-    pub fn foo(&self) -> Result<(), &'a ::libloading::Error> {
-        self.__library.foo.as_ref().map(|_| ())
-    }
-    pub fn bar(&self) -> Result<(), &'a ::libloading::Error> {
-        self.__library.bar.as_ref().map(|_| ())
     }
 }

--- a/tests/expectations/tests/dynamic_loading_with_class.rs
+++ b/tests/expectations/tests/dynamic_loading_with_class.rs
@@ -59,13 +59,13 @@ impl A {
 extern crate libloading;
 pub struct TestLib {
     __library: ::libloading::Library,
-    foo: Result<
+    pub foo: Result<
         unsafe extern "C" fn(
             x: *mut ::std::os::raw::c_void,
         ) -> ::std::os::raw::c_int,
         ::libloading::Error,
     >,
-    bar: Result<unsafe extern "C" fn(), ::libloading::Error>,
+    pub bar: Result<unsafe extern "C" fn(), ::libloading::Error>,
 }
 impl TestLib {
     pub unsafe fn new<P>(path: P) -> Result<Self, ::libloading::Error>
@@ -76,13 +76,10 @@ impl TestLib {
         let foo = __library.get("foo".as_bytes()).map(|sym| *sym);
         let bar = __library.get("bar".as_bytes()).map(|sym| *sym);
         Ok(TestLib {
-            __library: __library,
+            __library,
             foo,
             bar,
         })
-    }
-    pub fn can_call(&self) -> CheckTestLib {
-        CheckTestLib { __library: self }
     }
     pub unsafe fn foo(
         &self,
@@ -94,16 +91,5 @@ impl TestLib {
     pub unsafe fn bar(&self) -> () {
         let sym = self.bar.as_ref().expect("Expected function, got error.");
         (sym)()
-    }
-}
-pub struct CheckTestLib<'a> {
-    __library: &'a TestLib,
-}
-impl<'a> CheckTestLib<'a> {
-    pub fn foo(&self) -> Result<(), &'a ::libloading::Error> {
-        self.__library.foo.as_ref().map(|_| ())
-    }
-    pub fn bar(&self) -> Result<(), &'a ::libloading::Error> {
-        self.__library.bar.as_ref().map(|_| ())
     }
 }

--- a/tests/expectations/tests/dynamic_loading_with_whitelist.rs
+++ b/tests/expectations/tests/dynamic_loading_with_whitelist.rs
@@ -8,15 +8,22 @@
 extern crate libloading;
 pub struct TestLib {
     __library: ::libloading::Library,
-    foo: Result<
+    pub foo: Result<
         unsafe extern "C" fn(
             x: *mut ::std::os::raw::c_void,
         ) -> ::std::os::raw::c_int,
         ::libloading::Error,
     >,
-    baz: Result<
+    pub baz: Result<
         unsafe extern "C" fn(
             x: *mut ::std::os::raw::c_void,
+        ) -> ::std::os::raw::c_int,
+        ::libloading::Error,
+    >,
+    pub bazz: Result<
+        unsafe extern "C" fn(
+            arg1: ::std::os::raw::c_int,
+            ...
         ) -> ::std::os::raw::c_int,
         ::libloading::Error,
     >,
@@ -29,14 +36,13 @@ impl TestLib {
         let __library = ::libloading::Library::new(path)?;
         let foo = __library.get("foo".as_bytes()).map(|sym| *sym);
         let baz = __library.get("baz".as_bytes()).map(|sym| *sym);
+        let bazz = __library.get("bazz".as_bytes()).map(|sym| *sym);
         Ok(TestLib {
-            __library: __library,
+            __library,
             foo,
             baz,
+            bazz,
         })
-    }
-    pub fn can_call(&self) -> CheckTestLib {
-        CheckTestLib { __library: self }
     }
     pub unsafe fn foo(
         &self,
@@ -51,16 +57,5 @@ impl TestLib {
     ) -> ::std::os::raw::c_int {
         let sym = self.baz.as_ref().expect("Expected function, got error.");
         (sym)(x)
-    }
-}
-pub struct CheckTestLib<'a> {
-    __library: &'a TestLib,
-}
-impl<'a> CheckTestLib<'a> {
-    pub fn foo(&self) -> Result<(), &'a ::libloading::Error> {
-        self.__library.foo.as_ref().map(|_| ())
-    }
-    pub fn baz(&self) -> Result<(), &'a ::libloading::Error> {
-        self.__library.baz.as_ref().map(|_| ())
     }
 }

--- a/tests/headers/dynamic_loading_with_whitelist.hpp
+++ b/tests/headers/dynamic_loading_with_whitelist.hpp
@@ -1,4 +1,4 @@
-// bindgen-flags: --dynamic-loading TestLib --whitelist-function baz --whitelist-function foo
+// bindgen-flags: --dynamic-loading TestLib --whitelist-function baz --whitelist-function foo --whitelist-function bazz
 
 class X {
   int _x;
@@ -13,3 +13,4 @@ class X {
 int foo(void *x);
 int bar(void *x);
 int baz(void *x);
+int bazz(int, ...);


### PR DESCRIPTION
Right now trying to generate a dynamic library with variadic functions
panics because we don't account for the extra `...` in the arguments.

Keeping the current interface for variadic functions is tricky, as we
cannot "wrap" a variadic function (VaList[1] is nightly-only).

However, we don't need to. We're already exposing the libloading error,
so exposing the function pointer field as public is just fine and allows
consumers to call the variadic function.

At that point the can_call() / CheckFoo libraries become pointless (you
can just do library.function.is_ok() or such), so we can simplify the
code as well removing those.

[1]: https://doc.rust-lang.org/std/ffi/struct.VaList.html