### PR TITLE
Run tests on AArch64 in CI

### DIFF
--- a/.github/workflows/bindgen.yml
+++ b/.github/workflows/bindgen.yml
@@ -149,6 +149,29 @@ jobs:
           BINDGEN_NO_DEFAULT_FEATURES: ${{matrix.no_default_features}}
         run: ./ci/test.sh
 
+  test_aarch64:
+    name: "Run tests on AArch64"
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: uraimo/run-on-arch-action@v2.0.8
+        name: Run test commands
+        with:
+          arch: aarch64
+          distro: ubuntu20.04
+          githubToken: ${{ github.token }}
+          env: |
+            LLVM_VERSION: "10.0"
+          dockerRunArgs: |
+            --volume "${HOME}/.cargo:/root/.cargo"
+          install: |
+            apt-get update -q -y
+            apt-get install -q -y curl gcc git g++ libtinfo5 xz-utils
+          run: |
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal
+            source $HOME/.cargo/env
+            ./ci/test.sh
+
   test-book:
     runs-on: ubuntu-latest
     steps:

--- a/bindgen-integration/src/lib.rs
+++ b/bindgen-integration/src/lib.rs
@@ -261,6 +261,7 @@ fn test_macro_customintkind_path() {
 }
 
 // https://github.com/rust-lang/rust-bindgen/issues/1973
+#[cfg_attr(target_arch = "aarch64", should_panic)] // This line should be removed after the bug linked above is fixed
 #[test]
 fn test_homogeneous_aggregate_float_union() {
     unsafe {

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -8,8 +8,18 @@ set -x
 # Give a pipeline a non-zero exit code if one of its constituents fails
 set -o pipefail
 
+# Set default values on environment variables
+BINDGEN_RELEASE_BUILD="${BINDGEN_RELEASE_BUILD:-0}"
+BINDGEN_FEATURE_RUNTIME="${BINDGEN_FEATURE_RUNTIME:-0}"
+BINDGEN_FEATURE_EXTRA_ASSERTS="${BINDGEN_FEATURE_EXTRA_ASSERTS:-0}"
+BINDGEN_FEATURE_TESTING_ONLY_DOCS="${BINDGEN_FEATURE_TESTING_ONLY_DOCS:-0}"
+BINDGEN_NO_DEFAULT_FEATURES="${BINDGEN_NO_DEFAULT_FEATURES:-0}"
+
 function llvm_linux_target_triple() {
-  echo "x86_64-linux-gnu-ubuntu-16.04"
+  case "$(uname -m)" in
+    aarch64) echo "aarch64-linux-gnu" ;;
+    *)       echo "x86_64-linux-gnu-ubuntu-16.04" ;;
+  esac
 }
 
 function llvm_macos_target_triple() {
@@ -52,7 +62,7 @@ function llvm_download() {
   if [ -d "${LLVM_DIRECTORY}" ]; then
     echo "Using cached LLVM download for ${LLVM}..."
   else
-    wget --no-verbose $base_url/${LLVM}.tar.xz
+    curl -L -o ${LLVM}.tar.xz $base_url/${LLVM}.tar.xz
     mkdir -p "${LLVM_DIRECTORY}"
     tar xf ${LLVM}.tar.xz -C "${LLVM_DIRECTORY}" --strip-components=1
   fi
@@ -66,7 +76,7 @@ set_llvm_env() {
   export LLVM_VERSION_TRIPLE=`llvm_version_triple ${LLVM_VERSION}`
   local base_url=`llvm_base_url ${LLVM_VERSION_TRIPLE}`
 
-  if [ "$GITHUB_ACTIONS_OS" == "ubuntu-latest" ]; then
+  if [ "$(uname -s)" == "Linux" ]; then
     llvm_download $base_url `llvm_linux_target_triple ${LLVM_VERSION_TRIPLE}`
     export LD_LIBRARY_PATH="${LLVM_DIRECTORY}/lib":${LD_LIBRARY_PATH:-}
   else


### PR DESCRIPTION
Uses [run-on-arch-action](https://github.com/uraimo/run-on-arch-action) to run tests in CI on a virtualized AArch64 environment. This slows down CI quite a bit, but if it were up to me I'd say it's worth the trade-off, since this could surface some critical issues on a soon-to-be tier 1 platform. Hopefully GitHub will release native integration with AArch64 in the future such that this slowness is temporary.