### PR TITLE
comp: Fix bitfields to allow underaligned fields after them to take padding space.

### DIFF
--- a/bindgen-integration/src/lib.rs
+++ b/bindgen-integration/src/lib.rs
@@ -175,16 +175,19 @@ fn test_bitfields_seventh() {
 fn test_bitfield_constructors() {
     use std::mem;
     let mut first = bindings::bitfields::First {
+        _bitfield_align_1: [],
         _bitfield_1: bindings::bitfields::First::new_bitfield_1(1, 2, 3),
     };
     assert!(unsafe { first.assert(1, 2, 3) });
 
     let mut second = bindings::bitfields::Second {
+        _bitfield_align_1: [],
         _bitfield_1: bindings::bitfields::Second::new_bitfield_1(1337, true),
     };
     assert!(unsafe { second.assert(1337, true) });
 
     let mut third = bindings::bitfields::Third {
+        _bitfield_align_1: [],
         _bitfield_1: bindings::bitfields::Third::new_bitfield_1(
             42,
             false,

--- a/src/codegen/bitfield_unit.rs
+++ b/src/codegen/bitfield_unit.rs
@@ -1,18 +1,17 @@
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct __BindgenBitfieldUnit<Storage, Align> {
+pub struct __BindgenBitfieldUnit<Storage> {
     storage: Storage,
-    align: [Align; 0],
 }
 
-impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align> {
+impl<Storage> __BindgenBitfieldUnit<Storage> {
     #[inline]
     pub const fn new(storage: Storage) -> Self {
-        Self { storage, align: [] }
+        Self { storage }
     }
 }
 
-impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align>
+impl<Storage> __BindgenBitfieldUnit<Storage>
 where
     Storage: AsRef<[u8]> + AsMut<[u8]>,
 {

--- a/src/codegen/bitfield_unit_tests.rs
+++ b/src/codegen/bitfield_unit_tests.rs
@@ -22,12 +22,10 @@
 //! ```
 
 use super::bitfield_unit::__BindgenBitfieldUnit;
-use std::mem;
 
 #[test]
 fn bitfield_unit_get_bit() {
-    let unit =
-        __BindgenBitfieldUnit::<[u8; 2], u64>::new([0b10011101, 0b00011101]);
+    let unit = __BindgenBitfieldUnit::<[u8; 2]>::new([0b10011101, 0b00011101]);
 
     let mut bits = vec![];
     for i in 0..16 {
@@ -50,7 +48,7 @@ fn bitfield_unit_get_bit() {
 #[test]
 fn bitfield_unit_set_bit() {
     let mut unit =
-        __BindgenBitfieldUnit::<[u8; 2], u64>::new([0b00000000, 0b00000000]);
+        __BindgenBitfieldUnit::<[u8; 2]>::new([0b00000000, 0b00000000]);
 
     for i in 0..16 {
         if i % 3 == 0 {
@@ -63,7 +61,7 @@ fn bitfield_unit_set_bit() {
     }
 
     let mut unit =
-        __BindgenBitfieldUnit::<[u8; 2], u64>::new([0b11111111, 0b11111111]);
+        __BindgenBitfieldUnit::<[u8; 2]>::new([0b11111111, 0b11111111]);
 
     for i in 0..16 {
         if i % 3 == 0 {
@@ -76,43 +74,6 @@ fn bitfield_unit_set_bit() {
     }
 }
 
-#[test]
-fn bitfield_unit_align() {
-    assert_eq!(
-        mem::align_of::<__BindgenBitfieldUnit<[u8; 1], u8>>(),
-        mem::align_of::<u8>()
-    );
-    assert_eq!(
-        mem::align_of::<__BindgenBitfieldUnit<[u8; 1], u16>>(),
-        mem::align_of::<u16>()
-    );
-    assert_eq!(
-        mem::align_of::<__BindgenBitfieldUnit<[u8; 1], u32>>(),
-        mem::align_of::<u32>()
-    );
-    assert_eq!(
-        mem::align_of::<__BindgenBitfieldUnit<[u8; 1], u64>>(),
-        mem::align_of::<u64>()
-    );
-
-    assert_eq!(
-        mem::align_of::<__BindgenBitfieldUnit<[u8; 8], u8>>(),
-        mem::align_of::<u8>()
-    );
-    assert_eq!(
-        mem::align_of::<__BindgenBitfieldUnit<[u8; 8], u16>>(),
-        mem::align_of::<u16>()
-    );
-    assert_eq!(
-        mem::align_of::<__BindgenBitfieldUnit<[u8; 8], u32>>(),
-        mem::align_of::<u32>()
-    );
-    assert_eq!(
-        mem::align_of::<__BindgenBitfieldUnit<[u8; 8], u64>>(),
-        mem::align_of::<u64>()
-    );
-}
-
 macro_rules! bitfield_unit_get {
     (
         $(
@@ -123,7 +84,7 @@ macro_rules! bitfield_unit_get {
         fn bitfield_unit_get() {
             $({
                 let expected = $expected;
-                let unit = __BindgenBitfieldUnit::<_, u64>::new($storage);
+                let unit = __BindgenBitfieldUnit::<_>::new($storage);
                 let actual = unit.get($start, $len);
 
                 println!();
@@ -223,7 +184,7 @@ macro_rules! bitfield_unit_set {
         #[test]
         fn bitfield_unit_set() {
             $(
-                let mut unit = __BindgenBitfieldUnit::<[u8; 4], u64>::new([0, 0, 0, 0]);
+                let mut unit = __BindgenBitfieldUnit::<[u8; 4]>::new([0, 0, 0, 0]);
                 unit.set($start, $len, $val);
                 let actual = unit.get(0, 32);
 

--- a/src/codegen/helpers.rs
+++ b/src/codegen/helpers.rs
@@ -120,16 +120,9 @@ pub fn bitfield_unit(ctx: &BindgenContext, layout: Layout) -> TokenStream {
         tokens.append_all(quote! { root:: });
     }
 
-    let align = match layout.align {
-        n if n >= 8 => quote! { u64 },
-        4 => quote! { u32 },
-        2 => quote! { u16 },
-        _ => quote! { u8  },
-    };
-
     let size = layout.size;
     tokens.append_all(quote! {
-        __BindgenBitfieldUnit<[u8; #size], #align>
+        __BindgenBitfieldUnit<[u8; #size]>
     });
 
     tokens

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -1437,6 +1437,21 @@ impl<'a> FieldCodegen<'a> for BitfieldUnit {
             }
         };
 
+        {
+            let align_field_name = format!("_bitfield_align_{}", self.nth());
+            let align_field_ident = ctx.rust_ident(&align_field_name);
+            let align_ty = match self.layout().align {
+                n if n >= 8 => quote! { u64 },
+                4 => quote! { u32 },
+                2 => quote! { u16 },
+                _ => quote! { u8  },
+            };
+            let align_field = quote! {
+                pub #align_field_ident: [#align_ty; 0],
+            };
+            fields.extend(Some(align_field));
+        }
+
         let unit_field_name = format!("_bitfield_{}", self.nth());
         let unit_field_ident = ctx.rust_ident(&unit_field_name);
 

--- a/src/ir/comp.rs
+++ b/src/ir/comp.rs
@@ -575,7 +575,7 @@ where
         } else {
             bytes_from_bits_pow2(unit_align_in_bits)
         };
-        let size = align_to(unit_size_in_bits, align * 8) / 8;
+        let size = align_to(unit_size_in_bits, 8) / 8;
         let layout = Layout::new(size, align);
         fields.extend(Some(Field::Bitfields(BitfieldUnit {
             nth: *bitfield_unit_count,

--- a/tests/expectations/tests/bitfield-32bit-overflow.rs
+++ b/tests/expectations/tests/bitfield-32bit-overflow.rs
@@ -7,17 +7,16 @@
 
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct __BindgenBitfieldUnit<Storage, Align> {
+pub struct __BindgenBitfieldUnit<Storage> {
     storage: Storage,
-    align: [Align; 0],
 }
-impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align> {
+impl<Storage> __BindgenBitfieldUnit<Storage> {
     #[inline]
     pub const fn new(storage: Storage) -> Self {
-        Self { storage, align: [] }
+        Self { storage }
     }
 }
-impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align>
+impl<Storage> __BindgenBitfieldUnit<Storage>
 where
     Storage: AsRef<[u8]> + AsMut<[u8]>,
 {
@@ -95,7 +94,8 @@ where
 #[repr(C, packed)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct MuchBitfield {
-    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 5usize], u8>,
+    pub _bitfield_align_1: [u8; 0],
+    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 5usize]>,
 }
 #[test]
 fn bindgen_test_layout_MuchBitfield() {
@@ -575,11 +575,9 @@ impl MuchBitfield {
         m30: ::std::os::raw::c_char,
         m31: ::std::os::raw::c_char,
         m32: ::std::os::raw::c_char,
-    ) -> __BindgenBitfieldUnit<[u8; 5usize], u8> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<
-            [u8; 5usize],
-            u8,
-        > = Default::default();
+    ) -> __BindgenBitfieldUnit<[u8; 5usize]> {
+        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 5usize]> =
+            Default::default();
         __bindgen_bitfield_unit.set(0usize, 1u8, {
             let m0: u8 = unsafe { ::std::mem::transmute(m0) };
             m0 as u64

--- a/tests/expectations/tests/bitfield-large.rs
+++ b/tests/expectations/tests/bitfield-large.rs
@@ -7,17 +7,16 @@
 
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct __BindgenBitfieldUnit<Storage, Align> {
+pub struct __BindgenBitfieldUnit<Storage> {
     storage: Storage,
-    align: [Align; 0],
 }
-impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align> {
+impl<Storage> __BindgenBitfieldUnit<Storage> {
     #[inline]
     pub const fn new(storage: Storage) -> Self {
-        Self { storage, align: [] }
+        Self { storage }
     }
 }
-impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align>
+impl<Storage> __BindgenBitfieldUnit<Storage>
 where
     Storage: AsRef<[u8]> + AsMut<[u8]>,
 {
@@ -96,7 +95,8 @@ where
 #[repr(align(16))]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct HasBigBitfield {
-    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 16usize], u64>,
+    pub _bitfield_align_1: [u64; 0],
+    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 16usize]>,
 }
 #[test]
 fn bindgen_test_layout_HasBigBitfield() {
@@ -126,13 +126,9 @@ impl HasBigBitfield {
         }
     }
     #[inline]
-    pub fn new_bitfield_1(
-        x: i128,
-    ) -> __BindgenBitfieldUnit<[u8; 16usize], u64> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<
-            [u8; 16usize],
-            u64,
-        > = Default::default();
+    pub fn new_bitfield_1(x: i128) -> __BindgenBitfieldUnit<[u8; 16usize]> {
+        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 16usize]> =
+            Default::default();
         __bindgen_bitfield_unit.set(0usize, 128u8, {
             let x: u128 = unsafe { ::std::mem::transmute(x) };
             x as u64
@@ -144,7 +140,8 @@ impl HasBigBitfield {
 #[repr(align(16))]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct HasTwoBigBitfields {
-    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 16usize], u64>,
+    pub _bitfield_align_1: [u64; 0],
+    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 16usize]>,
 }
 #[test]
 fn bindgen_test_layout_HasTwoBigBitfields() {
@@ -190,11 +187,9 @@ impl HasTwoBigBitfields {
     pub fn new_bitfield_1(
         x: i128,
         y: i128,
-    ) -> __BindgenBitfieldUnit<[u8; 16usize], u64> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<
-            [u8; 16usize],
-            u64,
-        > = Default::default();
+    ) -> __BindgenBitfieldUnit<[u8; 16usize]> {
+        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 16usize]> =
+            Default::default();
         __bindgen_bitfield_unit.set(0usize, 80u8, {
             let x: u128 = unsafe { ::std::mem::transmute(x) };
             x as u64

--- a/tests/expectations/tests/bitfield-linux-32.rs
+++ b/tests/expectations/tests/bitfield-linux-32.rs
@@ -7,17 +7,16 @@
 
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct __BindgenBitfieldUnit<Storage, Align> {
+pub struct __BindgenBitfieldUnit<Storage> {
     storage: Storage,
-    align: [Align; 0],
 }
-impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align> {
+impl<Storage> __BindgenBitfieldUnit<Storage> {
     #[inline]
     pub const fn new(storage: Storage) -> Self {
-        Self { storage, align: [] }
+        Self { storage }
     }
 }
-impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align>
+impl<Storage> __BindgenBitfieldUnit<Storage>
 where
     Storage: AsRef<[u8]> + AsMut<[u8]>,
 {
@@ -96,7 +95,8 @@ where
 #[derive(Debug, Default, Copy, Clone)]
 pub struct Test {
     pub foo: u64,
-    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 8usize], u64>,
+    pub _bitfield_align_1: [u64; 0],
+    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 8usize]>,
 }
 #[test]
 fn bindgen_test_layout_Test() {
@@ -147,11 +147,9 @@ impl Test {
     pub fn new_bitfield_1(
         x: u64,
         y: u64,
-    ) -> __BindgenBitfieldUnit<[u8; 8usize], u64> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<
-            [u8; 8usize],
-            u64,
-        > = Default::default();
+    ) -> __BindgenBitfieldUnit<[u8; 8usize]> {
+        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 8usize]> =
+            Default::default();
         __bindgen_bitfield_unit.set(0usize, 56u8, {
             let x: u64 = unsafe { ::std::mem::transmute(x) };
             x as u64

--- a/tests/expectations/tests/bitfield-method-same-name.rs
+++ b/tests/expectations/tests/bitfield-method-same-name.rs
@@ -7,17 +7,16 @@
 
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct __BindgenBitfieldUnit<Storage, Align> {
+pub struct __BindgenBitfieldUnit<Storage> {
     storage: Storage,
-    align: [Align; 0],
 }
-impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align> {
+impl<Storage> __BindgenBitfieldUnit<Storage> {
     #[inline]
     pub const fn new(storage: Storage) -> Self {
-        Self { storage, align: [] }
+        Self { storage }
     }
 }
-impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align>
+impl<Storage> __BindgenBitfieldUnit<Storage>
 where
     Storage: AsRef<[u8]> + AsMut<[u8]>,
 {
@@ -95,7 +94,8 @@ where
 #[repr(C, packed)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct Foo {
-    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize], u8>,
+    pub _bitfield_align_1: [u8; 0],
+    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
 }
 #[test]
 fn bindgen_test_layout_Foo() {
@@ -139,11 +139,9 @@ impl Foo {
     #[inline]
     pub fn new_bitfield_1(
         type__bindgen_bitfield: ::std::os::raw::c_char,
-    ) -> __BindgenBitfieldUnit<[u8; 1usize], u8> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<
-            [u8; 1usize],
-            u8,
-        > = Default::default();
+    ) -> __BindgenBitfieldUnit<[u8; 1usize]> {
+        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 1usize]> =
+            Default::default();
         __bindgen_bitfield_unit.set(0usize, 3u8, {
             let type__bindgen_bitfield: u8 =
                 unsafe { ::std::mem::transmute(type__bindgen_bitfield) };

--- a/tests/expectations/tests/bitfield_align.rs
+++ b/tests/expectations/tests/bitfield_align.rs
@@ -7,17 +7,16 @@
 
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct __BindgenBitfieldUnit<Storage, Align> {
+pub struct __BindgenBitfieldUnit<Storage> {
     storage: Storage,
-    align: [Align; 0],
 }
-impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align> {
+impl<Storage> __BindgenBitfieldUnit<Storage> {
     #[inline]
     pub const fn new(storage: Storage) -> Self {
-        Self { storage, align: [] }
+        Self { storage }
     }
 }
-impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align>
+impl<Storage> __BindgenBitfieldUnit<Storage>
 where
     Storage: AsRef<[u8]> + AsMut<[u8]>,
 {
@@ -97,7 +96,8 @@ where
 #[derive(Debug, Default, Copy, Clone)]
 pub struct A {
     pub x: ::std::os::raw::c_uchar,
-    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 2usize], u8>,
+    pub _bitfield_align_1: [u8; 0],
+    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 2usize]>,
     pub y: ::std::os::raw::c_uchar,
 }
 #[test]
@@ -266,11 +266,9 @@ impl A {
         b8: ::std::os::raw::c_uint,
         b9: ::std::os::raw::c_uint,
         b10: ::std::os::raw::c_uint,
-    ) -> __BindgenBitfieldUnit<[u8; 2usize], u8> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<
-            [u8; 2usize],
-            u8,
-        > = Default::default();
+    ) -> __BindgenBitfieldUnit<[u8; 2usize]> {
+        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 2usize]> =
+            Default::default();
         __bindgen_bitfield_unit.set(0usize, 1u8, {
             let b1: u32 = unsafe { ::std::mem::transmute(b1) };
             b1 as u64
@@ -318,7 +316,8 @@ impl A {
 #[repr(align(4))]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct B {
-    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize], u32>,
+    pub _bitfield_align_1: [u32; 0],
+    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
 }
 #[test]
 fn bindgen_test_layout_B() {
@@ -364,11 +363,9 @@ impl B {
     pub fn new_bitfield_1(
         foo: ::std::os::raw::c_uint,
         bar: ::std::os::raw::c_uchar,
-    ) -> __BindgenBitfieldUnit<[u8; 4usize], u32> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<
-            [u8; 4usize],
-            u32,
-        > = Default::default();
+    ) -> __BindgenBitfieldUnit<[u8; 4usize]> {
+        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> =
+            Default::default();
         __bindgen_bitfield_unit.set(0usize, 31u8, {
             let foo: u32 = unsafe { ::std::mem::transmute(foo) };
             foo as u64
@@ -384,7 +381,8 @@ impl B {
 #[derive(Debug, Default, Copy, Clone)]
 pub struct C {
     pub x: ::std::os::raw::c_uchar,
-    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize], u8>,
+    pub _bitfield_align_1: [u8; 0],
+    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
     pub baz: ::std::os::raw::c_uint,
 }
 #[test]
@@ -441,11 +439,9 @@ impl C {
     pub fn new_bitfield_1(
         b1: ::std::os::raw::c_uint,
         b2: ::std::os::raw::c_uint,
-    ) -> __BindgenBitfieldUnit<[u8; 1usize], u8> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<
-            [u8; 1usize],
-            u8,
-        > = Default::default();
+    ) -> __BindgenBitfieldUnit<[u8; 1usize]> {
+        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 1usize]> =
+            Default::default();
         __bindgen_bitfield_unit.set(0usize, 1u8, {
             let b1: u32 = unsafe { ::std::mem::transmute(b1) };
             b1 as u64
@@ -461,7 +457,8 @@ impl C {
 #[repr(align(2))]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct Date1 {
-    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 3usize], u8>,
+    pub _bitfield_align_1: [u8; 0],
+    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 3usize]>,
     pub __bindgen_padding_0: u8,
 }
 #[test]
@@ -536,11 +533,9 @@ impl Date1 {
         nMonthDay: ::std::os::raw::c_ushort,
         nMonth: ::std::os::raw::c_ushort,
         nYear: ::std::os::raw::c_ushort,
-    ) -> __BindgenBitfieldUnit<[u8; 3usize], u8> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<
-            [u8; 3usize],
-            u8,
-        > = Default::default();
+    ) -> __BindgenBitfieldUnit<[u8; 3usize]> {
+        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 3usize]> =
+            Default::default();
         __bindgen_bitfield_unit.set(0usize, 3u8, {
             let nWeekDay: u16 = unsafe { ::std::mem::transmute(nWeekDay) };
             nWeekDay as u64
@@ -564,7 +559,8 @@ impl Date1 {
 #[repr(align(2))]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct Date2 {
-    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize], u8>,
+    pub _bitfield_align_1: [u8; 0],
+    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
 }
 #[test]
 fn bindgen_test_layout_Date2() {
@@ -652,11 +648,9 @@ impl Date2 {
         nMonth: ::std::os::raw::c_ushort,
         nYear: ::std::os::raw::c_ushort,
         byte: ::std::os::raw::c_uchar,
-    ) -> __BindgenBitfieldUnit<[u8; 4usize], u8> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<
-            [u8; 4usize],
-            u8,
-        > = Default::default();
+    ) -> __BindgenBitfieldUnit<[u8; 4usize]> {
+        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> =
+            Default::default();
         __bindgen_bitfield_unit.set(0usize, 3u8, {
             let nWeekDay: u16 = unsafe { ::std::mem::transmute(nWeekDay) };
             nWeekDay as u64
@@ -684,7 +678,8 @@ impl Date2 {
 #[repr(align(2))]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct Date3 {
-    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 3usize], u8>,
+    pub _bitfield_align_1: [u8; 0],
+    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 3usize]>,
     pub byte: ::std::os::raw::c_uchar,
 }
 #[test]
@@ -769,11 +764,9 @@ impl Date3 {
         nMonthDay: ::std::os::raw::c_ushort,
         nMonth: ::std::os::raw::c_ushort,
         nYear: ::std::os::raw::c_ushort,
-    ) -> __BindgenBitfieldUnit<[u8; 3usize], u8> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<
-            [u8; 3usize],
-            u8,
-        > = Default::default();
+    ) -> __BindgenBitfieldUnit<[u8; 3usize]> {
+        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 3usize]> =
+            Default::default();
         __bindgen_bitfield_unit.set(0usize, 3u8, {
             let nWeekDay: u16 = unsafe { ::std::mem::transmute(nWeekDay) };
             nWeekDay as u64

--- a/tests/expectations/tests/bitfield_align_2.rs
+++ b/tests/expectations/tests/bitfield_align_2.rs
@@ -7,17 +7,16 @@
 
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct __BindgenBitfieldUnit<Storage, Align> {
+pub struct __BindgenBitfieldUnit<Storage> {
     storage: Storage,
-    align: [Align; 0],
 }
-impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align> {
+impl<Storage> __BindgenBitfieldUnit<Storage> {
     #[inline]
     pub const fn new(storage: Storage) -> Self {
-        Self { storage, align: [] }
+        Self { storage }
     }
 }
-impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align>
+impl<Storage> __BindgenBitfieldUnit<Storage>
 where
     Storage: AsRef<[u8]> + AsMut<[u8]>,
 {
@@ -104,7 +103,8 @@ pub enum MyEnum {
 #[repr(align(8))]
 #[derive(Debug, Copy, Clone)]
 pub struct TaggedPtr {
-    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 8usize], u64>,
+    pub _bitfield_align_1: [u64; 0],
+    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 8usize]>,
 }
 #[test]
 fn bindgen_test_layout_TaggedPtr() {
@@ -155,11 +155,9 @@ impl TaggedPtr {
     pub fn new_bitfield_1(
         tag: MyEnum,
         ptr: ::std::os::raw::c_long,
-    ) -> __BindgenBitfieldUnit<[u8; 8usize], u64> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<
-            [u8; 8usize],
-            u64,
-        > = Default::default();
+    ) -> __BindgenBitfieldUnit<[u8; 8usize]> {
+        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 8usize]> =
+            Default::default();
         __bindgen_bitfield_unit.set(0usize, 2u8, {
             let tag: u32 = unsafe { ::std::mem::transmute(tag) };
             tag as u64

--- a/tests/expectations/tests/bitfield_method_mangling.rs
+++ b/tests/expectations/tests/bitfield_method_mangling.rs
@@ -7,17 +7,16 @@
 
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct __BindgenBitfieldUnit<Storage, Align> {
+pub struct __BindgenBitfieldUnit<Storage> {
     storage: Storage,
-    align: [Align; 0],
 }
-impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align> {
+impl<Storage> __BindgenBitfieldUnit<Storage> {
     #[inline]
     pub const fn new(storage: Storage) -> Self {
-        Self { storage, align: [] }
+        Self { storage }
     }
 }
-impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align>
+impl<Storage> __BindgenBitfieldUnit<Storage>
 where
     Storage: AsRef<[u8]> + AsMut<[u8]>,
 {
@@ -96,7 +95,8 @@ where
 #[repr(align(4))]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct mach_msg_type_descriptor_t {
-    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize], u32>,
+    pub _bitfield_align_1: [u32; 0],
+    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
 }
 #[test]
 fn bindgen_test_layout_mach_msg_type_descriptor_t() {
@@ -142,11 +142,9 @@ impl mach_msg_type_descriptor_t {
     pub fn new_bitfield_1(
         pad3: ::std::os::raw::c_uint,
         type_: ::std::os::raw::c_uint,
-    ) -> __BindgenBitfieldUnit<[u8; 4usize], u32> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<
-            [u8; 4usize],
-            u32,
-        > = Default::default();
+    ) -> __BindgenBitfieldUnit<[u8; 4usize]> {
+        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> =
+            Default::default();
         __bindgen_bitfield_unit.set(0usize, 24u8, {
             let pad3: u32 = unsafe { ::std::mem::transmute(pad3) };
             pad3 as u64

--- a/tests/expectations/tests/derive-bitfield-method-same-name.rs
+++ b/tests/expectations/tests/derive-bitfield-method-same-name.rs
@@ -7,17 +7,16 @@
 
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct __BindgenBitfieldUnit<Storage, Align> {
+pub struct __BindgenBitfieldUnit<Storage> {
     storage: Storage,
-    align: [Align; 0],
 }
-impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align> {
+impl<Storage> __BindgenBitfieldUnit<Storage> {
     #[inline]
     pub const fn new(storage: Storage) -> Self {
-        Self { storage, align: [] }
+        Self { storage }
     }
 }
-impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align>
+impl<Storage> __BindgenBitfieldUnit<Storage>
 where
     Storage: AsRef<[u8]> + AsMut<[u8]>,
 {
@@ -99,7 +98,8 @@ where
 #[derive(Copy, Clone)]
 pub struct Foo {
     pub large: [::std::os::raw::c_int; 33usize],
-    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 2usize], u8>,
+    pub _bitfield_align_1: [u8; 0],
+    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 2usize]>,
     pub __bindgen_padding_0: u16,
 }
 #[test]
@@ -183,11 +183,9 @@ impl Foo {
     #[inline]
     pub fn new_bitfield_1(
         type__bindgen_bitfield: ::std::os::raw::c_char,
-    ) -> __BindgenBitfieldUnit<[u8; 2usize], u8> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<
-            [u8; 2usize],
-            u8,
-        > = Default::default();
+    ) -> __BindgenBitfieldUnit<[u8; 2usize]> {
+        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 2usize]> =
+            Default::default();
         __bindgen_bitfield_unit.set(0usize, 3u8, {
             let type__bindgen_bitfield: u8 =
                 unsafe { ::std::mem::transmute(type__bindgen_bitfield) };

--- a/tests/expectations/tests/derive-debug-bitfield-core.rs
+++ b/tests/expectations/tests/derive-debug-bitfield-core.rs
@@ -9,17 +9,16 @@ extern crate core;
 
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct __BindgenBitfieldUnit<Storage, Align> {
+pub struct __BindgenBitfieldUnit<Storage> {
     storage: Storage,
-    align: [Align; 0],
 }
-impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align> {
+impl<Storage> __BindgenBitfieldUnit<Storage> {
     #[inline]
     pub const fn new(storage: Storage) -> Self {
-        Self { storage, align: [] }
+        Self { storage }
     }
 }
-impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align>
+impl<Storage> __BindgenBitfieldUnit<Storage>
 where
     Storage: AsRef<[u8]> + AsMut<[u8]>,
 {
@@ -97,7 +96,8 @@ where
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct C {
-    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize], u8>,
+    pub _bitfield_align_1: [u8; 0],
+    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
     pub large_array: [::std::os::raw::c_int; 50usize],
 }
 #[test]
@@ -171,11 +171,9 @@ impl C {
     pub fn new_bitfield_1(
         a: bool,
         b: bool,
-    ) -> __BindgenBitfieldUnit<[u8; 1usize], u8> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<
-            [u8; 1usize],
-            u8,
-        > = Default::default();
+    ) -> __BindgenBitfieldUnit<[u8; 1usize]> {
+        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 1usize]> =
+            Default::default();
         __bindgen_bitfield_unit.set(0usize, 1u8, {
             let a: u8 = unsafe { ::core::mem::transmute(a) };
             a as u64

--- a/tests/expectations/tests/derive-debug-bitfield.rs
+++ b/tests/expectations/tests/derive-debug-bitfield.rs
@@ -7,17 +7,16 @@
 
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct __BindgenBitfieldUnit<Storage, Align> {
+pub struct __BindgenBitfieldUnit<Storage> {
     storage: Storage,
-    align: [Align; 0],
 }
-impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align> {
+impl<Storage> __BindgenBitfieldUnit<Storage> {
     #[inline]
     pub const fn new(storage: Storage) -> Self {
-        Self { storage, align: [] }
+        Self { storage }
     }
 }
-impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align>
+impl<Storage> __BindgenBitfieldUnit<Storage>
 where
     Storage: AsRef<[u8]> + AsMut<[u8]>,
 {
@@ -95,7 +94,8 @@ where
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct C {
-    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize], u8>,
+    pub _bitfield_align_1: [u8; 0],
+    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
     pub large_array: [::std::os::raw::c_int; 50usize],
 }
 #[test]
@@ -178,11 +178,9 @@ impl C {
     pub fn new_bitfield_1(
         a: bool,
         b: bool,
-    ) -> __BindgenBitfieldUnit<[u8; 1usize], u8> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<
-            [u8; 1usize],
-            u8,
-        > = Default::default();
+    ) -> __BindgenBitfieldUnit<[u8; 1usize]> {
+        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 1usize]> =
+            Default::default();
         __bindgen_bitfield_unit.set(0usize, 1u8, {
             let a: u8 = unsafe { ::std::mem::transmute(a) };
             a as u64

--- a/tests/expectations/tests/derive-partialeq-bitfield.rs
+++ b/tests/expectations/tests/derive-partialeq-bitfield.rs
@@ -7,17 +7,16 @@
 
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct __BindgenBitfieldUnit<Storage, Align> {
+pub struct __BindgenBitfieldUnit<Storage> {
     storage: Storage,
-    align: [Align; 0],
 }
-impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align> {
+impl<Storage> __BindgenBitfieldUnit<Storage> {
     #[inline]
     pub const fn new(storage: Storage) -> Self {
-        Self { storage, align: [] }
+        Self { storage }
     }
 }
-impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align>
+impl<Storage> __BindgenBitfieldUnit<Storage>
 where
     Storage: AsRef<[u8]> + AsMut<[u8]>,
 {
@@ -95,7 +94,8 @@ where
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct C {
-    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize], u8>,
+    pub _bitfield_align_1: [u8; 0],
+    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
     pub large_array: [::std::os::raw::c_int; 50usize],
 }
 #[test]
@@ -166,11 +166,9 @@ impl C {
     pub fn new_bitfield_1(
         a: bool,
         b: bool,
-    ) -> __BindgenBitfieldUnit<[u8; 1usize], u8> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<
-            [u8; 1usize],
-            u8,
-        > = Default::default();
+    ) -> __BindgenBitfieldUnit<[u8; 1usize]> {
+        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 1usize]> =
+            Default::default();
         __bindgen_bitfield_unit.set(0usize, 1u8, {
             let a: u8 = unsafe { ::std::mem::transmute(a) };
             a as u64

--- a/tests/expectations/tests/divide-by-zero-in-struct-layout.rs
+++ b/tests/expectations/tests/divide-by-zero-in-struct-layout.rs
@@ -7,17 +7,16 @@
 
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct __BindgenBitfieldUnit<Storage, Align> {
+pub struct __BindgenBitfieldUnit<Storage> {
     storage: Storage,
-    align: [Align; 0],
 }
-impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align> {
+impl<Storage> __BindgenBitfieldUnit<Storage> {
     #[inline]
     pub const fn new(storage: Storage) -> Self {
-        Self { storage, align: [] }
+        Self { storage }
     }
 }
-impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align>
+impl<Storage> __BindgenBitfieldUnit<Storage>
 where
     Storage: AsRef<[u8]> + AsMut<[u8]>,
 {
@@ -95,49 +94,45 @@ where
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct WithBitfield {
-    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 0usize], u8>,
-    pub __bindgen_padding_0: u32,
+    pub _bitfield_align_1: [u8; 0],
+    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
     pub a: ::std::os::raw::c_uint,
 }
 impl WithBitfield {
     #[inline]
-    pub fn new_bitfield_1() -> __BindgenBitfieldUnit<[u8; 0usize], u8> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<
-            [u8; 0usize],
-            u8,
-        > = Default::default();
+    pub fn new_bitfield_1() -> __BindgenBitfieldUnit<[u8; 1usize]> {
+        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 1usize]> =
+            Default::default();
         __bindgen_bitfield_unit
     }
 }
 #[repr(C, packed)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct WithBitfieldAndAttrPacked {
-    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize], u8>,
+    pub _bitfield_align_1: [u8; 0],
+    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
     pub a: ::std::os::raw::c_uint,
 }
 impl WithBitfieldAndAttrPacked {
     #[inline]
-    pub fn new_bitfield_1() -> __BindgenBitfieldUnit<[u8; 1usize], u8> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<
-            [u8; 1usize],
-            u8,
-        > = Default::default();
+    pub fn new_bitfield_1() -> __BindgenBitfieldUnit<[u8; 1usize]> {
+        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 1usize]> =
+            Default::default();
         __bindgen_bitfield_unit
     }
 }
 #[repr(C, packed)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct WithBitfieldAndPacked {
-    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 0usize], u8>,
+    pub _bitfield_align_1: [u8; 0],
+    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
     pub a: ::std::os::raw::c_uint,
 }
 impl WithBitfieldAndPacked {
     #[inline]
-    pub fn new_bitfield_1() -> __BindgenBitfieldUnit<[u8; 0usize], u8> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<
-            [u8; 0usize],
-            u8,
-        > = Default::default();
+    pub fn new_bitfield_1() -> __BindgenBitfieldUnit<[u8; 1usize]> {
+        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 1usize]> =
+            Default::default();
         __bindgen_bitfield_unit
     }
 }

--- a/tests/expectations/tests/incomplete-array-padding.rs
+++ b/tests/expectations/tests/incomplete-array-padding.rs
@@ -7,17 +7,16 @@
 
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct __BindgenBitfieldUnit<Storage, Align> {
+pub struct __BindgenBitfieldUnit<Storage> {
     storage: Storage,
-    align: [Align; 0],
 }
-impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align> {
+impl<Storage> __BindgenBitfieldUnit<Storage> {
     #[inline]
     pub const fn new(storage: Storage) -> Self {
-        Self { storage, align: [] }
+        Self { storage }
     }
 }
-impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align>
+impl<Storage> __BindgenBitfieldUnit<Storage>
 where
     Storage: AsRef<[u8]> + AsMut<[u8]>,
 {
@@ -125,7 +124,8 @@ impl<T> ::std::fmt::Debug for __IncompleteArrayField<T> {
 #[repr(C)]
 #[derive(Debug)]
 pub struct foo {
-    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize], u8>,
+    pub _bitfield_align_1: [u8; 0],
+    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
     pub b: __IncompleteArrayField<*mut ::std::os::raw::c_void>,
 }
 #[test]
@@ -163,11 +163,9 @@ impl foo {
     #[inline]
     pub fn new_bitfield_1(
         a: ::std::os::raw::c_char,
-    ) -> __BindgenBitfieldUnit<[u8; 1usize], u8> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<
-            [u8; 1usize],
-            u8,
-        > = Default::default();
+    ) -> __BindgenBitfieldUnit<[u8; 1usize]> {
+        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 1usize]> =
+            Default::default();
         __bindgen_bitfield_unit.set(0usize, 1u8, {
             let a: u8 = unsafe { ::std::mem::transmute(a) };
             a as u64

--- a/tests/expectations/tests/issue-1034.rs
+++ b/tests/expectations/tests/issue-1034.rs
@@ -7,17 +7,16 @@
 
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct __BindgenBitfieldUnit<Storage, Align> {
+pub struct __BindgenBitfieldUnit<Storage> {
     storage: Storage,
-    align: [Align; 0],
 }
-impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align> {
+impl<Storage> __BindgenBitfieldUnit<Storage> {
     #[inline]
     pub const fn new(storage: Storage) -> Self {
-        Self { storage, align: [] }
+        Self { storage }
     }
 }
-impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align>
+impl<Storage> __BindgenBitfieldUnit<Storage>
 where
     Storage: AsRef<[u8]> + AsMut<[u8]>,
 {
@@ -92,11 +91,11 @@ where
         }
     }
 }
-#[repr(C)]
+#[repr(C, packed)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct S2 {
-    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize], u8>,
-    pub __bindgen_padding_0: u8,
+    pub _bitfield_align_1: [u8; 0],
+    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 2usize]>,
 }
 #[test]
 fn bindgen_test_layout_S2() {
@@ -113,11 +112,9 @@ fn bindgen_test_layout_S2() {
 }
 impl S2 {
     #[inline]
-    pub fn new_bitfield_1() -> __BindgenBitfieldUnit<[u8; 1usize], u8> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<
-            [u8; 1usize],
-            u8,
-        > = Default::default();
+    pub fn new_bitfield_1() -> __BindgenBitfieldUnit<[u8; 2usize]> {
+        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 2usize]> =
+            Default::default();
         __bindgen_bitfield_unit
     }
 }

--- a/tests/expectations/tests/issue-1076-unnamed-bitfield-alignment.rs
+++ b/tests/expectations/tests/issue-1076-unnamed-bitfield-alignment.rs
@@ -7,17 +7,16 @@
 
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct __BindgenBitfieldUnit<Storage, Align> {
+pub struct __BindgenBitfieldUnit<Storage> {
     storage: Storage,
-    align: [Align; 0],
 }
-impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align> {
+impl<Storage> __BindgenBitfieldUnit<Storage> {
     #[inline]
     pub const fn new(storage: Storage) -> Self {
-        Self { storage, align: [] }
+        Self { storage }
     }
 }
-impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align>
+impl<Storage> __BindgenBitfieldUnit<Storage>
 where
     Storage: AsRef<[u8]> + AsMut<[u8]>,
 {
@@ -92,11 +91,11 @@ where
         }
     }
 }
-#[repr(C)]
+#[repr(C, packed)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct S1 {
-    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 2usize], u8>,
-    pub __bindgen_padding_0: u8,
+    pub _bitfield_align_1: [u8; 0],
+    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 3usize]>,
 }
 #[test]
 fn bindgen_test_layout_S1() {
@@ -113,11 +112,9 @@ fn bindgen_test_layout_S1() {
 }
 impl S1 {
     #[inline]
-    pub fn new_bitfield_1() -> __BindgenBitfieldUnit<[u8; 2usize], u8> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<
-            [u8; 2usize],
-            u8,
-        > = Default::default();
+    pub fn new_bitfield_1() -> __BindgenBitfieldUnit<[u8; 3usize]> {
+        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 3usize]> =
+            Default::default();
         __bindgen_bitfield_unit
     }
 }

--- a/tests/expectations/tests/issue-1947.rs
+++ b/tests/expectations/tests/issue-1947.rs
@@ -1,0 +1,352 @@
+#![allow(
+    dead_code,
+    non_snake_case,
+    non_camel_case_types,
+    non_upper_case_globals
+)]
+
+#[repr(C)]
+#[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct __BindgenBitfieldUnit<Storage> {
+    storage: Storage,
+}
+impl<Storage> __BindgenBitfieldUnit<Storage> {
+    #[inline]
+    pub const fn new(storage: Storage) -> Self {
+        Self { storage }
+    }
+}
+impl<Storage> __BindgenBitfieldUnit<Storage>
+where
+    Storage: AsRef<[u8]> + AsMut<[u8]>,
+{
+    #[inline]
+    pub fn get_bit(&self, index: usize) -> bool {
+        debug_assert!(index / 8 < self.storage.as_ref().len());
+        let byte_index = index / 8;
+        let byte = self.storage.as_ref()[byte_index];
+        let bit_index = if cfg!(target_endian = "big") {
+            7 - (index % 8)
+        } else {
+            index % 8
+        };
+        let mask = 1 << bit_index;
+        byte & mask == mask
+    }
+    #[inline]
+    pub fn set_bit(&mut self, index: usize, val: bool) {
+        debug_assert!(index / 8 < self.storage.as_ref().len());
+        let byte_index = index / 8;
+        let byte = &mut self.storage.as_mut()[byte_index];
+        let bit_index = if cfg!(target_endian = "big") {
+            7 - (index % 8)
+        } else {
+            index % 8
+        };
+        let mask = 1 << bit_index;
+        if val {
+            *byte |= mask;
+        } else {
+            *byte &= !mask;
+        }
+    }
+    #[inline]
+    pub fn get(&self, bit_offset: usize, bit_width: u8) -> u64 {
+        debug_assert!(bit_width <= 64);
+        debug_assert!(bit_offset / 8 < self.storage.as_ref().len());
+        debug_assert!(
+            (bit_offset + (bit_width as usize)) / 8 <=
+                self.storage.as_ref().len()
+        );
+        let mut val = 0;
+        for i in 0..(bit_width as usize) {
+            if self.get_bit(i + bit_offset) {
+                let index = if cfg!(target_endian = "big") {
+                    bit_width as usize - 1 - i
+                } else {
+                    i
+                };
+                val |= 1 << index;
+            }
+        }
+        val
+    }
+    #[inline]
+    pub fn set(&mut self, bit_offset: usize, bit_width: u8, val: u64) {
+        debug_assert!(bit_width <= 64);
+        debug_assert!(bit_offset / 8 < self.storage.as_ref().len());
+        debug_assert!(
+            (bit_offset + (bit_width as usize)) / 8 <=
+                self.storage.as_ref().len()
+        );
+        for i in 0..(bit_width as usize) {
+            let mask = 1 << i;
+            let val_bit_is_set = val & mask == mask;
+            let index = if cfg!(target_endian = "big") {
+                bit_width as usize - 1 - i
+            } else {
+                i
+            };
+            self.set_bit(index + bit_offset, val_bit_is_set);
+        }
+    }
+}
+pub type U8 = ::std::os::raw::c_uchar;
+pub type U16 = ::std::os::raw::c_ushort;
+#[repr(C)]
+#[repr(align(2))]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct V56AMDY {
+    pub _bitfield_align_1: [u16; 0],
+    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 2usize]>,
+    pub MADK: U8,
+    pub MABR: U8,
+    pub _bitfield_align_2: [u16; 0],
+    pub _bitfield_2: __BindgenBitfieldUnit<[u8; 3usize]>,
+    pub _rB_: U8,
+}
+#[test]
+fn bindgen_test_layout_V56AMDY() {
+    assert_eq!(
+        ::std::mem::size_of::<V56AMDY>(),
+        8usize,
+        concat!("Size of: ", stringify!(V56AMDY))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<V56AMDY>(),
+        2usize,
+        concat!("Alignment of ", stringify!(V56AMDY))
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<V56AMDY>())).MADK as *const _ as usize
+        },
+        2usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(V56AMDY),
+            "::",
+            stringify!(MADK)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<V56AMDY>())).MABR as *const _ as usize
+        },
+        3usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(V56AMDY),
+            "::",
+            stringify!(MABR)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<V56AMDY>()))._rB_ as *const _ as usize
+        },
+        7usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(V56AMDY),
+            "::",
+            stringify!(_rB_)
+        )
+    );
+}
+impl V56AMDY {
+    #[inline]
+    pub fn MADZ(&self) -> U16 {
+        unsafe {
+            ::std::mem::transmute(self._bitfield_1.get(0usize, 10u8) as u16)
+        }
+    }
+    #[inline]
+    pub fn set_MADZ(&mut self, val: U16) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set(0usize, 10u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn MAI0(&self) -> U16 {
+        unsafe {
+            ::std::mem::transmute(self._bitfield_1.get(10usize, 2u8) as u16)
+        }
+    }
+    #[inline]
+    pub fn set_MAI0(&mut self, val: U16) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set(10usize, 2u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn MAI1(&self) -> U16 {
+        unsafe {
+            ::std::mem::transmute(self._bitfield_1.get(12usize, 2u8) as u16)
+        }
+    }
+    #[inline]
+    pub fn set_MAI1(&mut self, val: U16) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set(12usize, 2u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn MAI2(&self) -> U16 {
+        unsafe {
+            ::std::mem::transmute(self._bitfield_1.get(14usize, 2u8) as u16)
+        }
+    }
+    #[inline]
+    pub fn set_MAI2(&mut self, val: U16) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set(14usize, 2u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn new_bitfield_1(
+        MADZ: U16,
+        MAI0: U16,
+        MAI1: U16,
+        MAI2: U16,
+    ) -> __BindgenBitfieldUnit<[u8; 2usize]> {
+        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 2usize]> =
+            Default::default();
+        __bindgen_bitfield_unit.set(0usize, 10u8, {
+            let MADZ: u16 = unsafe { ::std::mem::transmute(MADZ) };
+            MADZ as u64
+        });
+        __bindgen_bitfield_unit.set(10usize, 2u8, {
+            let MAI0: u16 = unsafe { ::std::mem::transmute(MAI0) };
+            MAI0 as u64
+        });
+        __bindgen_bitfield_unit.set(12usize, 2u8, {
+            let MAI1: u16 = unsafe { ::std::mem::transmute(MAI1) };
+            MAI1 as u64
+        });
+        __bindgen_bitfield_unit.set(14usize, 2u8, {
+            let MAI2: u16 = unsafe { ::std::mem::transmute(MAI2) };
+            MAI2 as u64
+        });
+        __bindgen_bitfield_unit
+    }
+    #[inline]
+    pub fn MATH(&self) -> U16 {
+        unsafe {
+            ::std::mem::transmute(self._bitfield_2.get(0usize, 10u8) as u16)
+        }
+    }
+    #[inline]
+    pub fn set_MATH(&mut self, val: U16) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_2.set(0usize, 10u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn MATE(&self) -> U16 {
+        unsafe {
+            ::std::mem::transmute(self._bitfield_2.get(10usize, 4u8) as u16)
+        }
+    }
+    #[inline]
+    pub fn set_MATE(&mut self, val: U16) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_2.set(10usize, 4u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn MATW(&self) -> U16 {
+        unsafe {
+            ::std::mem::transmute(self._bitfield_2.get(14usize, 2u8) as u16)
+        }
+    }
+    #[inline]
+    pub fn set_MATW(&mut self, val: U16) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_2.set(14usize, 2u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn MASW(&self) -> U8 {
+        unsafe {
+            ::std::mem::transmute(self._bitfield_2.get(16usize, 4u8) as u8)
+        }
+    }
+    #[inline]
+    pub fn set_MASW(&mut self, val: U8) {
+        unsafe {
+            let val: u8 = ::std::mem::transmute(val);
+            self._bitfield_2.set(16usize, 4u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn MABW(&self) -> U8 {
+        unsafe {
+            ::std::mem::transmute(self._bitfield_2.get(20usize, 3u8) as u8)
+        }
+    }
+    #[inline]
+    pub fn set_MABW(&mut self, val: U8) {
+        unsafe {
+            let val: u8 = ::std::mem::transmute(val);
+            self._bitfield_2.set(20usize, 3u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn MAXN(&self) -> U8 {
+        unsafe {
+            ::std::mem::transmute(self._bitfield_2.get(23usize, 1u8) as u8)
+        }
+    }
+    #[inline]
+    pub fn set_MAXN(&mut self, val: U8) {
+        unsafe {
+            let val: u8 = ::std::mem::transmute(val);
+            self._bitfield_2.set(23usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn new_bitfield_2(
+        MATH: U16,
+        MATE: U16,
+        MATW: U16,
+        MASW: U8,
+        MABW: U8,
+        MAXN: U8,
+    ) -> __BindgenBitfieldUnit<[u8; 3usize]> {
+        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 3usize]> =
+            Default::default();
+        __bindgen_bitfield_unit.set(0usize, 10u8, {
+            let MATH: u16 = unsafe { ::std::mem::transmute(MATH) };
+            MATH as u64
+        });
+        __bindgen_bitfield_unit.set(10usize, 4u8, {
+            let MATE: u16 = unsafe { ::std::mem::transmute(MATE) };
+            MATE as u64
+        });
+        __bindgen_bitfield_unit.set(14usize, 2u8, {
+            let MATW: u16 = unsafe { ::std::mem::transmute(MATW) };
+            MATW as u64
+        });
+        __bindgen_bitfield_unit.set(16usize, 4u8, {
+            let MASW: u8 = unsafe { ::std::mem::transmute(MASW) };
+            MASW as u64
+        });
+        __bindgen_bitfield_unit.set(20usize, 3u8, {
+            let MABW: u8 = unsafe { ::std::mem::transmute(MABW) };
+            MABW as u64
+        });
+        __bindgen_bitfield_unit.set(23usize, 1u8, {
+            let MAXN: u8 = unsafe { ::std::mem::transmute(MAXN) };
+            MAXN as u64
+        });
+        __bindgen_bitfield_unit
+    }
+}

--- a/tests/expectations/tests/issue-739-pointer-wide-bitfield.rs
+++ b/tests/expectations/tests/issue-739-pointer-wide-bitfield.rs
@@ -7,17 +7,16 @@
 
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct __BindgenBitfieldUnit<Storage, Align> {
+pub struct __BindgenBitfieldUnit<Storage> {
     storage: Storage,
-    align: [Align; 0],
 }
-impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align> {
+impl<Storage> __BindgenBitfieldUnit<Storage> {
     #[inline]
     pub const fn new(storage: Storage) -> Self {
-        Self { storage, align: [] }
+        Self { storage }
     }
 }
-impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align>
+impl<Storage> __BindgenBitfieldUnit<Storage>
 where
     Storage: AsRef<[u8]> + AsMut<[u8]>,
 {
@@ -96,7 +95,8 @@ where
 #[repr(align(8))]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct Foo {
-    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 32usize], u64>,
+    pub _bitfield_align_1: [u64; 0],
+    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 32usize]>,
 }
 #[test]
 fn bindgen_test_layout_Foo() {
@@ -170,11 +170,9 @@ impl Foo {
         m_bar: ::std::os::raw::c_ulong,
         foo: ::std::os::raw::c_ulong,
         bar: ::std::os::raw::c_ulong,
-    ) -> __BindgenBitfieldUnit<[u8; 32usize], u64> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<
-            [u8; 32usize],
-            u64,
-        > = Default::default();
+    ) -> __BindgenBitfieldUnit<[u8; 32usize]> {
+        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 32usize]> =
+            Default::default();
         __bindgen_bitfield_unit.set(0usize, 64u8, {
             let m_bitfield: u64 = unsafe { ::std::mem::transmute(m_bitfield) };
             m_bitfield as u64

--- a/tests/expectations/tests/issue-816.rs
+++ b/tests/expectations/tests/issue-816.rs
@@ -7,17 +7,16 @@
 
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct __BindgenBitfieldUnit<Storage, Align> {
+pub struct __BindgenBitfieldUnit<Storage> {
     storage: Storage,
-    align: [Align; 0],
 }
-impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align> {
+impl<Storage> __BindgenBitfieldUnit<Storage> {
     #[inline]
     pub const fn new(storage: Storage) -> Self {
-        Self { storage, align: [] }
+        Self { storage }
     }
 }
-impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align>
+impl<Storage> __BindgenBitfieldUnit<Storage>
 where
     Storage: AsRef<[u8]> + AsMut<[u8]>,
 {
@@ -96,7 +95,8 @@ where
 #[repr(align(4))]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct capabilities {
-    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 16usize], u8>,
+    pub _bitfield_align_1: [u8; 0],
+    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 16usize]>,
 }
 #[test]
 fn bindgen_test_layout_capabilities() {
@@ -688,11 +688,9 @@ impl capabilities {
         bit_39: ::std::os::raw::c_uint,
         bit_40: ::std::os::raw::c_uint,
         bit_41: ::std::os::raw::c_uint,
-    ) -> __BindgenBitfieldUnit<[u8; 16usize], u8> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<
-            [u8; 16usize],
-            u8,
-        > = Default::default();
+    ) -> __BindgenBitfieldUnit<[u8; 16usize]> {
+        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 16usize]> =
+            Default::default();
         __bindgen_bitfield_unit.set(0usize, 1u8, {
             let bit_1: u32 = unsafe { ::std::mem::transmute(bit_1) };
             bit_1 as u64

--- a/tests/expectations/tests/jsval_layout_opaque.rs
+++ b/tests/expectations/tests/jsval_layout_opaque.rs
@@ -7,17 +7,16 @@
 
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct __BindgenBitfieldUnit<Storage, Align> {
+pub struct __BindgenBitfieldUnit<Storage> {
     storage: Storage,
-    align: [Align; 0],
 }
-impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align> {
+impl<Storage> __BindgenBitfieldUnit<Storage> {
     #[inline]
     pub const fn new(storage: Storage) -> Self {
-        Self { storage, align: [] }
+        Self { storage }
     }
 }
-impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align>
+impl<Storage> __BindgenBitfieldUnit<Storage>
 where
     Storage: AsRef<[u8]> + AsMut<[u8]>,
 {
@@ -195,7 +194,8 @@ pub union jsval_layout {
 #[repr(align(8))]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct jsval_layout__bindgen_ty_1 {
-    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 8usize], u64>,
+    pub _bitfield_align_1: [u64; 0],
+    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 8usize]>,
 }
 #[test]
 fn bindgen_test_layout_jsval_layout__bindgen_ty_1() {
@@ -246,11 +246,9 @@ impl jsval_layout__bindgen_ty_1 {
     pub fn new_bitfield_1(
         payload47: u64,
         tag: JSValueTag,
-    ) -> __BindgenBitfieldUnit<[u8; 8usize], u64> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<
-            [u8; 8usize],
-            u64,
-        > = Default::default();
+    ) -> __BindgenBitfieldUnit<[u8; 8usize]> {
+        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 8usize]> =
+            Default::default();
         __bindgen_bitfield_unit.set(0usize, 47u8, {
             let payload47: u64 = unsafe { ::std::mem::transmute(payload47) };
             payload47 as u64

--- a/tests/expectations/tests/jsval_layout_opaque_1_0.rs
+++ b/tests/expectations/tests/jsval_layout_opaque_1_0.rs
@@ -7,17 +7,16 @@
 
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct __BindgenBitfieldUnit<Storage, Align> {
+pub struct __BindgenBitfieldUnit<Storage> {
     storage: Storage,
-    align: [Align; 0],
 }
-impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align> {
+impl<Storage> __BindgenBitfieldUnit<Storage> {
     #[inline]
     pub fn new(storage: Storage) -> Self {
-        Self { storage, align: [] }
+        Self { storage }
     }
 }
-impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align>
+impl<Storage> __BindgenBitfieldUnit<Storage>
 where
     Storage: AsRef<[u8]> + AsMut<[u8]>,
 {
@@ -237,7 +236,8 @@ pub struct jsval_layout {
 #[repr(C)]
 #[derive(Debug, Copy, Hash, PartialEq, Eq)]
 pub struct jsval_layout__bindgen_ty_1 {
-    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 8usize], u64>,
+    pub _bitfield_align_1: [u64; 0],
+    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 8usize]>,
     pub __bindgen_align: [u64; 0usize],
 }
 #[test]
@@ -294,11 +294,9 @@ impl jsval_layout__bindgen_ty_1 {
     pub fn new_bitfield_1(
         payload47: u64,
         tag: JSValueTag,
-    ) -> __BindgenBitfieldUnit<[u8; 8usize], u64> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<
-            [u8; 8usize],
-            u64,
-        > = Default::default();
+    ) -> __BindgenBitfieldUnit<[u8; 8usize]> {
+        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 8usize]> =
+            Default::default();
         __bindgen_bitfield_unit.set(0usize, 47u8, {
             let payload47: u64 = unsafe { ::std::mem::transmute(payload47) };
             payload47 as u64

--- a/tests/expectations/tests/layout_align.rs
+++ b/tests/expectations/tests/layout_align.rs
@@ -7,17 +7,16 @@
 
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct __BindgenBitfieldUnit<Storage, Align> {
+pub struct __BindgenBitfieldUnit<Storage> {
     storage: Storage,
-    align: [Align; 0],
 }
-impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align> {
+impl<Storage> __BindgenBitfieldUnit<Storage> {
     #[inline]
     pub const fn new(storage: Storage) -> Self {
-        Self { storage, align: [] }
+        Self { storage }
     }
 }
-impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align>
+impl<Storage> __BindgenBitfieldUnit<Storage>
 where
     Storage: AsRef<[u8]> + AsMut<[u8]>,
 {
@@ -160,7 +159,8 @@ impl Default for rte_kni_fifo {
 pub struct rte_eth_link {
     ///< ETH_SPEED_NUM_
     pub link_speed: u32,
-    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize], u8>,
+    pub _bitfield_align_1: [u8; 0],
+    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
     pub __bindgen_padding_0: [u8; 3usize],
 }
 #[test]
@@ -234,11 +234,9 @@ impl rte_eth_link {
         link_duplex: u16,
         link_autoneg: u16,
         link_status: u16,
-    ) -> __BindgenBitfieldUnit<[u8; 1usize], u8> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<
-            [u8; 1usize],
-            u8,
-        > = Default::default();
+    ) -> __BindgenBitfieldUnit<[u8; 1usize]> {
+        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 1usize]> =
+            Default::default();
         __bindgen_bitfield_unit.set(0usize, 1u8, {
             let link_duplex: u16 =
                 unsafe { ::std::mem::transmute(link_duplex) };

--- a/tests/expectations/tests/layout_eth_conf.rs
+++ b/tests/expectations/tests/layout_eth_conf.rs
@@ -7,17 +7,16 @@
 
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct __BindgenBitfieldUnit<Storage, Align> {
+pub struct __BindgenBitfieldUnit<Storage> {
     storage: Storage,
-    align: [Align; 0],
 }
-impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align> {
+impl<Storage> __BindgenBitfieldUnit<Storage> {
     #[inline]
     pub const fn new(storage: Storage) -> Self {
-        Self { storage, align: [] }
+        Self { storage }
     }
 }
-impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align>
+impl<Storage> __BindgenBitfieldUnit<Storage>
 where
     Storage: AsRef<[u8]> + AsMut<[u8]>,
 {
@@ -156,7 +155,8 @@ pub struct rte_eth_rxmode {
     pub max_rx_pkt_len: u32,
     ///< hdr buf size (header_split enabled).
     pub split_hdr_size: u16,
-    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 2usize], u8>,
+    pub _bitfield_align_1: [u8; 0],
+    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 2usize]>,
 }
 #[test]
 fn bindgen_test_layout_rte_eth_rxmode() {
@@ -344,11 +344,9 @@ impl rte_eth_rxmode {
         hw_strip_crc: u16,
         enable_scatter: u16,
         enable_lro: u16,
-    ) -> __BindgenBitfieldUnit<[u8; 2usize], u8> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<
-            [u8; 2usize],
-            u8,
-        > = Default::default();
+    ) -> __BindgenBitfieldUnit<[u8; 2usize]> {
+        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 2usize]> =
+            Default::default();
         __bindgen_bitfield_unit.set(0usize, 1u8, {
             let header_split: u16 =
                 unsafe { ::std::mem::transmute(header_split) };
@@ -417,7 +415,8 @@ pub struct rte_eth_txmode {
     ///< TX multi-queues mode.
     pub mq_mode: rte_eth_tx_mq_mode,
     pub pvid: u16,
-    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize], u8>,
+    pub _bitfield_align_1: [u8; 0],
+    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
     pub __bindgen_padding_0: u8,
 }
 #[test]
@@ -508,11 +507,9 @@ impl rte_eth_txmode {
         hw_vlan_reject_tagged: u8,
         hw_vlan_reject_untagged: u8,
         hw_vlan_insert_pvid: u8,
-    ) -> __BindgenBitfieldUnit<[u8; 1usize], u8> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<
-            [u8; 1usize],
-            u8,
-        > = Default::default();
+    ) -> __BindgenBitfieldUnit<[u8; 1usize]> {
+        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 1usize]> =
+            Default::default();
         __bindgen_bitfield_unit.set(0usize, 1u8, {
             let hw_vlan_reject_tagged: u8 =
                 unsafe { ::std::mem::transmute(hw_vlan_reject_tagged) };

--- a/tests/expectations/tests/layout_eth_conf_1_0.rs
+++ b/tests/expectations/tests/layout_eth_conf_1_0.rs
@@ -7,17 +7,16 @@
 
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct __BindgenBitfieldUnit<Storage, Align> {
+pub struct __BindgenBitfieldUnit<Storage> {
     storage: Storage,
-    align: [Align; 0],
 }
-impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align> {
+impl<Storage> __BindgenBitfieldUnit<Storage> {
     #[inline]
     pub fn new(storage: Storage) -> Self {
-        Self { storage, align: [] }
+        Self { storage }
     }
 }
-impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align>
+impl<Storage> __BindgenBitfieldUnit<Storage>
 where
     Storage: AsRef<[u8]> + AsMut<[u8]>,
 {
@@ -199,7 +198,8 @@ pub struct rte_eth_rxmode {
     pub max_rx_pkt_len: u32,
     ///< hdr buf size (header_split enabled).
     pub split_hdr_size: u16,
-    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 2usize], u8>,
+    pub _bitfield_align_1: [u8; 0],
+    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 2usize]>,
 }
 #[test]
 fn bindgen_test_layout_rte_eth_rxmode() {
@@ -392,11 +392,9 @@ impl rte_eth_rxmode {
         hw_strip_crc: u16,
         enable_scatter: u16,
         enable_lro: u16,
-    ) -> __BindgenBitfieldUnit<[u8; 2usize], u8> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<
-            [u8; 2usize],
-            u8,
-        > = Default::default();
+    ) -> __BindgenBitfieldUnit<[u8; 2usize]> {
+        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 2usize]> =
+            Default::default();
         __bindgen_bitfield_unit.set(0usize, 1u8, {
             let header_split: u16 =
                 unsafe { ::std::mem::transmute(header_split) };
@@ -465,7 +463,8 @@ pub struct rte_eth_txmode {
     ///< TX multi-queues mode.
     pub mq_mode: rte_eth_tx_mq_mode,
     pub pvid: u16,
-    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize], u8>,
+    pub _bitfield_align_1: [u8; 0],
+    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
     pub __bindgen_padding_0: u8,
 }
 #[test]
@@ -561,11 +560,9 @@ impl rte_eth_txmode {
         hw_vlan_reject_tagged: u8,
         hw_vlan_reject_untagged: u8,
         hw_vlan_insert_pvid: u8,
-    ) -> __BindgenBitfieldUnit<[u8; 1usize], u8> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<
-            [u8; 1usize],
-            u8,
-        > = Default::default();
+    ) -> __BindgenBitfieldUnit<[u8; 1usize]> {
+        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 1usize]> =
+            Default::default();
         __bindgen_bitfield_unit.set(0usize, 1u8, {
             let hw_vlan_reject_tagged: u8 =
                 unsafe { ::std::mem::transmute(hw_vlan_reject_tagged) };

--- a/tests/expectations/tests/layout_mbuf.rs
+++ b/tests/expectations/tests/layout_mbuf.rs
@@ -7,17 +7,16 @@
 
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct __BindgenBitfieldUnit<Storage, Align> {
+pub struct __BindgenBitfieldUnit<Storage> {
     storage: Storage,
-    align: [Align; 0],
 }
-impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align> {
+impl<Storage> __BindgenBitfieldUnit<Storage> {
     #[inline]
     pub const fn new(storage: Storage) -> Self {
-        Self { storage, align: [] }
+        Self { storage }
     }
 }
-impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align>
+impl<Storage> __BindgenBitfieldUnit<Storage>
 where
     Storage: AsRef<[u8]> + AsMut<[u8]>,
 {
@@ -248,7 +247,8 @@ pub union rte_mbuf__bindgen_ty_2 {
 #[repr(align(4))]
 #[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct rte_mbuf__bindgen_ty_2__bindgen_ty_1 {
-    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize], u8>,
+    pub _bitfield_align_1: [u8; 0],
+    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
 }
 #[test]
 fn bindgen_test_layout_rte_mbuf__bindgen_ty_2__bindgen_ty_1() {
@@ -370,11 +370,9 @@ impl rte_mbuf__bindgen_ty_2__bindgen_ty_1 {
         inner_l2_type: u32,
         inner_l3_type: u32,
         inner_l4_type: u32,
-    ) -> __BindgenBitfieldUnit<[u8; 4usize], u8> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<
-            [u8; 4usize],
-            u8,
-        > = Default::default();
+    ) -> __BindgenBitfieldUnit<[u8; 4usize]> {
+        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> =
+            Default::default();
         __bindgen_bitfield_unit.set(0usize, 4u8, {
             let l2_type: u32 = unsafe { ::std::mem::transmute(l2_type) };
             l2_type as u64
@@ -746,7 +744,8 @@ pub union rte_mbuf__bindgen_ty_5 {
 #[repr(align(8))]
 #[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct rte_mbuf__bindgen_ty_5__bindgen_ty_1 {
-    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 8usize], u16>,
+    pub _bitfield_align_1: [u16; 0],
+    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 7usize]>,
 }
 #[test]
 fn bindgen_test_layout_rte_mbuf__bindgen_ty_5__bindgen_ty_1() {
@@ -854,11 +853,9 @@ impl rte_mbuf__bindgen_ty_5__bindgen_ty_1 {
         tso_segsz: u64,
         outer_l3_len: u64,
         outer_l2_len: u64,
-    ) -> __BindgenBitfieldUnit<[u8; 8usize], u16> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<
-            [u8; 8usize],
-            u16,
-        > = Default::default();
+    ) -> __BindgenBitfieldUnit<[u8; 7usize]> {
+        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 7usize]> =
+            Default::default();
         __bindgen_bitfield_unit.set(0usize, 7u8, {
             let l2_len: u64 = unsafe { ::std::mem::transmute(l2_len) };
             l2_len as u64

--- a/tests/expectations/tests/layout_mbuf_1_0.rs
+++ b/tests/expectations/tests/layout_mbuf_1_0.rs
@@ -7,17 +7,16 @@
 
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct __BindgenBitfieldUnit<Storage, Align> {
+pub struct __BindgenBitfieldUnit<Storage> {
     storage: Storage,
-    align: [Align; 0],
 }
-impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align> {
+impl<Storage> __BindgenBitfieldUnit<Storage> {
     #[inline]
     pub fn new(storage: Storage) -> Self {
-        Self { storage, align: [] }
+        Self { storage }
     }
 }
-impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align>
+impl<Storage> __BindgenBitfieldUnit<Storage>
 where
     Storage: AsRef<[u8]> + AsMut<[u8]>,
 {
@@ -296,7 +295,8 @@ pub struct rte_mbuf__bindgen_ty_2 {
 #[repr(C)]
 #[derive(Debug, Default, Copy, Hash, PartialEq, Eq)]
 pub struct rte_mbuf__bindgen_ty_2__bindgen_ty_1 {
-    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize], u8>,
+    pub _bitfield_align_1: [u8; 0],
+    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
     pub __bindgen_align: [u32; 0usize],
 }
 #[test]
@@ -424,11 +424,9 @@ impl rte_mbuf__bindgen_ty_2__bindgen_ty_1 {
         inner_l2_type: u32,
         inner_l3_type: u32,
         inner_l4_type: u32,
-    ) -> __BindgenBitfieldUnit<[u8; 4usize], u8> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<
-            [u8; 4usize],
-            u8,
-        > = Default::default();
+    ) -> __BindgenBitfieldUnit<[u8; 4usize]> {
+        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> =
+            Default::default();
         __bindgen_bitfield_unit.set(0usize, 4u8, {
             let l2_type: u32 = unsafe { ::std::mem::transmute(l2_type) };
             l2_type as u64
@@ -813,7 +811,8 @@ pub struct rte_mbuf__bindgen_ty_5 {
 #[repr(C)]
 #[derive(Debug, Default, Copy, Hash, PartialEq, Eq)]
 pub struct rte_mbuf__bindgen_ty_5__bindgen_ty_1 {
-    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 8usize], u16>,
+    pub _bitfield_align_1: [u16; 0],
+    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 7usize]>,
     pub __bindgen_align: [u64; 0usize],
 }
 #[test]
@@ -927,11 +926,9 @@ impl rte_mbuf__bindgen_ty_5__bindgen_ty_1 {
         tso_segsz: u64,
         outer_l3_len: u64,
         outer_l2_len: u64,
-    ) -> __BindgenBitfieldUnit<[u8; 8usize], u16> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<
-            [u8; 8usize],
-            u16,
-        > = Default::default();
+    ) -> __BindgenBitfieldUnit<[u8; 7usize]> {
+        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 7usize]> =
+            Default::default();
         __bindgen_bitfield_unit.set(0usize, 7u8, {
             let l2_len: u64 = unsafe { ::std::mem::transmute(l2_len) };
             l2_len as u64

--- a/tests/expectations/tests/libclang-9/incomplete-array-padding.rs
+++ b/tests/expectations/tests/libclang-9/incomplete-array-padding.rs
@@ -7,17 +7,16 @@
 
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct __BindgenBitfieldUnit<Storage, Align> {
+pub struct __BindgenBitfieldUnit<Storage> {
     storage: Storage,
-    align: [Align; 0],
 }
-impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align> {
+impl<Storage> __BindgenBitfieldUnit<Storage> {
     #[inline]
     pub const fn new(storage: Storage) -> Self {
-        Self { storage, align: [] }
+        Self { storage }
     }
 }
-impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align>
+impl<Storage> __BindgenBitfieldUnit<Storage>
 where
     Storage: AsRef<[u8]> + AsMut<[u8]>,
 {
@@ -125,7 +124,8 @@ impl<T> ::std::fmt::Debug for __IncompleteArrayField<T> {
 #[repr(C)]
 #[derive(Debug)]
 pub struct foo {
-    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize], u8>,
+    pub _bitfield_align_1: [u8; 0],
+    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
     pub b: __IncompleteArrayField<*mut ::std::os::raw::c_void>,
 }
 #[test]
@@ -168,11 +168,9 @@ impl foo {
     #[inline]
     pub fn new_bitfield_1(
         a: ::std::os::raw::c_char,
-    ) -> __BindgenBitfieldUnit<[u8; 1usize], u8> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<
-            [u8; 1usize],
-            u8,
-        > = Default::default();
+    ) -> __BindgenBitfieldUnit<[u8; 1usize]> {
+        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 1usize]> =
+            Default::default();
         __bindgen_bitfield_unit.set(0usize, 1u8, {
             let a: u8 = unsafe { ::std::mem::transmute(a) };
             a as u64

--- a/tests/expectations/tests/libclang-9/layout_align.rs
+++ b/tests/expectations/tests/libclang-9/layout_align.rs
@@ -7,17 +7,16 @@
 
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct __BindgenBitfieldUnit<Storage, Align> {
+pub struct __BindgenBitfieldUnit<Storage> {
     storage: Storage,
-    align: [Align; 0],
 }
-impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align> {
+impl<Storage> __BindgenBitfieldUnit<Storage> {
     #[inline]
     pub const fn new(storage: Storage) -> Self {
-        Self { storage, align: [] }
+        Self { storage }
     }
 }
-impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align>
+impl<Storage> __BindgenBitfieldUnit<Storage>
 where
     Storage: AsRef<[u8]> + AsMut<[u8]>,
 {
@@ -221,7 +220,8 @@ impl Default for rte_kni_fifo {
 pub struct rte_eth_link {
     ///< ETH_SPEED_NUM_
     pub link_speed: u32,
-    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize], u8>,
+    pub _bitfield_align_1: [u8; 0],
+    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
     pub __bindgen_padding_0: [u8; 3usize],
 }
 #[test]
@@ -295,11 +295,9 @@ impl rte_eth_link {
         link_duplex: u16,
         link_autoneg: u16,
         link_status: u16,
-    ) -> __BindgenBitfieldUnit<[u8; 1usize], u8> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<
-            [u8; 1usize],
-            u8,
-        > = Default::default();
+    ) -> __BindgenBitfieldUnit<[u8; 1usize]> {
+        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 1usize]> =
+            Default::default();
         __bindgen_bitfield_unit.set(0usize, 1u8, {
             let link_duplex: u16 =
                 unsafe { ::std::mem::transmute(link_duplex) };

--- a/tests/expectations/tests/only_bitfields.rs
+++ b/tests/expectations/tests/only_bitfields.rs
@@ -7,17 +7,16 @@
 
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct __BindgenBitfieldUnit<Storage, Align> {
+pub struct __BindgenBitfieldUnit<Storage> {
     storage: Storage,
-    align: [Align; 0],
 }
-impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align> {
+impl<Storage> __BindgenBitfieldUnit<Storage> {
     #[inline]
     pub const fn new(storage: Storage) -> Self {
-        Self { storage, align: [] }
+        Self { storage }
     }
 }
-impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align>
+impl<Storage> __BindgenBitfieldUnit<Storage>
 where
     Storage: AsRef<[u8]> + AsMut<[u8]>,
 {
@@ -95,7 +94,8 @@ where
 #[repr(C, packed)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct C {
-    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize], u8>,
+    pub _bitfield_align_1: [u8; 0],
+    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
 }
 #[test]
 fn bindgen_test_layout_C() {
@@ -141,11 +141,9 @@ impl C {
     pub fn new_bitfield_1(
         a: bool,
         b: bool,
-    ) -> __BindgenBitfieldUnit<[u8; 1usize], u8> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<
-            [u8; 1usize],
-            u8,
-        > = Default::default();
+    ) -> __BindgenBitfieldUnit<[u8; 1usize]> {
+        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 1usize]> =
+            Default::default();
         __bindgen_bitfield_unit.set(0usize, 1u8, {
             let a: u8 = unsafe { ::std::mem::transmute(a) };
             a as u64

--- a/tests/expectations/tests/packed-bitfield.rs
+++ b/tests/expectations/tests/packed-bitfield.rs
@@ -7,17 +7,16 @@
 
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct __BindgenBitfieldUnit<Storage, Align> {
+pub struct __BindgenBitfieldUnit<Storage> {
     storage: Storage,
-    align: [Align; 0],
 }
-impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align> {
+impl<Storage> __BindgenBitfieldUnit<Storage> {
     #[inline]
     pub const fn new(storage: Storage) -> Self {
-        Self { storage, align: [] }
+        Self { storage }
     }
 }
-impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align>
+impl<Storage> __BindgenBitfieldUnit<Storage>
 where
     Storage: AsRef<[u8]> + AsMut<[u8]>,
 {
@@ -95,7 +94,8 @@ where
 #[repr(C, packed)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct Date {
-    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 3usize], u8>,
+    pub _bitfield_align_1: [u8; 0],
+    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 3usize]>,
 }
 #[test]
 fn bindgen_test_layout_Date() {
@@ -155,11 +155,9 @@ impl Date {
         day: ::std::os::raw::c_uchar,
         month: ::std::os::raw::c_uchar,
         year: ::std::os::raw::c_short,
-    ) -> __BindgenBitfieldUnit<[u8; 3usize], u8> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<
-            [u8; 3usize],
-            u8,
-        > = Default::default();
+    ) -> __BindgenBitfieldUnit<[u8; 3usize]> {
+        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 3usize]> =
+            Default::default();
         __bindgen_bitfield_unit.set(0usize, 5u8, {
             let day: u8 = unsafe { ::std::mem::transmute(day) };
             day as u64

--- a/tests/expectations/tests/struct_with_bitfields.rs
+++ b/tests/expectations/tests/struct_with_bitfields.rs
@@ -7,17 +7,16 @@
 
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct __BindgenBitfieldUnit<Storage, Align> {
+pub struct __BindgenBitfieldUnit<Storage> {
     storage: Storage,
-    align: [Align; 0],
 }
-impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align> {
+impl<Storage> __BindgenBitfieldUnit<Storage> {
     #[inline]
     pub const fn new(storage: Storage) -> Self {
-        Self { storage, align: [] }
+        Self { storage }
     }
 }
-impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align>
+impl<Storage> __BindgenBitfieldUnit<Storage>
 where
     Storage: AsRef<[u8]> + AsMut<[u8]>,
 {
@@ -95,9 +94,11 @@ where
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct bitfield {
-    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize], u8>,
+    pub _bitfield_align_1: [u8; 0],
+    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
     pub e: ::std::os::raw::c_int,
-    pub _bitfield_2: __BindgenBitfieldUnit<[u8; 8usize], u32>,
+    pub _bitfield_align_2: [u32; 0],
+    pub _bitfield_2: __BindgenBitfieldUnit<[u8; 8usize]>,
 }
 #[test]
 fn bindgen_test_layout_bitfield() {
@@ -181,11 +182,9 @@ impl bitfield {
         b: ::std::os::raw::c_ushort,
         c: ::std::os::raw::c_ushort,
         d: ::std::os::raw::c_ushort,
-    ) -> __BindgenBitfieldUnit<[u8; 1usize], u8> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<
-            [u8; 1usize],
-            u8,
-        > = Default::default();
+    ) -> __BindgenBitfieldUnit<[u8; 1usize]> {
+        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 1usize]> =
+            Default::default();
         __bindgen_bitfield_unit.set(0usize, 1u8, {
             let a: u16 = unsafe { ::std::mem::transmute(a) };
             a as u64
@@ -234,11 +233,9 @@ impl bitfield {
     pub fn new_bitfield_2(
         f: ::std::os::raw::c_uint,
         g: ::std::os::raw::c_uint,
-    ) -> __BindgenBitfieldUnit<[u8; 8usize], u32> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<
-            [u8; 8usize],
-            u32,
-        > = Default::default();
+    ) -> __BindgenBitfieldUnit<[u8; 8usize]> {
+        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 8usize]> =
+            Default::default();
         __bindgen_bitfield_unit.set(0usize, 2u8, {
             let f: u32 = unsafe { ::std::mem::transmute(f) };
             f as u64

--- a/tests/expectations/tests/timex.rs
+++ b/tests/expectations/tests/timex.rs
@@ -7,17 +7,16 @@
 
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct __BindgenBitfieldUnit<Storage, Align> {
+pub struct __BindgenBitfieldUnit<Storage> {
     storage: Storage,
-    align: [Align; 0],
 }
-impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align> {
+impl<Storage> __BindgenBitfieldUnit<Storage> {
     #[inline]
     pub const fn new(storage: Storage) -> Self {
-        Self { storage, align: [] }
+        Self { storage }
     }
 }
-impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align>
+impl<Storage> __BindgenBitfieldUnit<Storage>
 where
     Storage: AsRef<[u8]> + AsMut<[u8]>,
 {
@@ -96,7 +95,8 @@ where
 #[derive(Copy, Clone)]
 pub struct timex {
     pub tai: ::std::os::raw::c_int,
-    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 44usize], u8>,
+    pub _bitfield_align_1: [u8; 0],
+    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 44usize]>,
 }
 #[test]
 fn bindgen_test_layout_timex() {
@@ -130,7 +130,8 @@ impl Default for timex {
 #[derive(Copy, Clone)]
 pub struct timex_named {
     pub tai: ::std::os::raw::c_int,
-    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 44usize], u32>,
+    pub _bitfield_align_1: [u32; 0],
+    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 44usize]>,
 }
 #[test]
 fn bindgen_test_layout_timex_named() {

--- a/tests/expectations/tests/union_bitfield.rs
+++ b/tests/expectations/tests/union_bitfield.rs
@@ -7,17 +7,16 @@
 
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct __BindgenBitfieldUnit<Storage, Align> {
+pub struct __BindgenBitfieldUnit<Storage> {
     storage: Storage,
-    align: [Align; 0],
 }
-impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align> {
+impl<Storage> __BindgenBitfieldUnit<Storage> {
     #[inline]
     pub const fn new(storage: Storage) -> Self {
-        Self { storage, align: [] }
+        Self { storage }
     }
 }
-impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align>
+impl<Storage> __BindgenBitfieldUnit<Storage>
 where
     Storage: AsRef<[u8]> + AsMut<[u8]>,
 {
@@ -95,7 +94,8 @@ where
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union U4 {
-    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize], u8>,
+    pub _bitfield_align_1: [u8; 0],
+    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
     _bindgen_union_align: u32,
 }
 #[test]
@@ -133,11 +133,9 @@ impl U4 {
     #[inline]
     pub fn new_bitfield_1(
         derp: ::std::os::raw::c_uint,
-    ) -> __BindgenBitfieldUnit<[u8; 1usize], u8> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<
-            [u8; 1usize],
-            u8,
-        > = Default::default();
+    ) -> __BindgenBitfieldUnit<[u8; 1usize]> {
+        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 1usize]> =
+            Default::default();
         __bindgen_bitfield_unit.set(0usize, 1u8, {
             let derp: u32 = unsafe { ::std::mem::transmute(derp) };
             derp as u64
@@ -148,7 +146,8 @@ impl U4 {
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union B {
-    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize], u32>,
+    pub _bitfield_align_1: [u32; 0],
+    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
     _bindgen_union_align: u32,
 }
 #[test]
@@ -200,11 +199,9 @@ impl B {
     pub fn new_bitfield_1(
         foo: ::std::os::raw::c_uint,
         bar: ::std::os::raw::c_uchar,
-    ) -> __BindgenBitfieldUnit<[u8; 4usize], u32> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<
-            [u8; 4usize],
-            u32,
-        > = Default::default();
+    ) -> __BindgenBitfieldUnit<[u8; 4usize]> {
+        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> =
+            Default::default();
         __bindgen_bitfield_unit.set(0usize, 31u8, {
             let foo: u32 = unsafe { ::std::mem::transmute(foo) };
             foo as u64

--- a/tests/expectations/tests/union_bitfield_1_0.rs
+++ b/tests/expectations/tests/union_bitfield_1_0.rs
@@ -7,17 +7,16 @@
 
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct __BindgenBitfieldUnit<Storage, Align> {
+pub struct __BindgenBitfieldUnit<Storage> {
     storage: Storage,
-    align: [Align; 0],
 }
-impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align> {
+impl<Storage> __BindgenBitfieldUnit<Storage> {
     #[inline]
     pub fn new(storage: Storage) -> Self {
-        Self { storage, align: [] }
+        Self { storage }
     }
 }
-impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align>
+impl<Storage> __BindgenBitfieldUnit<Storage>
 where
     Storage: AsRef<[u8]> + AsMut<[u8]>,
 {
@@ -138,8 +137,8 @@ impl<T> ::std::cmp::Eq for __BindgenUnionField<T> {}
 #[repr(C)]
 #[derive(Debug, Default, Copy, Hash, PartialEq, Eq)]
 pub struct U4 {
-    pub _bitfield_1:
-        __BindgenUnionField<__BindgenBitfieldUnit<[u8; 1usize], u8>>,
+    pub _bitfield_align_1: [u8; 0],
+    pub _bitfield_1: __BindgenUnionField<__BindgenBitfieldUnit<[u8; 1usize]>>,
     pub bindgen_union_field: u32,
 }
 #[test]
@@ -179,11 +178,9 @@ impl U4 {
     #[inline]
     pub fn new_bitfield_1(
         derp: ::std::os::raw::c_uint,
-    ) -> __BindgenBitfieldUnit<[u8; 1usize], u8> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<
-            [u8; 1usize],
-            u8,
-        > = Default::default();
+    ) -> __BindgenBitfieldUnit<[u8; 1usize]> {
+        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 1usize]> =
+            Default::default();
         __bindgen_bitfield_unit.set(0usize, 1u8, {
             let derp: u32 = unsafe { ::std::mem::transmute(derp) };
             derp as u64
@@ -194,8 +191,8 @@ impl U4 {
 #[repr(C)]
 #[derive(Debug, Default, Copy, Hash, PartialEq, Eq)]
 pub struct B {
-    pub _bitfield_1:
-        __BindgenUnionField<__BindgenBitfieldUnit<[u8; 4usize], u32>>,
+    pub _bitfield_align_1: [u32; 0],
+    pub _bitfield_1: __BindgenUnionField<__BindgenBitfieldUnit<[u8; 4usize]>>,
     pub bindgen_union_field: u32,
 }
 #[test]
@@ -251,11 +248,9 @@ impl B {
     pub fn new_bitfield_1(
         foo: ::std::os::raw::c_uint,
         bar: ::std::os::raw::c_uchar,
-    ) -> __BindgenBitfieldUnit<[u8; 4usize], u32> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<
-            [u8; 4usize],
-            u32,
-        > = Default::default();
+    ) -> __BindgenBitfieldUnit<[u8; 4usize]> {
+        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> =
+            Default::default();
         __bindgen_bitfield_unit.set(0usize, 31u8, {
             let foo: u32 = unsafe { ::std::mem::transmute(foo) };
             foo as u64
@@ -270,8 +265,8 @@ impl B {
 #[repr(C)]
 #[derive(Copy)]
 pub struct HasBigBitfield {
-    pub _bitfield_1:
-        __BindgenUnionField<__BindgenBitfieldUnit<[u8; 16usize], u64>>,
+    pub _bitfield_align_1: [u64; 0],
+    pub _bitfield_1: __BindgenUnionField<__BindgenBitfieldUnit<[u8; 16usize]>>,
     pub bindgen_union_field: [u8; 16usize],
 }
 #[test]

--- a/tests/expectations/tests/union_with_anon_struct_bitfield.rs
+++ b/tests/expectations/tests/union_with_anon_struct_bitfield.rs
@@ -7,17 +7,16 @@
 
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct __BindgenBitfieldUnit<Storage, Align> {
+pub struct __BindgenBitfieldUnit<Storage> {
     storage: Storage,
-    align: [Align; 0],
 }
-impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align> {
+impl<Storage> __BindgenBitfieldUnit<Storage> {
     #[inline]
     pub const fn new(storage: Storage) -> Self {
-        Self { storage, align: [] }
+        Self { storage }
     }
 }
-impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align>
+impl<Storage> __BindgenBitfieldUnit<Storage>
 where
     Storage: AsRef<[u8]> + AsMut<[u8]>,
 {
@@ -103,7 +102,8 @@ pub union foo {
 #[repr(align(4))]
 #[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct foo__bindgen_ty_1 {
-    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize], u32>,
+    pub _bitfield_align_1: [u32; 0],
+    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
 }
 #[test]
 fn bindgen_test_layout_foo__bindgen_ty_1() {
@@ -149,11 +149,9 @@ impl foo__bindgen_ty_1 {
     pub fn new_bitfield_1(
         b: ::std::os::raw::c_int,
         c: ::std::os::raw::c_int,
-    ) -> __BindgenBitfieldUnit<[u8; 4usize], u32> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<
-            [u8; 4usize],
-            u32,
-        > = Default::default();
+    ) -> __BindgenBitfieldUnit<[u8; 4usize]> {
+        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> =
+            Default::default();
         __bindgen_bitfield_unit.set(0usize, 7u8, {
             let b: u32 = unsafe { ::std::mem::transmute(b) };
             b as u64

--- a/tests/expectations/tests/union_with_anon_struct_bitfield_1_0.rs
+++ b/tests/expectations/tests/union_with_anon_struct_bitfield_1_0.rs
@@ -7,17 +7,16 @@
 
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct __BindgenBitfieldUnit<Storage, Align> {
+pub struct __BindgenBitfieldUnit<Storage> {
     storage: Storage,
-    align: [Align; 0],
 }
-impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align> {
+impl<Storage> __BindgenBitfieldUnit<Storage> {
     #[inline]
     pub fn new(storage: Storage) -> Self {
-        Self { storage, align: [] }
+        Self { storage }
     }
 }
-impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align>
+impl<Storage> __BindgenBitfieldUnit<Storage>
 where
     Storage: AsRef<[u8]> + AsMut<[u8]>,
 {
@@ -145,7 +144,8 @@ pub struct foo {
 #[repr(C)]
 #[derive(Debug, Default, Copy, Hash, PartialEq, Eq)]
 pub struct foo__bindgen_ty_1 {
-    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize], u32>,
+    pub _bitfield_align_1: [u32; 0],
+    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
     pub __bindgen_align: [u32; 0usize],
 }
 #[test]
@@ -197,11 +197,9 @@ impl foo__bindgen_ty_1 {
     pub fn new_bitfield_1(
         b: ::std::os::raw::c_int,
         c: ::std::os::raw::c_int,
-    ) -> __BindgenBitfieldUnit<[u8; 4usize], u32> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<
-            [u8; 4usize],
-            u32,
-        > = Default::default();
+    ) -> __BindgenBitfieldUnit<[u8; 4usize]> {
+        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> =
+            Default::default();
         __bindgen_bitfield_unit.set(0usize, 7u8, {
             let b: u32 = unsafe { ::std::mem::transmute(b) };
             b as u64

--- a/tests/expectations/tests/weird_bitfields.rs
+++ b/tests/expectations/tests/weird_bitfields.rs
@@ -7,17 +7,16 @@
 
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct __BindgenBitfieldUnit<Storage, Align> {
+pub struct __BindgenBitfieldUnit<Storage> {
     storage: Storage,
-    align: [Align; 0],
 }
-impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align> {
+impl<Storage> __BindgenBitfieldUnit<Storage> {
     #[inline]
     pub const fn new(storage: Storage) -> Self {
-        Self { storage, align: [] }
+        Self { storage }
     }
 }
-impl<Storage, Align> __BindgenBitfieldUnit<Storage, Align>
+impl<Storage> __BindgenBitfieldUnit<Storage>
 where
     Storage: AsRef<[u8]> + AsMut<[u8]>,
 {
@@ -103,7 +102,8 @@ pub enum nsStyleSVGOpacitySource {
 #[derive(Debug, Copy, Clone)]
 pub struct Weird {
     pub mStrokeDasharrayLength: ::std::os::raw::c_uint,
-    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize], u16>,
+    pub _bitfield_align_1: [u16; 0],
+    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
     pub mClipRule: ::std::os::raw::c_uchar,
     pub mColorInterpolation: ::std::os::raw::c_uchar,
     pub mColorInterpolationFilters: ::std::os::raw::c_uchar,
@@ -115,7 +115,8 @@ pub struct Weird {
     pub mStrokeLinejoin: ::std::os::raw::c_uchar,
     pub mTextAnchor: ::std::os::raw::c_uchar,
     pub mTextRendering: ::std::os::raw::c_uchar,
-    pub _bitfield_2: __BindgenBitfieldUnit<[u8; 2usize], u8>,
+    pub _bitfield_align_2: [u8; 0],
+    pub _bitfield_2: __BindgenBitfieldUnit<[u8; 2usize]>,
     pub __bindgen_padding_0: [u8; 3usize],
 }
 #[test]
@@ -319,11 +320,9 @@ impl Weird {
     pub fn new_bitfield_1(
         bitTest: ::std::os::raw::c_uint,
         bitTest2: ::std::os::raw::c_uint,
-    ) -> __BindgenBitfieldUnit<[u8; 4usize], u16> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<
-            [u8; 4usize],
-            u16,
-        > = Default::default();
+    ) -> __BindgenBitfieldUnit<[u8; 4usize]> {
+        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> =
+            Default::default();
         __bindgen_bitfield_unit.set(0usize, 16u8, {
             let bitTest: u32 = unsafe { ::std::mem::transmute(bitTest) };
             bitTest as u64
@@ -406,11 +405,9 @@ impl Weird {
         mStrokeDasharrayFromObject: bool,
         mStrokeDashoffsetFromObject: bool,
         mStrokeWidthFromObject: bool,
-    ) -> __BindgenBitfieldUnit<[u8; 2usize], u8> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<
-            [u8; 2usize],
-            u8,
-        > = Default::default();
+    ) -> __BindgenBitfieldUnit<[u8; 2usize]> {
+        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 2usize]> =
+            Default::default();
         __bindgen_bitfield_unit.set(0usize, 3u8, {
             let mFillOpacitySource: u32 =
                 unsafe { ::std::mem::transmute(mFillOpacitySource) };

--- a/tests/headers/issue-1947.h
+++ b/tests/headers/issue-1947.h
@@ -1,0 +1,9 @@
+typedef unsigned char U8;
+typedef unsigned short U16;
+
+typedef struct {
+    U16 MADZ : 10, MAI0 : 2, MAI1 : 2, MAI2 : 2;
+    U8 MADK, MABR;
+    U16 MATH : 10, MATE : 4, MATW : 2;
+    U8 MASW : 4, MABW : 3, MAXN : 1, _rB_;
+} V56AMDY;


### PR DESCRIPTION
Fixes #1947.

There are two separate issues here: First, the change in comp.rs ensures
that we don't round up the amount of storage to the alignment of the
bitfield. That generates the "expected" output in #1947
(`__BindgenBitfieldUnit<[u8; 3], u16>`).

But that's still not enough to fix that test-case because
__BindgenBitfieldUnit would be aligned and have padding, and Rust won't
put the extra field in the padding.

In order to ensure the bitfield starts at the right alignment, but that
Rust can put stuff in the extra field, we need to make a breaking change
and split the generated fields in two: One preceding that guarantees
alignment, and the actual storage, bit-aligned.

This keeps the existing behavior while fixing that test-case.