### PR TITLE
Support emitting Makefile-syntax depfiles like gcc/clang/rustc.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,6 +50,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
+ "tempfile",
  "which",
 ]
 
@@ -123,6 +124,17 @@ dependencies = [
  "log",
  "regex",
  "termcolor",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9495705279e7140bf035dde1f6e750c162df8b625267cd52cc44e0b156732c8"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
@@ -206,6 +218,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -221,6 +239,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa563d17ecb180e500da1cfd2b028310ac758de548efdd203e18f283af693f37"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ef9e7e66b4468674bfcb0c81af8b7fa0bb154fa9f28eb840da5c447baeb8d7e"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+ "rand_hc",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e12735cf05c9e10bf21534da50a147b924d555dc7a547c42e6bb2d5b6017ae0d"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34cf66eb183df1c5876e2dcf6b13d57340741e8dc255b48e40a26de954d06ae7"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3190ef7066a446f2e7f42e239d161e905420ccab01eb967c9eb27d21b2322a73"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94341e4e44e24f6b591b59e47a8a027df12e008d73fd5672dbea9cc22f4507d9"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]
@@ -242,6 +309,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b181ba2dcf07aaccad5448e8ead58db5b742cf85dfe035e2227f137a539a189"
 
 [[package]]
+name = "remove_dir_all"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -258,6 +334,20 @@ name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+
+[[package]]
+name = "tempfile"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "rand",
+ "redox_syscall",
+ "remove_dir_all",
+ "winapi",
+]
 
 [[package]]
 name = "termcolor"
@@ -309,6 +399,12 @@ name = "version_check"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
+
+[[package]]
+name = "wasi"
+version = "0.10.2+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "which"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ required-features = ["clap"]
 diff = "0.1"
 clap = "2"
 shlex = "1"
+tempfile = "3"
 
 [dependencies]
 bitflags = "1.0.3"

--- a/bindgen-integration/cpp/Test.h
+++ b/bindgen-integration/cpp/Test.h
@@ -1,3 +1,5 @@
+#include "stub.h" // this bad path is made valid by a `-I include` clang arg
+
 #pragma once
 
 #define TESTMACRO

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -4207,6 +4207,16 @@ pub(crate) fn codegen(
             }
         }
 
+        if let Some(spec) = context.options().depfile.as_ref() {
+            match spec.write(context.deps()) {
+                Ok(()) => info!(
+                    "Your depfile was generated successfully into: {}",
+                    spec.depfile_path.display()
+                ),
+                Err(e) => warn!("{}", e),
+            }
+        }
+
         context.resolve_item(context.root_module()).codegen(
             context,
             &mut result,

--- a/src/deps.rs
+++ b/src/deps.rs
@@ -1,0 +1,20 @@
+/// Generating build depfiles from parsed bindings.
+use std::{collections::BTreeSet, path::PathBuf};
+
+#[derive(Debug)]
+pub(crate) struct DepfileSpec {
+    pub output_module: String,
+    pub depfile_path: PathBuf,
+}
+
+impl DepfileSpec {
+    pub fn write(&self, deps: &BTreeSet<String>) -> std::io::Result<()> {
+        let mut buf = format!("{}:", self.output_module);
+
+        for file in deps {
+            buf = format!("{} {}", buf, file);
+        }
+
+        std::fs::write(&self.depfile_path, &buf)
+    }
+}

--- a/src/ir/item.rs
+++ b/src/ir/item.rs
@@ -1415,9 +1415,7 @@ impl ClangItemParser for Item {
                             );
                         }
                         Some(filename) => {
-                            if let Some(cb) = ctx.parse_callbacks() {
-                                cb.include_file(&filename)
-                            }
+                            ctx.include_file(filename);
                         }
                     }
                 }

--- a/src/options.rs
+++ b/src/options.rs
@@ -30,6 +30,10 @@ where
             Arg::with_name("header")
                 .help("C or C++ header file")
                 .required(true),
+            Arg::with_name("depfile")
+                .long("depfile")
+                .takes_value(true)
+                .help("Path to write depfile to"),
             Arg::with_name("default-enum-style")
                 .long("default-enum-style")
                 .help("The default style of code used to generate enums.")
@@ -848,8 +852,14 @@ where
 
     let output = if let Some(path) = matches.value_of("output") {
         let file = File::create(path)?;
+        if let Some(depfile) = matches.value_of("depfile") {
+            builder = builder.depfile(path, depfile);
+        }
         Box::new(io::BufWriter::new(file)) as Box<dyn io::Write>
     } else {
+        if let Some(depfile) = matches.value_of("depfile") {
+            builder = builder.depfile("-", depfile);
+        }
         Box::new(io::BufWriter::new(io::stdout())) as Box<dyn io::Write>
     };
 

--- a/tests/expectations/tests/enum-default-rust.d
+++ b/tests/expectations/tests/enum-default-rust.d
@@ -1,0 +1,1 @@
+tests/expectations/tests/enum-default-rust.rs: tests/headers/enum-default-rust.h tests/headers/enum.h


### PR DESCRIPTION
The motivation here is being able to use bindgen [during a ninja build] without losing dependency information.

I'm not particularly happy with the approach I've taken of wrapping ParseCallbacks. The main alternative I see is to have the parse callbacks separated into a concrete type and a trait object, and to always collect filenames in the struct. I'm open to suggestions for better ways to collect the needed metadata, though.

[during a ninja build]: https://fuchsia-review.googlesource.com/c/fuchsia/+/510318