### PR TITLE
Zero out padding in custom Default trait implementations

### DIFF
--- a/tests/expectations/tests/16-byte-alignment.rs
+++ b/tests/expectations/tests/16-byte-alignment.rs
@@ -99,7 +99,11 @@ fn bindgen_test_layout_rte_ipv4_tuple__bindgen_ty_1() {
 }
 impl Default for rte_ipv4_tuple__bindgen_ty_1 {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[test]
@@ -143,7 +147,11 @@ fn bindgen_test_layout_rte_ipv4_tuple() {
 }
 impl Default for rte_ipv4_tuple {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[repr(C)]
@@ -240,7 +248,11 @@ fn bindgen_test_layout_rte_ipv6_tuple__bindgen_ty_1() {
 }
 impl Default for rte_ipv6_tuple__bindgen_ty_1 {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[test]
@@ -284,7 +296,11 @@ fn bindgen_test_layout_rte_ipv6_tuple() {
 }
 impl Default for rte_ipv6_tuple {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[repr(C)]
@@ -333,6 +349,10 @@ fn bindgen_test_layout_rte_thash_tuple() {
 }
 impl Default for rte_thash_tuple {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }

--- a/tests/expectations/tests/16-byte-alignment_1_0.rs
+++ b/tests/expectations/tests/16-byte-alignment_1_0.rs
@@ -390,6 +390,10 @@ impl Clone for rte_thash_tuple {
 }
 impl Default for rte_thash_tuple {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        unsafe {
+            let mut s: Self = ::std::mem::uninitialized();
+            ::std::ptr::write_bytes(&mut s, 0, 1);
+            s
+        }
     }
 }

--- a/tests/expectations/tests/allowlist_basic.rs
+++ b/tests/expectations/tests/allowlist_basic.rs
@@ -20,11 +20,19 @@ pub struct AllowlistMe_Inner<T> {
 }
 impl<T> Default for AllowlistMe_Inner<T> {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 impl<T> Default for AllowlistMe<T> {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }

--- a/tests/expectations/tests/anon-fields-prefix.rs
+++ b/tests/expectations/tests/anon-fields-prefix.rs
@@ -150,6 +150,10 @@ fn bindgen_test_layout_color() {
 }
 impl Default for color {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }

--- a/tests/expectations/tests/anon_struct_in_union.rs
+++ b/tests/expectations/tests/anon_struct_in_union.rs
@@ -74,7 +74,11 @@ fn bindgen_test_layout_s__bindgen_ty_1() {
 }
 impl Default for s__bindgen_ty_1 {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[test]
@@ -97,6 +101,10 @@ fn bindgen_test_layout_s() {
 }
 impl Default for s {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }

--- a/tests/expectations/tests/anon_union.rs
+++ b/tests/expectations/tests/anon_union.rs
@@ -38,12 +38,20 @@ pub union TErrorResult__bindgen_ty_1 {
 }
 impl Default for TErrorResult__bindgen_ty_1 {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 impl Default for TErrorResult {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[repr(C)]
@@ -65,7 +73,11 @@ fn bindgen_test_layout_ErrorResult() {
 }
 impl Default for ErrorResult {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[test]

--- a/tests/expectations/tests/anon_union_1_0.rs
+++ b/tests/expectations/tests/anon_union_1_0.rs
@@ -83,7 +83,11 @@ pub struct TErrorResult__bindgen_ty_1 {
 }
 impl Default for TErrorResult {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        unsafe {
+            let mut s: Self = ::std::mem::uninitialized();
+            ::std::ptr::write_bytes(&mut s, 0, 1);
+            s
+        }
     }
 }
 #[repr(C)]
@@ -111,7 +115,11 @@ impl Clone for ErrorResult {
 }
 impl Default for ErrorResult {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        unsafe {
+            let mut s: Self = ::std::mem::uninitialized();
+            ::std::ptr::write_bytes(&mut s, 0, 1);
+            s
+        }
     }
 }
 #[test]

--- a/tests/expectations/tests/anonymous-template-types.rs
+++ b/tests/expectations/tests/anonymous-template-types.rs
@@ -13,7 +13,11 @@ pub struct Foo<T> {
 }
 impl<T> Default for Foo<T> {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[repr(C)]
@@ -29,7 +33,11 @@ pub struct Quux<V> {
 }
 impl<V> Default for Quux<V> {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[repr(C)]

--- a/tests/expectations/tests/bad-namespace-parenthood-inheritance.rs
+++ b/tests/expectations/tests/bad-namespace-parenthood-inheritance.rs
@@ -12,7 +12,11 @@ pub struct std_char_traits {
 }
 impl Default for std_char_traits {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[repr(C)]

--- a/tests/expectations/tests/bitfield_align_2.rs
+++ b/tests/expectations/tests/bitfield_align_2.rs
@@ -121,7 +121,11 @@ fn bindgen_test_layout_TaggedPtr() {
 }
 impl Default for TaggedPtr {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 impl TaggedPtr {

--- a/tests/expectations/tests/blocklist-and-impl-debug.rs
+++ b/tests/expectations/tests/blocklist-and-impl-debug.rs
@@ -40,7 +40,11 @@ fn bindgen_test_layout_ShouldManuallyImplDebug() {
 }
 impl Default for ShouldManuallyImplDebug {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 impl ::std::fmt::Debug for ShouldManuallyImplDebug {

--- a/tests/expectations/tests/blocks-signature.rs
+++ b/tests/expectations/tests/blocks-signature.rs
@@ -76,7 +76,11 @@ fn bindgen_test_layout_contains_block_pointers() {
 }
 impl Default for contains_block_pointers {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 pub type _bindgen_ty_id_33 = *const ::block::Block<(), ()>;

--- a/tests/expectations/tests/blocks.rs
+++ b/tests/expectations/tests/blocks.rs
@@ -75,6 +75,10 @@ fn bindgen_test_layout_contains_block_pointers() {
 }
 impl Default for contains_block_pointers {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }

--- a/tests/expectations/tests/c_naming.rs
+++ b/tests/expectations/tests/c_naming.rs
@@ -75,7 +75,11 @@ fn bindgen_test_layout_union_b() {
 }
 impl Default for union_b {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 pub type b = union_b;

--- a/tests/expectations/tests/class.rs
+++ b/tests/expectations/tests/class.rs
@@ -71,7 +71,11 @@ fn bindgen_test_layout_C() {
 }
 impl Default for C {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[repr(C)]
@@ -134,7 +138,11 @@ fn bindgen_test_layout_C_with_zero_length_array() {
 }
 impl Default for C_with_zero_length_array {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[repr(C)]
@@ -203,7 +211,11 @@ fn bindgen_test_layout_C_with_incomplete_array() {
 }
 impl Default for C_with_incomplete_array {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[repr(C)]
@@ -253,7 +265,11 @@ fn bindgen_test_layout_C_with_zero_length_array_and_incomplete_array() {
 }
 impl Default for C_with_zero_length_array_and_incomplete_array {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[repr(C)]
@@ -332,7 +348,11 @@ fn bindgen_test_layout_IncompleteArrayNonCopiable() {
 }
 impl Default for IncompleteArrayNonCopiable {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[repr(C)]
@@ -366,7 +386,11 @@ fn bindgen_test_layout_Union() {
 }
 impl Default for Union {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[repr(C)]
@@ -401,7 +425,11 @@ fn bindgen_test_layout_WithUnion() {
 }
 impl Default for WithUnion {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[repr(C)]

--- a/tests/expectations/tests/class_1_0.rs
+++ b/tests/expectations/tests/class_1_0.rs
@@ -119,7 +119,11 @@ impl Clone for C {
 }
 impl Default for C {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        unsafe {
+            let mut s: Self = ::std::mem::uninitialized();
+            ::std::ptr::write_bytes(&mut s, 0, 1);
+            s
+        }
     }
 }
 impl ::std::cmp::PartialEq for C {
@@ -187,7 +191,11 @@ fn bindgen_test_layout_C_with_zero_length_array() {
 }
 impl Default for C_with_zero_length_array {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        unsafe {
+            let mut s: Self = ::std::mem::uninitialized();
+            ::std::ptr::write_bytes(&mut s, 0, 1);
+            s
+        }
     }
 }
 #[repr(C)]
@@ -256,7 +264,11 @@ fn bindgen_test_layout_C_with_incomplete_array() {
 }
 impl Default for C_with_incomplete_array {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        unsafe {
+            let mut s: Self = ::std::mem::uninitialized();
+            ::std::ptr::write_bytes(&mut s, 0, 1);
+            s
+        }
     }
 }
 #[repr(C)]
@@ -306,7 +318,11 @@ fn bindgen_test_layout_C_with_zero_length_array_and_incomplete_array() {
 }
 impl Default for C_with_zero_length_array_and_incomplete_array {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        unsafe {
+            let mut s: Self = ::std::mem::uninitialized();
+            ::std::ptr::write_bytes(&mut s, 0, 1);
+            s
+        }
     }
 }
 #[repr(C)]
@@ -385,7 +401,11 @@ fn bindgen_test_layout_IncompleteArrayNonCopiable() {
 }
 impl Default for IncompleteArrayNonCopiable {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        unsafe {
+            let mut s: Self = ::std::mem::uninitialized();
+            ::std::ptr::write_bytes(&mut s, 0, 1);
+            s
+        }
     }
 }
 #[repr(C)]

--- a/tests/expectations/tests/class_nested.rs
+++ b/tests/expectations/tests/class_nested.rs
@@ -48,7 +48,11 @@ pub struct A_D<T> {
 }
 impl<T> Default for A_D<T> {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[test]
@@ -159,11 +163,19 @@ pub struct Templated_Templated_inner<T> {
 }
 impl<T> Default for Templated_Templated_inner<T> {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 impl<T> Default for Templated<T> {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }

--- a/tests/expectations/tests/class_with_dtor.rs
+++ b/tests/expectations/tests/class_with_dtor.rs
@@ -13,7 +13,11 @@ pub struct HandleWithDtor<T> {
 }
 impl<T> Default for HandleWithDtor<T> {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 pub type HandleValue = HandleWithDtor<::std::os::raw::c_int>;
@@ -50,7 +54,11 @@ fn bindgen_test_layout_WithoutDtor() {
 }
 impl Default for WithoutDtor {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[test]

--- a/tests/expectations/tests/class_with_inner_struct.rs
+++ b/tests/expectations/tests/class_with_inner_struct.rs
@@ -87,7 +87,11 @@ fn bindgen_test_layout_A__bindgen_ty_1() {
 }
 impl Default for A__bindgen_ty_1 {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[repr(C)]
@@ -122,7 +126,11 @@ fn bindgen_test_layout_A__bindgen_ty_2() {
 }
 impl Default for A__bindgen_ty_2 {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[test]
@@ -157,7 +165,11 @@ fn bindgen_test_layout_A() {
 }
 impl Default for A {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[repr(C)]
@@ -366,7 +378,11 @@ fn bindgen_test_layout_C__bindgen_ty_1__bindgen_ty_2() {
 }
 impl Default for C__bindgen_ty_1__bindgen_ty_2 {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[test]
@@ -397,7 +413,11 @@ fn bindgen_test_layout_C__bindgen_ty_1() {
 }
 impl Default for C__bindgen_ty_1 {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[repr(C)]
@@ -463,6 +483,10 @@ fn bindgen_test_layout_C() {
 }
 impl Default for C {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }

--- a/tests/expectations/tests/class_with_inner_struct_1_0.rs
+++ b/tests/expectations/tests/class_with_inner_struct_1_0.rs
@@ -437,7 +437,11 @@ impl Clone for C__bindgen_ty_1__bindgen_ty_2 {
 }
 impl Default for C__bindgen_ty_1__bindgen_ty_2 {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        unsafe {
+            let mut s: Self = ::std::mem::uninitialized();
+            ::std::ptr::write_bytes(&mut s, 0, 1);
+            s
+        }
     }
 }
 #[test]

--- a/tests/expectations/tests/class_with_typedef.rs
+++ b/tests/expectations/tests/class_with_typedef.rs
@@ -78,7 +78,11 @@ extern "C" {
 }
 impl Default for C {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 impl C {
@@ -125,6 +129,10 @@ fn bindgen_test_layout_D() {
 }
 impl Default for D {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }

--- a/tests/expectations/tests/complex.rs
+++ b/tests/expectations/tests/complex.rs
@@ -74,7 +74,11 @@ fn bindgen_test_layout_TestDoublePtr() {
 }
 impl Default for TestDoublePtr {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[repr(C)]
@@ -140,6 +144,10 @@ fn bindgen_test_layout_TestFloatPtr() {
 }
 impl Default for TestFloatPtr {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }

--- a/tests/expectations/tests/const-const-mut-ptr.rs
+++ b/tests/expectations/tests/const-const-mut-ptr.rs
@@ -30,6 +30,10 @@ fn bindgen_test_layout_foo() {
 }
 impl Default for foo {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }

--- a/tests/expectations/tests/const_tparam.rs
+++ b/tests/expectations/tests/const_tparam.rs
@@ -14,6 +14,10 @@ pub struct C<T> {
 }
 impl<T> Default for C<T> {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }

--- a/tests/expectations/tests/constify-all-enums.rs
+++ b/tests/expectations/tests/constify-all-enums.rs
@@ -42,6 +42,10 @@ fn bindgen_test_layout_bar() {
 }
 impl Default for bar {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }

--- a/tests/expectations/tests/constify-module-enums-basic.rs
+++ b/tests/expectations/tests/constify-module-enums-basic.rs
@@ -46,7 +46,11 @@ fn bindgen_test_layout_bar() {
 }
 impl Default for bar {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 extern "C" {

--- a/tests/expectations/tests/constify-module-enums-namespace.rs
+++ b/tests/expectations/tests/constify-module-enums-namespace.rs
@@ -58,7 +58,11 @@ pub mod root {
             }
             impl Default for bar {
                 fn default() -> Self {
-                    unsafe { ::std::mem::zeroed() }
+                    let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+                    unsafe {
+                        ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+                        s.assume_init()
+                    }
                 }
             }
         }

--- a/tests/expectations/tests/constify-module-enums-shadow-name.rs
+++ b/tests/expectations/tests/constify-module-enums-shadow-name.rs
@@ -42,6 +42,10 @@ fn bindgen_test_layout_bar() {
 }
 impl Default for bar {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }

--- a/tests/expectations/tests/constify-module-enums-simple-alias.rs
+++ b/tests/expectations/tests/constify-module-enums-simple-alias.rs
@@ -109,6 +109,10 @@ fn bindgen_test_layout_Bar() {
 }
 impl Default for Bar {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }

--- a/tests/expectations/tests/constify-module-enums-simple-nonamespace.rs
+++ b/tests/expectations/tests/constify-module-enums-simple-nonamespace.rs
@@ -41,6 +41,10 @@ fn bindgen_test_layout_Bar() {
 }
 impl Default for Bar {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }

--- a/tests/expectations/tests/constify-module-enums-types.rs
+++ b/tests/expectations/tests/constify-module-enums-types.rs
@@ -168,7 +168,11 @@ fn bindgen_test_layout_bar() {
 }
 impl Default for bar {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[repr(C)]
@@ -201,7 +205,11 @@ fn bindgen_test_layout_Baz() {
 }
 impl Default for Baz {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 pub mod one_Foo {
@@ -234,7 +242,11 @@ fn bindgen_test_layout_Bar() {
 }
 impl Default for Bar {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 extern "C" {
@@ -261,7 +273,11 @@ pub struct Thing<T> {
 }
 impl<T> Default for Thing<T> {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 extern "C" {

--- a/tests/expectations/tests/convert-cpp-comment-to-rust.rs
+++ b/tests/expectations/tests/convert-cpp-comment-to-rust.rs
@@ -68,6 +68,10 @@ fn bindgen_test_layout_mbedtls_mpi() {
 }
 impl Default for mbedtls_mpi {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }

--- a/tests/expectations/tests/convert-floats.rs
+++ b/tests/expectations/tests/convert-floats.rs
@@ -85,6 +85,10 @@ fn bindgen_test_layout_foo() {
 }
 impl Default for foo {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }

--- a/tests/expectations/tests/ctypes-prefix-path.rs
+++ b/tests/expectations/tests/ctypes-prefix-path.rs
@@ -49,6 +49,10 @@ fn bindgen_test_layout_foo() {
 }
 impl Default for foo {
     fn default() -> Self {
-        unsafe { ::core::mem::zeroed() }
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }

--- a/tests/expectations/tests/default-template-parameter.rs
+++ b/tests/expectations/tests/default-template-parameter.rs
@@ -15,7 +15,11 @@ pub struct Foo<T, U> {
 }
 impl<T, U> Default for Foo<T, U> {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[test]

--- a/tests/expectations/tests/derive-bitfield-method-same-name.rs
+++ b/tests/expectations/tests/derive-bitfield-method-same-name.rs
@@ -139,7 +139,11 @@ extern "C" {
 }
 impl Default for Foo {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 impl ::std::fmt::Debug for Foo {

--- a/tests/expectations/tests/derive-clone.rs
+++ b/tests/expectations/tests/derive-clone.rs
@@ -39,6 +39,10 @@ fn bindgen_test_layout_ShouldDeriveClone() {
 }
 impl Default for ShouldDeriveClone {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }

--- a/tests/expectations/tests/derive-clone_1_0.rs
+++ b/tests/expectations/tests/derive-clone_1_0.rs
@@ -45,6 +45,10 @@ impl Clone for ShouldImplClone {
 }
 impl Default for ShouldImplClone {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        unsafe {
+            let mut s: Self = ::std::mem::uninitialized();
+            ::std::ptr::write_bytes(&mut s, 0, 1);
+            s
+        }
     }
 }

--- a/tests/expectations/tests/derive-debug-bitfield-core.rs
+++ b/tests/expectations/tests/derive-debug-bitfield-core.rs
@@ -127,7 +127,11 @@ fn bindgen_test_layout_C() {
 }
 impl Default for C {
     fn default() -> Self {
-        unsafe { ::core::mem::zeroed() }
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 impl ::core::fmt::Debug for C {

--- a/tests/expectations/tests/derive-debug-bitfield.rs
+++ b/tests/expectations/tests/derive-debug-bitfield.rs
@@ -125,7 +125,11 @@ fn bindgen_test_layout_C() {
 }
 impl Default for C {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 impl ::std::fmt::Debug for C {

--- a/tests/expectations/tests/derive-debug-function-pointer.rs
+++ b/tests/expectations/tests/derive-debug-function-pointer.rs
@@ -52,7 +52,11 @@ fn bindgen_test_layout_Nice() {
 }
 impl Default for Nice {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 impl ::std::fmt::Debug for Nice {

--- a/tests/expectations/tests/derive-debug-generic.rs
+++ b/tests/expectations/tests/derive-debug-generic.rs
@@ -12,7 +12,11 @@ pub struct Generic<T> {
 }
 impl<T> Default for Generic<T> {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 impl<T> ::std::fmt::Debug for Generic<T> {

--- a/tests/expectations/tests/derive-debug-mangle-name.rs
+++ b/tests/expectations/tests/derive-debug-mangle-name.rs
@@ -59,7 +59,11 @@ fn bindgen_test_layout_perf_event_attr__bindgen_ty_1() {
 }
 impl Default for perf_event_attr__bindgen_ty_1 {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 impl ::std::fmt::Debug for perf_event_attr__bindgen_ty_1 {
@@ -107,7 +111,11 @@ fn bindgen_test_layout_perf_event_attr() {
 }
 impl Default for perf_event_attr {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 impl ::std::fmt::Debug for perf_event_attr {

--- a/tests/expectations/tests/derive-debug-opaque-template-instantiation.rs
+++ b/tests/expectations/tests/derive-debug-opaque-template-instantiation.rs
@@ -36,7 +36,11 @@ fn bindgen_test_layout_Instance() {
 }
 impl Default for Instance {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 impl ::std::fmt::Debug for Instance {

--- a/tests/expectations/tests/derive-debug-opaque.rs
+++ b/tests/expectations/tests/derive-debug-opaque.rs
@@ -25,7 +25,11 @@ fn bindgen_test_layout_Opaque() {
 }
 impl Default for Opaque {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 impl ::std::fmt::Debug for Opaque {
@@ -64,7 +68,11 @@ fn bindgen_test_layout_OpaqueUser() {
 }
 impl Default for OpaqueUser {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 impl ::std::fmt::Debug for OpaqueUser {

--- a/tests/expectations/tests/derive-default-and-blocklist.rs
+++ b/tests/expectations/tests/derive-default-and-blocklist.rs
@@ -41,6 +41,10 @@ fn bindgen_test_layout_ShouldNotDeriveDefault() {
 }
 impl Default for ShouldNotDeriveDefault {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }

--- a/tests/expectations/tests/derive-hash-and-blocklist.rs
+++ b/tests/expectations/tests/derive-hash-and-blocklist.rs
@@ -40,6 +40,10 @@ fn bindgen_test_layout_ShouldNotDeriveHash() {
 }
 impl Default for ShouldNotDeriveHash {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }

--- a/tests/expectations/tests/derive-hash-blocklisting.rs
+++ b/tests/expectations/tests/derive-hash-blocklisting.rs
@@ -45,7 +45,11 @@ fn bindgen_test_layout_AllowlistedOne() {
 }
 impl Default for AllowlistedOne {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 /// This can't derive(Hash/Eq) even if it didn't contain a blocklisted type.
@@ -80,6 +84,10 @@ fn bindgen_test_layout_AllowlistedTwo() {
 }
 impl Default for AllowlistedTwo {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }

--- a/tests/expectations/tests/derive-hash-struct-with-pointer.rs
+++ b/tests/expectations/tests/derive-hash-struct-with-pointer.rs
@@ -38,7 +38,11 @@ fn bindgen_test_layout_ConstPtrMutObj() {
 }
 impl Default for ConstPtrMutObj {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[repr(C)]
@@ -73,7 +77,11 @@ fn bindgen_test_layout_MutPtrMutObj() {
 }
 impl Default for MutPtrMutObj {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[repr(C)]
@@ -108,7 +116,11 @@ fn bindgen_test_layout_MutPtrConstObj() {
 }
 impl Default for MutPtrConstObj {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[repr(C)]
@@ -144,6 +156,10 @@ fn bindgen_test_layout_ConstPtrConstObj() {
 }
 impl Default for ConstPtrConstObj {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }

--- a/tests/expectations/tests/derive-hash-template-def-float.rs
+++ b/tests/expectations/tests/derive-hash-template-def-float.rs
@@ -15,6 +15,10 @@ pub struct foo<T> {
 }
 impl<T> Default for foo<T> {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }

--- a/tests/expectations/tests/derive-hash-template-inst-float.rs
+++ b/tests/expectations/tests/derive-hash-template-inst-float.rs
@@ -14,7 +14,11 @@ pub struct foo<T> {
 }
 impl<T> Default for foo<T> {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 /// Can derive Hash/PartialOrd/Ord/PartialEq/Eq when instantiated with int
@@ -43,7 +47,11 @@ fn bindgen_test_layout_IntStr() {
 }
 impl Default for IntStr {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 /// Cannot derive Hash/Eq/Ord when instantiated with float but can derive PartialEq/PartialOrd
@@ -77,7 +85,11 @@ fn bindgen_test_layout_FloatStr() {
 }
 impl Default for FloatStr {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[test]

--- a/tests/expectations/tests/derive-partialeq-and-blocklist.rs
+++ b/tests/expectations/tests/derive-partialeq-and-blocklist.rs
@@ -41,6 +41,10 @@ fn bindgen_test_layout_ShouldNotDerivePartialEq() {
 }
 impl Default for ShouldNotDerivePartialEq {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }

--- a/tests/expectations/tests/derive-partialeq-anonfield.rs
+++ b/tests/expectations/tests/derive-partialeq-anonfield.rs
@@ -32,7 +32,11 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_1() {
 }
 impl Default for rte_mbuf__bindgen_ty_1 {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[test]
@@ -50,6 +54,10 @@ fn bindgen_test_layout_rte_mbuf() {
 }
 impl Default for rte_mbuf {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }

--- a/tests/expectations/tests/derive-partialeq-base.rs
+++ b/tests/expectations/tests/derive-partialeq-base.rs
@@ -35,7 +35,11 @@ fn bindgen_test_layout_Base() {
 }
 impl Default for Base {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 impl ::std::cmp::PartialEq for Base {
@@ -63,7 +67,11 @@ fn bindgen_test_layout_ShouldDerivePartialEq() {
 }
 impl Default for ShouldDerivePartialEq {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 impl ::std::cmp::PartialEq for ShouldDerivePartialEq {

--- a/tests/expectations/tests/derive-partialeq-bitfield.rs
+++ b/tests/expectations/tests/derive-partialeq-bitfield.rs
@@ -125,7 +125,11 @@ fn bindgen_test_layout_C() {
 }
 impl Default for C {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 impl ::std::cmp::PartialEq for C {

--- a/tests/expectations/tests/derive-partialeq-core.rs
+++ b/tests/expectations/tests/derive-partialeq-core.rs
@@ -39,7 +39,11 @@ fn bindgen_test_layout_C() {
 }
 impl Default for C {
     fn default() -> Self {
-        unsafe { ::core::mem::zeroed() }
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 impl ::core::cmp::PartialEq for C {

--- a/tests/expectations/tests/derive-partialeq-pointer.rs
+++ b/tests/expectations/tests/derive-partialeq-pointer.rs
@@ -30,7 +30,11 @@ fn bindgen_test_layout_Bar() {
 }
 impl Default for Bar {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[repr(C)]
@@ -58,7 +62,11 @@ fn bindgen_test_layout_c__bindgen_ty_1() {
 }
 impl Default for c__bindgen_ty_1 {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[test]
@@ -76,7 +84,11 @@ fn bindgen_test_layout_c() {
 }
 impl Default for c {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[repr(C)]
@@ -104,6 +116,10 @@ fn bindgen_test_layout_a() {
 }
 impl Default for a {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }

--- a/tests/expectations/tests/derive-partialeq-union.rs
+++ b/tests/expectations/tests/derive-partialeq-union.rs
@@ -53,6 +53,10 @@ fn bindgen_test_layout_ShouldNotDerivePartialEq() {
 }
 impl Default for ShouldNotDerivePartialEq {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }

--- a/tests/expectations/tests/derive-partialeq-union_1_0.rs
+++ b/tests/expectations/tests/derive-partialeq-union_1_0.rs
@@ -102,7 +102,11 @@ impl Clone for ShouldDerivePartialEq {
 }
 impl Default for ShouldDerivePartialEq {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        unsafe {
+            let mut s: Self = ::std::mem::uninitialized();
+            ::std::ptr::write_bytes(&mut s, 0, 1);
+            s
+        }
     }
 }
 impl ::std::cmp::PartialEq for ShouldDerivePartialEq {

--- a/tests/expectations/tests/doggo-or-null.rs
+++ b/tests/expectations/tests/doggo-or-null.rs
@@ -73,6 +73,10 @@ fn bindgen_test_layout_DoggoOrNull() {
 }
 impl Default for DoggoOrNull {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }

--- a/tests/expectations/tests/duplicated-namespaces-definitions.rs
+++ b/tests/expectations/tests/duplicated-namespaces-definitions.rs
@@ -91,7 +91,11 @@ pub mod root {
         }
         impl Default for Foo {
             fn default() -> Self {
-                unsafe { ::std::mem::zeroed() }
+                let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+                unsafe {
+                    ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+                    s.assume_init()
+                }
             }
         }
     }

--- a/tests/expectations/tests/empty-union.rs
+++ b/tests/expectations/tests/empty-union.rs
@@ -12,6 +12,10 @@ pub union a__bindgen_ty_1 {
 }
 impl Default for a__bindgen_ty_1 {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }

--- a/tests/expectations/tests/enum-default-bitfield.rs
+++ b/tests/expectations/tests/enum-default-bitfield.rs
@@ -66,7 +66,11 @@ fn bindgen_test_layout_foo() {
 }
 impl Default for foo {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 impl Foo {

--- a/tests/expectations/tests/enum-default-consts.rs
+++ b/tests/expectations/tests/enum-default-consts.rs
@@ -38,7 +38,11 @@ fn bindgen_test_layout_foo() {
 }
 impl Default for foo {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 pub const Foo_Bar: Foo = 0;

--- a/tests/expectations/tests/enum-default-module.rs
+++ b/tests/expectations/tests/enum-default-module.rs
@@ -40,7 +40,11 @@ fn bindgen_test_layout_foo() {
 }
 impl Default for foo {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 pub mod Foo {

--- a/tests/expectations/tests/enum-default-rust.rs
+++ b/tests/expectations/tests/enum-default-rust.rs
@@ -43,7 +43,11 @@ fn bindgen_test_layout_foo() {
 }
 impl Default for foo {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[repr(u32)]

--- a/tests/expectations/tests/enum.rs
+++ b/tests/expectations/tests/enum.rs
@@ -38,7 +38,11 @@ fn bindgen_test_layout_foo() {
 }
 impl Default for foo {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 pub const Foo_Bar: Foo = 0;

--- a/tests/expectations/tests/enum_and_vtable_mangling.rs
+++ b/tests/expectations/tests/enum_and_vtable_mangling.rs
@@ -41,7 +41,11 @@ fn bindgen_test_layout_C() {
 }
 impl Default for C {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 extern "C" {

--- a/tests/expectations/tests/extern-const-struct.rs
+++ b/tests/expectations/tests/extern-const-struct.rs
@@ -37,7 +37,11 @@ fn bindgen_test_layout_nsFoo() {
 }
 impl Default for nsFoo {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 extern "C" {

--- a/tests/expectations/tests/forward-declaration-autoptr.rs
+++ b/tests/expectations/tests/forward-declaration-autoptr.rs
@@ -18,7 +18,11 @@ pub struct RefPtr<T> {
 }
 impl<T> Default for RefPtr<T> {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[repr(C)]
@@ -53,7 +57,11 @@ fn bindgen_test_layout_Bar() {
 }
 impl Default for Bar {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[test]

--- a/tests/expectations/tests/forward-inherit-struct-with-fields.rs
+++ b/tests/expectations/tests/forward-inherit-struct-with-fields.rs
@@ -14,7 +14,11 @@ pub struct js_RootedBase<T> {
 }
 impl<T> Default for js_RootedBase<T> {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[repr(C)]
@@ -25,6 +29,10 @@ pub struct Rooted<T> {
 }
 impl<T> Default for Rooted<T> {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }

--- a/tests/expectations/tests/forward-inherit-struct.rs
+++ b/tests/expectations/tests/forward-inherit-struct.rs
@@ -17,6 +17,10 @@ pub struct Rooted {
 }
 impl Default for Rooted {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }

--- a/tests/expectations/tests/forward_declared_complex_types.rs
+++ b/tests/expectations/tests/forward_declared_complex_types.rs
@@ -53,7 +53,11 @@ fn bindgen_test_layout_Bar() {
 }
 impl Default for Bar {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 extern "C" {

--- a/tests/expectations/tests/forward_declared_complex_types_1_0.rs
+++ b/tests/expectations/tests/forward_declared_complex_types_1_0.rs
@@ -68,7 +68,11 @@ impl Clone for Bar {
 }
 impl Default for Bar {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        unsafe {
+            let mut s: Self = ::std::mem::uninitialized();
+            ::std::ptr::write_bytes(&mut s, 0, 1);
+            s
+        }
     }
 }
 extern "C" {

--- a/tests/expectations/tests/incomplete-array-padding.rs
+++ b/tests/expectations/tests/incomplete-array-padding.rs
@@ -143,7 +143,11 @@ fn bindgen_test_layout_foo() {
 }
 impl Default for foo {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 impl foo {

--- a/tests/expectations/tests/inherit-from-template-instantiation-with-vtable.rs
+++ b/tests/expectations/tests/inherit-from-template-instantiation-with-vtable.rs
@@ -17,7 +17,11 @@ pub struct BaseWithVtable<T> {
 }
 impl<T> Default for BaseWithVtable<T> {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 /// This should not have an explicit vtable.
@@ -41,7 +45,11 @@ fn bindgen_test_layout_DerivedWithNoVirtualMethods() {
 }
 impl Default for DerivedWithNoVirtualMethods {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 /// This should not have an explicit vtable.
@@ -65,7 +73,11 @@ fn bindgen_test_layout_DerivedWithVirtualMethods() {
 }
 impl Default for DerivedWithVirtualMethods {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 /// This should not have any vtable.
@@ -77,7 +89,11 @@ pub struct BaseWithoutVtable<U> {
 }
 impl<U> Default for BaseWithoutVtable<U> {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[repr(C)]
@@ -104,7 +120,11 @@ fn bindgen_test_layout_DerivedWithVtable() {
 }
 impl Default for DerivedWithVtable {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 /// This should not have any vtable.
@@ -128,7 +148,11 @@ fn bindgen_test_layout_DerivedWithoutVtable() {
 }
 impl Default for DerivedWithoutVtable {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[test]

--- a/tests/expectations/tests/inherit-namespaced.rs
+++ b/tests/expectations/tests/inherit-namespaced.rs
@@ -17,6 +17,10 @@ pub struct Rooted {
 }
 impl Default for Rooted {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }

--- a/tests/expectations/tests/inherit_named.rs
+++ b/tests/expectations/tests/inherit_named.rs
@@ -18,6 +18,10 @@ pub struct Weeee<T> {
 }
 impl<T> Default for Weeee<T> {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }

--- a/tests/expectations/tests/inline_namespace_no_ns_enabled.rs
+++ b/tests/expectations/tests/inline_namespace_no_ns_enabled.rs
@@ -20,7 +20,11 @@ pub struct std_basic_string_Alloc_hider {
 }
 impl Default for std_basic_string_Alloc_hider {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[repr(C)]
@@ -31,11 +35,19 @@ pub struct std_basic_string__bindgen_ty_1<CharT> {
 }
 impl<CharT> Default for std_basic_string__bindgen_ty_1<CharT> {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 impl<CharT> Default for std_basic_string<CharT> {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }

--- a/tests/expectations/tests/inner_template_self.rs
+++ b/tests/expectations/tests/inner_template_self.rs
@@ -13,7 +13,11 @@ pub struct LinkedList {
 }
 impl Default for LinkedList {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[repr(C)]
@@ -49,7 +53,11 @@ fn bindgen_test_layout_InstantiateIt() {
 }
 impl Default for InstantiateIt {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[test]

--- a/tests/expectations/tests/issue-1113-template-references.rs
+++ b/tests/expectations/tests/issue-1113-template-references.rs
@@ -15,7 +15,11 @@ pub struct Entry<K, V> {
 }
 impl<K, V> Default for Entry<K, V> {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[repr(C)]
@@ -34,6 +38,10 @@ pub struct nsBaseHashtable_EntryPtr<K, V> {
 }
 impl<K, V> Default for nsBaseHashtable_EntryPtr<K, V> {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }

--- a/tests/expectations/tests/issue-1118-using-forward-decl.rs
+++ b/tests/expectations/tests/issue-1118-using-forward-decl.rs
@@ -38,7 +38,11 @@ fn bindgen_test_layout_nsTArray_base() {
 }
 impl Default for nsTArray_base {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[repr(C)]
@@ -48,7 +52,11 @@ pub struct nsTArray {
 }
 impl Default for nsTArray {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[repr(C)]
@@ -83,7 +91,11 @@ fn bindgen_test_layout_nsIContent() {
 }
 impl Default for nsIContent {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 extern "C" {

--- a/tests/expectations/tests/issue-1197-pure-virtual-stuff.rs
+++ b/tests/expectations/tests/issue-1197-pure-virtual-stuff.rs
@@ -27,6 +27,10 @@ fn bindgen_test_layout_Foo() {
 }
 impl Default for Foo {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }

--- a/tests/expectations/tests/issue-1285.rs
+++ b/tests/expectations/tests/issue-1285.rs
@@ -55,7 +55,11 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
 }
 impl Default for foo__bindgen_ty_1 {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[test]
@@ -78,6 +82,10 @@ fn bindgen_test_layout_foo() {
 }
 impl Default for foo {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }

--- a/tests/expectations/tests/issue-1443.rs
+++ b/tests/expectations/tests/issue-1443.rs
@@ -41,7 +41,11 @@ fn bindgen_test_layout_Bar() {
 }
 impl Default for Bar {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[repr(C)]
@@ -75,7 +79,11 @@ fn bindgen_test_layout_Baz() {
 }
 impl Default for Baz {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[repr(C)]
@@ -109,7 +117,11 @@ fn bindgen_test_layout_Tar() {
 }
 impl Default for Tar {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[repr(C)]
@@ -143,6 +155,10 @@ fn bindgen_test_layout_Taz() {
 }
 impl Default for Taz {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }

--- a/tests/expectations/tests/issue-1498.rs
+++ b/tests/expectations/tests/issue-1498.rs
@@ -72,7 +72,11 @@ fn bindgen_test_layout_rte_memseg__bindgen_ty_1() {
 }
 impl Default for rte_memseg__bindgen_ty_1 {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[test]
@@ -165,6 +169,10 @@ fn bindgen_test_layout_rte_memseg() {
 }
 impl Default for rte_memseg {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }

--- a/tests/expectations/tests/issue-1514.rs
+++ b/tests/expectations/tests/issue-1514.rs
@@ -18,7 +18,11 @@ pub struct Thing_Inner<T> {
 }
 impl<T> Default for Thing_Inner<T> {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[repr(C)]
@@ -29,6 +33,10 @@ pub struct Thing_AnotherInner<T> {
 }
 impl<T> Default for Thing_AnotherInner<T> {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }

--- a/tests/expectations/tests/issue-358.rs
+++ b/tests/expectations/tests/issue-358.rs
@@ -12,7 +12,11 @@ pub struct JS_PersistentRooted {
 }
 impl Default for JS_PersistentRooted {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[repr(C)]
@@ -22,6 +26,10 @@ pub struct a {
 }
 impl Default for a {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }

--- a/tests/expectations/tests/issue-372.rs
+++ b/tests/expectations/tests/issue-372.rs
@@ -46,7 +46,11 @@ pub mod root {
     }
     impl Default for i {
         fn default() -> Self {
-            unsafe { ::std::mem::zeroed() }
+            let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+            unsafe {
+                ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+                s.assume_init()
+            }
         }
     }
     #[repr(C)]
@@ -74,7 +78,11 @@ pub mod root {
     }
     impl Default for d {
         fn default() -> Self {
-            unsafe { ::std::mem::zeroed() }
+            let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+            unsafe {
+                ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+                s.assume_init()
+            }
         }
     }
     #[repr(u32)]
@@ -117,7 +125,11 @@ pub mod root {
     }
     impl Default for F {
         fn default() -> Self {
-            unsafe { ::std::mem::zeroed() }
+            let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+            unsafe {
+                ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+                s.assume_init()
+            }
         }
     }
 }

--- a/tests/expectations/tests/issue-446.rs
+++ b/tests/expectations/tests/issue-446.rs
@@ -12,7 +12,11 @@ pub struct List {
 }
 impl Default for List {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[repr(C)]
@@ -22,6 +26,10 @@ pub struct PersistentRooted {
 }
 impl Default for PersistentRooted {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }

--- a/tests/expectations/tests/issue-493.rs
+++ b/tests/expectations/tests/issue-493.rs
@@ -65,7 +65,11 @@ pub struct basic_string___long {
 }
 impl Default for basic_string___long {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 pub const basic_string___min_cap: basic_string__bindgen_ty_1 =
@@ -87,12 +91,20 @@ pub union basic_string___short__bindgen_ty_1 {
 }
 impl Default for basic_string___short__bindgen_ty_1 {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 impl Default for basic_string___short {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[repr(C)]
@@ -104,7 +116,11 @@ pub struct basic_string___ulx {
 }
 impl Default for basic_string___ulx {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 pub const basic_string___n_words: basic_string__bindgen_ty_2 =
@@ -121,7 +137,11 @@ pub struct basic_string___raw {
 }
 impl Default for basic_string___raw {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[repr(C)]
@@ -138,11 +158,19 @@ pub struct basic_string___rep__bindgen_ty_1 {
 }
 impl Default for basic_string___rep__bindgen_ty_1 {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 impl Default for basic_string___rep {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }

--- a/tests/expectations/tests/issue-493_1_0.rs
+++ b/tests/expectations/tests/issue-493_1_0.rs
@@ -65,7 +65,11 @@ pub struct basic_string___long {
 }
 impl Default for basic_string___long {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        unsafe {
+            let mut s: Self = ::std::mem::uninitialized();
+            ::std::ptr::write_bytes(&mut s, 0, 1);
+            s
+        }
     }
 }
 pub const basic_string___min_cap: basic_string__bindgen_ty_1 =
@@ -90,7 +94,11 @@ pub struct basic_string___short__bindgen_ty_1 {
 }
 impl Default for basic_string___short {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        unsafe {
+            let mut s: Self = ::std::mem::uninitialized();
+            ::std::ptr::write_bytes(&mut s, 0, 1);
+            s
+        }
     }
 }
 #[repr(C)]
@@ -114,7 +122,11 @@ pub struct basic_string___raw {
 }
 impl Default for basic_string___raw {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        unsafe {
+            let mut s: Self = ::std::mem::uninitialized();
+            ::std::ptr::write_bytes(&mut s, 0, 1);
+            s
+        }
     }
 }
 #[repr(C)]

--- a/tests/expectations/tests/issue-544-stylo-creduce-2.rs
+++ b/tests/expectations/tests/issue-544-stylo-creduce-2.rs
@@ -13,6 +13,10 @@ pub type Foo_FirstAlias = [u8; 0usize];
 pub type Foo_SecondAlias = [u8; 0usize];
 impl Default for Foo {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }

--- a/tests/expectations/tests/issue-569-non-type-template-params-causing-layout-test-failures.rs
+++ b/tests/expectations/tests/issue-569-non-type-template-params-causing-layout-test-failures.rs
@@ -21,7 +21,11 @@ pub struct JS_Base {
 }
 impl Default for JS_Base {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[repr(C)]
@@ -44,7 +48,11 @@ fn bindgen_test_layout_JS_AutoIdVector() {
 }
 impl Default for JS_AutoIdVector {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[test]

--- a/tests/expectations/tests/issue-584-stylo-template-analysis-panic.rs
+++ b/tests/expectations/tests/issue-584-stylo-template-analysis-panic.rs
@@ -33,7 +33,11 @@ pub struct e<c> {
 }
 impl<c> Default for e<c> {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[repr(C)]
@@ -65,7 +69,11 @@ fn bindgen_test_layout_g() {
 }
 impl Default for g {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[repr(C)]
@@ -87,7 +95,11 @@ fn bindgen_test_layout_b() {
 }
 impl Default for b {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 extern "C" {

--- a/tests/expectations/tests/issue-638-stylo-cannot-find-T-in-this-scope.rs
+++ b/tests/expectations/tests/issue-638-stylo-cannot-find-T-in-this-scope.rs
@@ -13,7 +13,11 @@ pub struct RefPtr<T> {
 }
 impl<T> Default for RefPtr<T> {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[repr(C)]
@@ -25,6 +29,10 @@ pub struct UsesRefPtrWithAliasedTypeParam<U> {
 pub type UsesRefPtrWithAliasedTypeParam_V<U> = U;
 impl<U> Default for UsesRefPtrWithAliasedTypeParam<U> {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }

--- a/tests/expectations/tests/issue-643-inner-struct.rs
+++ b/tests/expectations/tests/issue-643-inner-struct.rs
@@ -120,7 +120,11 @@ fn bindgen_test_layout_rte_ring() {
 }
 impl Default for rte_ring {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[repr(C)]

--- a/tests/expectations/tests/issue-645-cannot-find-type-T-in-this-scope.rs
+++ b/tests/expectations/tests/issue-645-cannot-find-type-T-in-this-scope.rs
@@ -16,6 +16,10 @@ pub struct HasRefPtr<T> {
 pub type HasRefPtr_TypedefOfT<T> = T;
 impl<T> Default for HasRefPtr<T> {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }

--- a/tests/expectations/tests/issue-648-derive-debug-with-padding.rs
+++ b/tests/expectations/tests/issue-648-derive-debug-with-padding.rs
@@ -40,7 +40,11 @@ fn bindgen_test_layout_NoDebug() {
 }
 impl Default for NoDebug {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 impl ::std::cmp::PartialEq for NoDebug {
@@ -100,7 +104,11 @@ fn bindgen_test_layout_ShouldDeriveDebugButDoesNot() {
 }
 impl Default for ShouldDeriveDebugButDoesNot {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 impl ::std::cmp::PartialEq for ShouldDeriveDebugButDoesNot {

--- a/tests/expectations/tests/issue-662-cannot-find-T-in-this-scope.rs
+++ b/tests/expectations/tests/issue-662-cannot-find-T-in-this-scope.rs
@@ -13,7 +13,11 @@ pub struct RefPtr<T> {
 }
 impl<T> Default for RefPtr<T> {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[repr(C)]
@@ -24,7 +28,11 @@ pub struct nsMainThreadPtrHolder<T> {
 }
 impl<T> Default for nsMainThreadPtrHolder<T> {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[repr(C)]
@@ -35,6 +43,10 @@ pub struct nsMainThreadPtrHandle<T> {
 }
 impl<T> Default for nsMainThreadPtrHandle<T> {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }

--- a/tests/expectations/tests/issue-662-part-2.rs
+++ b/tests/expectations/tests/issue-662-part-2.rs
@@ -16,7 +16,11 @@ pub struct nsMainThreadPtrHolder<T> {
 }
 impl<T> Default for nsMainThreadPtrHolder<T> {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[repr(C)]
@@ -26,6 +30,10 @@ pub struct nsMainThreadPtrHandle<U> {
 }
 impl<U> Default for nsMainThreadPtrHandle<U> {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }

--- a/tests/expectations/tests/issue-691-template-parameter-virtual.rs
+++ b/tests/expectations/tests/issue-691-template-parameter-virtual.rs
@@ -27,7 +27,11 @@ fn bindgen_test_layout_VirtualMethods() {
 }
 impl Default for VirtualMethods {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[repr(C)]
@@ -55,7 +59,11 @@ fn bindgen_test_layout_ServoElementSnapshotTable() {
 }
 impl Default for ServoElementSnapshotTable {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[test]

--- a/tests/expectations/tests/issue-848-replacement-system-include.rs
+++ b/tests/expectations/tests/issue-848-replacement-system-include.rs
@@ -19,7 +19,11 @@ pub struct nsTArray<T> {
 }
 impl<T> Default for nsTArray<T> {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 extern "C" {

--- a/tests/expectations/tests/issue-944-derive-copy-and-blocklisting.rs
+++ b/tests/expectations/tests/issue-944-derive-copy-and-blocklisting.rs
@@ -39,6 +39,10 @@ fn bindgen_test_layout_ShouldNotBeCopy() {
 }
 impl Default for ShouldNotBeCopy {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }

--- a/tests/expectations/tests/jsval_layout_opaque.rs
+++ b/tests/expectations/tests/jsval_layout_opaque.rs
@@ -211,7 +211,11 @@ fn bindgen_test_layout_jsval_layout__bindgen_ty_1() {
 }
 impl Default for jsval_layout__bindgen_ty_1 {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 impl jsval_layout__bindgen_ty_1 {
@@ -331,7 +335,11 @@ fn bindgen_test_layout_jsval_layout__bindgen_ty_2__bindgen_ty_1() {
 }
 impl Default for jsval_layout__bindgen_ty_2__bindgen_ty_1 {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[test]
@@ -362,7 +370,11 @@ fn bindgen_test_layout_jsval_layout__bindgen_ty_2() {
 }
 impl Default for jsval_layout__bindgen_ty_2 {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[test]
@@ -467,7 +479,11 @@ fn bindgen_test_layout_jsval_layout() {
 }
 impl Default for jsval_layout {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[repr(C)]
@@ -500,6 +516,10 @@ fn bindgen_test_layout_Value() {
 }
 impl Default for Value {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }

--- a/tests/expectations/tests/jsval_layout_opaque_1_0.rs
+++ b/tests/expectations/tests/jsval_layout_opaque_1_0.rs
@@ -260,7 +260,11 @@ impl Clone for jsval_layout__bindgen_ty_1 {
 }
 impl Default for jsval_layout__bindgen_ty_1 {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        unsafe {
+            let mut s: Self = ::std::mem::uninitialized();
+            ::std::ptr::write_bytes(&mut s, 0, 1);
+            s
+        }
     }
 }
 impl jsval_layout__bindgen_ty_1 {

--- a/tests/expectations/tests/layout.rs
+++ b/tests/expectations/tests/layout.rs
@@ -19,6 +19,10 @@ fn bindgen_test_layout_header() {
 }
 impl Default for header {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        unsafe {
+            let mut s: Self = ::std::mem::uninitialized();
+            ::std::ptr::write_bytes(&mut s, 0, 1);
+            s
+        }
     }
 }

--- a/tests/expectations/tests/layout_align.rs
+++ b/tests/expectations/tests/layout_align.rs
@@ -150,7 +150,11 @@ fn bindgen_test_layout_rte_kni_fifo() {
 }
 impl Default for rte_kni_fifo {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[repr(C)]

--- a/tests/expectations/tests/layout_array.rs
+++ b/tests/expectations/tests/layout_array.rs
@@ -160,7 +160,11 @@ fn bindgen_test_layout_rte_mempool_ops() {
 }
 impl Default for rte_mempool_ops {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 impl ::std::cmp::PartialEq for rte_mempool_ops {
@@ -279,7 +283,11 @@ fn bindgen_test_layout_rte_mempool_ops_table() {
 }
 impl Default for rte_mempool_ops_table {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 /// Structure to hold malloc heap
@@ -325,7 +333,11 @@ fn bindgen_test_layout_malloc_heap__bindgen_ty_1() {
 }
 impl Default for malloc_heap__bindgen_ty_1 {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[test]
@@ -394,7 +406,11 @@ fn bindgen_test_layout_malloc_heap() {
 }
 impl Default for malloc_heap {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 impl ::std::cmp::PartialEq for malloc_heap {

--- a/tests/expectations/tests/layout_array_too_long.rs
+++ b/tests/expectations/tests/layout_array_too_long.rs
@@ -78,7 +78,11 @@ fn bindgen_test_layout_ip_frag() {
 }
 impl Default for ip_frag {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 /// @internal <src addr, dst_addr, id> to uniquely indetify fragmented datagram.
@@ -209,7 +213,11 @@ fn bindgen_test_layout_ip_frag_pkt__bindgen_ty_1() {
 }
 impl Default for ip_frag_pkt__bindgen_ty_1 {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[test]
@@ -314,7 +322,11 @@ fn bindgen_test_layout_ip_frag_pkt() {
 }
 impl Default for ip_frag_pkt {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 impl ::std::cmp::PartialEq for ip_frag_pkt {

--- a/tests/expectations/tests/layout_cmdline_token.rs
+++ b/tests/expectations/tests/layout_cmdline_token.rs
@@ -54,7 +54,11 @@ fn bindgen_test_layout_cmdline_token_hdr() {
 }
 impl Default for cmdline_token_hdr {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 pub type cmdline_parse_token_hdr_t = cmdline_token_hdr;
@@ -221,7 +225,11 @@ fn bindgen_test_layout_cmdline_token_num_data() {
 }
 impl Default for cmdline_token_num_data {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[repr(C)]
@@ -271,7 +279,11 @@ fn bindgen_test_layout_cmdline_token_num() {
 }
 impl Default for cmdline_token_num {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 pub type cmdline_parse_token_num_t = cmdline_token_num;

--- a/tests/expectations/tests/layout_eth_conf.rs
+++ b/tests/expectations/tests/layout_eth_conf.rs
@@ -212,7 +212,11 @@ fn bindgen_test_layout_rte_eth_rxmode() {
 }
 impl Default for rte_eth_rxmode {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 impl rte_eth_rxmode {
@@ -459,7 +463,11 @@ fn bindgen_test_layout_rte_eth_txmode() {
 }
 impl Default for rte_eth_txmode {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 impl rte_eth_txmode {
@@ -607,7 +615,11 @@ fn bindgen_test_layout_rte_eth_rss_conf() {
 }
 impl Default for rte_eth_rss_conf {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[repr(u32)]
@@ -801,7 +813,11 @@ fn bindgen_test_layout_rte_eth_vmdq_dcb_conf() {
 }
 impl Default for rte_eth_vmdq_dcb_conf {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[repr(C)]
@@ -853,7 +869,11 @@ fn bindgen_test_layout_rte_eth_dcb_rx_conf() {
 }
 impl Default for rte_eth_dcb_rx_conf {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[repr(C)]
@@ -905,7 +925,11 @@ fn bindgen_test_layout_rte_eth_vmdq_dcb_tx_conf() {
 }
 impl Default for rte_eth_vmdq_dcb_tx_conf {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[repr(C)]
@@ -957,7 +981,11 @@ fn bindgen_test_layout_rte_eth_dcb_tx_conf() {
 }
 impl Default for rte_eth_dcb_tx_conf {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[repr(C)]
@@ -994,7 +1022,11 @@ fn bindgen_test_layout_rte_eth_vmdq_tx_conf() {
 }
 impl Default for rte_eth_vmdq_tx_conf {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[repr(C)]
@@ -1171,7 +1203,11 @@ fn bindgen_test_layout_rte_eth_vmdq_rx_conf() {
 }
 impl Default for rte_eth_vmdq_rx_conf {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[repr(u32)]
@@ -1600,7 +1636,11 @@ fn bindgen_test_layout_rte_eth_flex_payload_cfg() {
 }
 impl Default for rte_eth_flex_payload_cfg {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 /// A structure used to define FDIR masks for flexible payload
@@ -1729,7 +1769,11 @@ fn bindgen_test_layout_rte_eth_fdir_flex_conf() {
 }
 impl Default for rte_eth_fdir_flex_conf {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 /// A structure used to configure the Flow Director (FDIR) feature
@@ -1841,7 +1885,11 @@ fn bindgen_test_layout_rte_fdir_conf() {
 }
 impl Default for rte_fdir_conf {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 /// A structure used to enable/disable specific device interrupts.
@@ -2002,7 +2050,11 @@ fn bindgen_test_layout_rte_eth_conf__bindgen_ty_1() {
 }
 impl Default for rte_eth_conf__bindgen_ty_1 {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[repr(C)]
@@ -2066,7 +2118,11 @@ fn bindgen_test_layout_rte_eth_conf__bindgen_ty_2() {
 }
 impl Default for rte_eth_conf__bindgen_ty_2 {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[test]
@@ -2199,6 +2255,10 @@ fn bindgen_test_layout_rte_eth_conf() {
 }
 impl Default for rte_eth_conf {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }

--- a/tests/expectations/tests/layout_eth_conf_1_0.rs
+++ b/tests/expectations/tests/layout_eth_conf_1_0.rs
@@ -260,7 +260,11 @@ impl Clone for rte_eth_rxmode {
 }
 impl Default for rte_eth_rxmode {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        unsafe {
+            let mut s: Self = ::std::mem::uninitialized();
+            ::std::ptr::write_bytes(&mut s, 0, 1);
+            s
+        }
     }
 }
 impl rte_eth_rxmode {
@@ -512,7 +516,11 @@ impl Clone for rte_eth_txmode {
 }
 impl Default for rte_eth_txmode {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        unsafe {
+            let mut s: Self = ::std::mem::uninitialized();
+            ::std::ptr::write_bytes(&mut s, 0, 1);
+            s
+        }
     }
 }
 impl rte_eth_txmode {
@@ -665,7 +673,11 @@ impl Clone for rte_eth_rss_conf {
 }
 impl Default for rte_eth_rss_conf {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        unsafe {
+            let mut s: Self = ::std::mem::uninitialized();
+            ::std::ptr::write_bytes(&mut s, 0, 1);
+            s
+        }
     }
 }
 #[repr(u32)]
@@ -869,7 +881,11 @@ impl Clone for rte_eth_vmdq_dcb_conf {
 }
 impl Default for rte_eth_vmdq_dcb_conf {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        unsafe {
+            let mut s: Self = ::std::mem::uninitialized();
+            ::std::ptr::write_bytes(&mut s, 0, 1);
+            s
+        }
     }
 }
 #[repr(C)]
@@ -926,7 +942,11 @@ impl Clone for rte_eth_dcb_rx_conf {
 }
 impl Default for rte_eth_dcb_rx_conf {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        unsafe {
+            let mut s: Self = ::std::mem::uninitialized();
+            ::std::ptr::write_bytes(&mut s, 0, 1);
+            s
+        }
     }
 }
 #[repr(C)]
@@ -983,7 +1003,11 @@ impl Clone for rte_eth_vmdq_dcb_tx_conf {
 }
 impl Default for rte_eth_vmdq_dcb_tx_conf {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        unsafe {
+            let mut s: Self = ::std::mem::uninitialized();
+            ::std::ptr::write_bytes(&mut s, 0, 1);
+            s
+        }
     }
 }
 #[repr(C)]
@@ -1040,7 +1064,11 @@ impl Clone for rte_eth_dcb_tx_conf {
 }
 impl Default for rte_eth_dcb_tx_conf {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        unsafe {
+            let mut s: Self = ::std::mem::uninitialized();
+            ::std::ptr::write_bytes(&mut s, 0, 1);
+            s
+        }
     }
 }
 #[repr(C)]
@@ -1082,7 +1110,11 @@ impl Clone for rte_eth_vmdq_tx_conf {
 }
 impl Default for rte_eth_vmdq_tx_conf {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        unsafe {
+            let mut s: Self = ::std::mem::uninitialized();
+            ::std::ptr::write_bytes(&mut s, 0, 1);
+            s
+        }
     }
 }
 #[repr(C)]
@@ -1269,7 +1301,11 @@ impl Clone for rte_eth_vmdq_rx_conf {
 }
 impl Default for rte_eth_vmdq_rx_conf {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        unsafe {
+            let mut s: Self = ::std::mem::uninitialized();
+            ::std::ptr::write_bytes(&mut s, 0, 1);
+            s
+        }
     }
 }
 #[repr(u32)]
@@ -1718,7 +1754,11 @@ impl Clone for rte_eth_flex_payload_cfg {
 }
 impl Default for rte_eth_flex_payload_cfg {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        unsafe {
+            let mut s: Self = ::std::mem::uninitialized();
+            ::std::ptr::write_bytes(&mut s, 0, 1);
+            s
+        }
     }
 }
 /// A structure used to define FDIR masks for flexible payload
@@ -1857,7 +1897,11 @@ impl Clone for rte_eth_fdir_flex_conf {
 }
 impl Default for rte_eth_fdir_flex_conf {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        unsafe {
+            let mut s: Self = ::std::mem::uninitialized();
+            ::std::ptr::write_bytes(&mut s, 0, 1);
+            s
+        }
     }
 }
 /// A structure used to configure the Flow Director (FDIR) feature
@@ -1974,7 +2018,11 @@ impl Clone for rte_fdir_conf {
 }
 impl Default for rte_fdir_conf {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        unsafe {
+            let mut s: Self = ::std::mem::uninitialized();
+            ::std::ptr::write_bytes(&mut s, 0, 1);
+            s
+        }
     }
 }
 /// A structure used to enable/disable specific device interrupts.
@@ -2145,7 +2193,11 @@ impl Clone for rte_eth_conf__bindgen_ty_1 {
 }
 impl Default for rte_eth_conf__bindgen_ty_1 {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        unsafe {
+            let mut s: Self = ::std::mem::uninitialized();
+            ::std::ptr::write_bytes(&mut s, 0, 1);
+            s
+        }
     }
 }
 #[repr(C)]
@@ -2348,6 +2400,10 @@ impl Clone for rte_eth_conf {
 }
 impl Default for rte_eth_conf {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        unsafe {
+            let mut s: Self = ::std::mem::uninitialized();
+            ::std::ptr::write_bytes(&mut s, 0, 1);
+            s
+        }
     }
 }

--- a/tests/expectations/tests/layout_kni_mbuf.rs
+++ b/tests/expectations/tests/layout_kni_mbuf.rs
@@ -222,6 +222,10 @@ fn bindgen_test_layout_rte_kni_mbuf() {
 }
 impl Default for rte_kni_mbuf {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }

--- a/tests/expectations/tests/layout_large_align_field.rs
+++ b/tests/expectations/tests/layout_large_align_field.rs
@@ -108,7 +108,11 @@ fn bindgen_test_layout_ip_frag() {
 }
 impl Default for ip_frag {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 /// @internal <src addr, dst_addr, id> to uniquely indetify fragmented datagram.
@@ -239,7 +243,11 @@ fn bindgen_test_layout_ip_frag_pkt__bindgen_ty_1() {
 }
 impl Default for ip_frag_pkt__bindgen_ty_1 {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[test]
@@ -344,7 +352,11 @@ fn bindgen_test_layout_ip_frag_pkt() {
 }
 impl Default for ip_frag_pkt {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[repr(C)]
@@ -394,7 +406,11 @@ fn bindgen_test_layout_ip_pkt_list() {
 }
 impl Default for ip_pkt_list {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 /// fragmentation table statistics
@@ -508,7 +524,11 @@ fn bindgen_test_layout_ip_frag_tbl_stat() {
 }
 impl Default for ip_frag_tbl_stat {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 /// fragmentation table
@@ -695,7 +715,11 @@ fn bindgen_test_layout_rte_ip_frag_tbl() {
 }
 impl Default for rte_ip_frag_tbl {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 ///< fragment mbuf

--- a/tests/expectations/tests/layout_mbuf.rs
+++ b/tests/expectations/tests/layout_mbuf.rs
@@ -231,7 +231,11 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_1() {
 }
 impl Default for rte_mbuf__bindgen_ty_1 {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[repr(C)]
@@ -433,7 +437,11 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_2() {
 }
 impl Default for rte_mbuf__bindgen_ty_2 {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[repr(C)]
@@ -514,7 +522,11 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1() {
 }
 impl Default for rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1 {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[test]
@@ -551,7 +563,11 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_3__bindgen_ty_1() {
 }
 impl Default for rte_mbuf__bindgen_ty_3__bindgen_ty_1 {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[repr(C)]
@@ -672,7 +688,11 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_3() {
 }
 impl Default for rte_mbuf__bindgen_ty_3 {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[repr(C)]
@@ -724,7 +744,11 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_4() {
 }
 impl Default for rte_mbuf__bindgen_ty_4 {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[repr(C)]
@@ -907,7 +931,11 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_5() {
 }
 impl Default for rte_mbuf__bindgen_ty_5 {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[test]
@@ -1180,7 +1208,11 @@ fn bindgen_test_layout_rte_mbuf() {
 }
 impl Default for rte_mbuf {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 ///< Pool from which mbuf was allocated.

--- a/tests/expectations/tests/layout_mbuf_1_0.rs
+++ b/tests/expectations/tests/layout_mbuf_1_0.rs
@@ -1254,7 +1254,11 @@ fn bindgen_test_layout_rte_mbuf() {
 }
 impl Default for rte_mbuf {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        unsafe {
+            let mut s: Self = ::std::mem::uninitialized();
+            ::std::ptr::write_bytes(&mut s, 0, 1);
+            s
+        }
     }
 }
 ///< Pool from which mbuf was allocated.

--- a/tests/expectations/tests/libclang-3.9/issue-769-bad-instantiation-test.rs
+++ b/tests/expectations/tests/libclang-3.9/issue-769-bad-instantiation-test.rs
@@ -17,7 +17,11 @@ pub mod root {
     }
     impl<T> Default for Rooted<T> {
         fn default() -> Self {
-            unsafe { ::std::mem::zeroed() }
+            let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+            unsafe {
+                ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+                s.assume_init()
+            }
         }
     }
     #[test]

--- a/tests/expectations/tests/libclang-4/issue-769-bad-instantiation-test.rs
+++ b/tests/expectations/tests/libclang-4/issue-769-bad-instantiation-test.rs
@@ -17,7 +17,11 @@ pub mod root {
     }
     impl<T> Default for Rooted<T> {
         fn default() -> Self {
-            unsafe { ::std::mem::zeroed() }
+            let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+            unsafe {
+                ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+                s.assume_init()
+            }
         }
     }
     pub type AutoValueVector_Alias = ::std::os::raw::c_int;

--- a/tests/expectations/tests/libclang-4/type_alias_template_specialized.rs
+++ b/tests/expectations/tests/libclang-4/type_alias_template_specialized.rs
@@ -35,7 +35,11 @@ fn bindgen_test_layout_Rooted() {
 }
 impl Default for Rooted {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 /// <div rustbindgen replaces="MaybeWrapped"></div>

--- a/tests/expectations/tests/libclang-5/issue-769-bad-instantiation-test.rs
+++ b/tests/expectations/tests/libclang-5/issue-769-bad-instantiation-test.rs
@@ -17,7 +17,11 @@ pub mod root {
     }
     impl<T> Default for Rooted<T> {
         fn default() -> Self {
-            unsafe { ::std::mem::zeroed() }
+            let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+            unsafe {
+                ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+                s.assume_init()
+            }
         }
     }
     pub type AutoValueVector_Alias = ::std::os::raw::c_int;

--- a/tests/expectations/tests/libclang-5/type_alias_template_specialized.rs
+++ b/tests/expectations/tests/libclang-5/type_alias_template_specialized.rs
@@ -35,7 +35,11 @@ fn bindgen_test_layout_Rooted() {
 }
 impl Default for Rooted {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 /// <div rustbindgen replaces="MaybeWrapped"></div>

--- a/tests/expectations/tests/libclang-9/class.rs
+++ b/tests/expectations/tests/libclang-9/class.rs
@@ -71,7 +71,11 @@ fn bindgen_test_layout_C() {
 }
 impl Default for C {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[repr(C)]
@@ -134,7 +138,11 @@ fn bindgen_test_layout_C_with_zero_length_array() {
 }
 impl Default for C_with_zero_length_array {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[repr(C)]
@@ -242,7 +250,11 @@ fn bindgen_test_layout_C_with_incomplete_array() {
 }
 impl Default for C_with_incomplete_array {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[repr(C)]
@@ -378,7 +390,11 @@ fn bindgen_test_layout_C_with_zero_length_array_and_incomplete_array() {
 }
 impl Default for C_with_zero_length_array_and_incomplete_array {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[repr(C)]
@@ -528,7 +544,11 @@ fn bindgen_test_layout_IncompleteArrayNonCopiable() {
 }
 impl Default for IncompleteArrayNonCopiable {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[repr(C)]
@@ -562,7 +582,11 @@ fn bindgen_test_layout_Union() {
 }
 impl Default for Union {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[repr(C)]
@@ -597,7 +621,11 @@ fn bindgen_test_layout_WithUnion() {
 }
 impl Default for WithUnion {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[repr(C)]

--- a/tests/expectations/tests/libclang-9/class_1_0.rs
+++ b/tests/expectations/tests/libclang-9/class_1_0.rs
@@ -119,7 +119,11 @@ impl Clone for C {
 }
 impl Default for C {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        unsafe {
+            let mut s: Self = ::std::mem::uninitialized();
+            ::std::ptr::write_bytes(&mut s, 0, 1);
+            s
+        }
     }
 }
 impl ::std::cmp::PartialEq for C {
@@ -187,7 +191,11 @@ fn bindgen_test_layout_C_with_zero_length_array() {
 }
 impl Default for C_with_zero_length_array {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        unsafe {
+            let mut s: Self = ::std::mem::uninitialized();
+            ::std::ptr::write_bytes(&mut s, 0, 1);
+            s
+        }
     }
 }
 #[repr(C)]
@@ -295,7 +303,11 @@ fn bindgen_test_layout_C_with_incomplete_array() {
 }
 impl Default for C_with_incomplete_array {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        unsafe {
+            let mut s: Self = ::std::mem::uninitialized();
+            ::std::ptr::write_bytes(&mut s, 0, 1);
+            s
+        }
     }
 }
 #[repr(C)]
@@ -431,7 +443,11 @@ fn bindgen_test_layout_C_with_zero_length_array_and_incomplete_array() {
 }
 impl Default for C_with_zero_length_array_and_incomplete_array {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        unsafe {
+            let mut s: Self = ::std::mem::uninitialized();
+            ::std::ptr::write_bytes(&mut s, 0, 1);
+            s
+        }
     }
 }
 #[repr(C)]
@@ -581,7 +597,11 @@ fn bindgen_test_layout_IncompleteArrayNonCopiable() {
 }
 impl Default for IncompleteArrayNonCopiable {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        unsafe {
+            let mut s: Self = ::std::mem::uninitialized();
+            ::std::ptr::write_bytes(&mut s, 0, 1);
+            s
+        }
     }
 }
 #[repr(C)]

--- a/tests/expectations/tests/libclang-9/incomplete-array-padding.rs
+++ b/tests/expectations/tests/libclang-9/incomplete-array-padding.rs
@@ -148,7 +148,11 @@ fn bindgen_test_layout_foo() {
 }
 impl Default for foo {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 impl foo {

--- a/tests/expectations/tests/libclang-9/issue-643-inner-struct.rs
+++ b/tests/expectations/tests/libclang-9/issue-643-inner-struct.rs
@@ -168,7 +168,11 @@ fn bindgen_test_layout_rte_ring() {
 }
 impl Default for rte_ring {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[repr(C)]

--- a/tests/expectations/tests/libclang-9/issue-769-bad-instantiation-test.rs
+++ b/tests/expectations/tests/libclang-9/issue-769-bad-instantiation-test.rs
@@ -17,7 +17,11 @@ pub mod root {
     }
     impl<T> Default for Rooted<T> {
         fn default() -> Self {
-            unsafe { ::std::mem::zeroed() }
+            let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+            unsafe {
+                ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+                s.assume_init()
+            }
         }
     }
     pub type AutoValueVector_Alias = ::std::os::raw::c_int;

--- a/tests/expectations/tests/libclang-9/layout_align.rs
+++ b/tests/expectations/tests/libclang-9/layout_align.rs
@@ -211,7 +211,11 @@ fn bindgen_test_layout_rte_kni_fifo() {
 }
 impl Default for rte_kni_fifo {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[repr(C)]

--- a/tests/expectations/tests/libclang-9/type_alias_template_specialized.rs
+++ b/tests/expectations/tests/libclang-9/type_alias_template_specialized.rs
@@ -35,7 +35,11 @@ fn bindgen_test_layout_Rooted() {
 }
 impl Default for Rooted {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 /// <div rustbindgen replaces="MaybeWrapped"></div>

--- a/tests/expectations/tests/namespace.rs
+++ b/tests/expectations/tests/namespace.rs
@@ -66,7 +66,11 @@ pub mod root {
     }
     impl<T> Default for C<T> {
         fn default() -> Self {
-            unsafe { ::std::mem::zeroed() }
+            let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+            unsafe {
+                ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+                s.assume_init()
+            }
         }
     }
     pub mod w {
@@ -82,7 +86,11 @@ pub mod root {
         }
         impl<T> Default for D<T> {
             fn default() -> Self {
-                unsafe { ::std::mem::zeroed() }
+                let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+                unsafe {
+                    ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+                    s.assume_init()
+                }
             }
         }
         extern "C" {

--- a/tests/expectations/tests/nested_vtable.rs
+++ b/tests/expectations/tests/nested_vtable.rs
@@ -27,7 +27,11 @@ fn bindgen_test_layout_nsISupports() {
 }
 impl Default for nsISupports {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 extern "C" {
@@ -56,7 +60,11 @@ fn bindgen_test_layout_nsIRunnable() {
 }
 impl Default for nsIRunnable {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[repr(C)]
@@ -79,6 +87,10 @@ fn bindgen_test_layout_Runnable() {
 }
 impl Default for Runnable {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }

--- a/tests/expectations/tests/no-derive-debug.rs
+++ b/tests/expectations/tests/no-derive-debug.rs
@@ -44,6 +44,10 @@ fn bindgen_test_layout_bar() {
 }
 impl Default for bar {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }

--- a/tests/expectations/tests/no-recursive-allowlisting.rs
+++ b/tests/expectations/tests/no-recursive-allowlisting.rs
@@ -32,6 +32,10 @@ fn bindgen_test_layout_Foo() {
 }
 impl Default for Foo {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }

--- a/tests/expectations/tests/no-std.rs
+++ b/tests/expectations/tests/no-std.rs
@@ -47,6 +47,10 @@ fn bindgen_test_layout_foo() {
 }
 impl Default for foo {
     fn default() -> Self {
-        unsafe { ::core::mem::zeroed() }
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }

--- a/tests/expectations/tests/no_debug_bypass_impl_debug.rs
+++ b/tests/expectations/tests/no_debug_bypass_impl_debug.rs
@@ -12,7 +12,11 @@ pub struct Generic<T> {
 }
 impl<T> Default for Generic<T> {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 impl<T> ::std::fmt::Debug for Generic<T> {
@@ -27,6 +31,10 @@ pub struct NoDebug<T> {
 }
 impl<T> Default for NoDebug<T> {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }

--- a/tests/expectations/tests/no_default.rs
+++ b/tests/expectations/tests/no_default.rs
@@ -18,6 +18,10 @@ pub struct DefaultButWaitDerived {
 }
 impl Default for DefaultButWaitDerived {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }

--- a/tests/expectations/tests/no_default_bypass_derive_default.rs
+++ b/tests/expectations/tests/no_default_bypass_derive_default.rs
@@ -12,7 +12,11 @@ pub struct Generic<T> {
 }
 impl<T> Default for Generic<T> {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[repr(C)]

--- a/tests/expectations/tests/nsBaseHashtable.rs
+++ b/tests/expectations/tests/nsBaseHashtable.rs
@@ -31,7 +31,11 @@ pub struct nsBaseHashtable_LookupResult {
 }
 impl Default for nsBaseHashtable_LookupResult {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[repr(C)]
@@ -42,11 +46,19 @@ pub struct nsBaseHashtable_EntryPtr {
 }
 impl Default for nsBaseHashtable_EntryPtr {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 impl Default for nsBaseHashtable {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }

--- a/tests/expectations/tests/nsStyleAutoArray.rs
+++ b/tests/expectations/tests/nsStyleAutoArray.rs
@@ -13,7 +13,11 @@ pub struct nsTArray<T> {
 }
 impl<T> Default for nsTArray<T> {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[repr(C)]
@@ -30,6 +34,10 @@ pub enum nsStyleAutoArray_WithSingleInitialElement {
 }
 impl<T> Default for nsStyleAutoArray<T> {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }

--- a/tests/expectations/tests/objc_interface_type.rs
+++ b/tests/expectations/tests/objc_interface_type.rs
@@ -59,7 +59,11 @@ fn bindgen_test_layout_FooStruct() {
 }
 impl Default for FooStruct {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 extern "C" {

--- a/tests/expectations/tests/opaque-template-inst-member-2.rs
+++ b/tests/expectations/tests/opaque-template-inst-member-2.rs
@@ -93,6 +93,10 @@ fn bindgen_test_layout_InheritsOpaqueTemplate() {
 }
 impl Default for InheritsOpaqueTemplate {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }

--- a/tests/expectations/tests/opaque-template-inst-member.rs
+++ b/tests/expectations/tests/opaque-template-inst-member.rs
@@ -58,7 +58,11 @@ fn bindgen_test_layout_ContainsOpaqueTemplate() {
 }
 impl Default for ContainsOpaqueTemplate {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 impl ::std::cmp::PartialEq for ContainsOpaqueTemplate {
@@ -101,7 +105,11 @@ fn bindgen_test_layout_InheritsOpaqueTemplate() {
 }
 impl Default for InheritsOpaqueTemplate {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 impl ::std::cmp::PartialEq for InheritsOpaqueTemplate {

--- a/tests/expectations/tests/opaque-template-instantiation-namespaced.rs
+++ b/tests/expectations/tests/opaque-template-instantiation-namespaced.rs
@@ -21,7 +21,11 @@ pub mod root {
         }
         impl<T> Default for Template<T> {
             fn default() -> Self {
-                unsafe { ::std::mem::zeroed() }
+                let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+                unsafe {
+                    ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+                    s.assume_init()
+                }
             }
         }
         #[repr(C)]
@@ -117,7 +121,11 @@ pub mod root {
         }
         impl Default for ContainsInstantiation {
             fn default() -> Self {
-                unsafe { ::std::mem::zeroed() }
+                let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+                unsafe {
+                    ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+                    s.assume_init()
+                }
             }
         }
         #[repr(C)]

--- a/tests/expectations/tests/opaque-template-instantiation.rs
+++ b/tests/expectations/tests/opaque-template-instantiation.rs
@@ -13,7 +13,11 @@ pub struct Template<T> {
 }
 impl<T> Default for Template<T> {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[repr(C)]
@@ -49,7 +53,11 @@ fn bindgen_test_layout_ContainsInstantiation() {
 }
 impl Default for ContainsInstantiation {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[repr(C)]

--- a/tests/expectations/tests/opaque_pointer.rs
+++ b/tests/expectations/tests/opaque_pointer.rs
@@ -90,6 +90,10 @@ fn bindgen_test_layout_WithOpaquePtr() {
 }
 impl Default for WithOpaquePtr {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }

--- a/tests/expectations/tests/packed-vtable.rs
+++ b/tests/expectations/tests/packed-vtable.rs
@@ -28,7 +28,11 @@ fn bindgen_test_layout_PackedVtable() {
 }
 impl Default for PackedVtable {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        unsafe {
+            let mut s: Self = ::std::mem::uninitialized();
+            ::std::ptr::write_bytes(&mut s, 0, 1);
+            s
+        }
     }
 }
 extern "C" {

--- a/tests/expectations/tests/private_fields.rs
+++ b/tests/expectations/tests/private_fields.rs
@@ -498,7 +498,11 @@ fn bindgen_test_layout_WithAnonUnion__bindgen_ty_1() {
 }
 impl Default for WithAnonUnion__bindgen_ty_1 {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[test]
@@ -516,6 +520,10 @@ fn bindgen_test_layout_WithAnonUnion() {
 }
 impl Default for WithAnonUnion {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }

--- a/tests/expectations/tests/ref_argument_array.rs
+++ b/tests/expectations/tests/ref_argument_array.rs
@@ -28,7 +28,11 @@ fn bindgen_test_layout_nsID() {
 }
 impl Default for nsID {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 extern "C" {

--- a/tests/expectations/tests/replace_template_alias.rs
+++ b/tests/expectations/tests/replace_template_alias.rs
@@ -17,6 +17,10 @@ pub struct JS_Rooted<T> {
 }
 impl<T> Default for JS_Rooted<T> {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }

--- a/tests/expectations/tests/replaces_double.rs
+++ b/tests/expectations/tests/replaces_double.rs
@@ -13,7 +13,11 @@ pub struct Wrapper_Wrapped<T> {
 }
 impl<T> Default for Wrapper_Wrapped<T> {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 pub type Wrapper_Type<T> = Wrapper_Wrapped<T>;
@@ -27,6 +31,10 @@ pub struct Rooted<T> {
 pub type Rooted_MaybeWrapped<T> = T;
 impl<T> Default for Rooted<T> {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }

--- a/tests/expectations/tests/size_t_is_usize.rs
+++ b/tests/expectations/tests/size_t_is_usize.rs
@@ -42,6 +42,10 @@ fn bindgen_test_layout_A() {
 }
 impl Default for A {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }

--- a/tests/expectations/tests/struct_containing_forward_declared_struct.rs
+++ b/tests/expectations/tests/struct_containing_forward_declared_struct.rs
@@ -30,7 +30,11 @@ fn bindgen_test_layout_a() {
 }
 impl Default for a {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[repr(C)]

--- a/tests/expectations/tests/struct_typedef.rs
+++ b/tests/expectations/tests/struct_typedef.rs
@@ -69,7 +69,11 @@ fn bindgen_test_layout__bindgen_ty_1() {
 }
 impl Default for _bindgen_ty_1 {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 pub type struct_ptr_t = *mut _bindgen_ty_1;

--- a/tests/expectations/tests/struct_with_anon_struct_pointer.rs
+++ b/tests/expectations/tests/struct_with_anon_struct_pointer.rs
@@ -73,6 +73,10 @@ fn bindgen_test_layout_foo() {
 }
 impl Default for foo {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }

--- a/tests/expectations/tests/struct_with_anon_union.rs
+++ b/tests/expectations/tests/struct_with_anon_union.rs
@@ -55,7 +55,11 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
 }
 impl Default for foo__bindgen_ty_1 {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[test]
@@ -78,6 +82,10 @@ fn bindgen_test_layout_foo() {
 }
 impl Default for foo {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }

--- a/tests/expectations/tests/struct_with_anon_unnamed_union.rs
+++ b/tests/expectations/tests/struct_with_anon_unnamed_union.rs
@@ -55,7 +55,11 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
 }
 impl Default for foo__bindgen_ty_1 {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[test]
@@ -73,6 +77,10 @@ fn bindgen_test_layout_foo() {
 }
 impl Default for foo {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }

--- a/tests/expectations/tests/struct_with_derive_debug.rs
+++ b/tests/expectations/tests/struct_with_derive_debug.rs
@@ -65,7 +65,11 @@ fn bindgen_test_layout_BigArray() {
 }
 impl Default for BigArray {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[repr(C)]
@@ -130,6 +134,10 @@ fn bindgen_test_layout_WithBigArray() {
 }
 impl Default for WithBigArray {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }

--- a/tests/expectations/tests/struct_with_large_array.rs
+++ b/tests/expectations/tests/struct_with_large_array.rs
@@ -37,7 +37,11 @@ fn bindgen_test_layout_S() {
 }
 impl Default for S {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[repr(C)]
@@ -47,6 +51,10 @@ pub struct ST<T> {
 }
 impl<T> Default for ST<T> {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }

--- a/tests/expectations/tests/struct_with_nesting.rs
+++ b/tests/expectations/tests/struct_with_nesting.rs
@@ -163,7 +163,11 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
 }
 impl Default for foo__bindgen_ty_1 {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[test]
@@ -186,6 +190,10 @@ fn bindgen_test_layout_foo() {
 }
 impl Default for foo {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }

--- a/tests/expectations/tests/template-param-usage-0.rs
+++ b/tests/expectations/tests/template-param-usage-0.rs
@@ -13,6 +13,10 @@ pub struct UsesTemplateParameter<T> {
 }
 impl<T> Default for UsesTemplateParameter<T> {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }

--- a/tests/expectations/tests/template-param-usage-10.rs
+++ b/tests/expectations/tests/template-param-usage-10.rs
@@ -24,11 +24,19 @@ pub struct DoublyIndirectUsage_IndirectUsage<T, U> {
 }
 impl<T, U> Default for DoublyIndirectUsage_IndirectUsage<T, U> {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 impl<T, U> Default for DoublyIndirectUsage<T, U> {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }

--- a/tests/expectations/tests/template-param-usage-12.rs
+++ b/tests/expectations/tests/template-param-usage-12.rs
@@ -13,7 +13,11 @@ pub struct BaseUsesT<T> {
 }
 impl<T> Default for BaseUsesT<T> {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[repr(C)]
@@ -25,6 +29,10 @@ pub struct CrtpUsesU<U> {
 }
 impl<U> Default for CrtpUsesU<U> {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }

--- a/tests/expectations/tests/template-param-usage-13.rs
+++ b/tests/expectations/tests/template-param-usage-13.rs
@@ -19,6 +19,10 @@ pub struct CrtpUsesU<U> {
 }
 impl<U> Default for CrtpUsesU<U> {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }

--- a/tests/expectations/tests/template-param-usage-14.rs
+++ b/tests/expectations/tests/template-param-usage-14.rs
@@ -18,6 +18,10 @@ pub struct CrtpIgnoresU {
 }
 impl Default for CrtpIgnoresU {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }

--- a/tests/expectations/tests/template-param-usage-15.rs
+++ b/tests/expectations/tests/template-param-usage-15.rs
@@ -13,7 +13,11 @@ pub struct BaseUsesT<T> {
 }
 impl<T> Default for BaseUsesT<T> {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[repr(C)]
@@ -24,6 +28,10 @@ pub struct CrtpIgnoresU {
 }
 impl Default for CrtpIgnoresU {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }

--- a/tests/expectations/tests/template-param-usage-2.rs
+++ b/tests/expectations/tests/template-param-usage-2.rs
@@ -19,11 +19,19 @@ pub struct UsesTemplateParameter_AlsoUsesTemplateParameter<T> {
 }
 impl<T> Default for UsesTemplateParameter_AlsoUsesTemplateParameter<T> {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 impl<T> Default for UsesTemplateParameter<T> {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }

--- a/tests/expectations/tests/template-param-usage-3.rs
+++ b/tests/expectations/tests/template-param-usage-3.rs
@@ -23,11 +23,19 @@ impl<T, U> Default
     for UsesTemplateParameter_AlsoUsesTemplateParameterAndMore<T, U>
 {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 impl<T> Default for UsesTemplateParameter<T> {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }

--- a/tests/expectations/tests/template-param-usage-4.rs
+++ b/tests/expectations/tests/template-param-usage-4.rs
@@ -18,6 +18,10 @@ pub struct UsesTemplateParameter_DoesNotUseTemplateParameters {
 }
 impl<T> Default for UsesTemplateParameter<T> {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }

--- a/tests/expectations/tests/template-param-usage-5.rs
+++ b/tests/expectations/tests/template-param-usage-5.rs
@@ -14,6 +14,10 @@ pub struct IndirectlyUsesTemplateParameter<T> {
 pub type IndirectlyUsesTemplateParameter_Aliased<T> = T;
 impl<T> Default for IndirectlyUsesTemplateParameter<T> {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }

--- a/tests/expectations/tests/template-param-usage-7.rs
+++ b/tests/expectations/tests/template-param-usage-7.rs
@@ -15,7 +15,11 @@ pub struct DoesNotUseU<T, V> {
 }
 impl<T, V> Default for DoesNotUseU<T, V> {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 pub type Alias = DoesNotUseU<::std::os::raw::c_int, ::std::os::raw::c_char>;

--- a/tests/expectations/tests/template-param-usage-8.rs
+++ b/tests/expectations/tests/template-param-usage-8.rs
@@ -17,6 +17,10 @@ pub type IndirectUsage_Typedefed<T> = T;
 pub type IndirectUsage_Aliased<U> = U;
 impl<T, U> Default for IndirectUsage<T, U> {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }

--- a/tests/expectations/tests/template-param-usage-9.rs
+++ b/tests/expectations/tests/template-param-usage-9.rs
@@ -22,6 +22,10 @@ pub struct DoesNotUse_IndirectUsage<T, U> {
 }
 impl<T, U> Default for DoesNotUse_IndirectUsage<T, U> {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }

--- a/tests/expectations/tests/template.rs
+++ b/tests/expectations/tests/template.rs
@@ -15,7 +15,11 @@ pub struct Foo<T> {
 }
 impl<T> Default for Foo<T> {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[repr(C)]
@@ -26,7 +30,11 @@ pub struct B<T> {
 }
 impl<T> Default for B<T> {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 extern "C" {
@@ -231,7 +239,11 @@ fn bindgen_test_layout_C() {
 }
 impl Default for C {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[repr(C)]
@@ -249,12 +261,20 @@ pub struct D_U<Z> {
 }
 impl<Z> Default for D_U<Z> {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 impl Default for D {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[repr(C)]
@@ -267,7 +287,11 @@ pub struct Rooted<T> {
 }
 impl<T> Default for Rooted<T> {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[repr(C)]
@@ -303,7 +327,11 @@ fn bindgen_test_layout_RootedContainer() {
 }
 impl Default for RootedContainer {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 pub type WithDtorIntFwd = WithDtor<::std::os::raw::c_int>;
@@ -315,7 +343,11 @@ pub struct WithDtor<T> {
 }
 impl<T> Default for WithDtor<T> {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[repr(C)]
@@ -351,7 +383,11 @@ fn bindgen_test_layout_PODButContainsDtor() {
 }
 impl Default for PODButContainsDtor {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 /// <div rustbindgen opaque>
@@ -399,7 +435,11 @@ pub struct NestedReplaced<T> {
 }
 impl<T> Default for NestedReplaced<T> {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[repr(C)]
@@ -410,7 +450,11 @@ pub struct NestedBase<T> {
 }
 impl<T> Default for NestedBase<T> {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[repr(C)]
@@ -423,7 +467,11 @@ pub struct NestedContainer<T> {
 }
 impl<T> Default for NestedContainer<T> {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[repr(C)]
@@ -434,7 +482,11 @@ pub struct Incomplete<T> {
 }
 impl<T> Default for Incomplete<T> {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[repr(C)]
@@ -472,7 +524,11 @@ pub struct ReplacedWithoutDestructor<T> {
 }
 impl<T> Default for ReplacedWithoutDestructor<T> {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[repr(C)]
@@ -483,7 +539,11 @@ pub struct ShouldNotBeCopiable<T> {
 }
 impl<T> Default for ShouldNotBeCopiable<T> {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[repr(C)]
@@ -494,7 +554,11 @@ pub struct ShouldNotBeCopiableAsWell<U> {
 }
 impl<U> Default for ShouldNotBeCopiableAsWell<U> {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 /// If the replacement doesn't happen at the parse level the container would be
@@ -509,7 +573,11 @@ pub struct ReplacedWithoutDestructorFwd<T> {
 }
 impl<T> Default for ReplacedWithoutDestructorFwd<T> {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[test]

--- a/tests/expectations/tests/template_alias.rs
+++ b/tests/expectations/tests/template_alias.rs
@@ -14,6 +14,10 @@ pub struct JS_Rooted<T> {
 }
 impl<T> Default for JS_Rooted<T> {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }

--- a/tests/expectations/tests/template_alias_namespace.rs
+++ b/tests/expectations/tests/template_alias_namespace.rs
@@ -26,7 +26,11 @@ pub mod root {
         }
         impl<T> Default for Rooted<T> {
             fn default() -> Self {
-                unsafe { ::std::mem::zeroed() }
+                let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+                unsafe {
+                    ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+                    s.assume_init()
+                }
             }
         }
     }

--- a/tests/expectations/tests/template_typedef_transitive_param.rs
+++ b/tests/expectations/tests/template_typedef_transitive_param.rs
@@ -18,7 +18,11 @@ pub struct Wrapper_Wrapped<T> {
 }
 impl<T> Default for Wrapper_Wrapped<T> {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 pub type Wrapper_Type<T> = Wrapper_Wrapped<T>;

--- a/tests/expectations/tests/timex.rs
+++ b/tests/expectations/tests/timex.rs
@@ -123,7 +123,11 @@ fn bindgen_test_layout_timex() {
 }
 impl Default for timex {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[repr(C)]
@@ -160,6 +164,10 @@ fn bindgen_test_layout_timex_named() {
 }
 impl Default for timex_named {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }

--- a/tests/expectations/tests/transform-op.rs
+++ b/tests/expectations/tests/transform-op.rs
@@ -57,7 +57,11 @@ pub struct StylePoint<T> {
 }
 impl<T> Default for StylePoint<T> {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        unsafe {
+            let mut s: Self = ::std::mem::uninitialized();
+            ::std::ptr::write_bytes(&mut s, 0, 1);
+            s
+        }
     }
 }
 #[repr(C)]
@@ -86,7 +90,11 @@ pub struct StyleFoo_Foo_Body<T> {
 }
 impl<T> Default for StyleFoo_Foo_Body<T> {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        unsafe {
+            let mut s: Self = ::std::mem::uninitialized();
+            ::std::ptr::write_bytes(&mut s, 0, 1);
+            s
+        }
     }
 }
 #[repr(C)]
@@ -98,7 +106,11 @@ pub struct StyleFoo_Bar_Body<T> {
 }
 impl<T> Default for StyleFoo_Bar_Body<T> {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        unsafe {
+            let mut s: Self = ::std::mem::uninitialized();
+            ::std::ptr::write_bytes(&mut s, 0, 1);
+            s
+        }
     }
 }
 #[repr(C)]
@@ -110,7 +122,11 @@ pub struct StyleFoo_Baz_Body<T> {
 }
 impl<T> Default for StyleFoo_Baz_Body<T> {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        unsafe {
+            let mut s: Self = ::std::mem::uninitialized();
+            ::std::ptr::write_bytes(&mut s, 0, 1);
+            s
+        }
     }
 }
 #[repr(C)]
@@ -120,7 +136,11 @@ pub struct StyleFoo__bindgen_ty_1 {
 }
 impl Default for StyleFoo__bindgen_ty_1 {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        unsafe {
+            let mut s: Self = ::std::mem::uninitialized();
+            ::std::ptr::write_bytes(&mut s, 0, 1);
+            s
+        }
     }
 }
 #[repr(C)]
@@ -145,7 +165,11 @@ pub struct StyleBar_StyleBar1_Body<T> {
 }
 impl<T> Default for StyleBar_StyleBar1_Body<T> {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        unsafe {
+            let mut s: Self = ::std::mem::uninitialized();
+            ::std::ptr::write_bytes(&mut s, 0, 1);
+            s
+        }
     }
 }
 #[repr(C)]
@@ -156,7 +180,11 @@ pub struct StyleBar_StyleBar2_Body<T> {
 }
 impl<T> Default for StyleBar_StyleBar2_Body<T> {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        unsafe {
+            let mut s: Self = ::std::mem::uninitialized();
+            ::std::ptr::write_bytes(&mut s, 0, 1);
+            s
+        }
     }
 }
 #[repr(C)]
@@ -167,7 +195,11 @@ pub struct StyleBar_StyleBar3_Body<T> {
 }
 impl<T> Default for StyleBar_StyleBar3_Body<T> {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        unsafe {
+            let mut s: Self = ::std::mem::uninitialized();
+            ::std::ptr::write_bytes(&mut s, 0, 1);
+            s
+        }
     }
 }
 #[repr(C)]
@@ -181,7 +213,11 @@ pub struct StyleBar__bindgen_ty_1<T> {
 }
 impl<T> Default for StyleBar<T> {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        unsafe {
+            let mut s: Self = ::std::mem::uninitialized();
+            ::std::ptr::write_bytes(&mut s, 0, 1);
+            s
+        }
     }
 }
 #[test]

--- a/tests/expectations/tests/type_alias_partial_template_especialization.rs
+++ b/tests/expectations/tests/type_alias_partial_template_especialization.rs
@@ -14,6 +14,10 @@ pub struct Rooted<T> {
 }
 impl<T> Default for Rooted<T> {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }

--- a/tests/expectations/tests/typeref.rs
+++ b/tests/expectations/tests/typeref.rs
@@ -65,12 +65,20 @@ pub union mozilla_StyleShapeSource__bindgen_ty_1 {
 }
 impl Default for mozilla_StyleShapeSource__bindgen_ty_1 {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 impl Default for mozilla_StyleShapeSource {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[repr(C)]
@@ -98,7 +106,11 @@ fn bindgen_test_layout_Bar() {
 }
 impl Default for Bar {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[repr(C)]
@@ -130,7 +142,11 @@ fn bindgen_test_layout_nsFoo() {
 }
 impl Default for nsFoo {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[test]

--- a/tests/expectations/tests/typeref_1_0.rs
+++ b/tests/expectations/tests/typeref_1_0.rs
@@ -149,7 +149,11 @@ impl Clone for Bar {
 }
 impl Default for Bar {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        unsafe {
+            let mut s: Self = ::std::mem::uninitialized();
+            ::std::ptr::write_bytes(&mut s, 0, 1);
+            s
+        }
     }
 }
 #[repr(C)]

--- a/tests/expectations/tests/union-align.rs
+++ b/tests/expectations/tests/union-align.rs
@@ -31,7 +31,11 @@ fn bindgen_test_layout_Bar() {
 }
 impl Default for Bar {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        unsafe {
+            let mut s: Self = ::std::mem::uninitialized();
+            ::std::ptr::write_bytes(&mut s, 0, 1);
+            s
+        }
     }
 }
 #[repr(C)]
@@ -60,6 +64,10 @@ fn bindgen_test_layout_Baz() {
 }
 impl Default for Baz {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        unsafe {
+            let mut s: Self = ::std::mem::uninitialized();
+            ::std::ptr::write_bytes(&mut s, 0, 1);
+            s
+        }
     }
 }

--- a/tests/expectations/tests/union-in-ns.rs
+++ b/tests/expectations/tests/union-in-ns.rs
@@ -39,7 +39,11 @@ pub mod root {
     }
     impl Default for bar {
         fn default() -> Self {
-            unsafe { ::std::mem::zeroed() }
+            let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+            unsafe {
+                ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+                s.assume_init()
+            }
         }
     }
 }

--- a/tests/expectations/tests/union_bitfield.rs
+++ b/tests/expectations/tests/union_bitfield.rs
@@ -113,7 +113,11 @@ fn bindgen_test_layout_U4() {
 }
 impl Default for U4 {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 impl U4 {
@@ -165,7 +169,11 @@ fn bindgen_test_layout_B() {
 }
 impl Default for B {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 impl B {

--- a/tests/expectations/tests/union_bitfield_1_0.rs
+++ b/tests/expectations/tests/union_bitfield_1_0.rs
@@ -284,7 +284,11 @@ impl Clone for HasBigBitfield {
 }
 impl Default for HasBigBitfield {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        unsafe {
+            let mut s: Self = ::std::mem::uninitialized();
+            ::std::ptr::write_bytes(&mut s, 0, 1);
+            s
+        }
     }
 }
 impl ::std::cmp::PartialEq for HasBigBitfield {

--- a/tests/expectations/tests/union_dtor.rs
+++ b/tests/expectations/tests/union_dtor.rs
@@ -53,7 +53,11 @@ extern "C" {
 }
 impl Default for UnionWithDtor {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 impl UnionWithDtor {

--- a/tests/expectations/tests/union_fields.rs
+++ b/tests/expectations/tests/union_fields.rs
@@ -64,6 +64,10 @@ fn bindgen_test_layout_nsStyleUnion() {
 }
 impl Default for nsStyleUnion {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }

--- a/tests/expectations/tests/union_template.rs
+++ b/tests/expectations/tests/union_template.rs
@@ -18,7 +18,11 @@ pub union NastyStruct__bindgen_ty_1 {
 }
 impl Default for NastyStruct__bindgen_ty_1 {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[repr(C)]
@@ -28,12 +32,20 @@ pub union NastyStruct__bindgen_ty_2 {
 }
 impl Default for NastyStruct__bindgen_ty_2 {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 impl Default for NastyStruct {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[repr(C)]
@@ -43,6 +55,10 @@ pub union Whatever {
 }
 impl Default for Whatever {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }

--- a/tests/expectations/tests/union_with_anon_struct.rs
+++ b/tests/expectations/tests/union_with_anon_struct.rs
@@ -73,6 +73,10 @@ fn bindgen_test_layout_foo() {
 }
 impl Default for foo {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }

--- a/tests/expectations/tests/union_with_anon_struct_bitfield.rs
+++ b/tests/expectations/tests/union_with_anon_struct_bitfield.rs
@@ -182,6 +182,10 @@ fn bindgen_test_layout_foo() {
 }
 impl Default for foo {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }

--- a/tests/expectations/tests/union_with_anon_union.rs
+++ b/tests/expectations/tests/union_with_anon_union.rs
@@ -55,7 +55,11 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
 }
 impl Default for foo__bindgen_ty_1 {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[test]
@@ -78,6 +82,10 @@ fn bindgen_test_layout_foo() {
 }
 impl Default for foo {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }

--- a/tests/expectations/tests/union_with_anon_unnamed_struct.rs
+++ b/tests/expectations/tests/union_with_anon_unnamed_struct.rs
@@ -109,6 +109,10 @@ fn bindgen_test_layout_pixel() {
 }
 impl Default for pixel {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }

--- a/tests/expectations/tests/union_with_anon_unnamed_union.rs
+++ b/tests/expectations/tests/union_with_anon_unnamed_union.rs
@@ -56,7 +56,11 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
 }
 impl Default for foo__bindgen_ty_1 {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[test]
@@ -79,6 +83,10 @@ fn bindgen_test_layout_foo() {
 }
 impl Default for foo {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }

--- a/tests/expectations/tests/union_with_big_member.rs
+++ b/tests/expectations/tests/union_with_big_member.rs
@@ -50,7 +50,11 @@ fn bindgen_test_layout_WithBigArray() {
 }
 impl Default for WithBigArray {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[repr(C)]
@@ -98,7 +102,11 @@ fn bindgen_test_layout_WithBigArray2() {
 }
 impl Default for WithBigArray2 {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[repr(C)]
@@ -146,6 +154,10 @@ fn bindgen_test_layout_WithBigMember() {
 }
 impl Default for WithBigMember {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }

--- a/tests/expectations/tests/union_with_big_member_1_0.rs
+++ b/tests/expectations/tests/union_with_big_member_1_0.rs
@@ -99,7 +99,11 @@ impl Clone for WithBigArray {
 }
 impl Default for WithBigArray {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        unsafe {
+            let mut s: Self = ::std::mem::uninitialized();
+            ::std::ptr::write_bytes(&mut s, 0, 1);
+            s
+        }
     }
 }
 #[repr(C)]
@@ -202,6 +206,10 @@ impl Clone for WithBigMember {
 }
 impl Default for WithBigMember {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        unsafe {
+            let mut s: Self = ::std::mem::uninitialized();
+            ::std::ptr::write_bytes(&mut s, 0, 1);
+            s
+        }
     }
 }

--- a/tests/expectations/tests/union_with_nesting.rs
+++ b/tests/expectations/tests/union_with_nesting.rs
@@ -64,7 +64,11 @@ fn bindgen_test_layout_foo__bindgen_ty_1__bindgen_ty_1() {
 }
 impl Default for foo__bindgen_ty_1__bindgen_ty_1 {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[repr(C)]
@@ -114,7 +118,11 @@ fn bindgen_test_layout_foo__bindgen_ty_1__bindgen_ty_2() {
 }
 impl Default for foo__bindgen_ty_1__bindgen_ty_2 {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[test]
@@ -132,7 +140,11 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
 }
 impl Default for foo__bindgen_ty_1 {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[test]
@@ -155,6 +167,10 @@ fn bindgen_test_layout_foo() {
 }
 impl Default for foo {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }

--- a/tests/expectations/tests/use-core.rs
+++ b/tests/expectations/tests/use-core.rs
@@ -44,7 +44,11 @@ fn bindgen_test_layout_foo() {
 }
 impl Default for foo {
     fn default() -> Self {
-        unsafe { ::core::mem::zeroed() }
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[repr(C)]
@@ -92,7 +96,11 @@ fn bindgen_test_layout__bindgen_ty_1() {
 }
 impl Default for _bindgen_ty_1 {
     fn default() -> Self {
-        unsafe { ::core::mem::zeroed() }
+        let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::core::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 extern "C" {

--- a/tests/expectations/tests/use-core_1_0.rs
+++ b/tests/expectations/tests/use-core_1_0.rs
@@ -92,7 +92,11 @@ impl Clone for foo {
 }
 impl Default for foo {
     fn default() -> Self {
-        unsafe { ::core::mem::zeroed() }
+        unsafe {
+            let mut s: Self = ::core::mem::uninitialized();
+            ::core::ptr::write_bytes(&mut s, 0, 1);
+            s
+        }
     }
 }
 #[repr(C)]

--- a/tests/expectations/tests/using.rs
+++ b/tests/expectations/tests/using.rs
@@ -14,7 +14,11 @@ pub struct Point<T> {
 }
 impl<T> Default for Point<T> {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 pub type IntPoint2D = Point<::std::os::raw::c_int>;

--- a/tests/expectations/tests/virtual_dtor.rs
+++ b/tests/expectations/tests/virtual_dtor.rs
@@ -27,7 +27,11 @@ fn bindgen_test_layout_nsSlots() {
 }
 impl Default for nsSlots {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 extern "C" {

--- a/tests/expectations/tests/virtual_inheritance.rs
+++ b/tests/expectations/tests/virtual_inheritance.rs
@@ -56,7 +56,11 @@ fn bindgen_test_layout_B() {
 }
 impl Default for B {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[repr(C)]
@@ -87,7 +91,11 @@ fn bindgen_test_layout_C() {
 }
 impl Default for C {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 #[repr(C)]
@@ -112,6 +120,10 @@ fn bindgen_test_layout_D() {
 }
 impl Default for D {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }

--- a/tests/expectations/tests/virtual_overloaded.rs
+++ b/tests/expectations/tests/virtual_overloaded.rs
@@ -27,7 +27,11 @@ fn bindgen_test_layout_C() {
 }
 impl Default for C {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 extern "C" {

--- a/tests/expectations/tests/vtable_recursive_sig.rs
+++ b/tests/expectations/tests/vtable_recursive_sig.rs
@@ -27,7 +27,11 @@ fn bindgen_test_layout_Base() {
 }
 impl Default for Base {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 extern "C" {
@@ -54,6 +58,10 @@ fn bindgen_test_layout_Derived() {
 }
 impl Default for Derived {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }

--- a/tests/expectations/tests/weird_bitfields.rs
+++ b/tests/expectations/tests/weird_bitfields.rs
@@ -286,7 +286,11 @@ fn bindgen_test_layout_Weird() {
 }
 impl Default for Weird {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 impl Weird {

--- a/tests/expectations/tests/what_is_going_on.rs
+++ b/tests/expectations/tests/what_is_going_on.rs
@@ -33,7 +33,11 @@ pub struct PointTyped<F> {
 }
 impl<F> Default for PointTyped<F> {
     fn default() -> Self {
-        unsafe { ::std::mem::zeroed() }
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
     }
 }
 pub type IntPoint = PointTyped<f32>;


### PR DESCRIPTION
Previously, we were using `std::mem::zeroed()` which unfortunately does
not necessarily zero out padding. It'd be better if the padding is
zeroed out because some libraries are sensitive to non-zero'd out bytes,
especially when forward/backward compatability is involved.

This commit ensures all bytes are zeroed out in custom Default trait
implementations.

This closes #2050 .

Note that I kept these commits separate to help with review. They should
probably be squashed before merge so tests are still bisectable.
