### PR TITLE
Translate types that were declared inside functions as opaque types.

### DIFF
--- a/src/ir/function.rs
+++ b/src/ir/function.rs
@@ -28,7 +28,9 @@ pub enum FunctionKind {
 }
 
 impl FunctionKind {
-    fn from_cursor(cursor: &clang::Cursor) -> Option<FunctionKind> {
+    /// Given a clang cursor, return the kind of function it represents, or
+    /// `None` otherwise.
+    pub fn from_cursor(cursor: &clang::Cursor) -> Option<FunctionKind> {
         // FIXME(emilio): Deduplicate logic with `ir::comp`.
         Some(match cursor.kind() {
             clang_sys::CXCursor_FunctionDecl => FunctionKind::Function,

--- a/tests/expectations/tests/libclang-3.9/template_instantiation_with_fn_local_type.rs
+++ b/tests/expectations/tests/libclang-3.9/template_instantiation_with_fn_local_type.rs
@@ -1,0 +1,60 @@
+#![allow(
+    dead_code,
+    non_snake_case,
+    non_camel_case_types,
+    non_upper_case_globals
+)]
+
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct Foo {
+    pub _address: u8,
+}
+extern "C" {
+    #[link_name = "\u{1}_Z1fv"]
+    pub fn f();
+}
+#[test]
+fn __bindgen_test_layout_Foo_open0__bindgen_ty_id_20_close0_instantiation() {
+    assert_eq!(
+        ::std::mem::size_of::<Foo>(),
+        1usize,
+        concat!("Size of template specialization: ", stringify!(Foo))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<Foo>(),
+        1usize,
+        concat!("Alignment of template specialization: ", stringify!(Foo))
+    );
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct Baz {
+    pub _address: u8,
+}
+#[test]
+fn bindgen_test_layout_Baz() {
+    assert_eq!(
+        ::std::mem::size_of::<Baz>(),
+        1usize,
+        concat!("Size of: ", stringify!(Baz))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<Baz>(),
+        1usize,
+        concat!("Alignment of ", stringify!(Baz))
+    );
+}
+ #[test]
+fn __bindgen_test_layout_Foo_open0__bindgen_ty_id_21_close0_instantiation() {
+    assert_eq!(
+        ::std::mem::size_of::<Foo>(),
+        1usize,
+        concat!("Size of template specialization: ", stringify!(Foo))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<Foo>(),
+        1usize,
+        concat!("Alignment of template specialization: ", stringify!(Foo))
+    );
+}

--- a/tests/expectations/tests/template_instantiation_with_fn_local_type.rs
+++ b/tests/expectations/tests/template_instantiation_with_fn_local_type.rs
@@ -1,0 +1,96 @@
+#![allow(
+    dead_code,
+    non_snake_case,
+    non_camel_case_types,
+    non_upper_case_globals
+)]
+
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct Foo {
+    pub _address: u8,
+}
+extern "C" {
+    #[link_name = "\u{1}_Z1fv"]
+    pub fn f();
+}
+#[test]
+fn __bindgen_test_layout_Foo_open0_Bar_close0_instantiation() {
+    assert_eq!(
+        ::std::mem::size_of::<Foo>(),
+        1usize,
+        concat!("Size of template specialization: ", stringify!(Foo))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<Foo>(),
+        1usize,
+        concat!("Alignment of template specialization: ", stringify!(Foo))
+    );
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct Baz {
+    pub _address: u8,
+}
+#[test]
+fn bindgen_test_layout_Baz() {
+    assert_eq!(
+        ::std::mem::size_of::<Baz>(),
+        1usize,
+        concat!("Size of: ", stringify!(Baz))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<Baz>(),
+        1usize,
+        concat!("Alignment of ", stringify!(Baz))
+    );
+}
+#[test]
+fn __bindgen_test_layout_Foo_open0_Boo_close0_instantiation() {
+    assert_eq!(
+        ::std::mem::size_of::<Foo>(),
+        1usize,
+        concat!("Size of template specialization: ", stringify!(Foo))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<Foo>(),
+        1usize,
+        concat!("Alignment of template specialization: ", stringify!(Foo))
+    );
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct Bar {
+    pub _address: u8,
+}
+#[test]
+fn bindgen_test_layout_Bar() {
+    assert_eq!(
+        ::std::mem::size_of::<Bar>(),
+        1usize,
+        concat!("Size of: ", stringify!(Bar))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<Bar>(),
+        1usize,
+        concat!("Alignment of ", stringify!(Bar))
+    );
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct Boo {
+    pub _address: u8,
+}
+#[test]
+fn bindgen_test_layout_Boo() {
+    assert_eq!(
+        ::std::mem::size_of::<Boo>(),
+        1usize,
+        concat!("Size of: ", stringify!(Boo))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<Boo>(),
+        1usize,
+        concat!("Alignment of ", stringify!(Boo))
+    );
+}

--- a/tests/headers/template_instantiation_with_fn_local_type.hpp
+++ b/tests/headers/template_instantiation_with_fn_local_type.hpp
@@ -1,0 +1,27 @@
+// bindgen-flags: -- -std=c++14
+//
+// https://github.com/rust-lang/rust-bindgen/issues/2036
+
+template<typename T>
+struct Foo {};
+template<typename T>
+Foo<T> foo{};
+
+// Struct inside function
+void f() {
+  struct Bar {
+    Bar() {}
+  };
+  foo<Bar>;
+}
+
+// Struct inside method
+class Baz {
+  void f() {
+    struct Boo {
+      Boo() {}
+    };
+    foo<Boo>;
+  }
+};
+


### PR DESCRIPTION
This fixes a panic with the following header:

    template<typename T>
    struct Foo {};
    template<typename T>
    Foo<T> foo{};

    void f() {
      struct Bar {
        Bar() {}
      };
      foo<Bar>;
    }

Because we don't parse the insides of function bodies, code like this could
cause us to parse a type (here, `Bar`) that we didn't see in our initial pass,
which can cause subtle problems.

Closes #2036.