### PR TITLE
Use original name when checking allowlist for anonymous enum variants

### DIFF
--- a/src/ir/context.rs
+++ b/src/ir/context.rs
@@ -2299,7 +2299,9 @@ If you encounter an error missing from this list, please file an issue or a PR!"
                             let mut prefix_path =
                                 parent.path_for_allowlisting(self).clone();
                             enum_.variants().iter().any(|variant| {
-                                prefix_path.push(variant.name().into());
+                                prefix_path.push(
+                                    variant.name_for_allowlisting().into(),
+                                );
                                 let name = prefix_path[1..].join("::");
                                 prefix_path.pop().unwrap();
                                 self.options().allowlisted_vars.matches(&name)

--- a/src/ir/enum_ty.rs
+++ b/src/ir/enum_ty.rs
@@ -118,7 +118,7 @@ impl Enum {
                             }
                         });
 
-                    let name = ctx
+                    let new_name = ctx
                         .parse_callbacks()
                         .and_then(|callbacks| {
                             callbacks.enum_variant_name(type_name, &name, val)
@@ -130,10 +130,11 @@ impl Enum {
                                 .last()
                                 .cloned()
                         })
-                        .unwrap_or(name);
+                        .unwrap_or_else(|| name.clone());
 
                     let comment = cursor.raw_comment();
                     variants.push(EnumVariant::new(
+                        new_name,
                         name,
                         comment,
                         val,
@@ -224,6 +225,9 @@ pub struct EnumVariant {
     /// The name of the variant.
     name: String,
 
+    /// The original name of the variant (without user mangling)
+    name_for_allowlisting: String,
+
     /// An optional doc comment.
     comment: Option<String>,
 
@@ -251,12 +255,14 @@ impl EnumVariant {
     /// Construct a new enumeration variant from the given parts.
     pub fn new(
         name: String,
+        name_for_allowlisting: String,
         comment: Option<String>,
         val: EnumVariantValue,
         custom_behavior: Option<EnumVariantCustomBehavior>,
     ) -> Self {
         EnumVariant {
             name,
+            name_for_allowlisting,
             comment,
             val,
             custom_behavior,
@@ -266,6 +272,11 @@ impl EnumVariant {
     /// Get this variant's name.
     pub fn name(&self) -> &str {
         &self.name
+    }
+
+    /// Get this variant's name.
+    pub fn name_for_allowlisting(&self) -> &str {
+        &self.name_for_allowlisting
     }
 
     /// Get this variant's value.

--- a/tests/expectations/tests/parsecb-anonymous-enum-variant-rename.rs
+++ b/tests/expectations/tests/parsecb-anonymous-enum-variant-rename.rs
@@ -1,0 +1,9 @@
+#![allow(
+    dead_code,
+    non_snake_case,
+    non_camel_case_types,
+    non_upper_case_globals
+)]
+
+pub const RENAMED_MyVal: ::std::os::raw::c_uint = 0;
+pub type _bindgen_ty_1 = ::std::os::raw::c_uint;

--- a/tests/headers/parsecb-anonymous-enum-variant-rename.h
+++ b/tests/headers/parsecb-anonymous-enum-variant-rename.h
@@ -1,0 +1,6 @@
+// bindgen-flags: --allowlist-var ^MyVal$
+// bindgen-parse-callbacks: enum-variant-rename
+
+enum {
+    MyVal = 0,
+};

--- a/tests/parse_callbacks/mod.rs
+++ b/tests/parse_callbacks/mod.rs
@@ -1,0 +1,7 @@
+use bindgen::callbacks::ParseCallbacks;
+
+pub fn lookup(cb: &str) -> Box<dyn ParseCallbacks> {
+    match cb {
+        _ => panic!("Couldn't find name ParseCallbacks: {}", cb),
+    }
+}

--- a/tests/parse_callbacks/mod.rs
+++ b/tests/parse_callbacks/mod.rs
@@ -1,7 +1,22 @@
 use bindgen::callbacks::ParseCallbacks;
 
+#[derive(Debug)]
+struct EnumVariantRename;
+
+impl ParseCallbacks for EnumVariantRename {
+    fn enum_variant_name(
+        &self,
+        _enum_name: Option<&str>,
+        original_variant_name: &str,
+        _variant_value: bindgen::callbacks::EnumVariantValue,
+    ) -> Option<String> {
+        Some(format!("RENAMED_{}", original_variant_name))
+    }
+}
+
 pub fn lookup(cb: &str) -> Box<dyn ParseCallbacks> {
     match cb {
+        "enum-variant-rename" => Box::new(EnumVariantRename),
         _ => panic!("Couldn't find name ParseCallbacks: {}", cb),
     }
 }


### PR DESCRIPTION
Prior to this PR, this header

```c
enum {
    MyVal = 0,
};
```

in combination with `allowlist_var("^MyVal$")` and an implementation of `ParseCallbacks::enum_variant_name` would generate no code. This is because the renamed variant name is checked against the variable allowlist. All other allowlist checks are against the unrenamed name. This PR makes that consistent. This is a breaking change but I think the old behavior is clearly wrong.

Additionally, I've added a way to test ParseCallbacks in CI.