### PR TITLE
Add a flag to ensure all symbols are resolved when a dynamic library is loaded

### DIFF
--- a/src/codegen/dyngen.rs
+++ b/src/codegen/dyngen.rs
@@ -5,11 +5,6 @@ use proc_macro2::Ident;
 /// Used to build the output tokens for dynamic bindings.
 #[derive(Default)]
 pub struct DynamicItems {
-    /// Tracks whether or not we contain any required symbols.
-    /// If so, the signature of the generated `from_library` function
-    /// will be altered to return a `Result<Self, ::libloading::Error>`
-    has_required: bool,
-
     /// Tracks the tokens that will appears inside the library struct -- e.g.:
     /// ```ignore
     /// struct Lib {
@@ -135,8 +130,6 @@ impl DynamicItems {
         if !is_variadic {
             assert_eq!(args.len(), args_identifiers.len());
         }
-
-        self.has_required |= is_required;
 
         self.struct_members.push(
             if is_required {

--- a/src/codegen/dyngen.rs
+++ b/src/codegen/dyngen.rs
@@ -78,10 +78,6 @@ impl DynamicItems {
         let init_fields = &self.init_fields;
         let struct_implementation = &self.struct_implementation;
 
-        // FIXME: Is there a better way to lay this out? Conditional in the quote
-        // macro?
-        // If we have any required symbols, we must alter the signature of `from_library`
-        // so that it can return a failure code.
         quote! {
             extern crate libloading;
 

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -3869,6 +3869,7 @@ impl CodeGenerator for Function {
                 ident,
                 abi,
                 signature.is_variadic(),
+                ctx.options().dynamic_link_require_all,
                 args,
                 args_identifiers,
                 ret,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -545,6 +545,10 @@ impl Builder {
             output_vector.push(name.clone());
         }
 
+        if self.options.dynamic_link_require_all {
+            output_vector.push("--dynamic-link-require-all".into());
+        }
+
         if self.options.respect_cxx_access_specs {
             output_vector.push("--respect-cxx-access-specs".into());
         }
@@ -1567,6 +1571,14 @@ impl Builder {
         self
     }
 
+    /// Require successful linkage for all routines in a shared library.
+    /// This allows us to optimize function calls by being able to safely assume function pointers
+    /// are valid.
+    pub fn dynamic_link_require_all(mut self, req: bool) -> Self {
+        self.options.dynamic_link_require_all = req;
+        self
+    }
+
     /// Generate bindings as `pub` only if the bound item is publically accessible by C++.
     pub fn respect_cxx_access_specs(mut self, doit: bool) -> Self {
         self.options.respect_cxx_access_specs = doit;
@@ -1870,6 +1882,11 @@ struct BindgenOptions {
     /// this is None, no dynamic bindings are created.
     dynamic_library_name: Option<String>,
 
+    /// Require successful linkage for all routines in a shared library.
+    /// This allows us to optimize function calls by being able to safely assume function pointers
+    /// are valid. No effect if `dynamic_library_name` is None.
+    dynamic_link_require_all: bool,
+
     /// Only make generated bindings `pub` if the items would be publically accessible
     /// by C++.
     respect_cxx_access_specs: bool,
@@ -2012,6 +2029,7 @@ impl Default for BindgenOptions {
             array_pointers_in_arguments: false,
             wasm_import_module_name: None,
             dynamic_library_name: None,
+            dynamic_link_require_all: false,
             respect_cxx_access_specs: false,
             translate_enum_integer_types: false,
         }

--- a/src/options.rs
+++ b/src/options.rs
@@ -500,6 +500,9 @@ where
                 .long("dynamic-loading")
                 .takes_value(true)
                 .help("Use dynamic loading mode with the given library name."),
+            Arg::with_name("dynamic-link-require-all")
+                .long("dynamic-link-require-all")
+                .help("Require successful linkage to all functions in the library."),
             Arg::with_name("respect-cxx-access-specs")
                 .long("respect-cxx-access-specs")
                 .help("Makes generated bindings `pub` only for items if the items are publically accessible in C++."),
@@ -926,6 +929,10 @@ where
 
     if let Some(dynamic_library_name) = matches.value_of("dynamic-loading") {
         builder = builder.dynamic_library_name(dynamic_library_name);
+    }
+
+    if matches.is_present("dynamic-link-require-all") {
+        builder = builder.dynamic_link_require_all(true);
     }
 
     if matches.is_present("respect-cxx-access-specs") {

--- a/tests/expectations/tests/dynamic_loading_required.rs
+++ b/tests/expectations/tests/dynamic_loading_required.rs
@@ -8,23 +8,14 @@
 extern crate libloading;
 pub struct TestLib {
     __library: ::libloading::Library,
-    pub foo: Result<
-        unsafe extern "C" fn(
-            x: ::std::os::raw::c_int,
-            y: ::std::os::raw::c_int,
-        ) -> ::std::os::raw::c_int,
-        ::libloading::Error,
-    >,
-    pub bar: Result<
-        unsafe extern "C" fn(
-            x: *mut ::std::os::raw::c_void,
-        ) -> ::std::os::raw::c_int,
-        ::libloading::Error,
-    >,
-    pub baz: Result<
-        unsafe extern "C" fn() -> ::std::os::raw::c_int,
-        ::libloading::Error,
-    >,
+    pub foo: unsafe extern "C" fn(
+        x: ::std::os::raw::c_int,
+        y: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int,
+    pub bar: unsafe extern "C" fn(
+        x: *mut ::std::os::raw::c_void,
+    ) -> ::std::os::raw::c_int,
+    pub baz: unsafe extern "C" fn() -> ::std::os::raw::c_int,
 }
 impl TestLib {
     pub unsafe fn new<P>(path: P) -> Result<Self, ::libloading::Error>
@@ -39,9 +30,9 @@ impl TestLib {
         L: Into<::libloading::Library>,
     {
         let __library = library.into();
-        let foo = __library.get(b"foo\0").map(|sym| *sym);
-        let bar = __library.get(b"bar\0").map(|sym| *sym);
-        let baz = __library.get(b"baz\0").map(|sym| *sym);
+        let foo = __library.get(b"foo\0").map(|sym| *sym)?;
+        let bar = __library.get(b"bar\0").map(|sym| *sym)?;
+        let baz = __library.get(b"baz\0").map(|sym| *sym)?;
         Ok(TestLib {
             __library,
             foo,
@@ -54,18 +45,15 @@ impl TestLib {
         x: ::std::os::raw::c_int,
         y: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int {
-        let sym = self.foo.as_ref().expect("Expected function, got error.");
-        (sym)(x, y)
+        self.foo(x, y)
     }
     pub unsafe fn bar(
         &self,
         x: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int {
-        let sym = self.bar.as_ref().expect("Expected function, got error.");
-        (sym)(x)
+        self.bar(x)
     }
     pub unsafe fn baz(&self) -> ::std::os::raw::c_int {
-        let sym = self.baz.as_ref().expect("Expected function, got error.");
-        (sym)()
+        self.baz()
     }
 }

--- a/tests/expectations/tests/dynamic_loading_template.rs
+++ b/tests/expectations/tests/dynamic_loading_template.rs
@@ -20,20 +20,20 @@ impl TestLib {
         P: AsRef<::std::ffi::OsStr>,
     {
         let library = ::libloading::Library::new(path)?;
-        Ok(Self::from_library(library))
+        Self::from_library(library)
     }
-    pub unsafe fn from_library<L>(library: L) -> Self
+    pub unsafe fn from_library<L>(library: L) -> Result<Self, ::libloading::Error>
     where
         L: Into<::libloading::Library>,
     {
         let __library = library.into();
         let foo = __library.get(b"foo\0").map(|sym| *sym);
         let foo1 = __library.get(b"foo1\0").map(|sym| *sym);
-        TestLib {
+        Ok(TestLib {
             __library,
             foo,
             foo1,
-        }
+        })
     }
     pub unsafe fn foo(
         &self,

--- a/tests/expectations/tests/dynamic_loading_with_allowlist.rs
+++ b/tests/expectations/tests/dynamic_loading_with_allowlist.rs
@@ -34,9 +34,9 @@ impl TestLib {
         P: AsRef<::std::ffi::OsStr>,
     {
         let library = ::libloading::Library::new(path)?;
-        Ok(Self::from_library(library))
+        Self::from_library(library)
     }
-    pub unsafe fn from_library<L>(library: L) -> Self
+    pub unsafe fn from_library<L>(library: L) -> Result<Self, ::libloading::Error>
     where
         L: Into<::libloading::Library>,
     {
@@ -44,12 +44,12 @@ impl TestLib {
         let foo = __library.get(b"foo\0").map(|sym| *sym);
         let baz = __library.get(b"baz\0").map(|sym| *sym);
         let bazz = __library.get(b"bazz\0").map(|sym| *sym);
-        TestLib {
+        Ok(TestLib {
             __library,
             foo,
             baz,
             bazz,
-        }
+        })
     }
     pub unsafe fn foo(
         &self,

--- a/tests/expectations/tests/dynamic_loading_with_blocklist.rs
+++ b/tests/expectations/tests/dynamic_loading_with_blocklist.rs
@@ -78,20 +78,20 @@ impl TestLib {
         P: AsRef<::std::ffi::OsStr>,
     {
         let library = ::libloading::Library::new(path)?;
-        Ok(Self::from_library(library))
+        Self::from_library(library)
     }
-    pub unsafe fn from_library<L>(library: L) -> Self
+    pub unsafe fn from_library<L>(library: L) -> Result<Self, ::libloading::Error>
     where
         L: Into<::libloading::Library>,
     {
         let __library = library.into();
         let foo = __library.get(b"foo\0").map(|sym| *sym);
         let bar = __library.get(b"bar\0").map(|sym| *sym);
-        TestLib {
+        Ok(TestLib {
             __library,
             foo,
             bar,
-        }
+        })
     }
     pub unsafe fn foo(
         &self,

--- a/tests/expectations/tests/dynamic_loading_with_class.rs
+++ b/tests/expectations/tests/dynamic_loading_with_class.rs
@@ -73,20 +73,20 @@ impl TestLib {
         P: AsRef<::std::ffi::OsStr>,
     {
         let library = ::libloading::Library::new(path)?;
-        Ok(Self::from_library(library))
+        Self::from_library(library)
     }
-    pub unsafe fn from_library<L>(library: L) -> Self
+    pub unsafe fn from_library<L>(library: L) -> Result<Self, ::libloading::Error>
     where
         L: Into<::libloading::Library>,
     {
         let __library = library.into();
         let foo = __library.get(b"foo\0").map(|sym| *sym);
         let bar = __library.get(b"bar\0").map(|sym| *sym);
-        TestLib {
+        Ok(TestLib {
             __library,
             foo,
             bar,
-        }
+        })
     }
     pub unsafe fn foo(
         &self,

--- a/tests/headers/dynamic_loading_required.h
+++ b/tests/headers/dynamic_loading_required.h
@@ -1,0 +1,5 @@
+// bindgen-flags: --dynamic-loading TestLib --dynamic-link-require-all
+
+int foo(int x, int y);
+int bar(void *x);
+int baz();


### PR DESCRIPTION
Currently, `bindgen` allows symbols to go unresolved when loading a dynamic library, only to panic later when a function call is attempted against an unresolved symbol.
Instead, it'd be better to return an error code when we detect an unresolved symbol while loading the library, thereby avoiding any unforeseen runtime errors.

In addition, this will also allow us to save function pointers on our struct instead of a `Result`, saving us the cost of having to unwrap the `Result` every time we make a function call.

---
I'm expecting some criticism from the way I've changed the `quote!` calls, and I'm all for suggestions on how to change the code for the better.
Ideally there would be a way to branch on a conditional, inline in the `quote!` macro, but I haven't seen a way to do so yet.

In addition, there is a good argument to make this the default behavior (as long as it is acceptable to potentially break existing code).