### PR TITLE
codegen: signed bitfield handling

### DIFF
--- a/src/codegen/bitfield_unit.rs
+++ b/src/codegen/bitfield_unit.rs
@@ -100,3 +100,21 @@ where
         }
     }
 }
+
+#[inline]
+pub fn signed_val(val: u64, bits: usize) -> i64 {
+    if bits == 64 {
+        return val as i64;
+    }
+
+    debug_assert!(val < (1 << bits));
+
+    let is_neg = ((1 << (bits - 1)) & val) != 0;
+    if !is_neg {
+        return val as i64;
+    }
+
+    let mask = (1 << bits) as u64 - 1;
+    let val = (!(val - 1) & mask) as i64;
+    -val
+}

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -1632,6 +1632,7 @@ impl<'a> FieldCodegen<'a> for Bitfield {
                 }
             };
 
+        let is_signed = bitfield_ty.as_integer().unwrap().is_signed();
         let bitfield_ty =
             bitfield_ty.to_rust_ty_or_opaque(ctx, bitfield_ty_item);
 
@@ -1647,10 +1648,18 @@ impl<'a> FieldCodegen<'a> for Bitfield {
                 #[inline]
                 #access_spec fn #getter_name(&self) -> #bitfield_ty {
                     unsafe {
-                        ::#prefix::mem::transmute(
-                            self.#unit_field_ident.as_ref().get(#offset, #width)
-                                as #bitfield_int_ty
-                        )
+                        let val = self.#unit_field_ident.as_ref().get(
+                            #offset,
+                            #width
+                        );
+                        if (#is_signed) {
+                            ::#prefix::mem::transmute(
+                                signed_val(val, #width as usize)
+                                    as #bitfield_int_ty
+                            )
+                        } else {
+                            ::#prefix::mem::transmute(val as #bitfield_int_ty)
+                        }
                     }
                 }
 
@@ -1671,10 +1680,15 @@ impl<'a> FieldCodegen<'a> for Bitfield {
                 #[inline]
                 #access_spec fn #getter_name(&self) -> #bitfield_ty {
                     unsafe {
-                        ::#prefix::mem::transmute(
-                            self.#unit_field_ident.get(#offset, #width)
-                                as #bitfield_int_ty
-                        )
+                        let val = self.#unit_field_ident.get(#offset, #width);
+                        if (#is_signed) {
+                            ::#prefix::mem::transmute(
+                                signed_val(val, #width as usize)
+                                    as #bitfield_int_ty
+                            )
+                        } else {
+                            ::#prefix::mem::transmute(val as #bitfield_int_ty)
+                        }
                     }
                 }
 


### PR DESCRIPTION
This PR aims to fix #1160 

Now we have the correct behavior:
```
Print C walk
StructWithBitfields: a:0, b:0, c:0
StructWithBitfields: a:0, b:0, c:1
StructWithBitfields: a:0, b:0, c:-2
StructWithBitfields: a:0, b:0, c:-1
StructWithBitfields: a:0, b:0, c:0
StructWithBitfields: a:0, b:0, c:-1
StructWithBitfields: a:0, b:0, c:-2
StructWithBitfields: a:0, b:0, c:1
StructWithBitfields: a:0, b:0, c:0
Print Rust walk
c set to 0
c set to 1
c set to -2
c set to -1
c set to 0
c set to -1
c set to -2
c set to 1
c set to 0
```
Signed-off-by: Hengqi Chen <chenhengqi@outlook.com>