### PR TITLE
Upgrade to shlex 1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -247,9 +247,9 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "shlex"
-version = "0.1.1"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fdf1b9db47230893d76faad238fd6097fd6d6a9245cd7a4d90dbd639536bbd2"
+checksum = "42a568c8f2cd051a4d283bd6eb0343ac214c1b0f1ac19f93e1175b2dee38c73d"
 
 [[package]]
 name = "strsim"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ required-features = ["clap"]
 [dev-dependencies]
 diff = "0.1"
 clap = "2"
-shlex = "0.1"
+shlex = "1"
 
 [dependencies]
 bitflags = "1.0.3"
@@ -56,7 +56,7 @@ peeking_take_while = "0.1.2"
 quote = { version = "1", default-features = false }
 regex = { version = "1.0", default-features = false , features = [ "std", "unicode"]}
 which = { version = "3.0", optional = true, default-features = false }
-shlex = "0.1"
+shlex = "1"
 rustc-hash = "1.0.1"
 # New validation in 0.3.6 breaks bindgen-integration:
 # https://github.com/alexcrichton/proc-macro2/commit/489c642.


### PR DESCRIPTION
This upgrades the [shlex](https://docs.rs/shlex) dependency from version 0.1 to 1. The breaking change in shlex 1 is a fix for [a correctness bug](https://github.com/comex/rust-shlex/issues/6). I haven't looked closely at how shlex is used in bindgen so it should probably be made sure that this doesn't break anything that relied on the incorrect behavior.