### PR TITLE
context: Escape the dyn keyword properly.

### DIFF
--- a/src/ir/context.rs
+++ b/src/ir/context.rs
@@ -807,9 +807,9 @@ If you encounter an error missing from this list, please file an issue or a PR!"
             match name {
                 "abstract" | "alignof" | "as" | "async" | "become" |
                 "box" | "break" | "const" | "continue" | "crate" | "do" |
-                "else" | "enum" | "extern" | "false" | "final" | "fn" |
-                "for" | "if" | "impl" | "in" | "let" | "loop" | "macro" |
-                "match" | "mod" | "move" | "mut" | "offsetof" |
+                "dyn" | "else" | "enum" | "extern" | "false" | "final" |
+                "fn" | "for" | "if" | "impl" | "in" | "let" | "loop" |
+                "macro" | "match" | "mod" | "move" | "mut" | "offsetof" |
                 "override" | "priv" | "proc" | "pub" | "pure" | "ref" |
                 "return" | "Self" | "self" | "sizeof" | "static" |
                 "struct" | "super" | "trait" | "true" | "type" | "typeof" |

--- a/tests/expectations/tests/keywords.rs
+++ b/tests/expectations/tests/keywords.rs
@@ -62,6 +62,10 @@ extern "C" {
     pub static mut str_: ::std::os::raw::c_int;
 }
 extern "C" {
+    #[link_name = "\u{1}dyn"]
+    pub static mut dyn_: ::std::os::raw::c_int;
+}
+extern "C" {
     #[link_name = "\u{1}as"]
     pub static mut as_: ::std::os::raw::c_int;
 }

--- a/tests/headers/keywords.h
+++ b/tests/headers/keywords.h
@@ -12,6 +12,7 @@ int usize;
 int isize;
 int bool;
 int str;
+int dyn;
 
 int as;
 int box;


### PR DESCRIPTION
Fixes #1946