### PR TITLE
cli: Expose module_raw_lines to the CLI.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -494,6 +494,14 @@ impl Builder {
             output_vector.push(line.clone());
         }
 
+        for (module, lines) in &self.options.module_lines {
+            for line in lines.iter() {
+                output_vector.push("--module-raw-line".into());
+                output_vector.push(module.clone());
+                output_vector.push(line.clone());
+            }
+        }
+
         if self.options.use_core {
             output_vector.push("--use-core".into());
         }

--- a/src/options.rs
+++ b/src/options.rs
@@ -338,6 +338,13 @@ where
                 .takes_value(true)
                 .multiple(true)
                 .number_of_values(1),
+            Arg::with_name("module-raw-line")
+                .long("module-raw-line")
+                .help("Add a raw line of Rust code to a given module.")
+                .takes_value(true)
+                .multiple(true)
+                .number_of_values(2)
+                .value_names(&["module-name", "raw-line"]),
             Arg::with_name("rust-target")
                 .long("rust-target")
                 .help(&rust_target_help)
@@ -766,6 +773,13 @@ where
     if let Some(lines) = matches.values_of("raw-line") {
         for line in lines {
             builder = builder.raw_line(line);
+        }
+    }
+
+    if let Some(mut values) = matches.values_of("module-raw-line") {
+        while let Some(module) = values.next() {
+            let line = values.next().unwrap();
+            builder = builder.module_raw_line(module, line);
         }
     }
 

--- a/tests/expectations/tests/namespace.rs
+++ b/tests/expectations/tests/namespace.rs
@@ -16,6 +16,7 @@ pub mod root {
     pub mod whatever {
         #[allow(unused_imports)]
         use self::super::super::root;
+        pub type whatever_other_thing_t = whatever_int_t;
         pub type whatever_int_t = ::std::os::raw::c_int;
         extern "C" {
             #[link_name = "\u{1}_ZN8whatever11in_whateverEv"]

--- a/tests/headers/namespace.hpp
+++ b/tests/headers/namespace.hpp
@@ -1,4 +1,4 @@
-// bindgen-flags: --enable-cxx-namespaces
+// bindgen-flags: --enable-cxx-namespaces --module-raw-line root::whatever 'pub type whatever_other_thing_t = whatever_int_t;'
 
 void top_level();
 


### PR DESCRIPTION
This makes command_line_args properly return them, instead of dropping
them on the floor.