### PR TITLE
Implement AArch64 tests with Debian multiarch and QEMU

### DIFF
--- a/.github/workflows/bindgen.yml
+++ b/.github/workflows/bindgen.yml
@@ -149,29 +149,6 @@ jobs:
           BINDGEN_NO_DEFAULT_FEATURES: ${{matrix.no_default_features}}
         run: ./ci/test.sh
 
-  test_aarch64:
-    name: "Run tests on AArch64"
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: actions/checkout@v2
-      - uses: uraimo/run-on-arch-action@v2.0.8
-        name: Run test commands
-        with:
-          arch: aarch64
-          distro: ubuntu20.04
-          githubToken: ${{ github.token }}
-          env: |
-            LLVM_VERSION: "10.0"
-          dockerRunArgs: |
-            --volume "${HOME}/.cargo:/root/.cargo"
-          install: |
-            apt-get update -q -y
-            apt-get install -q -y curl gcc git g++ libtinfo5 xz-utils
-          run: |
-            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal
-            source $HOME/.cargo/env
-            ./ci/test.sh
-
   test-book:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/bindgen.yml
+++ b/.github/workflows/bindgen.yml
@@ -89,7 +89,12 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
+        target:
+          - debian: null
+            cross: null
+            rust: null
         llvm_version: ["3.9", "4.0", "5.0", "9.0"]
+        main_tests: [1]
         release_build: [0, 1]
         no_default_features: [0, 1]
         # FIXME: There are no pre-built static libclang libraries, so the
@@ -121,6 +126,17 @@ jobs:
             feature_extra_asserts: 1
             feature_testing_only_docs: 1
 
+          - os: ubuntu-latest
+            target:
+              debian: arm64
+              cross: aarch64-linux-gnu
+              rust: aarch64-unknown-linux-gnu
+            llvm_version: "9.0"
+            main_tests: 0
+            release_build: 0
+            feature_extra_asserts: 0
+            feature_testing_only_docs: 0
+
           # Ensure stuff works on macos too
           - os: macos-latest
             llvm_version: "9.0"
@@ -131,17 +147,36 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Install multiarch packages
+        if: matrix.target.debian
+        run: |
+          sudo apt-get install binfmt-support qemu-user-static gcc-${{matrix.target.cross}} g++-${{matrix.target.cross}}
+          source /etc/lsb-release
+          sudo tee /etc/apt/sources.list <<EOF >/dev/null
+          deb [arch=${{matrix.target.debian}}] http://ports.ubuntu.com/ubuntu-ports/ $DISTRIB_CODENAME main
+          deb [arch=${{matrix.target.debian}}] http://ports.ubuntu.com/ubuntu-ports/ $DISTRIB_CODENAME-updates main
+          deb [arch=${{matrix.target.debian}}] http://ports.ubuntu.com/ubuntu-ports/ $DISTRIB_CODENAME-backports main
+          deb [arch=${{matrix.target.debian}}] http://ports.ubuntu.com/ubuntu-ports/ $DISTRIB_CODENAME-security main
+          EOF
+          sudo dpkg --add-architecture ${{matrix.target.debian}}
+          sudo apt-get update
+          sudo apt-get install libc6:${{matrix.target.debian}} libstdc++6:${{matrix.target.debian}}
+
       - name: Install stable
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: stable
+          target: ${{matrix.target.rust}}
           override: true
 
       - name: Run all the tests
         env:
           GITHUB_ACTIONS_OS: ${{matrix.os}}
+          RUST_CROSS_COMPILER: ${{matrix.target.cross}}
+          RUST_TARGET: ${{matrix.target.rust}}
           LLVM_VERSION: ${{matrix.llvm_version}}
