### PR TITLE
Add from_library for generated dynamic library structs

### DIFF
--- a/src/codegen/dyngen.rs
+++ b/src/codegen/dyngen.rs
@@ -90,14 +90,20 @@ impl DynamicItems {
                     path: P
                 ) -> Result<Self, ::libloading::Error>
                 where P: AsRef<::std::ffi::OsStr> {
-                    let __library = ::libloading::Library::new(path)?;
+                    let library = ::libloading::Library::new(path)?;
+                    Ok(Self::from_library(library))
+                }
+
+                pub unsafe fn from_library<L>(
+                    library: L
+                ) -> Self
+                where L: Into<::libloading::Library> {
+                    let __library = library.into();
                     #( #constructor_inits )*
-                    Ok(
-                        #lib_ident {
-                            __library,
-                            #( #init_fields ),*
-                        }
-                    )
+                    #lib_ident {
+                        __library,
+                        #( #init_fields ),*
+                    }
                 }
 
                 #( #struct_implementation )*

--- a/tests/expectations/tests/dynamic_loading_simple.rs
+++ b/tests/expectations/tests/dynamic_loading_simple.rs
@@ -31,16 +31,23 @@ impl TestLib {
     where
         P: AsRef<::std::ffi::OsStr>,
     {
-        let __library = ::libloading::Library::new(path)?;
+        let library = ::libloading::Library::new(path)?;
+        Ok(Self::from_library(library))
+    }
+    pub unsafe fn from_library<L>(library: L) -> Self
+    where
+        L: Into<::libloading::Library>,
+    {
+        let __library = library.into();
         let foo = __library.get(b"foo\0").map(|sym| *sym);
         let bar = __library.get(b"bar\0").map(|sym| *sym);
         let baz = __library.get(b"baz\0").map(|sym| *sym);
-        Ok(TestLib {
+        TestLib {
             __library,
             foo,
             bar,
             baz,
-        })
+        }
     }
     pub unsafe fn foo(
         &self,

--- a/tests/expectations/tests/dynamic_loading_template.rs
+++ b/tests/expectations/tests/dynamic_loading_template.rs
@@ -19,14 +19,21 @@ impl TestLib {
     where
         P: AsRef<::std::ffi::OsStr>,
     {
-        let __library = ::libloading::Library::new(path)?;
+        let library = ::libloading::Library::new(path)?;
+        Ok(Self::from_library(library))
+    }
+    pub unsafe fn from_library<L>(library: L) -> Self
+    where
+        L: Into<::libloading::Library>,
+    {
+        let __library = library.into();
         let foo = __library.get(b"foo\0").map(|sym| *sym);
         let foo1 = __library.get(b"foo1\0").map(|sym| *sym);
-        Ok(TestLib {
+        TestLib {
             __library,
             foo,
             foo1,
-        })
+        }
     }
     pub unsafe fn foo(
         &self,

--- a/tests/expectations/tests/dynamic_loading_with_allowlist.rs
+++ b/tests/expectations/tests/dynamic_loading_with_allowlist.rs
@@ -33,16 +33,23 @@ impl TestLib {
     where
         P: AsRef<::std::ffi::OsStr>,
     {
-        let __library = ::libloading::Library::new(path)?;
+        let library = ::libloading::Library::new(path)?;
+        Ok(Self::from_library(library))
+    }
+    pub unsafe fn from_library<L>(library: L) -> Self
+    where
+        L: Into<::libloading::Library>,
+    {
+        let __library = library.into();
         let foo = __library.get(b"foo\0").map(|sym| *sym);
         let baz = __library.get(b"baz\0").map(|sym| *sym);
         let bazz = __library.get(b"bazz\0").map(|sym| *sym);
-        Ok(TestLib {
+        TestLib {
             __library,
             foo,
             baz,
             bazz,
-        })
+        }
     }
     pub unsafe fn foo(
         &self,

--- a/tests/expectations/tests/dynamic_loading_with_blocklist.rs
+++ b/tests/expectations/tests/dynamic_loading_with_blocklist.rs
@@ -77,14 +77,21 @@ impl TestLib {
     where
         P: AsRef<::std::ffi::OsStr>,
     {
-        let __library = ::libloading::Library::new(path)?;
+        let library = ::libloading::Library::new(path)?;
+        Ok(Self::from_library(library))
+    }
+    pub unsafe fn from_library<L>(library: L) -> Self
+    where
+        L: Into<::libloading::Library>,
+    {
+        let __library = library.into();
         let foo = __library.get(b"foo\0").map(|sym| *sym);
         let bar = __library.get(b"bar\0").map(|sym| *sym);
-        Ok(TestLib {
+        TestLib {
             __library,
             foo,
             bar,
-        })
+        }
     }
     pub unsafe fn foo(
         &self,

--- a/tests/expectations/tests/dynamic_loading_with_class.rs
+++ b/tests/expectations/tests/dynamic_loading_with_class.rs
@@ -72,14 +72,21 @@ impl TestLib {
     where
         P: AsRef<::std::ffi::OsStr>,
     {
-        let __library = ::libloading::Library::new(path)?;
+        let library = ::libloading::Library::new(path)?;
+        Ok(Self::from_library(library))
+    }
+    pub unsafe fn from_library<L>(library: L) -> Self
+    where
+        L: Into<::libloading::Library>,
+    {
+        let __library = library.into();
         let foo = __library.get(b"foo\0").map(|sym| *sym);
         let bar = __library.get(b"bar\0").map(|sym| *sym);
-        Ok(TestLib {
+        TestLib {
             __library,
             foo,
             bar,
-        })
+        }
     }
     pub unsafe fn foo(
         &self,


### PR DESCRIPTION
The `new` method of generated dynamic library structs only allows to load library in a standard way. But under some circumstance a user might want to load the dynamic library with some platform-specific parameters (https://docs.rs/libloading/0.7.0/libloading/os/index.html).

This PR adds a `from_library` method that accepts an already loaded `Library` instance.
