### PR TITLE
Add a C naming option

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -557,6 +557,10 @@ impl Builder {
             output_vector.push("--translate-enum-integer-types".into());
         }
 
+        if self.options.c_naming {
+            output_vector.push("--c-naming".into());
+        }
+
         // Add clang arguments
 
         output_vector.push("--".into());
@@ -1600,6 +1604,15 @@ impl Builder {
         self.options.translate_enum_integer_types = doit;
         self
     }
+
+    /// Generate types with C style naming.
+    ///
+    /// This will add prefixes to the generated type names. For example instead of a struct `A` we
+    /// will generate struct `struct_A`. Currently applies to structs, unions, and enums.
+    pub fn c_naming(mut self, doit: bool) -> Self {
+        self.options.c_naming = doit;
+        self
+    }
 }
 
 /// Configuration options for generated bindings.
@@ -1899,6 +1912,9 @@ struct BindgenOptions {
 
     /// Always translate enum integer types to native Rust integer types.
     translate_enum_integer_types: bool,
+
+    /// Generate types with C style naming.
+    c_naming: bool,
 }
 
 /// TODO(emilio): This is sort of a lie (see the error message that results from
@@ -2038,6 +2054,7 @@ impl Default for BindgenOptions {
             dynamic_link_require_all: false,
             respect_cxx_access_specs: false,
             translate_enum_integer_types: false,
+            c_naming: false,
         }
     }
 }

--- a/src/options.rs
+++ b/src/options.rs
@@ -509,6 +509,9 @@ where
             Arg::with_name("translate-enum-integer-types")
                 .long("translate-enum-integer-types")
                 .help("Always translate enum integer types to native Rust integer types."),
+            Arg::with_name("c-naming")
+                .long("c-naming")
+                .help("Generate types with C style naming."),
         ]) // .args()
         .get_matches_from(args);
 
@@ -941,6 +944,10 @@ where
 
     if matches.is_present("translate-enum-integer-types") {
         builder = builder.translate_enum_integer_types(true);
+    }
+
+    if matches.is_present("c-naming") {
+        builder = builder.c_naming(true);
     }
 
     let verbose = matches.is_present("verbose");

--- a/tests/expectations/tests/c_naming.rs
+++ b/tests/expectations/tests/c_naming.rs
@@ -1,0 +1,92 @@
+#![allow(
+    dead_code,
+    non_snake_case,
+    non_camel_case_types,
+    non_upper_case_globals
+)]
+
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct struct_a {
+    pub a: ::std::os::raw::c_int,
+}
+#[test]
+fn bindgen_test_layout_struct_a() {
+    assert_eq!(
+        ::std::mem::size_of::<struct_a>(),
+        4usize,
+        concat!("Size of: ", stringify!(struct_a))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<struct_a>(),
+        4usize,
+        concat!("Alignment of ", stringify!(struct_a))
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<struct_a>())).a as *const _ as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(struct_a),
+            "::",
+            stringify!(a)
+        )
+    );
+}
+pub type a = *const struct_a;
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub union union_b {
+    pub a: ::std::os::raw::c_int,
+    pub b: ::std::os::raw::c_int,
+}
+#[test]
+fn bindgen_test_layout_union_b() {
+    assert_eq!(
+        ::std::mem::size_of::<union_b>(),
+        4usize,
+        concat!("Size of: ", stringify!(union_b))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<union_b>(),
+        4usize,
+        concat!("Alignment of ", stringify!(union_b))
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<union_b>())).a as *const _ as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(union_b),
+            "::",
+            stringify!(a)
+        )
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<union_b>())).b as *const _ as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(union_b),
+            "::",
+            stringify!(b)
+        )
+    );
+}
+impl Default for union_b {
+    fn default() -> Self {
+        unsafe { ::std::mem::zeroed() }
+    }
+}
+pub type b = union_b;
+pub const enum_c_A: enum_c = 0;
+pub type enum_c = ::std::os::raw::c_uint;
+extern "C" {
+    pub fn takes_a(arg: a);
+}
+extern "C" {
+    pub fn takes_b(arg: b);
+}
+extern "C" {
+    pub fn takes_c(arg: enum_c);
+}

--- a/tests/headers/c_naming.h
+++ b/tests/headers/c_naming.h
@@ -1,0 +1,19 @@
+// bindgen-flags: --c-naming
+
+typedef const struct a {
+    int a;
+} *a;
+
+union b {
+    int a;
+    int b;
+};
+typedef union b b;
+
+enum c {
+    A,
+};
+
+void takes_a(a arg) {}
+void takes_b(b arg) {}
+void takes_c(enum c arg) {}


### PR DESCRIPTION
Implements [this idea](https://github.com/rust-lang/rust-bindgen/issues/1252#issuecomment-365240751) since I've needed bindings for [libplacebo](https://github.com/haasn/libplacebo) which has recently switched to `typedef`ing its main types in https://github.com/haasn/libplacebo/commit/dd755a09c4a22deaab82da8b4178ce8a50584b7c which bindgen can't generate valid bindings for. The problematic typedefs have this structure:
```C
typedef const struct a {
    int a;
} *a;
```

Not sure at all about the implementation and whether this is actually desired... But at least seems to work well when generating bindings for libplacebo.