### PR TITLE
Add callback to check derives for blocklisted types

### DIFF
--- a/src/callbacks.rs
+++ b/src/callbacks.rs
@@ -1,5 +1,7 @@
 //! A public API for more fine-grained customization of bindgen behavior.
 
+pub use crate::ir::analysis::DeriveTrait;
+pub use crate::ir::derive::CanDerive as ImplementsTrait;
 pub use crate::ir::enum_ty::{EnumVariantCustomBehavior, EnumVariantValue};
 pub use crate::ir::int::IntKind;
 use std::fmt;
@@ -76,4 +78,21 @@ pub trait ParseCallbacks: fmt::Debug + UnwindSafe {
 
     /// This will be called on every file inclusion, with the full path of the included file.
     fn include_file(&self, _filename: &str) {}
+
+    /// This will be called to determine whether a particular blocklisted type
+    /// implements a trait or not. This will be used to implement traits on
+    /// other types containing the blocklisted type.
+    ///
+    /// * `None`: use the default behavior
+    /// * `Some(ImplementsTrait::Yes)`: `_name` implements `_derive_trait`
+    /// * `Some(ImplementsTrait::Manually)`: any type including `_name` can't
+    ///   derive `_derive_trait` but can implemented it manually
+    /// * `Some(ImplementsTrait::No)`: `_name` doesn't implement `_derive_trait`
+    fn blocklisted_type_implements_trait(
+        &self,
+        _name: &str,
+        _derive_trait: DeriveTrait,
+    ) -> Option<ImplementsTrait> {
+        None
+    }
 }

--- a/tests/expectations/tests/issue-1454.rs
+++ b/tests/expectations/tests/issue-1454.rs
@@ -1,0 +1,41 @@
+#![allow(
+    dead_code,
+    non_snake_case,
+    non_camel_case_types,
+    non_upper_case_globals
+)]
+
+#[repr(C)]
+#[derive(Debug)]
+pub struct extern_type;
+
+#[repr(C)]
+#[derive(Debug)]
+pub struct local_type {
+    pub inner: extern_type,
+}
+#[test]
+fn bindgen_test_layout_local_type() {
+    assert_eq!(
+        ::std::mem::size_of::<local_type>(),
+        0usize,
+        concat!("Size of: ", stringify!(local_type))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<local_type>(),
+        1usize,
+        concat!("Alignment of ", stringify!(local_type))
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<local_type>())).inner as *const _ as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(local_type),
+            "::",
+            stringify!(inner)
+        )
+    );
+}

--- a/tests/headers/issue-1454.h
+++ b/tests/headers/issue-1454.h
@@ -1,0 +1,10 @@
+// bindgen-flags: --no-recursive-allowlist --allowlist-type "local_type" --with-derive-hash --no-derive-copy --no-derive-default --raw-line "#[repr(C)] #[derive(Debug)] pub struct extern_type;"
+// bindgen-parse-callbacks: blocklisted-type-implements-trait
+
+struct extern_type {};
+
+typedef struct
+{
+    struct extern_type inner;
+}
+local_type;

--- a/tests/parse_callbacks/mod.rs
+++ b/tests/parse_callbacks/mod.rs
@@ -1,4 +1,4 @@
-use bindgen::callbacks::ParseCallbacks;
+use bindgen::callbacks::*;
 
 #[derive(Debug)]
 struct EnumVariantRename;
@@ -8,15 +8,35 @@ impl ParseCallbacks for EnumVariantRename {
         &self,
         _enum_name: Option<&str>,
         original_variant_name: &str,
-        _variant_value: bindgen::callbacks::EnumVariantValue,
+        _variant_value: EnumVariantValue,
     ) -> Option<String> {
         Some(format!("RENAMED_{}", original_variant_name))
+    }
+}
+
+#[derive(Debug)]
+struct BlocklistedTypeImplementsTrait;
+
+impl ParseCallbacks for BlocklistedTypeImplementsTrait {
+    fn blocklisted_type_implements_trait(
+        &self,
+        _name: &str,
+        derive_trait: DeriveTrait,
+    ) -> Option<ImplementsTrait> {
+        if derive_trait == DeriveTrait::Hash {
+            Some(ImplementsTrait::No)
+        } else {
+            Some(ImplementsTrait::Yes)
+        }
     }
 }
 
 pub fn lookup(cb: &str) -> Box<dyn ParseCallbacks> {
     match cb {
         "enum-variant-rename" => Box::new(EnumVariantRename),
+        "blocklisted-type-implements-trait" => {
+            Box::new(BlocklistedTypeImplementsTrait)
+        }
         _ => panic!("Couldn't find name ParseCallbacks: {}", cb),
     }
 }


### PR DESCRIPTION
Fixes #1454 #2003

This includes #2006 because it needs the ParseCallbacks testing framework