+          BINDGEN_MAIN_TESTS: ${{matrix.main_tests}}
           BINDGEN_RELEASE_BUILD: ${{matrix.release_build}}
           BINDGEN_FEATURE_RUNTIME: ${{matrix.feature_runtime}}
           BINDGEN_FEATURE_EXTRA_ASSERTS: ${{matrix.feature_extra_asserts}}

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -94,6 +94,9 @@ set_rustfmt_env
 
 get_cargo_args() {
   local args=""
+  if [ ! -z "$RUST_TARGET" ]; then
+    args+=" --target $RUST_TARGET"
+  fi
   if [ "$BINDGEN_RELEASE_BUILD" == "1" ]; then
     args+=" --release"
   fi
@@ -116,13 +119,19 @@ get_cargo_args() {
   echo $args
 }
 
+if [ ! -z "$RUST_CROSS_COMPILER" ]; then
+  export RUSTFLAGS="-C linker=${RUST_CROSS_COMPILER}-gcc"
+fi
+
 CARGO_ARGS=`get_cargo_args`
 
 # Ensure we build without warnings
 cargo rustc --lib $CARGO_ARGS -- -Dwarnings
 
-# Run the tests
-cargo test $CARGO_ARGS
+if [ "$BINDGEN_MAIN_TESTS" == "1" ]; then
+  # Run the tests
+  cargo test $CARGO_ARGS
+fi
 
 assert_no_diff
 

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -8,18 +8,8 @@ set -x
 # Give a pipeline a non-zero exit code if one of its constituents fails
 set -o pipefail
 
-# Set default values on environment variables
-BINDGEN_RELEASE_BUILD="${BINDGEN_RELEASE_BUILD:-0}"
-BINDGEN_FEATURE_RUNTIME="${BINDGEN_FEATURE_RUNTIME:-0}"
-BINDGEN_FEATURE_EXTRA_ASSERTS="${BINDGEN_FEATURE_EXTRA_ASSERTS:-0}"
-BINDGEN_FEATURE_TESTING_ONLY_DOCS="${BINDGEN_FEATURE_TESTING_ONLY_DOCS:-0}"
-BINDGEN_NO_DEFAULT_FEATURES="${BINDGEN_NO_DEFAULT_FEATURES:-0}"
-
 function llvm_linux_target_triple() {
-  case "$(uname -m)" in
-    aarch64) echo "aarch64-linux-gnu" ;;
-    *)       echo "x86_64-linux-gnu-ubuntu-16.04" ;;
-  esac
+  echo "x86_64-linux-gnu-ubuntu-16.04"
 }
 
 function llvm_macos_target_triple() {
@@ -62,7 +52,7 @@ function llvm_download() {
   if [ -d "${LLVM_DIRECTORY}" ]; then
     echo "Using cached LLVM download for ${LLVM}..."
   else
-    curl -L -o ${LLVM}.tar.xz $base_url/${LLVM}.tar.xz
+    wget --no-verbose $base_url/${LLVM}.tar.xz
     mkdir -p "${LLVM_DIRECTORY}"
     tar xf ${LLVM}.tar.xz -C "${LLVM_DIRECTORY}" --strip-components=1
   fi
@@ -76,7 +66,7 @@ set_llvm_env() {
   export LLVM_VERSION_TRIPLE=`llvm_version_triple ${LLVM_VERSION}`
   local base_url=`llvm_base_url ${LLVM_VERSION_TRIPLE}`
 
-  if [ "$(uname -s)" == "Linux" ]; then
+  if [ "$GITHUB_ACTIONS_OS" == "ubuntu-latest" ]; then
     llvm_download $base_url `llvm_linux_target_triple ${LLVM_VERSION_TRIPLE}`
     export LD_LIBRARY_PATH="${LLVM_DIRECTORY}/lib":${LD_LIBRARY_PATH:-}
   else


### PR DESCRIPTION
This is a re-implementation of #1980, as described in my comment on that pull request.

I'm not sure if you'll want to merge this because it has advantages and disadvantages:

Pros:
 - Runs in about 3 minutes, instead of over 30 minutes
 - Easy to add other architectures as long as Ubuntu supports them

Cons:
 - Only runs the integration tests on aarch64, not the full test suite - because the build script runs on x86_64 (and uses the x86_64 LibClang), but the tests run on aarch64 (and would require an aarch64 LibClang).

cc @frewsxcv 