### PR TITLE
Add failing regression test for opaque types in #1973

### DIFF
--- a/bindgen-integration/build.rs
+++ b/bindgen-integration/build.rs
@@ -163,6 +163,7 @@ fn main() {
         .blacklist_function("my_prefixed_function_to_remove")
         .constified_enum("my_prefixed_enum_to_be_constified")
         .opaque_type("my_prefixed_templated_foo<my_prefixed_baz>")
+        .opaque_type("CoordOpaque")
         .generate()
         .expect("Unable to generate bindings");
 

--- a/bindgen-integration/cpp/Test.cc
+++ b/bindgen-integration/cpp/Test.cc
@@ -144,3 +144,12 @@ Coord coord(double x, double y, double z, double t) {
     res.v[3] = t;
     return res;
 }
+
+CoordOpaque coord_opaque(double x, double y, double z, double t) {
+    CoordOpaque res;
+    res.v[0] = x;
+    res.v[1] = y;
+    res.v[2] = z;
+    res.v[3] = t;
+    return res;
+}

--- a/bindgen-integration/cpp/Test.h
+++ b/bindgen-integration/cpp/Test.h
@@ -232,3 +232,9 @@ typedef union {
 } Coord;
 
 Coord coord(double x, double y, double z, double t);
+
+typedef struct {
+  double v[4];
+} CoordOpaque;
+
+CoordOpaque coord_opaque(double x, double y, double z, double t);

--- a/bindgen-integration/src/lib.rs
+++ b/bindgen-integration/src/lib.rs
@@ -7,6 +7,7 @@ mod bindings {
 use std::ffi::CStr;
 use std::mem;
 use std::os::raw::c_int;
+use std::slice;
 
 #[allow(unused)]
 use bindings::testing::Bar; // This type is generated from module_raw_line.
@@ -267,5 +268,16 @@ fn test_homogeneous_aggregate_float_union() {
     unsafe {
         let coord = &bindings::coord(1., 2., 3., 4.);
         assert_eq!([1., 2., 3., 4.], coord.v)
+    }
+}
+
+// https://github.com/rust-lang/rust-bindgen/issues/1973
+#[cfg_attr(target_arch = "aarch64", should_panic)] // This line should be removed after the bug linked above is fixed
+#[test]
+fn test_homogeneous_aggregate_float_opaque() {
+    unsafe {
+        let coord = &bindings::coord_opaque(1., 2., 3., 4.);
+        let v = unsafe { slice::from_raw_parts(coord as *const _ as *const f64, 4) };
+        assert_eq!([1., 2., 3., 4.], v)
     }
 }


### PR DESCRIPTION
The proposed fix #1984 changes the way unions are emitted, but the issue described in #1973 also affects homogenous aggregates emitted as opaque types. This pull request adds a similar integration test for that case.