### PR TITLE
dyngen: Pass null-terminated byte strings to libloading.

### DIFF
--- a/src/codegen/dyngen.rs
+++ b/src/codegen/dyngen.rs
@@ -1,3 +1,4 @@
+use crate::codegen;
 use crate::ir::function::Abi;
 use proc_macro2::Ident;
 
@@ -133,9 +134,9 @@ impl DynamicItems {
             });
         }
 
-        let ident_str = ident.to_string();
+        let ident_str = codegen::helpers::ast_ty::cstr_expr(ident.to_string());
         self.constructor_inits.push(quote! {
-            let #ident = __library.get(#ident_str.as_bytes()).map(|sym| *sym);
+            let #ident = __library.get(#ident_str).map(|sym| *sym);
         });
 
         self.init_fields.push(quote! {

--- a/tests/expectations/tests/dynamic_loading_simple.rs
+++ b/tests/expectations/tests/dynamic_loading_simple.rs
@@ -32,9 +32,9 @@ impl TestLib {
         P: AsRef<::std::ffi::OsStr>,
     {
         let __library = ::libloading::Library::new(path)?;
-        let foo = __library.get("foo".as_bytes()).map(|sym| *sym);
-        let bar = __library.get("bar".as_bytes()).map(|sym| *sym);
-        let baz = __library.get("baz".as_bytes()).map(|sym| *sym);
+        let foo = __library.get(b"foo\0").map(|sym| *sym);
+        let bar = __library.get(b"bar\0").map(|sym| *sym);
+        let baz = __library.get(b"baz\0").map(|sym| *sym);
         Ok(TestLib {
             __library,
             foo,

--- a/tests/expectations/tests/dynamic_loading_template.rs
+++ b/tests/expectations/tests/dynamic_loading_template.rs
@@ -20,8 +20,8 @@ impl TestLib {
         P: AsRef<::std::ffi::OsStr>,
     {
         let __library = ::libloading::Library::new(path)?;
-        let foo = __library.get("foo".as_bytes()).map(|sym| *sym);
-        let foo1 = __library.get("foo1".as_bytes()).map(|sym| *sym);
+        let foo = __library.get(b"foo\0").map(|sym| *sym);
+        let foo1 = __library.get(b"foo1\0").map(|sym| *sym);
         Ok(TestLib {
             __library,
             foo,

--- a/tests/expectations/tests/dynamic_loading_with_blacklist.rs
+++ b/tests/expectations/tests/dynamic_loading_with_blacklist.rs
@@ -78,8 +78,8 @@ impl TestLib {
         P: AsRef<::std::ffi::OsStr>,
     {
         let __library = ::libloading::Library::new(path)?;
-        let foo = __library.get("foo".as_bytes()).map(|sym| *sym);
-        let bar = __library.get("bar".as_bytes()).map(|sym| *sym);
+        let foo = __library.get(b"foo\0").map(|sym| *sym);
+        let bar = __library.get(b"bar\0").map(|sym| *sym);
         Ok(TestLib {
             __library,
             foo,

--- a/tests/expectations/tests/dynamic_loading_with_class.rs
+++ b/tests/expectations/tests/dynamic_loading_with_class.rs
@@ -73,8 +73,8 @@ impl TestLib {
         P: AsRef<::std::ffi::OsStr>,
     {
         let __library = ::libloading::Library::new(path)?;
-        let foo = __library.get("foo".as_bytes()).map(|sym| *sym);
-        let bar = __library.get("bar".as_bytes()).map(|sym| *sym);
+        let foo = __library.get(b"foo\0").map(|sym| *sym);
+        let bar = __library.get(b"bar\0").map(|sym| *sym);
         Ok(TestLib {
             __library,
             foo,

--- a/tests/expectations/tests/dynamic_loading_with_whitelist.rs
+++ b/tests/expectations/tests/dynamic_loading_with_whitelist.rs
@@ -34,9 +34,9 @@ impl TestLib {
         P: AsRef<::std::ffi::OsStr>,
     {
         let __library = ::libloading::Library::new(path)?;
-        let foo = __library.get("foo".as_bytes()).map(|sym| *sym);
-        let baz = __library.get("baz".as_bytes()).map(|sym| *sym);
-        let bazz = __library.get("bazz".as_bytes()).map(|sym| *sym);
+        let foo = __library.get(b"foo\0").map(|sym| *sym);
+        let baz = __library.get(b"baz\0").map(|sym| *sym);
+        let bazz = __library.get(b"bazz\0").map(|sym| *sym);
         Ok(TestLib {
             __library,
             foo,


### PR DESCRIPTION
Fixes #1938.