### PR TITLE
Add env var EXTRA_CLANG_ARGS_<TARGET>

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,10 @@ End-users should set these environment variables to modify `bindgen`'s behavior 
     - Examples:
         - Specify alternate sysroot: `--sysroot=/path/to/sysroot`
         - Add include search path with spaces: `-I"/path/with spaces"`
+- `BINDGEN_EXTRA_CLANG_ARGS_<TARGET>`: similar to `BINDGEN_EXTRA_CLANG_ARGS`,
+   but used to set per-target arguments to pass to clang. Useful to set system include
+   directories in a target-specific way in cross-compilation environments with multiple targets.
+   Has precedence over `BINDGEN_EXTRA_CLANG_ARGS`.
 
 Additionally, `bindgen` uses `libclang` to parse C and C++ header files.
 To modify how `bindgen` searches for `libclang`, see the [`clang-sys` documentation][clang-sys-env].

--- a/build.rs
+++ b/build.rs
@@ -79,4 +79,12 @@ fn main() {
     println!("cargo:rerun-if-env-changed=LIBCLANG_PATH");
     println!("cargo:rerun-if-env-changed=LIBCLANG_STATIC_PATH");
     println!("cargo:rerun-if-env-changed=BINDGEN_EXTRA_CLANG_ARGS");
+    println!(
+        "cargo:rerun-if-env-changed=BINDGEN_EXTRA_CLANG_ARGS_{}",
+        std::env::var("TARGET").unwrap()
+    );
+    println!(
+        "cargo:rerun-if-env-changed=BINDGEN_EXTRA_CLANG_ARGS_{}",
+        std::env::var("TARGET").unwrap().replace("-", "_")
+    );
 }


### PR DESCRIPTION
Closes #2009

As suggested in the issue, I've done it the same way the `cc` crate does it in its [`get_var`](https://github.com/alexcrichton/cc-rs/blob/c8b47ee8b53a57a505ecd0f0981c1bb3b4b58fb4/src/lib.rs#L2180) function. 