### PR TITLE
Add failing regression test for #1973.

### DIFF
--- a/bindgen-integration/cpp/Test.cc
+++ b/bindgen-integration/cpp/Test.cc
@@ -135,3 +135,12 @@ Seventh::assert(bool first,
 int my_prefixed_function_name() {
   return 4;
 }
+
+Coord coord(double x, double y, double z, double t) {
+    Coord res;
+    res.v[0] = x;
+    res.v[1] = y;
+    res.v[2] = z;
+    res.v[3] = t;
+    return res;
+}

--- a/bindgen-integration/cpp/Test.h
+++ b/bindgen-integration/cpp/Test.h
@@ -226,3 +226,9 @@ struct my_prefixed_templated_foo {
 my_prefixed_templated_foo<my_prefixed_baz> TEMPLATED_CONST_VALUE;
 
 void my_prefixed_function_to_remove();
+
+typedef union {
+  double v[4];
+} Coord;
+
+Coord coord(double x, double y, double z, double t);

--- a/bindgen-integration/src/lib.rs
+++ b/bindgen-integration/src/lib.rs
@@ -259,3 +259,12 @@ fn test_macro_customintkind_path() {
     let v: &std::any::Any = &bindings::TESTMACRO_CUSTOMINTKIND_PATH;
     assert!(v.is::<MacroInteger>())
 }
+
+// https://github.com/rust-lang/rust-bindgen/issues/1973
+#[test]
+fn test_homogeneous_aggregate_float_union() {
+    unsafe {
+        let coord = &bindings::coord(1., 2., 3., 4.);
+        assert_eq!([1., 2., 3., 4.], coord.v)
+    }
+}


### PR DESCRIPTION
https://github.com/rust-lang/rust-bindgen/pull/1973

```
failures:

---- test_homogeneous_aggregate_float_union stdout ----
thread 'test_homogeneous_aggregate_float_union' panicked at 'assertion failed: `(left == right)`
  left: `[1.0, 2.0, 3.0, 4.0]`,
 right: `[0.00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000029021264197102883, 0.0, 0.0, 0.0]`', src/lib.rs:268:9
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```