### PR TITLE
Fix docstring comment for constants

### DIFF
--- a/tests/expectations/tests/issue-1995.rs
+++ b/tests/expectations/tests/issue-1995.rs
@@ -1,0 +1,37 @@
+#![allow(
+    dead_code,
+    non_snake_case,
+    non_camel_case_types,
+    non_upper_case_globals
+)]
+
+/// This is a constant that has a docstring
+///
+/// And expected to be found in generated bindings code too.
+pub const FOO: ::std::os::raw::c_int = 1;
+/// This is a constant that has a docstring
+///
+/// And expected to be found in generated bindings code too.
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct Bar {
+    pub baz: ::std::os::raw::c_int,
+}
+#[test]
+fn bindgen_test_layout_Bar() {
+    assert_eq!(
+        ::std::mem::size_of::<Bar>(),
+        4usize,
+        concat!("Size of: ", stringify!(Bar))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<Bar>(),
+        4usize,
+        concat!("Alignment of ", stringify!(Bar))
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<Bar>())).baz as *const _ as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(Bar), "::", stringify!(baz))
+    );
+}

--- a/tests/headers/issue-1995.h
+++ b/tests/headers/issue-1995.h
@@ -1,0 +1,12 @@
+/// This is a constant that has a docstring
+///
+/// And expected to be found in generated bindings code too.
+const int FOO = 1;
+
+/// This is a constant that has a docstring
+///
+/// And expected to be found in generated bindings code too.
+struct Bar
+{
+    int baz;
+};


### PR DESCRIPTION
As a first contribution, here's a small and possibly quite naive fix and test for #1995  :)