### PR TITLE
Document clang installation method on Fedora

### DIFF
--- a/book/src/requirements.md
+++ b/book/src/requirements.md
@@ -63,6 +63,12 @@ repos to get version 3.9. See http://apt.llvm.org/.
 # pacman -S clang
 ```
 
+#### Fedora
+
+```bash
+# dnf install clang-devel
+```
+
 #### OpenBSD
 
 ```bash


### PR DESCRIPTION
Installation instructions are currently provided for `apt`-based platforms, but there is no mention of `dnf`-based platforms.

Verified on my Fedora 33 install with `dnf provides /usr/lib64/libclang.so`.