### PR TITLE
Make clang version parsing logic more robust

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2444,10 +2444,12 @@ pub struct ClangVersion {
 pub fn clang_version() -> ClangVersion {
     ensure_libclang_is_loaded();
 
+    //Debian clang version 11.0.1-2
     let raw_v: String = clang::extract_clang_version();
     let split_v: Option<Vec<&str>> = raw_v
         .split_whitespace()
-        .nth(2)
+        .filter(|t| t.chars().next().map_or(false, |v| v.is_ascii_digit()))
+        .next()
         .map(|v| v.split('.').collect());
     match split_v {
         Some(v) => {


### PR DESCRIPTION
Previously the function assumed that the version number appeared in the
third word. This PR adds a heuristic - take the first word that starts
with a number.

This way we can also parse: 
* Debian clang version 11.0
* Apple clang version 12.0.0