### PR TITLE
tests: Guess modern libclang version when we fail to parse a version.

### DIFF
--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -146,7 +146,7 @@ fn compare_generated_header(
             expectation.push("libclang-3.9");
         } else {
             match clang_version().parsed {
-                None => {}
+                None => expectation.push("libclang-9"),
                 Some(version) => {
                     let (maj, min) = version;
                     let version_str = if maj >= 9 {


### PR DESCRIPTION
Should fix the test failures described in #1991 and #1975 on modern Mac.