### PR TITLE
Fix an UB in layout tests

### DIFF
--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -2111,12 +2111,10 @@ impl CodeGenerator for CompInfo {
                                             assert_eq!(
                                                 {
                                                     // Create an instance of #canonical_ident struct from zero bit pattern
-                                                    const STRUCT_SIZE: usize = std::mem::size_of::<#canonical_ident>();
-                                                    let buffer = [0u8; STRUCT_SIZE];
                                                     let struct_instance = unsafe {
-                                                        // It's safe since #canonical_ident struct allows zero bit pattern
-                                                        std::mem::transmute::<[u8; STRUCT_SIZE], #canonical_ident>(buffer)
+                                                        std::mem::zeroed::<#canonical_ident>()
                                                     };
+
                                                     // Get the pointers to the struct and its field
                                                     let struct_ptr = &struct_instance as *const #canonical_ident;
                                                     let field_ptr = std::ptr::addr_of!(struct_instance.#field_name);

--- a/tests/expectations/tests/16-byte-alignment.rs
+++ b/tests/expectations/tests/16-byte-alignment.rs
@@ -43,10 +43,24 @@ fn bindgen_test_layout_rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1>(
-            )))
-            .dport as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<
+                rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1,
+            >();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<
+                    [u8; STRUCT_SIZE],
+                    rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1,
+                >(buffer)
+            };
+            let struct_ptr = &struct_instance
+                as *const rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1;
+            let field_ptr = std::ptr::addr_of!(struct_instance.dport);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -57,10 +71,24 @@ fn bindgen_test_layout_rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1>(
-            )))
-            .sport as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<
+                rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1,
+            >();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<
+                    [u8; STRUCT_SIZE],
+                    rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1,
+                >(buffer)
+            };
+            let struct_ptr = &struct_instance
+                as *const rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1;
+            let field_ptr = std::ptr::addr_of!(struct_instance.sport);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         2usize,
         concat!(
@@ -82,19 +110,6 @@ fn bindgen_test_layout_rte_ipv4_tuple__bindgen_ty_1() {
         ::std::mem::align_of::<rte_ipv4_tuple__bindgen_ty_1>(),
         4usize,
         concat!("Alignment of ", stringify!(rte_ipv4_tuple__bindgen_ty_1))
-    );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_ipv4_tuple__bindgen_ty_1>())).sctp_tag
-                as *const _ as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_ipv4_tuple__bindgen_ty_1),
-            "::",
-            stringify!(sctp_tag)
-        )
     );
 }
 impl Default for rte_ipv4_tuple__bindgen_ty_1 {
@@ -119,9 +134,18 @@ fn bindgen_test_layout_rte_ipv4_tuple() {
         concat!("Alignment of ", stringify!(rte_ipv4_tuple))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_ipv4_tuple>())).src_addr as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_ipv4_tuple>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_ipv4_tuple>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const rte_ipv4_tuple;
+            let field_ptr = std::ptr::addr_of!(struct_instance.src_addr);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -132,9 +156,18 @@ fn bindgen_test_layout_rte_ipv4_tuple() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_ipv4_tuple>())).dst_addr as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_ipv4_tuple>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_ipv4_tuple>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const rte_ipv4_tuple;
+            let field_ptr = std::ptr::addr_of!(struct_instance.dst_addr);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         4usize,
         concat!(
@@ -192,10 +225,24 @@ fn bindgen_test_layout_rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1>(
-            )))
-            .dport as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<
+                rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1,
+            >();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<
+                    [u8; STRUCT_SIZE],
+                    rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1,
+                >(buffer)
+            };
+            let struct_ptr = &struct_instance
+                as *const rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1;
+            let field_ptr = std::ptr::addr_of!(struct_instance.dport);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -206,10 +253,24 @@ fn bindgen_test_layout_rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1>(
-            )))
-            .sport as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<
+                rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1,
+            >();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<
+                    [u8; STRUCT_SIZE],
+                    rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1,
+                >(buffer)
+            };
+            let struct_ptr = &struct_instance
+                as *const rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1;
+            let field_ptr = std::ptr::addr_of!(struct_instance.sport);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         2usize,
         concat!(
@@ -231,19 +292,6 @@ fn bindgen_test_layout_rte_ipv6_tuple__bindgen_ty_1() {
         ::std::mem::align_of::<rte_ipv6_tuple__bindgen_ty_1>(),
         4usize,
         concat!("Alignment of ", stringify!(rte_ipv6_tuple__bindgen_ty_1))
-    );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_ipv6_tuple__bindgen_ty_1>())).sctp_tag
-                as *const _ as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_ipv6_tuple__bindgen_ty_1),
-            "::",
-            stringify!(sctp_tag)
-        )
     );
 }
 impl Default for rte_ipv6_tuple__bindgen_ty_1 {
@@ -268,9 +316,18 @@ fn bindgen_test_layout_rte_ipv6_tuple() {
         concat!("Alignment of ", stringify!(rte_ipv6_tuple))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_ipv6_tuple>())).src_addr as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_ipv6_tuple>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_ipv6_tuple>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const rte_ipv6_tuple;
+            let field_ptr = std::ptr::addr_of!(struct_instance.src_addr);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -281,9 +338,18 @@ fn bindgen_test_layout_rte_ipv6_tuple() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_ipv6_tuple>())).dst_addr as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_ipv6_tuple>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_ipv6_tuple>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const rte_ipv6_tuple;
+            let field_ptr = std::ptr::addr_of!(struct_instance.dst_addr);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         16usize,
         concat!(
@@ -321,30 +387,6 @@ fn bindgen_test_layout_rte_thash_tuple() {
         ::std::mem::align_of::<rte_thash_tuple>(),
         16usize,
         concat!("Alignment of ", stringify!(rte_thash_tuple))
-    );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_thash_tuple>())).v4 as *const _ as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_thash_tuple),
-            "::",
-            stringify!(v4)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_thash_tuple>())).v6 as *const _ as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_thash_tuple),
-            "::",
-            stringify!(v6)
-        )
     );
 }
 impl Default for rte_thash_tuple {

--- a/tests/expectations/tests/16-byte-alignment.rs
+++ b/tests/expectations/tests/16-byte-alignment.rs
@@ -44,15 +44,8 @@ fn bindgen_test_layout_rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<
-                rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1,
-            >();
-            let buffer = [0u8; STRUCT_SIZE];
             let struct_instance = unsafe {
-                std::mem::transmute::<
-                    [u8; STRUCT_SIZE],
-                    rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1,
-                >(buffer)
+                std::mem::zeroed::<rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1>()
             };
             let struct_ptr = &struct_instance
                 as *const rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1;
@@ -72,15 +65,8 @@ fn bindgen_test_layout_rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<
-                rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1,
-            >();
-            let buffer = [0u8; STRUCT_SIZE];
             let struct_instance = unsafe {
-                std::mem::transmute::<
-                    [u8; STRUCT_SIZE],
-                    rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1,
-                >(buffer)
+                std::mem::zeroed::<rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1>()
             };
             let struct_ptr = &struct_instance
                 as *const rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1;
@@ -135,11 +121,8 @@ fn bindgen_test_layout_rte_ipv4_tuple() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_ipv4_tuple>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_ipv4_tuple>(buffer)
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_ipv4_tuple>() };
             let struct_ptr = &struct_instance as *const rte_ipv4_tuple;
             let field_ptr = std::ptr::addr_of!(struct_instance.src_addr);
             let struct_address = struct_ptr as usize;
@@ -157,11 +140,8 @@ fn bindgen_test_layout_rte_ipv4_tuple() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_ipv4_tuple>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_ipv4_tuple>(buffer)
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_ipv4_tuple>() };
             let struct_ptr = &struct_instance as *const rte_ipv4_tuple;
             let field_ptr = std::ptr::addr_of!(struct_instance.dst_addr);
             let struct_address = struct_ptr as usize;
@@ -226,15 +206,8 @@ fn bindgen_test_layout_rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<
-                rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1,
-            >();
-            let buffer = [0u8; STRUCT_SIZE];
             let struct_instance = unsafe {
-                std::mem::transmute::<
-                    [u8; STRUCT_SIZE],
-                    rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1,
-                >(buffer)
+                std::mem::zeroed::<rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1>()
             };
             let struct_ptr = &struct_instance
                 as *const rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1;
@@ -254,15 +227,8 @@ fn bindgen_test_layout_rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<
-                rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1,
-            >();
-            let buffer = [0u8; STRUCT_SIZE];
             let struct_instance = unsafe {
-                std::mem::transmute::<
-                    [u8; STRUCT_SIZE],
-                    rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1,
-                >(buffer)
+                std::mem::zeroed::<rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1>()
             };
             let struct_ptr = &struct_instance
                 as *const rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1;
@@ -317,11 +283,8 @@ fn bindgen_test_layout_rte_ipv6_tuple() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_ipv6_tuple>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_ipv6_tuple>(buffer)
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_ipv6_tuple>() };
             let struct_ptr = &struct_instance as *const rte_ipv6_tuple;
             let field_ptr = std::ptr::addr_of!(struct_instance.src_addr);
             let struct_address = struct_ptr as usize;
@@ -339,11 +302,8 @@ fn bindgen_test_layout_rte_ipv6_tuple() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_ipv6_tuple>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_ipv6_tuple>(buffer)
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_ipv6_tuple>() };
             let struct_ptr = &struct_instance as *const rte_ipv6_tuple;
             let field_ptr = std::ptr::addr_of!(struct_instance.dst_addr);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/16-byte-alignment_1_0.rs
+++ b/tests/expectations/tests/16-byte-alignment_1_0.rs
@@ -88,10 +88,24 @@ fn bindgen_test_layout_rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1>(
-            )))
-            .dport as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<
+                rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1,
+            >();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<
+                    [u8; STRUCT_SIZE],
+                    rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1,
+                >(buffer)
+            };
+            let struct_ptr = &struct_instance
+                as *const rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1;
+            let field_ptr = std::ptr::addr_of!(struct_instance.dport);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -102,10 +116,24 @@ fn bindgen_test_layout_rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1>(
-            )))
-            .sport as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<
+                rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1,
+            >();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<
+                    [u8; STRUCT_SIZE],
+                    rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1,
+                >(buffer)
+            };
+            let struct_ptr = &struct_instance
+                as *const rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1;
+            let field_ptr = std::ptr::addr_of!(struct_instance.sport);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         2usize,
         concat!(
@@ -133,19 +161,6 @@ fn bindgen_test_layout_rte_ipv4_tuple__bindgen_ty_1() {
         4usize,
         concat!("Alignment of ", stringify!(rte_ipv4_tuple__bindgen_ty_1))
     );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_ipv4_tuple__bindgen_ty_1>())).sctp_tag
-                as *const _ as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_ipv4_tuple__bindgen_ty_1),
-            "::",
-            stringify!(sctp_tag)
-        )
-    );
 }
 impl Clone for rte_ipv4_tuple__bindgen_ty_1 {
     fn clone(&self) -> Self {
@@ -165,9 +180,18 @@ fn bindgen_test_layout_rte_ipv4_tuple() {
         concat!("Alignment of ", stringify!(rte_ipv4_tuple))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_ipv4_tuple>())).src_addr as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_ipv4_tuple>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_ipv4_tuple>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const rte_ipv4_tuple;
+            let field_ptr = std::ptr::addr_of!(struct_instance.src_addr);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -178,9 +202,18 @@ fn bindgen_test_layout_rte_ipv4_tuple() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_ipv4_tuple>())).dst_addr as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_ipv4_tuple>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_ipv4_tuple>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const rte_ipv4_tuple;
+            let field_ptr = std::ptr::addr_of!(struct_instance.dst_addr);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         4usize,
         concat!(
@@ -236,10 +269,24 @@ fn bindgen_test_layout_rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1>(
-            )))
-            .dport as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<
+                rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1,
+            >();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<
+                    [u8; STRUCT_SIZE],
+                    rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1,
+                >(buffer)
+            };
+            let struct_ptr = &struct_instance
+                as *const rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1;
+            let field_ptr = std::ptr::addr_of!(struct_instance.dport);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -250,10 +297,24 @@ fn bindgen_test_layout_rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1>(
-            )))
-            .sport as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<
+                rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1,
+            >();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<
+                    [u8; STRUCT_SIZE],
+                    rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1,
+                >(buffer)
+            };
+            let struct_ptr = &struct_instance
+                as *const rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1;
+            let field_ptr = std::ptr::addr_of!(struct_instance.sport);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         2usize,
         concat!(
@@ -281,19 +342,6 @@ fn bindgen_test_layout_rte_ipv6_tuple__bindgen_ty_1() {
         4usize,
         concat!("Alignment of ", stringify!(rte_ipv6_tuple__bindgen_ty_1))
     );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_ipv6_tuple__bindgen_ty_1>())).sctp_tag
-                as *const _ as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_ipv6_tuple__bindgen_ty_1),
-            "::",
-            stringify!(sctp_tag)
-        )
-    );
 }
 impl Clone for rte_ipv6_tuple__bindgen_ty_1 {
     fn clone(&self) -> Self {
@@ -313,9 +361,18 @@ fn bindgen_test_layout_rte_ipv6_tuple() {
         concat!("Alignment of ", stringify!(rte_ipv6_tuple))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_ipv6_tuple>())).src_addr as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_ipv6_tuple>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_ipv6_tuple>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const rte_ipv6_tuple;
+            let field_ptr = std::ptr::addr_of!(struct_instance.src_addr);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -326,9 +383,18 @@ fn bindgen_test_layout_rte_ipv6_tuple() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_ipv6_tuple>())).dst_addr as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_ipv6_tuple>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_ipv6_tuple>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const rte_ipv6_tuple;
+            let field_ptr = std::ptr::addr_of!(struct_instance.dst_addr);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         16usize,
         concat!(
@@ -357,30 +423,6 @@ fn bindgen_test_layout_rte_thash_tuple() {
         ::std::mem::size_of::<rte_thash_tuple>(),
         48usize,
         concat!("Size of: ", stringify!(rte_thash_tuple))
-    );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_thash_tuple>())).v4 as *const _ as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_thash_tuple),
-            "::",
-            stringify!(v4)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_thash_tuple>())).v6 as *const _ as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_thash_tuple),
-            "::",
-            stringify!(v6)
-        )
     );
 }
 impl Clone for rte_thash_tuple {

--- a/tests/expectations/tests/16-byte-alignment_1_0.rs
+++ b/tests/expectations/tests/16-byte-alignment_1_0.rs
@@ -89,15 +89,8 @@ fn bindgen_test_layout_rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<
-                rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1,
-            >();
-            let buffer = [0u8; STRUCT_SIZE];
             let struct_instance = unsafe {
-                std::mem::transmute::<
-                    [u8; STRUCT_SIZE],
-                    rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1,
-                >(buffer)
+                std::mem::zeroed::<rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1>()
             };
             let struct_ptr = &struct_instance
                 as *const rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1;
@@ -117,15 +110,8 @@ fn bindgen_test_layout_rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<
-                rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1,
-            >();
-            let buffer = [0u8; STRUCT_SIZE];
             let struct_instance = unsafe {
-                std::mem::transmute::<
-                    [u8; STRUCT_SIZE],
-                    rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1,
-                >(buffer)
+                std::mem::zeroed::<rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1>()
             };
             let struct_ptr = &struct_instance
                 as *const rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1;
@@ -181,11 +167,8 @@ fn bindgen_test_layout_rte_ipv4_tuple() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_ipv4_tuple>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_ipv4_tuple>(buffer)
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_ipv4_tuple>() };
             let struct_ptr = &struct_instance as *const rte_ipv4_tuple;
             let field_ptr = std::ptr::addr_of!(struct_instance.src_addr);
             let struct_address = struct_ptr as usize;
@@ -203,11 +186,8 @@ fn bindgen_test_layout_rte_ipv4_tuple() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_ipv4_tuple>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_ipv4_tuple>(buffer)
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_ipv4_tuple>() };
             let struct_ptr = &struct_instance as *const rte_ipv4_tuple;
             let field_ptr = std::ptr::addr_of!(struct_instance.dst_addr);
             let struct_address = struct_ptr as usize;
@@ -270,15 +250,8 @@ fn bindgen_test_layout_rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<
-                rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1,
-            >();
-            let buffer = [0u8; STRUCT_SIZE];
             let struct_instance = unsafe {
-                std::mem::transmute::<
-                    [u8; STRUCT_SIZE],
-                    rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1,
-                >(buffer)
+                std::mem::zeroed::<rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1>()
             };
             let struct_ptr = &struct_instance
                 as *const rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1;
@@ -298,15 +271,8 @@ fn bindgen_test_layout_rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<
-                rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1,
-            >();
-            let buffer = [0u8; STRUCT_SIZE];
             let struct_instance = unsafe {
-                std::mem::transmute::<
-                    [u8; STRUCT_SIZE],
-                    rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1,
-                >(buffer)
+                std::mem::zeroed::<rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1>()
             };
             let struct_ptr = &struct_instance
                 as *const rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1;
@@ -362,11 +328,8 @@ fn bindgen_test_layout_rte_ipv6_tuple() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_ipv6_tuple>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_ipv6_tuple>(buffer)
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_ipv6_tuple>() };
             let struct_ptr = &struct_instance as *const rte_ipv6_tuple;
             let field_ptr = std::ptr::addr_of!(struct_instance.src_addr);
             let struct_address = struct_ptr as usize;
@@ -384,11 +347,8 @@ fn bindgen_test_layout_rte_ipv6_tuple() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_ipv6_tuple>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_ipv6_tuple>(buffer)
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_ipv6_tuple>() };
             let struct_ptr = &struct_instance as *const rte_ipv6_tuple;
             let field_ptr = std::ptr::addr_of!(struct_instance.dst_addr);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/accessors.rs
+++ b/tests/expectations/tests/accessors.rs
@@ -30,11 +30,8 @@ fn bindgen_test_layout_SomeAccessors() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<SomeAccessors>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], SomeAccessors>(buffer)
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<SomeAccessors>() };
             let struct_ptr = &struct_instance as *const SomeAccessors;
             let field_ptr = std::ptr::addr_of!(struct_instance.mNoAccessor);
             let struct_address = struct_ptr as usize;
@@ -52,11 +49,8 @@ fn bindgen_test_layout_SomeAccessors() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<SomeAccessors>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], SomeAccessors>(buffer)
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<SomeAccessors>() };
             let struct_ptr = &struct_instance as *const SomeAccessors;
             let field_ptr = std::ptr::addr_of!(struct_instance.mBothAccessors);
             let struct_address = struct_ptr as usize;
@@ -74,11 +68,8 @@ fn bindgen_test_layout_SomeAccessors() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<SomeAccessors>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], SomeAccessors>(buffer)
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<SomeAccessors>() };
             let struct_ptr = &struct_instance as *const SomeAccessors;
             let field_ptr =
                 std::ptr::addr_of!(struct_instance.mUnsafeAccessors);
@@ -97,11 +88,8 @@ fn bindgen_test_layout_SomeAccessors() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<SomeAccessors>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], SomeAccessors>(buffer)
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<SomeAccessors>() };
             let struct_ptr = &struct_instance as *const SomeAccessors;
             let field_ptr =
                 std::ptr::addr_of!(struct_instance.mImmutableAccessor);
@@ -164,11 +152,7 @@ fn bindgen_test_layout_AllAccessors() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<AllAccessors>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], AllAccessors>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<AllAccessors>() };
             let struct_ptr = &struct_instance as *const AllAccessors;
             let field_ptr = std::ptr::addr_of!(struct_instance.mBothAccessors);
             let struct_address = struct_ptr as usize;
@@ -186,11 +170,7 @@ fn bindgen_test_layout_AllAccessors() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<AllAccessors>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], AllAccessors>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<AllAccessors>() };
             let struct_ptr = &struct_instance as *const AllAccessors;
             let field_ptr =
                 std::ptr::addr_of!(struct_instance.mAlsoBothAccessors);
@@ -247,14 +227,8 @@ fn bindgen_test_layout_AllUnsafeAccessors() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<AllUnsafeAccessors>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], AllUnsafeAccessors>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<AllUnsafeAccessors>() };
             let struct_ptr = &struct_instance as *const AllUnsafeAccessors;
             let field_ptr = std::ptr::addr_of!(struct_instance.mBothAccessors);
             let struct_address = struct_ptr as usize;
@@ -272,14 +246,8 @@ fn bindgen_test_layout_AllUnsafeAccessors() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<AllUnsafeAccessors>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], AllUnsafeAccessors>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<AllUnsafeAccessors>() };
             let struct_ptr = &struct_instance as *const AllUnsafeAccessors;
             let field_ptr =
                 std::ptr::addr_of!(struct_instance.mAlsoBothAccessors);
@@ -345,14 +313,8 @@ fn bindgen_test_layout_ContradictAccessors() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<ContradictAccessors>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], ContradictAccessors>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<ContradictAccessors>() };
             let struct_ptr = &struct_instance as *const ContradictAccessors;
             let field_ptr = std::ptr::addr_of!(struct_instance.mBothAccessors);
             let struct_address = struct_ptr as usize;
@@ -370,14 +332,8 @@ fn bindgen_test_layout_ContradictAccessors() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<ContradictAccessors>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], ContradictAccessors>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<ContradictAccessors>() };
             let struct_ptr = &struct_instance as *const ContradictAccessors;
             let field_ptr = std::ptr::addr_of!(struct_instance.mNoAccessors);
             let struct_address = struct_ptr as usize;
@@ -395,14 +351,8 @@ fn bindgen_test_layout_ContradictAccessors() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<ContradictAccessors>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], ContradictAccessors>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<ContradictAccessors>() };
             let struct_ptr = &struct_instance as *const ContradictAccessors;
             let field_ptr =
                 std::ptr::addr_of!(struct_instance.mUnsafeAccessors);
@@ -421,14 +371,8 @@ fn bindgen_test_layout_ContradictAccessors() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<ContradictAccessors>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], ContradictAccessors>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<ContradictAccessors>() };
             let struct_ptr = &struct_instance as *const ContradictAccessors;
             let field_ptr =
                 std::ptr::addr_of!(struct_instance.mImmutableAccessor);
@@ -490,11 +434,7 @@ fn bindgen_test_layout_Replaced() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<Replaced>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], Replaced>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<Replaced>() };
             let struct_ptr = &struct_instance as *const Replaced;
             let field_ptr = std::ptr::addr_of!(struct_instance.mAccessor);
             let struct_address = struct_ptr as usize;
@@ -541,11 +481,7 @@ fn bindgen_test_layout_Wrapper() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<Wrapper>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], Wrapper>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<Wrapper>() };
             let struct_ptr = &struct_instance as *const Wrapper;
             let field_ptr = std::ptr::addr_of!(struct_instance.mReplaced);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/accessors.rs
+++ b/tests/expectations/tests/accessors.rs
@@ -29,9 +29,18 @@ fn bindgen_test_layout_SomeAccessors() {
         concat!("Alignment of ", stringify!(SomeAccessors))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<SomeAccessors>())).mNoAccessor as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<SomeAccessors>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], SomeAccessors>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const SomeAccessors;
+            let field_ptr = std::ptr::addr_of!(struct_instance.mNoAccessor);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -42,9 +51,18 @@ fn bindgen_test_layout_SomeAccessors() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<SomeAccessors>())).mBothAccessors as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<SomeAccessors>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], SomeAccessors>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const SomeAccessors;
+            let field_ptr = std::ptr::addr_of!(struct_instance.mBothAccessors);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         4usize,
         concat!(
@@ -55,9 +73,19 @@ fn bindgen_test_layout_SomeAccessors() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<SomeAccessors>())).mUnsafeAccessors
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<SomeAccessors>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], SomeAccessors>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const SomeAccessors;
+            let field_ptr =
+                std::ptr::addr_of!(struct_instance.mUnsafeAccessors);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         8usize,
         concat!(
@@ -68,9 +96,19 @@ fn bindgen_test_layout_SomeAccessors() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<SomeAccessors>())).mImmutableAccessor
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<SomeAccessors>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], SomeAccessors>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const SomeAccessors;
+            let field_ptr =
+                std::ptr::addr_of!(struct_instance.mImmutableAccessor);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         12usize,
         concat!(
@@ -125,9 +163,18 @@ fn bindgen_test_layout_AllAccessors() {
         concat!("Alignment of ", stringify!(AllAccessors))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<AllAccessors>())).mBothAccessors as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<AllAccessors>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], AllAccessors>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const AllAccessors;
+            let field_ptr = std::ptr::addr_of!(struct_instance.mBothAccessors);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -138,9 +185,19 @@ fn bindgen_test_layout_AllAccessors() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<AllAccessors>())).mAlsoBothAccessors
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<AllAccessors>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], AllAccessors>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const AllAccessors;
+            let field_ptr =
+                std::ptr::addr_of!(struct_instance.mAlsoBothAccessors);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         4usize,
         concat!(
@@ -189,9 +246,21 @@ fn bindgen_test_layout_AllUnsafeAccessors() {
         concat!("Alignment of ", stringify!(AllUnsafeAccessors))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<AllUnsafeAccessors>())).mBothAccessors
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<AllUnsafeAccessors>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], AllUnsafeAccessors>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const AllUnsafeAccessors;
+            let field_ptr = std::ptr::addr_of!(struct_instance.mBothAccessors);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -202,9 +271,22 @@ fn bindgen_test_layout_AllUnsafeAccessors() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<AllUnsafeAccessors>())).mAlsoBothAccessors
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<AllUnsafeAccessors>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], AllUnsafeAccessors>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const AllUnsafeAccessors;
+            let field_ptr =
+                std::ptr::addr_of!(struct_instance.mAlsoBothAccessors);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         4usize,
         concat!(
@@ -262,9 +344,21 @@ fn bindgen_test_layout_ContradictAccessors() {
         concat!("Alignment of ", stringify!(ContradictAccessors))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<ContradictAccessors>())).mBothAccessors
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<ContradictAccessors>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], ContradictAccessors>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const ContradictAccessors;
+            let field_ptr = std::ptr::addr_of!(struct_instance.mBothAccessors);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -275,9 +369,21 @@ fn bindgen_test_layout_ContradictAccessors() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<ContradictAccessors>())).mNoAccessors
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<ContradictAccessors>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], ContradictAccessors>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const ContradictAccessors;
+            let field_ptr = std::ptr::addr_of!(struct_instance.mNoAccessors);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         4usize,
         concat!(
@@ -288,9 +394,22 @@ fn bindgen_test_layout_ContradictAccessors() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<ContradictAccessors>())).mUnsafeAccessors
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<ContradictAccessors>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], ContradictAccessors>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const ContradictAccessors;
+            let field_ptr =
+                std::ptr::addr_of!(struct_instance.mUnsafeAccessors);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         8usize,
         concat!(
@@ -301,9 +420,22 @@ fn bindgen_test_layout_ContradictAccessors() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<ContradictAccessors>())).mImmutableAccessor
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<ContradictAccessors>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], ContradictAccessors>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const ContradictAccessors;
+            let field_ptr =
+                std::ptr::addr_of!(struct_instance.mImmutableAccessor);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         12usize,
         concat!(
@@ -357,8 +489,18 @@ fn bindgen_test_layout_Replaced() {
         concat!("Alignment of ", stringify!(Replaced))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<Replaced>())).mAccessor as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<Replaced>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], Replaced>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const Replaced;
+            let field_ptr = std::ptr::addr_of!(struct_instance.mAccessor);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -398,8 +540,18 @@ fn bindgen_test_layout_Wrapper() {
         concat!("Alignment of ", stringify!(Wrapper))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<Wrapper>())).mReplaced as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<Wrapper>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], Wrapper>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const Wrapper;
+            let field_ptr = std::ptr::addr_of!(struct_instance.mReplaced);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(

--- a/tests/expectations/tests/allowlist-namespaces.rs
+++ b/tests/expectations/tests/allowlist-namespaces.rs
@@ -53,11 +53,7 @@ pub mod root {
             );
             assert_eq!(
                 {
-                    const STRUCT_SIZE: usize = std::mem::size_of::<Test>();
-                    let buffer = [0u8; STRUCT_SIZE];
-                    let struct_instance = unsafe {
-                        std::mem::transmute::<[u8; STRUCT_SIZE], Test>(buffer)
-                    };
+                    let struct_instance = unsafe { std::mem::zeroed::<Test>() };
                     let struct_ptr = &struct_instance as *const Test;
                     let field_ptr = std::ptr::addr_of!(struct_instance.helper);
                     let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/allowlist-namespaces.rs
+++ b/tests/expectations/tests/allowlist-namespaces.rs
@@ -52,8 +52,18 @@ pub mod root {
                 concat!("Alignment of ", stringify!(Test))
             );
             assert_eq!(
-                unsafe {
-                    &(*(::std::ptr::null::<Test>())).helper as *const _ as usize
+                {
+                    const STRUCT_SIZE: usize = std::mem::size_of::<Test>();
+                    let buffer = [0u8; STRUCT_SIZE];
+                    let struct_instance = unsafe {
+                        std::mem::transmute::<[u8; STRUCT_SIZE], Test>(buffer)
+                    };
+                    let struct_ptr = &struct_instance as *const Test;
+                    let field_ptr = std::ptr::addr_of!(struct_instance.helper);
+                    let struct_address = struct_ptr as usize;
+                    let field_address = field_ptr as usize;
+                    std::mem::forget(struct_instance);
+                    field_address.checked_sub(struct_address).unwrap()
                 },
                 0usize,
                 concat!(

--- a/tests/expectations/tests/allowlisted-item-references-no-hash.rs
+++ b/tests/expectations/tests/allowlisted-item-references-no-hash.rs
@@ -42,11 +42,7 @@ fn bindgen_test_layout_AllowlistMe() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<AllowlistMe>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], AllowlistMe>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<AllowlistMe>() };
             let struct_ptr = &struct_instance as *const AllowlistMe;
             let field_ptr = std::ptr::addr_of!(struct_instance.a);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/allowlisted-item-references-no-hash.rs
+++ b/tests/expectations/tests/allowlisted-item-references-no-hash.rs
@@ -41,8 +41,18 @@ fn bindgen_test_layout_AllowlistMe() {
         concat!("Alignment of ", stringify!(AllowlistMe))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<AllowlistMe>())).a as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<AllowlistMe>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], AllowlistMe>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const AllowlistMe;
+            let field_ptr = std::ptr::addr_of!(struct_instance.a);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(

--- a/tests/expectations/tests/allowlisted-item-references-no-partialeq.rs
+++ b/tests/expectations/tests/allowlisted-item-references-no-partialeq.rs
@@ -42,11 +42,7 @@ fn bindgen_test_layout_AllowlistMe() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<AllowlistMe>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], AllowlistMe>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<AllowlistMe>() };
             let struct_ptr = &struct_instance as *const AllowlistMe;
             let field_ptr = std::ptr::addr_of!(struct_instance.a);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/allowlisted-item-references-no-partialeq.rs
+++ b/tests/expectations/tests/allowlisted-item-references-no-partialeq.rs
@@ -41,8 +41,18 @@ fn bindgen_test_layout_AllowlistMe() {
         concat!("Alignment of ", stringify!(AllowlistMe))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<AllowlistMe>())).a as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<AllowlistMe>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], AllowlistMe>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const AllowlistMe;
+            let field_ptr = std::ptr::addr_of!(struct_instance.a);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(

--- a/tests/expectations/tests/allowlisted_item_references_no_copy.rs
+++ b/tests/expectations/tests/allowlisted_item_references_no_copy.rs
@@ -42,11 +42,7 @@ fn bindgen_test_layout_AllowlistMe() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<AllowlistMe>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], AllowlistMe>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<AllowlistMe>() };
             let struct_ptr = &struct_instance as *const AllowlistMe;
             let field_ptr = std::ptr::addr_of!(struct_instance.a);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/allowlisted_item_references_no_copy.rs
+++ b/tests/expectations/tests/allowlisted_item_references_no_copy.rs
@@ -41,8 +41,18 @@ fn bindgen_test_layout_AllowlistMe() {
         concat!("Alignment of ", stringify!(AllowlistMe))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<AllowlistMe>())).a as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<AllowlistMe>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], AllowlistMe>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const AllowlistMe;
+            let field_ptr = std::ptr::addr_of!(struct_instance.a);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(

--- a/tests/expectations/tests/annotation_hide.rs
+++ b/tests/expectations/tests/annotation_hide.rs
@@ -43,8 +43,18 @@ fn bindgen_test_layout_NotAnnotated() {
         concat!("Alignment of ", stringify!(NotAnnotated))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<NotAnnotated>())).f as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<NotAnnotated>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], NotAnnotated>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const NotAnnotated;
+            let field_ptr = std::ptr::addr_of!(struct_instance.f);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(

--- a/tests/expectations/tests/annotation_hide.rs
+++ b/tests/expectations/tests/annotation_hide.rs
@@ -44,11 +44,7 @@ fn bindgen_test_layout_NotAnnotated() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<NotAnnotated>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], NotAnnotated>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<NotAnnotated>() };
             let struct_ptr = &struct_instance as *const NotAnnotated;
             let field_ptr = std::ptr::addr_of!(struct_instance.f);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/anon-fields-prefix.rs
+++ b/tests/expectations/tests/anon-fields-prefix.rs
@@ -33,14 +33,8 @@ fn bindgen_test_layout_color__bindgen_ty_1() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<color__bindgen_ty_1>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], color__bindgen_ty_1>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<color__bindgen_ty_1>() };
             let struct_ptr = &struct_instance as *const color__bindgen_ty_1;
             let field_ptr = std::ptr::addr_of!(struct_instance.r);
             let struct_address = struct_ptr as usize;
@@ -58,14 +52,8 @@ fn bindgen_test_layout_color__bindgen_ty_1() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<color__bindgen_ty_1>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], color__bindgen_ty_1>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<color__bindgen_ty_1>() };
             let struct_ptr = &struct_instance as *const color__bindgen_ty_1;
             let field_ptr = std::ptr::addr_of!(struct_instance.g);
             let struct_address = struct_ptr as usize;
@@ -83,14 +71,8 @@ fn bindgen_test_layout_color__bindgen_ty_1() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<color__bindgen_ty_1>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], color__bindgen_ty_1>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<color__bindgen_ty_1>() };
             let struct_ptr = &struct_instance as *const color__bindgen_ty_1;
             let field_ptr = std::ptr::addr_of!(struct_instance.b);
             let struct_address = struct_ptr as usize;
@@ -128,14 +110,8 @@ fn bindgen_test_layout_color__bindgen_ty_2() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<color__bindgen_ty_2>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], color__bindgen_ty_2>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<color__bindgen_ty_2>() };
             let struct_ptr = &struct_instance as *const color__bindgen_ty_2;
             let field_ptr = std::ptr::addr_of!(struct_instance.y);
             let struct_address = struct_ptr as usize;
@@ -153,14 +129,8 @@ fn bindgen_test_layout_color__bindgen_ty_2() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<color__bindgen_ty_2>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], color__bindgen_ty_2>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<color__bindgen_ty_2>() };
             let struct_ptr = &struct_instance as *const color__bindgen_ty_2;
             let field_ptr = std::ptr::addr_of!(struct_instance.u);
             let struct_address = struct_ptr as usize;
@@ -178,14 +148,8 @@ fn bindgen_test_layout_color__bindgen_ty_2() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<color__bindgen_ty_2>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], color__bindgen_ty_2>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<color__bindgen_ty_2>() };
             let struct_ptr = &struct_instance as *const color__bindgen_ty_2;
             let field_ptr = std::ptr::addr_of!(struct_instance.v);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/anon-fields-prefix.rs
+++ b/tests/expectations/tests/anon-fields-prefix.rs
@@ -32,9 +32,21 @@ fn bindgen_test_layout_color__bindgen_ty_1() {
         concat!("Alignment of ", stringify!(color__bindgen_ty_1))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<color__bindgen_ty_1>())).r as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<color__bindgen_ty_1>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], color__bindgen_ty_1>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const color__bindgen_ty_1;
+            let field_ptr = std::ptr::addr_of!(struct_instance.r);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -45,9 +57,21 @@ fn bindgen_test_layout_color__bindgen_ty_1() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<color__bindgen_ty_1>())).g as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<color__bindgen_ty_1>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], color__bindgen_ty_1>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const color__bindgen_ty_1;
+            let field_ptr = std::ptr::addr_of!(struct_instance.g);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         1usize,
         concat!(
@@ -58,9 +82,21 @@ fn bindgen_test_layout_color__bindgen_ty_1() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<color__bindgen_ty_1>())).b as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<color__bindgen_ty_1>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], color__bindgen_ty_1>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const color__bindgen_ty_1;
+            let field_ptr = std::ptr::addr_of!(struct_instance.b);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         2usize,
         concat!(
@@ -91,9 +127,21 @@ fn bindgen_test_layout_color__bindgen_ty_2() {
         concat!("Alignment of ", stringify!(color__bindgen_ty_2))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<color__bindgen_ty_2>())).y as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<color__bindgen_ty_2>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], color__bindgen_ty_2>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const color__bindgen_ty_2;
+            let field_ptr = std::ptr::addr_of!(struct_instance.y);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -104,9 +152,21 @@ fn bindgen_test_layout_color__bindgen_ty_2() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<color__bindgen_ty_2>())).u as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<color__bindgen_ty_2>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], color__bindgen_ty_2>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const color__bindgen_ty_2;
+            let field_ptr = std::ptr::addr_of!(struct_instance.u);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         1usize,
         concat!(
@@ -117,9 +177,21 @@ fn bindgen_test_layout_color__bindgen_ty_2() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<color__bindgen_ty_2>())).v as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<color__bindgen_ty_2>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], color__bindgen_ty_2>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const color__bindgen_ty_2;
+            let field_ptr = std::ptr::addr_of!(struct_instance.v);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         2usize,
         concat!(
@@ -141,11 +213,6 @@ fn bindgen_test_layout_color() {
         ::std::mem::align_of::<color>(),
         1usize,
         concat!("Alignment of ", stringify!(color))
-    );
-    assert_eq!(
-        unsafe { &(*(::std::ptr::null::<color>())).v3 as *const _ as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(color), "::", stringify!(v3))
     );
 }
 impl Default for color {

--- a/tests/expectations/tests/anon_enum.rs
+++ b/tests/expectations/tests/anon_enum.rs
@@ -31,11 +31,7 @@ fn bindgen_test_layout_Test() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<Test>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], Test>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<Test>() };
             let struct_ptr = &struct_instance as *const Test;
             let field_ptr = std::ptr::addr_of!(struct_instance.foo);
             let struct_address = struct_ptr as usize;
@@ -48,11 +44,7 @@ fn bindgen_test_layout_Test() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<Test>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], Test>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<Test>() };
             let struct_ptr = &struct_instance as *const Test;
             let field_ptr = std::ptr::addr_of!(struct_instance.bar);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/anon_enum.rs
+++ b/tests/expectations/tests/anon_enum.rs
@@ -30,12 +30,36 @@ fn bindgen_test_layout_Test() {
         concat!("Alignment of ", stringify!(Test))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Test>())).foo as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<Test>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], Test>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const Test;
+            let field_ptr = std::ptr::addr_of!(struct_instance.foo);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!("Offset of field: ", stringify!(Test), "::", stringify!(foo))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Test>())).bar as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<Test>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], Test>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const Test;
+            let field_ptr = std::ptr::addr_of!(struct_instance.bar);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         4usize,
         concat!("Offset of field: ", stringify!(Test), "::", stringify!(bar))
     );

--- a/tests/expectations/tests/anon_struct_in_union.rs
+++ b/tests/expectations/tests/anon_struct_in_union.rs
@@ -33,9 +33,21 @@ fn bindgen_test_layout_s__bindgen_ty_1_inner() {
         concat!("Alignment of ", stringify!(s__bindgen_ty_1_inner))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<s__bindgen_ty_1_inner>())).b as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<s__bindgen_ty_1_inner>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], s__bindgen_ty_1_inner>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const s__bindgen_ty_1_inner;
+            let field_ptr = std::ptr::addr_of!(struct_instance.b);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -57,19 +69,6 @@ fn bindgen_test_layout_s__bindgen_ty_1() {
         ::std::mem::align_of::<s__bindgen_ty_1>(),
         4usize,
         concat!("Alignment of ", stringify!(s__bindgen_ty_1))
-    );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<s__bindgen_ty_1>())).field as *const _
-                as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(s__bindgen_ty_1),
-            "::",
-            stringify!(field)
-        )
     );
 }
 impl Default for s__bindgen_ty_1 {
@@ -94,7 +93,18 @@ fn bindgen_test_layout_s() {
         concat!("Alignment of ", stringify!(s))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<s>())).u as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<s>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance =
+                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], s>(buffer) };
+            let struct_ptr = &struct_instance as *const s;
+            let field_ptr = std::ptr::addr_of!(struct_instance.u);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!("Offset of field: ", stringify!(s), "::", stringify!(u))
     );

--- a/tests/expectations/tests/anon_struct_in_union.rs
+++ b/tests/expectations/tests/anon_struct_in_union.rs
@@ -34,14 +34,8 @@ fn bindgen_test_layout_s__bindgen_ty_1_inner() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<s__bindgen_ty_1_inner>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], s__bindgen_ty_1_inner>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<s__bindgen_ty_1_inner>() };
             let struct_ptr = &struct_instance as *const s__bindgen_ty_1_inner;
             let field_ptr = std::ptr::addr_of!(struct_instance.b);
             let struct_address = struct_ptr as usize;
@@ -94,10 +88,7 @@ fn bindgen_test_layout_s() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<s>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance =
-                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], s>(buffer) };
+            let struct_instance = unsafe { std::mem::zeroed::<s>() };
             let struct_ptr = &struct_instance as *const s;
             let field_ptr = std::ptr::addr_of!(struct_instance.u);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/anon_struct_in_union_1_0.rs
+++ b/tests/expectations/tests/anon_struct_in_union_1_0.rs
@@ -78,14 +78,8 @@ fn bindgen_test_layout_s__bindgen_ty_1_inner() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<s__bindgen_ty_1_inner>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], s__bindgen_ty_1_inner>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<s__bindgen_ty_1_inner>() };
             let struct_ptr = &struct_instance as *const s__bindgen_ty_1_inner;
             let field_ptr = std::ptr::addr_of!(struct_instance.b);
             let struct_address = struct_ptr as usize;
@@ -139,10 +133,7 @@ fn bindgen_test_layout_s() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<s>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance =
-                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], s>(buffer) };
+            let struct_instance = unsafe { std::mem::zeroed::<s>() };
             let struct_ptr = &struct_instance as *const s;
             let field_ptr = std::ptr::addr_of!(struct_instance.u);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/anon_struct_in_union_1_0.rs
+++ b/tests/expectations/tests/anon_struct_in_union_1_0.rs
@@ -77,9 +77,21 @@ fn bindgen_test_layout_s__bindgen_ty_1_inner() {
         concat!("Alignment of ", stringify!(s__bindgen_ty_1_inner))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<s__bindgen_ty_1_inner>())).b as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<s__bindgen_ty_1_inner>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], s__bindgen_ty_1_inner>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const s__bindgen_ty_1_inner;
+            let field_ptr = std::ptr::addr_of!(struct_instance.b);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -107,19 +119,6 @@ fn bindgen_test_layout_s__bindgen_ty_1() {
         4usize,
         concat!("Alignment of ", stringify!(s__bindgen_ty_1))
     );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<s__bindgen_ty_1>())).field as *const _
-                as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(s__bindgen_ty_1),
-            "::",
-            stringify!(field)
-        )
-    );
 }
 impl Clone for s__bindgen_ty_1 {
     fn clone(&self) -> Self {
@@ -139,7 +138,18 @@ fn bindgen_test_layout_s() {
         concat!("Alignment of ", stringify!(s))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<s>())).u as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<s>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance =
+                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], s>(buffer) };
+            let struct_ptr = &struct_instance as *const s;
+            let field_ptr = std::ptr::addr_of!(struct_instance.u);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!("Offset of field: ", stringify!(s), "::", stringify!(u))
     );

--- a/tests/expectations/tests/array-of-zero-sized-types.rs
+++ b/tests/expectations/tests/array-of-zero-sized-types.rs
@@ -45,13 +45,8 @@ fn bindgen_test_layout_HasArrayOfEmpty() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<HasArrayOfEmpty>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], HasArrayOfEmpty>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<HasArrayOfEmpty>() };
             let struct_ptr = &struct_instance as *const HasArrayOfEmpty;
             let field_ptr = std::ptr::addr_of!(struct_instance.empties);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/array-of-zero-sized-types.rs
+++ b/tests/expectations/tests/array-of-zero-sized-types.rs
@@ -44,9 +44,20 @@ fn bindgen_test_layout_HasArrayOfEmpty() {
         concat!("Alignment of ", stringify!(HasArrayOfEmpty))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<HasArrayOfEmpty>())).empties as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<HasArrayOfEmpty>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], HasArrayOfEmpty>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const HasArrayOfEmpty;
+            let field_ptr = std::ptr::addr_of!(struct_instance.empties);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(

--- a/tests/expectations/tests/bindgen-union-inside-namespace.rs
+++ b/tests/expectations/tests/bindgen-union-inside-namespace.rs
@@ -77,30 +77,6 @@ pub mod root {
                 4usize,
                 concat!("Alignment of ", stringify!(Bar))
             );
-            assert_eq!(
-                unsafe {
-                    &(*(::std::ptr::null::<Bar>())).foo as *const _ as usize
-                },
-                0usize,
-                concat!(
-                    "Offset of field: ",
-                    stringify!(Bar),
-                    "::",
-                    stringify!(foo)
-                )
-            );
-            assert_eq!(
-                unsafe {
-                    &(*(::std::ptr::null::<Bar>())).bar as *const _ as usize
-                },
-                0usize,
-                concat!(
-                    "Offset of field: ",
-                    stringify!(Bar),
-                    "::",
-                    stringify!(bar)
-                )
-            );
         }
         impl Clone for Bar {
             fn clone(&self) -> Self {

--- a/tests/expectations/tests/bitfield-linux-32.rs
+++ b/tests/expectations/tests/bitfield-linux-32.rs
@@ -112,11 +112,7 @@ fn bindgen_test_layout_Test() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<Test>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], Test>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<Test>() };
             let struct_ptr = &struct_instance as *const Test;
             let field_ptr = std::ptr::addr_of!(struct_instance.foo);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/bitfield-linux-32.rs
+++ b/tests/expectations/tests/bitfield-linux-32.rs
@@ -111,7 +111,19 @@ fn bindgen_test_layout_Test() {
         concat!("Alignment of ", stringify!(Test))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Test>())).foo as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<Test>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], Test>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const Test;
+            let field_ptr = std::ptr::addr_of!(struct_instance.foo);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!("Offset of field: ", stringify!(Test), "::", stringify!(foo))
     );

--- a/tests/expectations/tests/bitfield_align.rs
+++ b/tests/expectations/tests/bitfield_align.rs
@@ -114,10 +114,7 @@ fn bindgen_test_layout_A() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<A>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance =
-                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], A>(buffer) };
+            let struct_instance = unsafe { std::mem::zeroed::<A>() };
             let struct_ptr = &struct_instance as *const A;
             let field_ptr = std::ptr::addr_of!(struct_instance.x);
             let struct_address = struct_ptr as usize;
@@ -130,10 +127,7 @@ fn bindgen_test_layout_A() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<A>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance =
-                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], A>(buffer) };
+            let struct_instance = unsafe { std::mem::zeroed::<A>() };
             let struct_ptr = &struct_instance as *const A;
             let field_ptr = std::ptr::addr_of!(struct_instance.y);
             let struct_address = struct_ptr as usize;
@@ -421,10 +415,7 @@ fn bindgen_test_layout_C() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<C>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance =
-                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], C>(buffer) };
+            let struct_instance = unsafe { std::mem::zeroed::<C>() };
             let struct_ptr = &struct_instance as *const C;
             let field_ptr = std::ptr::addr_of!(struct_instance.x);
             let struct_address = struct_ptr as usize;
@@ -437,10 +428,7 @@ fn bindgen_test_layout_C() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<C>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance =
-                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], C>(buffer) };
+            let struct_instance = unsafe { std::mem::zeroed::<C>() };
             let struct_ptr = &struct_instance as *const C;
             let field_ptr = std::ptr::addr_of!(struct_instance.baz);
             let struct_address = struct_ptr as usize;
@@ -740,11 +728,7 @@ fn bindgen_test_layout_Date3() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<Date3>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], Date3>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<Date3>() };
             let struct_ptr = &struct_instance as *const Date3;
             let field_ptr = std::ptr::addr_of!(struct_instance.byte);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/bitfield_align.rs
+++ b/tests/expectations/tests/bitfield_align.rs
@@ -113,12 +113,34 @@ fn bindgen_test_layout_A() {
         concat!("Alignment of ", stringify!(A))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<A>())).x as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<A>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance =
+                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], A>(buffer) };
+            let struct_ptr = &struct_instance as *const A;
+            let field_ptr = std::ptr::addr_of!(struct_instance.x);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!("Offset of field: ", stringify!(A), "::", stringify!(x))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<A>())).y as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<A>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance =
+                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], A>(buffer) };
+            let struct_ptr = &struct_instance as *const A;
+            let field_ptr = std::ptr::addr_of!(struct_instance.y);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         3usize,
         concat!("Offset of field: ", stringify!(A), "::", stringify!(y))
     );
@@ -398,12 +420,34 @@ fn bindgen_test_layout_C() {
         concat!("Alignment of ", stringify!(C))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<C>())).x as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<C>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance =
+                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], C>(buffer) };
+            let struct_ptr = &struct_instance as *const C;
+            let field_ptr = std::ptr::addr_of!(struct_instance.x);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!("Offset of field: ", stringify!(C), "::", stringify!(x))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<C>())).baz as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<C>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance =
+                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], C>(buffer) };
+            let struct_ptr = &struct_instance as *const C;
+            let field_ptr = std::ptr::addr_of!(struct_instance.baz);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         4usize,
         concat!("Offset of field: ", stringify!(C), "::", stringify!(baz))
     );
@@ -695,7 +739,19 @@ fn bindgen_test_layout_Date3() {
         concat!("Alignment of ", stringify!(Date3))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Date3>())).byte as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<Date3>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], Date3>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const Date3;
+            let field_ptr = std::ptr::addr_of!(struct_instance.byte);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         3usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/blocklist-and-impl-debug.rs
+++ b/tests/expectations/tests/blocklist-and-impl-debug.rs
@@ -26,14 +26,8 @@ fn bindgen_test_layout_ShouldManuallyImplDebug() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<ShouldManuallyImplDebug>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], ShouldManuallyImplDebug>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<ShouldManuallyImplDebug>() };
             let struct_ptr = &struct_instance as *const ShouldManuallyImplDebug;
             let field_ptr = std::ptr::addr_of!(struct_instance.a);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/blocklist-and-impl-debug.rs
+++ b/tests/expectations/tests/blocklist-and-impl-debug.rs
@@ -25,9 +25,21 @@ fn bindgen_test_layout_ShouldManuallyImplDebug() {
         concat!("Alignment of ", stringify!(ShouldManuallyImplDebug))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<ShouldManuallyImplDebug>())).a as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<ShouldManuallyImplDebug>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], ShouldManuallyImplDebug>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const ShouldManuallyImplDebug;
+            let field_ptr = std::ptr::addr_of!(struct_instance.a);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(

--- a/tests/expectations/tests/blocks-signature.rs
+++ b/tests/expectations/tests/blocks-signature.rs
@@ -48,9 +48,21 @@ fn bindgen_test_layout_contains_block_pointers() {
         concat!("Alignment of ", stringify!(contains_block_pointers))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<contains_block_pointers>())).val as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<contains_block_pointers>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], contains_block_pointers>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const contains_block_pointers;
+            let field_ptr = std::ptr::addr_of!(struct_instance.val);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -61,9 +73,21 @@ fn bindgen_test_layout_contains_block_pointers() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<contains_block_pointers>())).ptr_val
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<contains_block_pointers>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], contains_block_pointers>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const contains_block_pointers;
+            let field_ptr = std::ptr::addr_of!(struct_instance.ptr_val);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         8usize,
         concat!(

--- a/tests/expectations/tests/blocks-signature.rs
+++ b/tests/expectations/tests/blocks-signature.rs
@@ -49,14 +49,8 @@ fn bindgen_test_layout_contains_block_pointers() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<contains_block_pointers>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], contains_block_pointers>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<contains_block_pointers>() };
             let struct_ptr = &struct_instance as *const contains_block_pointers;
             let field_ptr = std::ptr::addr_of!(struct_instance.val);
             let struct_address = struct_ptr as usize;
@@ -74,14 +68,8 @@ fn bindgen_test_layout_contains_block_pointers() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<contains_block_pointers>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], contains_block_pointers>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<contains_block_pointers>() };
             let struct_ptr = &struct_instance as *const contains_block_pointers;
             let field_ptr = std::ptr::addr_of!(struct_instance.ptr_val);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/blocks.rs
+++ b/tests/expectations/tests/blocks.rs
@@ -47,9 +47,21 @@ fn bindgen_test_layout_contains_block_pointers() {
         concat!("Alignment of ", stringify!(contains_block_pointers))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<contains_block_pointers>())).val as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<contains_block_pointers>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], contains_block_pointers>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const contains_block_pointers;
+            let field_ptr = std::ptr::addr_of!(struct_instance.val);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -60,9 +72,21 @@ fn bindgen_test_layout_contains_block_pointers() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<contains_block_pointers>())).ptr_val
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<contains_block_pointers>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], contains_block_pointers>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const contains_block_pointers;
+            let field_ptr = std::ptr::addr_of!(struct_instance.ptr_val);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         8usize,
         concat!(

--- a/tests/expectations/tests/blocks.rs
+++ b/tests/expectations/tests/blocks.rs
@@ -48,14 +48,8 @@ fn bindgen_test_layout_contains_block_pointers() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<contains_block_pointers>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], contains_block_pointers>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<contains_block_pointers>() };
             let struct_ptr = &struct_instance as *const contains_block_pointers;
             let field_ptr = std::ptr::addr_of!(struct_instance.val);
             let struct_address = struct_ptr as usize;
@@ -73,14 +67,8 @@ fn bindgen_test_layout_contains_block_pointers() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<contains_block_pointers>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], contains_block_pointers>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<contains_block_pointers>() };
             let struct_ptr = &struct_instance as *const contains_block_pointers;
             let field_ptr = std::ptr::addr_of!(struct_instance.ptr_val);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/c_naming.rs
+++ b/tests/expectations/tests/c_naming.rs
@@ -24,11 +24,7 @@ fn bindgen_test_layout_struct_a() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<struct_a>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], struct_a>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<struct_a>() };
             let struct_ptr = &struct_instance as *const struct_a;
             let field_ptr = std::ptr::addr_of!(struct_instance.a);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/c_naming.rs
+++ b/tests/expectations/tests/c_naming.rs
@@ -23,7 +23,19 @@ fn bindgen_test_layout_struct_a() {
         concat!("Alignment of ", stringify!(struct_a))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<struct_a>())).a as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<struct_a>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], struct_a>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const struct_a;
+            let field_ptr = std::ptr::addr_of!(struct_instance.a);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!(
             "Offset of field: ",
@@ -51,26 +63,6 @@ fn bindgen_test_layout_union_b() {
         ::std::mem::align_of::<union_b>(),
         4usize,
         concat!("Alignment of ", stringify!(union_b))
-    );
-    assert_eq!(
-        unsafe { &(*(::std::ptr::null::<union_b>())).a as *const _ as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(union_b),
-            "::",
-            stringify!(a)
-        )
-    );
-    assert_eq!(
-        unsafe { &(*(::std::ptr::null::<union_b>())).b as *const _ as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(union_b),
-            "::",
-            stringify!(b)
-        )
     );
 }
 impl Default for union_b {

--- a/tests/expectations/tests/char.rs
+++ b/tests/expectations/tests/char.rs
@@ -38,11 +38,7 @@ fn bindgen_test_layout_Test() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<Test>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], Test>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<Test>() };
             let struct_ptr = &struct_instance as *const Test;
             let field_ptr = std::ptr::addr_of!(struct_instance.ch);
             let struct_address = struct_ptr as usize;
@@ -55,11 +51,7 @@ fn bindgen_test_layout_Test() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<Test>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], Test>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<Test>() };
             let struct_ptr = &struct_instance as *const Test;
             let field_ptr = std::ptr::addr_of!(struct_instance.u);
             let struct_address = struct_ptr as usize;
@@ -72,11 +64,7 @@ fn bindgen_test_layout_Test() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<Test>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], Test>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<Test>() };
             let struct_ptr = &struct_instance as *const Test;
             let field_ptr = std::ptr::addr_of!(struct_instance.d);
             let struct_address = struct_ptr as usize;
@@ -89,11 +77,7 @@ fn bindgen_test_layout_Test() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<Test>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], Test>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<Test>() };
             let struct_ptr = &struct_instance as *const Test;
             let field_ptr = std::ptr::addr_of!(struct_instance.cch);
             let struct_address = struct_ptr as usize;
@@ -106,11 +90,7 @@ fn bindgen_test_layout_Test() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<Test>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], Test>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<Test>() };
             let struct_ptr = &struct_instance as *const Test;
             let field_ptr = std::ptr::addr_of!(struct_instance.cu);
             let struct_address = struct_ptr as usize;
@@ -123,11 +103,7 @@ fn bindgen_test_layout_Test() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<Test>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], Test>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<Test>() };
             let struct_ptr = &struct_instance as *const Test;
             let field_ptr = std::ptr::addr_of!(struct_instance.cd);
             let struct_address = struct_ptr as usize;
@@ -140,11 +116,7 @@ fn bindgen_test_layout_Test() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<Test>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], Test>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<Test>() };
             let struct_ptr = &struct_instance as *const Test;
             let field_ptr = std::ptr::addr_of!(struct_instance.Cch);
             let struct_address = struct_ptr as usize;
@@ -157,11 +129,7 @@ fn bindgen_test_layout_Test() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<Test>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], Test>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<Test>() };
             let struct_ptr = &struct_instance as *const Test;
             let field_ptr = std::ptr::addr_of!(struct_instance.Cu);
             let struct_address = struct_ptr as usize;
@@ -174,11 +142,7 @@ fn bindgen_test_layout_Test() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<Test>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], Test>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<Test>() };
             let struct_ptr = &struct_instance as *const Test;
             let field_ptr = std::ptr::addr_of!(struct_instance.Cd);
             let struct_address = struct_ptr as usize;
@@ -191,11 +155,7 @@ fn bindgen_test_layout_Test() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<Test>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], Test>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<Test>() };
             let struct_ptr = &struct_instance as *const Test;
             let field_ptr = std::ptr::addr_of!(struct_instance.Ccch);
             let struct_address = struct_ptr as usize;
@@ -213,11 +173,7 @@ fn bindgen_test_layout_Test() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<Test>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], Test>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<Test>() };
             let struct_ptr = &struct_instance as *const Test;
             let field_ptr = std::ptr::addr_of!(struct_instance.Ccu);
             let struct_address = struct_ptr as usize;
@@ -230,11 +186,7 @@ fn bindgen_test_layout_Test() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<Test>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], Test>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<Test>() };
             let struct_ptr = &struct_instance as *const Test;
             let field_ptr = std::ptr::addr_of!(struct_instance.Ccd);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/char.rs
+++ b/tests/expectations/tests/char.rs
@@ -37,52 +37,172 @@ fn bindgen_test_layout_Test() {
         concat!("Alignment of ", stringify!(Test))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Test>())).ch as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<Test>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], Test>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const Test;
+            let field_ptr = std::ptr::addr_of!(struct_instance.ch);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!("Offset of field: ", stringify!(Test), "::", stringify!(ch))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Test>())).u as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<Test>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], Test>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const Test;
+            let field_ptr = std::ptr::addr_of!(struct_instance.u);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         1usize,
         concat!("Offset of field: ", stringify!(Test), "::", stringify!(u))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Test>())).d as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<Test>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], Test>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const Test;
+            let field_ptr = std::ptr::addr_of!(struct_instance.d);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         2usize,
         concat!("Offset of field: ", stringify!(Test), "::", stringify!(d))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Test>())).cch as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<Test>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], Test>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const Test;
+            let field_ptr = std::ptr::addr_of!(struct_instance.cch);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         3usize,
         concat!("Offset of field: ", stringify!(Test), "::", stringify!(cch))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Test>())).cu as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<Test>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], Test>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const Test;
+            let field_ptr = std::ptr::addr_of!(struct_instance.cu);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         4usize,
         concat!("Offset of field: ", stringify!(Test), "::", stringify!(cu))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Test>())).cd as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<Test>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], Test>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const Test;
+            let field_ptr = std::ptr::addr_of!(struct_instance.cd);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         5usize,
         concat!("Offset of field: ", stringify!(Test), "::", stringify!(cd))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Test>())).Cch as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<Test>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], Test>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const Test;
+            let field_ptr = std::ptr::addr_of!(struct_instance.Cch);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         6usize,
         concat!("Offset of field: ", stringify!(Test), "::", stringify!(Cch))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Test>())).Cu as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<Test>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], Test>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const Test;
+            let field_ptr = std::ptr::addr_of!(struct_instance.Cu);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         7usize,
         concat!("Offset of field: ", stringify!(Test), "::", stringify!(Cu))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Test>())).Cd as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<Test>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], Test>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const Test;
+            let field_ptr = std::ptr::addr_of!(struct_instance.Cd);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         8usize,
         concat!("Offset of field: ", stringify!(Test), "::", stringify!(Cd))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Test>())).Ccch as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<Test>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], Test>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const Test;
+            let field_ptr = std::ptr::addr_of!(struct_instance.Ccch);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         9usize,
         concat!(
             "Offset of field: ",
@@ -92,12 +212,36 @@ fn bindgen_test_layout_Test() {
         )
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Test>())).Ccu as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<Test>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], Test>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const Test;
+            let field_ptr = std::ptr::addr_of!(struct_instance.Ccu);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         10usize,
         concat!("Offset of field: ", stringify!(Test), "::", stringify!(Ccu))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Test>())).Ccd as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<Test>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], Test>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const Test;
+            let field_ptr = std::ptr::addr_of!(struct_instance.Ccd);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         11usize,
         concat!("Offset of field: ", stringify!(Test), "::", stringify!(Ccd))
     );

--- a/tests/expectations/tests/class_nested.rs
+++ b/tests/expectations/tests/class_nested.rs
@@ -28,8 +28,18 @@ fn bindgen_test_layout_A_B() {
         concat!("Alignment of ", stringify!(A_B))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<A_B>())).member_b as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<A_B>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], A_B>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const A_B;
+            let field_ptr = std::ptr::addr_of!(struct_instance.member_b);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -68,7 +78,18 @@ fn bindgen_test_layout_A() {
         concat!("Alignment of ", stringify!(A))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<A>())).member_a as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<A>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance =
+                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], A>(buffer) };
+            let struct_ptr = &struct_instance as *const A;
+            let field_ptr = std::ptr::addr_of!(struct_instance.member_a);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!(
             "Offset of field: ",
@@ -96,7 +117,19 @@ fn bindgen_test_layout_A_C() {
         concat!("Alignment of ", stringify!(A_C))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<A_C>())).baz as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<A_C>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], A_C>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const A_C;
+            let field_ptr = std::ptr::addr_of!(struct_instance.baz);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!("Offset of field: ", stringify!(A_C), "::", stringify!(baz))
     );
@@ -144,7 +177,18 @@ fn bindgen_test_layout_D() {
         concat!("Alignment of ", stringify!(D))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<D>())).member as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<D>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance =
+                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], D>(buffer) };
+            let struct_ptr = &struct_instance as *const D;
+            let field_ptr = std::ptr::addr_of!(struct_instance.member);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!("Offset of field: ", stringify!(D), "::", stringify!(member))
     );

--- a/tests/expectations/tests/class_nested.rs
+++ b/tests/expectations/tests/class_nested.rs
@@ -29,11 +29,7 @@ fn bindgen_test_layout_A_B() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<A_B>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], A_B>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<A_B>() };
             let struct_ptr = &struct_instance as *const A_B;
             let field_ptr = std::ptr::addr_of!(struct_instance.member_b);
             let struct_address = struct_ptr as usize;
@@ -79,10 +75,7 @@ fn bindgen_test_layout_A() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<A>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance =
-                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], A>(buffer) };
+            let struct_instance = unsafe { std::mem::zeroed::<A>() };
             let struct_ptr = &struct_instance as *const A;
             let field_ptr = std::ptr::addr_of!(struct_instance.member_a);
             let struct_address = struct_ptr as usize;
@@ -118,11 +111,7 @@ fn bindgen_test_layout_A_C() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<A_C>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], A_C>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<A_C>() };
             let struct_ptr = &struct_instance as *const A_C;
             let field_ptr = std::ptr::addr_of!(struct_instance.baz);
             let struct_address = struct_ptr as usize;
@@ -178,10 +167,7 @@ fn bindgen_test_layout_D() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<D>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance =
-                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], D>(buffer) };
+            let struct_instance = unsafe { std::mem::zeroed::<D>() };
             let struct_ptr = &struct_instance as *const D;
             let field_ptr = std::ptr::addr_of!(struct_instance.member);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/class_no_members.rs
+++ b/tests/expectations/tests/class_no_members.rs
@@ -59,9 +59,23 @@ fn bindgen_test_layout_whatever_child_with_member() {
         concat!("Alignment of ", stringify!(whatever_child_with_member))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<whatever_child_with_member>())).m_member
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<whatever_child_with_member>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<
+                    [u8; STRUCT_SIZE],
+                    whatever_child_with_member,
+                >(buffer)
+            };
+            let struct_ptr =
+                &struct_instance as *const whatever_child_with_member;
+            let field_ptr = std::ptr::addr_of!(struct_instance.m_member);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(

--- a/tests/expectations/tests/class_no_members.rs
+++ b/tests/expectations/tests/class_no_members.rs
@@ -60,15 +60,8 @@ fn bindgen_test_layout_whatever_child_with_member() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<whatever_child_with_member>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<
-                    [u8; STRUCT_SIZE],
-                    whatever_child_with_member,
-                >(buffer)
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<whatever_child_with_member>() };
             let struct_ptr =
                 &struct_instance as *const whatever_child_with_member;
             let field_ptr = std::ptr::addr_of!(struct_instance.m_member);

--- a/tests/expectations/tests/class_use_as.rs
+++ b/tests/expectations/tests/class_use_as.rs
@@ -24,9 +24,18 @@ fn bindgen_test_layout_whatever() {
         concat!("Alignment of ", stringify!(whatever))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<whatever>())).replacement as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<whatever>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], whatever>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const whatever;
+            let field_ptr = std::ptr::addr_of!(struct_instance.replacement);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -55,7 +64,19 @@ fn bindgen_test_layout_container() {
         concat!("Alignment of ", stringify!(container))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<container>())).c as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<container>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], container>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const container;
+            let field_ptr = std::ptr::addr_of!(struct_instance.c);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/class_use_as.rs
+++ b/tests/expectations/tests/class_use_as.rs
@@ -25,11 +25,7 @@ fn bindgen_test_layout_whatever() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<whatever>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], whatever>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<whatever>() };
             let struct_ptr = &struct_instance as *const whatever;
             let field_ptr = std::ptr::addr_of!(struct_instance.replacement);
             let struct_address = struct_ptr as usize;
@@ -65,11 +61,7 @@ fn bindgen_test_layout_container() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<container>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], container>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<container>() };
             let struct_ptr = &struct_instance as *const container;
             let field_ptr = std::ptr::addr_of!(struct_instance.c);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/class_with_dtor.rs
+++ b/tests/expectations/tests/class_with_dtor.rs
@@ -40,11 +40,7 @@ fn bindgen_test_layout_WithoutDtor() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<WithoutDtor>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], WithoutDtor>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<WithoutDtor>() };
             let struct_ptr = &struct_instance as *const WithoutDtor;
             let field_ptr =
                 std::ptr::addr_of!(struct_instance.shouldBeWithDtor);

--- a/tests/expectations/tests/class_with_dtor.rs
+++ b/tests/expectations/tests/class_with_dtor.rs
@@ -39,9 +39,19 @@ fn bindgen_test_layout_WithoutDtor() {
         concat!("Alignment of ", stringify!(WithoutDtor))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<WithoutDtor>())).shouldBeWithDtor as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<WithoutDtor>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], WithoutDtor>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const WithoutDtor;
+            let field_ptr =
+                std::ptr::addr_of!(struct_instance.shouldBeWithDtor);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(

--- a/tests/expectations/tests/class_with_inner_struct.rs
+++ b/tests/expectations/tests/class_with_inner_struct.rs
@@ -32,11 +32,7 @@ fn bindgen_test_layout_A_Segment() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<A_Segment>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], A_Segment>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<A_Segment>() };
             let struct_ptr = &struct_instance as *const A_Segment;
             let field_ptr = std::ptr::addr_of!(struct_instance.begin);
             let struct_address = struct_ptr as usize;
@@ -54,11 +50,7 @@ fn bindgen_test_layout_A_Segment() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<A_Segment>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], A_Segment>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<A_Segment>() };
             let struct_ptr = &struct_instance as *const A_Segment;
             let field_ptr = std::ptr::addr_of!(struct_instance.end);
             let struct_address = struct_ptr as usize;
@@ -143,10 +135,7 @@ fn bindgen_test_layout_A() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<A>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance =
-                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], A>(buffer) };
+            let struct_instance = unsafe { std::mem::zeroed::<A>() };
             let struct_ptr = &struct_instance as *const A;
             let field_ptr = std::ptr::addr_of!(struct_instance.c);
             let struct_address = struct_ptr as usize;
@@ -159,10 +148,7 @@ fn bindgen_test_layout_A() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<A>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance =
-                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], A>(buffer) };
+            let struct_instance = unsafe { std::mem::zeroed::<A>() };
             let struct_ptr = &struct_instance as *const A;
             let field_ptr = std::ptr::addr_of!(struct_instance.named_union);
             let struct_address = struct_ptr as usize;
@@ -213,11 +199,7 @@ fn bindgen_test_layout_B_Segment() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<B_Segment>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], B_Segment>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<B_Segment>() };
             let struct_ptr = &struct_instance as *const B_Segment;
             let field_ptr = std::ptr::addr_of!(struct_instance.begin);
             let struct_address = struct_ptr as usize;
@@ -235,11 +217,7 @@ fn bindgen_test_layout_B_Segment() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<B_Segment>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], B_Segment>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<B_Segment>() };
             let struct_ptr = &struct_instance as *const B_Segment;
             let field_ptr = std::ptr::addr_of!(struct_instance.end);
             let struct_address = struct_ptr as usize;
@@ -270,10 +248,7 @@ fn bindgen_test_layout_B() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<B>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance =
-                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], B>(buffer) };
+            let struct_instance = unsafe { std::mem::zeroed::<B>() };
             let struct_ptr = &struct_instance as *const B;
             let field_ptr = std::ptr::addr_of!(struct_instance.d);
             let struct_address = struct_ptr as usize;
@@ -327,15 +302,8 @@ fn bindgen_test_layout_C__bindgen_ty_1__bindgen_ty_1() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<C__bindgen_ty_1__bindgen_ty_1>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<
-                    [u8; STRUCT_SIZE],
-                    C__bindgen_ty_1__bindgen_ty_1,
-                >(buffer)
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<C__bindgen_ty_1__bindgen_ty_1>() };
             let struct_ptr =
                 &struct_instance as *const C__bindgen_ty_1__bindgen_ty_1;
             let field_ptr = std::ptr::addr_of!(struct_instance.mX1);
@@ -354,15 +322,8 @@ fn bindgen_test_layout_C__bindgen_ty_1__bindgen_ty_1() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<C__bindgen_ty_1__bindgen_ty_1>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<
-                    [u8; STRUCT_SIZE],
-                    C__bindgen_ty_1__bindgen_ty_1,
-                >(buffer)
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<C__bindgen_ty_1__bindgen_ty_1>() };
             let struct_ptr =
                 &struct_instance as *const C__bindgen_ty_1__bindgen_ty_1;
             let field_ptr = std::ptr::addr_of!(struct_instance.mY1);
@@ -381,15 +342,8 @@ fn bindgen_test_layout_C__bindgen_ty_1__bindgen_ty_1() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<C__bindgen_ty_1__bindgen_ty_1>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<
-                    [u8; STRUCT_SIZE],
-                    C__bindgen_ty_1__bindgen_ty_1,
-                >(buffer)
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<C__bindgen_ty_1__bindgen_ty_1>() };
             let struct_ptr =
                 &struct_instance as *const C__bindgen_ty_1__bindgen_ty_1;
             let field_ptr = std::ptr::addr_of!(struct_instance.mX2);
@@ -408,15 +362,8 @@ fn bindgen_test_layout_C__bindgen_ty_1__bindgen_ty_1() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<C__bindgen_ty_1__bindgen_ty_1>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<
-                    [u8; STRUCT_SIZE],
-                    C__bindgen_ty_1__bindgen_ty_1,
-                >(buffer)
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<C__bindgen_ty_1__bindgen_ty_1>() };
             let struct_ptr =
                 &struct_instance as *const C__bindgen_ty_1__bindgen_ty_1;
             let field_ptr = std::ptr::addr_of!(struct_instance.mY2);
@@ -454,15 +401,8 @@ fn bindgen_test_layout_C__bindgen_ty_1__bindgen_ty_2() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<C__bindgen_ty_1__bindgen_ty_2>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<
-                    [u8; STRUCT_SIZE],
-                    C__bindgen_ty_1__bindgen_ty_2,
-                >(buffer)
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<C__bindgen_ty_1__bindgen_ty_2>() };
             let struct_ptr =
                 &struct_instance as *const C__bindgen_ty_1__bindgen_ty_2;
             let field_ptr = std::ptr::addr_of!(struct_instance.mStepSyntax);
@@ -481,15 +421,8 @@ fn bindgen_test_layout_C__bindgen_ty_1__bindgen_ty_2() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<C__bindgen_ty_1__bindgen_ty_2>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<
-                    [u8; STRUCT_SIZE],
-                    C__bindgen_ty_1__bindgen_ty_2,
-                >(buffer)
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<C__bindgen_ty_1__bindgen_ty_2>() };
             let struct_ptr =
                 &struct_instance as *const C__bindgen_ty_1__bindgen_ty_2;
             let field_ptr = std::ptr::addr_of!(struct_instance.mSteps);
@@ -558,11 +491,7 @@ fn bindgen_test_layout_C_Segment() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<C_Segment>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], C_Segment>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<C_Segment>() };
             let struct_ptr = &struct_instance as *const C_Segment;
             let field_ptr = std::ptr::addr_of!(struct_instance.begin);
             let struct_address = struct_ptr as usize;
@@ -580,11 +509,7 @@ fn bindgen_test_layout_C_Segment() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<C_Segment>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], C_Segment>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<C_Segment>() };
             let struct_ptr = &struct_instance as *const C_Segment;
             let field_ptr = std::ptr::addr_of!(struct_instance.end);
             let struct_address = struct_ptr as usize;
@@ -615,10 +540,7 @@ fn bindgen_test_layout_C() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<C>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance =
-                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], C>(buffer) };
+            let struct_instance = unsafe { std::mem::zeroed::<C>() };
             let struct_ptr = &struct_instance as *const C;
             let field_ptr = std::ptr::addr_of!(struct_instance.d);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/class_with_inner_struct.rs
+++ b/tests/expectations/tests/class_with_inner_struct.rs
@@ -31,8 +31,18 @@ fn bindgen_test_layout_A_Segment() {
         concat!("Alignment of ", stringify!(A_Segment))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<A_Segment>())).begin as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<A_Segment>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], A_Segment>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const A_Segment;
+            let field_ptr = std::ptr::addr_of!(struct_instance.begin);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -43,8 +53,18 @@ fn bindgen_test_layout_A_Segment() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<A_Segment>())).end as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<A_Segment>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], A_Segment>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const A_Segment;
+            let field_ptr = std::ptr::addr_of!(struct_instance.end);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         4usize,
         concat!(
@@ -71,18 +91,6 @@ fn bindgen_test_layout_A__bindgen_ty_1() {
         ::std::mem::align_of::<A__bindgen_ty_1>(),
         4usize,
         concat!("Alignment of ", stringify!(A__bindgen_ty_1))
-    );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<A__bindgen_ty_1>())).f as *const _ as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(A__bindgen_ty_1),
-            "::",
-            stringify!(f)
-        )
     );
 }
 impl Default for A__bindgen_ty_1 {
@@ -111,18 +119,6 @@ fn bindgen_test_layout_A__bindgen_ty_2() {
         4usize,
         concat!("Alignment of ", stringify!(A__bindgen_ty_2))
     );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<A__bindgen_ty_2>())).d as *const _ as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(A__bindgen_ty_2),
-            "::",
-            stringify!(d)
-        )
-    );
 }
 impl Default for A__bindgen_ty_2 {
     fn default() -> Self {
@@ -146,13 +142,33 @@ fn bindgen_test_layout_A() {
         concat!("Alignment of ", stringify!(A))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<A>())).c as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<A>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance =
+                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], A>(buffer) };
+            let struct_ptr = &struct_instance as *const A;
+            let field_ptr = std::ptr::addr_of!(struct_instance.c);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!("Offset of field: ", stringify!(A), "::", stringify!(c))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<A>())).named_union as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<A>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance =
+                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], A>(buffer) };
+            let struct_ptr = &struct_instance as *const A;
+            let field_ptr = std::ptr::addr_of!(struct_instance.named_union);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         4usize,
         concat!(
@@ -196,8 +212,18 @@ fn bindgen_test_layout_B_Segment() {
         concat!("Alignment of ", stringify!(B_Segment))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<B_Segment>())).begin as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<B_Segment>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], B_Segment>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const B_Segment;
+            let field_ptr = std::ptr::addr_of!(struct_instance.begin);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -208,8 +234,18 @@ fn bindgen_test_layout_B_Segment() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<B_Segment>())).end as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<B_Segment>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], B_Segment>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const B_Segment;
+            let field_ptr = std::ptr::addr_of!(struct_instance.end);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         4usize,
         concat!(
@@ -233,7 +269,18 @@ fn bindgen_test_layout_B() {
         concat!("Alignment of ", stringify!(B))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<B>())).d as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<B>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance =
+                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], B>(buffer) };
+            let struct_ptr = &struct_instance as *const B;
+            let field_ptr = std::ptr::addr_of!(struct_instance.d);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!("Offset of field: ", stringify!(B), "::", stringify!(d))
     );
@@ -279,9 +326,23 @@ fn bindgen_test_layout_C__bindgen_ty_1__bindgen_ty_1() {
         concat!("Alignment of ", stringify!(C__bindgen_ty_1__bindgen_ty_1))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<C__bindgen_ty_1__bindgen_ty_1>())).mX1
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<C__bindgen_ty_1__bindgen_ty_1>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<
+                    [u8; STRUCT_SIZE],
+                    C__bindgen_ty_1__bindgen_ty_1,
+                >(buffer)
+            };
+            let struct_ptr =
+                &struct_instance as *const C__bindgen_ty_1__bindgen_ty_1;
+            let field_ptr = std::ptr::addr_of!(struct_instance.mX1);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -292,9 +353,23 @@ fn bindgen_test_layout_C__bindgen_ty_1__bindgen_ty_1() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<C__bindgen_ty_1__bindgen_ty_1>())).mY1
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<C__bindgen_ty_1__bindgen_ty_1>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<
+                    [u8; STRUCT_SIZE],
+                    C__bindgen_ty_1__bindgen_ty_1,
+                >(buffer)
+            };
+            let struct_ptr =
+                &struct_instance as *const C__bindgen_ty_1__bindgen_ty_1;
+            let field_ptr = std::ptr::addr_of!(struct_instance.mY1);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         4usize,
         concat!(
@@ -305,9 +380,23 @@ fn bindgen_test_layout_C__bindgen_ty_1__bindgen_ty_1() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<C__bindgen_ty_1__bindgen_ty_1>())).mX2
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<C__bindgen_ty_1__bindgen_ty_1>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<
+                    [u8; STRUCT_SIZE],
+                    C__bindgen_ty_1__bindgen_ty_1,
+                >(buffer)
+            };
+            let struct_ptr =
+                &struct_instance as *const C__bindgen_ty_1__bindgen_ty_1;
+            let field_ptr = std::ptr::addr_of!(struct_instance.mX2);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         8usize,
         concat!(
@@ -318,9 +407,23 @@ fn bindgen_test_layout_C__bindgen_ty_1__bindgen_ty_1() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<C__bindgen_ty_1__bindgen_ty_1>())).mY2
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<C__bindgen_ty_1__bindgen_ty_1>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<
+                    [u8; STRUCT_SIZE],
+                    C__bindgen_ty_1__bindgen_ty_1,
+                >(buffer)
+            };
+            let struct_ptr =
+                &struct_instance as *const C__bindgen_ty_1__bindgen_ty_1;
+            let field_ptr = std::ptr::addr_of!(struct_instance.mY2);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         12usize,
         concat!(
@@ -350,9 +453,23 @@ fn bindgen_test_layout_C__bindgen_ty_1__bindgen_ty_2() {
         concat!("Alignment of ", stringify!(C__bindgen_ty_1__bindgen_ty_2))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<C__bindgen_ty_1__bindgen_ty_2>()))
-                .mStepSyntax as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<C__bindgen_ty_1__bindgen_ty_2>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<
+                    [u8; STRUCT_SIZE],
+                    C__bindgen_ty_1__bindgen_ty_2,
+                >(buffer)
+            };
+            let struct_ptr =
+                &struct_instance as *const C__bindgen_ty_1__bindgen_ty_2;
+            let field_ptr = std::ptr::addr_of!(struct_instance.mStepSyntax);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -363,9 +480,23 @@ fn bindgen_test_layout_C__bindgen_ty_1__bindgen_ty_2() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<C__bindgen_ty_1__bindgen_ty_2>())).mSteps
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<C__bindgen_ty_1__bindgen_ty_2>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<
+                    [u8; STRUCT_SIZE],
+                    C__bindgen_ty_1__bindgen_ty_2,
+                >(buffer)
+            };
+            let struct_ptr =
+                &struct_instance as *const C__bindgen_ty_1__bindgen_ty_2;
+            let field_ptr = std::ptr::addr_of!(struct_instance.mSteps);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         4usize,
         concat!(
@@ -397,19 +528,6 @@ fn bindgen_test_layout_C__bindgen_ty_1() {
         4usize,
         concat!("Alignment of ", stringify!(C__bindgen_ty_1))
     );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<C__bindgen_ty_1>())).mFunc as *const _
-                as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C__bindgen_ty_1),
-            "::",
-            stringify!(mFunc)
-        )
-    );
 }
 impl Default for C__bindgen_ty_1 {
     fn default() -> Self {
@@ -439,8 +557,18 @@ fn bindgen_test_layout_C_Segment() {
         concat!("Alignment of ", stringify!(C_Segment))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<C_Segment>())).begin as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<C_Segment>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], C_Segment>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const C_Segment;
+            let field_ptr = std::ptr::addr_of!(struct_instance.begin);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -451,8 +579,18 @@ fn bindgen_test_layout_C_Segment() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<C_Segment>())).end as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<C_Segment>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], C_Segment>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const C_Segment;
+            let field_ptr = std::ptr::addr_of!(struct_instance.end);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         4usize,
         concat!(
@@ -476,7 +614,18 @@ fn bindgen_test_layout_C() {
         concat!("Alignment of ", stringify!(C))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<C>())).d as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<C>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance =
+                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], C>(buffer) };
+            let struct_ptr = &struct_instance as *const C;
+            let field_ptr = std::ptr::addr_of!(struct_instance.d);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!("Offset of field: ", stringify!(C), "::", stringify!(d))
     );

--- a/tests/expectations/tests/class_with_inner_struct_1_0.rs
+++ b/tests/expectations/tests/class_with_inner_struct_1_0.rs
@@ -74,8 +74,18 @@ fn bindgen_test_layout_A_Segment() {
         concat!("Alignment of ", stringify!(A_Segment))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<A_Segment>())).begin as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<A_Segment>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], A_Segment>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const A_Segment;
+            let field_ptr = std::ptr::addr_of!(struct_instance.begin);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -86,8 +96,18 @@ fn bindgen_test_layout_A_Segment() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<A_Segment>())).end as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<A_Segment>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], A_Segment>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const A_Segment;
+            let field_ptr = std::ptr::addr_of!(struct_instance.end);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         4usize,
         concat!(
@@ -121,18 +141,6 @@ fn bindgen_test_layout_A__bindgen_ty_1() {
         4usize,
         concat!("Alignment of ", stringify!(A__bindgen_ty_1))
     );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<A__bindgen_ty_1>())).f as *const _ as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(A__bindgen_ty_1),
-            "::",
-            stringify!(f)
-        )
-    );
 }
 impl Clone for A__bindgen_ty_1 {
     fn clone(&self) -> Self {
@@ -157,18 +165,6 @@ fn bindgen_test_layout_A__bindgen_ty_2() {
         4usize,
         concat!("Alignment of ", stringify!(A__bindgen_ty_2))
     );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<A__bindgen_ty_2>())).d as *const _ as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(A__bindgen_ty_2),
-            "::",
-            stringify!(d)
-        )
-    );
 }
 impl Clone for A__bindgen_ty_2 {
     fn clone(&self) -> Self {
@@ -188,13 +184,33 @@ fn bindgen_test_layout_A() {
         concat!("Alignment of ", stringify!(A))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<A>())).c as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<A>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance =
+                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], A>(buffer) };
+            let struct_ptr = &struct_instance as *const A;
+            let field_ptr = std::ptr::addr_of!(struct_instance.c);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!("Offset of field: ", stringify!(A), "::", stringify!(c))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<A>())).named_union as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<A>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance =
+                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], A>(buffer) };
+            let struct_ptr = &struct_instance as *const A;
+            let field_ptr = std::ptr::addr_of!(struct_instance.named_union);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         4usize,
         concat!(
@@ -234,8 +250,18 @@ fn bindgen_test_layout_B_Segment() {
         concat!("Alignment of ", stringify!(B_Segment))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<B_Segment>())).begin as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<B_Segment>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], B_Segment>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const B_Segment;
+            let field_ptr = std::ptr::addr_of!(struct_instance.begin);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -246,8 +272,18 @@ fn bindgen_test_layout_B_Segment() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<B_Segment>())).end as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<B_Segment>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], B_Segment>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const B_Segment;
+            let field_ptr = std::ptr::addr_of!(struct_instance.end);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         4usize,
         concat!(
@@ -276,7 +312,18 @@ fn bindgen_test_layout_B() {
         concat!("Alignment of ", stringify!(B))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<B>())).d as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<B>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance =
+                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], B>(buffer) };
+            let struct_ptr = &struct_instance as *const B;
+            let field_ptr = std::ptr::addr_of!(struct_instance.d);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!("Offset of field: ", stringify!(B), "::", stringify!(d))
     );
@@ -328,9 +375,23 @@ fn bindgen_test_layout_C__bindgen_ty_1__bindgen_ty_1() {
         concat!("Alignment of ", stringify!(C__bindgen_ty_1__bindgen_ty_1))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<C__bindgen_ty_1__bindgen_ty_1>())).mX1
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<C__bindgen_ty_1__bindgen_ty_1>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<
+                    [u8; STRUCT_SIZE],
+                    C__bindgen_ty_1__bindgen_ty_1,
+                >(buffer)
+            };
+            let struct_ptr =
+                &struct_instance as *const C__bindgen_ty_1__bindgen_ty_1;
+            let field_ptr = std::ptr::addr_of!(struct_instance.mX1);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -341,9 +402,23 @@ fn bindgen_test_layout_C__bindgen_ty_1__bindgen_ty_1() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<C__bindgen_ty_1__bindgen_ty_1>())).mY1
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<C__bindgen_ty_1__bindgen_ty_1>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<
+                    [u8; STRUCT_SIZE],
+                    C__bindgen_ty_1__bindgen_ty_1,
+                >(buffer)
+            };
+            let struct_ptr =
+                &struct_instance as *const C__bindgen_ty_1__bindgen_ty_1;
+            let field_ptr = std::ptr::addr_of!(struct_instance.mY1);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         4usize,
         concat!(
@@ -354,9 +429,23 @@ fn bindgen_test_layout_C__bindgen_ty_1__bindgen_ty_1() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<C__bindgen_ty_1__bindgen_ty_1>())).mX2
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<C__bindgen_ty_1__bindgen_ty_1>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<
+                    [u8; STRUCT_SIZE],
+                    C__bindgen_ty_1__bindgen_ty_1,
+                >(buffer)
+            };
+            let struct_ptr =
+                &struct_instance as *const C__bindgen_ty_1__bindgen_ty_1;
+            let field_ptr = std::ptr::addr_of!(struct_instance.mX2);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         8usize,
         concat!(
@@ -367,9 +456,23 @@ fn bindgen_test_layout_C__bindgen_ty_1__bindgen_ty_1() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<C__bindgen_ty_1__bindgen_ty_1>())).mY2
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<C__bindgen_ty_1__bindgen_ty_1>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<
+                    [u8; STRUCT_SIZE],
+                    C__bindgen_ty_1__bindgen_ty_1,
+                >(buffer)
+            };
+            let struct_ptr =
+                &struct_instance as *const C__bindgen_ty_1__bindgen_ty_1;
+            let field_ptr = std::ptr::addr_of!(struct_instance.mY2);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         12usize,
         concat!(
@@ -404,9 +507,23 @@ fn bindgen_test_layout_C__bindgen_ty_1__bindgen_ty_2() {
         concat!("Alignment of ", stringify!(C__bindgen_ty_1__bindgen_ty_2))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<C__bindgen_ty_1__bindgen_ty_2>()))
-                .mStepSyntax as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<C__bindgen_ty_1__bindgen_ty_2>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<
+                    [u8; STRUCT_SIZE],
+                    C__bindgen_ty_1__bindgen_ty_2,
+                >(buffer)
+            };
+            let struct_ptr =
+                &struct_instance as *const C__bindgen_ty_1__bindgen_ty_2;
+            let field_ptr = std::ptr::addr_of!(struct_instance.mStepSyntax);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -417,9 +534,23 @@ fn bindgen_test_layout_C__bindgen_ty_1__bindgen_ty_2() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<C__bindgen_ty_1__bindgen_ty_2>())).mSteps
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<C__bindgen_ty_1__bindgen_ty_2>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<
+                    [u8; STRUCT_SIZE],
+                    C__bindgen_ty_1__bindgen_ty_2,
+                >(buffer)
+            };
+            let struct_ptr =
+                &struct_instance as *const C__bindgen_ty_1__bindgen_ty_2;
+            let field_ptr = std::ptr::addr_of!(struct_instance.mSteps);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         4usize,
         concat!(
@@ -456,19 +587,6 @@ fn bindgen_test_layout_C__bindgen_ty_1() {
         4usize,
         concat!("Alignment of ", stringify!(C__bindgen_ty_1))
     );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<C__bindgen_ty_1>())).mFunc as *const _
-                as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C__bindgen_ty_1),
-            "::",
-            stringify!(mFunc)
-        )
-    );
 }
 impl Clone for C__bindgen_ty_1 {
     fn clone(&self) -> Self {
@@ -494,8 +612,18 @@ fn bindgen_test_layout_C_Segment() {
         concat!("Alignment of ", stringify!(C_Segment))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<C_Segment>())).begin as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<C_Segment>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], C_Segment>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const C_Segment;
+            let field_ptr = std::ptr::addr_of!(struct_instance.begin);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -506,8 +634,18 @@ fn bindgen_test_layout_C_Segment() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<C_Segment>())).end as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<C_Segment>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], C_Segment>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const C_Segment;
+            let field_ptr = std::ptr::addr_of!(struct_instance.end);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         4usize,
         concat!(
@@ -536,7 +674,18 @@ fn bindgen_test_layout_C() {
         concat!("Alignment of ", stringify!(C))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<C>())).d as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<C>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance =
+                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], C>(buffer) };
+            let struct_ptr = &struct_instance as *const C;
+            let field_ptr = std::ptr::addr_of!(struct_instance.d);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!("Offset of field: ", stringify!(C), "::", stringify!(d))
     );

--- a/tests/expectations/tests/class_with_inner_struct_1_0.rs
+++ b/tests/expectations/tests/class_with_inner_struct_1_0.rs
@@ -75,11 +75,7 @@ fn bindgen_test_layout_A_Segment() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<A_Segment>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], A_Segment>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<A_Segment>() };
             let struct_ptr = &struct_instance as *const A_Segment;
             let field_ptr = std::ptr::addr_of!(struct_instance.begin);
             let struct_address = struct_ptr as usize;
@@ -97,11 +93,7 @@ fn bindgen_test_layout_A_Segment() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<A_Segment>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], A_Segment>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<A_Segment>() };
             let struct_ptr = &struct_instance as *const A_Segment;
             let field_ptr = std::ptr::addr_of!(struct_instance.end);
             let struct_address = struct_ptr as usize;
@@ -185,10 +177,7 @@ fn bindgen_test_layout_A() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<A>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance =
-                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], A>(buffer) };
+            let struct_instance = unsafe { std::mem::zeroed::<A>() };
             let struct_ptr = &struct_instance as *const A;
             let field_ptr = std::ptr::addr_of!(struct_instance.c);
             let struct_address = struct_ptr as usize;
@@ -201,10 +190,7 @@ fn bindgen_test_layout_A() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<A>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance =
-                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], A>(buffer) };
+            let struct_instance = unsafe { std::mem::zeroed::<A>() };
             let struct_ptr = &struct_instance as *const A;
             let field_ptr = std::ptr::addr_of!(struct_instance.named_union);
             let struct_address = struct_ptr as usize;
@@ -251,11 +237,7 @@ fn bindgen_test_layout_B_Segment() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<B_Segment>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], B_Segment>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<B_Segment>() };
             let struct_ptr = &struct_instance as *const B_Segment;
             let field_ptr = std::ptr::addr_of!(struct_instance.begin);
             let struct_address = struct_ptr as usize;
@@ -273,11 +255,7 @@ fn bindgen_test_layout_B_Segment() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<B_Segment>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], B_Segment>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<B_Segment>() };
             let struct_ptr = &struct_instance as *const B_Segment;
             let field_ptr = std::ptr::addr_of!(struct_instance.end);
             let struct_address = struct_ptr as usize;
@@ -313,10 +291,7 @@ fn bindgen_test_layout_B() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<B>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance =
-                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], B>(buffer) };
+            let struct_instance = unsafe { std::mem::zeroed::<B>() };
             let struct_ptr = &struct_instance as *const B;
             let field_ptr = std::ptr::addr_of!(struct_instance.d);
             let struct_address = struct_ptr as usize;
@@ -376,15 +351,8 @@ fn bindgen_test_layout_C__bindgen_ty_1__bindgen_ty_1() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<C__bindgen_ty_1__bindgen_ty_1>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<
-                    [u8; STRUCT_SIZE],
-                    C__bindgen_ty_1__bindgen_ty_1,
-                >(buffer)
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<C__bindgen_ty_1__bindgen_ty_1>() };
             let struct_ptr =
                 &struct_instance as *const C__bindgen_ty_1__bindgen_ty_1;
             let field_ptr = std::ptr::addr_of!(struct_instance.mX1);
@@ -403,15 +371,8 @@ fn bindgen_test_layout_C__bindgen_ty_1__bindgen_ty_1() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<C__bindgen_ty_1__bindgen_ty_1>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<
-                    [u8; STRUCT_SIZE],
-                    C__bindgen_ty_1__bindgen_ty_1,
-                >(buffer)
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<C__bindgen_ty_1__bindgen_ty_1>() };
             let struct_ptr =
                 &struct_instance as *const C__bindgen_ty_1__bindgen_ty_1;
             let field_ptr = std::ptr::addr_of!(struct_instance.mY1);
@@ -430,15 +391,8 @@ fn bindgen_test_layout_C__bindgen_ty_1__bindgen_ty_1() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<C__bindgen_ty_1__bindgen_ty_1>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<
-                    [u8; STRUCT_SIZE],
-                    C__bindgen_ty_1__bindgen_ty_1,
-                >(buffer)
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<C__bindgen_ty_1__bindgen_ty_1>() };
             let struct_ptr =
                 &struct_instance as *const C__bindgen_ty_1__bindgen_ty_1;
             let field_ptr = std::ptr::addr_of!(struct_instance.mX2);
@@ -457,15 +411,8 @@ fn bindgen_test_layout_C__bindgen_ty_1__bindgen_ty_1() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<C__bindgen_ty_1__bindgen_ty_1>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<
-                    [u8; STRUCT_SIZE],
-                    C__bindgen_ty_1__bindgen_ty_1,
-                >(buffer)
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<C__bindgen_ty_1__bindgen_ty_1>() };
             let struct_ptr =
                 &struct_instance as *const C__bindgen_ty_1__bindgen_ty_1;
             let field_ptr = std::ptr::addr_of!(struct_instance.mY2);
@@ -508,15 +455,8 @@ fn bindgen_test_layout_C__bindgen_ty_1__bindgen_ty_2() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<C__bindgen_ty_1__bindgen_ty_2>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<
-                    [u8; STRUCT_SIZE],
-                    C__bindgen_ty_1__bindgen_ty_2,
-                >(buffer)
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<C__bindgen_ty_1__bindgen_ty_2>() };
             let struct_ptr =
                 &struct_instance as *const C__bindgen_ty_1__bindgen_ty_2;
             let field_ptr = std::ptr::addr_of!(struct_instance.mStepSyntax);
@@ -535,15 +475,8 @@ fn bindgen_test_layout_C__bindgen_ty_1__bindgen_ty_2() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<C__bindgen_ty_1__bindgen_ty_2>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<
-                    [u8; STRUCT_SIZE],
-                    C__bindgen_ty_1__bindgen_ty_2,
-                >(buffer)
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<C__bindgen_ty_1__bindgen_ty_2>() };
             let struct_ptr =
                 &struct_instance as *const C__bindgen_ty_1__bindgen_ty_2;
             let field_ptr = std::ptr::addr_of!(struct_instance.mSteps);
@@ -613,11 +546,7 @@ fn bindgen_test_layout_C_Segment() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<C_Segment>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], C_Segment>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<C_Segment>() };
             let struct_ptr = &struct_instance as *const C_Segment;
             let field_ptr = std::ptr::addr_of!(struct_instance.begin);
             let struct_address = struct_ptr as usize;
@@ -635,11 +564,7 @@ fn bindgen_test_layout_C_Segment() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<C_Segment>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], C_Segment>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<C_Segment>() };
             let struct_ptr = &struct_instance as *const C_Segment;
             let field_ptr = std::ptr::addr_of!(struct_instance.end);
             let struct_address = struct_ptr as usize;
@@ -675,10 +600,7 @@ fn bindgen_test_layout_C() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<C>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance =
-                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], C>(buffer) };
+            let struct_instance = unsafe { std::mem::zeroed::<C>() };
             let struct_ptr = &struct_instance as *const C;
             let field_ptr = std::ptr::addr_of!(struct_instance.d);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/class_with_typedef.rs
+++ b/tests/expectations/tests/class_with_typedef.rs
@@ -30,27 +30,82 @@ fn bindgen_test_layout_C() {
         concat!("Alignment of ", stringify!(C))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<C>())).c as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<C>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance =
+                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], C>(buffer) };
+            let struct_ptr = &struct_instance as *const C;
+            let field_ptr = std::ptr::addr_of!(struct_instance.c);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!("Offset of field: ", stringify!(C), "::", stringify!(c))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<C>())).ptr as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<C>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance =
+                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], C>(buffer) };
+            let struct_ptr = &struct_instance as *const C;
+            let field_ptr = std::ptr::addr_of!(struct_instance.ptr);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         8usize,
         concat!("Offset of field: ", stringify!(C), "::", stringify!(ptr))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<C>())).arr as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<C>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance =
+                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], C>(buffer) };
+            let struct_ptr = &struct_instance as *const C;
+            let field_ptr = std::ptr::addr_of!(struct_instance.arr);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         16usize,
         concat!("Offset of field: ", stringify!(C), "::", stringify!(arr))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<C>())).d as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<C>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance =
+                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], C>(buffer) };
+            let struct_ptr = &struct_instance as *const C;
+            let field_ptr = std::ptr::addr_of!(struct_instance.d);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         56usize,
         concat!("Offset of field: ", stringify!(C), "::", stringify!(d))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<C>())).other_ptr as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<C>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance =
+                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], C>(buffer) };
+            let struct_ptr = &struct_instance as *const C;
+            let field_ptr = std::ptr::addr_of!(struct_instance.other_ptr);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         64usize,
         concat!(
             "Offset of field: ",
@@ -122,7 +177,18 @@ fn bindgen_test_layout_D() {
         concat!("Alignment of ", stringify!(D))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<D>())).ptr as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<D>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance =
+                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], D>(buffer) };
+            let struct_ptr = &struct_instance as *const D;
+            let field_ptr = std::ptr::addr_of!(struct_instance.ptr);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         72usize,
         concat!("Offset of field: ", stringify!(D), "::", stringify!(ptr))
     );

--- a/tests/expectations/tests/class_with_typedef.rs
+++ b/tests/expectations/tests/class_with_typedef.rs
@@ -31,10 +31,7 @@ fn bindgen_test_layout_C() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<C>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance =
-                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], C>(buffer) };
+            let struct_instance = unsafe { std::mem::zeroed::<C>() };
             let struct_ptr = &struct_instance as *const C;
             let field_ptr = std::ptr::addr_of!(struct_instance.c);
             let struct_address = struct_ptr as usize;
@@ -47,10 +44,7 @@ fn bindgen_test_layout_C() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<C>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance =
-                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], C>(buffer) };
+            let struct_instance = unsafe { std::mem::zeroed::<C>() };
             let struct_ptr = &struct_instance as *const C;
             let field_ptr = std::ptr::addr_of!(struct_instance.ptr);
             let struct_address = struct_ptr as usize;
@@ -63,10 +57,7 @@ fn bindgen_test_layout_C() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<C>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance =
-                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], C>(buffer) };
+            let struct_instance = unsafe { std::mem::zeroed::<C>() };
             let struct_ptr = &struct_instance as *const C;
             let field_ptr = std::ptr::addr_of!(struct_instance.arr);
             let struct_address = struct_ptr as usize;
@@ -79,10 +70,7 @@ fn bindgen_test_layout_C() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<C>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance =
-                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], C>(buffer) };
+            let struct_instance = unsafe { std::mem::zeroed::<C>() };
             let struct_ptr = &struct_instance as *const C;
             let field_ptr = std::ptr::addr_of!(struct_instance.d);
             let struct_address = struct_ptr as usize;
@@ -95,10 +83,7 @@ fn bindgen_test_layout_C() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<C>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance =
-                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], C>(buffer) };
+            let struct_instance = unsafe { std::mem::zeroed::<C>() };
             let struct_ptr = &struct_instance as *const C;
             let field_ptr = std::ptr::addr_of!(struct_instance.other_ptr);
             let struct_address = struct_ptr as usize;
@@ -178,10 +163,7 @@ fn bindgen_test_layout_D() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<D>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance =
-                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], D>(buffer) };
+            let struct_instance = unsafe { std::mem::zeroed::<D>() };
             let struct_ptr = &struct_instance as *const D;
             let field_ptr = std::ptr::addr_of!(struct_instance.ptr);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/comment-indent.rs
+++ b/tests/expectations/tests/comment-indent.rs
@@ -82,11 +82,7 @@ pub mod root {
             );
             assert_eq!(
                 {
-                    const STRUCT_SIZE: usize = std::mem::size_of::<Baz>();
-                    let buffer = [0u8; STRUCT_SIZE];
-                    let struct_instance = unsafe {
-                        std::mem::transmute::<[u8; STRUCT_SIZE], Baz>(buffer)
-                    };
+                    let struct_instance = unsafe { std::mem::zeroed::<Baz>() };
                     let struct_ptr = &struct_instance as *const Baz;
                     let field_ptr = std::ptr::addr_of!(struct_instance.member);
                     let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/comment-indent.rs
+++ b/tests/expectations/tests/comment-indent.rs
@@ -81,8 +81,18 @@ pub mod root {
                 concat!("Alignment of ", stringify!(Baz))
             );
             assert_eq!(
-                unsafe {
-                    &(*(::std::ptr::null::<Baz>())).member as *const _ as usize
+                {
+                    const STRUCT_SIZE: usize = std::mem::size_of::<Baz>();
+                    let buffer = [0u8; STRUCT_SIZE];
+                    let struct_instance = unsafe {
+                        std::mem::transmute::<[u8; STRUCT_SIZE], Baz>(buffer)
+                    };
+                    let struct_ptr = &struct_instance as *const Baz;
+                    let field_ptr = std::ptr::addr_of!(struct_instance.member);
+                    let struct_address = struct_ptr as usize;
+                    let field_address = field_ptr as usize;
+                    std::mem::forget(struct_instance);
+                    field_address.checked_sub(struct_address).unwrap()
                 },
                 0usize,
                 concat!(

--- a/tests/expectations/tests/complex.rs
+++ b/tests/expectations/tests/complex.rs
@@ -29,8 +29,18 @@ fn bindgen_test_layout_TestDouble() {
         concat!("Alignment of ", stringify!(TestDouble))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<TestDouble>())).mMember as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<TestDouble>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], TestDouble>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const TestDouble;
+            let field_ptr = std::ptr::addr_of!(struct_instance.mMember);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -59,9 +69,18 @@ fn bindgen_test_layout_TestDoublePtr() {
         concat!("Alignment of ", stringify!(TestDoublePtr))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<TestDoublePtr>())).mMember as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<TestDoublePtr>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], TestDoublePtr>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const TestDoublePtr;
+            let field_ptr = std::ptr::addr_of!(struct_instance.mMember);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -99,8 +118,18 @@ fn bindgen_test_layout_TestFloat() {
         concat!("Alignment of ", stringify!(TestFloat))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<TestFloat>())).mMember as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<TestFloat>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], TestFloat>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const TestFloat;
+            let field_ptr = std::ptr::addr_of!(struct_instance.mMember);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -129,9 +158,18 @@ fn bindgen_test_layout_TestFloatPtr() {
         concat!("Alignment of ", stringify!(TestFloatPtr))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<TestFloatPtr>())).mMember as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<TestFloatPtr>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], TestFloatPtr>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const TestFloatPtr;
+            let field_ptr = std::ptr::addr_of!(struct_instance.mMember);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(

--- a/tests/expectations/tests/complex.rs
+++ b/tests/expectations/tests/complex.rs
@@ -30,11 +30,7 @@ fn bindgen_test_layout_TestDouble() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<TestDouble>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], TestDouble>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<TestDouble>() };
             let struct_ptr = &struct_instance as *const TestDouble;
             let field_ptr = std::ptr::addr_of!(struct_instance.mMember);
             let struct_address = struct_ptr as usize;
@@ -70,11 +66,8 @@ fn bindgen_test_layout_TestDoublePtr() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<TestDoublePtr>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], TestDoublePtr>(buffer)
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<TestDoublePtr>() };
             let struct_ptr = &struct_instance as *const TestDoublePtr;
             let field_ptr = std::ptr::addr_of!(struct_instance.mMember);
             let struct_address = struct_ptr as usize;
@@ -119,11 +112,7 @@ fn bindgen_test_layout_TestFloat() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<TestFloat>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], TestFloat>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<TestFloat>() };
             let struct_ptr = &struct_instance as *const TestFloat;
             let field_ptr = std::ptr::addr_of!(struct_instance.mMember);
             let struct_address = struct_ptr as usize;
@@ -159,11 +148,7 @@ fn bindgen_test_layout_TestFloatPtr() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<TestFloatPtr>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], TestFloatPtr>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<TestFloatPtr>() };
             let struct_ptr = &struct_instance as *const TestFloatPtr;
             let field_ptr = std::ptr::addr_of!(struct_instance.mMember);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/const-const-mut-ptr.rs
+++ b/tests/expectations/tests/const-const-mut-ptr.rs
@@ -24,11 +24,7 @@ fn bindgen_test_layout_foo() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<foo>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], foo>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<foo>() };
             let struct_ptr = &struct_instance as *const foo;
             let field_ptr = std::ptr::addr_of!(struct_instance.bar);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/const-const-mut-ptr.rs
+++ b/tests/expectations/tests/const-const-mut-ptr.rs
@@ -23,7 +23,19 @@ fn bindgen_test_layout_foo() {
         concat!("Alignment of ", stringify!(foo))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<foo>())).bar as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<foo>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], foo>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const foo;
+            let field_ptr = std::ptr::addr_of!(struct_instance.bar);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar))
     );

--- a/tests/expectations/tests/constify-all-enums.rs
+++ b/tests/expectations/tests/constify-all-enums.rs
@@ -27,9 +27,19 @@ fn bindgen_test_layout_bar() {
         concat!("Alignment of ", stringify!(bar))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<bar>())).this_should_work as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<bar>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], bar>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const bar;
+            let field_ptr =
+                std::ptr::addr_of!(struct_instance.this_should_work);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(

--- a/tests/expectations/tests/constify-all-enums.rs
+++ b/tests/expectations/tests/constify-all-enums.rs
@@ -28,11 +28,7 @@ fn bindgen_test_layout_bar() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<bar>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], bar>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<bar>() };
             let struct_ptr = &struct_instance as *const bar;
             let field_ptr =
                 std::ptr::addr_of!(struct_instance.this_should_work);

--- a/tests/expectations/tests/constify-module-enums-basic.rs
+++ b/tests/expectations/tests/constify-module-enums-basic.rs
@@ -31,9 +31,19 @@ fn bindgen_test_layout_bar() {
         concat!("Alignment of ", stringify!(bar))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<bar>())).this_should_work as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<bar>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], bar>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const bar;
+            let field_ptr =
+                std::ptr::addr_of!(struct_instance.this_should_work);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(

--- a/tests/expectations/tests/constify-module-enums-basic.rs
+++ b/tests/expectations/tests/constify-module-enums-basic.rs
@@ -32,11 +32,7 @@ fn bindgen_test_layout_bar() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<bar>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], bar>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<bar>() };
             let struct_ptr = &struct_instance as *const bar;
             let field_ptr =
                 std::ptr::addr_of!(struct_instance.this_should_work);

--- a/tests/expectations/tests/constify-module-enums-namespace.rs
+++ b/tests/expectations/tests/constify-module-enums-namespace.rs
@@ -43,9 +43,22 @@ pub mod root {
                     concat!("Alignment of ", stringify!(bar))
                 );
                 assert_eq!(
-                    unsafe {
-                        &(*(::std::ptr::null::<bar>())).this_should_work
-                            as *const _ as usize
+                    {
+                        const STRUCT_SIZE: usize = std::mem::size_of::<bar>();
+                        let buffer = [0u8; STRUCT_SIZE];
+                        let struct_instance = unsafe {
+                            std::mem::transmute::<[u8; STRUCT_SIZE], bar>(
+                                buffer,
+                            )
+                        };
+                        let struct_ptr = &struct_instance as *const bar;
+                        let field_ptr = std::ptr::addr_of!(
+                            struct_instance.this_should_work
+                        );
+                        let struct_address = struct_ptr as usize;
+                        let field_address = field_ptr as usize;
+                        std::mem::forget(struct_instance);
+                        field_address.checked_sub(struct_address).unwrap()
                     },
                     0usize,
                     concat!(

--- a/tests/expectations/tests/constify-module-enums-namespace.rs
+++ b/tests/expectations/tests/constify-module-enums-namespace.rs
@@ -44,13 +44,8 @@ pub mod root {
                 );
                 assert_eq!(
                     {
-                        const STRUCT_SIZE: usize = std::mem::size_of::<bar>();
-                        let buffer = [0u8; STRUCT_SIZE];
-                        let struct_instance = unsafe {
-                            std::mem::transmute::<[u8; STRUCT_SIZE], bar>(
-                                buffer,
-                            )
-                        };
+                        let struct_instance =
+                            unsafe { std::mem::zeroed::<bar>() };
                         let struct_ptr = &struct_instance as *const bar;
                         let field_ptr = std::ptr::addr_of!(
                             struct_instance.this_should_work

--- a/tests/expectations/tests/constify-module-enums-shadow-name.rs
+++ b/tests/expectations/tests/constify-module-enums-shadow-name.rs
@@ -30,7 +30,19 @@ fn bindgen_test_layout_bar() {
         concat!("Alignment of ", stringify!(bar))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<bar>())).member as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<bar>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], bar>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const bar;
+            let field_ptr = std::ptr::addr_of!(struct_instance.member);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/constify-module-enums-shadow-name.rs
+++ b/tests/expectations/tests/constify-module-enums-shadow-name.rs
@@ -31,11 +31,7 @@ fn bindgen_test_layout_bar() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<bar>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], bar>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<bar>() };
             let struct_ptr = &struct_instance as *const bar;
             let field_ptr = std::ptr::addr_of!(struct_instance.member);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/constify-module-enums-simple-alias.rs
+++ b/tests/expectations/tests/constify-module-enums-simple-alias.rs
@@ -40,11 +40,7 @@ fn bindgen_test_layout_Bar() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<Bar>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], Bar>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<Bar>() };
             let struct_ptr = &struct_instance as *const Bar;
             let field_ptr = std::ptr::addr_of!(struct_instance.baz1);
             let struct_address = struct_ptr as usize;
@@ -57,11 +53,7 @@ fn bindgen_test_layout_Bar() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<Bar>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], Bar>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<Bar>() };
             let struct_ptr = &struct_instance as *const Bar;
             let field_ptr = std::ptr::addr_of!(struct_instance.baz2);
             let struct_address = struct_ptr as usize;
@@ -74,11 +66,7 @@ fn bindgen_test_layout_Bar() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<Bar>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], Bar>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<Bar>() };
             let struct_ptr = &struct_instance as *const Bar;
             let field_ptr = std::ptr::addr_of!(struct_instance.baz3);
             let struct_address = struct_ptr as usize;
@@ -91,11 +79,7 @@ fn bindgen_test_layout_Bar() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<Bar>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], Bar>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<Bar>() };
             let struct_ptr = &struct_instance as *const Bar;
             let field_ptr = std::ptr::addr_of!(struct_instance.baz4);
             let struct_address = struct_ptr as usize;
@@ -108,11 +92,7 @@ fn bindgen_test_layout_Bar() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<Bar>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], Bar>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<Bar>() };
             let struct_ptr = &struct_instance as *const Bar;
             let field_ptr = std::ptr::addr_of!(struct_instance.baz_ptr1);
             let struct_address = struct_ptr as usize;
@@ -130,11 +110,7 @@ fn bindgen_test_layout_Bar() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<Bar>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], Bar>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<Bar>() };
             let struct_ptr = &struct_instance as *const Bar;
             let field_ptr = std::ptr::addr_of!(struct_instance.baz_ptr2);
             let struct_address = struct_ptr as usize;
@@ -152,11 +128,7 @@ fn bindgen_test_layout_Bar() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<Bar>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], Bar>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<Bar>() };
             let struct_ptr = &struct_instance as *const Bar;
             let field_ptr = std::ptr::addr_of!(struct_instance.baz_ptr3);
             let struct_address = struct_ptr as usize;
@@ -174,11 +146,7 @@ fn bindgen_test_layout_Bar() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<Bar>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], Bar>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<Bar>() };
             let struct_ptr = &struct_instance as *const Bar;
             let field_ptr = std::ptr::addr_of!(struct_instance.baz_ptr4);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/constify-module-enums-simple-alias.rs
+++ b/tests/expectations/tests/constify-module-enums-simple-alias.rs
@@ -39,28 +39,86 @@ fn bindgen_test_layout_Bar() {
         concat!("Alignment of ", stringify!(Bar))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Bar>())).baz1 as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<Bar>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], Bar>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const Bar;
+            let field_ptr = std::ptr::addr_of!(struct_instance.baz1);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!("Offset of field: ", stringify!(Bar), "::", stringify!(baz1))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Bar>())).baz2 as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<Bar>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], Bar>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const Bar;
+            let field_ptr = std::ptr::addr_of!(struct_instance.baz2);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         4usize,
         concat!("Offset of field: ", stringify!(Bar), "::", stringify!(baz2))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Bar>())).baz3 as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<Bar>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], Bar>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const Bar;
+            let field_ptr = std::ptr::addr_of!(struct_instance.baz3);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         8usize,
         concat!("Offset of field: ", stringify!(Bar), "::", stringify!(baz3))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Bar>())).baz4 as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<Bar>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], Bar>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const Bar;
+            let field_ptr = std::ptr::addr_of!(struct_instance.baz4);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         12usize,
         concat!("Offset of field: ", stringify!(Bar), "::", stringify!(baz4))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<Bar>())).baz_ptr1 as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<Bar>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], Bar>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const Bar;
+            let field_ptr = std::ptr::addr_of!(struct_instance.baz_ptr1);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         16usize,
         concat!(
@@ -71,8 +129,18 @@ fn bindgen_test_layout_Bar() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<Bar>())).baz_ptr2 as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<Bar>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], Bar>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const Bar;
+            let field_ptr = std::ptr::addr_of!(struct_instance.baz_ptr2);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         24usize,
         concat!(
@@ -83,8 +151,18 @@ fn bindgen_test_layout_Bar() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<Bar>())).baz_ptr3 as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<Bar>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], Bar>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const Bar;
+            let field_ptr = std::ptr::addr_of!(struct_instance.baz_ptr3);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         32usize,
         concat!(
@@ -95,8 +173,18 @@ fn bindgen_test_layout_Bar() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<Bar>())).baz_ptr4 as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<Bar>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], Bar>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const Bar;
+            let field_ptr = std::ptr::addr_of!(struct_instance.baz_ptr4);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         40usize,
         concat!(

--- a/tests/expectations/tests/constify-module-enums-simple-nonamespace.rs
+++ b/tests/expectations/tests/constify-module-enums-simple-nonamespace.rs
@@ -30,11 +30,7 @@ fn bindgen_test_layout_Bar() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<Bar>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], Bar>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<Bar>() };
             let struct_ptr = &struct_instance as *const Bar;
             let field_ptr = std::ptr::addr_of!(struct_instance.baz1);
             let struct_address = struct_ptr as usize;
@@ -47,11 +43,7 @@ fn bindgen_test_layout_Bar() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<Bar>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], Bar>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<Bar>() };
             let struct_ptr = &struct_instance as *const Bar;
             let field_ptr = std::ptr::addr_of!(struct_instance.baz2);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/constify-module-enums-simple-nonamespace.rs
+++ b/tests/expectations/tests/constify-module-enums-simple-nonamespace.rs
@@ -29,12 +29,36 @@ fn bindgen_test_layout_Bar() {
         concat!("Alignment of ", stringify!(Bar))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Bar>())).baz1 as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<Bar>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], Bar>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const Bar;
+            let field_ptr = std::ptr::addr_of!(struct_instance.baz1);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!("Offset of field: ", stringify!(Bar), "::", stringify!(baz1))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Bar>())).baz2 as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<Bar>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], Bar>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const Bar;
+            let field_ptr = std::ptr::addr_of!(struct_instance.baz2);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         8usize,
         concat!("Offset of field: ", stringify!(Bar), "::", stringify!(baz2))
     );

--- a/tests/expectations/tests/constify-module-enums-types.rs
+++ b/tests/expectations/tests/constify-module-enums-types.rs
@@ -65,11 +65,7 @@ fn bindgen_test_layout_bar() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<bar>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], bar>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<bar>() };
             let struct_ptr = &struct_instance as *const bar;
             let field_ptr = std::ptr::addr_of!(struct_instance.member1);
             let struct_address = struct_ptr as usize;
@@ -87,11 +83,7 @@ fn bindgen_test_layout_bar() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<bar>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], bar>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<bar>() };
             let struct_ptr = &struct_instance as *const bar;
             let field_ptr = std::ptr::addr_of!(struct_instance.member2);
             let struct_address = struct_ptr as usize;
@@ -109,11 +101,7 @@ fn bindgen_test_layout_bar() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<bar>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], bar>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<bar>() };
             let struct_ptr = &struct_instance as *const bar;
             let field_ptr = std::ptr::addr_of!(struct_instance.member3);
             let struct_address = struct_ptr as usize;
@@ -131,11 +119,7 @@ fn bindgen_test_layout_bar() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<bar>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], bar>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<bar>() };
             let struct_ptr = &struct_instance as *const bar;
             let field_ptr = std::ptr::addr_of!(struct_instance.member4);
             let struct_address = struct_ptr as usize;
@@ -153,11 +137,7 @@ fn bindgen_test_layout_bar() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<bar>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], bar>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<bar>() };
             let struct_ptr = &struct_instance as *const bar;
             let field_ptr = std::ptr::addr_of!(struct_instance.member5);
             let struct_address = struct_ptr as usize;
@@ -175,11 +155,7 @@ fn bindgen_test_layout_bar() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<bar>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], bar>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<bar>() };
             let struct_ptr = &struct_instance as *const bar;
             let field_ptr = std::ptr::addr_of!(struct_instance.member6);
             let struct_address = struct_ptr as usize;
@@ -197,11 +173,7 @@ fn bindgen_test_layout_bar() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<bar>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], bar>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<bar>() };
             let struct_ptr = &struct_instance as *const bar;
             let field_ptr = std::ptr::addr_of!(struct_instance.member7);
             let struct_address = struct_ptr as usize;
@@ -219,11 +191,7 @@ fn bindgen_test_layout_bar() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<bar>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], bar>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<bar>() };
             let struct_ptr = &struct_instance as *const bar;
             let field_ptr = std::ptr::addr_of!(struct_instance.member8);
             let struct_address = struct_ptr as usize;
@@ -241,11 +209,7 @@ fn bindgen_test_layout_bar() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<bar>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], bar>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<bar>() };
             let struct_ptr = &struct_instance as *const bar;
             let field_ptr = std::ptr::addr_of!(struct_instance.member9);
             let struct_address = struct_ptr as usize;
@@ -263,11 +227,7 @@ fn bindgen_test_layout_bar() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<bar>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], bar>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<bar>() };
             let struct_ptr = &struct_instance as *const bar;
             let field_ptr = std::ptr::addr_of!(struct_instance.member10);
             let struct_address = struct_ptr as usize;
@@ -312,11 +272,7 @@ fn bindgen_test_layout_Baz() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<Baz>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], Baz>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<Baz>() };
             let struct_ptr = &struct_instance as *const Baz;
             let field_ptr = std::ptr::addr_of!(struct_instance.member1);
             let struct_address = struct_ptr as usize;
@@ -366,11 +322,7 @@ fn bindgen_test_layout_Bar() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<Bar>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], Bar>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<Bar>() };
             let struct_ptr = &struct_instance as *const Bar;
             let field_ptr = std::ptr::addr_of!(struct_instance.baz);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/constify-module-enums-types.rs
+++ b/tests/expectations/tests/constify-module-enums-types.rs
@@ -64,7 +64,19 @@ fn bindgen_test_layout_bar() {
         concat!("Alignment of ", stringify!(bar))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<bar>())).member1 as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<bar>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], bar>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const bar;
+            let field_ptr = std::ptr::addr_of!(struct_instance.member1);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!(
             "Offset of field: ",
@@ -74,7 +86,19 @@ fn bindgen_test_layout_bar() {
         )
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<bar>())).member2 as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<bar>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], bar>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const bar;
+            let field_ptr = std::ptr::addr_of!(struct_instance.member2);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         4usize,
         concat!(
             "Offset of field: ",
@@ -84,7 +108,19 @@ fn bindgen_test_layout_bar() {
         )
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<bar>())).member3 as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<bar>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], bar>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const bar;
+            let field_ptr = std::ptr::addr_of!(struct_instance.member3);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         8usize,
         concat!(
             "Offset of field: ",
@@ -94,7 +130,19 @@ fn bindgen_test_layout_bar() {
         )
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<bar>())).member4 as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<bar>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], bar>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const bar;
+            let field_ptr = std::ptr::addr_of!(struct_instance.member4);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         12usize,
         concat!(
             "Offset of field: ",
@@ -104,7 +152,19 @@ fn bindgen_test_layout_bar() {
         )
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<bar>())).member5 as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<bar>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], bar>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const bar;
+            let field_ptr = std::ptr::addr_of!(struct_instance.member5);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         16usize,
         concat!(
             "Offset of field: ",
@@ -114,7 +174,19 @@ fn bindgen_test_layout_bar() {
         )
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<bar>())).member6 as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<bar>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], bar>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const bar;
+            let field_ptr = std::ptr::addr_of!(struct_instance.member6);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         24usize,
         concat!(
             "Offset of field: ",
@@ -124,7 +196,19 @@ fn bindgen_test_layout_bar() {
         )
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<bar>())).member7 as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<bar>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], bar>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const bar;
+            let field_ptr = std::ptr::addr_of!(struct_instance.member7);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         32usize,
         concat!(
             "Offset of field: ",
@@ -134,7 +218,19 @@ fn bindgen_test_layout_bar() {
         )
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<bar>())).member8 as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<bar>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], bar>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const bar;
+            let field_ptr = std::ptr::addr_of!(struct_instance.member8);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         36usize,
         concat!(
             "Offset of field: ",
@@ -144,7 +240,19 @@ fn bindgen_test_layout_bar() {
         )
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<bar>())).member9 as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<bar>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], bar>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const bar;
+            let field_ptr = std::ptr::addr_of!(struct_instance.member9);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         40usize,
         concat!(
             "Offset of field: ",
@@ -154,8 +262,18 @@ fn bindgen_test_layout_bar() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<bar>())).member10 as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<bar>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], bar>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const bar;
+            let field_ptr = std::ptr::addr_of!(struct_instance.member10);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         44usize,
         concat!(
@@ -193,7 +311,19 @@ fn bindgen_test_layout_Baz() {
         concat!("Alignment of ", stringify!(Baz))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Baz>())).member1 as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<Baz>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], Baz>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const Baz;
+            let field_ptr = std::ptr::addr_of!(struct_instance.member1);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!(
             "Offset of field: ",
@@ -235,7 +365,19 @@ fn bindgen_test_layout_Bar() {
         concat!("Alignment of ", stringify!(Bar))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Bar>())).baz as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<Bar>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], Bar>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const Bar;
+            let field_ptr = std::ptr::addr_of!(struct_instance.baz);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!("Offset of field: ", stringify!(Bar), "::", stringify!(baz))
     );

--- a/tests/expectations/tests/contains-vs-inherits-zero-sized.rs
+++ b/tests/expectations/tests/contains-vs-inherits-zero-sized.rs
@@ -45,11 +45,7 @@ fn bindgen_test_layout_Inherits() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<Inherits>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], Inherits>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<Inherits>() };
             let struct_ptr = &struct_instance as *const Inherits;
             let field_ptr = std::ptr::addr_of!(struct_instance.b);
             let struct_address = struct_ptr as usize;
@@ -88,11 +84,7 @@ fn bindgen_test_layout_Contains() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<Contains>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], Contains>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<Contains>() };
             let struct_ptr = &struct_instance as *const Contains;
             let field_ptr = std::ptr::addr_of!(struct_instance.empty);
             let struct_address = struct_ptr as usize;
@@ -110,11 +102,7 @@ fn bindgen_test_layout_Contains() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<Contains>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], Contains>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<Contains>() };
             let struct_ptr = &struct_instance as *const Contains;
             let field_ptr = std::ptr::addr_of!(struct_instance.b);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/contains-vs-inherits-zero-sized.rs
+++ b/tests/expectations/tests/contains-vs-inherits-zero-sized.rs
@@ -44,7 +44,19 @@ fn bindgen_test_layout_Inherits() {
         concat!("Alignment of ", stringify!(Inherits))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Inherits>())).b as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<Inherits>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], Inherits>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const Inherits;
+            let field_ptr = std::ptr::addr_of!(struct_instance.b);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!(
             "Offset of field: ",
@@ -75,8 +87,18 @@ fn bindgen_test_layout_Contains() {
         concat!("Alignment of ", stringify!(Contains))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<Contains>())).empty as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<Contains>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], Contains>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const Contains;
+            let field_ptr = std::ptr::addr_of!(struct_instance.empty);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -87,7 +109,19 @@ fn bindgen_test_layout_Contains() {
         )
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Contains>())).b as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<Contains>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], Contains>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const Contains;
+            let field_ptr = std::ptr::addr_of!(struct_instance.b);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         1usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/convert-cpp-comment-to-rust.rs
+++ b/tests/expectations/tests/convert-cpp-comment-to-rust.rs
@@ -31,11 +31,7 @@ fn bindgen_test_layout_mbedtls_mpi() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<mbedtls_mpi>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], mbedtls_mpi>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<mbedtls_mpi>() };
             let struct_ptr = &struct_instance as *const mbedtls_mpi;
             let field_ptr = std::ptr::addr_of!(struct_instance.s);
             let struct_address = struct_ptr as usize;
@@ -53,11 +49,7 @@ fn bindgen_test_layout_mbedtls_mpi() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<mbedtls_mpi>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], mbedtls_mpi>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<mbedtls_mpi>() };
             let struct_ptr = &struct_instance as *const mbedtls_mpi;
             let field_ptr = std::ptr::addr_of!(struct_instance.n);
             let struct_address = struct_ptr as usize;
@@ -75,11 +67,7 @@ fn bindgen_test_layout_mbedtls_mpi() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<mbedtls_mpi>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], mbedtls_mpi>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<mbedtls_mpi>() };
             let struct_ptr = &struct_instance as *const mbedtls_mpi;
             let field_ptr = std::ptr::addr_of!(struct_instance.p);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/convert-cpp-comment-to-rust.rs
+++ b/tests/expectations/tests/convert-cpp-comment-to-rust.rs
@@ -30,8 +30,18 @@ fn bindgen_test_layout_mbedtls_mpi() {
         concat!("Alignment of ", stringify!(mbedtls_mpi))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<mbedtls_mpi>())).s as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<mbedtls_mpi>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], mbedtls_mpi>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const mbedtls_mpi;
+            let field_ptr = std::ptr::addr_of!(struct_instance.s);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -42,8 +52,18 @@ fn bindgen_test_layout_mbedtls_mpi() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<mbedtls_mpi>())).n as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<mbedtls_mpi>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], mbedtls_mpi>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const mbedtls_mpi;
+            let field_ptr = std::ptr::addr_of!(struct_instance.n);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         8usize,
         concat!(
@@ -54,8 +74,18 @@ fn bindgen_test_layout_mbedtls_mpi() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<mbedtls_mpi>())).p as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<mbedtls_mpi>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], mbedtls_mpi>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const mbedtls_mpi;
+            let field_ptr = std::ptr::addr_of!(struct_instance.p);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         16usize,
         concat!(

--- a/tests/expectations/tests/convert-floats.rs
+++ b/tests/expectations/tests/convert-floats.rs
@@ -35,11 +35,7 @@ fn bindgen_test_layout_foo() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<foo>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], foo>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<foo>() };
             let struct_ptr = &struct_instance as *const foo;
             let field_ptr = std::ptr::addr_of!(struct_instance.bar);
             let struct_address = struct_ptr as usize;
@@ -52,11 +48,7 @@ fn bindgen_test_layout_foo() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<foo>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], foo>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<foo>() };
             let struct_ptr = &struct_instance as *const foo;
             let field_ptr = std::ptr::addr_of!(struct_instance.baz);
             let struct_address = struct_ptr as usize;
@@ -69,11 +61,7 @@ fn bindgen_test_layout_foo() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<foo>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], foo>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<foo>() };
             let struct_ptr = &struct_instance as *const foo;
             let field_ptr = std::ptr::addr_of!(struct_instance.bazz);
             let struct_address = struct_ptr as usize;
@@ -86,11 +74,7 @@ fn bindgen_test_layout_foo() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<foo>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], foo>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<foo>() };
             let struct_ptr = &struct_instance as *const foo;
             let field_ptr = std::ptr::addr_of!(struct_instance.bazzz);
             let struct_address = struct_ptr as usize;
@@ -108,11 +92,7 @@ fn bindgen_test_layout_foo() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<foo>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], foo>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<foo>() };
             let struct_ptr = &struct_instance as *const foo;
             let field_ptr = std::ptr::addr_of!(struct_instance.complexFloat);
             let struct_address = struct_ptr as usize;
@@ -130,11 +110,7 @@ fn bindgen_test_layout_foo() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<foo>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], foo>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<foo>() };
             let struct_ptr = &struct_instance as *const foo;
             let field_ptr = std::ptr::addr_of!(struct_instance.complexDouble);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/convert-floats.rs
+++ b/tests/expectations/tests/convert-floats.rs
@@ -34,22 +34,70 @@ fn bindgen_test_layout_foo() {
         concat!("Alignment of ", stringify!(foo))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<foo>())).bar as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<foo>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], foo>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const foo;
+            let field_ptr = std::ptr::addr_of!(struct_instance.bar);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<foo>())).baz as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<foo>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], foo>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const foo;
+            let field_ptr = std::ptr::addr_of!(struct_instance.baz);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         4usize,
         concat!("Offset of field: ", stringify!(foo), "::", stringify!(baz))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<foo>())).bazz as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<foo>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], foo>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const foo;
+            let field_ptr = std::ptr::addr_of!(struct_instance.bazz);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         8usize,
         concat!("Offset of field: ", stringify!(foo), "::", stringify!(bazz))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<foo>())).bazzz as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<foo>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], foo>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const foo;
+            let field_ptr = std::ptr::addr_of!(struct_instance.bazzz);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         16usize,
         concat!(
             "Offset of field: ",
@@ -59,8 +107,18 @@ fn bindgen_test_layout_foo() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<foo>())).complexFloat as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<foo>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], foo>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const foo;
+            let field_ptr = std::ptr::addr_of!(struct_instance.complexFloat);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         24usize,
         concat!(
@@ -71,8 +129,18 @@ fn bindgen_test_layout_foo() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<foo>())).complexDouble as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<foo>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], foo>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const foo;
+            let field_ptr = std::ptr::addr_of!(struct_instance.complexDouble);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         32usize,
         concat!(

--- a/tests/expectations/tests/ctypes-prefix-path.rs
+++ b/tests/expectations/tests/ctypes-prefix-path.rs
@@ -33,11 +33,7 @@ fn bindgen_test_layout_foo() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<foo>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], foo>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<foo>() };
             let struct_ptr = &struct_instance as *const foo;
             let field_ptr = std::ptr::addr_of!(struct_instance.a);
             let struct_address = struct_ptr as usize;
@@ -50,11 +46,7 @@ fn bindgen_test_layout_foo() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<foo>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], foo>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<foo>() };
             let struct_ptr = &struct_instance as *const foo;
             let field_ptr = std::ptr::addr_of!(struct_instance.b);
             let struct_address = struct_ptr as usize;
@@ -67,11 +59,7 @@ fn bindgen_test_layout_foo() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<foo>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], foo>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<foo>() };
             let struct_ptr = &struct_instance as *const foo;
             let field_ptr = std::ptr::addr_of!(struct_instance.bar);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/ctypes-prefix-path.rs
+++ b/tests/expectations/tests/ctypes-prefix-path.rs
@@ -32,17 +32,53 @@ fn bindgen_test_layout_foo() {
         concat!("Alignment of ", stringify!(foo))
     );
     assert_eq!(
-        unsafe { &(*(::core::ptr::null::<foo>())).a as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<foo>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], foo>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const foo;
+            let field_ptr = std::ptr::addr_of!(struct_instance.a);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!("Offset of field: ", stringify!(foo), "::", stringify!(a))
     );
     assert_eq!(
-        unsafe { &(*(::core::ptr::null::<foo>())).b as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<foo>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], foo>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const foo;
+            let field_ptr = std::ptr::addr_of!(struct_instance.b);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         4usize,
         concat!("Offset of field: ", stringify!(foo), "::", stringify!(b))
     );
     assert_eq!(
-        unsafe { &(*(::core::ptr::null::<foo>())).bar as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<foo>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], foo>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const foo;
+            let field_ptr = std::ptr::addr_of!(struct_instance.bar);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         8usize,
         concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar))
     );

--- a/tests/expectations/tests/derive-bitfield-method-same-name.rs
+++ b/tests/expectations/tests/derive-bitfield-method-same-name.rs
@@ -115,7 +115,19 @@ fn bindgen_test_layout_Foo() {
         concat!("Alignment of ", stringify!(Foo))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Foo>())).large as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<Foo>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], Foo>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const Foo;
+            let field_ptr = std::ptr::addr_of!(struct_instance.large);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/derive-bitfield-method-same-name.rs
+++ b/tests/expectations/tests/derive-bitfield-method-same-name.rs
@@ -116,11 +116,7 @@ fn bindgen_test_layout_Foo() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<Foo>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], Foo>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<Foo>() };
             let struct_ptr = &struct_instance as *const Foo;
             let field_ptr = std::ptr::addr_of!(struct_instance.large);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/derive-clone.rs
+++ b/tests/expectations/tests/derive-clone.rs
@@ -24,9 +24,20 @@ fn bindgen_test_layout_ShouldDeriveClone() {
         concat!("Alignment of ", stringify!(ShouldDeriveClone))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<ShouldDeriveClone>())).large as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<ShouldDeriveClone>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], ShouldDeriveClone>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const ShouldDeriveClone;
+            let field_ptr = std::ptr::addr_of!(struct_instance.large);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(

--- a/tests/expectations/tests/derive-clone.rs
+++ b/tests/expectations/tests/derive-clone.rs
@@ -25,13 +25,8 @@ fn bindgen_test_layout_ShouldDeriveClone() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<ShouldDeriveClone>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], ShouldDeriveClone>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<ShouldDeriveClone>() };
             let struct_ptr = &struct_instance as *const ShouldDeriveClone;
             let field_ptr = std::ptr::addr_of!(struct_instance.large);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/derive-clone_1_0.rs
+++ b/tests/expectations/tests/derive-clone_1_0.rs
@@ -25,9 +25,20 @@ fn bindgen_test_layout_ShouldImplClone() {
         concat!("Alignment of ", stringify!(ShouldImplClone))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<ShouldImplClone>())).large as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<ShouldImplClone>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], ShouldImplClone>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const ShouldImplClone;
+            let field_ptr = std::ptr::addr_of!(struct_instance.large);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(

--- a/tests/expectations/tests/derive-clone_1_0.rs
+++ b/tests/expectations/tests/derive-clone_1_0.rs
@@ -26,13 +26,8 @@ fn bindgen_test_layout_ShouldImplClone() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<ShouldImplClone>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], ShouldImplClone>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<ShouldImplClone>() };
             let struct_ptr = &struct_instance as *const ShouldImplClone;
             let field_ptr = std::ptr::addr_of!(struct_instance.large);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/derive-custom.rs
+++ b/tests/expectations/tests/derive-custom.rs
@@ -24,7 +24,19 @@ fn bindgen_test_layout_my_type() {
         concat!("Alignment of ", stringify!(my_type))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<my_type>())).a as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<my_type>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], my_type>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const my_type;
+            let field_ptr = std::ptr::addr_of!(struct_instance.a);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!(
             "Offset of field: ",
@@ -54,7 +66,19 @@ fn bindgen_test_layout_my_type2() {
         concat!("Alignment of ", stringify!(my_type2))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<my_type2>())).a as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<my_type2>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], my_type2>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const my_type2;
+            let field_ptr = std::ptr::addr_of!(struct_instance.a);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!(
             "Offset of field: ",
@@ -83,7 +107,19 @@ fn bindgen_test_layout_my_type3() {
         concat!("Alignment of ", stringify!(my_type3))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<my_type3>())).a as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<my_type3>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], my_type3>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const my_type3;
+            let field_ptr = std::ptr::addr_of!(struct_instance.a);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/derive-custom.rs
+++ b/tests/expectations/tests/derive-custom.rs
@@ -25,11 +25,7 @@ fn bindgen_test_layout_my_type() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<my_type>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], my_type>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<my_type>() };
             let struct_ptr = &struct_instance as *const my_type;
             let field_ptr = std::ptr::addr_of!(struct_instance.a);
             let struct_address = struct_ptr as usize;
@@ -67,11 +63,7 @@ fn bindgen_test_layout_my_type2() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<my_type2>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], my_type2>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<my_type2>() };
             let struct_ptr = &struct_instance as *const my_type2;
             let field_ptr = std::ptr::addr_of!(struct_instance.a);
             let struct_address = struct_ptr as usize;
@@ -108,11 +100,7 @@ fn bindgen_test_layout_my_type3() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<my_type3>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], my_type3>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<my_type3>() };
             let struct_ptr = &struct_instance as *const my_type3;
             let field_ptr = std::ptr::addr_of!(struct_instance.a);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/derive-debug-bitfield-core.rs
+++ b/tests/expectations/tests/derive-debug-bitfield-core.rs
@@ -113,8 +113,17 @@ fn bindgen_test_layout_C() {
         concat!("Alignment of ", stringify!(C))
     );
     assert_eq!(
-        unsafe {
-            &(*(::core::ptr::null::<C>())).large_array as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<C>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance =
+                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], C>(buffer) };
+            let struct_ptr = &struct_instance as *const C;
+            let field_ptr = std::ptr::addr_of!(struct_instance.large_array);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         4usize,
         concat!(

--- a/tests/expectations/tests/derive-debug-bitfield-core.rs
+++ b/tests/expectations/tests/derive-debug-bitfield-core.rs
@@ -114,10 +114,7 @@ fn bindgen_test_layout_C() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<C>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance =
-                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], C>(buffer) };
+            let struct_instance = unsafe { std::mem::zeroed::<C>() };
             let struct_ptr = &struct_instance as *const C;
             let field_ptr = std::ptr::addr_of!(struct_instance.large_array);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/derive-debug-bitfield.rs
+++ b/tests/expectations/tests/derive-debug-bitfield.rs
@@ -112,10 +112,7 @@ fn bindgen_test_layout_C() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<C>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance =
-                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], C>(buffer) };
+            let struct_instance = unsafe { std::mem::zeroed::<C>() };
             let struct_ptr = &struct_instance as *const C;
             let field_ptr = std::ptr::addr_of!(struct_instance.large_array);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/derive-debug-bitfield.rs
+++ b/tests/expectations/tests/derive-debug-bitfield.rs
@@ -111,8 +111,17 @@ fn bindgen_test_layout_C() {
         concat!("Alignment of ", stringify!(C))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<C>())).large_array as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<C>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance =
+                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], C>(buffer) };
+            let struct_ptr = &struct_instance as *const C;
+            let field_ptr = std::ptr::addr_of!(struct_instance.large_array);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         4usize,
         concat!(

--- a/tests/expectations/tests/derive-debug-function-pointer.rs
+++ b/tests/expectations/tests/derive-debug-function-pointer.rs
@@ -27,11 +27,7 @@ fn bindgen_test_layout_Nice() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<Nice>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], Nice>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<Nice>() };
             let struct_ptr = &struct_instance as *const Nice;
             let field_ptr = std::ptr::addr_of!(struct_instance.pointer);
             let struct_address = struct_ptr as usize;
@@ -49,11 +45,7 @@ fn bindgen_test_layout_Nice() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<Nice>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], Nice>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<Nice>() };
             let struct_ptr = &struct_instance as *const Nice;
             let field_ptr = std::ptr::addr_of!(struct_instance.large_array);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/derive-debug-function-pointer.rs
+++ b/tests/expectations/tests/derive-debug-function-pointer.rs
@@ -26,8 +26,18 @@ fn bindgen_test_layout_Nice() {
         concat!("Alignment of ", stringify!(Nice))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<Nice>())).pointer as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<Nice>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], Nice>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const Nice;
+            let field_ptr = std::ptr::addr_of!(struct_instance.pointer);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -38,8 +48,18 @@ fn bindgen_test_layout_Nice() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<Nice>())).large_array as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<Nice>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], Nice>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const Nice;
+            let field_ptr = std::ptr::addr_of!(struct_instance.large_array);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         8usize,
         concat!(

--- a/tests/expectations/tests/derive-debug-mangle-name.rs
+++ b/tests/expectations/tests/derive-debug-mangle-name.rs
@@ -59,13 +59,8 @@ fn bindgen_test_layout_perf_event_attr() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<perf_event_attr>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], perf_event_attr>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<perf_event_attr>() };
             let struct_ptr = &struct_instance as *const perf_event_attr;
             let field_ptr = std::ptr::addr_of!(struct_instance.type_);
             let struct_address = struct_ptr as usize;
@@ -83,13 +78,8 @@ fn bindgen_test_layout_perf_event_attr() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<perf_event_attr>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], perf_event_attr>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<perf_event_attr>() };
             let struct_ptr = &struct_instance as *const perf_event_attr;
             let field_ptr = std::ptr::addr_of!(struct_instance.a);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/derive-debug-mangle-name.rs
+++ b/tests/expectations/tests/derive-debug-mangle-name.rs
@@ -30,32 +30,6 @@ fn bindgen_test_layout_perf_event_attr__bindgen_ty_1() {
         4usize,
         concat!("Alignment of ", stringify!(perf_event_attr__bindgen_ty_1))
     );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<perf_event_attr__bindgen_ty_1>())).b
-                as *const _ as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(perf_event_attr__bindgen_ty_1),
-            "::",
-            stringify!(b)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<perf_event_attr__bindgen_ty_1>())).c
-                as *const _ as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(perf_event_attr__bindgen_ty_1),
-            "::",
-            stringify!(c)
-        )
-    );
 }
 impl Default for perf_event_attr__bindgen_ty_1 {
     fn default() -> Self {
@@ -84,9 +58,20 @@ fn bindgen_test_layout_perf_event_attr() {
         concat!("Alignment of ", stringify!(perf_event_attr))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<perf_event_attr>())).type_ as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<perf_event_attr>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], perf_event_attr>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const perf_event_attr;
+            let field_ptr = std::ptr::addr_of!(struct_instance.type_);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -97,8 +82,20 @@ fn bindgen_test_layout_perf_event_attr() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<perf_event_attr>())).a as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<perf_event_attr>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], perf_event_attr>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const perf_event_attr;
+            let field_ptr = std::ptr::addr_of!(struct_instance.a);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         4usize,
         concat!(

--- a/tests/expectations/tests/derive-debug-opaque-template-instantiation.rs
+++ b/tests/expectations/tests/derive-debug-opaque-template-instantiation.rs
@@ -23,11 +23,7 @@ fn bindgen_test_layout_Instance() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<Instance>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], Instance>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<Instance>() };
             let struct_ptr = &struct_instance as *const Instance;
             let field_ptr = std::ptr::addr_of!(struct_instance.val);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/derive-debug-opaque-template-instantiation.rs
+++ b/tests/expectations/tests/derive-debug-opaque-template-instantiation.rs
@@ -22,8 +22,18 @@ fn bindgen_test_layout_Instance() {
         concat!("Alignment of ", stringify!(Instance))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<Instance>())).val as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<Instance>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], Instance>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const Instance;
+            let field_ptr = std::ptr::addr_of!(struct_instance.val);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(

--- a/tests/expectations/tests/derive-debug-opaque.rs
+++ b/tests/expectations/tests/derive-debug-opaque.rs
@@ -55,11 +55,7 @@ fn bindgen_test_layout_OpaqueUser() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<OpaqueUser>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], OpaqueUser>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<OpaqueUser>() };
             let struct_ptr = &struct_instance as *const OpaqueUser;
             let field_ptr = std::ptr::addr_of!(struct_instance.opaque);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/derive-debug-opaque.rs
+++ b/tests/expectations/tests/derive-debug-opaque.rs
@@ -54,8 +54,18 @@ fn bindgen_test_layout_OpaqueUser() {
         concat!("Alignment of ", stringify!(OpaqueUser))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<OpaqueUser>())).opaque as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<OpaqueUser>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], OpaqueUser>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const OpaqueUser;
+            let field_ptr = std::ptr::addr_of!(struct_instance.opaque);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(

--- a/tests/expectations/tests/derive-default-and-blocklist.rs
+++ b/tests/expectations/tests/derive-default-and-blocklist.rs
@@ -26,9 +26,21 @@ fn bindgen_test_layout_ShouldNotDeriveDefault() {
         concat!("Alignment of ", stringify!(ShouldNotDeriveDefault))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<ShouldNotDeriveDefault>())).a as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<ShouldNotDeriveDefault>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], ShouldNotDeriveDefault>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const ShouldNotDeriveDefault;
+            let field_ptr = std::ptr::addr_of!(struct_instance.a);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(

--- a/tests/expectations/tests/derive-default-and-blocklist.rs
+++ b/tests/expectations/tests/derive-default-and-blocklist.rs
@@ -27,14 +27,8 @@ fn bindgen_test_layout_ShouldNotDeriveDefault() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<ShouldNotDeriveDefault>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], ShouldNotDeriveDefault>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<ShouldNotDeriveDefault>() };
             let struct_ptr = &struct_instance as *const ShouldNotDeriveDefault;
             let field_ptr = std::ptr::addr_of!(struct_instance.a);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/derive-fn-ptr.rs
+++ b/tests/expectations/tests/derive-fn-ptr.rs
@@ -44,11 +44,7 @@ fn bindgen_test_layout_Foo() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<Foo>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], Foo>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<Foo>() };
             let struct_ptr = &struct_instance as *const Foo;
             let field_ptr = std::ptr::addr_of!(struct_instance.callback);
             let struct_address = struct_ptr as usize;
@@ -100,11 +96,7 @@ fn bindgen_test_layout_Bar() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<Bar>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], Bar>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<Bar>() };
             let struct_ptr = &struct_instance as *const Bar;
             let field_ptr = std::ptr::addr_of!(struct_instance.callback);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/derive-fn-ptr.rs
+++ b/tests/expectations/tests/derive-fn-ptr.rs
@@ -43,8 +43,18 @@ fn bindgen_test_layout_Foo() {
         concat!("Alignment of ", stringify!(Foo))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<Foo>())).callback as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<Foo>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], Foo>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const Foo;
+            let field_ptr = std::ptr::addr_of!(struct_instance.callback);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -89,8 +99,18 @@ fn bindgen_test_layout_Bar() {
         concat!("Alignment of ", stringify!(Bar))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<Bar>())).callback as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<Bar>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], Bar>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const Bar;
+            let field_ptr = std::ptr::addr_of!(struct_instance.callback);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(

--- a/tests/expectations/tests/derive-hash-and-blocklist.rs
+++ b/tests/expectations/tests/derive-hash-and-blocklist.rs
@@ -25,9 +25,21 @@ fn bindgen_test_layout_ShouldNotDeriveHash() {
         concat!("Alignment of ", stringify!(ShouldNotDeriveHash))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<ShouldNotDeriveHash>())).a as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<ShouldNotDeriveHash>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], ShouldNotDeriveHash>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const ShouldNotDeriveHash;
+            let field_ptr = std::ptr::addr_of!(struct_instance.a);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(

--- a/tests/expectations/tests/derive-hash-and-blocklist.rs
+++ b/tests/expectations/tests/derive-hash-and-blocklist.rs
@@ -26,14 +26,8 @@ fn bindgen_test_layout_ShouldNotDeriveHash() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<ShouldNotDeriveHash>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], ShouldNotDeriveHash>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<ShouldNotDeriveHash>() };
             let struct_ptr = &struct_instance as *const ShouldNotDeriveHash;
             let field_ptr = std::ptr::addr_of!(struct_instance.a);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/derive-hash-blocklisting.rs
+++ b/tests/expectations/tests/derive-hash-blocklisting.rs
@@ -31,8 +31,18 @@ fn bindgen_test_layout_AllowlistedOne() {
         concat!("Alignment of ", stringify!(AllowlistedOne))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<AllowlistedOne>())).a as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<AllowlistedOne>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], AllowlistedOne>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const AllowlistedOne;
+            let field_ptr = std::ptr::addr_of!(struct_instance.a);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -70,8 +80,18 @@ fn bindgen_test_layout_AllowlistedTwo() {
         concat!("Alignment of ", stringify!(AllowlistedTwo))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<AllowlistedTwo>())).b as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<AllowlistedTwo>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], AllowlistedTwo>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const AllowlistedTwo;
+            let field_ptr = std::ptr::addr_of!(struct_instance.b);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(

--- a/tests/expectations/tests/derive-hash-blocklisting.rs
+++ b/tests/expectations/tests/derive-hash-blocklisting.rs
@@ -32,11 +32,8 @@ fn bindgen_test_layout_AllowlistedOne() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<AllowlistedOne>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], AllowlistedOne>(buffer)
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<AllowlistedOne>() };
             let struct_ptr = &struct_instance as *const AllowlistedOne;
             let field_ptr = std::ptr::addr_of!(struct_instance.a);
             let struct_address = struct_ptr as usize;
@@ -81,11 +78,8 @@ fn bindgen_test_layout_AllowlistedTwo() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<AllowlistedTwo>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], AllowlistedTwo>(buffer)
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<AllowlistedTwo>() };
             let struct_ptr = &struct_instance as *const AllowlistedTwo;
             let field_ptr = std::ptr::addr_of!(struct_instance.b);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/derive-hash-struct-with-anon-struct-float.rs
+++ b/tests/expectations/tests/derive-hash-struct-with-anon-struct-float.rs
@@ -31,13 +31,8 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<foo__bindgen_ty_1>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], foo__bindgen_ty_1>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<foo__bindgen_ty_1>() };
             let struct_ptr = &struct_instance as *const foo__bindgen_ty_1;
             let field_ptr = std::ptr::addr_of!(struct_instance.a);
             let struct_address = struct_ptr as usize;
@@ -55,13 +50,8 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<foo__bindgen_ty_1>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], foo__bindgen_ty_1>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<foo__bindgen_ty_1>() };
             let struct_ptr = &struct_instance as *const foo__bindgen_ty_1;
             let field_ptr = std::ptr::addr_of!(struct_instance.b);
             let struct_address = struct_ptr as usize;
@@ -92,11 +82,7 @@ fn bindgen_test_layout_foo() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<foo>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], foo>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<foo>() };
             let struct_ptr = &struct_instance as *const foo;
             let field_ptr = std::ptr::addr_of!(struct_instance.bar);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/derive-hash-struct-with-anon-struct-float.rs
+++ b/tests/expectations/tests/derive-hash-struct-with-anon-struct-float.rs
@@ -30,8 +30,20 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
         concat!("Alignment of ", stringify!(foo__bindgen_ty_1))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<foo__bindgen_ty_1>())).a as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<foo__bindgen_ty_1>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], foo__bindgen_ty_1>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const foo__bindgen_ty_1;
+            let field_ptr = std::ptr::addr_of!(struct_instance.a);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -42,8 +54,20 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<foo__bindgen_ty_1>())).b as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<foo__bindgen_ty_1>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], foo__bindgen_ty_1>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const foo__bindgen_ty_1;
+            let field_ptr = std::ptr::addr_of!(struct_instance.b);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         4usize,
         concat!(
@@ -67,7 +91,19 @@ fn bindgen_test_layout_foo() {
         concat!("Alignment of ", stringify!(foo))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<foo>())).bar as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<foo>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], foo>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const foo;
+            let field_ptr = std::ptr::addr_of!(struct_instance.bar);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar))
     );

--- a/tests/expectations/tests/derive-hash-struct-with-float-array.rs
+++ b/tests/expectations/tests/derive-hash-struct-with-float-array.rs
@@ -24,7 +24,19 @@ fn bindgen_test_layout_foo() {
         concat!("Alignment of ", stringify!(foo))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<foo>())).bar as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<foo>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], foo>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const foo;
+            let field_ptr = std::ptr::addr_of!(struct_instance.bar);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar))
     );

--- a/tests/expectations/tests/derive-hash-struct-with-float-array.rs
+++ b/tests/expectations/tests/derive-hash-struct-with-float-array.rs
@@ -25,11 +25,7 @@ fn bindgen_test_layout_foo() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<foo>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], foo>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<foo>() };
             let struct_ptr = &struct_instance as *const foo;
             let field_ptr = std::ptr::addr_of!(struct_instance.bar);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/derive-hash-struct-with-pointer.rs
+++ b/tests/expectations/tests/derive-hash-struct-with-pointer.rs
@@ -25,11 +25,8 @@ fn bindgen_test_layout_ConstPtrMutObj() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<ConstPtrMutObj>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], ConstPtrMutObj>(buffer)
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<ConstPtrMutObj>() };
             let struct_ptr = &struct_instance as *const ConstPtrMutObj;
             let field_ptr = std::ptr::addr_of!(struct_instance.bar);
             let struct_address = struct_ptr as usize;
@@ -74,11 +71,7 @@ fn bindgen_test_layout_MutPtrMutObj() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<MutPtrMutObj>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], MutPtrMutObj>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<MutPtrMutObj>() };
             let struct_ptr = &struct_instance as *const MutPtrMutObj;
             let field_ptr = std::ptr::addr_of!(struct_instance.bar);
             let struct_address = struct_ptr as usize;
@@ -123,11 +116,8 @@ fn bindgen_test_layout_MutPtrConstObj() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<MutPtrConstObj>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], MutPtrConstObj>(buffer)
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<MutPtrConstObj>() };
             let struct_ptr = &struct_instance as *const MutPtrConstObj;
             let field_ptr = std::ptr::addr_of!(struct_instance.bar);
             let struct_address = struct_ptr as usize;
@@ -172,13 +162,8 @@ fn bindgen_test_layout_ConstPtrConstObj() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<ConstPtrConstObj>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], ConstPtrConstObj>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<ConstPtrConstObj>() };
             let struct_ptr = &struct_instance as *const ConstPtrConstObj;
             let field_ptr = std::ptr::addr_of!(struct_instance.bar);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/derive-hash-struct-with-pointer.rs
+++ b/tests/expectations/tests/derive-hash-struct-with-pointer.rs
@@ -24,8 +24,18 @@ fn bindgen_test_layout_ConstPtrMutObj() {
         concat!("Alignment of ", stringify!(ConstPtrMutObj))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<ConstPtrMutObj>())).bar as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<ConstPtrMutObj>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], ConstPtrMutObj>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const ConstPtrMutObj;
+            let field_ptr = std::ptr::addr_of!(struct_instance.bar);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -63,8 +73,18 @@ fn bindgen_test_layout_MutPtrMutObj() {
         concat!("Alignment of ", stringify!(MutPtrMutObj))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<MutPtrMutObj>())).bar as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<MutPtrMutObj>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], MutPtrMutObj>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const MutPtrMutObj;
+            let field_ptr = std::ptr::addr_of!(struct_instance.bar);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -102,8 +122,18 @@ fn bindgen_test_layout_MutPtrConstObj() {
         concat!("Alignment of ", stringify!(MutPtrConstObj))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<MutPtrConstObj>())).bar as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<MutPtrConstObj>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], MutPtrConstObj>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const MutPtrConstObj;
+            let field_ptr = std::ptr::addr_of!(struct_instance.bar);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -141,9 +171,20 @@ fn bindgen_test_layout_ConstPtrConstObj() {
         concat!("Alignment of ", stringify!(ConstPtrConstObj))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<ConstPtrConstObj>())).bar as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<ConstPtrConstObj>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], ConstPtrConstObj>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const ConstPtrConstObj;
+            let field_ptr = std::ptr::addr_of!(struct_instance.bar);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(

--- a/tests/expectations/tests/derive-hash-template-inst-float.rs
+++ b/tests/expectations/tests/derive-hash-template-inst-float.rs
@@ -40,7 +40,19 @@ fn bindgen_test_layout_IntStr() {
         concat!("Alignment of ", stringify!(IntStr))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<IntStr>())).a as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<IntStr>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], IntStr>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const IntStr;
+            let field_ptr = std::ptr::addr_of!(struct_instance.a);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!("Offset of field: ", stringify!(IntStr), "::", stringify!(a))
     );
@@ -73,7 +85,19 @@ fn bindgen_test_layout_FloatStr() {
         concat!("Alignment of ", stringify!(FloatStr))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<FloatStr>())).a as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<FloatStr>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], FloatStr>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const FloatStr;
+            let field_ptr = std::ptr::addr_of!(struct_instance.a);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/derive-hash-template-inst-float.rs
+++ b/tests/expectations/tests/derive-hash-template-inst-float.rs
@@ -41,11 +41,7 @@ fn bindgen_test_layout_IntStr() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<IntStr>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], IntStr>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<IntStr>() };
             let struct_ptr = &struct_instance as *const IntStr;
             let field_ptr = std::ptr::addr_of!(struct_instance.a);
             let struct_address = struct_ptr as usize;
@@ -86,11 +82,7 @@ fn bindgen_test_layout_FloatStr() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<FloatStr>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], FloatStr>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<FloatStr>() };
             let struct_ptr = &struct_instance as *const FloatStr;
             let field_ptr = std::ptr::addr_of!(struct_instance.a);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/derive-partialeq-and-blocklist.rs
+++ b/tests/expectations/tests/derive-partialeq-and-blocklist.rs
@@ -27,14 +27,8 @@ fn bindgen_test_layout_ShouldNotDerivePartialEq() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<ShouldNotDerivePartialEq>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], ShouldNotDerivePartialEq>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<ShouldNotDerivePartialEq>() };
             let struct_ptr =
                 &struct_instance as *const ShouldNotDerivePartialEq;
             let field_ptr = std::ptr::addr_of!(struct_instance.a);

--- a/tests/expectations/tests/derive-partialeq-and-blocklist.rs
+++ b/tests/expectations/tests/derive-partialeq-and-blocklist.rs
@@ -26,9 +26,22 @@ fn bindgen_test_layout_ShouldNotDerivePartialEq() {
         concat!("Alignment of ", stringify!(ShouldNotDerivePartialEq))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<ShouldNotDerivePartialEq>())).a as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<ShouldNotDerivePartialEq>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], ShouldNotDerivePartialEq>(
+                    buffer,
+                )
+            };
+            let struct_ptr =
+                &struct_instance as *const ShouldNotDerivePartialEq;
+            let field_ptr = std::ptr::addr_of!(struct_instance.a);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(

--- a/tests/expectations/tests/derive-partialeq-base.rs
+++ b/tests/expectations/tests/derive-partialeq-base.rs
@@ -23,7 +23,19 @@ fn bindgen_test_layout_Base() {
         concat!("Alignment of ", stringify!(Base))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Base>())).large as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<Base>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], Base>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const Base;
+            let field_ptr = std::ptr::addr_of!(struct_instance.large);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/derive-partialeq-base.rs
+++ b/tests/expectations/tests/derive-partialeq-base.rs
@@ -24,11 +24,7 @@ fn bindgen_test_layout_Base() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<Base>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], Base>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<Base>() };
             let struct_ptr = &struct_instance as *const Base;
             let field_ptr = std::ptr::addr_of!(struct_instance.large);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/derive-partialeq-bitfield.rs
+++ b/tests/expectations/tests/derive-partialeq-bitfield.rs
@@ -112,10 +112,7 @@ fn bindgen_test_layout_C() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<C>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance =
-                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], C>(buffer) };
+            let struct_instance = unsafe { std::mem::zeroed::<C>() };
             let struct_ptr = &struct_instance as *const C;
             let field_ptr = std::ptr::addr_of!(struct_instance.large_array);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/derive-partialeq-bitfield.rs
+++ b/tests/expectations/tests/derive-partialeq-bitfield.rs
@@ -111,8 +111,17 @@ fn bindgen_test_layout_C() {
         concat!("Alignment of ", stringify!(C))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<C>())).large_array as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<C>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance =
+                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], C>(buffer) };
+            let struct_ptr = &struct_instance as *const C;
+            let field_ptr = std::ptr::addr_of!(struct_instance.large_array);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         4usize,
         concat!(

--- a/tests/expectations/tests/derive-partialeq-core.rs
+++ b/tests/expectations/tests/derive-partialeq-core.rs
@@ -25,8 +25,17 @@ fn bindgen_test_layout_C() {
         concat!("Alignment of ", stringify!(C))
     );
     assert_eq!(
-        unsafe {
-            &(*(::core::ptr::null::<C>())).large_array as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<C>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance =
+                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], C>(buffer) };
+            let struct_ptr = &struct_instance as *const C;
+            let field_ptr = std::ptr::addr_of!(struct_instance.large_array);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(

--- a/tests/expectations/tests/derive-partialeq-core.rs
+++ b/tests/expectations/tests/derive-partialeq-core.rs
@@ -26,10 +26,7 @@ fn bindgen_test_layout_C() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<C>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance =
-                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], C>(buffer) };
+            let struct_instance = unsafe { std::mem::zeroed::<C>() };
             let struct_ptr = &struct_instance as *const C;
             let field_ptr = std::ptr::addr_of!(struct_instance.large_array);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/derive-partialeq-pointer.rs
+++ b/tests/expectations/tests/derive-partialeq-pointer.rs
@@ -23,7 +23,19 @@ fn bindgen_test_layout_Bar() {
         concat!("Alignment of ", stringify!(Bar))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Bar>())).b as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<Bar>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], Bar>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const Bar;
+            let field_ptr = std::ptr::addr_of!(struct_instance.b);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!("Offset of field: ", stringify!(Bar), "::", stringify!(b))
     );
@@ -109,7 +121,18 @@ fn bindgen_test_layout_a() {
         concat!("Alignment of ", stringify!(a))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<a>())).d as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<a>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance =
+                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], a>(buffer) };
+            let struct_ptr = &struct_instance as *const a;
+            let field_ptr = std::ptr::addr_of!(struct_instance.d);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!("Offset of field: ", stringify!(a), "::", stringify!(d))
     );

--- a/tests/expectations/tests/derive-partialeq-pointer.rs
+++ b/tests/expectations/tests/derive-partialeq-pointer.rs
@@ -24,11 +24,7 @@ fn bindgen_test_layout_Bar() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<Bar>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], Bar>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<Bar>() };
             let struct_ptr = &struct_instance as *const Bar;
             let field_ptr = std::ptr::addr_of!(struct_instance.b);
             let struct_address = struct_ptr as usize;
@@ -122,10 +118,7 @@ fn bindgen_test_layout_a() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<a>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance =
-                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], a>(buffer) };
+            let struct_instance = unsafe { std::mem::zeroed::<a>() };
             let struct_ptr = &struct_instance as *const a;
             let field_ptr = std::ptr::addr_of!(struct_instance.d);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/derive-partialeq-union.rs
+++ b/tests/expectations/tests/derive-partialeq-union.rs
@@ -24,32 +24,6 @@ fn bindgen_test_layout_ShouldNotDerivePartialEq() {
         4usize,
         concat!("Alignment of ", stringify!(ShouldNotDerivePartialEq))
     );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<ShouldNotDerivePartialEq>())).a as *const _
-                as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(ShouldNotDerivePartialEq),
-            "::",
-            stringify!(a)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<ShouldNotDerivePartialEq>())).b as *const _
-                as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(ShouldNotDerivePartialEq),
-            "::",
-            stringify!(b)
-        )
-    );
 }
 impl Default for ShouldNotDerivePartialEq {
     fn default() -> Self {

--- a/tests/expectations/tests/derive-partialeq-union_1_0.rs
+++ b/tests/expectations/tests/derive-partialeq-union_1_0.rs
@@ -68,32 +68,6 @@ fn bindgen_test_layout_ShouldDerivePartialEq() {
         4usize,
         concat!("Alignment of ", stringify!(ShouldDerivePartialEq))
     );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<ShouldDerivePartialEq>())).a as *const _
-                as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(ShouldDerivePartialEq),
-            "::",
-            stringify!(a)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<ShouldDerivePartialEq>())).b as *const _
-                as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(ShouldDerivePartialEq),
-            "::",
-            stringify!(b)
-        )
-    );
 }
 impl Clone for ShouldDerivePartialEq {
     fn clone(&self) -> Self {

--- a/tests/expectations/tests/disable-nested-struct-naming.rs
+++ b/tests/expectations/tests/disable-nested-struct-naming.rs
@@ -47,11 +47,7 @@ fn bindgen_test_layout_bar4() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<bar4>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], bar4>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<bar4>() };
             let struct_ptr = &struct_instance as *const bar4;
             let field_ptr = std::ptr::addr_of!(struct_instance.x4);
             let struct_address = struct_ptr as usize;
@@ -80,14 +76,8 @@ fn bindgen_test_layout_bar1__bindgen_ty_1__bindgen_ty_1() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<bar1__bindgen_ty_1__bindgen_ty_1>();
-            let buffer = [0u8; STRUCT_SIZE];
             let struct_instance = unsafe {
-                std::mem::transmute::<
-                    [u8; STRUCT_SIZE],
-                    bar1__bindgen_ty_1__bindgen_ty_1,
-                >(buffer)
+                std::mem::zeroed::<bar1__bindgen_ty_1__bindgen_ty_1>()
             };
             let struct_ptr =
                 &struct_instance as *const bar1__bindgen_ty_1__bindgen_ty_1;
@@ -107,14 +97,8 @@ fn bindgen_test_layout_bar1__bindgen_ty_1__bindgen_ty_1() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<bar1__bindgen_ty_1__bindgen_ty_1>();
-            let buffer = [0u8; STRUCT_SIZE];
             let struct_instance = unsafe {
-                std::mem::transmute::<
-                    [u8; STRUCT_SIZE],
-                    bar1__bindgen_ty_1__bindgen_ty_1,
-                >(buffer)
+                std::mem::zeroed::<bar1__bindgen_ty_1__bindgen_ty_1>()
             };
             let struct_ptr =
                 &struct_instance as *const bar1__bindgen_ty_1__bindgen_ty_1;
@@ -147,14 +131,8 @@ fn bindgen_test_layout_bar1__bindgen_ty_1() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<bar1__bindgen_ty_1>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], bar1__bindgen_ty_1>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<bar1__bindgen_ty_1>() };
             let struct_ptr = &struct_instance as *const bar1__bindgen_ty_1;
             let field_ptr = std::ptr::addr_of!(struct_instance.x2);
             let struct_address = struct_ptr as usize;
@@ -172,14 +150,8 @@ fn bindgen_test_layout_bar1__bindgen_ty_1() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<bar1__bindgen_ty_1>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], bar1__bindgen_ty_1>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<bar1__bindgen_ty_1>() };
             let struct_ptr = &struct_instance as *const bar1__bindgen_ty_1;
             let field_ptr = std::ptr::addr_of!(struct_instance.b3);
             let struct_address = struct_ptr as usize;
@@ -210,11 +182,7 @@ fn bindgen_test_layout_bar1() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<bar1>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], bar1>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<bar1>() };
             let struct_ptr = &struct_instance as *const bar1;
             let field_ptr = std::ptr::addr_of!(struct_instance.x1);
             let struct_address = struct_ptr as usize;
@@ -227,11 +195,7 @@ fn bindgen_test_layout_bar1() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<bar1>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], bar1>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<bar1>() };
             let struct_ptr = &struct_instance as *const bar1;
             let field_ptr = std::ptr::addr_of!(struct_instance.b2);
             let struct_address = struct_ptr as usize;
@@ -257,11 +221,7 @@ fn bindgen_test_layout_foo() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<foo>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], foo>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<foo>() };
             let struct_ptr = &struct_instance as *const foo;
             let field_ptr = std::ptr::addr_of!(struct_instance.b1);
             let struct_address = struct_ptr as usize;
@@ -302,11 +262,7 @@ fn bindgen_test_layout_baz() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<baz>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], baz>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<baz>() };
             let struct_ptr = &struct_instance as *const baz;
             let field_ptr = std::ptr::addr_of!(struct_instance.x);
             let struct_address = struct_ptr as usize;
@@ -332,15 +288,8 @@ fn bindgen_test_layout__bindgen_ty_1__bindgen_ty_1() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<_bindgen_ty_1__bindgen_ty_1>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<
-                    [u8; STRUCT_SIZE],
-                    _bindgen_ty_1__bindgen_ty_1,
-                >(buffer)
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<_bindgen_ty_1__bindgen_ty_1>() };
             let struct_ptr =
                 &struct_instance as *const _bindgen_ty_1__bindgen_ty_1;
             let field_ptr = std::ptr::addr_of!(struct_instance.b);
@@ -372,11 +321,8 @@ fn bindgen_test_layout__bindgen_ty_1() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<_bindgen_ty_1>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], _bindgen_ty_1>(buffer)
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<_bindgen_ty_1>() };
             let struct_ptr = &struct_instance as *const _bindgen_ty_1;
             let field_ptr = std::ptr::addr_of!(struct_instance.anon2);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/disable-nested-struct-naming.rs
+++ b/tests/expectations/tests/disable-nested-struct-naming.rs
@@ -46,7 +46,19 @@ fn bindgen_test_layout_bar4() {
         concat!("Alignment of ", stringify!(bar4))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<bar4>())).x4 as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<bar4>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], bar4>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const bar4;
+            let field_ptr = std::ptr::addr_of!(struct_instance.x4);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!("Offset of field: ", stringify!(bar4), "::", stringify!(x4))
     );
@@ -67,9 +79,23 @@ fn bindgen_test_layout_bar1__bindgen_ty_1__bindgen_ty_1() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<bar1__bindgen_ty_1__bindgen_ty_1>())).x3
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<bar1__bindgen_ty_1__bindgen_ty_1>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<
+                    [u8; STRUCT_SIZE],
+                    bar1__bindgen_ty_1__bindgen_ty_1,
+                >(buffer)
+            };
+            let struct_ptr =
+                &struct_instance as *const bar1__bindgen_ty_1__bindgen_ty_1;
+            let field_ptr = std::ptr::addr_of!(struct_instance.x3);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -80,9 +106,23 @@ fn bindgen_test_layout_bar1__bindgen_ty_1__bindgen_ty_1() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<bar1__bindgen_ty_1__bindgen_ty_1>())).b4
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<bar1__bindgen_ty_1__bindgen_ty_1>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<
+                    [u8; STRUCT_SIZE],
+                    bar1__bindgen_ty_1__bindgen_ty_1,
+                >(buffer)
+            };
+            let struct_ptr =
+                &struct_instance as *const bar1__bindgen_ty_1__bindgen_ty_1;
+            let field_ptr = std::ptr::addr_of!(struct_instance.b4);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         4usize,
         concat!(
@@ -106,9 +146,21 @@ fn bindgen_test_layout_bar1__bindgen_ty_1() {
         concat!("Alignment of ", stringify!(bar1__bindgen_ty_1))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<bar1__bindgen_ty_1>())).x2 as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<bar1__bindgen_ty_1>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], bar1__bindgen_ty_1>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const bar1__bindgen_ty_1;
+            let field_ptr = std::ptr::addr_of!(struct_instance.x2);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -119,9 +171,21 @@ fn bindgen_test_layout_bar1__bindgen_ty_1() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<bar1__bindgen_ty_1>())).b3 as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<bar1__bindgen_ty_1>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], bar1__bindgen_ty_1>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const bar1__bindgen_ty_1;
+            let field_ptr = std::ptr::addr_of!(struct_instance.b3);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         4usize,
         concat!(
@@ -145,12 +209,36 @@ fn bindgen_test_layout_bar1() {
         concat!("Alignment of ", stringify!(bar1))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<bar1>())).x1 as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<bar1>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], bar1>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const bar1;
+            let field_ptr = std::ptr::addr_of!(struct_instance.x1);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!("Offset of field: ", stringify!(bar1), "::", stringify!(x1))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<bar1>())).b2 as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<bar1>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], bar1>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const bar1;
+            let field_ptr = std::ptr::addr_of!(struct_instance.b2);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         4usize,
         concat!("Offset of field: ", stringify!(bar1), "::", stringify!(b2))
     );
@@ -168,7 +256,19 @@ fn bindgen_test_layout_foo() {
         concat!("Alignment of ", stringify!(foo))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<foo>())).b1 as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<foo>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], foo>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const foo;
+            let field_ptr = std::ptr::addr_of!(struct_instance.b1);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!("Offset of field: ", stringify!(foo), "::", stringify!(b1))
     );
@@ -201,7 +301,19 @@ fn bindgen_test_layout_baz() {
         concat!("Alignment of ", stringify!(baz))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<baz>())).x as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<baz>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], baz>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const baz;
+            let field_ptr = std::ptr::addr_of!(struct_instance.x);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!("Offset of field: ", stringify!(baz), "::", stringify!(x))
     );
@@ -219,9 +331,23 @@ fn bindgen_test_layout__bindgen_ty_1__bindgen_ty_1() {
         concat!("Alignment of ", stringify!(_bindgen_ty_1__bindgen_ty_1))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<_bindgen_ty_1__bindgen_ty_1>())).b
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<_bindgen_ty_1__bindgen_ty_1>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<
+                    [u8; STRUCT_SIZE],
+                    _bindgen_ty_1__bindgen_ty_1,
+                >(buffer)
+            };
+            let struct_ptr =
+                &struct_instance as *const _bindgen_ty_1__bindgen_ty_1;
+            let field_ptr = std::ptr::addr_of!(struct_instance.b);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -245,8 +371,18 @@ fn bindgen_test_layout__bindgen_ty_1() {
         concat!("Alignment of ", stringify!(_bindgen_ty_1))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<_bindgen_ty_1>())).anon2 as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<_bindgen_ty_1>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], _bindgen_ty_1>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const _bindgen_ty_1;
+            let field_ptr = std::ptr::addr_of!(struct_instance.anon2);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(

--- a/tests/expectations/tests/disable-untagged-union.rs
+++ b/tests/expectations/tests/disable-untagged-union.rs
@@ -67,14 +67,4 @@ fn bindgen_test_layout_Foo() {
         4usize,
         concat!("Alignment of ", stringify!(Foo))
     );
-    assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Foo>())).bar as *const _ as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(Foo), "::", stringify!(bar))
-    );
-    assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Foo>())).baz as *const _ as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(Foo), "::", stringify!(baz))
-    );
 }

--- a/tests/expectations/tests/do-not-derive-copy.rs
+++ b/tests/expectations/tests/do-not-derive-copy.rs
@@ -26,9 +26,23 @@ fn bindgen_test_layout_WouldBeCopyButWeAreNotDerivingCopy() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<WouldBeCopyButWeAreNotDerivingCopy>())).x
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<WouldBeCopyButWeAreNotDerivingCopy>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<
+                    [u8; STRUCT_SIZE],
+                    WouldBeCopyButWeAreNotDerivingCopy,
+                >(buffer)
+            };
+            let struct_ptr =
+                &struct_instance as *const WouldBeCopyButWeAreNotDerivingCopy;
+            let field_ptr = std::ptr::addr_of!(struct_instance.x);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(

--- a/tests/expectations/tests/do-not-derive-copy.rs
+++ b/tests/expectations/tests/do-not-derive-copy.rs
@@ -27,14 +27,8 @@ fn bindgen_test_layout_WouldBeCopyButWeAreNotDerivingCopy() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<WouldBeCopyButWeAreNotDerivingCopy>();
-            let buffer = [0u8; STRUCT_SIZE];
             let struct_instance = unsafe {
-                std::mem::transmute::<
-                    [u8; STRUCT_SIZE],
-                    WouldBeCopyButWeAreNotDerivingCopy,
-                >(buffer)
+                std::mem::zeroed::<WouldBeCopyButWeAreNotDerivingCopy>()
             };
             let struct_ptr =
                 &struct_instance as *const WouldBeCopyButWeAreNotDerivingCopy;

--- a/tests/expectations/tests/doggo-or-null.rs
+++ b/tests/expectations/tests/doggo-or-null.rs
@@ -24,11 +24,7 @@ fn bindgen_test_layout_Doggo() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<Doggo>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], Doggo>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<Doggo>() };
             let struct_ptr = &struct_instance as *const Doggo;
             let field_ptr = std::ptr::addr_of!(struct_instance.x);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/doggo-or-null.rs
+++ b/tests/expectations/tests/doggo-or-null.rs
@@ -23,7 +23,19 @@ fn bindgen_test_layout_Doggo() {
         concat!("Alignment of ", stringify!(Doggo))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Doggo>())).x as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<Doggo>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], Doggo>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const Doggo;
+            let field_ptr = std::ptr::addr_of!(struct_instance.x);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!("Offset of field: ", stringify!(Doggo), "::", stringify!(x))
     );

--- a/tests/expectations/tests/duplicated-namespaces-definitions.rs
+++ b/tests/expectations/tests/duplicated-namespaces-definitions.rs
@@ -32,11 +32,7 @@ pub mod root {
             );
             assert_eq!(
                 {
-                    const STRUCT_SIZE: usize = std::mem::size_of::<Bar>();
-                    let buffer = [0u8; STRUCT_SIZE];
-                    let struct_instance = unsafe {
-                        std::mem::transmute::<[u8; STRUCT_SIZE], Bar>(buffer)
-                    };
+                    let struct_instance = unsafe { std::mem::zeroed::<Bar>() };
                     let struct_ptr = &struct_instance as *const Bar;
                     let field_ptr = std::ptr::addr_of!(struct_instance.foo);
                     let struct_address = struct_ptr as usize;
@@ -54,11 +50,7 @@ pub mod root {
             );
             assert_eq!(
                 {
-                    const STRUCT_SIZE: usize = std::mem::size_of::<Bar>();
-                    let buffer = [0u8; STRUCT_SIZE];
-                    let struct_instance = unsafe {
-                        std::mem::transmute::<[u8; STRUCT_SIZE], Bar>(buffer)
-                    };
+                    let struct_instance = unsafe { std::mem::zeroed::<Bar>() };
                     let struct_ptr = &struct_instance as *const Bar;
                     let field_ptr = std::ptr::addr_of!(struct_instance.baz);
                     let struct_address = struct_ptr as usize;
@@ -98,11 +90,7 @@ pub mod root {
             );
             assert_eq!(
                 {
-                    const STRUCT_SIZE: usize = std::mem::size_of::<Foo>();
-                    let buffer = [0u8; STRUCT_SIZE];
-                    let struct_instance = unsafe {
-                        std::mem::transmute::<[u8; STRUCT_SIZE], Foo>(buffer)
-                    };
+                    let struct_instance = unsafe { std::mem::zeroed::<Foo>() };
                     let struct_ptr = &struct_instance as *const Foo;
                     let field_ptr = std::ptr::addr_of!(struct_instance.ptr);
                     let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/duplicated-namespaces-definitions.rs
+++ b/tests/expectations/tests/duplicated-namespaces-definitions.rs
@@ -31,8 +31,18 @@ pub mod root {
                 concat!("Alignment of ", stringify!(Bar))
             );
             assert_eq!(
-                unsafe {
-                    &(*(::std::ptr::null::<Bar>())).foo as *const _ as usize
+                {
+                    const STRUCT_SIZE: usize = std::mem::size_of::<Bar>();
+                    let buffer = [0u8; STRUCT_SIZE];
+                    let struct_instance = unsafe {
+                        std::mem::transmute::<[u8; STRUCT_SIZE], Bar>(buffer)
+                    };
+                    let struct_ptr = &struct_instance as *const Bar;
+                    let field_ptr = std::ptr::addr_of!(struct_instance.foo);
+                    let struct_address = struct_ptr as usize;
+                    let field_address = field_ptr as usize;
+                    std::mem::forget(struct_instance);
+                    field_address.checked_sub(struct_address).unwrap()
                 },
                 0usize,
                 concat!(
@@ -43,8 +53,18 @@ pub mod root {
                 )
             );
             assert_eq!(
-                unsafe {
-                    &(*(::std::ptr::null::<Bar>())).baz as *const _ as usize
+                {
+                    const STRUCT_SIZE: usize = std::mem::size_of::<Bar>();
+                    let buffer = [0u8; STRUCT_SIZE];
+                    let struct_instance = unsafe {
+                        std::mem::transmute::<[u8; STRUCT_SIZE], Bar>(buffer)
+                    };
+                    let struct_ptr = &struct_instance as *const Bar;
+                    let field_ptr = std::ptr::addr_of!(struct_instance.baz);
+                    let struct_address = struct_ptr as usize;
+                    let field_address = field_ptr as usize;
+                    std::mem::forget(struct_instance);
+                    field_address.checked_sub(struct_address).unwrap()
                 },
                 4usize,
                 concat!(
@@ -77,8 +97,18 @@ pub mod root {
                 concat!("Alignment of ", stringify!(Foo))
             );
             assert_eq!(
-                unsafe {
-                    &(*(::std::ptr::null::<Foo>())).ptr as *const _ as usize
+                {
+                    const STRUCT_SIZE: usize = std::mem::size_of::<Foo>();
+                    let buffer = [0u8; STRUCT_SIZE];
+                    let struct_instance = unsafe {
+                        std::mem::transmute::<[u8; STRUCT_SIZE], Foo>(buffer)
+                    };
+                    let struct_ptr = &struct_instance as *const Foo;
+                    let field_ptr = std::ptr::addr_of!(struct_instance.ptr);
+                    let struct_address = struct_ptr as usize;
+                    let field_address = field_ptr as usize;
+                    std::mem::forget(struct_instance);
+                    field_address.checked_sub(struct_address).unwrap()
                 },
                 0usize,
                 concat!(

--- a/tests/expectations/tests/dynamic_loading_with_blocklist.rs
+++ b/tests/expectations/tests/dynamic_loading_with_blocklist.rs
@@ -24,10 +24,7 @@ fn bindgen_test_layout_X() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<X>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance =
-                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], X>(buffer) };
+            let struct_instance = unsafe { std::mem::zeroed::<X>() };
             let struct_ptr = &struct_instance as *const X;
             let field_ptr = std::ptr::addr_of!(struct_instance._x);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/dynamic_loading_with_blocklist.rs
+++ b/tests/expectations/tests/dynamic_loading_with_blocklist.rs
@@ -23,7 +23,18 @@ fn bindgen_test_layout_X() {
         concat!("Alignment of ", stringify!(X))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<X>()))._x as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<X>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance =
+                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], X>(buffer) };
+            let struct_ptr = &struct_instance as *const X;
+            let field_ptr = std::ptr::addr_of!(struct_instance._x);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!("Offset of field: ", stringify!(X), "::", stringify!(_x))
     );

--- a/tests/expectations/tests/dynamic_loading_with_class.rs
+++ b/tests/expectations/tests/dynamic_loading_with_class.rs
@@ -23,7 +23,18 @@ fn bindgen_test_layout_A() {
         concat!("Alignment of ", stringify!(A))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<A>()))._x as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<A>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance =
+                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], A>(buffer) };
+            let struct_ptr = &struct_instance as *const A;
+            let field_ptr = std::ptr::addr_of!(struct_instance._x);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!("Offset of field: ", stringify!(A), "::", stringify!(_x))
     );

--- a/tests/expectations/tests/dynamic_loading_with_class.rs
+++ b/tests/expectations/tests/dynamic_loading_with_class.rs
@@ -24,10 +24,7 @@ fn bindgen_test_layout_A() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<A>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance =
-                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], A>(buffer) };
+            let struct_instance = unsafe { std::mem::zeroed::<A>() };
             let struct_ptr = &struct_instance as *const A;
             let field_ptr = std::ptr::addr_of!(struct_instance._x);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/enum-default-bitfield.rs
+++ b/tests/expectations/tests/enum-default-bitfield.rs
@@ -54,7 +54,19 @@ fn bindgen_test_layout_foo() {
         concat!("Alignment of ", stringify!(foo))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<foo>())).member as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<foo>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], foo>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const foo;
+            let field_ptr = std::ptr::addr_of!(struct_instance.member);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/enum-default-bitfield.rs
+++ b/tests/expectations/tests/enum-default-bitfield.rs
@@ -55,11 +55,7 @@ fn bindgen_test_layout_foo() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<foo>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], foo>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<foo>() };
             let struct_ptr = &struct_instance as *const foo;
             let field_ptr = std::ptr::addr_of!(struct_instance.member);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/enum-default-consts.rs
+++ b/tests/expectations/tests/enum-default-consts.rs
@@ -26,7 +26,19 @@ fn bindgen_test_layout_foo() {
         concat!("Alignment of ", stringify!(foo))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<foo>())).member as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<foo>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], foo>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const foo;
+            let field_ptr = std::ptr::addr_of!(struct_instance.member);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/enum-default-consts.rs
+++ b/tests/expectations/tests/enum-default-consts.rs
@@ -27,11 +27,7 @@ fn bindgen_test_layout_foo() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<foo>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], foo>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<foo>() };
             let struct_ptr = &struct_instance as *const foo;
             let field_ptr = std::ptr::addr_of!(struct_instance.member);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/enum-default-module.rs
+++ b/tests/expectations/tests/enum-default-module.rs
@@ -29,11 +29,7 @@ fn bindgen_test_layout_foo() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<foo>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], foo>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<foo>() };
             let struct_ptr = &struct_instance as *const foo;
             let field_ptr = std::ptr::addr_of!(struct_instance.member);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/enum-default-module.rs
+++ b/tests/expectations/tests/enum-default-module.rs
@@ -28,7 +28,19 @@ fn bindgen_test_layout_foo() {
         concat!("Alignment of ", stringify!(foo))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<foo>())).member as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<foo>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], foo>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const foo;
+            let field_ptr = std::ptr::addr_of!(struct_instance.member);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/enum-default-rust.rs
+++ b/tests/expectations/tests/enum-default-rust.rs
@@ -32,11 +32,7 @@ fn bindgen_test_layout_foo() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<foo>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], foo>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<foo>() };
             let struct_ptr = &struct_instance as *const foo;
             let field_ptr = std::ptr::addr_of!(struct_instance.member);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/enum-default-rust.rs
+++ b/tests/expectations/tests/enum-default-rust.rs
@@ -31,7 +31,19 @@ fn bindgen_test_layout_foo() {
         concat!("Alignment of ", stringify!(foo))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<foo>())).member as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<foo>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], foo>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const foo;
+            let field_ptr = std::ptr::addr_of!(struct_instance.member);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/enum.rs
+++ b/tests/expectations/tests/enum.rs
@@ -26,7 +26,19 @@ fn bindgen_test_layout_foo() {
         concat!("Alignment of ", stringify!(foo))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<foo>())).member as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<foo>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], foo>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const foo;
+            let field_ptr = std::ptr::addr_of!(struct_instance.member);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/enum.rs
+++ b/tests/expectations/tests/enum.rs
@@ -27,11 +27,7 @@ fn bindgen_test_layout_foo() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<foo>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], foo>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<foo>() };
             let struct_ptr = &struct_instance as *const foo;
             let field_ptr = std::ptr::addr_of!(struct_instance.member);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/enum_and_vtable_mangling.rs
+++ b/tests/expectations/tests/enum_and_vtable_mangling.rs
@@ -35,10 +35,7 @@ fn bindgen_test_layout_C() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<C>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance =
-                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], C>(buffer) };
+            let struct_instance = unsafe { std::mem::zeroed::<C>() };
             let struct_ptr = &struct_instance as *const C;
             let field_ptr = std::ptr::addr_of!(struct_instance.i);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/enum_and_vtable_mangling.rs
+++ b/tests/expectations/tests/enum_and_vtable_mangling.rs
@@ -34,7 +34,18 @@ fn bindgen_test_layout_C() {
         concat!("Alignment of ", stringify!(C))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<C>())).i as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<C>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance =
+                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], C>(buffer) };
+            let struct_ptr = &struct_instance as *const C;
+            let field_ptr = std::ptr::addr_of!(struct_instance.i);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         8usize,
         concat!("Offset of field: ", stringify!(C), "::", stringify!(i))
     );

--- a/tests/expectations/tests/extern-const-struct.rs
+++ b/tests/expectations/tests/extern-const-struct.rs
@@ -23,8 +23,18 @@ fn bindgen_test_layout_nsFoo() {
         concat!("Alignment of ", stringify!(nsFoo))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<nsFoo>())).details as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<nsFoo>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], nsFoo>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const nsFoo;
+            let field_ptr = std::ptr::addr_of!(struct_instance.details);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(

--- a/tests/expectations/tests/extern-const-struct.rs
+++ b/tests/expectations/tests/extern-const-struct.rs
@@ -24,11 +24,7 @@ fn bindgen_test_layout_nsFoo() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<nsFoo>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], nsFoo>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<nsFoo>() };
             let struct_ptr = &struct_instance as *const nsFoo;
             let field_ptr = std::ptr::addr_of!(struct_instance.details);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/forward-declaration-autoptr.rs
+++ b/tests/expectations/tests/forward-declaration-autoptr.rs
@@ -44,11 +44,7 @@ fn bindgen_test_layout_Bar() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<Bar>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], Bar>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<Bar>() };
             let struct_ptr = &struct_instance as *const Bar;
             let field_ptr = std::ptr::addr_of!(struct_instance.m_member);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/forward-declaration-autoptr.rs
+++ b/tests/expectations/tests/forward-declaration-autoptr.rs
@@ -43,8 +43,18 @@ fn bindgen_test_layout_Bar() {
         concat!("Alignment of ", stringify!(Bar))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<Bar>())).m_member as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<Bar>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], Bar>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const Bar;
+            let field_ptr = std::ptr::addr_of!(struct_instance.m_member);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(

--- a/tests/expectations/tests/forward_declared_complex_types.rs
+++ b/tests/expectations/tests/forward_declared_complex_types.rs
@@ -46,7 +46,19 @@ fn bindgen_test_layout_Bar() {
         concat!("Alignment of ", stringify!(Bar))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Bar>())).f as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<Bar>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], Bar>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const Bar;
+            let field_ptr = std::ptr::addr_of!(struct_instance.f);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!("Offset of field: ", stringify!(Bar), "::", stringify!(f))
     );

--- a/tests/expectations/tests/forward_declared_complex_types.rs
+++ b/tests/expectations/tests/forward_declared_complex_types.rs
@@ -47,11 +47,7 @@ fn bindgen_test_layout_Bar() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<Bar>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], Bar>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<Bar>() };
             let struct_ptr = &struct_instance as *const Bar;
             let field_ptr = std::ptr::addr_of!(struct_instance.f);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/forward_declared_complex_types_1_0.rs
+++ b/tests/expectations/tests/forward_declared_complex_types_1_0.rs
@@ -56,7 +56,19 @@ fn bindgen_test_layout_Bar() {
         concat!("Alignment of ", stringify!(Bar))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Bar>())).f as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<Bar>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], Bar>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const Bar;
+            let field_ptr = std::ptr::addr_of!(struct_instance.f);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!("Offset of field: ", stringify!(Bar), "::", stringify!(f))
     );

--- a/tests/expectations/tests/forward_declared_complex_types_1_0.rs
+++ b/tests/expectations/tests/forward_declared_complex_types_1_0.rs
@@ -57,11 +57,7 @@ fn bindgen_test_layout_Bar() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<Bar>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], Bar>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<Bar>() };
             let struct_ptr = &struct_instance as *const Bar;
             let field_ptr = std::ptr::addr_of!(struct_instance.f);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/forward_declared_struct.rs
+++ b/tests/expectations/tests/forward_declared_struct.rs
@@ -23,7 +23,18 @@ fn bindgen_test_layout_a() {
         concat!("Alignment of ", stringify!(a))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<a>())).b as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<a>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance =
+                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], a>(buffer) };
+            let struct_ptr = &struct_instance as *const a;
+            let field_ptr = std::ptr::addr_of!(struct_instance.b);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!("Offset of field: ", stringify!(a), "::", stringify!(b))
     );
@@ -46,7 +57,18 @@ fn bindgen_test_layout_c() {
         concat!("Alignment of ", stringify!(c))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<c>())).d as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<c>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance =
+                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], c>(buffer) };
+            let struct_ptr = &struct_instance as *const c;
+            let field_ptr = std::ptr::addr_of!(struct_instance.d);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!("Offset of field: ", stringify!(c), "::", stringify!(d))
     );

--- a/tests/expectations/tests/forward_declared_struct.rs
+++ b/tests/expectations/tests/forward_declared_struct.rs
@@ -24,10 +24,7 @@ fn bindgen_test_layout_a() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<a>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance =
-                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], a>(buffer) };
+            let struct_instance = unsafe { std::mem::zeroed::<a>() };
             let struct_ptr = &struct_instance as *const a;
             let field_ptr = std::ptr::addr_of!(struct_instance.b);
             let struct_address = struct_ptr as usize;
@@ -58,10 +55,7 @@ fn bindgen_test_layout_c() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<c>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance =
-                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], c>(buffer) };
+            let struct_instance = unsafe { std::mem::zeroed::<c>() };
             let struct_ptr = &struct_instance as *const c;
             let field_ptr = std::ptr::addr_of!(struct_instance.d);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/func_ptr_in_struct.rs
+++ b/tests/expectations/tests/func_ptr_in_struct.rs
@@ -34,11 +34,7 @@ fn bindgen_test_layout_Foo() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<Foo>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], Foo>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<Foo>() };
             let struct_ptr = &struct_instance as *const Foo;
             let field_ptr = std::ptr::addr_of!(struct_instance.bar);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/func_ptr_in_struct.rs
+++ b/tests/expectations/tests/func_ptr_in_struct.rs
@@ -33,7 +33,19 @@ fn bindgen_test_layout_Foo() {
         concat!("Alignment of ", stringify!(Foo))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Foo>())).bar as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<Foo>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], Foo>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const Foo;
+            let field_ptr = std::ptr::addr_of!(struct_instance.bar);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!("Offset of field: ", stringify!(Foo), "::", stringify!(bar))
     );

--- a/tests/expectations/tests/gen-destructors-neg.rs
+++ b/tests/expectations/tests/gen-destructors-neg.rs
@@ -24,11 +24,7 @@ fn bindgen_test_layout_Foo() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<Foo>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], Foo>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<Foo>() };
             let struct_ptr = &struct_instance as *const Foo;
             let field_ptr = std::ptr::addr_of!(struct_instance.bar);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/gen-destructors-neg.rs
+++ b/tests/expectations/tests/gen-destructors-neg.rs
@@ -23,7 +23,19 @@ fn bindgen_test_layout_Foo() {
         concat!("Alignment of ", stringify!(Foo))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Foo>())).bar as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<Foo>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], Foo>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const Foo;
+            let field_ptr = std::ptr::addr_of!(struct_instance.bar);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!("Offset of field: ", stringify!(Foo), "::", stringify!(bar))
     );

--- a/tests/expectations/tests/gen-destructors.rs
+++ b/tests/expectations/tests/gen-destructors.rs
@@ -24,11 +24,7 @@ fn bindgen_test_layout_Foo() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<Foo>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], Foo>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<Foo>() };
             let struct_ptr = &struct_instance as *const Foo;
             let field_ptr = std::ptr::addr_of!(struct_instance.bar);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/gen-destructors.rs
+++ b/tests/expectations/tests/gen-destructors.rs
@@ -23,7 +23,19 @@ fn bindgen_test_layout_Foo() {
         concat!("Alignment of ", stringify!(Foo))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Foo>())).bar as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<Foo>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], Foo>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const Foo;
+            let field_ptr = std::ptr::addr_of!(struct_instance.bar);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!("Offset of field: ", stringify!(Foo), "::", stringify!(bar))
     );

--- a/tests/expectations/tests/i128.rs
+++ b/tests/expectations/tests/i128.rs
@@ -26,11 +26,7 @@ fn bindgen_test_layout_foo() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<foo>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], foo>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<foo>() };
             let struct_ptr = &struct_instance as *const foo;
             let field_ptr = std::ptr::addr_of!(struct_instance.my_signed);
             let struct_address = struct_ptr as usize;
@@ -48,11 +44,7 @@ fn bindgen_test_layout_foo() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<foo>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], foo>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<foo>() };
             let struct_ptr = &struct_instance as *const foo;
             let field_ptr = std::ptr::addr_of!(struct_instance.my_unsigned);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/i128.rs
+++ b/tests/expectations/tests/i128.rs
@@ -25,8 +25,18 @@ fn bindgen_test_layout_foo() {
         concat!("Alignment of ", stringify!(foo))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<foo>())).my_signed as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<foo>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], foo>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const foo;
+            let field_ptr = std::ptr::addr_of!(struct_instance.my_signed);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -37,8 +47,18 @@ fn bindgen_test_layout_foo() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<foo>())).my_unsigned as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<foo>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], foo>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const foo;
+            let field_ptr = std::ptr::addr_of!(struct_instance.my_unsigned);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         16usize,
         concat!(

--- a/tests/expectations/tests/inline_namespace.rs
+++ b/tests/expectations/tests/inline_namespace.rs
@@ -33,11 +33,7 @@ pub mod root {
         );
         assert_eq!(
             {
-                const STRUCT_SIZE: usize = std::mem::size_of::<Bar>();
-                let buffer = [0u8; STRUCT_SIZE];
-                let struct_instance = unsafe {
-                    std::mem::transmute::<[u8; STRUCT_SIZE], Bar>(buffer)
-                };
+                let struct_instance = unsafe { std::mem::zeroed::<Bar>() };
                 let struct_ptr = &struct_instance as *const Bar;
                 let field_ptr = std::ptr::addr_of!(struct_instance.baz);
                 let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/inline_namespace.rs
+++ b/tests/expectations/tests/inline_namespace.rs
@@ -32,7 +32,19 @@ pub mod root {
             concat!("Alignment of ", stringify!(Bar))
         );
         assert_eq!(
-            unsafe { &(*(::std::ptr::null::<Bar>())).baz as *const _ as usize },
+            {
+                const STRUCT_SIZE: usize = std::mem::size_of::<Bar>();
+                let buffer = [0u8; STRUCT_SIZE];
+                let struct_instance = unsafe {
+                    std::mem::transmute::<[u8; STRUCT_SIZE], Bar>(buffer)
+                };
+                let struct_ptr = &struct_instance as *const Bar;
+                let field_ptr = std::ptr::addr_of!(struct_instance.baz);
+                let struct_address = struct_ptr as usize;
+                let field_address = field_ptr as usize;
+                std::mem::forget(struct_instance);
+                field_address.checked_sub(struct_address).unwrap()
+            },
             0usize,
             concat!(
                 "Offset of field: ",

--- a/tests/expectations/tests/inline_namespace_conservative.rs
+++ b/tests/expectations/tests/inline_namespace_conservative.rs
@@ -37,7 +37,19 @@ pub mod root {
             concat!("Alignment of ", stringify!(Bar))
         );
         assert_eq!(
-            unsafe { &(*(::std::ptr::null::<Bar>())).baz as *const _ as usize },
+            {
+                const STRUCT_SIZE: usize = std::mem::size_of::<Bar>();
+                let buffer = [0u8; STRUCT_SIZE];
+                let struct_instance = unsafe {
+                    std::mem::transmute::<[u8; STRUCT_SIZE], Bar>(buffer)
+                };
+                let struct_ptr = &struct_instance as *const Bar;
+                let field_ptr = std::ptr::addr_of!(struct_instance.baz);
+                let struct_address = struct_ptr as usize;
+                let field_address = field_ptr as usize;
+                std::mem::forget(struct_instance);
+                field_address.checked_sub(struct_address).unwrap()
+            },
             0usize,
             concat!(
                 "Offset of field: ",

--- a/tests/expectations/tests/inline_namespace_conservative.rs
+++ b/tests/expectations/tests/inline_namespace_conservative.rs
@@ -38,11 +38,7 @@ pub mod root {
         );
         assert_eq!(
             {
-                const STRUCT_SIZE: usize = std::mem::size_of::<Bar>();
-                let buffer = [0u8; STRUCT_SIZE];
-                let struct_instance = unsafe {
-                    std::mem::transmute::<[u8; STRUCT_SIZE], Bar>(buffer)
-                };
+                let struct_instance = unsafe { std::mem::zeroed::<Bar>() };
                 let struct_ptr = &struct_instance as *const Bar;
                 let field_ptr = std::ptr::addr_of!(struct_instance.baz);
                 let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/inner_const.rs
+++ b/tests/expectations/tests/inner_const.rs
@@ -32,11 +32,7 @@ fn bindgen_test_layout_Foo() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<Foo>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], Foo>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<Foo>() };
             let struct_ptr = &struct_instance as *const Foo;
             let field_ptr = std::ptr::addr_of!(struct_instance.bar);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/inner_const.rs
+++ b/tests/expectations/tests/inner_const.rs
@@ -31,7 +31,19 @@ fn bindgen_test_layout_Foo() {
         concat!("Alignment of ", stringify!(Foo))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Foo>())).bar as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<Foo>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], Foo>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const Foo;
+            let field_ptr = std::ptr::addr_of!(struct_instance.bar);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!("Offset of field: ", stringify!(Foo), "::", stringify!(bar))
     );

--- a/tests/expectations/tests/inner_template_self.rs
+++ b/tests/expectations/tests/inner_template_self.rs
@@ -38,9 +38,18 @@ fn bindgen_test_layout_InstantiateIt() {
         concat!("Alignment of ", stringify!(InstantiateIt))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<InstantiateIt>())).m_list as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<InstantiateIt>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], InstantiateIt>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const InstantiateIt;
+            let field_ptr = std::ptr::addr_of!(struct_instance.m_list);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(

--- a/tests/expectations/tests/inner_template_self.rs
+++ b/tests/expectations/tests/inner_template_self.rs
@@ -39,11 +39,8 @@ fn bindgen_test_layout_InstantiateIt() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<InstantiateIt>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], InstantiateIt>(buffer)
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<InstantiateIt>() };
             let struct_ptr = &struct_instance as *const InstantiateIt;
             let field_ptr = std::ptr::addr_of!(struct_instance.m_list);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/issue-1118-using-forward-decl.rs
+++ b/tests/expectations/tests/issue-1118-using-forward-decl.rs
@@ -24,8 +24,18 @@ fn bindgen_test_layout_nsTArray_base() {
         concat!("Alignment of ", stringify!(nsTArray_base))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<nsTArray_base>())).d as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<nsTArray_base>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], nsTArray_base>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const nsTArray_base;
+            let field_ptr = std::ptr::addr_of!(struct_instance.d);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -77,8 +87,18 @@ fn bindgen_test_layout_nsIContent() {
         concat!("Alignment of ", stringify!(nsIContent))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<nsIContent>())).foo as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<nsIContent>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], nsIContent>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const nsIContent;
+            let field_ptr = std::ptr::addr_of!(struct_instance.foo);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(

--- a/tests/expectations/tests/issue-1118-using-forward-decl.rs
+++ b/tests/expectations/tests/issue-1118-using-forward-decl.rs
@@ -25,11 +25,8 @@ fn bindgen_test_layout_nsTArray_base() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<nsTArray_base>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], nsTArray_base>(buffer)
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<nsTArray_base>() };
             let struct_ptr = &struct_instance as *const nsTArray_base;
             let field_ptr = std::ptr::addr_of!(struct_instance.d);
             let struct_address = struct_ptr as usize;
@@ -88,11 +85,7 @@ fn bindgen_test_layout_nsIContent() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<nsIContent>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], nsIContent>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<nsIContent>() };
             let struct_ptr = &struct_instance as *const nsIContent;
             let field_ptr = std::ptr::addr_of!(struct_instance.foo);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/issue-1216-variadic-member.rs
+++ b/tests/expectations/tests/issue-1216-variadic-member.rs
@@ -33,7 +33,19 @@ fn bindgen_test_layout_Foo() {
         concat!("Alignment of ", stringify!(Foo))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Foo>())).f as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<Foo>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], Foo>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const Foo;
+            let field_ptr = std::ptr::addr_of!(struct_instance.f);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!("Offset of field: ", stringify!(Foo), "::", stringify!(f))
     );

--- a/tests/expectations/tests/issue-1216-variadic-member.rs
+++ b/tests/expectations/tests/issue-1216-variadic-member.rs
@@ -34,11 +34,7 @@ fn bindgen_test_layout_Foo() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<Foo>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], Foo>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<Foo>() };
             let struct_ptr = &struct_instance as *const Foo;
             let field_ptr = std::ptr::addr_of!(struct_instance.f);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/issue-1281.rs
+++ b/tests/expectations/tests/issue-1281.rs
@@ -29,11 +29,7 @@ fn bindgen_test_layout_foo() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<foo>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], foo>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<foo>() };
             let struct_ptr = &struct_instance as *const foo;
             let field_ptr = std::ptr::addr_of!(struct_instance.foo);
             let struct_address = struct_ptr as usize;
@@ -59,11 +55,7 @@ fn bindgen_test_layout_bar() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<bar>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], bar>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<bar>() };
             let struct_ptr = &struct_instance as *const bar;
             let field_ptr = std::ptr::addr_of!(struct_instance.u);
             let struct_address = struct_ptr as usize;
@@ -95,11 +87,7 @@ fn bindgen_test_layout_baz() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<baz>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], baz>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<baz>() };
             let struct_ptr = &struct_instance as *const baz;
             let field_ptr = std::ptr::addr_of!(struct_instance.f);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/issue-1281.rs
+++ b/tests/expectations/tests/issue-1281.rs
@@ -28,7 +28,19 @@ fn bindgen_test_layout_foo() {
         concat!("Alignment of ", stringify!(foo))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<foo>())).foo as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<foo>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], foo>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const foo;
+            let field_ptr = std::ptr::addr_of!(struct_instance.foo);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!("Offset of field: ", stringify!(foo), "::", stringify!(foo))
     );
@@ -46,7 +58,19 @@ fn bindgen_test_layout_bar() {
         concat!("Alignment of ", stringify!(bar))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<bar>())).u as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<bar>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], bar>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const bar;
+            let field_ptr = std::ptr::addr_of!(struct_instance.u);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!("Offset of field: ", stringify!(bar), "::", stringify!(u))
     );
@@ -70,7 +94,19 @@ fn bindgen_test_layout_baz() {
         concat!("Alignment of ", stringify!(baz))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<baz>())).f as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<baz>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], baz>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const baz;
+            let field_ptr = std::ptr::addr_of!(struct_instance.f);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!("Offset of field: ", stringify!(baz), "::", stringify!(f))
     );

--- a/tests/expectations/tests/issue-1285.rs
+++ b/tests/expectations/tests/issue-1285.rs
@@ -52,11 +52,7 @@ fn bindgen_test_layout_foo() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<foo>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], foo>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<foo>() };
             let struct_ptr = &struct_instance as *const foo;
             let field_ptr = std::ptr::addr_of!(struct_instance.bar);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/issue-1285.rs
+++ b/tests/expectations/tests/issue-1285.rs
@@ -28,30 +28,6 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
         4usize,
         concat!("Alignment of ", stringify!(foo__bindgen_ty_1))
     );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<foo__bindgen_ty_1>())).a as *const _ as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(foo__bindgen_ty_1),
-            "::",
-            stringify!(a)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<foo__bindgen_ty_1>())).b as *const _ as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(foo__bindgen_ty_1),
-            "::",
-            stringify!(b)
-        )
-    );
 }
 impl Default for foo__bindgen_ty_1 {
     fn default() -> Self {
@@ -75,7 +51,19 @@ fn bindgen_test_layout_foo() {
         concat!("Alignment of ", stringify!(foo))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<foo>())).bar as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<foo>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], foo>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const foo;
+            let field_ptr = std::ptr::addr_of!(struct_instance.bar);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar))
     );

--- a/tests/expectations/tests/issue-1291.rs
+++ b/tests/expectations/tests/issue-1291.rs
@@ -38,7 +38,19 @@ fn bindgen_test_layout_RTCRay() {
         concat!("Alignment of ", stringify!(RTCRay))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<RTCRay>())).org as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<RTCRay>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], RTCRay>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const RTCRay;
+            let field_ptr = std::ptr::addr_of!(struct_instance.org);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!(
             "Offset of field: ",
@@ -48,8 +60,18 @@ fn bindgen_test_layout_RTCRay() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<RTCRay>())).align0 as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<RTCRay>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], RTCRay>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const RTCRay;
+            let field_ptr = std::ptr::addr_of!(struct_instance.align0);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         12usize,
         concat!(
@@ -60,7 +82,19 @@ fn bindgen_test_layout_RTCRay() {
         )
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<RTCRay>())).dir as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<RTCRay>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], RTCRay>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const RTCRay;
+            let field_ptr = std::ptr::addr_of!(struct_instance.dir);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         16usize,
         concat!(
             "Offset of field: ",
@@ -70,8 +104,18 @@ fn bindgen_test_layout_RTCRay() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<RTCRay>())).align1 as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<RTCRay>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], RTCRay>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const RTCRay;
+            let field_ptr = std::ptr::addr_of!(struct_instance.align1);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         28usize,
         concat!(
@@ -82,8 +126,18 @@ fn bindgen_test_layout_RTCRay() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<RTCRay>())).tnear as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<RTCRay>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], RTCRay>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const RTCRay;
+            let field_ptr = std::ptr::addr_of!(struct_instance.tnear);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         32usize,
         concat!(
@@ -94,7 +148,19 @@ fn bindgen_test_layout_RTCRay() {
         )
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<RTCRay>())).tfar as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<RTCRay>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], RTCRay>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const RTCRay;
+            let field_ptr = std::ptr::addr_of!(struct_instance.tfar);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         36usize,
         concat!(
             "Offset of field: ",
@@ -104,7 +170,19 @@ fn bindgen_test_layout_RTCRay() {
         )
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<RTCRay>())).time as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<RTCRay>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], RTCRay>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const RTCRay;
+            let field_ptr = std::ptr::addr_of!(struct_instance.time);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         40usize,
         concat!(
             "Offset of field: ",
@@ -114,7 +192,19 @@ fn bindgen_test_layout_RTCRay() {
         )
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<RTCRay>())).mask as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<RTCRay>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], RTCRay>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const RTCRay;
+            let field_ptr = std::ptr::addr_of!(struct_instance.mask);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         44usize,
         concat!(
             "Offset of field: ",
@@ -124,7 +214,19 @@ fn bindgen_test_layout_RTCRay() {
         )
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<RTCRay>())).Ng as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<RTCRay>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], RTCRay>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const RTCRay;
+            let field_ptr = std::ptr::addr_of!(struct_instance.Ng);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         48usize,
         concat!(
             "Offset of field: ",
@@ -134,8 +236,18 @@ fn bindgen_test_layout_RTCRay() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<RTCRay>())).align2 as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<RTCRay>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], RTCRay>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const RTCRay;
+            let field_ptr = std::ptr::addr_of!(struct_instance.align2);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         60usize,
         concat!(
@@ -146,18 +258,52 @@ fn bindgen_test_layout_RTCRay() {
         )
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<RTCRay>())).u as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<RTCRay>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], RTCRay>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const RTCRay;
+            let field_ptr = std::ptr::addr_of!(struct_instance.u);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         64usize,
         concat!("Offset of field: ", stringify!(RTCRay), "::", stringify!(u))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<RTCRay>())).v as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<RTCRay>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], RTCRay>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const RTCRay;
+            let field_ptr = std::ptr::addr_of!(struct_instance.v);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         68usize,
         concat!("Offset of field: ", stringify!(RTCRay), "::", stringify!(v))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<RTCRay>())).geomID as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<RTCRay>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], RTCRay>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const RTCRay;
+            let field_ptr = std::ptr::addr_of!(struct_instance.geomID);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         72usize,
         concat!(
@@ -168,8 +314,18 @@ fn bindgen_test_layout_RTCRay() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<RTCRay>())).primID as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<RTCRay>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], RTCRay>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const RTCRay;
+            let field_ptr = std::ptr::addr_of!(struct_instance.primID);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         76usize,
         concat!(
@@ -180,8 +336,18 @@ fn bindgen_test_layout_RTCRay() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<RTCRay>())).instID as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<RTCRay>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], RTCRay>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const RTCRay;
+            let field_ptr = std::ptr::addr_of!(struct_instance.instID);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         80usize,
         concat!(

--- a/tests/expectations/tests/issue-1291.rs
+++ b/tests/expectations/tests/issue-1291.rs
@@ -39,11 +39,7 @@ fn bindgen_test_layout_RTCRay() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<RTCRay>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], RTCRay>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<RTCRay>() };
             let struct_ptr = &struct_instance as *const RTCRay;
             let field_ptr = std::ptr::addr_of!(struct_instance.org);
             let struct_address = struct_ptr as usize;
@@ -61,11 +57,7 @@ fn bindgen_test_layout_RTCRay() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<RTCRay>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], RTCRay>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<RTCRay>() };
             let struct_ptr = &struct_instance as *const RTCRay;
             let field_ptr = std::ptr::addr_of!(struct_instance.align0);
             let struct_address = struct_ptr as usize;
@@ -83,11 +75,7 @@ fn bindgen_test_layout_RTCRay() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<RTCRay>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], RTCRay>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<RTCRay>() };
             let struct_ptr = &struct_instance as *const RTCRay;
             let field_ptr = std::ptr::addr_of!(struct_instance.dir);
             let struct_address = struct_ptr as usize;
@@ -105,11 +93,7 @@ fn bindgen_test_layout_RTCRay() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<RTCRay>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], RTCRay>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<RTCRay>() };
             let struct_ptr = &struct_instance as *const RTCRay;
             let field_ptr = std::ptr::addr_of!(struct_instance.align1);
             let struct_address = struct_ptr as usize;
@@ -127,11 +111,7 @@ fn bindgen_test_layout_RTCRay() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<RTCRay>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], RTCRay>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<RTCRay>() };
             let struct_ptr = &struct_instance as *const RTCRay;
             let field_ptr = std::ptr::addr_of!(struct_instance.tnear);
             let struct_address = struct_ptr as usize;
@@ -149,11 +129,7 @@ fn bindgen_test_layout_RTCRay() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<RTCRay>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], RTCRay>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<RTCRay>() };
             let struct_ptr = &struct_instance as *const RTCRay;
             let field_ptr = std::ptr::addr_of!(struct_instance.tfar);
             let struct_address = struct_ptr as usize;
@@ -171,11 +147,7 @@ fn bindgen_test_layout_RTCRay() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<RTCRay>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], RTCRay>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<RTCRay>() };
             let struct_ptr = &struct_instance as *const RTCRay;
             let field_ptr = std::ptr::addr_of!(struct_instance.time);
             let struct_address = struct_ptr as usize;
@@ -193,11 +165,7 @@ fn bindgen_test_layout_RTCRay() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<RTCRay>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], RTCRay>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<RTCRay>() };
             let struct_ptr = &struct_instance as *const RTCRay;
             let field_ptr = std::ptr::addr_of!(struct_instance.mask);
             let struct_address = struct_ptr as usize;
@@ -215,11 +183,7 @@ fn bindgen_test_layout_RTCRay() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<RTCRay>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], RTCRay>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<RTCRay>() };
             let struct_ptr = &struct_instance as *const RTCRay;
             let field_ptr = std::ptr::addr_of!(struct_instance.Ng);
             let struct_address = struct_ptr as usize;
@@ -237,11 +201,7 @@ fn bindgen_test_layout_RTCRay() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<RTCRay>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], RTCRay>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<RTCRay>() };
             let struct_ptr = &struct_instance as *const RTCRay;
             let field_ptr = std::ptr::addr_of!(struct_instance.align2);
             let struct_address = struct_ptr as usize;
@@ -259,11 +219,7 @@ fn bindgen_test_layout_RTCRay() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<RTCRay>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], RTCRay>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<RTCRay>() };
             let struct_ptr = &struct_instance as *const RTCRay;
             let field_ptr = std::ptr::addr_of!(struct_instance.u);
             let struct_address = struct_ptr as usize;
@@ -276,11 +232,7 @@ fn bindgen_test_layout_RTCRay() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<RTCRay>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], RTCRay>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<RTCRay>() };
             let struct_ptr = &struct_instance as *const RTCRay;
             let field_ptr = std::ptr::addr_of!(struct_instance.v);
             let struct_address = struct_ptr as usize;
@@ -293,11 +245,7 @@ fn bindgen_test_layout_RTCRay() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<RTCRay>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], RTCRay>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<RTCRay>() };
             let struct_ptr = &struct_instance as *const RTCRay;
             let field_ptr = std::ptr::addr_of!(struct_instance.geomID);
             let struct_address = struct_ptr as usize;
@@ -315,11 +263,7 @@ fn bindgen_test_layout_RTCRay() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<RTCRay>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], RTCRay>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<RTCRay>() };
             let struct_ptr = &struct_instance as *const RTCRay;
             let field_ptr = std::ptr::addr_of!(struct_instance.primID);
             let struct_address = struct_ptr as usize;
@@ -337,11 +281,7 @@ fn bindgen_test_layout_RTCRay() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<RTCRay>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], RTCRay>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<RTCRay>() };
             let struct_ptr = &struct_instance as *const RTCRay;
             let field_ptr = std::ptr::addr_of!(struct_instance.instID);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/issue-1382-rust-primitive-types.rs
+++ b/tests/expectations/tests/issue-1382-rust-primitive-types.rs
@@ -44,47 +44,155 @@ fn bindgen_test_layout_Foo() {
         concat!("Alignment of ", stringify!(Foo))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Foo>())).i8_ as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<Foo>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], Foo>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const Foo;
+            let field_ptr = std::ptr::addr_of!(struct_instance.i8_);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!("Offset of field: ", stringify!(Foo), "::", stringify!(i8_))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Foo>())).u8_ as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<Foo>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], Foo>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const Foo;
+            let field_ptr = std::ptr::addr_of!(struct_instance.u8_);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         4usize,
         concat!("Offset of field: ", stringify!(Foo), "::", stringify!(u8_))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Foo>())).i16_ as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<Foo>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], Foo>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const Foo;
+            let field_ptr = std::ptr::addr_of!(struct_instance.i16_);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         8usize,
         concat!("Offset of field: ", stringify!(Foo), "::", stringify!(i16_))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Foo>())).u16_ as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<Foo>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], Foo>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const Foo;
+            let field_ptr = std::ptr::addr_of!(struct_instance.u16_);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         12usize,
         concat!("Offset of field: ", stringify!(Foo), "::", stringify!(u16_))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Foo>())).i32_ as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<Foo>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], Foo>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const Foo;
+            let field_ptr = std::ptr::addr_of!(struct_instance.i32_);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         16usize,
         concat!("Offset of field: ", stringify!(Foo), "::", stringify!(i32_))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Foo>())).u32_ as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<Foo>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], Foo>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const Foo;
+            let field_ptr = std::ptr::addr_of!(struct_instance.u32_);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         20usize,
         concat!("Offset of field: ", stringify!(Foo), "::", stringify!(u32_))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Foo>())).i64_ as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<Foo>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], Foo>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const Foo;
+            let field_ptr = std::ptr::addr_of!(struct_instance.i64_);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         24usize,
         concat!("Offset of field: ", stringify!(Foo), "::", stringify!(i64_))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Foo>())).u64_ as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<Foo>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], Foo>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const Foo;
+            let field_ptr = std::ptr::addr_of!(struct_instance.u64_);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         28usize,
         concat!("Offset of field: ", stringify!(Foo), "::", stringify!(u64_))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Foo>())).i128_ as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<Foo>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], Foo>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const Foo;
+            let field_ptr = std::ptr::addr_of!(struct_instance.i128_);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         32usize,
         concat!(
             "Offset of field: ",
@@ -94,7 +202,19 @@ fn bindgen_test_layout_Foo() {
         )
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Foo>())).u128_ as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<Foo>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], Foo>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const Foo;
+            let field_ptr = std::ptr::addr_of!(struct_instance.u128_);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         36usize,
         concat!(
             "Offset of field: ",
@@ -104,7 +224,19 @@ fn bindgen_test_layout_Foo() {
         )
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Foo>())).isize_ as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<Foo>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], Foo>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const Foo;
+            let field_ptr = std::ptr::addr_of!(struct_instance.isize_);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         40usize,
         concat!(
             "Offset of field: ",
@@ -114,7 +246,19 @@ fn bindgen_test_layout_Foo() {
         )
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Foo>())).usize_ as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<Foo>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], Foo>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const Foo;
+            let field_ptr = std::ptr::addr_of!(struct_instance.usize_);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         44usize,
         concat!(
             "Offset of field: ",
@@ -124,12 +268,36 @@ fn bindgen_test_layout_Foo() {
         )
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Foo>())).f32_ as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<Foo>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], Foo>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const Foo;
+            let field_ptr = std::ptr::addr_of!(struct_instance.f32_);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         48usize,
         concat!("Offset of field: ", stringify!(Foo), "::", stringify!(f32_))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Foo>())).f64_ as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<Foo>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], Foo>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const Foo;
+            let field_ptr = std::ptr::addr_of!(struct_instance.f64_);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         52usize,
         concat!("Offset of field: ", stringify!(Foo), "::", stringify!(f64_))
     );

--- a/tests/expectations/tests/issue-1382-rust-primitive-types.rs
+++ b/tests/expectations/tests/issue-1382-rust-primitive-types.rs
@@ -45,11 +45,7 @@ fn bindgen_test_layout_Foo() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<Foo>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], Foo>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<Foo>() };
             let struct_ptr = &struct_instance as *const Foo;
             let field_ptr = std::ptr::addr_of!(struct_instance.i8_);
             let struct_address = struct_ptr as usize;
@@ -62,11 +58,7 @@ fn bindgen_test_layout_Foo() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<Foo>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], Foo>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<Foo>() };
             let struct_ptr = &struct_instance as *const Foo;
             let field_ptr = std::ptr::addr_of!(struct_instance.u8_);
             let struct_address = struct_ptr as usize;
@@ -79,11 +71,7 @@ fn bindgen_test_layout_Foo() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<Foo>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], Foo>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<Foo>() };
             let struct_ptr = &struct_instance as *const Foo;
             let field_ptr = std::ptr::addr_of!(struct_instance.i16_);
             let struct_address = struct_ptr as usize;
@@ -96,11 +84,7 @@ fn bindgen_test_layout_Foo() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<Foo>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], Foo>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<Foo>() };
             let struct_ptr = &struct_instance as *const Foo;
             let field_ptr = std::ptr::addr_of!(struct_instance.u16_);
             let struct_address = struct_ptr as usize;
@@ -113,11 +97,7 @@ fn bindgen_test_layout_Foo() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<Foo>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], Foo>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<Foo>() };
             let struct_ptr = &struct_instance as *const Foo;
             let field_ptr = std::ptr::addr_of!(struct_instance.i32_);
             let struct_address = struct_ptr as usize;
@@ -130,11 +110,7 @@ fn bindgen_test_layout_Foo() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<Foo>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], Foo>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<Foo>() };
             let struct_ptr = &struct_instance as *const Foo;
             let field_ptr = std::ptr::addr_of!(struct_instance.u32_);
             let struct_address = struct_ptr as usize;
@@ -147,11 +123,7 @@ fn bindgen_test_layout_Foo() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<Foo>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], Foo>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<Foo>() };
             let struct_ptr = &struct_instance as *const Foo;
             let field_ptr = std::ptr::addr_of!(struct_instance.i64_);
             let struct_address = struct_ptr as usize;
@@ -164,11 +136,7 @@ fn bindgen_test_layout_Foo() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<Foo>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], Foo>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<Foo>() };
             let struct_ptr = &struct_instance as *const Foo;
             let field_ptr = std::ptr::addr_of!(struct_instance.u64_);
             let struct_address = struct_ptr as usize;
@@ -181,11 +149,7 @@ fn bindgen_test_layout_Foo() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<Foo>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], Foo>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<Foo>() };
             let struct_ptr = &struct_instance as *const Foo;
             let field_ptr = std::ptr::addr_of!(struct_instance.i128_);
             let struct_address = struct_ptr as usize;
@@ -203,11 +167,7 @@ fn bindgen_test_layout_Foo() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<Foo>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], Foo>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<Foo>() };
             let struct_ptr = &struct_instance as *const Foo;
             let field_ptr = std::ptr::addr_of!(struct_instance.u128_);
             let struct_address = struct_ptr as usize;
@@ -225,11 +185,7 @@ fn bindgen_test_layout_Foo() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<Foo>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], Foo>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<Foo>() };
             let struct_ptr = &struct_instance as *const Foo;
             let field_ptr = std::ptr::addr_of!(struct_instance.isize_);
             let struct_address = struct_ptr as usize;
@@ -247,11 +203,7 @@ fn bindgen_test_layout_Foo() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<Foo>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], Foo>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<Foo>() };
             let struct_ptr = &struct_instance as *const Foo;
             let field_ptr = std::ptr::addr_of!(struct_instance.usize_);
             let struct_address = struct_ptr as usize;
@@ -269,11 +221,7 @@ fn bindgen_test_layout_Foo() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<Foo>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], Foo>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<Foo>() };
             let struct_ptr = &struct_instance as *const Foo;
             let field_ptr = std::ptr::addr_of!(struct_instance.f32_);
             let struct_address = struct_ptr as usize;
@@ -286,11 +234,7 @@ fn bindgen_test_layout_Foo() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<Foo>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], Foo>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<Foo>() };
             let struct_ptr = &struct_instance as *const Foo;
             let field_ptr = std::ptr::addr_of!(struct_instance.f64_);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/issue-1443.rs
+++ b/tests/expectations/tests/issue-1443.rs
@@ -29,12 +29,36 @@ fn bindgen_test_layout_Bar() {
         concat!("Alignment of ", stringify!(Bar))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Bar>())).f as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<Bar>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], Bar>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const Bar;
+            let field_ptr = std::ptr::addr_of!(struct_instance.f);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!("Offset of field: ", stringify!(Bar), "::", stringify!(f))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Bar>())).m as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<Bar>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], Bar>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const Bar;
+            let field_ptr = std::ptr::addr_of!(struct_instance.m);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         8usize,
         concat!("Offset of field: ", stringify!(Bar), "::", stringify!(m))
     );
@@ -67,12 +91,36 @@ fn bindgen_test_layout_Baz() {
         concat!("Alignment of ", stringify!(Baz))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Baz>())).f as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<Baz>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], Baz>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const Baz;
+            let field_ptr = std::ptr::addr_of!(struct_instance.f);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!("Offset of field: ", stringify!(Baz), "::", stringify!(f))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Baz>())).m as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<Baz>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], Baz>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const Baz;
+            let field_ptr = std::ptr::addr_of!(struct_instance.m);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         8usize,
         concat!("Offset of field: ", stringify!(Baz), "::", stringify!(m))
     );
@@ -105,12 +153,36 @@ fn bindgen_test_layout_Tar() {
         concat!("Alignment of ", stringify!(Tar))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Tar>())).f as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<Tar>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], Tar>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const Tar;
+            let field_ptr = std::ptr::addr_of!(struct_instance.f);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!("Offset of field: ", stringify!(Tar), "::", stringify!(f))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Tar>())).m as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<Tar>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], Tar>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const Tar;
+            let field_ptr = std::ptr::addr_of!(struct_instance.m);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         8usize,
         concat!("Offset of field: ", stringify!(Tar), "::", stringify!(m))
     );
@@ -143,12 +215,36 @@ fn bindgen_test_layout_Taz() {
         concat!("Alignment of ", stringify!(Taz))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Taz>())).f as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<Taz>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], Taz>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const Taz;
+            let field_ptr = std::ptr::addr_of!(struct_instance.f);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!("Offset of field: ", stringify!(Taz), "::", stringify!(f))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Taz>())).m as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<Taz>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], Taz>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const Taz;
+            let field_ptr = std::ptr::addr_of!(struct_instance.m);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         8usize,
         concat!("Offset of field: ", stringify!(Taz), "::", stringify!(m))
     );

--- a/tests/expectations/tests/issue-1443.rs
+++ b/tests/expectations/tests/issue-1443.rs
@@ -30,11 +30,7 @@ fn bindgen_test_layout_Bar() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<Bar>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], Bar>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<Bar>() };
             let struct_ptr = &struct_instance as *const Bar;
             let field_ptr = std::ptr::addr_of!(struct_instance.f);
             let struct_address = struct_ptr as usize;
@@ -47,11 +43,7 @@ fn bindgen_test_layout_Bar() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<Bar>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], Bar>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<Bar>() };
             let struct_ptr = &struct_instance as *const Bar;
             let field_ptr = std::ptr::addr_of!(struct_instance.m);
             let struct_address = struct_ptr as usize;
@@ -92,11 +84,7 @@ fn bindgen_test_layout_Baz() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<Baz>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], Baz>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<Baz>() };
             let struct_ptr = &struct_instance as *const Baz;
             let field_ptr = std::ptr::addr_of!(struct_instance.f);
             let struct_address = struct_ptr as usize;
@@ -109,11 +97,7 @@ fn bindgen_test_layout_Baz() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<Baz>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], Baz>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<Baz>() };
             let struct_ptr = &struct_instance as *const Baz;
             let field_ptr = std::ptr::addr_of!(struct_instance.m);
             let struct_address = struct_ptr as usize;
@@ -154,11 +138,7 @@ fn bindgen_test_layout_Tar() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<Tar>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], Tar>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<Tar>() };
             let struct_ptr = &struct_instance as *const Tar;
             let field_ptr = std::ptr::addr_of!(struct_instance.f);
             let struct_address = struct_ptr as usize;
@@ -171,11 +151,7 @@ fn bindgen_test_layout_Tar() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<Tar>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], Tar>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<Tar>() };
             let struct_ptr = &struct_instance as *const Tar;
             let field_ptr = std::ptr::addr_of!(struct_instance.m);
             let struct_address = struct_ptr as usize;
@@ -216,11 +192,7 @@ fn bindgen_test_layout_Taz() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<Taz>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], Taz>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<Taz>() };
             let struct_ptr = &struct_instance as *const Taz;
             let field_ptr = std::ptr::addr_of!(struct_instance.f);
             let struct_address = struct_ptr as usize;
@@ -233,11 +205,7 @@ fn bindgen_test_layout_Taz() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<Taz>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], Taz>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<Taz>() };
             let struct_ptr = &struct_instance as *const Taz;
             let field_ptr = std::ptr::addr_of!(struct_instance.m);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/issue-1454.rs
+++ b/tests/expectations/tests/issue-1454.rs
@@ -28,11 +28,7 @@ fn bindgen_test_layout_local_type() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<local_type>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], local_type>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<local_type>() };
             let struct_ptr = &struct_instance as *const local_type;
             let field_ptr = std::ptr::addr_of!(struct_instance.inner);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/issue-1454.rs
+++ b/tests/expectations/tests/issue-1454.rs
@@ -27,8 +27,18 @@ fn bindgen_test_layout_local_type() {
         concat!("Alignment of ", stringify!(local_type))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<local_type>())).inner as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<local_type>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], local_type>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const local_type;
+            let field_ptr = std::ptr::addr_of!(struct_instance.inner);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(

--- a/tests/expectations/tests/issue-1498.rs
+++ b/tests/expectations/tests/issue-1498.rs
@@ -67,11 +67,7 @@ fn bindgen_test_layout_rte_memseg() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_memseg>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_memseg>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<rte_memseg>() };
             let struct_ptr = &struct_instance as *const rte_memseg;
             let field_ptr = std::ptr::addr_of!(struct_instance.phys_addr);
             let struct_address = struct_ptr as usize;
@@ -89,11 +85,7 @@ fn bindgen_test_layout_rte_memseg() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_memseg>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_memseg>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<rte_memseg>() };
             let struct_ptr = &struct_instance as *const rte_memseg;
             let field_ptr = std::ptr::addr_of!(struct_instance.len);
             let struct_address = struct_ptr as usize;
@@ -111,11 +103,7 @@ fn bindgen_test_layout_rte_memseg() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_memseg>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_memseg>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<rte_memseg>() };
             let struct_ptr = &struct_instance as *const rte_memseg;
             let field_ptr = std::ptr::addr_of!(struct_instance.hugepage_sz);
             let struct_address = struct_ptr as usize;
@@ -133,11 +121,7 @@ fn bindgen_test_layout_rte_memseg() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_memseg>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_memseg>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<rte_memseg>() };
             let struct_ptr = &struct_instance as *const rte_memseg;
             let field_ptr = std::ptr::addr_of!(struct_instance.socket_id);
             let struct_address = struct_ptr as usize;
@@ -155,11 +139,7 @@ fn bindgen_test_layout_rte_memseg() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_memseg>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_memseg>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<rte_memseg>() };
             let struct_ptr = &struct_instance as *const rte_memseg;
             let field_ptr = std::ptr::addr_of!(struct_instance.nchannel);
             let struct_address = struct_ptr as usize;
@@ -177,11 +157,7 @@ fn bindgen_test_layout_rte_memseg() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_memseg>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_memseg>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<rte_memseg>() };
             let struct_ptr = &struct_instance as *const rte_memseg;
             let field_ptr = std::ptr::addr_of!(struct_instance.nrank);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/issue-1498.rs
+++ b/tests/expectations/tests/issue-1498.rs
@@ -43,32 +43,6 @@ fn bindgen_test_layout_rte_memseg__bindgen_ty_1() {
         8usize,
         concat!("Alignment of ", stringify!(rte_memseg__bindgen_ty_1))
     );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_memseg__bindgen_ty_1>())).addr
-                as *const _ as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_memseg__bindgen_ty_1),
-            "::",
-            stringify!(addr)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_memseg__bindgen_ty_1>())).addr_64
-                as *const _ as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_memseg__bindgen_ty_1),
-            "::",
-            stringify!(addr_64)
-        )
-    );
 }
 impl Default for rte_memseg__bindgen_ty_1 {
     fn default() -> Self {
@@ -92,9 +66,18 @@ fn bindgen_test_layout_rte_memseg() {
         concat!("Alignment of ", stringify!(rte_memseg))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_memseg>())).phys_addr as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_memseg>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_memseg>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const rte_memseg;
+            let field_ptr = std::ptr::addr_of!(struct_instance.phys_addr);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -105,8 +88,18 @@ fn bindgen_test_layout_rte_memseg() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_memseg>())).len as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_memseg>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_memseg>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const rte_memseg;
+            let field_ptr = std::ptr::addr_of!(struct_instance.len);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         16usize,
         concat!(
@@ -117,9 +110,18 @@ fn bindgen_test_layout_rte_memseg() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_memseg>())).hugepage_sz as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_memseg>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_memseg>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const rte_memseg;
+            let field_ptr = std::ptr::addr_of!(struct_instance.hugepage_sz);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         24usize,
         concat!(
@@ -130,9 +132,18 @@ fn bindgen_test_layout_rte_memseg() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_memseg>())).socket_id as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_memseg>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_memseg>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const rte_memseg;
+            let field_ptr = std::ptr::addr_of!(struct_instance.socket_id);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         32usize,
         concat!(
@@ -143,8 +154,18 @@ fn bindgen_test_layout_rte_memseg() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_memseg>())).nchannel as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_memseg>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_memseg>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const rte_memseg;
+            let field_ptr = std::ptr::addr_of!(struct_instance.nchannel);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         36usize,
         concat!(
@@ -155,8 +176,18 @@ fn bindgen_test_layout_rte_memseg() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_memseg>())).nrank as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_memseg>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_memseg>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const rte_memseg;
+            let field_ptr = std::ptr::addr_of!(struct_instance.nrank);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         40usize,
         concat!(

--- a/tests/expectations/tests/issue-1947.rs
+++ b/tests/expectations/tests/issue-1947.rs
@@ -118,8 +118,18 @@ fn bindgen_test_layout_V56AMDY() {
         concat!("Alignment of ", stringify!(V56AMDY))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<V56AMDY>())).MADK as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<V56AMDY>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], V56AMDY>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const V56AMDY;
+            let field_ptr = std::ptr::addr_of!(struct_instance.MADK);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         2usize,
         concat!(
@@ -130,8 +140,18 @@ fn bindgen_test_layout_V56AMDY() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<V56AMDY>())).MABR as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<V56AMDY>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], V56AMDY>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const V56AMDY;
+            let field_ptr = std::ptr::addr_of!(struct_instance.MABR);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         3usize,
         concat!(
@@ -142,8 +162,18 @@ fn bindgen_test_layout_V56AMDY() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<V56AMDY>()))._rB_ as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<V56AMDY>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], V56AMDY>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const V56AMDY;
+            let field_ptr = std::ptr::addr_of!(struct_instance._rB_);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         7usize,
         concat!(

--- a/tests/expectations/tests/issue-1947.rs
+++ b/tests/expectations/tests/issue-1947.rs
@@ -119,11 +119,7 @@ fn bindgen_test_layout_V56AMDY() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<V56AMDY>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], V56AMDY>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<V56AMDY>() };
             let struct_ptr = &struct_instance as *const V56AMDY;
             let field_ptr = std::ptr::addr_of!(struct_instance.MADK);
             let struct_address = struct_ptr as usize;
@@ -141,11 +137,7 @@ fn bindgen_test_layout_V56AMDY() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<V56AMDY>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], V56AMDY>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<V56AMDY>() };
             let struct_ptr = &struct_instance as *const V56AMDY;
             let field_ptr = std::ptr::addr_of!(struct_instance.MABR);
             let struct_address = struct_ptr as usize;
@@ -163,11 +155,7 @@ fn bindgen_test_layout_V56AMDY() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<V56AMDY>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], V56AMDY>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<V56AMDY>() };
             let struct_ptr = &struct_instance as *const V56AMDY;
             let field_ptr = std::ptr::addr_of!(struct_instance._rB_);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/issue-1995.rs
+++ b/tests/expectations/tests/issue-1995.rs
@@ -30,7 +30,19 @@ fn bindgen_test_layout_Bar() {
         concat!("Alignment of ", stringify!(Bar))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Bar>())).baz as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<Bar>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], Bar>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const Bar;
+            let field_ptr = std::ptr::addr_of!(struct_instance.baz);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!("Offset of field: ", stringify!(Bar), "::", stringify!(baz))
     );

--- a/tests/expectations/tests/issue-1995.rs
+++ b/tests/expectations/tests/issue-1995.rs
@@ -31,11 +31,7 @@ fn bindgen_test_layout_Bar() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<Bar>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], Bar>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<Bar>() };
             let struct_ptr = &struct_instance as *const Bar;
             let field_ptr = std::ptr::addr_of!(struct_instance.baz);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/issue-2019.rs
+++ b/tests/expectations/tests/issue-2019.rs
@@ -24,10 +24,7 @@ fn bindgen_test_layout_A() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<A>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance =
-                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], A>(buffer) };
+            let struct_instance = unsafe { std::mem::zeroed::<A>() };
             let struct_ptr = &struct_instance as *const A;
             let field_ptr = std::ptr::addr_of!(struct_instance.a);
             let struct_address = struct_ptr as usize;
@@ -68,10 +65,7 @@ fn bindgen_test_layout_B() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<B>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance =
-                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], B>(buffer) };
+            let struct_instance = unsafe { std::mem::zeroed::<B>() };
             let struct_ptr = &struct_instance as *const B;
             let field_ptr = std::ptr::addr_of!(struct_instance.b);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/issue-2019.rs
+++ b/tests/expectations/tests/issue-2019.rs
@@ -23,7 +23,18 @@ fn bindgen_test_layout_A() {
         concat!("Alignment of ", stringify!(A))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<A>())).a as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<A>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance =
+                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], A>(buffer) };
+            let struct_ptr = &struct_instance as *const A;
+            let field_ptr = std::ptr::addr_of!(struct_instance.a);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!("Offset of field: ", stringify!(A), "::", stringify!(a))
     );
@@ -56,7 +67,18 @@ fn bindgen_test_layout_B() {
         concat!("Alignment of ", stringify!(B))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<B>())).b as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<B>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance =
+                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], B>(buffer) };
+            let struct_ptr = &struct_instance as *const B;
+            let field_ptr = std::ptr::addr_of!(struct_instance.b);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!("Offset of field: ", stringify!(B), "::", stringify!(b))
     );

--- a/tests/expectations/tests/issue-372.rs
+++ b/tests/expectations/tests/issue-372.rs
@@ -29,17 +29,53 @@ pub mod root {
             concat!("Alignment of ", stringify!(i))
         );
         assert_eq!(
-            unsafe { &(*(::std::ptr::null::<i>())).j as *const _ as usize },
+            {
+                const STRUCT_SIZE: usize = std::mem::size_of::<i>();
+                let buffer = [0u8; STRUCT_SIZE];
+                let struct_instance = unsafe {
+                    std::mem::transmute::<[u8; STRUCT_SIZE], i>(buffer)
+                };
+                let struct_ptr = &struct_instance as *const i;
+                let field_ptr = std::ptr::addr_of!(struct_instance.j);
+                let struct_address = struct_ptr as usize;
+                let field_address = field_ptr as usize;
+                std::mem::forget(struct_instance);
+                field_address.checked_sub(struct_address).unwrap()
+            },
             0usize,
             concat!("Offset of field: ", stringify!(i), "::", stringify!(j))
         );
         assert_eq!(
-            unsafe { &(*(::std::ptr::null::<i>())).k as *const _ as usize },
+            {
+                const STRUCT_SIZE: usize = std::mem::size_of::<i>();
+                let buffer = [0u8; STRUCT_SIZE];
+                let struct_instance = unsafe {
+                    std::mem::transmute::<[u8; STRUCT_SIZE], i>(buffer)
+                };
+                let struct_ptr = &struct_instance as *const i;
+                let field_ptr = std::ptr::addr_of!(struct_instance.k);
+                let struct_address = struct_ptr as usize;
+                let field_address = field_ptr as usize;
+                std::mem::forget(struct_instance);
+                field_address.checked_sub(struct_address).unwrap()
+            },
             8usize,
             concat!("Offset of field: ", stringify!(i), "::", stringify!(k))
         );
         assert_eq!(
-            unsafe { &(*(::std::ptr::null::<i>())).l as *const _ as usize },
+            {
+                const STRUCT_SIZE: usize = std::mem::size_of::<i>();
+                let buffer = [0u8; STRUCT_SIZE];
+                let struct_instance = unsafe {
+                    std::mem::transmute::<[u8; STRUCT_SIZE], i>(buffer)
+                };
+                let struct_ptr = &struct_instance as *const i;
+                let field_ptr = std::ptr::addr_of!(struct_instance.l);
+                let struct_address = struct_ptr as usize;
+                let field_address = field_ptr as usize;
+                std::mem::forget(struct_instance);
+                field_address.checked_sub(struct_address).unwrap()
+            },
             16usize,
             concat!("Offset of field: ", stringify!(i), "::", stringify!(l))
         );
@@ -71,7 +107,19 @@ pub mod root {
             concat!("Alignment of ", stringify!(d))
         );
         assert_eq!(
-            unsafe { &(*(::std::ptr::null::<d>())).m as *const _ as usize },
+            {
+                const STRUCT_SIZE: usize = std::mem::size_of::<d>();
+                let buffer = [0u8; STRUCT_SIZE];
+                let struct_instance = unsafe {
+                    std::mem::transmute::<[u8; STRUCT_SIZE], d>(buffer)
+                };
+                let struct_ptr = &struct_instance as *const d;
+                let field_ptr = std::ptr::addr_of!(struct_instance.m);
+                let struct_address = struct_ptr as usize;
+                let field_address = field_ptr as usize;
+                std::mem::forget(struct_instance);
+                field_address.checked_sub(struct_address).unwrap()
+            },
             0usize,
             concat!("Offset of field: ", stringify!(d), "::", stringify!(m))
         );
@@ -118,7 +166,19 @@ pub mod root {
             concat!("Alignment of ", stringify!(F))
         );
         assert_eq!(
-            unsafe { &(*(::std::ptr::null::<F>())).w as *const _ as usize },
+            {
+                const STRUCT_SIZE: usize = std::mem::size_of::<F>();
+                let buffer = [0u8; STRUCT_SIZE];
+                let struct_instance = unsafe {
+                    std::mem::transmute::<[u8; STRUCT_SIZE], F>(buffer)
+                };
+                let struct_ptr = &struct_instance as *const F;
+                let field_ptr = std::ptr::addr_of!(struct_instance.w);
+                let struct_address = struct_ptr as usize;
+                let field_address = field_ptr as usize;
+                std::mem::forget(struct_instance);
+                field_address.checked_sub(struct_address).unwrap()
+            },
             0usize,
             concat!("Offset of field: ", stringify!(F), "::", stringify!(w))
         );

--- a/tests/expectations/tests/issue-372.rs
+++ b/tests/expectations/tests/issue-372.rs
@@ -30,11 +30,7 @@ pub mod root {
         );
         assert_eq!(
             {
-                const STRUCT_SIZE: usize = std::mem::size_of::<i>();
-                let buffer = [0u8; STRUCT_SIZE];
-                let struct_instance = unsafe {
-                    std::mem::transmute::<[u8; STRUCT_SIZE], i>(buffer)
-                };
+                let struct_instance = unsafe { std::mem::zeroed::<i>() };
                 let struct_ptr = &struct_instance as *const i;
                 let field_ptr = std::ptr::addr_of!(struct_instance.j);
                 let struct_address = struct_ptr as usize;
@@ -47,11 +43,7 @@ pub mod root {
         );
         assert_eq!(
             {
-                const STRUCT_SIZE: usize = std::mem::size_of::<i>();
-                let buffer = [0u8; STRUCT_SIZE];
-                let struct_instance = unsafe {
-                    std::mem::transmute::<[u8; STRUCT_SIZE], i>(buffer)
-                };
+                let struct_instance = unsafe { std::mem::zeroed::<i>() };
                 let struct_ptr = &struct_instance as *const i;
                 let field_ptr = std::ptr::addr_of!(struct_instance.k);
                 let struct_address = struct_ptr as usize;
@@ -64,11 +56,7 @@ pub mod root {
         );
         assert_eq!(
             {
-                const STRUCT_SIZE: usize = std::mem::size_of::<i>();
-                let buffer = [0u8; STRUCT_SIZE];
-                let struct_instance = unsafe {
-                    std::mem::transmute::<[u8; STRUCT_SIZE], i>(buffer)
-                };
+                let struct_instance = unsafe { std::mem::zeroed::<i>() };
                 let struct_ptr = &struct_instance as *const i;
                 let field_ptr = std::ptr::addr_of!(struct_instance.l);
                 let struct_address = struct_ptr as usize;
@@ -108,11 +96,7 @@ pub mod root {
         );
         assert_eq!(
             {
-                const STRUCT_SIZE: usize = std::mem::size_of::<d>();
-                let buffer = [0u8; STRUCT_SIZE];
-                let struct_instance = unsafe {
-                    std::mem::transmute::<[u8; STRUCT_SIZE], d>(buffer)
-                };
+                let struct_instance = unsafe { std::mem::zeroed::<d>() };
                 let struct_ptr = &struct_instance as *const d;
                 let field_ptr = std::ptr::addr_of!(struct_instance.m);
                 let struct_address = struct_ptr as usize;
@@ -167,11 +151,7 @@ pub mod root {
         );
         assert_eq!(
             {
-                const STRUCT_SIZE: usize = std::mem::size_of::<F>();
-                let buffer = [0u8; STRUCT_SIZE];
-                let struct_instance = unsafe {
-                    std::mem::transmute::<[u8; STRUCT_SIZE], F>(buffer)
-                };
+                let struct_instance = unsafe { std::mem::zeroed::<F>() };
                 let struct_ptr = &struct_instance as *const F;
                 let field_ptr = std::ptr::addr_of!(struct_instance.w);
                 let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/issue-537-repr-packed-n.rs
+++ b/tests/expectations/tests/issue-537-repr-packed-n.rs
@@ -26,8 +26,18 @@ fn bindgen_test_layout_AlignedToOne() {
         concat!("Alignment of ", stringify!(AlignedToOne))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<AlignedToOne>())).i as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<AlignedToOne>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], AlignedToOne>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const AlignedToOne;
+            let field_ptr = std::ptr::addr_of!(struct_instance.i);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -57,8 +67,18 @@ fn bindgen_test_layout_AlignedToTwo() {
         concat!("Alignment of ", stringify!(AlignedToTwo))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<AlignedToTwo>())).i as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<AlignedToTwo>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], AlignedToTwo>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const AlignedToTwo;
+            let field_ptr = std::ptr::addr_of!(struct_instance.i);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -91,8 +111,18 @@ fn bindgen_test_layout_PackedToOne() {
         concat!("Alignment of ", stringify!(PackedToOne))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<PackedToOne>())).x as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<PackedToOne>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], PackedToOne>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const PackedToOne;
+            let field_ptr = std::ptr::addr_of!(struct_instance.x);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -103,8 +133,18 @@ fn bindgen_test_layout_PackedToOne() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<PackedToOne>())).y as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<PackedToOne>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], PackedToOne>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const PackedToOne;
+            let field_ptr = std::ptr::addr_of!(struct_instance.y);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         4usize,
         concat!(
@@ -135,8 +175,18 @@ fn bindgen_test_layout_PackedToTwo() {
         concat!("Alignment of ", stringify!(PackedToTwo))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<PackedToTwo>())).x as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<PackedToTwo>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], PackedToTwo>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const PackedToTwo;
+            let field_ptr = std::ptr::addr_of!(struct_instance.x);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -147,8 +197,18 @@ fn bindgen_test_layout_PackedToTwo() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<PackedToTwo>())).y as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<PackedToTwo>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], PackedToTwo>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const PackedToTwo;
+            let field_ptr = std::ptr::addr_of!(struct_instance.y);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         4usize,
         concat!(

--- a/tests/expectations/tests/issue-537-repr-packed-n.rs
+++ b/tests/expectations/tests/issue-537-repr-packed-n.rs
@@ -27,11 +27,7 @@ fn bindgen_test_layout_AlignedToOne() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<AlignedToOne>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], AlignedToOne>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<AlignedToOne>() };
             let struct_ptr = &struct_instance as *const AlignedToOne;
             let field_ptr = std::ptr::addr_of!(struct_instance.i);
             let struct_address = struct_ptr as usize;
@@ -68,11 +64,7 @@ fn bindgen_test_layout_AlignedToTwo() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<AlignedToTwo>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], AlignedToTwo>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<AlignedToTwo>() };
             let struct_ptr = &struct_instance as *const AlignedToTwo;
             let field_ptr = std::ptr::addr_of!(struct_instance.i);
             let struct_address = struct_ptr as usize;
@@ -112,11 +104,7 @@ fn bindgen_test_layout_PackedToOne() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<PackedToOne>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], PackedToOne>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<PackedToOne>() };
             let struct_ptr = &struct_instance as *const PackedToOne;
             let field_ptr = std::ptr::addr_of!(struct_instance.x);
             let struct_address = struct_ptr as usize;
@@ -134,11 +122,7 @@ fn bindgen_test_layout_PackedToOne() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<PackedToOne>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], PackedToOne>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<PackedToOne>() };
             let struct_ptr = &struct_instance as *const PackedToOne;
             let field_ptr = std::ptr::addr_of!(struct_instance.y);
             let struct_address = struct_ptr as usize;
@@ -176,11 +160,7 @@ fn bindgen_test_layout_PackedToTwo() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<PackedToTwo>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], PackedToTwo>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<PackedToTwo>() };
             let struct_ptr = &struct_instance as *const PackedToTwo;
             let field_ptr = std::ptr::addr_of!(struct_instance.x);
             let struct_address = struct_ptr as usize;
@@ -198,11 +178,7 @@ fn bindgen_test_layout_PackedToTwo() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<PackedToTwo>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], PackedToTwo>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<PackedToTwo>() };
             let struct_ptr = &struct_instance as *const PackedToTwo;
             let field_ptr = std::ptr::addr_of!(struct_instance.y);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/issue-537.rs
+++ b/tests/expectations/tests/issue-537.rs
@@ -25,8 +25,18 @@ fn bindgen_test_layout_AlignedToOne() {
         concat!("Alignment of ", stringify!(AlignedToOne))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<AlignedToOne>())).i as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<AlignedToOne>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], AlignedToOne>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const AlignedToOne;
+            let field_ptr = std::ptr::addr_of!(struct_instance.i);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -57,8 +67,18 @@ fn bindgen_test_layout_AlignedToTwo() {
         concat!("Alignment of ", stringify!(AlignedToTwo))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<AlignedToTwo>())).i as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<AlignedToTwo>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], AlignedToTwo>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const AlignedToTwo;
+            let field_ptr = std::ptr::addr_of!(struct_instance.i);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -91,8 +111,18 @@ fn bindgen_test_layout_PackedToOne() {
         concat!("Alignment of ", stringify!(PackedToOne))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<PackedToOne>())).x as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<PackedToOne>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], PackedToOne>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const PackedToOne;
+            let field_ptr = std::ptr::addr_of!(struct_instance.x);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -103,8 +133,18 @@ fn bindgen_test_layout_PackedToOne() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<PackedToOne>())).y as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<PackedToOne>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], PackedToOne>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const PackedToOne;
+            let field_ptr = std::ptr::addr_of!(struct_instance.y);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         4usize,
         concat!(
@@ -137,8 +177,18 @@ fn bindgen_test_layout_PackedToTwo() {
         concat!("Alignment of ", stringify!(PackedToTwo))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<PackedToTwo>())).x as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<PackedToTwo>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], PackedToTwo>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const PackedToTwo;
+            let field_ptr = std::ptr::addr_of!(struct_instance.x);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -149,8 +199,18 @@ fn bindgen_test_layout_PackedToTwo() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<PackedToTwo>())).y as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<PackedToTwo>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], PackedToTwo>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const PackedToTwo;
+            let field_ptr = std::ptr::addr_of!(struct_instance.y);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         4usize,
         concat!(

--- a/tests/expectations/tests/issue-537.rs
+++ b/tests/expectations/tests/issue-537.rs
@@ -26,11 +26,7 @@ fn bindgen_test_layout_AlignedToOne() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<AlignedToOne>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], AlignedToOne>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<AlignedToOne>() };
             let struct_ptr = &struct_instance as *const AlignedToOne;
             let field_ptr = std::ptr::addr_of!(struct_instance.i);
             let struct_address = struct_ptr as usize;
@@ -68,11 +64,7 @@ fn bindgen_test_layout_AlignedToTwo() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<AlignedToTwo>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], AlignedToTwo>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<AlignedToTwo>() };
             let struct_ptr = &struct_instance as *const AlignedToTwo;
             let field_ptr = std::ptr::addr_of!(struct_instance.i);
             let struct_address = struct_ptr as usize;
@@ -112,11 +104,7 @@ fn bindgen_test_layout_PackedToOne() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<PackedToOne>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], PackedToOne>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<PackedToOne>() };
             let struct_ptr = &struct_instance as *const PackedToOne;
             let field_ptr = std::ptr::addr_of!(struct_instance.x);
             let struct_address = struct_ptr as usize;
@@ -134,11 +122,7 @@ fn bindgen_test_layout_PackedToOne() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<PackedToOne>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], PackedToOne>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<PackedToOne>() };
             let struct_ptr = &struct_instance as *const PackedToOne;
             let field_ptr = std::ptr::addr_of!(struct_instance.y);
             let struct_address = struct_ptr as usize;
@@ -178,11 +162,7 @@ fn bindgen_test_layout_PackedToTwo() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<PackedToTwo>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], PackedToTwo>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<PackedToTwo>() };
             let struct_ptr = &struct_instance as *const PackedToTwo;
             let field_ptr = std::ptr::addr_of!(struct_instance.x);
             let struct_address = struct_ptr as usize;
@@ -200,11 +180,7 @@ fn bindgen_test_layout_PackedToTwo() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<PackedToTwo>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], PackedToTwo>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<PackedToTwo>() };
             let struct_ptr = &struct_instance as *const PackedToTwo;
             let field_ptr = std::ptr::addr_of!(struct_instance.y);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/issue-573-layout-test-failures.rs
+++ b/tests/expectations/tests/issue-573-layout-test-failures.rs
@@ -28,8 +28,18 @@ fn bindgen_test_layout_AutoIdVector() {
         concat!("Alignment of ", stringify!(AutoIdVector))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<AutoIdVector>())).ar as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<AutoIdVector>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], AutoIdVector>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const AutoIdVector;
+            let field_ptr = std::ptr::addr_of!(struct_instance.ar);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(

--- a/tests/expectations/tests/issue-573-layout-test-failures.rs
+++ b/tests/expectations/tests/issue-573-layout-test-failures.rs
@@ -29,11 +29,7 @@ fn bindgen_test_layout_AutoIdVector() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<AutoIdVector>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], AutoIdVector>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<AutoIdVector>() };
             let struct_ptr = &struct_instance as *const AutoIdVector;
             let field_ptr = std::ptr::addr_of!(struct_instance.ar);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/issue-574-assertion-failure-in-codegen.rs
+++ b/tests/expectations/tests/issue-574-assertion-failure-in-codegen.rs
@@ -29,11 +29,8 @@ fn bindgen_test_layout__bindgen_ty_1() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<_bindgen_ty_1>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], _bindgen_ty_1>(buffer)
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<_bindgen_ty_1>() };
             let struct_ptr = &struct_instance as *const _bindgen_ty_1;
             let field_ptr = std::ptr::addr_of!(struct_instance.ar);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/issue-574-assertion-failure-in-codegen.rs
+++ b/tests/expectations/tests/issue-574-assertion-failure-in-codegen.rs
@@ -28,8 +28,18 @@ fn bindgen_test_layout__bindgen_ty_1() {
         concat!("Alignment of ", stringify!(_bindgen_ty_1))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<_bindgen_ty_1>())).ar as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<_bindgen_ty_1>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], _bindgen_ty_1>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const _bindgen_ty_1;
+            let field_ptr = std::ptr::addr_of!(struct_instance.ar);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(

--- a/tests/expectations/tests/issue-584-stylo-template-analysis-panic.rs
+++ b/tests/expectations/tests/issue-584-stylo-template-analysis-panic.rs
@@ -62,7 +62,18 @@ fn bindgen_test_layout_g() {
         concat!("Alignment of ", stringify!(g))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<g>())).h as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<g>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance =
+                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], g>(buffer) };
+            let struct_ptr = &struct_instance as *const g;
+            let field_ptr = std::ptr::addr_of!(struct_instance.h);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!("Offset of field: ", stringify!(g), "::", stringify!(h))
     );

--- a/tests/expectations/tests/issue-584-stylo-template-analysis-panic.rs
+++ b/tests/expectations/tests/issue-584-stylo-template-analysis-panic.rs
@@ -63,10 +63,7 @@ fn bindgen_test_layout_g() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<g>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance =
-                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], g>(buffer) };
+            let struct_instance = unsafe { std::mem::zeroed::<g>() };
             let struct_ptr = &struct_instance as *const g;
             let field_ptr = std::ptr::addr_of!(struct_instance.h);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/issue-639-typedef-anon-field.rs
+++ b/tests/expectations/tests/issue-639-typedef-anon-field.rs
@@ -29,11 +29,7 @@ fn bindgen_test_layout_Foo_Bar() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<Foo_Bar>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], Foo_Bar>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<Foo_Bar>() };
             let struct_ptr = &struct_instance as *const Foo_Bar;
             let field_ptr = std::ptr::addr_of!(struct_instance.abc);
             let struct_address = struct_ptr as usize;
@@ -64,11 +60,7 @@ fn bindgen_test_layout_Foo() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<Foo>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], Foo>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<Foo>() };
             let struct_ptr = &struct_instance as *const Foo;
             let field_ptr = std::ptr::addr_of!(struct_instance.bar);
             let struct_address = struct_ptr as usize;
@@ -104,11 +96,7 @@ fn bindgen_test_layout_Baz_Bar() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<Baz_Bar>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], Baz_Bar>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<Baz_Bar>() };
             let struct_ptr = &struct_instance as *const Baz_Bar;
             let field_ptr = std::ptr::addr_of!(struct_instance.abc);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/issue-639-typedef-anon-field.rs
+++ b/tests/expectations/tests/issue-639-typedef-anon-field.rs
@@ -28,7 +28,19 @@ fn bindgen_test_layout_Foo_Bar() {
         concat!("Alignment of ", stringify!(Foo_Bar))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Foo_Bar>())).abc as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<Foo_Bar>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], Foo_Bar>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const Foo_Bar;
+            let field_ptr = std::ptr::addr_of!(struct_instance.abc);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!(
             "Offset of field: ",
@@ -51,7 +63,19 @@ fn bindgen_test_layout_Foo() {
         concat!("Alignment of ", stringify!(Foo))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Foo>())).bar as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<Foo>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], Foo>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const Foo;
+            let field_ptr = std::ptr::addr_of!(struct_instance.bar);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!("Offset of field: ", stringify!(Foo), "::", stringify!(bar))
     );
@@ -79,7 +103,19 @@ fn bindgen_test_layout_Baz_Bar() {
         concat!("Alignment of ", stringify!(Baz_Bar))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Baz_Bar>())).abc as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<Baz_Bar>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], Baz_Bar>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const Baz_Bar;
+            let field_ptr = std::ptr::addr_of!(struct_instance.abc);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/issue-648-derive-debug-with-padding.rs
+++ b/tests/expectations/tests/issue-648-derive-debug-with-padding.rs
@@ -29,11 +29,7 @@ fn bindgen_test_layout_NoDebug() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<NoDebug>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], NoDebug>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<NoDebug>() };
             let struct_ptr = &struct_instance as *const NoDebug;
             let field_ptr = std::ptr::addr_of!(struct_instance.c);
             let struct_address = struct_ptr as usize;
@@ -89,15 +85,8 @@ fn bindgen_test_layout_ShouldDeriveDebugButDoesNot() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<ShouldDeriveDebugButDoesNot>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<
-                    [u8; STRUCT_SIZE],
-                    ShouldDeriveDebugButDoesNot,
-                >(buffer)
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<ShouldDeriveDebugButDoesNot>() };
             let struct_ptr =
                 &struct_instance as *const ShouldDeriveDebugButDoesNot;
             let field_ptr = std::ptr::addr_of!(struct_instance.c);
@@ -116,15 +105,8 @@ fn bindgen_test_layout_ShouldDeriveDebugButDoesNot() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<ShouldDeriveDebugButDoesNot>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<
-                    [u8; STRUCT_SIZE],
-                    ShouldDeriveDebugButDoesNot,
-                >(buffer)
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<ShouldDeriveDebugButDoesNot>() };
             let struct_ptr =
                 &struct_instance as *const ShouldDeriveDebugButDoesNot;
             let field_ptr = std::ptr::addr_of!(struct_instance.d);

--- a/tests/expectations/tests/issue-648-derive-debug-with-padding.rs
+++ b/tests/expectations/tests/issue-648-derive-debug-with-padding.rs
@@ -28,7 +28,19 @@ fn bindgen_test_layout_NoDebug() {
         concat!("Alignment of ", stringify!(NoDebug))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<NoDebug>())).c as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<NoDebug>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], NoDebug>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const NoDebug;
+            let field_ptr = std::ptr::addr_of!(struct_instance.c);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!(
             "Offset of field: ",
@@ -76,9 +88,23 @@ fn bindgen_test_layout_ShouldDeriveDebugButDoesNot() {
         concat!("Alignment of ", stringify!(ShouldDeriveDebugButDoesNot))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<ShouldDeriveDebugButDoesNot>())).c
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<ShouldDeriveDebugButDoesNot>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<
+                    [u8; STRUCT_SIZE],
+                    ShouldDeriveDebugButDoesNot,
+                >(buffer)
+            };
+            let struct_ptr =
+                &struct_instance as *const ShouldDeriveDebugButDoesNot;
+            let field_ptr = std::ptr::addr_of!(struct_instance.c);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -89,9 +115,23 @@ fn bindgen_test_layout_ShouldDeriveDebugButDoesNot() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<ShouldDeriveDebugButDoesNot>())).d
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<ShouldDeriveDebugButDoesNot>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<
+                    [u8; STRUCT_SIZE],
+                    ShouldDeriveDebugButDoesNot,
+                >(buffer)
+            };
+            let struct_ptr =
+                &struct_instance as *const ShouldDeriveDebugButDoesNot;
+            let field_ptr = std::ptr::addr_of!(struct_instance.d);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         32usize,
         concat!(

--- a/tests/expectations/tests/issue-674-1.rs
+++ b/tests/expectations/tests/issue-674-1.rs
@@ -38,14 +38,8 @@ pub mod root {
         );
         assert_eq!(
             {
-                const STRUCT_SIZE: usize =
-                    std::mem::size_of::<CapturingContentInfo>();
-                let buffer = [0u8; STRUCT_SIZE];
-                let struct_instance = unsafe {
-                    std::mem::transmute::<[u8; STRUCT_SIZE], CapturingContentInfo>(
-                        buffer,
-                    )
-                };
+                let struct_instance =
+                    unsafe { std::mem::zeroed::<CapturingContentInfo>() };
                 let struct_ptr =
                     &struct_instance as *const CapturingContentInfo;
                 let field_ptr = std::ptr::addr_of!(struct_instance.a);

--- a/tests/expectations/tests/issue-674-1.rs
+++ b/tests/expectations/tests/issue-674-1.rs
@@ -37,9 +37,22 @@ pub mod root {
             concat!("Alignment of ", stringify!(CapturingContentInfo))
         );
         assert_eq!(
-            unsafe {
-                &(*(::std::ptr::null::<CapturingContentInfo>())).a as *const _
-                    as usize
+            {
+                const STRUCT_SIZE: usize =
+                    std::mem::size_of::<CapturingContentInfo>();
+                let buffer = [0u8; STRUCT_SIZE];
+                let struct_instance = unsafe {
+                    std::mem::transmute::<[u8; STRUCT_SIZE], CapturingContentInfo>(
+                        buffer,
+                    )
+                };
+                let struct_ptr =
+                    &struct_instance as *const CapturingContentInfo;
+                let field_ptr = std::ptr::addr_of!(struct_instance.a);
+                let struct_address = struct_ptr as usize;
+                let field_address = field_ptr as usize;
+                std::mem::forget(struct_instance);
+                field_address.checked_sub(struct_address).unwrap()
             },
             0usize,
             concat!(

--- a/tests/expectations/tests/issue-674-2.rs
+++ b/tests/expectations/tests/issue-674-2.rs
@@ -37,7 +37,19 @@ pub mod root {
             concat!("Alignment of ", stringify!(c))
         );
         assert_eq!(
-            unsafe { &(*(::std::ptr::null::<c>())).b as *const _ as usize },
+            {
+                const STRUCT_SIZE: usize = std::mem::size_of::<c>();
+                let buffer = [0u8; STRUCT_SIZE];
+                let struct_instance = unsafe {
+                    std::mem::transmute::<[u8; STRUCT_SIZE], c>(buffer)
+                };
+                let struct_ptr = &struct_instance as *const c;
+                let field_ptr = std::ptr::addr_of!(struct_instance.b);
+                let struct_address = struct_ptr as usize;
+                let field_address = field_ptr as usize;
+                std::mem::forget(struct_instance);
+                field_address.checked_sub(struct_address).unwrap()
+            },
             0usize,
             concat!("Offset of field: ", stringify!(c), "::", stringify!(b))
         );
@@ -60,7 +72,19 @@ pub mod root {
             concat!("Alignment of ", stringify!(B))
         );
         assert_eq!(
-            unsafe { &(*(::std::ptr::null::<B>())).a as *const _ as usize },
+            {
+                const STRUCT_SIZE: usize = std::mem::size_of::<B>();
+                let buffer = [0u8; STRUCT_SIZE];
+                let struct_instance = unsafe {
+                    std::mem::transmute::<[u8; STRUCT_SIZE], B>(buffer)
+                };
+                let struct_ptr = &struct_instance as *const B;
+                let field_ptr = std::ptr::addr_of!(struct_instance.a);
+                let struct_address = struct_ptr as usize;
+                let field_address = field_ptr as usize;
+                std::mem::forget(struct_instance);
+                field_address.checked_sub(struct_address).unwrap()
+            },
             0usize,
             concat!("Offset of field: ", stringify!(B), "::", stringify!(a))
         );

--- a/tests/expectations/tests/issue-674-2.rs
+++ b/tests/expectations/tests/issue-674-2.rs
@@ -38,11 +38,7 @@ pub mod root {
         );
         assert_eq!(
             {
-                const STRUCT_SIZE: usize = std::mem::size_of::<c>();
-                let buffer = [0u8; STRUCT_SIZE];
-                let struct_instance = unsafe {
-                    std::mem::transmute::<[u8; STRUCT_SIZE], c>(buffer)
-                };
+                let struct_instance = unsafe { std::mem::zeroed::<c>() };
                 let struct_ptr = &struct_instance as *const c;
                 let field_ptr = std::ptr::addr_of!(struct_instance.b);
                 let struct_address = struct_ptr as usize;
@@ -73,11 +69,7 @@ pub mod root {
         );
         assert_eq!(
             {
-                const STRUCT_SIZE: usize = std::mem::size_of::<B>();
-                let buffer = [0u8; STRUCT_SIZE];
-                let struct_instance = unsafe {
-                    std::mem::transmute::<[u8; STRUCT_SIZE], B>(buffer)
-                };
+                let struct_instance = unsafe { std::mem::zeroed::<B>() };
                 let struct_ptr = &struct_instance as *const B;
                 let field_ptr = std::ptr::addr_of!(struct_instance.a);
                 let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/issue-674-3.rs
+++ b/tests/expectations/tests/issue-674-3.rs
@@ -33,7 +33,19 @@ pub mod root {
             concat!("Alignment of ", stringify!(a))
         );
         assert_eq!(
-            unsafe { &(*(::std::ptr::null::<a>())).b as *const _ as usize },
+            {
+                const STRUCT_SIZE: usize = std::mem::size_of::<a>();
+                let buffer = [0u8; STRUCT_SIZE];
+                let struct_instance = unsafe {
+                    std::mem::transmute::<[u8; STRUCT_SIZE], a>(buffer)
+                };
+                let struct_ptr = &struct_instance as *const a;
+                let field_ptr = std::ptr::addr_of!(struct_instance.b);
+                let struct_address = struct_ptr as usize;
+                let field_address = field_ptr as usize;
+                std::mem::forget(struct_instance);
+                field_address.checked_sub(struct_address).unwrap()
+            },
             0usize,
             concat!("Offset of field: ", stringify!(a), "::", stringify!(b))
         );
@@ -56,8 +68,18 @@ pub mod root {
             concat!("Alignment of ", stringify!(nsCSSValue))
         );
         assert_eq!(
-            unsafe {
-                &(*(::std::ptr::null::<nsCSSValue>())).c as *const _ as usize
+            {
+                const STRUCT_SIZE: usize = std::mem::size_of::<nsCSSValue>();
+                let buffer = [0u8; STRUCT_SIZE];
+                let struct_instance = unsafe {
+                    std::mem::transmute::<[u8; STRUCT_SIZE], nsCSSValue>(buffer)
+                };
+                let struct_ptr = &struct_instance as *const nsCSSValue;
+                let field_ptr = std::ptr::addr_of!(struct_instance.c);
+                let struct_address = struct_ptr as usize;
+                let field_address = field_ptr as usize;
+                std::mem::forget(struct_instance);
+                field_address.checked_sub(struct_address).unwrap()
             },
             0usize,
             concat!(

--- a/tests/expectations/tests/issue-674-3.rs
+++ b/tests/expectations/tests/issue-674-3.rs
@@ -34,11 +34,7 @@ pub mod root {
         );
         assert_eq!(
             {
-                const STRUCT_SIZE: usize = std::mem::size_of::<a>();
-                let buffer = [0u8; STRUCT_SIZE];
-                let struct_instance = unsafe {
-                    std::mem::transmute::<[u8; STRUCT_SIZE], a>(buffer)
-                };
+                let struct_instance = unsafe { std::mem::zeroed::<a>() };
                 let struct_ptr = &struct_instance as *const a;
                 let field_ptr = std::ptr::addr_of!(struct_instance.b);
                 let struct_address = struct_ptr as usize;
@@ -69,11 +65,8 @@ pub mod root {
         );
         assert_eq!(
             {
-                const STRUCT_SIZE: usize = std::mem::size_of::<nsCSSValue>();
-                let buffer = [0u8; STRUCT_SIZE];
-                let struct_instance = unsafe {
-                    std::mem::transmute::<[u8; STRUCT_SIZE], nsCSSValue>(buffer)
-                };
+                let struct_instance =
+                    unsafe { std::mem::zeroed::<nsCSSValue>() };
                 let struct_ptr = &struct_instance as *const nsCSSValue;
                 let field_ptr = std::ptr::addr_of!(struct_instance.c);
                 let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/issue-801-opaque-sloppiness.rs
+++ b/tests/expectations/tests/issue-801-opaque-sloppiness.rs
@@ -52,10 +52,7 @@ fn bindgen_test_layout_C() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<C>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance =
-                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], C>(buffer) };
+            let struct_instance = unsafe { std::mem::zeroed::<C>() };
             let struct_ptr = &struct_instance as *const C;
             let field_ptr = std::ptr::addr_of!(struct_instance.b);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/issue-801-opaque-sloppiness.rs
+++ b/tests/expectations/tests/issue-801-opaque-sloppiness.rs
@@ -51,7 +51,18 @@ fn bindgen_test_layout_C() {
         concat!("Alignment of ", stringify!(C))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<C>())).b as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<C>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance =
+                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], C>(buffer) };
+            let struct_ptr = &struct_instance as *const C;
+            let field_ptr = std::ptr::addr_of!(struct_instance.b);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!("Offset of field: ", stringify!(C), "::", stringify!(b))
     );

--- a/tests/expectations/tests/issue-807-opaque-types-methods-being-generated.rs
+++ b/tests/expectations/tests/issue-807-opaque-types-methods-being-generated.rs
@@ -120,9 +120,18 @@ fn bindgen_test_layout_Allowlisted() {
         concat!("Alignment of ", stringify!(Allowlisted))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<Allowlisted>())).some_member as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<Allowlisted>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], Allowlisted>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const Allowlisted;
+            let field_ptr = std::ptr::addr_of!(struct_instance.some_member);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(

--- a/tests/expectations/tests/issue-807-opaque-types-methods-being-generated.rs
+++ b/tests/expectations/tests/issue-807-opaque-types-methods-being-generated.rs
@@ -121,11 +121,7 @@ fn bindgen_test_layout_Allowlisted() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<Allowlisted>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], Allowlisted>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<Allowlisted>() };
             let struct_ptr = &struct_instance as *const Allowlisted;
             let field_ptr = std::ptr::addr_of!(struct_instance.some_member);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/issue-944-derive-copy-and-blocklisting.rs
+++ b/tests/expectations/tests/issue-944-derive-copy-and-blocklisting.rs
@@ -25,8 +25,20 @@ fn bindgen_test_layout_ShouldNotBeCopy() {
         concat!("Alignment of ", stringify!(ShouldNotBeCopy))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<ShouldNotBeCopy>())).a as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<ShouldNotBeCopy>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], ShouldNotBeCopy>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const ShouldNotBeCopy;
+            let field_ptr = std::ptr::addr_of!(struct_instance.a);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(

--- a/tests/expectations/tests/issue-944-derive-copy-and-blocklisting.rs
+++ b/tests/expectations/tests/issue-944-derive-copy-and-blocklisting.rs
@@ -26,13 +26,8 @@ fn bindgen_test_layout_ShouldNotBeCopy() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<ShouldNotBeCopy>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], ShouldNotBeCopy>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<ShouldNotBeCopy>() };
             let struct_ptr = &struct_instance as *const ShouldNotBeCopy;
             let field_ptr = std::ptr::addr_of!(struct_instance.a);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/jsval_layout_opaque.rs
+++ b/tests/expectations/tests/jsval_layout_opaque.rs
@@ -317,15 +317,8 @@ fn bindgen_test_layout_jsval_layout__bindgen_ty_2() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<jsval_layout__bindgen_ty_2>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<
-                    [u8; STRUCT_SIZE],
-                    jsval_layout__bindgen_ty_2,
-                >(buffer)
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<jsval_layout__bindgen_ty_2>() };
             let struct_ptr =
                 &struct_instance as *const jsval_layout__bindgen_ty_2;
             let field_ptr = std::ptr::addr_of!(struct_instance.payload);
@@ -393,11 +386,7 @@ fn bindgen_test_layout_Value() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<Value>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], Value>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<Value>() };
             let struct_ptr = &struct_instance as *const Value;
             let field_ptr = std::ptr::addr_of!(struct_instance.data);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/jsval_layout_opaque.rs
+++ b/tests/expectations/tests/jsval_layout_opaque.rs
@@ -293,45 +293,6 @@ fn bindgen_test_layout_jsval_layout__bindgen_ty_2__bindgen_ty_1() {
             stringify!(jsval_layout__bindgen_ty_2__bindgen_ty_1)
         )
     );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<jsval_layout__bindgen_ty_2__bindgen_ty_1>()))
-                .i32_ as *const _ as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(jsval_layout__bindgen_ty_2__bindgen_ty_1),
-            "::",
-            stringify!(i32_)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<jsval_layout__bindgen_ty_2__bindgen_ty_1>()))
-                .u32_ as *const _ as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(jsval_layout__bindgen_ty_2__bindgen_ty_1),
-            "::",
-            stringify!(u32_)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<jsval_layout__bindgen_ty_2__bindgen_ty_1>()))
-                .why as *const _ as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(jsval_layout__bindgen_ty_2__bindgen_ty_1),
-            "::",
-            stringify!(why)
-        )
-    );
 }
 impl Default for jsval_layout__bindgen_ty_2__bindgen_ty_1 {
     fn default() -> Self {
@@ -355,9 +316,23 @@ fn bindgen_test_layout_jsval_layout__bindgen_ty_2() {
         concat!("Alignment of ", stringify!(jsval_layout__bindgen_ty_2))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<jsval_layout__bindgen_ty_2>())).payload
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<jsval_layout__bindgen_ty_2>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<
+                    [u8; STRUCT_SIZE],
+                    jsval_layout__bindgen_ty_2,
+                >(buffer)
+            };
+            let struct_ptr =
+                &struct_instance as *const jsval_layout__bindgen_ty_2;
+            let field_ptr = std::ptr::addr_of!(struct_instance.payload);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -389,93 +364,6 @@ fn bindgen_test_layout_jsval_layout() {
         8usize,
         concat!("Alignment of ", stringify!(jsval_layout))
     );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<jsval_layout>())).asBits as *const _ as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(jsval_layout),
-            "::",
-            stringify!(asBits)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<jsval_layout>())).debugView as *const _
-                as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(jsval_layout),
-            "::",
-            stringify!(debugView)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<jsval_layout>())).s as *const _ as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(jsval_layout),
-            "::",
-            stringify!(s)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<jsval_layout>())).asDouble as *const _
-                as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(jsval_layout),
-            "::",
-            stringify!(asDouble)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<jsval_layout>())).asPtr as *const _ as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(jsval_layout),
-            "::",
-            stringify!(asPtr)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<jsval_layout>())).asWord as *const _ as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(jsval_layout),
-            "::",
-            stringify!(asWord)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<jsval_layout>())).asUIntPtr as *const _
-                as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(jsval_layout),
-            "::",
-            stringify!(asUIntPtr)
-        )
-    );
 }
 impl Default for jsval_layout {
     fn default() -> Self {
@@ -504,7 +392,19 @@ fn bindgen_test_layout_Value() {
         concat!("Alignment of ", stringify!(Value))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Value>())).data as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<Value>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], Value>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const Value;
+            let field_ptr = std::ptr::addr_of!(struct_instance.data);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/jsval_layout_opaque_1_0.rs
+++ b/tests/expectations/tests/jsval_layout_opaque_1_0.rs
@@ -343,45 +343,6 @@ fn bindgen_test_layout_jsval_layout__bindgen_ty_2__bindgen_ty_1() {
             stringify!(jsval_layout__bindgen_ty_2__bindgen_ty_1)
         )
     );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<jsval_layout__bindgen_ty_2__bindgen_ty_1>()))
-                .i32_ as *const _ as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(jsval_layout__bindgen_ty_2__bindgen_ty_1),
-            "::",
-            stringify!(i32_)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<jsval_layout__bindgen_ty_2__bindgen_ty_1>()))
-                .u32_ as *const _ as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(jsval_layout__bindgen_ty_2__bindgen_ty_1),
-            "::",
-            stringify!(u32_)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<jsval_layout__bindgen_ty_2__bindgen_ty_1>()))
-                .why as *const _ as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(jsval_layout__bindgen_ty_2__bindgen_ty_1),
-            "::",
-            stringify!(why)
-        )
-    );
 }
 impl Clone for jsval_layout__bindgen_ty_2__bindgen_ty_1 {
     fn clone(&self) -> Self {
@@ -401,9 +362,23 @@ fn bindgen_test_layout_jsval_layout__bindgen_ty_2() {
         concat!("Alignment of ", stringify!(jsval_layout__bindgen_ty_2))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<jsval_layout__bindgen_ty_2>())).payload
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<jsval_layout__bindgen_ty_2>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<
+                    [u8; STRUCT_SIZE],
+                    jsval_layout__bindgen_ty_2,
+                >(buffer)
+            };
+            let struct_ptr =
+                &struct_instance as *const jsval_layout__bindgen_ty_2;
+            let field_ptr = std::ptr::addr_of!(struct_instance.payload);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -431,93 +406,6 @@ fn bindgen_test_layout_jsval_layout() {
         8usize,
         concat!("Alignment of ", stringify!(jsval_layout))
     );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<jsval_layout>())).asBits as *const _ as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(jsval_layout),
-            "::",
-            stringify!(asBits)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<jsval_layout>())).debugView as *const _
-                as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(jsval_layout),
-            "::",
-            stringify!(debugView)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<jsval_layout>())).s as *const _ as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(jsval_layout),
-            "::",
-            stringify!(s)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<jsval_layout>())).asDouble as *const _
-                as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(jsval_layout),
-            "::",
-            stringify!(asDouble)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<jsval_layout>())).asPtr as *const _ as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(jsval_layout),
-            "::",
-            stringify!(asPtr)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<jsval_layout>())).asWord as *const _ as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(jsval_layout),
-            "::",
-            stringify!(asWord)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<jsval_layout>())).asUIntPtr as *const _
-                as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(jsval_layout),
-            "::",
-            stringify!(asUIntPtr)
-        )
-    );
 }
 impl Clone for jsval_layout {
     fn clone(&self) -> Self {
@@ -542,7 +430,19 @@ fn bindgen_test_layout_Value() {
         concat!("Alignment of ", stringify!(Value))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Value>())).data as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<Value>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], Value>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const Value;
+            let field_ptr = std::ptr::addr_of!(struct_instance.data);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/jsval_layout_opaque_1_0.rs
+++ b/tests/expectations/tests/jsval_layout_opaque_1_0.rs
@@ -363,15 +363,8 @@ fn bindgen_test_layout_jsval_layout__bindgen_ty_2() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<jsval_layout__bindgen_ty_2>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<
-                    [u8; STRUCT_SIZE],
-                    jsval_layout__bindgen_ty_2,
-                >(buffer)
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<jsval_layout__bindgen_ty_2>() };
             let struct_ptr =
                 &struct_instance as *const jsval_layout__bindgen_ty_2;
             let field_ptr = std::ptr::addr_of!(struct_instance.payload);
@@ -431,11 +424,7 @@ fn bindgen_test_layout_Value() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<Value>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], Value>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<Value>() };
             let struct_ptr = &struct_instance as *const Value;
             let field_ptr = std::ptr::addr_of!(struct_instance.data);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/layout_arp.rs
+++ b/tests/expectations/tests/layout_arp.rs
@@ -41,9 +41,18 @@ fn bindgen_test_layout_ether_addr() {
         concat!("Alignment of ", stringify!(ether_addr))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<ether_addr>())).addr_bytes as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<ether_addr>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], ether_addr>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const ether_addr;
+            let field_ptr = std::ptr::addr_of!(struct_instance.addr_bytes);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -80,8 +89,18 @@ fn bindgen_test_layout_arp_ipv4() {
         concat!("Alignment of ", stringify!(arp_ipv4))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<arp_ipv4>())).arp_sha as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<arp_ipv4>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], arp_ipv4>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const arp_ipv4;
+            let field_ptr = std::ptr::addr_of!(struct_instance.arp_sha);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -92,8 +111,18 @@ fn bindgen_test_layout_arp_ipv4() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<arp_ipv4>())).arp_sip as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<arp_ipv4>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], arp_ipv4>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const arp_ipv4;
+            let field_ptr = std::ptr::addr_of!(struct_instance.arp_sip);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         6usize,
         concat!(
@@ -104,8 +133,18 @@ fn bindgen_test_layout_arp_ipv4() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<arp_ipv4>())).arp_tha as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<arp_ipv4>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], arp_ipv4>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const arp_ipv4;
+            let field_ptr = std::ptr::addr_of!(struct_instance.arp_tha);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         10usize,
         concat!(
@@ -116,8 +155,18 @@ fn bindgen_test_layout_arp_ipv4() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<arp_ipv4>())).arp_tip as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<arp_ipv4>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], arp_ipv4>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const arp_ipv4;
+            let field_ptr = std::ptr::addr_of!(struct_instance.arp_tip);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         16usize,
         concat!(
@@ -152,8 +201,18 @@ fn bindgen_test_layout_arp_hdr() {
         concat!("Alignment of ", stringify!(arp_hdr))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<arp_hdr>())).arp_hrd as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<arp_hdr>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], arp_hdr>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const arp_hdr;
+            let field_ptr = std::ptr::addr_of!(struct_instance.arp_hrd);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -164,8 +223,18 @@ fn bindgen_test_layout_arp_hdr() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<arp_hdr>())).arp_pro as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<arp_hdr>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], arp_hdr>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const arp_hdr;
+            let field_ptr = std::ptr::addr_of!(struct_instance.arp_pro);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         2usize,
         concat!(
@@ -176,8 +245,18 @@ fn bindgen_test_layout_arp_hdr() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<arp_hdr>())).arp_hln as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<arp_hdr>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], arp_hdr>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const arp_hdr;
+            let field_ptr = std::ptr::addr_of!(struct_instance.arp_hln);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         4usize,
         concat!(
@@ -188,8 +267,18 @@ fn bindgen_test_layout_arp_hdr() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<arp_hdr>())).arp_pln as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<arp_hdr>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], arp_hdr>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const arp_hdr;
+            let field_ptr = std::ptr::addr_of!(struct_instance.arp_pln);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         5usize,
         concat!(
@@ -200,8 +289,18 @@ fn bindgen_test_layout_arp_hdr() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<arp_hdr>())).arp_op as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<arp_hdr>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], arp_hdr>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const arp_hdr;
+            let field_ptr = std::ptr::addr_of!(struct_instance.arp_op);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         6usize,
         concat!(
@@ -212,8 +311,18 @@ fn bindgen_test_layout_arp_hdr() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<arp_hdr>())).arp_data as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<arp_hdr>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], arp_hdr>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const arp_hdr;
+            let field_ptr = std::ptr::addr_of!(struct_instance.arp_data);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         8usize,
         concat!(

--- a/tests/expectations/tests/layout_arp.rs
+++ b/tests/expectations/tests/layout_arp.rs
@@ -42,11 +42,7 @@ fn bindgen_test_layout_ether_addr() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<ether_addr>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], ether_addr>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<ether_addr>() };
             let struct_ptr = &struct_instance as *const ether_addr;
             let field_ptr = std::ptr::addr_of!(struct_instance.addr_bytes);
             let struct_address = struct_ptr as usize;
@@ -90,11 +86,7 @@ fn bindgen_test_layout_arp_ipv4() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<arp_ipv4>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], arp_ipv4>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<arp_ipv4>() };
             let struct_ptr = &struct_instance as *const arp_ipv4;
             let field_ptr = std::ptr::addr_of!(struct_instance.arp_sha);
             let struct_address = struct_ptr as usize;
@@ -112,11 +104,7 @@ fn bindgen_test_layout_arp_ipv4() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<arp_ipv4>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], arp_ipv4>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<arp_ipv4>() };
             let struct_ptr = &struct_instance as *const arp_ipv4;
             let field_ptr = std::ptr::addr_of!(struct_instance.arp_sip);
             let struct_address = struct_ptr as usize;
@@ -134,11 +122,7 @@ fn bindgen_test_layout_arp_ipv4() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<arp_ipv4>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], arp_ipv4>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<arp_ipv4>() };
             let struct_ptr = &struct_instance as *const arp_ipv4;
             let field_ptr = std::ptr::addr_of!(struct_instance.arp_tha);
             let struct_address = struct_ptr as usize;
@@ -156,11 +140,7 @@ fn bindgen_test_layout_arp_ipv4() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<arp_ipv4>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], arp_ipv4>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<arp_ipv4>() };
             let struct_ptr = &struct_instance as *const arp_ipv4;
             let field_ptr = std::ptr::addr_of!(struct_instance.arp_tip);
             let struct_address = struct_ptr as usize;
@@ -202,11 +182,7 @@ fn bindgen_test_layout_arp_hdr() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<arp_hdr>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], arp_hdr>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<arp_hdr>() };
             let struct_ptr = &struct_instance as *const arp_hdr;
             let field_ptr = std::ptr::addr_of!(struct_instance.arp_hrd);
             let struct_address = struct_ptr as usize;
@@ -224,11 +200,7 @@ fn bindgen_test_layout_arp_hdr() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<arp_hdr>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], arp_hdr>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<arp_hdr>() };
             let struct_ptr = &struct_instance as *const arp_hdr;
             let field_ptr = std::ptr::addr_of!(struct_instance.arp_pro);
             let struct_address = struct_ptr as usize;
@@ -246,11 +218,7 @@ fn bindgen_test_layout_arp_hdr() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<arp_hdr>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], arp_hdr>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<arp_hdr>() };
             let struct_ptr = &struct_instance as *const arp_hdr;
             let field_ptr = std::ptr::addr_of!(struct_instance.arp_hln);
             let struct_address = struct_ptr as usize;
@@ -268,11 +236,7 @@ fn bindgen_test_layout_arp_hdr() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<arp_hdr>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], arp_hdr>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<arp_hdr>() };
             let struct_ptr = &struct_instance as *const arp_hdr;
             let field_ptr = std::ptr::addr_of!(struct_instance.arp_pln);
             let struct_address = struct_ptr as usize;
@@ -290,11 +254,7 @@ fn bindgen_test_layout_arp_hdr() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<arp_hdr>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], arp_hdr>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<arp_hdr>() };
             let struct_ptr = &struct_instance as *const arp_hdr;
             let field_ptr = std::ptr::addr_of!(struct_instance.arp_op);
             let struct_address = struct_ptr as usize;
@@ -312,11 +272,7 @@ fn bindgen_test_layout_arp_hdr() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<arp_hdr>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], arp_hdr>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<arp_hdr>() };
             let struct_ptr = &struct_instance as *const arp_hdr;
             let field_ptr = std::ptr::addr_of!(struct_instance.arp_data);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/layout_array.rs
+++ b/tests/expectations/tests/layout_array.rs
@@ -81,13 +81,8 @@ fn bindgen_test_layout_rte_mempool_ops() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_mempool_ops>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_mempool_ops>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_mempool_ops>() };
             let struct_ptr = &struct_instance as *const rte_mempool_ops;
             let field_ptr = std::ptr::addr_of!(struct_instance.name);
             let struct_address = struct_ptr as usize;
@@ -105,13 +100,8 @@ fn bindgen_test_layout_rte_mempool_ops() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_mempool_ops>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_mempool_ops>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_mempool_ops>() };
             let struct_ptr = &struct_instance as *const rte_mempool_ops;
             let field_ptr = std::ptr::addr_of!(struct_instance.alloc);
             let struct_address = struct_ptr as usize;
@@ -129,13 +119,8 @@ fn bindgen_test_layout_rte_mempool_ops() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_mempool_ops>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_mempool_ops>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_mempool_ops>() };
             let struct_ptr = &struct_instance as *const rte_mempool_ops;
             let field_ptr = std::ptr::addr_of!(struct_instance.free);
             let struct_address = struct_ptr as usize;
@@ -153,13 +138,8 @@ fn bindgen_test_layout_rte_mempool_ops() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_mempool_ops>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_mempool_ops>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_mempool_ops>() };
             let struct_ptr = &struct_instance as *const rte_mempool_ops;
             let field_ptr = std::ptr::addr_of!(struct_instance.enqueue);
             let struct_address = struct_ptr as usize;
@@ -177,13 +157,8 @@ fn bindgen_test_layout_rte_mempool_ops() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_mempool_ops>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_mempool_ops>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_mempool_ops>() };
             let struct_ptr = &struct_instance as *const rte_mempool_ops;
             let field_ptr = std::ptr::addr_of!(struct_instance.dequeue);
             let struct_address = struct_ptr as usize;
@@ -201,13 +176,8 @@ fn bindgen_test_layout_rte_mempool_ops() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_mempool_ops>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_mempool_ops>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_mempool_ops>() };
             let struct_ptr = &struct_instance as *const rte_mempool_ops;
             let field_ptr = std::ptr::addr_of!(struct_instance.get_count);
             let struct_address = struct_ptr as usize;
@@ -264,11 +234,8 @@ fn bindgen_test_layout_rte_spinlock_t() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_spinlock_t>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_spinlock_t>(buffer)
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_spinlock_t>() };
             let struct_ptr = &struct_instance as *const rte_spinlock_t;
             let field_ptr = std::ptr::addr_of!(struct_instance.locked);
             let struct_address = struct_ptr as usize;
@@ -318,14 +285,8 @@ fn bindgen_test_layout_rte_mempool_ops_table() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<rte_mempool_ops_table>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_mempool_ops_table>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_mempool_ops_table>() };
             let struct_ptr = &struct_instance as *const rte_mempool_ops_table;
             let field_ptr = std::ptr::addr_of!(struct_instance.sl);
             let struct_address = struct_ptr as usize;
@@ -343,14 +304,8 @@ fn bindgen_test_layout_rte_mempool_ops_table() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<rte_mempool_ops_table>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_mempool_ops_table>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_mempool_ops_table>() };
             let struct_ptr = &struct_instance as *const rte_mempool_ops_table;
             let field_ptr = std::ptr::addr_of!(struct_instance.num_ops);
             let struct_address = struct_ptr as usize;
@@ -368,14 +323,8 @@ fn bindgen_test_layout_rte_mempool_ops_table() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<rte_mempool_ops_table>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_mempool_ops_table>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_mempool_ops_table>() };
             let struct_ptr = &struct_instance as *const rte_mempool_ops_table;
             let field_ptr = std::ptr::addr_of!(struct_instance.ops);
             let struct_address = struct_ptr as usize;
@@ -430,15 +379,8 @@ fn bindgen_test_layout_malloc_heap__bindgen_ty_1() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<malloc_heap__bindgen_ty_1>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<
-                    [u8; STRUCT_SIZE],
-                    malloc_heap__bindgen_ty_1,
-                >(buffer)
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<malloc_heap__bindgen_ty_1>() };
             let struct_ptr =
                 &struct_instance as *const malloc_heap__bindgen_ty_1;
             let field_ptr = std::ptr::addr_of!(struct_instance.lh_first);
@@ -479,11 +421,7 @@ fn bindgen_test_layout_malloc_heap() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<malloc_heap>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], malloc_heap>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<malloc_heap>() };
             let struct_ptr = &struct_instance as *const malloc_heap;
             let field_ptr = std::ptr::addr_of!(struct_instance.lock);
             let struct_address = struct_ptr as usize;
@@ -501,11 +439,7 @@ fn bindgen_test_layout_malloc_heap() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<malloc_heap>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], malloc_heap>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<malloc_heap>() };
             let struct_ptr = &struct_instance as *const malloc_heap;
             let field_ptr = std::ptr::addr_of!(struct_instance.free_head);
             let struct_address = struct_ptr as usize;
@@ -523,11 +457,7 @@ fn bindgen_test_layout_malloc_heap() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<malloc_heap>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], malloc_heap>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<malloc_heap>() };
             let struct_ptr = &struct_instance as *const malloc_heap;
             let field_ptr = std::ptr::addr_of!(struct_instance.alloc_count);
             let struct_address = struct_ptr as usize;
@@ -545,11 +475,7 @@ fn bindgen_test_layout_malloc_heap() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<malloc_heap>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], malloc_heap>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<malloc_heap>() };
             let struct_ptr = &struct_instance as *const malloc_heap;
             let field_ptr = std::ptr::addr_of!(struct_instance.total_size);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/layout_array.rs
+++ b/tests/expectations/tests/layout_array.rs
@@ -80,9 +80,20 @@ fn bindgen_test_layout_rte_mempool_ops() {
         concat!("Alignment of ", stringify!(rte_mempool_ops))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_mempool_ops>())).name as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_mempool_ops>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_mempool_ops>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const rte_mempool_ops;
+            let field_ptr = std::ptr::addr_of!(struct_instance.name);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -93,9 +104,20 @@ fn bindgen_test_layout_rte_mempool_ops() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_mempool_ops>())).alloc as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_mempool_ops>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_mempool_ops>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const rte_mempool_ops;
+            let field_ptr = std::ptr::addr_of!(struct_instance.alloc);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         32usize,
         concat!(
@@ -106,9 +128,20 @@ fn bindgen_test_layout_rte_mempool_ops() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_mempool_ops>())).free as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_mempool_ops>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_mempool_ops>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const rte_mempool_ops;
+            let field_ptr = std::ptr::addr_of!(struct_instance.free);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         40usize,
         concat!(
@@ -119,9 +152,20 @@ fn bindgen_test_layout_rte_mempool_ops() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_mempool_ops>())).enqueue as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_mempool_ops>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_mempool_ops>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const rte_mempool_ops;
+            let field_ptr = std::ptr::addr_of!(struct_instance.enqueue);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         48usize,
         concat!(
@@ -132,9 +176,20 @@ fn bindgen_test_layout_rte_mempool_ops() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_mempool_ops>())).dequeue as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_mempool_ops>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_mempool_ops>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const rte_mempool_ops;
+            let field_ptr = std::ptr::addr_of!(struct_instance.dequeue);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         56usize,
         concat!(
@@ -145,9 +200,20 @@ fn bindgen_test_layout_rte_mempool_ops() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_mempool_ops>())).get_count as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_mempool_ops>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_mempool_ops>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const rte_mempool_ops;
+            let field_ptr = std::ptr::addr_of!(struct_instance.get_count);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         64usize,
         concat!(
@@ -197,9 +263,18 @@ fn bindgen_test_layout_rte_spinlock_t() {
         concat!("Alignment of ", stringify!(rte_spinlock_t))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_spinlock_t>())).locked as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_spinlock_t>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_spinlock_t>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const rte_spinlock_t;
+            let field_ptr = std::ptr::addr_of!(struct_instance.locked);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -242,9 +317,21 @@ fn bindgen_test_layout_rte_mempool_ops_table() {
         concat!("Alignment of ", stringify!(rte_mempool_ops_table))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_mempool_ops_table>())).sl as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<rte_mempool_ops_table>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_mempool_ops_table>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const rte_mempool_ops_table;
+            let field_ptr = std::ptr::addr_of!(struct_instance.sl);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -255,9 +342,21 @@ fn bindgen_test_layout_rte_mempool_ops_table() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_mempool_ops_table>())).num_ops
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<rte_mempool_ops_table>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_mempool_ops_table>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const rte_mempool_ops_table;
+            let field_ptr = std::ptr::addr_of!(struct_instance.num_ops);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         4usize,
         concat!(
@@ -268,9 +367,21 @@ fn bindgen_test_layout_rte_mempool_ops_table() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_mempool_ops_table>())).ops as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<rte_mempool_ops_table>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_mempool_ops_table>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const rte_mempool_ops_table;
+            let field_ptr = std::ptr::addr_of!(struct_instance.ops);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         64usize,
         concat!(
@@ -318,9 +429,23 @@ fn bindgen_test_layout_malloc_heap__bindgen_ty_1() {
         concat!("Alignment of ", stringify!(malloc_heap__bindgen_ty_1))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<malloc_heap__bindgen_ty_1>())).lh_first
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<malloc_heap__bindgen_ty_1>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<
+                    [u8; STRUCT_SIZE],
+                    malloc_heap__bindgen_ty_1,
+                >(buffer)
+            };
+            let struct_ptr =
+                &struct_instance as *const malloc_heap__bindgen_ty_1;
+            let field_ptr = std::ptr::addr_of!(struct_instance.lh_first);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -353,8 +478,18 @@ fn bindgen_test_layout_malloc_heap() {
         concat!("Alignment of ", stringify!(malloc_heap))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<malloc_heap>())).lock as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<malloc_heap>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], malloc_heap>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const malloc_heap;
+            let field_ptr = std::ptr::addr_of!(struct_instance.lock);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -365,9 +500,18 @@ fn bindgen_test_layout_malloc_heap() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<malloc_heap>())).free_head as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<malloc_heap>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], malloc_heap>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const malloc_heap;
+            let field_ptr = std::ptr::addr_of!(struct_instance.free_head);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         8usize,
         concat!(
@@ -378,9 +522,18 @@ fn bindgen_test_layout_malloc_heap() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<malloc_heap>())).alloc_count as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<malloc_heap>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], malloc_heap>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const malloc_heap;
+            let field_ptr = std::ptr::addr_of!(struct_instance.alloc_count);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         112usize,
         concat!(
@@ -391,9 +544,18 @@ fn bindgen_test_layout_malloc_heap() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<malloc_heap>())).total_size as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<malloc_heap>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], malloc_heap>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const malloc_heap;
+            let field_ptr = std::ptr::addr_of!(struct_instance.total_size);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         120usize,
         concat!(

--- a/tests/expectations/tests/layout_array_too_long.rs
+++ b/tests/expectations/tests/layout_array_too_long.rs
@@ -46,7 +46,19 @@ fn bindgen_test_layout_ip_frag() {
         concat!("Alignment of ", stringify!(ip_frag))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<ip_frag>())).ofs as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<ip_frag>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], ip_frag>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const ip_frag;
+            let field_ptr = std::ptr::addr_of!(struct_instance.ofs);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!(
             "Offset of field: ",
@@ -56,7 +68,19 @@ fn bindgen_test_layout_ip_frag() {
         )
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<ip_frag>())).len as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<ip_frag>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], ip_frag>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const ip_frag;
+            let field_ptr = std::ptr::addr_of!(struct_instance.len);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         2usize,
         concat!(
             "Offset of field: ",
@@ -66,7 +90,19 @@ fn bindgen_test_layout_ip_frag() {
         )
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<ip_frag>())).mb as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<ip_frag>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], ip_frag>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const ip_frag;
+            let field_ptr = std::ptr::addr_of!(struct_instance.mb);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         8usize,
         concat!(
             "Offset of field: ",
@@ -109,8 +145,18 @@ fn bindgen_test_layout_ip_frag_key() {
         concat!("Alignment of ", stringify!(ip_frag_key))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<ip_frag_key>())).src_dst as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<ip_frag_key>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], ip_frag_key>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const ip_frag_key;
+            let field_ptr = std::ptr::addr_of!(struct_instance.src_dst);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -121,8 +167,18 @@ fn bindgen_test_layout_ip_frag_key() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<ip_frag_key>())).id as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<ip_frag_key>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], ip_frag_key>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const ip_frag_key;
+            let field_ptr = std::ptr::addr_of!(struct_instance.id);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         32usize,
         concat!(
@@ -133,8 +189,18 @@ fn bindgen_test_layout_ip_frag_key() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<ip_frag_key>())).key_len as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<ip_frag_key>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], ip_frag_key>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const ip_frag_key;
+            let field_ptr = std::ptr::addr_of!(struct_instance.key_len);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         36usize,
         concat!(
@@ -185,9 +251,23 @@ fn bindgen_test_layout_ip_frag_pkt__bindgen_ty_1() {
         concat!("Alignment of ", stringify!(ip_frag_pkt__bindgen_ty_1))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<ip_frag_pkt__bindgen_ty_1>())).tqe_next
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<ip_frag_pkt__bindgen_ty_1>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<
+                    [u8; STRUCT_SIZE],
+                    ip_frag_pkt__bindgen_ty_1,
+                >(buffer)
+            };
+            let struct_ptr =
+                &struct_instance as *const ip_frag_pkt__bindgen_ty_1;
+            let field_ptr = std::ptr::addr_of!(struct_instance.tqe_next);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -198,9 +278,23 @@ fn bindgen_test_layout_ip_frag_pkt__bindgen_ty_1() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<ip_frag_pkt__bindgen_ty_1>())).tqe_prev
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<ip_frag_pkt__bindgen_ty_1>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<
+                    [u8; STRUCT_SIZE],
+                    ip_frag_pkt__bindgen_ty_1,
+                >(buffer)
+            };
+            let struct_ptr =
+                &struct_instance as *const ip_frag_pkt__bindgen_ty_1;
+            let field_ptr = std::ptr::addr_of!(struct_instance.tqe_prev);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         8usize,
         concat!(
@@ -233,8 +327,18 @@ fn bindgen_test_layout_ip_frag_pkt() {
         concat!("Alignment of ", stringify!(ip_frag_pkt))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<ip_frag_pkt>())).lru as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<ip_frag_pkt>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], ip_frag_pkt>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const ip_frag_pkt;
+            let field_ptr = std::ptr::addr_of!(struct_instance.lru);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -245,8 +349,18 @@ fn bindgen_test_layout_ip_frag_pkt() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<ip_frag_pkt>())).key as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<ip_frag_pkt>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], ip_frag_pkt>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const ip_frag_pkt;
+            let field_ptr = std::ptr::addr_of!(struct_instance.key);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         16usize,
         concat!(
@@ -257,8 +371,18 @@ fn bindgen_test_layout_ip_frag_pkt() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<ip_frag_pkt>())).start as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<ip_frag_pkt>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], ip_frag_pkt>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const ip_frag_pkt;
+            let field_ptr = std::ptr::addr_of!(struct_instance.start);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         56usize,
         concat!(
@@ -269,9 +393,18 @@ fn bindgen_test_layout_ip_frag_pkt() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<ip_frag_pkt>())).total_size as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<ip_frag_pkt>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], ip_frag_pkt>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const ip_frag_pkt;
+            let field_ptr = std::ptr::addr_of!(struct_instance.total_size);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         64usize,
         concat!(
@@ -282,9 +415,18 @@ fn bindgen_test_layout_ip_frag_pkt() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<ip_frag_pkt>())).frag_size as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<ip_frag_pkt>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], ip_frag_pkt>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const ip_frag_pkt;
+            let field_ptr = std::ptr::addr_of!(struct_instance.frag_size);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         68usize,
         concat!(
@@ -295,9 +437,18 @@ fn bindgen_test_layout_ip_frag_pkt() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<ip_frag_pkt>())).last_idx as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<ip_frag_pkt>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], ip_frag_pkt>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const ip_frag_pkt;
+            let field_ptr = std::ptr::addr_of!(struct_instance.last_idx);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         72usize,
         concat!(
@@ -308,8 +459,18 @@ fn bindgen_test_layout_ip_frag_pkt() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<ip_frag_pkt>())).frags as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<ip_frag_pkt>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], ip_frag_pkt>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const ip_frag_pkt;
+            let field_ptr = std::ptr::addr_of!(struct_instance.frags);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         80usize,
         concat!(

--- a/tests/expectations/tests/layout_array_too_long.rs
+++ b/tests/expectations/tests/layout_array_too_long.rs
@@ -47,11 +47,7 @@ fn bindgen_test_layout_ip_frag() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<ip_frag>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], ip_frag>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<ip_frag>() };
             let struct_ptr = &struct_instance as *const ip_frag;
             let field_ptr = std::ptr::addr_of!(struct_instance.ofs);
             let struct_address = struct_ptr as usize;
@@ -69,11 +65,7 @@ fn bindgen_test_layout_ip_frag() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<ip_frag>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], ip_frag>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<ip_frag>() };
             let struct_ptr = &struct_instance as *const ip_frag;
             let field_ptr = std::ptr::addr_of!(struct_instance.len);
             let struct_address = struct_ptr as usize;
@@ -91,11 +83,7 @@ fn bindgen_test_layout_ip_frag() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<ip_frag>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], ip_frag>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<ip_frag>() };
             let struct_ptr = &struct_instance as *const ip_frag;
             let field_ptr = std::ptr::addr_of!(struct_instance.mb);
             let struct_address = struct_ptr as usize;
@@ -146,11 +134,7 @@ fn bindgen_test_layout_ip_frag_key() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<ip_frag_key>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], ip_frag_key>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<ip_frag_key>() };
             let struct_ptr = &struct_instance as *const ip_frag_key;
             let field_ptr = std::ptr::addr_of!(struct_instance.src_dst);
             let struct_address = struct_ptr as usize;
@@ -168,11 +152,7 @@ fn bindgen_test_layout_ip_frag_key() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<ip_frag_key>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], ip_frag_key>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<ip_frag_key>() };
             let struct_ptr = &struct_instance as *const ip_frag_key;
             let field_ptr = std::ptr::addr_of!(struct_instance.id);
             let struct_address = struct_ptr as usize;
@@ -190,11 +170,7 @@ fn bindgen_test_layout_ip_frag_key() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<ip_frag_key>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], ip_frag_key>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<ip_frag_key>() };
             let struct_ptr = &struct_instance as *const ip_frag_key;
             let field_ptr = std::ptr::addr_of!(struct_instance.key_len);
             let struct_address = struct_ptr as usize;
@@ -252,15 +228,8 @@ fn bindgen_test_layout_ip_frag_pkt__bindgen_ty_1() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<ip_frag_pkt__bindgen_ty_1>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<
-                    [u8; STRUCT_SIZE],
-                    ip_frag_pkt__bindgen_ty_1,
-                >(buffer)
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<ip_frag_pkt__bindgen_ty_1>() };
             let struct_ptr =
                 &struct_instance as *const ip_frag_pkt__bindgen_ty_1;
             let field_ptr = std::ptr::addr_of!(struct_instance.tqe_next);
@@ -279,15 +248,8 @@ fn bindgen_test_layout_ip_frag_pkt__bindgen_ty_1() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<ip_frag_pkt__bindgen_ty_1>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<
-                    [u8; STRUCT_SIZE],
-                    ip_frag_pkt__bindgen_ty_1,
-                >(buffer)
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<ip_frag_pkt__bindgen_ty_1>() };
             let struct_ptr =
                 &struct_instance as *const ip_frag_pkt__bindgen_ty_1;
             let field_ptr = std::ptr::addr_of!(struct_instance.tqe_prev);
@@ -328,11 +290,7 @@ fn bindgen_test_layout_ip_frag_pkt() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<ip_frag_pkt>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], ip_frag_pkt>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<ip_frag_pkt>() };
             let struct_ptr = &struct_instance as *const ip_frag_pkt;
             let field_ptr = std::ptr::addr_of!(struct_instance.lru);
             let struct_address = struct_ptr as usize;
@@ -350,11 +308,7 @@ fn bindgen_test_layout_ip_frag_pkt() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<ip_frag_pkt>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], ip_frag_pkt>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<ip_frag_pkt>() };
             let struct_ptr = &struct_instance as *const ip_frag_pkt;
             let field_ptr = std::ptr::addr_of!(struct_instance.key);
             let struct_address = struct_ptr as usize;
@@ -372,11 +326,7 @@ fn bindgen_test_layout_ip_frag_pkt() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<ip_frag_pkt>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], ip_frag_pkt>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<ip_frag_pkt>() };
             let struct_ptr = &struct_instance as *const ip_frag_pkt;
             let field_ptr = std::ptr::addr_of!(struct_instance.start);
             let struct_address = struct_ptr as usize;
@@ -394,11 +344,7 @@ fn bindgen_test_layout_ip_frag_pkt() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<ip_frag_pkt>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], ip_frag_pkt>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<ip_frag_pkt>() };
             let struct_ptr = &struct_instance as *const ip_frag_pkt;
             let field_ptr = std::ptr::addr_of!(struct_instance.total_size);
             let struct_address = struct_ptr as usize;
@@ -416,11 +362,7 @@ fn bindgen_test_layout_ip_frag_pkt() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<ip_frag_pkt>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], ip_frag_pkt>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<ip_frag_pkt>() };
             let struct_ptr = &struct_instance as *const ip_frag_pkt;
             let field_ptr = std::ptr::addr_of!(struct_instance.frag_size);
             let struct_address = struct_ptr as usize;
@@ -438,11 +380,7 @@ fn bindgen_test_layout_ip_frag_pkt() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<ip_frag_pkt>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], ip_frag_pkt>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<ip_frag_pkt>() };
             let struct_ptr = &struct_instance as *const ip_frag_pkt;
             let field_ptr = std::ptr::addr_of!(struct_instance.last_idx);
             let struct_address = struct_ptr as usize;
@@ -460,11 +398,7 @@ fn bindgen_test_layout_ip_frag_pkt() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<ip_frag_pkt>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], ip_frag_pkt>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<ip_frag_pkt>() };
             let struct_ptr = &struct_instance as *const ip_frag_pkt;
             let field_ptr = std::ptr::addr_of!(struct_instance.frags);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/layout_cmdline_token.rs
+++ b/tests/expectations/tests/layout_cmdline_token.rs
@@ -26,9 +26,20 @@ fn bindgen_test_layout_cmdline_token_hdr() {
         concat!("Alignment of ", stringify!(cmdline_token_hdr))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<cmdline_token_hdr>())).ops as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<cmdline_token_hdr>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], cmdline_token_hdr>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const cmdline_token_hdr;
+            let field_ptr = std::ptr::addr_of!(struct_instance.ops);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -39,9 +50,20 @@ fn bindgen_test_layout_cmdline_token_hdr() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<cmdline_token_hdr>())).offset as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<cmdline_token_hdr>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], cmdline_token_hdr>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const cmdline_token_hdr;
+            let field_ptr = std::ptr::addr_of!(struct_instance.offset);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         8usize,
         concat!(
@@ -128,9 +150,20 @@ fn bindgen_test_layout_cmdline_token_ops() {
         concat!("Alignment of ", stringify!(cmdline_token_ops))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<cmdline_token_ops>())).parse as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<cmdline_token_ops>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], cmdline_token_ops>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const cmdline_token_ops;
+            let field_ptr = std::ptr::addr_of!(struct_instance.parse);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -141,9 +174,20 @@ fn bindgen_test_layout_cmdline_token_ops() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<cmdline_token_ops>())).complete_get_nb
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<cmdline_token_ops>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], cmdline_token_ops>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const cmdline_token_ops;
+            let field_ptr = std::ptr::addr_of!(struct_instance.complete_get_nb);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         8usize,
         concat!(
@@ -154,9 +198,21 @@ fn bindgen_test_layout_cmdline_token_ops() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<cmdline_token_ops>())).complete_get_elt
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<cmdline_token_ops>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], cmdline_token_ops>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const cmdline_token_ops;
+            let field_ptr =
+                std::ptr::addr_of!(struct_instance.complete_get_elt);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         16usize,
         concat!(
@@ -167,9 +223,20 @@ fn bindgen_test_layout_cmdline_token_ops() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<cmdline_token_ops>())).get_help as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<cmdline_token_ops>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], cmdline_token_ops>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const cmdline_token_ops;
+            let field_ptr = std::ptr::addr_of!(struct_instance.get_help);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         24usize,
         concat!(
@@ -210,9 +277,21 @@ fn bindgen_test_layout_cmdline_token_num_data() {
         concat!("Alignment of ", stringify!(cmdline_token_num_data))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<cmdline_token_num_data>())).type_ as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<cmdline_token_num_data>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], cmdline_token_num_data>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const cmdline_token_num_data;
+            let field_ptr = std::ptr::addr_of!(struct_instance.type_);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -251,9 +330,20 @@ fn bindgen_test_layout_cmdline_token_num() {
         concat!("Alignment of ", stringify!(cmdline_token_num))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<cmdline_token_num>())).hdr as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<cmdline_token_num>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], cmdline_token_num>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const cmdline_token_num;
+            let field_ptr = std::ptr::addr_of!(struct_instance.hdr);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -264,9 +354,20 @@ fn bindgen_test_layout_cmdline_token_num() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<cmdline_token_num>())).num_data as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<cmdline_token_num>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], cmdline_token_num>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const cmdline_token_num;
+            let field_ptr = std::ptr::addr_of!(struct_instance.num_data);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         16usize,
         concat!(

--- a/tests/expectations/tests/layout_cmdline_token.rs
+++ b/tests/expectations/tests/layout_cmdline_token.rs
@@ -27,13 +27,8 @@ fn bindgen_test_layout_cmdline_token_hdr() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<cmdline_token_hdr>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], cmdline_token_hdr>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<cmdline_token_hdr>() };
             let struct_ptr = &struct_instance as *const cmdline_token_hdr;
             let field_ptr = std::ptr::addr_of!(struct_instance.ops);
             let struct_address = struct_ptr as usize;
@@ -51,13 +46,8 @@ fn bindgen_test_layout_cmdline_token_hdr() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<cmdline_token_hdr>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], cmdline_token_hdr>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<cmdline_token_hdr>() };
             let struct_ptr = &struct_instance as *const cmdline_token_hdr;
             let field_ptr = std::ptr::addr_of!(struct_instance.offset);
             let struct_address = struct_ptr as usize;
@@ -151,13 +141,8 @@ fn bindgen_test_layout_cmdline_token_ops() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<cmdline_token_ops>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], cmdline_token_ops>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<cmdline_token_ops>() };
             let struct_ptr = &struct_instance as *const cmdline_token_ops;
             let field_ptr = std::ptr::addr_of!(struct_instance.parse);
             let struct_address = struct_ptr as usize;
@@ -175,13 +160,8 @@ fn bindgen_test_layout_cmdline_token_ops() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<cmdline_token_ops>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], cmdline_token_ops>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<cmdline_token_ops>() };
             let struct_ptr = &struct_instance as *const cmdline_token_ops;
             let field_ptr = std::ptr::addr_of!(struct_instance.complete_get_nb);
             let struct_address = struct_ptr as usize;
@@ -199,13 +179,8 @@ fn bindgen_test_layout_cmdline_token_ops() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<cmdline_token_ops>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], cmdline_token_ops>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<cmdline_token_ops>() };
             let struct_ptr = &struct_instance as *const cmdline_token_ops;
             let field_ptr =
                 std::ptr::addr_of!(struct_instance.complete_get_elt);
@@ -224,13 +199,8 @@ fn bindgen_test_layout_cmdline_token_ops() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<cmdline_token_ops>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], cmdline_token_ops>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<cmdline_token_ops>() };
             let struct_ptr = &struct_instance as *const cmdline_token_ops;
             let field_ptr = std::ptr::addr_of!(struct_instance.get_help);
             let struct_address = struct_ptr as usize;
@@ -278,14 +248,8 @@ fn bindgen_test_layout_cmdline_token_num_data() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<cmdline_token_num_data>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], cmdline_token_num_data>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<cmdline_token_num_data>() };
             let struct_ptr = &struct_instance as *const cmdline_token_num_data;
             let field_ptr = std::ptr::addr_of!(struct_instance.type_);
             let struct_address = struct_ptr as usize;
@@ -331,13 +295,8 @@ fn bindgen_test_layout_cmdline_token_num() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<cmdline_token_num>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], cmdline_token_num>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<cmdline_token_num>() };
             let struct_ptr = &struct_instance as *const cmdline_token_num;
             let field_ptr = std::ptr::addr_of!(struct_instance.hdr);
             let struct_address = struct_ptr as usize;
@@ -355,13 +314,8 @@ fn bindgen_test_layout_cmdline_token_num() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<cmdline_token_num>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], cmdline_token_num>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<cmdline_token_num>() };
             let struct_ptr = &struct_instance as *const cmdline_token_num;
             let field_ptr = std::ptr::addr_of!(struct_instance.num_data);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/layout_eth_conf.rs
+++ b/tests/expectations/tests/layout_eth_conf.rs
@@ -172,11 +172,8 @@ fn bindgen_test_layout_rte_eth_rxmode() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_eth_rxmode>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_rxmode>(buffer)
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_eth_rxmode>() };
             let struct_ptr = &struct_instance as *const rte_eth_rxmode;
             let field_ptr = std::ptr::addr_of!(struct_instance.mq_mode);
             let struct_address = struct_ptr as usize;
@@ -194,11 +191,8 @@ fn bindgen_test_layout_rte_eth_rxmode() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_eth_rxmode>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_rxmode>(buffer)
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_eth_rxmode>() };
             let struct_ptr = &struct_instance as *const rte_eth_rxmode;
             let field_ptr = std::ptr::addr_of!(struct_instance.max_rx_pkt_len);
             let struct_address = struct_ptr as usize;
@@ -216,11 +210,8 @@ fn bindgen_test_layout_rte_eth_rxmode() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_eth_rxmode>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_rxmode>(buffer)
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_eth_rxmode>() };
             let struct_ptr = &struct_instance as *const rte_eth_rxmode;
             let field_ptr = std::ptr::addr_of!(struct_instance.split_hdr_size);
             let struct_address = struct_ptr as usize;
@@ -464,11 +455,8 @@ fn bindgen_test_layout_rte_eth_txmode() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_eth_txmode>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_txmode>(buffer)
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_eth_txmode>() };
             let struct_ptr = &struct_instance as *const rte_eth_txmode;
             let field_ptr = std::ptr::addr_of!(struct_instance.mq_mode);
             let struct_address = struct_ptr as usize;
@@ -486,11 +474,8 @@ fn bindgen_test_layout_rte_eth_txmode() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_eth_txmode>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_txmode>(buffer)
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_eth_txmode>() };
             let struct_ptr = &struct_instance as *const rte_eth_txmode;
             let field_ptr = std::ptr::addr_of!(struct_instance.pvid);
             let struct_address = struct_ptr as usize;
@@ -621,13 +606,8 @@ fn bindgen_test_layout_rte_eth_rss_conf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_eth_rss_conf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_rss_conf>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_eth_rss_conf>() };
             let struct_ptr = &struct_instance as *const rte_eth_rss_conf;
             let field_ptr = std::ptr::addr_of!(struct_instance.rss_key);
             let struct_address = struct_ptr as usize;
@@ -645,13 +625,8 @@ fn bindgen_test_layout_rte_eth_rss_conf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_eth_rss_conf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_rss_conf>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_eth_rss_conf>() };
             let struct_ptr = &struct_instance as *const rte_eth_rss_conf;
             let field_ptr = std::ptr::addr_of!(struct_instance.rss_key_len);
             let struct_address = struct_ptr as usize;
@@ -669,13 +644,8 @@ fn bindgen_test_layout_rte_eth_rss_conf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_eth_rss_conf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_rss_conf>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_eth_rss_conf>() };
             let struct_ptr = &struct_instance as *const rte_eth_rss_conf;
             let field_ptr = std::ptr::addr_of!(struct_instance.rss_hf);
             let struct_address = struct_ptr as usize;
@@ -774,14 +744,8 @@ fn bindgen_test_layout_rte_eth_vmdq_dcb_conf__bindgen_ty_1() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<rte_eth_vmdq_dcb_conf__bindgen_ty_1>();
-            let buffer = [0u8; STRUCT_SIZE];
             let struct_instance = unsafe {
-                std::mem::transmute::<
-                    [u8; STRUCT_SIZE],
-                    rte_eth_vmdq_dcb_conf__bindgen_ty_1,
-                >(buffer)
+                std::mem::zeroed::<rte_eth_vmdq_dcb_conf__bindgen_ty_1>()
             };
             let struct_ptr =
                 &struct_instance as *const rte_eth_vmdq_dcb_conf__bindgen_ty_1;
@@ -801,14 +765,8 @@ fn bindgen_test_layout_rte_eth_vmdq_dcb_conf__bindgen_ty_1() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<rte_eth_vmdq_dcb_conf__bindgen_ty_1>();
-            let buffer = [0u8; STRUCT_SIZE];
             let struct_instance = unsafe {
-                std::mem::transmute::<
-                    [u8; STRUCT_SIZE],
-                    rte_eth_vmdq_dcb_conf__bindgen_ty_1,
-                >(buffer)
+                std::mem::zeroed::<rte_eth_vmdq_dcb_conf__bindgen_ty_1>()
             };
             let struct_ptr =
                 &struct_instance as *const rte_eth_vmdq_dcb_conf__bindgen_ty_1;
@@ -841,14 +799,8 @@ fn bindgen_test_layout_rte_eth_vmdq_dcb_conf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<rte_eth_vmdq_dcb_conf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_vmdq_dcb_conf>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_eth_vmdq_dcb_conf>() };
             let struct_ptr = &struct_instance as *const rte_eth_vmdq_dcb_conf;
             let field_ptr = std::ptr::addr_of!(struct_instance.nb_queue_pools);
             let struct_address = struct_ptr as usize;
@@ -866,14 +818,8 @@ fn bindgen_test_layout_rte_eth_vmdq_dcb_conf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<rte_eth_vmdq_dcb_conf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_vmdq_dcb_conf>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_eth_vmdq_dcb_conf>() };
             let struct_ptr = &struct_instance as *const rte_eth_vmdq_dcb_conf;
             let field_ptr =
                 std::ptr::addr_of!(struct_instance.enable_default_pool);
@@ -892,14 +838,8 @@ fn bindgen_test_layout_rte_eth_vmdq_dcb_conf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<rte_eth_vmdq_dcb_conf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_vmdq_dcb_conf>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_eth_vmdq_dcb_conf>() };
             let struct_ptr = &struct_instance as *const rte_eth_vmdq_dcb_conf;
             let field_ptr = std::ptr::addr_of!(struct_instance.default_pool);
             let struct_address = struct_ptr as usize;
@@ -917,14 +857,8 @@ fn bindgen_test_layout_rte_eth_vmdq_dcb_conf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<rte_eth_vmdq_dcb_conf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_vmdq_dcb_conf>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_eth_vmdq_dcb_conf>() };
             let struct_ptr = &struct_instance as *const rte_eth_vmdq_dcb_conf;
             let field_ptr = std::ptr::addr_of!(struct_instance.nb_pool_maps);
             let struct_address = struct_ptr as usize;
@@ -942,14 +876,8 @@ fn bindgen_test_layout_rte_eth_vmdq_dcb_conf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<rte_eth_vmdq_dcb_conf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_vmdq_dcb_conf>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_eth_vmdq_dcb_conf>() };
             let struct_ptr = &struct_instance as *const rte_eth_vmdq_dcb_conf;
             let field_ptr = std::ptr::addr_of!(struct_instance.pool_map);
             let struct_address = struct_ptr as usize;
@@ -967,14 +895,8 @@ fn bindgen_test_layout_rte_eth_vmdq_dcb_conf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<rte_eth_vmdq_dcb_conf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_vmdq_dcb_conf>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_eth_vmdq_dcb_conf>() };
             let struct_ptr = &struct_instance as *const rte_eth_vmdq_dcb_conf;
             let field_ptr = std::ptr::addr_of!(struct_instance.dcb_tc);
             let struct_address = struct_ptr as usize;
@@ -1022,14 +944,8 @@ fn bindgen_test_layout_rte_eth_dcb_rx_conf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<rte_eth_dcb_rx_conf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_dcb_rx_conf>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_eth_dcb_rx_conf>() };
             let struct_ptr = &struct_instance as *const rte_eth_dcb_rx_conf;
             let field_ptr = std::ptr::addr_of!(struct_instance.nb_tcs);
             let struct_address = struct_ptr as usize;
@@ -1047,14 +963,8 @@ fn bindgen_test_layout_rte_eth_dcb_rx_conf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<rte_eth_dcb_rx_conf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_dcb_rx_conf>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_eth_dcb_rx_conf>() };
             let struct_ptr = &struct_instance as *const rte_eth_dcb_rx_conf;
             let field_ptr = std::ptr::addr_of!(struct_instance.dcb_tc);
             let struct_address = struct_ptr as usize;
@@ -1102,14 +1012,8 @@ fn bindgen_test_layout_rte_eth_vmdq_dcb_tx_conf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<rte_eth_vmdq_dcb_tx_conf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_vmdq_dcb_tx_conf>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_eth_vmdq_dcb_tx_conf>() };
             let struct_ptr =
                 &struct_instance as *const rte_eth_vmdq_dcb_tx_conf;
             let field_ptr = std::ptr::addr_of!(struct_instance.nb_queue_pools);
@@ -1128,14 +1032,8 @@ fn bindgen_test_layout_rte_eth_vmdq_dcb_tx_conf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<rte_eth_vmdq_dcb_tx_conf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_vmdq_dcb_tx_conf>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_eth_vmdq_dcb_tx_conf>() };
             let struct_ptr =
                 &struct_instance as *const rte_eth_vmdq_dcb_tx_conf;
             let field_ptr = std::ptr::addr_of!(struct_instance.dcb_tc);
@@ -1184,14 +1082,8 @@ fn bindgen_test_layout_rte_eth_dcb_tx_conf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<rte_eth_dcb_tx_conf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_dcb_tx_conf>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_eth_dcb_tx_conf>() };
             let struct_ptr = &struct_instance as *const rte_eth_dcb_tx_conf;
             let field_ptr = std::ptr::addr_of!(struct_instance.nb_tcs);
             let struct_address = struct_ptr as usize;
@@ -1209,14 +1101,8 @@ fn bindgen_test_layout_rte_eth_dcb_tx_conf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<rte_eth_dcb_tx_conf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_dcb_tx_conf>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_eth_dcb_tx_conf>() };
             let struct_ptr = &struct_instance as *const rte_eth_dcb_tx_conf;
             let field_ptr = std::ptr::addr_of!(struct_instance.dcb_tc);
             let struct_address = struct_ptr as usize;
@@ -1262,14 +1148,8 @@ fn bindgen_test_layout_rte_eth_vmdq_tx_conf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<rte_eth_vmdq_tx_conf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_vmdq_tx_conf>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_eth_vmdq_tx_conf>() };
             let struct_ptr = &struct_instance as *const rte_eth_vmdq_tx_conf;
             let field_ptr = std::ptr::addr_of!(struct_instance.nb_queue_pools);
             let struct_address = struct_ptr as usize;
@@ -1338,14 +1218,8 @@ fn bindgen_test_layout_rte_eth_vmdq_rx_conf__bindgen_ty_1() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<rte_eth_vmdq_rx_conf__bindgen_ty_1>();
-            let buffer = [0u8; STRUCT_SIZE];
             let struct_instance = unsafe {
-                std::mem::transmute::<
-                    [u8; STRUCT_SIZE],
-                    rte_eth_vmdq_rx_conf__bindgen_ty_1,
-                >(buffer)
+                std::mem::zeroed::<rte_eth_vmdq_rx_conf__bindgen_ty_1>()
             };
             let struct_ptr =
                 &struct_instance as *const rte_eth_vmdq_rx_conf__bindgen_ty_1;
@@ -1365,14 +1239,8 @@ fn bindgen_test_layout_rte_eth_vmdq_rx_conf__bindgen_ty_1() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<rte_eth_vmdq_rx_conf__bindgen_ty_1>();
-            let buffer = [0u8; STRUCT_SIZE];
             let struct_instance = unsafe {
-                std::mem::transmute::<
-                    [u8; STRUCT_SIZE],
-                    rte_eth_vmdq_rx_conf__bindgen_ty_1,
-                >(buffer)
+                std::mem::zeroed::<rte_eth_vmdq_rx_conf__bindgen_ty_1>()
             };
             let struct_ptr =
                 &struct_instance as *const rte_eth_vmdq_rx_conf__bindgen_ty_1;
@@ -1405,14 +1273,8 @@ fn bindgen_test_layout_rte_eth_vmdq_rx_conf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<rte_eth_vmdq_rx_conf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_vmdq_rx_conf>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_eth_vmdq_rx_conf>() };
             let struct_ptr = &struct_instance as *const rte_eth_vmdq_rx_conf;
             let field_ptr = std::ptr::addr_of!(struct_instance.nb_queue_pools);
             let struct_address = struct_ptr as usize;
@@ -1430,14 +1292,8 @@ fn bindgen_test_layout_rte_eth_vmdq_rx_conf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<rte_eth_vmdq_rx_conf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_vmdq_rx_conf>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_eth_vmdq_rx_conf>() };
             let struct_ptr = &struct_instance as *const rte_eth_vmdq_rx_conf;
             let field_ptr =
                 std::ptr::addr_of!(struct_instance.enable_default_pool);
@@ -1456,14 +1312,8 @@ fn bindgen_test_layout_rte_eth_vmdq_rx_conf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<rte_eth_vmdq_rx_conf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_vmdq_rx_conf>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_eth_vmdq_rx_conf>() };
             let struct_ptr = &struct_instance as *const rte_eth_vmdq_rx_conf;
             let field_ptr = std::ptr::addr_of!(struct_instance.default_pool);
             let struct_address = struct_ptr as usize;
@@ -1481,14 +1331,8 @@ fn bindgen_test_layout_rte_eth_vmdq_rx_conf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<rte_eth_vmdq_rx_conf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_vmdq_rx_conf>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_eth_vmdq_rx_conf>() };
             let struct_ptr = &struct_instance as *const rte_eth_vmdq_rx_conf;
             let field_ptr =
                 std::ptr::addr_of!(struct_instance.enable_loop_back);
@@ -1507,14 +1351,8 @@ fn bindgen_test_layout_rte_eth_vmdq_rx_conf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<rte_eth_vmdq_rx_conf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_vmdq_rx_conf>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_eth_vmdq_rx_conf>() };
             let struct_ptr = &struct_instance as *const rte_eth_vmdq_rx_conf;
             let field_ptr = std::ptr::addr_of!(struct_instance.nb_pool_maps);
             let struct_address = struct_ptr as usize;
@@ -1532,14 +1370,8 @@ fn bindgen_test_layout_rte_eth_vmdq_rx_conf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<rte_eth_vmdq_rx_conf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_vmdq_rx_conf>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_eth_vmdq_rx_conf>() };
             let struct_ptr = &struct_instance as *const rte_eth_vmdq_rx_conf;
             let field_ptr = std::ptr::addr_of!(struct_instance.rx_mode);
             let struct_address = struct_ptr as usize;
@@ -1557,14 +1389,8 @@ fn bindgen_test_layout_rte_eth_vmdq_rx_conf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<rte_eth_vmdq_rx_conf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_vmdq_rx_conf>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_eth_vmdq_rx_conf>() };
             let struct_ptr = &struct_instance as *const rte_eth_vmdq_rx_conf;
             let field_ptr = std::ptr::addr_of!(struct_instance.pool_map);
             let struct_address = struct_ptr as usize;
@@ -1657,13 +1483,8 @@ fn bindgen_test_layout_rte_eth_ipv4_flow() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_eth_ipv4_flow>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_ipv4_flow>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_eth_ipv4_flow>() };
             let struct_ptr = &struct_instance as *const rte_eth_ipv4_flow;
             let field_ptr = std::ptr::addr_of!(struct_instance.src_ip);
             let struct_address = struct_ptr as usize;
@@ -1681,13 +1502,8 @@ fn bindgen_test_layout_rte_eth_ipv4_flow() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_eth_ipv4_flow>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_ipv4_flow>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_eth_ipv4_flow>() };
             let struct_ptr = &struct_instance as *const rte_eth_ipv4_flow;
             let field_ptr = std::ptr::addr_of!(struct_instance.dst_ip);
             let struct_address = struct_ptr as usize;
@@ -1705,13 +1521,8 @@ fn bindgen_test_layout_rte_eth_ipv4_flow() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_eth_ipv4_flow>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_ipv4_flow>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_eth_ipv4_flow>() };
             let struct_ptr = &struct_instance as *const rte_eth_ipv4_flow;
             let field_ptr = std::ptr::addr_of!(struct_instance.tos);
             let struct_address = struct_ptr as usize;
@@ -1729,13 +1540,8 @@ fn bindgen_test_layout_rte_eth_ipv4_flow() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_eth_ipv4_flow>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_ipv4_flow>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_eth_ipv4_flow>() };
             let struct_ptr = &struct_instance as *const rte_eth_ipv4_flow;
             let field_ptr = std::ptr::addr_of!(struct_instance.ttl);
             let struct_address = struct_ptr as usize;
@@ -1753,13 +1559,8 @@ fn bindgen_test_layout_rte_eth_ipv4_flow() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_eth_ipv4_flow>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_ipv4_flow>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_eth_ipv4_flow>() };
             let struct_ptr = &struct_instance as *const rte_eth_ipv4_flow;
             let field_ptr = std::ptr::addr_of!(struct_instance.proto);
             let struct_address = struct_ptr as usize;
@@ -1805,13 +1606,8 @@ fn bindgen_test_layout_rte_eth_ipv6_flow() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_eth_ipv6_flow>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_ipv6_flow>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_eth_ipv6_flow>() };
             let struct_ptr = &struct_instance as *const rte_eth_ipv6_flow;
             let field_ptr = std::ptr::addr_of!(struct_instance.src_ip);
             let struct_address = struct_ptr as usize;
@@ -1829,13 +1625,8 @@ fn bindgen_test_layout_rte_eth_ipv6_flow() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_eth_ipv6_flow>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_ipv6_flow>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_eth_ipv6_flow>() };
             let struct_ptr = &struct_instance as *const rte_eth_ipv6_flow;
             let field_ptr = std::ptr::addr_of!(struct_instance.dst_ip);
             let struct_address = struct_ptr as usize;
@@ -1853,13 +1644,8 @@ fn bindgen_test_layout_rte_eth_ipv6_flow() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_eth_ipv6_flow>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_ipv6_flow>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_eth_ipv6_flow>() };
             let struct_ptr = &struct_instance as *const rte_eth_ipv6_flow;
             let field_ptr = std::ptr::addr_of!(struct_instance.tc);
             let struct_address = struct_ptr as usize;
@@ -1877,13 +1663,8 @@ fn bindgen_test_layout_rte_eth_ipv6_flow() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_eth_ipv6_flow>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_ipv6_flow>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_eth_ipv6_flow>() };
             let struct_ptr = &struct_instance as *const rte_eth_ipv6_flow;
             let field_ptr = std::ptr::addr_of!(struct_instance.proto);
             let struct_address = struct_ptr as usize;
@@ -1901,13 +1682,8 @@ fn bindgen_test_layout_rte_eth_ipv6_flow() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_eth_ipv6_flow>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_ipv6_flow>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_eth_ipv6_flow>() };
             let struct_ptr = &struct_instance as *const rte_eth_ipv6_flow;
             let field_ptr = std::ptr::addr_of!(struct_instance.hop_limits);
             let struct_address = struct_ptr as usize;
@@ -1962,14 +1738,8 @@ fn bindgen_test_layout_rte_eth_fdir_masks() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<rte_eth_fdir_masks>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_fdir_masks>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_eth_fdir_masks>() };
             let struct_ptr = &struct_instance as *const rte_eth_fdir_masks;
             let field_ptr = std::ptr::addr_of!(struct_instance.vlan_tci_mask);
             let struct_address = struct_ptr as usize;
@@ -1987,14 +1757,8 @@ fn bindgen_test_layout_rte_eth_fdir_masks() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<rte_eth_fdir_masks>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_fdir_masks>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_eth_fdir_masks>() };
             let struct_ptr = &struct_instance as *const rte_eth_fdir_masks;
             let field_ptr = std::ptr::addr_of!(struct_instance.ipv4_mask);
             let struct_address = struct_ptr as usize;
@@ -2012,14 +1776,8 @@ fn bindgen_test_layout_rte_eth_fdir_masks() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<rte_eth_fdir_masks>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_fdir_masks>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_eth_fdir_masks>() };
             let struct_ptr = &struct_instance as *const rte_eth_fdir_masks;
             let field_ptr = std::ptr::addr_of!(struct_instance.ipv6_mask);
             let struct_address = struct_ptr as usize;
@@ -2037,14 +1795,8 @@ fn bindgen_test_layout_rte_eth_fdir_masks() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<rte_eth_fdir_masks>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_fdir_masks>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_eth_fdir_masks>() };
             let struct_ptr = &struct_instance as *const rte_eth_fdir_masks;
             let field_ptr = std::ptr::addr_of!(struct_instance.src_port_mask);
             let struct_address = struct_ptr as usize;
@@ -2062,14 +1814,8 @@ fn bindgen_test_layout_rte_eth_fdir_masks() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<rte_eth_fdir_masks>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_fdir_masks>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_eth_fdir_masks>() };
             let struct_ptr = &struct_instance as *const rte_eth_fdir_masks;
             let field_ptr = std::ptr::addr_of!(struct_instance.dst_port_mask);
             let struct_address = struct_ptr as usize;
@@ -2087,14 +1833,8 @@ fn bindgen_test_layout_rte_eth_fdir_masks() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<rte_eth_fdir_masks>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_fdir_masks>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_eth_fdir_masks>() };
             let struct_ptr = &struct_instance as *const rte_eth_fdir_masks;
             let field_ptr =
                 std::ptr::addr_of!(struct_instance.mac_addr_byte_mask);
@@ -2113,14 +1853,8 @@ fn bindgen_test_layout_rte_eth_fdir_masks() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<rte_eth_fdir_masks>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_fdir_masks>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_eth_fdir_masks>() };
             let struct_ptr = &struct_instance as *const rte_eth_fdir_masks;
             let field_ptr = std::ptr::addr_of!(struct_instance.tunnel_id_mask);
             let struct_address = struct_ptr as usize;
@@ -2138,14 +1872,8 @@ fn bindgen_test_layout_rte_eth_fdir_masks() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<rte_eth_fdir_masks>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_fdir_masks>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_eth_fdir_masks>() };
             let struct_ptr = &struct_instance as *const rte_eth_fdir_masks;
             let field_ptr =
                 std::ptr::addr_of!(struct_instance.tunnel_type_mask);
@@ -2197,14 +1925,8 @@ fn bindgen_test_layout_rte_eth_flex_payload_cfg() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<rte_eth_flex_payload_cfg>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_flex_payload_cfg>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_eth_flex_payload_cfg>() };
             let struct_ptr =
                 &struct_instance as *const rte_eth_flex_payload_cfg;
             let field_ptr = std::ptr::addr_of!(struct_instance.type_);
@@ -2223,14 +1945,8 @@ fn bindgen_test_layout_rte_eth_flex_payload_cfg() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<rte_eth_flex_payload_cfg>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_flex_payload_cfg>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_eth_flex_payload_cfg>() };
             let struct_ptr =
                 &struct_instance as *const rte_eth_flex_payload_cfg;
             let field_ptr = std::ptr::addr_of!(struct_instance.src_offset);
@@ -2279,14 +1995,8 @@ fn bindgen_test_layout_rte_eth_fdir_flex_mask() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<rte_eth_fdir_flex_mask>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_fdir_flex_mask>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_eth_fdir_flex_mask>() };
             let struct_ptr = &struct_instance as *const rte_eth_fdir_flex_mask;
             let field_ptr = std::ptr::addr_of!(struct_instance.flow_type);
             let struct_address = struct_ptr as usize;
@@ -2304,14 +2014,8 @@ fn bindgen_test_layout_rte_eth_fdir_flex_mask() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<rte_eth_fdir_flex_mask>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_fdir_flex_mask>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_eth_fdir_flex_mask>() };
             let struct_ptr = &struct_instance as *const rte_eth_fdir_flex_mask;
             let field_ptr = std::ptr::addr_of!(struct_instance.mask);
             let struct_address = struct_ptr as usize;
@@ -2354,14 +2058,8 @@ fn bindgen_test_layout_rte_eth_fdir_flex_conf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<rte_eth_fdir_flex_conf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_fdir_flex_conf>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_eth_fdir_flex_conf>() };
             let struct_ptr = &struct_instance as *const rte_eth_fdir_flex_conf;
             let field_ptr = std::ptr::addr_of!(struct_instance.nb_payloads);
             let struct_address = struct_ptr as usize;
@@ -2379,14 +2077,8 @@ fn bindgen_test_layout_rte_eth_fdir_flex_conf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<rte_eth_fdir_flex_conf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_fdir_flex_conf>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_eth_fdir_flex_conf>() };
             let struct_ptr = &struct_instance as *const rte_eth_fdir_flex_conf;
             let field_ptr = std::ptr::addr_of!(struct_instance.nb_flexmasks);
             let struct_address = struct_ptr as usize;
@@ -2404,14 +2096,8 @@ fn bindgen_test_layout_rte_eth_fdir_flex_conf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<rte_eth_fdir_flex_conf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_fdir_flex_conf>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_eth_fdir_flex_conf>() };
             let struct_ptr = &struct_instance as *const rte_eth_fdir_flex_conf;
             let field_ptr = std::ptr::addr_of!(struct_instance.flex_set);
             let struct_address = struct_ptr as usize;
@@ -2429,14 +2115,8 @@ fn bindgen_test_layout_rte_eth_fdir_flex_conf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<rte_eth_fdir_flex_conf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_fdir_flex_conf>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_eth_fdir_flex_conf>() };
             let struct_ptr = &struct_instance as *const rte_eth_fdir_flex_conf;
             let field_ptr = std::ptr::addr_of!(struct_instance.flex_mask);
             let struct_address = struct_ptr as usize;
@@ -2494,11 +2174,8 @@ fn bindgen_test_layout_rte_fdir_conf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_fdir_conf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_fdir_conf>(buffer)
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_fdir_conf>() };
             let struct_ptr = &struct_instance as *const rte_fdir_conf;
             let field_ptr = std::ptr::addr_of!(struct_instance.mode);
             let struct_address = struct_ptr as usize;
@@ -2516,11 +2193,8 @@ fn bindgen_test_layout_rte_fdir_conf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_fdir_conf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_fdir_conf>(buffer)
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_fdir_conf>() };
             let struct_ptr = &struct_instance as *const rte_fdir_conf;
             let field_ptr = std::ptr::addr_of!(struct_instance.pballoc);
             let struct_address = struct_ptr as usize;
@@ -2538,11 +2212,8 @@ fn bindgen_test_layout_rte_fdir_conf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_fdir_conf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_fdir_conf>(buffer)
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_fdir_conf>() };
             let struct_ptr = &struct_instance as *const rte_fdir_conf;
             let field_ptr = std::ptr::addr_of!(struct_instance.status);
             let struct_address = struct_ptr as usize;
@@ -2560,11 +2231,8 @@ fn bindgen_test_layout_rte_fdir_conf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_fdir_conf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_fdir_conf>(buffer)
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_fdir_conf>() };
             let struct_ptr = &struct_instance as *const rte_fdir_conf;
             let field_ptr = std::ptr::addr_of!(struct_instance.drop_queue);
             let struct_address = struct_ptr as usize;
@@ -2582,11 +2250,8 @@ fn bindgen_test_layout_rte_fdir_conf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_fdir_conf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_fdir_conf>(buffer)
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_fdir_conf>() };
             let struct_ptr = &struct_instance as *const rte_fdir_conf;
             let field_ptr = std::ptr::addr_of!(struct_instance.mask);
             let struct_address = struct_ptr as usize;
@@ -2604,11 +2269,8 @@ fn bindgen_test_layout_rte_fdir_conf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_fdir_conf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_fdir_conf>(buffer)
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_fdir_conf>() };
             let struct_ptr = &struct_instance as *const rte_fdir_conf;
             let field_ptr = std::ptr::addr_of!(struct_instance.flex_conf);
             let struct_address = struct_ptr as usize;
@@ -2657,11 +2319,8 @@ fn bindgen_test_layout_rte_intr_conf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_intr_conf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_intr_conf>(buffer)
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_intr_conf>() };
             let struct_ptr = &struct_instance as *const rte_intr_conf;
             let field_ptr = std::ptr::addr_of!(struct_instance.lsc);
             let struct_address = struct_ptr as usize;
@@ -2679,11 +2338,8 @@ fn bindgen_test_layout_rte_intr_conf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_intr_conf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_intr_conf>(buffer)
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_intr_conf>() };
             let struct_ptr = &struct_instance as *const rte_intr_conf;
             let field_ptr = std::ptr::addr_of!(struct_instance.rxq);
             let struct_address = struct_ptr as usize;
@@ -2759,15 +2415,8 @@ fn bindgen_test_layout_rte_eth_conf__bindgen_ty_1() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<rte_eth_conf__bindgen_ty_1>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<
-                    [u8; STRUCT_SIZE],
-                    rte_eth_conf__bindgen_ty_1,
-                >(buffer)
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_eth_conf__bindgen_ty_1>() };
             let struct_ptr =
                 &struct_instance as *const rte_eth_conf__bindgen_ty_1;
             let field_ptr = std::ptr::addr_of!(struct_instance.rss_conf);
@@ -2786,15 +2435,8 @@ fn bindgen_test_layout_rte_eth_conf__bindgen_ty_1() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<rte_eth_conf__bindgen_ty_1>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<
-                    [u8; STRUCT_SIZE],
-                    rte_eth_conf__bindgen_ty_1,
-                >(buffer)
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_eth_conf__bindgen_ty_1>() };
             let struct_ptr =
                 &struct_instance as *const rte_eth_conf__bindgen_ty_1;
             let field_ptr = std::ptr::addr_of!(struct_instance.vmdq_dcb_conf);
@@ -2813,15 +2455,8 @@ fn bindgen_test_layout_rte_eth_conf__bindgen_ty_1() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<rte_eth_conf__bindgen_ty_1>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<
-                    [u8; STRUCT_SIZE],
-                    rte_eth_conf__bindgen_ty_1,
-                >(buffer)
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_eth_conf__bindgen_ty_1>() };
             let struct_ptr =
                 &struct_instance as *const rte_eth_conf__bindgen_ty_1;
             let field_ptr = std::ptr::addr_of!(struct_instance.dcb_rx_conf);
@@ -2840,15 +2475,8 @@ fn bindgen_test_layout_rte_eth_conf__bindgen_ty_1() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<rte_eth_conf__bindgen_ty_1>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<
-                    [u8; STRUCT_SIZE],
-                    rte_eth_conf__bindgen_ty_1,
-                >(buffer)
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_eth_conf__bindgen_ty_1>() };
             let struct_ptr =
                 &struct_instance as *const rte_eth_conf__bindgen_ty_1;
             let field_ptr = std::ptr::addr_of!(struct_instance.vmdq_rx_conf);
@@ -2918,11 +2546,7 @@ fn bindgen_test_layout_rte_eth_conf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_eth_conf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_conf>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<rte_eth_conf>() };
             let struct_ptr = &struct_instance as *const rte_eth_conf;
             let field_ptr = std::ptr::addr_of!(struct_instance.link_speeds);
             let struct_address = struct_ptr as usize;
@@ -2940,11 +2564,7 @@ fn bindgen_test_layout_rte_eth_conf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_eth_conf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_conf>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<rte_eth_conf>() };
             let struct_ptr = &struct_instance as *const rte_eth_conf;
             let field_ptr = std::ptr::addr_of!(struct_instance.rxmode);
             let struct_address = struct_ptr as usize;
@@ -2962,11 +2582,7 @@ fn bindgen_test_layout_rte_eth_conf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_eth_conf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_conf>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<rte_eth_conf>() };
             let struct_ptr = &struct_instance as *const rte_eth_conf;
             let field_ptr = std::ptr::addr_of!(struct_instance.txmode);
             let struct_address = struct_ptr as usize;
@@ -2984,11 +2600,7 @@ fn bindgen_test_layout_rte_eth_conf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_eth_conf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_conf>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<rte_eth_conf>() };
             let struct_ptr = &struct_instance as *const rte_eth_conf;
             let field_ptr = std::ptr::addr_of!(struct_instance.lpbk_mode);
             let struct_address = struct_ptr as usize;
@@ -3006,11 +2618,7 @@ fn bindgen_test_layout_rte_eth_conf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_eth_conf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_conf>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<rte_eth_conf>() };
             let struct_ptr = &struct_instance as *const rte_eth_conf;
             let field_ptr = std::ptr::addr_of!(struct_instance.rx_adv_conf);
             let struct_address = struct_ptr as usize;
@@ -3028,11 +2636,7 @@ fn bindgen_test_layout_rte_eth_conf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_eth_conf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_conf>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<rte_eth_conf>() };
             let struct_ptr = &struct_instance as *const rte_eth_conf;
             let field_ptr = std::ptr::addr_of!(struct_instance.tx_adv_conf);
             let struct_address = struct_ptr as usize;
@@ -3050,11 +2654,7 @@ fn bindgen_test_layout_rte_eth_conf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_eth_conf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_conf>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<rte_eth_conf>() };
             let struct_ptr = &struct_instance as *const rte_eth_conf;
             let field_ptr =
                 std::ptr::addr_of!(struct_instance.dcb_capability_en);
@@ -3073,11 +2673,7 @@ fn bindgen_test_layout_rte_eth_conf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_eth_conf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_conf>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<rte_eth_conf>() };
             let struct_ptr = &struct_instance as *const rte_eth_conf;
             let field_ptr = std::ptr::addr_of!(struct_instance.fdir_conf);
             let struct_address = struct_ptr as usize;
@@ -3095,11 +2691,7 @@ fn bindgen_test_layout_rte_eth_conf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_eth_conf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_conf>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<rte_eth_conf>() };
             let struct_ptr = &struct_instance as *const rte_eth_conf;
             let field_ptr = std::ptr::addr_of!(struct_instance.intr_conf);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/layout_eth_conf.rs
+++ b/tests/expectations/tests/layout_eth_conf.rs
@@ -171,9 +171,18 @@ fn bindgen_test_layout_rte_eth_rxmode() {
         concat!("Alignment of ", stringify!(rte_eth_rxmode))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_rxmode>())).mq_mode as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_eth_rxmode>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_rxmode>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const rte_eth_rxmode;
+            let field_ptr = std::ptr::addr_of!(struct_instance.mq_mode);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -184,9 +193,18 @@ fn bindgen_test_layout_rte_eth_rxmode() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_rxmode>())).max_rx_pkt_len
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_eth_rxmode>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_rxmode>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const rte_eth_rxmode;
+            let field_ptr = std::ptr::addr_of!(struct_instance.max_rx_pkt_len);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         4usize,
         concat!(
@@ -197,9 +215,18 @@ fn bindgen_test_layout_rte_eth_rxmode() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_rxmode>())).split_hdr_size
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_eth_rxmode>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_rxmode>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const rte_eth_rxmode;
+            let field_ptr = std::ptr::addr_of!(struct_instance.split_hdr_size);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         8usize,
         concat!(
@@ -436,9 +463,18 @@ fn bindgen_test_layout_rte_eth_txmode() {
         concat!("Alignment of ", stringify!(rte_eth_txmode))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_txmode>())).mq_mode as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_eth_txmode>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_txmode>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const rte_eth_txmode;
+            let field_ptr = std::ptr::addr_of!(struct_instance.mq_mode);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -449,8 +485,18 @@ fn bindgen_test_layout_rte_eth_txmode() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_txmode>())).pvid as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_eth_txmode>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_txmode>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const rte_eth_txmode;
+            let field_ptr = std::ptr::addr_of!(struct_instance.pvid);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         4usize,
         concat!(
@@ -574,9 +620,20 @@ fn bindgen_test_layout_rte_eth_rss_conf() {
         concat!("Alignment of ", stringify!(rte_eth_rss_conf))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_rss_conf>())).rss_key as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_eth_rss_conf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_rss_conf>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const rte_eth_rss_conf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.rss_key);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -587,9 +644,20 @@ fn bindgen_test_layout_rte_eth_rss_conf() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_rss_conf>())).rss_key_len as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_eth_rss_conf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_rss_conf>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const rte_eth_rss_conf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.rss_key_len);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         8usize,
         concat!(
@@ -600,9 +668,20 @@ fn bindgen_test_layout_rte_eth_rss_conf() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_rss_conf>())).rss_hf as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_eth_rss_conf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_rss_conf>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const rte_eth_rss_conf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.rss_hf);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         16usize,
         concat!(
@@ -694,9 +773,23 @@ fn bindgen_test_layout_rte_eth_vmdq_dcb_conf__bindgen_ty_1() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_vmdq_dcb_conf__bindgen_ty_1>()))
-                .vlan_id as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<rte_eth_vmdq_dcb_conf__bindgen_ty_1>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<
+                    [u8; STRUCT_SIZE],
+                    rte_eth_vmdq_dcb_conf__bindgen_ty_1,
+                >(buffer)
+            };
+            let struct_ptr =
+                &struct_instance as *const rte_eth_vmdq_dcb_conf__bindgen_ty_1;
+            let field_ptr = std::ptr::addr_of!(struct_instance.vlan_id);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -707,9 +800,23 @@ fn bindgen_test_layout_rte_eth_vmdq_dcb_conf__bindgen_ty_1() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_vmdq_dcb_conf__bindgen_ty_1>()))
-                .pools as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<rte_eth_vmdq_dcb_conf__bindgen_ty_1>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<
+                    [u8; STRUCT_SIZE],
+                    rte_eth_vmdq_dcb_conf__bindgen_ty_1,
+                >(buffer)
+            };
+            let struct_ptr =
+                &struct_instance as *const rte_eth_vmdq_dcb_conf__bindgen_ty_1;
+            let field_ptr = std::ptr::addr_of!(struct_instance.pools);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         8usize,
         concat!(
@@ -733,9 +840,21 @@ fn bindgen_test_layout_rte_eth_vmdq_dcb_conf() {
         concat!("Alignment of ", stringify!(rte_eth_vmdq_dcb_conf))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_vmdq_dcb_conf>())).nb_queue_pools
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<rte_eth_vmdq_dcb_conf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_vmdq_dcb_conf>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const rte_eth_vmdq_dcb_conf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.nb_queue_pools);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -746,9 +865,22 @@ fn bindgen_test_layout_rte_eth_vmdq_dcb_conf() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_vmdq_dcb_conf>()))
-                .enable_default_pool as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<rte_eth_vmdq_dcb_conf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_vmdq_dcb_conf>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const rte_eth_vmdq_dcb_conf;
+            let field_ptr =
+                std::ptr::addr_of!(struct_instance.enable_default_pool);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         4usize,
         concat!(
@@ -759,9 +891,21 @@ fn bindgen_test_layout_rte_eth_vmdq_dcb_conf() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_vmdq_dcb_conf>())).default_pool
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<rte_eth_vmdq_dcb_conf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_vmdq_dcb_conf>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const rte_eth_vmdq_dcb_conf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.default_pool);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         5usize,
         concat!(
@@ -772,9 +916,21 @@ fn bindgen_test_layout_rte_eth_vmdq_dcb_conf() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_vmdq_dcb_conf>())).nb_pool_maps
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<rte_eth_vmdq_dcb_conf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_vmdq_dcb_conf>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const rte_eth_vmdq_dcb_conf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.nb_pool_maps);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         6usize,
         concat!(
@@ -785,9 +941,21 @@ fn bindgen_test_layout_rte_eth_vmdq_dcb_conf() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_vmdq_dcb_conf>())).pool_map
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<rte_eth_vmdq_dcb_conf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_vmdq_dcb_conf>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const rte_eth_vmdq_dcb_conf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.pool_map);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         8usize,
         concat!(
@@ -798,9 +966,21 @@ fn bindgen_test_layout_rte_eth_vmdq_dcb_conf() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_vmdq_dcb_conf>())).dcb_tc as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<rte_eth_vmdq_dcb_conf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_vmdq_dcb_conf>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const rte_eth_vmdq_dcb_conf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.dcb_tc);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         1032usize,
         concat!(
@@ -841,9 +1021,21 @@ fn bindgen_test_layout_rte_eth_dcb_rx_conf() {
         concat!("Alignment of ", stringify!(rte_eth_dcb_rx_conf))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_dcb_rx_conf>())).nb_tcs as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<rte_eth_dcb_rx_conf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_dcb_rx_conf>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const rte_eth_dcb_rx_conf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.nb_tcs);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -854,9 +1046,21 @@ fn bindgen_test_layout_rte_eth_dcb_rx_conf() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_dcb_rx_conf>())).dcb_tc as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<rte_eth_dcb_rx_conf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_dcb_rx_conf>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const rte_eth_dcb_rx_conf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.dcb_tc);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         4usize,
         concat!(
@@ -897,9 +1101,22 @@ fn bindgen_test_layout_rte_eth_vmdq_dcb_tx_conf() {
         concat!("Alignment of ", stringify!(rte_eth_vmdq_dcb_tx_conf))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_vmdq_dcb_tx_conf>())).nb_queue_pools
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<rte_eth_vmdq_dcb_tx_conf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_vmdq_dcb_tx_conf>(
+                    buffer,
+                )
+            };
+            let struct_ptr =
+                &struct_instance as *const rte_eth_vmdq_dcb_tx_conf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.nb_queue_pools);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -910,9 +1127,22 @@ fn bindgen_test_layout_rte_eth_vmdq_dcb_tx_conf() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_vmdq_dcb_tx_conf>())).dcb_tc
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<rte_eth_vmdq_dcb_tx_conf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_vmdq_dcb_tx_conf>(
+                    buffer,
+                )
+            };
+            let struct_ptr =
+                &struct_instance as *const rte_eth_vmdq_dcb_tx_conf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.dcb_tc);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         4usize,
         concat!(
@@ -953,9 +1183,21 @@ fn bindgen_test_layout_rte_eth_dcb_tx_conf() {
         concat!("Alignment of ", stringify!(rte_eth_dcb_tx_conf))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_dcb_tx_conf>())).nb_tcs as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<rte_eth_dcb_tx_conf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_dcb_tx_conf>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const rte_eth_dcb_tx_conf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.nb_tcs);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -966,9 +1208,21 @@ fn bindgen_test_layout_rte_eth_dcb_tx_conf() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_dcb_tx_conf>())).dcb_tc as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<rte_eth_dcb_tx_conf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_dcb_tx_conf>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const rte_eth_dcb_tx_conf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.dcb_tc);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         4usize,
         concat!(
@@ -1007,9 +1261,21 @@ fn bindgen_test_layout_rte_eth_vmdq_tx_conf() {
         concat!("Alignment of ", stringify!(rte_eth_vmdq_tx_conf))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_vmdq_tx_conf>())).nb_queue_pools
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<rte_eth_vmdq_tx_conf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_vmdq_tx_conf>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const rte_eth_vmdq_tx_conf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.nb_queue_pools);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -1071,9 +1337,23 @@ fn bindgen_test_layout_rte_eth_vmdq_rx_conf__bindgen_ty_1() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_vmdq_rx_conf__bindgen_ty_1>()))
-                .vlan_id as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<rte_eth_vmdq_rx_conf__bindgen_ty_1>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<
+                    [u8; STRUCT_SIZE],
+                    rte_eth_vmdq_rx_conf__bindgen_ty_1,
+                >(buffer)
+            };
+            let struct_ptr =
+                &struct_instance as *const rte_eth_vmdq_rx_conf__bindgen_ty_1;
+            let field_ptr = std::ptr::addr_of!(struct_instance.vlan_id);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -1084,9 +1364,23 @@ fn bindgen_test_layout_rte_eth_vmdq_rx_conf__bindgen_ty_1() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_vmdq_rx_conf__bindgen_ty_1>())).pools
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<rte_eth_vmdq_rx_conf__bindgen_ty_1>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<
+                    [u8; STRUCT_SIZE],
+                    rte_eth_vmdq_rx_conf__bindgen_ty_1,
+                >(buffer)
+            };
+            let struct_ptr =
+                &struct_instance as *const rte_eth_vmdq_rx_conf__bindgen_ty_1;
+            let field_ptr = std::ptr::addr_of!(struct_instance.pools);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         8usize,
         concat!(
@@ -1110,9 +1404,21 @@ fn bindgen_test_layout_rte_eth_vmdq_rx_conf() {
         concat!("Alignment of ", stringify!(rte_eth_vmdq_rx_conf))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_vmdq_rx_conf>())).nb_queue_pools
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<rte_eth_vmdq_rx_conf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_vmdq_rx_conf>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const rte_eth_vmdq_rx_conf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.nb_queue_pools);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -1123,9 +1429,22 @@ fn bindgen_test_layout_rte_eth_vmdq_rx_conf() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_vmdq_rx_conf>())).enable_default_pool
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<rte_eth_vmdq_rx_conf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_vmdq_rx_conf>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const rte_eth_vmdq_rx_conf;
+            let field_ptr =
+                std::ptr::addr_of!(struct_instance.enable_default_pool);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         4usize,
         concat!(
@@ -1136,9 +1455,21 @@ fn bindgen_test_layout_rte_eth_vmdq_rx_conf() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_vmdq_rx_conf>())).default_pool
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<rte_eth_vmdq_rx_conf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_vmdq_rx_conf>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const rte_eth_vmdq_rx_conf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.default_pool);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         5usize,
         concat!(
@@ -1149,9 +1480,22 @@ fn bindgen_test_layout_rte_eth_vmdq_rx_conf() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_vmdq_rx_conf>())).enable_loop_back
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<rte_eth_vmdq_rx_conf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_vmdq_rx_conf>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const rte_eth_vmdq_rx_conf;
+            let field_ptr =
+                std::ptr::addr_of!(struct_instance.enable_loop_back);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         6usize,
         concat!(
@@ -1162,9 +1506,21 @@ fn bindgen_test_layout_rte_eth_vmdq_rx_conf() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_vmdq_rx_conf>())).nb_pool_maps
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<rte_eth_vmdq_rx_conf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_vmdq_rx_conf>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const rte_eth_vmdq_rx_conf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.nb_pool_maps);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         7usize,
         concat!(
@@ -1175,9 +1531,21 @@ fn bindgen_test_layout_rte_eth_vmdq_rx_conf() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_vmdq_rx_conf>())).rx_mode as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<rte_eth_vmdq_rx_conf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_vmdq_rx_conf>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const rte_eth_vmdq_rx_conf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.rx_mode);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         8usize,
         concat!(
@@ -1188,9 +1556,21 @@ fn bindgen_test_layout_rte_eth_vmdq_rx_conf() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_vmdq_rx_conf>())).pool_map
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<rte_eth_vmdq_rx_conf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_vmdq_rx_conf>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const rte_eth_vmdq_rx_conf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.pool_map);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         16usize,
         concat!(
@@ -1276,9 +1656,20 @@ fn bindgen_test_layout_rte_eth_ipv4_flow() {
         concat!("Alignment of ", stringify!(rte_eth_ipv4_flow))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_ipv4_flow>())).src_ip as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_eth_ipv4_flow>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_ipv4_flow>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const rte_eth_ipv4_flow;
+            let field_ptr = std::ptr::addr_of!(struct_instance.src_ip);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -1289,9 +1680,20 @@ fn bindgen_test_layout_rte_eth_ipv4_flow() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_ipv4_flow>())).dst_ip as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_eth_ipv4_flow>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_ipv4_flow>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const rte_eth_ipv4_flow;
+            let field_ptr = std::ptr::addr_of!(struct_instance.dst_ip);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         4usize,
         concat!(
@@ -1302,9 +1704,20 @@ fn bindgen_test_layout_rte_eth_ipv4_flow() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_ipv4_flow>())).tos as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_eth_ipv4_flow>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_ipv4_flow>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const rte_eth_ipv4_flow;
+            let field_ptr = std::ptr::addr_of!(struct_instance.tos);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         8usize,
         concat!(
@@ -1315,9 +1728,20 @@ fn bindgen_test_layout_rte_eth_ipv4_flow() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_ipv4_flow>())).ttl as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_eth_ipv4_flow>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_ipv4_flow>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const rte_eth_ipv4_flow;
+            let field_ptr = std::ptr::addr_of!(struct_instance.ttl);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         9usize,
         concat!(
@@ -1328,9 +1752,20 @@ fn bindgen_test_layout_rte_eth_ipv4_flow() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_ipv4_flow>())).proto as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_eth_ipv4_flow>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_ipv4_flow>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const rte_eth_ipv4_flow;
+            let field_ptr = std::ptr::addr_of!(struct_instance.proto);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         10usize,
         concat!(
@@ -1369,9 +1804,20 @@ fn bindgen_test_layout_rte_eth_ipv6_flow() {
         concat!("Alignment of ", stringify!(rte_eth_ipv6_flow))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_ipv6_flow>())).src_ip as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_eth_ipv6_flow>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_ipv6_flow>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const rte_eth_ipv6_flow;
+            let field_ptr = std::ptr::addr_of!(struct_instance.src_ip);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -1382,9 +1828,20 @@ fn bindgen_test_layout_rte_eth_ipv6_flow() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_ipv6_flow>())).dst_ip as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_eth_ipv6_flow>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_ipv6_flow>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const rte_eth_ipv6_flow;
+            let field_ptr = std::ptr::addr_of!(struct_instance.dst_ip);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         16usize,
         concat!(
@@ -1395,9 +1852,20 @@ fn bindgen_test_layout_rte_eth_ipv6_flow() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_ipv6_flow>())).tc as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_eth_ipv6_flow>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_ipv6_flow>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const rte_eth_ipv6_flow;
+            let field_ptr = std::ptr::addr_of!(struct_instance.tc);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         32usize,
         concat!(
@@ -1408,9 +1876,20 @@ fn bindgen_test_layout_rte_eth_ipv6_flow() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_ipv6_flow>())).proto as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_eth_ipv6_flow>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_ipv6_flow>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const rte_eth_ipv6_flow;
+            let field_ptr = std::ptr::addr_of!(struct_instance.proto);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         33usize,
         concat!(
@@ -1421,9 +1900,20 @@ fn bindgen_test_layout_rte_eth_ipv6_flow() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_ipv6_flow>())).hop_limits as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_eth_ipv6_flow>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_ipv6_flow>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const rte_eth_ipv6_flow;
+            let field_ptr = std::ptr::addr_of!(struct_instance.hop_limits);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         34usize,
         concat!(
@@ -1471,9 +1961,21 @@ fn bindgen_test_layout_rte_eth_fdir_masks() {
         concat!("Alignment of ", stringify!(rte_eth_fdir_masks))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_fdir_masks>())).vlan_tci_mask
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<rte_eth_fdir_masks>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_fdir_masks>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const rte_eth_fdir_masks;
+            let field_ptr = std::ptr::addr_of!(struct_instance.vlan_tci_mask);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -1484,9 +1986,21 @@ fn bindgen_test_layout_rte_eth_fdir_masks() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_fdir_masks>())).ipv4_mask as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<rte_eth_fdir_masks>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_fdir_masks>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const rte_eth_fdir_masks;
+            let field_ptr = std::ptr::addr_of!(struct_instance.ipv4_mask);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         4usize,
         concat!(
@@ -1497,9 +2011,21 @@ fn bindgen_test_layout_rte_eth_fdir_masks() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_fdir_masks>())).ipv6_mask as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<rte_eth_fdir_masks>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_fdir_masks>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const rte_eth_fdir_masks;
+            let field_ptr = std::ptr::addr_of!(struct_instance.ipv6_mask);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         16usize,
         concat!(
@@ -1510,9 +2036,21 @@ fn bindgen_test_layout_rte_eth_fdir_masks() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_fdir_masks>())).src_port_mask
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<rte_eth_fdir_masks>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_fdir_masks>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const rte_eth_fdir_masks;
+            let field_ptr = std::ptr::addr_of!(struct_instance.src_port_mask);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         52usize,
         concat!(
@@ -1523,9 +2061,21 @@ fn bindgen_test_layout_rte_eth_fdir_masks() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_fdir_masks>())).dst_port_mask
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<rte_eth_fdir_masks>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_fdir_masks>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const rte_eth_fdir_masks;
+            let field_ptr = std::ptr::addr_of!(struct_instance.dst_port_mask);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         54usize,
         concat!(
@@ -1536,9 +2086,22 @@ fn bindgen_test_layout_rte_eth_fdir_masks() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_fdir_masks>())).mac_addr_byte_mask
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<rte_eth_fdir_masks>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_fdir_masks>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const rte_eth_fdir_masks;
+            let field_ptr =
+                std::ptr::addr_of!(struct_instance.mac_addr_byte_mask);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         56usize,
         concat!(
@@ -1549,9 +2112,21 @@ fn bindgen_test_layout_rte_eth_fdir_masks() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_fdir_masks>())).tunnel_id_mask
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<rte_eth_fdir_masks>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_fdir_masks>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const rte_eth_fdir_masks;
+            let field_ptr = std::ptr::addr_of!(struct_instance.tunnel_id_mask);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         60usize,
         concat!(
@@ -1562,9 +2137,22 @@ fn bindgen_test_layout_rte_eth_fdir_masks() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_fdir_masks>())).tunnel_type_mask
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<rte_eth_fdir_masks>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_fdir_masks>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const rte_eth_fdir_masks;
+            let field_ptr =
+                std::ptr::addr_of!(struct_instance.tunnel_type_mask);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         64usize,
         concat!(
@@ -1608,9 +2196,22 @@ fn bindgen_test_layout_rte_eth_flex_payload_cfg() {
         concat!("Alignment of ", stringify!(rte_eth_flex_payload_cfg))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_flex_payload_cfg>())).type_
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<rte_eth_flex_payload_cfg>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_flex_payload_cfg>(
+                    buffer,
+                )
+            };
+            let struct_ptr =
+                &struct_instance as *const rte_eth_flex_payload_cfg;
+            let field_ptr = std::ptr::addr_of!(struct_instance.type_);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -1621,9 +2222,22 @@ fn bindgen_test_layout_rte_eth_flex_payload_cfg() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_flex_payload_cfg>())).src_offset
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<rte_eth_flex_payload_cfg>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_flex_payload_cfg>(
+                    buffer,
+                )
+            };
+            let struct_ptr =
+                &struct_instance as *const rte_eth_flex_payload_cfg;
+            let field_ptr = std::ptr::addr_of!(struct_instance.src_offset);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         4usize,
         concat!(
@@ -1664,9 +2278,21 @@ fn bindgen_test_layout_rte_eth_fdir_flex_mask() {
         concat!("Alignment of ", stringify!(rte_eth_fdir_flex_mask))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_fdir_flex_mask>())).flow_type
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<rte_eth_fdir_flex_mask>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_fdir_flex_mask>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const rte_eth_fdir_flex_mask;
+            let field_ptr = std::ptr::addr_of!(struct_instance.flow_type);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -1677,9 +2303,21 @@ fn bindgen_test_layout_rte_eth_fdir_flex_mask() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_fdir_flex_mask>())).mask as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<rte_eth_fdir_flex_mask>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_fdir_flex_mask>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const rte_eth_fdir_flex_mask;
+            let field_ptr = std::ptr::addr_of!(struct_instance.mask);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         2usize,
         concat!(
@@ -1715,9 +2353,21 @@ fn bindgen_test_layout_rte_eth_fdir_flex_conf() {
         concat!("Alignment of ", stringify!(rte_eth_fdir_flex_conf))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_fdir_flex_conf>())).nb_payloads
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<rte_eth_fdir_flex_conf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_fdir_flex_conf>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const rte_eth_fdir_flex_conf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.nb_payloads);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -1728,9 +2378,21 @@ fn bindgen_test_layout_rte_eth_fdir_flex_conf() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_fdir_flex_conf>())).nb_flexmasks
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<rte_eth_fdir_flex_conf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_fdir_flex_conf>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const rte_eth_fdir_flex_conf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.nb_flexmasks);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         2usize,
         concat!(
@@ -1741,9 +2403,21 @@ fn bindgen_test_layout_rte_eth_fdir_flex_conf() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_fdir_flex_conf>())).flex_set
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<rte_eth_fdir_flex_conf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_fdir_flex_conf>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const rte_eth_fdir_flex_conf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.flex_set);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         4usize,
         concat!(
@@ -1754,9 +2428,21 @@ fn bindgen_test_layout_rte_eth_fdir_flex_conf() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_fdir_flex_conf>())).flex_mask
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<rte_eth_fdir_flex_conf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_fdir_flex_conf>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const rte_eth_fdir_flex_conf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.flex_mask);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         292usize,
         concat!(
@@ -1807,8 +2493,18 @@ fn bindgen_test_layout_rte_fdir_conf() {
         concat!("Alignment of ", stringify!(rte_fdir_conf))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_fdir_conf>())).mode as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_fdir_conf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_fdir_conf>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const rte_fdir_conf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.mode);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -1819,9 +2515,18 @@ fn bindgen_test_layout_rte_fdir_conf() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_fdir_conf>())).pballoc as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_fdir_conf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_fdir_conf>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const rte_fdir_conf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.pballoc);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         4usize,
         concat!(
@@ -1832,9 +2537,18 @@ fn bindgen_test_layout_rte_fdir_conf() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_fdir_conf>())).status as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_fdir_conf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_fdir_conf>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const rte_fdir_conf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.status);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         8usize,
         concat!(
@@ -1845,9 +2559,18 @@ fn bindgen_test_layout_rte_fdir_conf() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_fdir_conf>())).drop_queue as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_fdir_conf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_fdir_conf>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const rte_fdir_conf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.drop_queue);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         12usize,
         concat!(
@@ -1858,8 +2581,18 @@ fn bindgen_test_layout_rte_fdir_conf() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_fdir_conf>())).mask as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_fdir_conf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_fdir_conf>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const rte_fdir_conf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.mask);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         16usize,
         concat!(
@@ -1870,9 +2603,18 @@ fn bindgen_test_layout_rte_fdir_conf() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_fdir_conf>())).flex_conf as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_fdir_conf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_fdir_conf>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const rte_fdir_conf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.flex_conf);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         84usize,
         concat!(
@@ -1914,8 +2656,18 @@ fn bindgen_test_layout_rte_intr_conf() {
         concat!("Alignment of ", stringify!(rte_intr_conf))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_intr_conf>())).lsc as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_intr_conf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_intr_conf>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const rte_intr_conf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.lsc);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -1926,8 +2678,18 @@ fn bindgen_test_layout_rte_intr_conf() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_intr_conf>())).rxq as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_intr_conf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_intr_conf>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const rte_intr_conf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.rxq);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         2usize,
         concat!(
@@ -1996,9 +2758,23 @@ fn bindgen_test_layout_rte_eth_conf__bindgen_ty_1() {
         concat!("Alignment of ", stringify!(rte_eth_conf__bindgen_ty_1))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_conf__bindgen_ty_1>())).rss_conf
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<rte_eth_conf__bindgen_ty_1>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<
+                    [u8; STRUCT_SIZE],
+                    rte_eth_conf__bindgen_ty_1,
+                >(buffer)
+            };
+            let struct_ptr =
+                &struct_instance as *const rte_eth_conf__bindgen_ty_1;
+            let field_ptr = std::ptr::addr_of!(struct_instance.rss_conf);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -2009,9 +2785,23 @@ fn bindgen_test_layout_rte_eth_conf__bindgen_ty_1() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_conf__bindgen_ty_1>())).vmdq_dcb_conf
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<rte_eth_conf__bindgen_ty_1>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<
+                    [u8; STRUCT_SIZE],
+                    rte_eth_conf__bindgen_ty_1,
+                >(buffer)
+            };
+            let struct_ptr =
+                &struct_instance as *const rte_eth_conf__bindgen_ty_1;
+            let field_ptr = std::ptr::addr_of!(struct_instance.vmdq_dcb_conf);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         24usize,
         concat!(
@@ -2022,9 +2812,23 @@ fn bindgen_test_layout_rte_eth_conf__bindgen_ty_1() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_conf__bindgen_ty_1>())).dcb_rx_conf
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<rte_eth_conf__bindgen_ty_1>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<
+                    [u8; STRUCT_SIZE],
+                    rte_eth_conf__bindgen_ty_1,
+                >(buffer)
+            };
+            let struct_ptr =
+                &struct_instance as *const rte_eth_conf__bindgen_ty_1;
+            let field_ptr = std::ptr::addr_of!(struct_instance.dcb_rx_conf);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         1064usize,
         concat!(
@@ -2035,9 +2839,23 @@ fn bindgen_test_layout_rte_eth_conf__bindgen_ty_1() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_conf__bindgen_ty_1>())).vmdq_rx_conf
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<rte_eth_conf__bindgen_ty_1>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<
+                    [u8; STRUCT_SIZE],
+                    rte_eth_conf__bindgen_ty_1,
+                >(buffer)
+            };
+            let struct_ptr =
+                &struct_instance as *const rte_eth_conf__bindgen_ty_1;
+            let field_ptr = std::ptr::addr_of!(struct_instance.vmdq_rx_conf);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         1080usize,
         concat!(
@@ -2076,45 +2894,6 @@ fn bindgen_test_layout_rte_eth_conf__bindgen_ty_2() {
         4usize,
         concat!("Alignment of ", stringify!(rte_eth_conf__bindgen_ty_2))
     );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_conf__bindgen_ty_2>()))
-                .vmdq_dcb_tx_conf as *const _ as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_conf__bindgen_ty_2),
-            "::",
-            stringify!(vmdq_dcb_tx_conf)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_conf__bindgen_ty_2>())).dcb_tx_conf
-                as *const _ as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_conf__bindgen_ty_2),
-            "::",
-            stringify!(dcb_tx_conf)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_conf__bindgen_ty_2>())).vmdq_tx_conf
-                as *const _ as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_conf__bindgen_ty_2),
-            "::",
-            stringify!(vmdq_tx_conf)
-        )
-    );
 }
 impl Default for rte_eth_conf__bindgen_ty_2 {
     fn default() -> Self {
@@ -2138,9 +2917,18 @@ fn bindgen_test_layout_rte_eth_conf() {
         concat!("Alignment of ", stringify!(rte_eth_conf))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_conf>())).link_speeds as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_eth_conf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_conf>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const rte_eth_conf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.link_speeds);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -2151,8 +2939,18 @@ fn bindgen_test_layout_rte_eth_conf() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_conf>())).rxmode as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_eth_conf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_conf>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const rte_eth_conf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.rxmode);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         4usize,
         concat!(
@@ -2163,8 +2961,18 @@ fn bindgen_test_layout_rte_eth_conf() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_conf>())).txmode as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_eth_conf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_conf>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const rte_eth_conf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.txmode);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         16usize,
         concat!(
@@ -2175,9 +2983,18 @@ fn bindgen_test_layout_rte_eth_conf() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_conf>())).lpbk_mode as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_eth_conf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_conf>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const rte_eth_conf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.lpbk_mode);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         24usize,
         concat!(
@@ -2188,9 +3005,18 @@ fn bindgen_test_layout_rte_eth_conf() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_conf>())).rx_adv_conf as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_eth_conf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_conf>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const rte_eth_conf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.rx_adv_conf);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         32usize,
         concat!(
@@ -2201,9 +3027,18 @@ fn bindgen_test_layout_rte_eth_conf() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_conf>())).tx_adv_conf as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_eth_conf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_conf>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const rte_eth_conf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.tx_adv_conf);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         2152usize,
         concat!(
@@ -2214,9 +3049,19 @@ fn bindgen_test_layout_rte_eth_conf() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_conf>())).dcb_capability_en
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_eth_conf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_conf>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const rte_eth_conf;
+            let field_ptr =
+                std::ptr::addr_of!(struct_instance.dcb_capability_en);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         2164usize,
         concat!(
@@ -2227,9 +3072,18 @@ fn bindgen_test_layout_rte_eth_conf() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_conf>())).fdir_conf as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_eth_conf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_conf>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const rte_eth_conf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.fdir_conf);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         2168usize,
         concat!(
@@ -2240,9 +3094,18 @@ fn bindgen_test_layout_rte_eth_conf() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_conf>())).intr_conf as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_eth_conf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_conf>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const rte_eth_conf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.intr_conf);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         2940usize,
         concat!(

--- a/tests/expectations/tests/layout_eth_conf_1_0.rs
+++ b/tests/expectations/tests/layout_eth_conf_1_0.rs
@@ -214,9 +214,18 @@ fn bindgen_test_layout_rte_eth_rxmode() {
         concat!("Alignment of ", stringify!(rte_eth_rxmode))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_rxmode>())).mq_mode as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_eth_rxmode>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_rxmode>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const rte_eth_rxmode;
+            let field_ptr = std::ptr::addr_of!(struct_instance.mq_mode);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -227,9 +236,18 @@ fn bindgen_test_layout_rte_eth_rxmode() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_rxmode>())).max_rx_pkt_len
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_eth_rxmode>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_rxmode>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const rte_eth_rxmode;
+            let field_ptr = std::ptr::addr_of!(struct_instance.max_rx_pkt_len);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         4usize,
         concat!(
@@ -240,9 +258,18 @@ fn bindgen_test_layout_rte_eth_rxmode() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_rxmode>())).split_hdr_size
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_eth_rxmode>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_rxmode>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const rte_eth_rxmode;
+            let field_ptr = std::ptr::addr_of!(struct_instance.split_hdr_size);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         8usize,
         concat!(
@@ -484,9 +511,18 @@ fn bindgen_test_layout_rte_eth_txmode() {
         concat!("Alignment of ", stringify!(rte_eth_txmode))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_txmode>())).mq_mode as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_eth_txmode>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_txmode>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const rte_eth_txmode;
+            let field_ptr = std::ptr::addr_of!(struct_instance.mq_mode);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -497,8 +533,18 @@ fn bindgen_test_layout_rte_eth_txmode() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_txmode>())).pvid as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_eth_txmode>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_txmode>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const rte_eth_txmode;
+            let field_ptr = std::ptr::addr_of!(struct_instance.pvid);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         4usize,
         concat!(
@@ -627,9 +673,20 @@ fn bindgen_test_layout_rte_eth_rss_conf() {
         concat!("Alignment of ", stringify!(rte_eth_rss_conf))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_rss_conf>())).rss_key as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_eth_rss_conf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_rss_conf>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const rte_eth_rss_conf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.rss_key);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -640,9 +697,20 @@ fn bindgen_test_layout_rte_eth_rss_conf() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_rss_conf>())).rss_key_len as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_eth_rss_conf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_rss_conf>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const rte_eth_rss_conf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.rss_key_len);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         8usize,
         concat!(
@@ -653,9 +721,20 @@ fn bindgen_test_layout_rte_eth_rss_conf() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_rss_conf>())).rss_hf as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_eth_rss_conf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_rss_conf>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const rte_eth_rss_conf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.rss_hf);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         16usize,
         concat!(
@@ -752,9 +831,23 @@ fn bindgen_test_layout_rte_eth_vmdq_dcb_conf__bindgen_ty_1() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_vmdq_dcb_conf__bindgen_ty_1>()))
-                .vlan_id as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<rte_eth_vmdq_dcb_conf__bindgen_ty_1>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<
+                    [u8; STRUCT_SIZE],
+                    rte_eth_vmdq_dcb_conf__bindgen_ty_1,
+                >(buffer)
+            };
+            let struct_ptr =
+                &struct_instance as *const rte_eth_vmdq_dcb_conf__bindgen_ty_1;
+            let field_ptr = std::ptr::addr_of!(struct_instance.vlan_id);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -765,9 +858,23 @@ fn bindgen_test_layout_rte_eth_vmdq_dcb_conf__bindgen_ty_1() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_vmdq_dcb_conf__bindgen_ty_1>()))
-                .pools as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<rte_eth_vmdq_dcb_conf__bindgen_ty_1>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<
+                    [u8; STRUCT_SIZE],
+                    rte_eth_vmdq_dcb_conf__bindgen_ty_1,
+                >(buffer)
+            };
+            let struct_ptr =
+                &struct_instance as *const rte_eth_vmdq_dcb_conf__bindgen_ty_1;
+            let field_ptr = std::ptr::addr_of!(struct_instance.pools);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         8usize,
         concat!(
@@ -796,9 +903,21 @@ fn bindgen_test_layout_rte_eth_vmdq_dcb_conf() {
         concat!("Alignment of ", stringify!(rte_eth_vmdq_dcb_conf))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_vmdq_dcb_conf>())).nb_queue_pools
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<rte_eth_vmdq_dcb_conf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_vmdq_dcb_conf>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const rte_eth_vmdq_dcb_conf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.nb_queue_pools);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -809,9 +928,22 @@ fn bindgen_test_layout_rte_eth_vmdq_dcb_conf() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_vmdq_dcb_conf>()))
-                .enable_default_pool as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<rte_eth_vmdq_dcb_conf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_vmdq_dcb_conf>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const rte_eth_vmdq_dcb_conf;
+            let field_ptr =
+                std::ptr::addr_of!(struct_instance.enable_default_pool);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         4usize,
         concat!(
@@ -822,9 +954,21 @@ fn bindgen_test_layout_rte_eth_vmdq_dcb_conf() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_vmdq_dcb_conf>())).default_pool
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<rte_eth_vmdq_dcb_conf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_vmdq_dcb_conf>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const rte_eth_vmdq_dcb_conf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.default_pool);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         5usize,
         concat!(
@@ -835,9 +979,21 @@ fn bindgen_test_layout_rte_eth_vmdq_dcb_conf() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_vmdq_dcb_conf>())).nb_pool_maps
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<rte_eth_vmdq_dcb_conf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_vmdq_dcb_conf>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const rte_eth_vmdq_dcb_conf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.nb_pool_maps);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         6usize,
         concat!(
@@ -848,9 +1004,21 @@ fn bindgen_test_layout_rte_eth_vmdq_dcb_conf() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_vmdq_dcb_conf>())).pool_map
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<rte_eth_vmdq_dcb_conf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_vmdq_dcb_conf>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const rte_eth_vmdq_dcb_conf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.pool_map);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         8usize,
         concat!(
@@ -861,9 +1029,21 @@ fn bindgen_test_layout_rte_eth_vmdq_dcb_conf() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_vmdq_dcb_conf>())).dcb_tc as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<rte_eth_vmdq_dcb_conf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_vmdq_dcb_conf>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const rte_eth_vmdq_dcb_conf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.dcb_tc);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         1032usize,
         concat!(
@@ -909,9 +1089,21 @@ fn bindgen_test_layout_rte_eth_dcb_rx_conf() {
         concat!("Alignment of ", stringify!(rte_eth_dcb_rx_conf))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_dcb_rx_conf>())).nb_tcs as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<rte_eth_dcb_rx_conf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_dcb_rx_conf>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const rte_eth_dcb_rx_conf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.nb_tcs);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -922,9 +1114,21 @@ fn bindgen_test_layout_rte_eth_dcb_rx_conf() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_dcb_rx_conf>())).dcb_tc as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<rte_eth_dcb_rx_conf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_dcb_rx_conf>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const rte_eth_dcb_rx_conf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.dcb_tc);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         4usize,
         concat!(
@@ -970,9 +1174,22 @@ fn bindgen_test_layout_rte_eth_vmdq_dcb_tx_conf() {
         concat!("Alignment of ", stringify!(rte_eth_vmdq_dcb_tx_conf))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_vmdq_dcb_tx_conf>())).nb_queue_pools
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<rte_eth_vmdq_dcb_tx_conf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_vmdq_dcb_tx_conf>(
+                    buffer,
+                )
+            };
+            let struct_ptr =
+                &struct_instance as *const rte_eth_vmdq_dcb_tx_conf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.nb_queue_pools);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -983,9 +1200,22 @@ fn bindgen_test_layout_rte_eth_vmdq_dcb_tx_conf() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_vmdq_dcb_tx_conf>())).dcb_tc
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<rte_eth_vmdq_dcb_tx_conf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_vmdq_dcb_tx_conf>(
+                    buffer,
+                )
+            };
+            let struct_ptr =
+                &struct_instance as *const rte_eth_vmdq_dcb_tx_conf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.dcb_tc);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         4usize,
         concat!(
@@ -1031,9 +1261,21 @@ fn bindgen_test_layout_rte_eth_dcb_tx_conf() {
         concat!("Alignment of ", stringify!(rte_eth_dcb_tx_conf))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_dcb_tx_conf>())).nb_tcs as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<rte_eth_dcb_tx_conf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_dcb_tx_conf>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const rte_eth_dcb_tx_conf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.nb_tcs);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -1044,9 +1286,21 @@ fn bindgen_test_layout_rte_eth_dcb_tx_conf() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_dcb_tx_conf>())).dcb_tc as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<rte_eth_dcb_tx_conf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_dcb_tx_conf>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const rte_eth_dcb_tx_conf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.dcb_tc);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         4usize,
         concat!(
@@ -1090,9 +1344,21 @@ fn bindgen_test_layout_rte_eth_vmdq_tx_conf() {
         concat!("Alignment of ", stringify!(rte_eth_vmdq_tx_conf))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_vmdq_tx_conf>())).nb_queue_pools
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<rte_eth_vmdq_tx_conf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_vmdq_tx_conf>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const rte_eth_vmdq_tx_conf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.nb_queue_pools);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -1159,9 +1425,23 @@ fn bindgen_test_layout_rte_eth_vmdq_rx_conf__bindgen_ty_1() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_vmdq_rx_conf__bindgen_ty_1>()))
-                .vlan_id as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<rte_eth_vmdq_rx_conf__bindgen_ty_1>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<
+                    [u8; STRUCT_SIZE],
+                    rte_eth_vmdq_rx_conf__bindgen_ty_1,
+                >(buffer)
+            };
+            let struct_ptr =
+                &struct_instance as *const rte_eth_vmdq_rx_conf__bindgen_ty_1;
+            let field_ptr = std::ptr::addr_of!(struct_instance.vlan_id);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -1172,9 +1452,23 @@ fn bindgen_test_layout_rte_eth_vmdq_rx_conf__bindgen_ty_1() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_vmdq_rx_conf__bindgen_ty_1>())).pools
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<rte_eth_vmdq_rx_conf__bindgen_ty_1>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<
+                    [u8; STRUCT_SIZE],
+                    rte_eth_vmdq_rx_conf__bindgen_ty_1,
+                >(buffer)
+            };
+            let struct_ptr =
+                &struct_instance as *const rte_eth_vmdq_rx_conf__bindgen_ty_1;
+            let field_ptr = std::ptr::addr_of!(struct_instance.pools);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         8usize,
         concat!(
@@ -1203,9 +1497,21 @@ fn bindgen_test_layout_rte_eth_vmdq_rx_conf() {
         concat!("Alignment of ", stringify!(rte_eth_vmdq_rx_conf))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_vmdq_rx_conf>())).nb_queue_pools
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<rte_eth_vmdq_rx_conf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_vmdq_rx_conf>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const rte_eth_vmdq_rx_conf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.nb_queue_pools);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -1216,9 +1522,22 @@ fn bindgen_test_layout_rte_eth_vmdq_rx_conf() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_vmdq_rx_conf>())).enable_default_pool
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<rte_eth_vmdq_rx_conf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_vmdq_rx_conf>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const rte_eth_vmdq_rx_conf;
+            let field_ptr =
+                std::ptr::addr_of!(struct_instance.enable_default_pool);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         4usize,
         concat!(
@@ -1229,9 +1548,21 @@ fn bindgen_test_layout_rte_eth_vmdq_rx_conf() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_vmdq_rx_conf>())).default_pool
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<rte_eth_vmdq_rx_conf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_vmdq_rx_conf>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const rte_eth_vmdq_rx_conf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.default_pool);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         5usize,
         concat!(
@@ -1242,9 +1573,22 @@ fn bindgen_test_layout_rte_eth_vmdq_rx_conf() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_vmdq_rx_conf>())).enable_loop_back
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<rte_eth_vmdq_rx_conf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_vmdq_rx_conf>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const rte_eth_vmdq_rx_conf;
+            let field_ptr =
+                std::ptr::addr_of!(struct_instance.enable_loop_back);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         6usize,
         concat!(
@@ -1255,9 +1599,21 @@ fn bindgen_test_layout_rte_eth_vmdq_rx_conf() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_vmdq_rx_conf>())).nb_pool_maps
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<rte_eth_vmdq_rx_conf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_vmdq_rx_conf>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const rte_eth_vmdq_rx_conf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.nb_pool_maps);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         7usize,
         concat!(
@@ -1268,9 +1624,21 @@ fn bindgen_test_layout_rte_eth_vmdq_rx_conf() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_vmdq_rx_conf>())).rx_mode as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<rte_eth_vmdq_rx_conf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_vmdq_rx_conf>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const rte_eth_vmdq_rx_conf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.rx_mode);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         8usize,
         concat!(
@@ -1281,9 +1649,21 @@ fn bindgen_test_layout_rte_eth_vmdq_rx_conf() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_vmdq_rx_conf>())).pool_map
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<rte_eth_vmdq_rx_conf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_vmdq_rx_conf>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const rte_eth_vmdq_rx_conf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.pool_map);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         16usize,
         concat!(
@@ -1374,9 +1754,20 @@ fn bindgen_test_layout_rte_eth_ipv4_flow() {
         concat!("Alignment of ", stringify!(rte_eth_ipv4_flow))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_ipv4_flow>())).src_ip as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_eth_ipv4_flow>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_ipv4_flow>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const rte_eth_ipv4_flow;
+            let field_ptr = std::ptr::addr_of!(struct_instance.src_ip);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -1387,9 +1778,20 @@ fn bindgen_test_layout_rte_eth_ipv4_flow() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_ipv4_flow>())).dst_ip as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_eth_ipv4_flow>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_ipv4_flow>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const rte_eth_ipv4_flow;
+            let field_ptr = std::ptr::addr_of!(struct_instance.dst_ip);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         4usize,
         concat!(
@@ -1400,9 +1802,20 @@ fn bindgen_test_layout_rte_eth_ipv4_flow() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_ipv4_flow>())).tos as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_eth_ipv4_flow>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_ipv4_flow>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const rte_eth_ipv4_flow;
+            let field_ptr = std::ptr::addr_of!(struct_instance.tos);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         8usize,
         concat!(
@@ -1413,9 +1826,20 @@ fn bindgen_test_layout_rte_eth_ipv4_flow() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_ipv4_flow>())).ttl as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_eth_ipv4_flow>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_ipv4_flow>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const rte_eth_ipv4_flow;
+            let field_ptr = std::ptr::addr_of!(struct_instance.ttl);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         9usize,
         concat!(
@@ -1426,9 +1850,20 @@ fn bindgen_test_layout_rte_eth_ipv4_flow() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_ipv4_flow>())).proto as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_eth_ipv4_flow>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_ipv4_flow>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const rte_eth_ipv4_flow;
+            let field_ptr = std::ptr::addr_of!(struct_instance.proto);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         10usize,
         concat!(
@@ -1472,9 +1907,20 @@ fn bindgen_test_layout_rte_eth_ipv6_flow() {
         concat!("Alignment of ", stringify!(rte_eth_ipv6_flow))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_ipv6_flow>())).src_ip as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_eth_ipv6_flow>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_ipv6_flow>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const rte_eth_ipv6_flow;
+            let field_ptr = std::ptr::addr_of!(struct_instance.src_ip);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -1485,9 +1931,20 @@ fn bindgen_test_layout_rte_eth_ipv6_flow() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_ipv6_flow>())).dst_ip as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_eth_ipv6_flow>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_ipv6_flow>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const rte_eth_ipv6_flow;
+            let field_ptr = std::ptr::addr_of!(struct_instance.dst_ip);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         16usize,
         concat!(
@@ -1498,9 +1955,20 @@ fn bindgen_test_layout_rte_eth_ipv6_flow() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_ipv6_flow>())).tc as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_eth_ipv6_flow>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_ipv6_flow>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const rte_eth_ipv6_flow;
+            let field_ptr = std::ptr::addr_of!(struct_instance.tc);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         32usize,
         concat!(
@@ -1511,9 +1979,20 @@ fn bindgen_test_layout_rte_eth_ipv6_flow() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_ipv6_flow>())).proto as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_eth_ipv6_flow>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_ipv6_flow>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const rte_eth_ipv6_flow;
+            let field_ptr = std::ptr::addr_of!(struct_instance.proto);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         33usize,
         concat!(
@@ -1524,9 +2003,20 @@ fn bindgen_test_layout_rte_eth_ipv6_flow() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_ipv6_flow>())).hop_limits as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_eth_ipv6_flow>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_ipv6_flow>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const rte_eth_ipv6_flow;
+            let field_ptr = std::ptr::addr_of!(struct_instance.hop_limits);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         34usize,
         concat!(
@@ -1579,9 +2069,21 @@ fn bindgen_test_layout_rte_eth_fdir_masks() {
         concat!("Alignment of ", stringify!(rte_eth_fdir_masks))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_fdir_masks>())).vlan_tci_mask
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<rte_eth_fdir_masks>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_fdir_masks>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const rte_eth_fdir_masks;
+            let field_ptr = std::ptr::addr_of!(struct_instance.vlan_tci_mask);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -1592,9 +2094,21 @@ fn bindgen_test_layout_rte_eth_fdir_masks() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_fdir_masks>())).ipv4_mask as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<rte_eth_fdir_masks>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_fdir_masks>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const rte_eth_fdir_masks;
+            let field_ptr = std::ptr::addr_of!(struct_instance.ipv4_mask);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         4usize,
         concat!(
@@ -1605,9 +2119,21 @@ fn bindgen_test_layout_rte_eth_fdir_masks() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_fdir_masks>())).ipv6_mask as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<rte_eth_fdir_masks>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_fdir_masks>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const rte_eth_fdir_masks;
+            let field_ptr = std::ptr::addr_of!(struct_instance.ipv6_mask);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         16usize,
         concat!(
@@ -1618,9 +2144,21 @@ fn bindgen_test_layout_rte_eth_fdir_masks() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_fdir_masks>())).src_port_mask
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<rte_eth_fdir_masks>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_fdir_masks>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const rte_eth_fdir_masks;
+            let field_ptr = std::ptr::addr_of!(struct_instance.src_port_mask);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         52usize,
         concat!(
@@ -1631,9 +2169,21 @@ fn bindgen_test_layout_rte_eth_fdir_masks() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_fdir_masks>())).dst_port_mask
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<rte_eth_fdir_masks>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_fdir_masks>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const rte_eth_fdir_masks;
+            let field_ptr = std::ptr::addr_of!(struct_instance.dst_port_mask);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         54usize,
         concat!(
@@ -1644,9 +2194,22 @@ fn bindgen_test_layout_rte_eth_fdir_masks() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_fdir_masks>())).mac_addr_byte_mask
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<rte_eth_fdir_masks>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_fdir_masks>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const rte_eth_fdir_masks;
+            let field_ptr =
+                std::ptr::addr_of!(struct_instance.mac_addr_byte_mask);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         56usize,
         concat!(
@@ -1657,9 +2220,21 @@ fn bindgen_test_layout_rte_eth_fdir_masks() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_fdir_masks>())).tunnel_id_mask
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<rte_eth_fdir_masks>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_fdir_masks>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const rte_eth_fdir_masks;
+            let field_ptr = std::ptr::addr_of!(struct_instance.tunnel_id_mask);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         60usize,
         concat!(
@@ -1670,9 +2245,22 @@ fn bindgen_test_layout_rte_eth_fdir_masks() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_fdir_masks>())).tunnel_type_mask
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<rte_eth_fdir_masks>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_fdir_masks>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const rte_eth_fdir_masks;
+            let field_ptr =
+                std::ptr::addr_of!(struct_instance.tunnel_type_mask);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         64usize,
         concat!(
@@ -1721,9 +2309,22 @@ fn bindgen_test_layout_rte_eth_flex_payload_cfg() {
         concat!("Alignment of ", stringify!(rte_eth_flex_payload_cfg))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_flex_payload_cfg>())).type_
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<rte_eth_flex_payload_cfg>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_flex_payload_cfg>(
+                    buffer,
+                )
+            };
+            let struct_ptr =
+                &struct_instance as *const rte_eth_flex_payload_cfg;
+            let field_ptr = std::ptr::addr_of!(struct_instance.type_);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -1734,9 +2335,22 @@ fn bindgen_test_layout_rte_eth_flex_payload_cfg() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_flex_payload_cfg>())).src_offset
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<rte_eth_flex_payload_cfg>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_flex_payload_cfg>(
+                    buffer,
+                )
+            };
+            let struct_ptr =
+                &struct_instance as *const rte_eth_flex_payload_cfg;
+            let field_ptr = std::ptr::addr_of!(struct_instance.src_offset);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         4usize,
         concat!(
@@ -1782,9 +2396,21 @@ fn bindgen_test_layout_rte_eth_fdir_flex_mask() {
         concat!("Alignment of ", stringify!(rte_eth_fdir_flex_mask))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_fdir_flex_mask>())).flow_type
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<rte_eth_fdir_flex_mask>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_fdir_flex_mask>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const rte_eth_fdir_flex_mask;
+            let field_ptr = std::ptr::addr_of!(struct_instance.flow_type);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -1795,9 +2421,21 @@ fn bindgen_test_layout_rte_eth_fdir_flex_mask() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_fdir_flex_mask>())).mask as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<rte_eth_fdir_flex_mask>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_fdir_flex_mask>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const rte_eth_fdir_flex_mask;
+            let field_ptr = std::ptr::addr_of!(struct_instance.mask);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         2usize,
         concat!(
@@ -1838,9 +2476,21 @@ fn bindgen_test_layout_rte_eth_fdir_flex_conf() {
         concat!("Alignment of ", stringify!(rte_eth_fdir_flex_conf))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_fdir_flex_conf>())).nb_payloads
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<rte_eth_fdir_flex_conf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_fdir_flex_conf>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const rte_eth_fdir_flex_conf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.nb_payloads);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -1851,9 +2501,21 @@ fn bindgen_test_layout_rte_eth_fdir_flex_conf() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_fdir_flex_conf>())).nb_flexmasks
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<rte_eth_fdir_flex_conf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_fdir_flex_conf>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const rte_eth_fdir_flex_conf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.nb_flexmasks);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         2usize,
         concat!(
@@ -1864,9 +2526,21 @@ fn bindgen_test_layout_rte_eth_fdir_flex_conf() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_fdir_flex_conf>())).flex_set
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<rte_eth_fdir_flex_conf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_fdir_flex_conf>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const rte_eth_fdir_flex_conf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.flex_set);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         4usize,
         concat!(
@@ -1877,9 +2551,21 @@ fn bindgen_test_layout_rte_eth_fdir_flex_conf() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_fdir_flex_conf>())).flex_mask
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<rte_eth_fdir_flex_conf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_fdir_flex_conf>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const rte_eth_fdir_flex_conf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.flex_mask);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         292usize,
         concat!(
@@ -1935,8 +2621,18 @@ fn bindgen_test_layout_rte_fdir_conf() {
         concat!("Alignment of ", stringify!(rte_fdir_conf))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_fdir_conf>())).mode as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_fdir_conf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_fdir_conf>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const rte_fdir_conf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.mode);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -1947,9 +2643,18 @@ fn bindgen_test_layout_rte_fdir_conf() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_fdir_conf>())).pballoc as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_fdir_conf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_fdir_conf>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const rte_fdir_conf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.pballoc);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         4usize,
         concat!(
@@ -1960,9 +2665,18 @@ fn bindgen_test_layout_rte_fdir_conf() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_fdir_conf>())).status as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_fdir_conf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_fdir_conf>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const rte_fdir_conf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.status);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         8usize,
         concat!(
@@ -1973,9 +2687,18 @@ fn bindgen_test_layout_rte_fdir_conf() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_fdir_conf>())).drop_queue as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_fdir_conf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_fdir_conf>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const rte_fdir_conf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.drop_queue);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         12usize,
         concat!(
@@ -1986,8 +2709,18 @@ fn bindgen_test_layout_rte_fdir_conf() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_fdir_conf>())).mask as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_fdir_conf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_fdir_conf>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const rte_fdir_conf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.mask);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         16usize,
         concat!(
@@ -1998,9 +2731,18 @@ fn bindgen_test_layout_rte_fdir_conf() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_fdir_conf>())).flex_conf as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_fdir_conf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_fdir_conf>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const rte_fdir_conf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.flex_conf);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         84usize,
         concat!(
@@ -2047,8 +2789,18 @@ fn bindgen_test_layout_rte_intr_conf() {
         concat!("Alignment of ", stringify!(rte_intr_conf))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_intr_conf>())).lsc as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_intr_conf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_intr_conf>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const rte_intr_conf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.lsc);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -2059,8 +2811,18 @@ fn bindgen_test_layout_rte_intr_conf() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_intr_conf>())).rxq as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_intr_conf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_intr_conf>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const rte_intr_conf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.rxq);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         2usize,
         concat!(
@@ -2134,9 +2896,23 @@ fn bindgen_test_layout_rte_eth_conf__bindgen_ty_1() {
         concat!("Alignment of ", stringify!(rte_eth_conf__bindgen_ty_1))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_conf__bindgen_ty_1>())).rss_conf
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<rte_eth_conf__bindgen_ty_1>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<
+                    [u8; STRUCT_SIZE],
+                    rte_eth_conf__bindgen_ty_1,
+                >(buffer)
+            };
+            let struct_ptr =
+                &struct_instance as *const rte_eth_conf__bindgen_ty_1;
+            let field_ptr = std::ptr::addr_of!(struct_instance.rss_conf);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -2147,9 +2923,23 @@ fn bindgen_test_layout_rte_eth_conf__bindgen_ty_1() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_conf__bindgen_ty_1>())).vmdq_dcb_conf
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<rte_eth_conf__bindgen_ty_1>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<
+                    [u8; STRUCT_SIZE],
+                    rte_eth_conf__bindgen_ty_1,
+                >(buffer)
+            };
+            let struct_ptr =
+                &struct_instance as *const rte_eth_conf__bindgen_ty_1;
+            let field_ptr = std::ptr::addr_of!(struct_instance.vmdq_dcb_conf);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         24usize,
         concat!(
@@ -2160,9 +2950,23 @@ fn bindgen_test_layout_rte_eth_conf__bindgen_ty_1() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_conf__bindgen_ty_1>())).dcb_rx_conf
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<rte_eth_conf__bindgen_ty_1>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<
+                    [u8; STRUCT_SIZE],
+                    rte_eth_conf__bindgen_ty_1,
+                >(buffer)
+            };
+            let struct_ptr =
+                &struct_instance as *const rte_eth_conf__bindgen_ty_1;
+            let field_ptr = std::ptr::addr_of!(struct_instance.dcb_rx_conf);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         1064usize,
         concat!(
@@ -2173,9 +2977,23 @@ fn bindgen_test_layout_rte_eth_conf__bindgen_ty_1() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_conf__bindgen_ty_1>())).vmdq_rx_conf
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<rte_eth_conf__bindgen_ty_1>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<
+                    [u8; STRUCT_SIZE],
+                    rte_eth_conf__bindgen_ty_1,
+                >(buffer)
+            };
+            let struct_ptr =
+                &struct_instance as *const rte_eth_conf__bindgen_ty_1;
+            let field_ptr = std::ptr::addr_of!(struct_instance.vmdq_rx_conf);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         1080usize,
         concat!(
@@ -2220,45 +3038,6 @@ fn bindgen_test_layout_rte_eth_conf__bindgen_ty_2() {
         4usize,
         concat!("Alignment of ", stringify!(rte_eth_conf__bindgen_ty_2))
     );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_conf__bindgen_ty_2>()))
-                .vmdq_dcb_tx_conf as *const _ as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_conf__bindgen_ty_2),
-            "::",
-            stringify!(vmdq_dcb_tx_conf)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_conf__bindgen_ty_2>())).dcb_tx_conf
-                as *const _ as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_conf__bindgen_ty_2),
-            "::",
-            stringify!(dcb_tx_conf)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_conf__bindgen_ty_2>())).vmdq_tx_conf
-                as *const _ as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_conf__bindgen_ty_2),
-            "::",
-            stringify!(vmdq_tx_conf)
-        )
-    );
 }
 impl Clone for rte_eth_conf__bindgen_ty_2 {
     fn clone(&self) -> Self {
@@ -2278,9 +3057,18 @@ fn bindgen_test_layout_rte_eth_conf() {
         concat!("Alignment of ", stringify!(rte_eth_conf))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_conf>())).link_speeds as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_eth_conf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_conf>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const rte_eth_conf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.link_speeds);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -2291,8 +3079,18 @@ fn bindgen_test_layout_rte_eth_conf() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_conf>())).rxmode as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_eth_conf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_conf>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const rte_eth_conf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.rxmode);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         4usize,
         concat!(
@@ -2303,8 +3101,18 @@ fn bindgen_test_layout_rte_eth_conf() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_conf>())).txmode as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_eth_conf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_conf>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const rte_eth_conf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.txmode);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         16usize,
         concat!(
@@ -2315,9 +3123,18 @@ fn bindgen_test_layout_rte_eth_conf() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_conf>())).lpbk_mode as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_eth_conf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_conf>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const rte_eth_conf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.lpbk_mode);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         24usize,
         concat!(
@@ -2328,9 +3145,18 @@ fn bindgen_test_layout_rte_eth_conf() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_conf>())).rx_adv_conf as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_eth_conf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_conf>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const rte_eth_conf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.rx_adv_conf);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         32usize,
         concat!(
@@ -2341,9 +3167,18 @@ fn bindgen_test_layout_rte_eth_conf() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_conf>())).tx_adv_conf as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_eth_conf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_conf>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const rte_eth_conf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.tx_adv_conf);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         2152usize,
         concat!(
@@ -2354,9 +3189,19 @@ fn bindgen_test_layout_rte_eth_conf() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_conf>())).dcb_capability_en
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_eth_conf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_conf>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const rte_eth_conf;
+            let field_ptr =
+                std::ptr::addr_of!(struct_instance.dcb_capability_en);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         2164usize,
         concat!(
@@ -2367,9 +3212,18 @@ fn bindgen_test_layout_rte_eth_conf() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_conf>())).fdir_conf as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_eth_conf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_conf>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const rte_eth_conf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.fdir_conf);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         2168usize,
         concat!(
@@ -2380,9 +3234,18 @@ fn bindgen_test_layout_rte_eth_conf() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_conf>())).intr_conf as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_eth_conf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_conf>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const rte_eth_conf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.intr_conf);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         2940usize,
         concat!(

--- a/tests/expectations/tests/layout_eth_conf_1_0.rs
+++ b/tests/expectations/tests/layout_eth_conf_1_0.rs
@@ -215,11 +215,8 @@ fn bindgen_test_layout_rte_eth_rxmode() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_eth_rxmode>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_rxmode>(buffer)
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_eth_rxmode>() };
             let struct_ptr = &struct_instance as *const rte_eth_rxmode;
             let field_ptr = std::ptr::addr_of!(struct_instance.mq_mode);
             let struct_address = struct_ptr as usize;
@@ -237,11 +234,8 @@ fn bindgen_test_layout_rte_eth_rxmode() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_eth_rxmode>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_rxmode>(buffer)
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_eth_rxmode>() };
             let struct_ptr = &struct_instance as *const rte_eth_rxmode;
             let field_ptr = std::ptr::addr_of!(struct_instance.max_rx_pkt_len);
             let struct_address = struct_ptr as usize;
@@ -259,11 +253,8 @@ fn bindgen_test_layout_rte_eth_rxmode() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_eth_rxmode>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_rxmode>(buffer)
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_eth_rxmode>() };
             let struct_ptr = &struct_instance as *const rte_eth_rxmode;
             let field_ptr = std::ptr::addr_of!(struct_instance.split_hdr_size);
             let struct_address = struct_ptr as usize;
@@ -512,11 +503,8 @@ fn bindgen_test_layout_rte_eth_txmode() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_eth_txmode>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_txmode>(buffer)
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_eth_txmode>() };
             let struct_ptr = &struct_instance as *const rte_eth_txmode;
             let field_ptr = std::ptr::addr_of!(struct_instance.mq_mode);
             let struct_address = struct_ptr as usize;
@@ -534,11 +522,8 @@ fn bindgen_test_layout_rte_eth_txmode() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_eth_txmode>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_txmode>(buffer)
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_eth_txmode>() };
             let struct_ptr = &struct_instance as *const rte_eth_txmode;
             let field_ptr = std::ptr::addr_of!(struct_instance.pvid);
             let struct_address = struct_ptr as usize;
@@ -674,13 +659,8 @@ fn bindgen_test_layout_rte_eth_rss_conf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_eth_rss_conf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_rss_conf>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_eth_rss_conf>() };
             let struct_ptr = &struct_instance as *const rte_eth_rss_conf;
             let field_ptr = std::ptr::addr_of!(struct_instance.rss_key);
             let struct_address = struct_ptr as usize;
@@ -698,13 +678,8 @@ fn bindgen_test_layout_rte_eth_rss_conf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_eth_rss_conf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_rss_conf>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_eth_rss_conf>() };
             let struct_ptr = &struct_instance as *const rte_eth_rss_conf;
             let field_ptr = std::ptr::addr_of!(struct_instance.rss_key_len);
             let struct_address = struct_ptr as usize;
@@ -722,13 +697,8 @@ fn bindgen_test_layout_rte_eth_rss_conf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_eth_rss_conf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_rss_conf>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_eth_rss_conf>() };
             let struct_ptr = &struct_instance as *const rte_eth_rss_conf;
             let field_ptr = std::ptr::addr_of!(struct_instance.rss_hf);
             let struct_address = struct_ptr as usize;
@@ -832,14 +802,8 @@ fn bindgen_test_layout_rte_eth_vmdq_dcb_conf__bindgen_ty_1() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<rte_eth_vmdq_dcb_conf__bindgen_ty_1>();
-            let buffer = [0u8; STRUCT_SIZE];
             let struct_instance = unsafe {
-                std::mem::transmute::<
-                    [u8; STRUCT_SIZE],
-                    rte_eth_vmdq_dcb_conf__bindgen_ty_1,
-                >(buffer)
+                std::mem::zeroed::<rte_eth_vmdq_dcb_conf__bindgen_ty_1>()
             };
             let struct_ptr =
                 &struct_instance as *const rte_eth_vmdq_dcb_conf__bindgen_ty_1;
@@ -859,14 +823,8 @@ fn bindgen_test_layout_rte_eth_vmdq_dcb_conf__bindgen_ty_1() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<rte_eth_vmdq_dcb_conf__bindgen_ty_1>();
-            let buffer = [0u8; STRUCT_SIZE];
             let struct_instance = unsafe {
-                std::mem::transmute::<
-                    [u8; STRUCT_SIZE],
-                    rte_eth_vmdq_dcb_conf__bindgen_ty_1,
-                >(buffer)
+                std::mem::zeroed::<rte_eth_vmdq_dcb_conf__bindgen_ty_1>()
             };
             let struct_ptr =
                 &struct_instance as *const rte_eth_vmdq_dcb_conf__bindgen_ty_1;
@@ -904,14 +862,8 @@ fn bindgen_test_layout_rte_eth_vmdq_dcb_conf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<rte_eth_vmdq_dcb_conf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_vmdq_dcb_conf>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_eth_vmdq_dcb_conf>() };
             let struct_ptr = &struct_instance as *const rte_eth_vmdq_dcb_conf;
             let field_ptr = std::ptr::addr_of!(struct_instance.nb_queue_pools);
             let struct_address = struct_ptr as usize;
@@ -929,14 +881,8 @@ fn bindgen_test_layout_rte_eth_vmdq_dcb_conf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<rte_eth_vmdq_dcb_conf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_vmdq_dcb_conf>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_eth_vmdq_dcb_conf>() };
             let struct_ptr = &struct_instance as *const rte_eth_vmdq_dcb_conf;
             let field_ptr =
                 std::ptr::addr_of!(struct_instance.enable_default_pool);
@@ -955,14 +901,8 @@ fn bindgen_test_layout_rte_eth_vmdq_dcb_conf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<rte_eth_vmdq_dcb_conf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_vmdq_dcb_conf>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_eth_vmdq_dcb_conf>() };
             let struct_ptr = &struct_instance as *const rte_eth_vmdq_dcb_conf;
             let field_ptr = std::ptr::addr_of!(struct_instance.default_pool);
             let struct_address = struct_ptr as usize;
@@ -980,14 +920,8 @@ fn bindgen_test_layout_rte_eth_vmdq_dcb_conf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<rte_eth_vmdq_dcb_conf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_vmdq_dcb_conf>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_eth_vmdq_dcb_conf>() };
             let struct_ptr = &struct_instance as *const rte_eth_vmdq_dcb_conf;
             let field_ptr = std::ptr::addr_of!(struct_instance.nb_pool_maps);
             let struct_address = struct_ptr as usize;
@@ -1005,14 +939,8 @@ fn bindgen_test_layout_rte_eth_vmdq_dcb_conf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<rte_eth_vmdq_dcb_conf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_vmdq_dcb_conf>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_eth_vmdq_dcb_conf>() };
             let struct_ptr = &struct_instance as *const rte_eth_vmdq_dcb_conf;
             let field_ptr = std::ptr::addr_of!(struct_instance.pool_map);
             let struct_address = struct_ptr as usize;
@@ -1030,14 +958,8 @@ fn bindgen_test_layout_rte_eth_vmdq_dcb_conf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<rte_eth_vmdq_dcb_conf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_vmdq_dcb_conf>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_eth_vmdq_dcb_conf>() };
             let struct_ptr = &struct_instance as *const rte_eth_vmdq_dcb_conf;
             let field_ptr = std::ptr::addr_of!(struct_instance.dcb_tc);
             let struct_address = struct_ptr as usize;
@@ -1090,14 +1012,8 @@ fn bindgen_test_layout_rte_eth_dcb_rx_conf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<rte_eth_dcb_rx_conf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_dcb_rx_conf>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_eth_dcb_rx_conf>() };
             let struct_ptr = &struct_instance as *const rte_eth_dcb_rx_conf;
             let field_ptr = std::ptr::addr_of!(struct_instance.nb_tcs);
             let struct_address = struct_ptr as usize;
@@ -1115,14 +1031,8 @@ fn bindgen_test_layout_rte_eth_dcb_rx_conf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<rte_eth_dcb_rx_conf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_dcb_rx_conf>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_eth_dcb_rx_conf>() };
             let struct_ptr = &struct_instance as *const rte_eth_dcb_rx_conf;
             let field_ptr = std::ptr::addr_of!(struct_instance.dcb_tc);
             let struct_address = struct_ptr as usize;
@@ -1175,14 +1085,8 @@ fn bindgen_test_layout_rte_eth_vmdq_dcb_tx_conf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<rte_eth_vmdq_dcb_tx_conf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_vmdq_dcb_tx_conf>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_eth_vmdq_dcb_tx_conf>() };
             let struct_ptr =
                 &struct_instance as *const rte_eth_vmdq_dcb_tx_conf;
             let field_ptr = std::ptr::addr_of!(struct_instance.nb_queue_pools);
@@ -1201,14 +1105,8 @@ fn bindgen_test_layout_rte_eth_vmdq_dcb_tx_conf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<rte_eth_vmdq_dcb_tx_conf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_vmdq_dcb_tx_conf>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_eth_vmdq_dcb_tx_conf>() };
             let struct_ptr =
                 &struct_instance as *const rte_eth_vmdq_dcb_tx_conf;
             let field_ptr = std::ptr::addr_of!(struct_instance.dcb_tc);
@@ -1262,14 +1160,8 @@ fn bindgen_test_layout_rte_eth_dcb_tx_conf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<rte_eth_dcb_tx_conf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_dcb_tx_conf>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_eth_dcb_tx_conf>() };
             let struct_ptr = &struct_instance as *const rte_eth_dcb_tx_conf;
             let field_ptr = std::ptr::addr_of!(struct_instance.nb_tcs);
             let struct_address = struct_ptr as usize;
@@ -1287,14 +1179,8 @@ fn bindgen_test_layout_rte_eth_dcb_tx_conf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<rte_eth_dcb_tx_conf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_dcb_tx_conf>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_eth_dcb_tx_conf>() };
             let struct_ptr = &struct_instance as *const rte_eth_dcb_tx_conf;
             let field_ptr = std::ptr::addr_of!(struct_instance.dcb_tc);
             let struct_address = struct_ptr as usize;
@@ -1345,14 +1231,8 @@ fn bindgen_test_layout_rte_eth_vmdq_tx_conf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<rte_eth_vmdq_tx_conf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_vmdq_tx_conf>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_eth_vmdq_tx_conf>() };
             let struct_ptr = &struct_instance as *const rte_eth_vmdq_tx_conf;
             let field_ptr = std::ptr::addr_of!(struct_instance.nb_queue_pools);
             let struct_address = struct_ptr as usize;
@@ -1426,14 +1306,8 @@ fn bindgen_test_layout_rte_eth_vmdq_rx_conf__bindgen_ty_1() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<rte_eth_vmdq_rx_conf__bindgen_ty_1>();
-            let buffer = [0u8; STRUCT_SIZE];
             let struct_instance = unsafe {
-                std::mem::transmute::<
-                    [u8; STRUCT_SIZE],
-                    rte_eth_vmdq_rx_conf__bindgen_ty_1,
-                >(buffer)
+                std::mem::zeroed::<rte_eth_vmdq_rx_conf__bindgen_ty_1>()
             };
             let struct_ptr =
                 &struct_instance as *const rte_eth_vmdq_rx_conf__bindgen_ty_1;
@@ -1453,14 +1327,8 @@ fn bindgen_test_layout_rte_eth_vmdq_rx_conf__bindgen_ty_1() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<rte_eth_vmdq_rx_conf__bindgen_ty_1>();
-            let buffer = [0u8; STRUCT_SIZE];
             let struct_instance = unsafe {
-                std::mem::transmute::<
-                    [u8; STRUCT_SIZE],
-                    rte_eth_vmdq_rx_conf__bindgen_ty_1,
-                >(buffer)
+                std::mem::zeroed::<rte_eth_vmdq_rx_conf__bindgen_ty_1>()
             };
             let struct_ptr =
                 &struct_instance as *const rte_eth_vmdq_rx_conf__bindgen_ty_1;
@@ -1498,14 +1366,8 @@ fn bindgen_test_layout_rte_eth_vmdq_rx_conf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<rte_eth_vmdq_rx_conf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_vmdq_rx_conf>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_eth_vmdq_rx_conf>() };
             let struct_ptr = &struct_instance as *const rte_eth_vmdq_rx_conf;
             let field_ptr = std::ptr::addr_of!(struct_instance.nb_queue_pools);
             let struct_address = struct_ptr as usize;
@@ -1523,14 +1385,8 @@ fn bindgen_test_layout_rte_eth_vmdq_rx_conf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<rte_eth_vmdq_rx_conf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_vmdq_rx_conf>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_eth_vmdq_rx_conf>() };
             let struct_ptr = &struct_instance as *const rte_eth_vmdq_rx_conf;
             let field_ptr =
                 std::ptr::addr_of!(struct_instance.enable_default_pool);
@@ -1549,14 +1405,8 @@ fn bindgen_test_layout_rte_eth_vmdq_rx_conf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<rte_eth_vmdq_rx_conf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_vmdq_rx_conf>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_eth_vmdq_rx_conf>() };
             let struct_ptr = &struct_instance as *const rte_eth_vmdq_rx_conf;
             let field_ptr = std::ptr::addr_of!(struct_instance.default_pool);
             let struct_address = struct_ptr as usize;
@@ -1574,14 +1424,8 @@ fn bindgen_test_layout_rte_eth_vmdq_rx_conf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<rte_eth_vmdq_rx_conf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_vmdq_rx_conf>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_eth_vmdq_rx_conf>() };
             let struct_ptr = &struct_instance as *const rte_eth_vmdq_rx_conf;
             let field_ptr =
                 std::ptr::addr_of!(struct_instance.enable_loop_back);
@@ -1600,14 +1444,8 @@ fn bindgen_test_layout_rte_eth_vmdq_rx_conf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<rte_eth_vmdq_rx_conf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_vmdq_rx_conf>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_eth_vmdq_rx_conf>() };
             let struct_ptr = &struct_instance as *const rte_eth_vmdq_rx_conf;
             let field_ptr = std::ptr::addr_of!(struct_instance.nb_pool_maps);
             let struct_address = struct_ptr as usize;
@@ -1625,14 +1463,8 @@ fn bindgen_test_layout_rte_eth_vmdq_rx_conf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<rte_eth_vmdq_rx_conf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_vmdq_rx_conf>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_eth_vmdq_rx_conf>() };
             let struct_ptr = &struct_instance as *const rte_eth_vmdq_rx_conf;
             let field_ptr = std::ptr::addr_of!(struct_instance.rx_mode);
             let struct_address = struct_ptr as usize;
@@ -1650,14 +1482,8 @@ fn bindgen_test_layout_rte_eth_vmdq_rx_conf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<rte_eth_vmdq_rx_conf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_vmdq_rx_conf>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_eth_vmdq_rx_conf>() };
             let struct_ptr = &struct_instance as *const rte_eth_vmdq_rx_conf;
             let field_ptr = std::ptr::addr_of!(struct_instance.pool_map);
             let struct_address = struct_ptr as usize;
@@ -1755,13 +1581,8 @@ fn bindgen_test_layout_rte_eth_ipv4_flow() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_eth_ipv4_flow>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_ipv4_flow>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_eth_ipv4_flow>() };
             let struct_ptr = &struct_instance as *const rte_eth_ipv4_flow;
             let field_ptr = std::ptr::addr_of!(struct_instance.src_ip);
             let struct_address = struct_ptr as usize;
@@ -1779,13 +1600,8 @@ fn bindgen_test_layout_rte_eth_ipv4_flow() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_eth_ipv4_flow>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_ipv4_flow>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_eth_ipv4_flow>() };
             let struct_ptr = &struct_instance as *const rte_eth_ipv4_flow;
             let field_ptr = std::ptr::addr_of!(struct_instance.dst_ip);
             let struct_address = struct_ptr as usize;
@@ -1803,13 +1619,8 @@ fn bindgen_test_layout_rte_eth_ipv4_flow() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_eth_ipv4_flow>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_ipv4_flow>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_eth_ipv4_flow>() };
             let struct_ptr = &struct_instance as *const rte_eth_ipv4_flow;
             let field_ptr = std::ptr::addr_of!(struct_instance.tos);
             let struct_address = struct_ptr as usize;
@@ -1827,13 +1638,8 @@ fn bindgen_test_layout_rte_eth_ipv4_flow() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_eth_ipv4_flow>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_ipv4_flow>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_eth_ipv4_flow>() };
             let struct_ptr = &struct_instance as *const rte_eth_ipv4_flow;
             let field_ptr = std::ptr::addr_of!(struct_instance.ttl);
             let struct_address = struct_ptr as usize;
@@ -1851,13 +1657,8 @@ fn bindgen_test_layout_rte_eth_ipv4_flow() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_eth_ipv4_flow>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_ipv4_flow>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_eth_ipv4_flow>() };
             let struct_ptr = &struct_instance as *const rte_eth_ipv4_flow;
             let field_ptr = std::ptr::addr_of!(struct_instance.proto);
             let struct_address = struct_ptr as usize;
@@ -1908,13 +1709,8 @@ fn bindgen_test_layout_rte_eth_ipv6_flow() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_eth_ipv6_flow>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_ipv6_flow>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_eth_ipv6_flow>() };
             let struct_ptr = &struct_instance as *const rte_eth_ipv6_flow;
             let field_ptr = std::ptr::addr_of!(struct_instance.src_ip);
             let struct_address = struct_ptr as usize;
@@ -1932,13 +1728,8 @@ fn bindgen_test_layout_rte_eth_ipv6_flow() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_eth_ipv6_flow>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_ipv6_flow>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_eth_ipv6_flow>() };
             let struct_ptr = &struct_instance as *const rte_eth_ipv6_flow;
             let field_ptr = std::ptr::addr_of!(struct_instance.dst_ip);
             let struct_address = struct_ptr as usize;
@@ -1956,13 +1747,8 @@ fn bindgen_test_layout_rte_eth_ipv6_flow() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_eth_ipv6_flow>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_ipv6_flow>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_eth_ipv6_flow>() };
             let struct_ptr = &struct_instance as *const rte_eth_ipv6_flow;
             let field_ptr = std::ptr::addr_of!(struct_instance.tc);
             let struct_address = struct_ptr as usize;
@@ -1980,13 +1766,8 @@ fn bindgen_test_layout_rte_eth_ipv6_flow() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_eth_ipv6_flow>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_ipv6_flow>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_eth_ipv6_flow>() };
             let struct_ptr = &struct_instance as *const rte_eth_ipv6_flow;
             let field_ptr = std::ptr::addr_of!(struct_instance.proto);
             let struct_address = struct_ptr as usize;
@@ -2004,13 +1785,8 @@ fn bindgen_test_layout_rte_eth_ipv6_flow() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_eth_ipv6_flow>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_ipv6_flow>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_eth_ipv6_flow>() };
             let struct_ptr = &struct_instance as *const rte_eth_ipv6_flow;
             let field_ptr = std::ptr::addr_of!(struct_instance.hop_limits);
             let struct_address = struct_ptr as usize;
@@ -2070,14 +1846,8 @@ fn bindgen_test_layout_rte_eth_fdir_masks() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<rte_eth_fdir_masks>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_fdir_masks>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_eth_fdir_masks>() };
             let struct_ptr = &struct_instance as *const rte_eth_fdir_masks;
             let field_ptr = std::ptr::addr_of!(struct_instance.vlan_tci_mask);
             let struct_address = struct_ptr as usize;
@@ -2095,14 +1865,8 @@ fn bindgen_test_layout_rte_eth_fdir_masks() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<rte_eth_fdir_masks>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_fdir_masks>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_eth_fdir_masks>() };
             let struct_ptr = &struct_instance as *const rte_eth_fdir_masks;
             let field_ptr = std::ptr::addr_of!(struct_instance.ipv4_mask);
             let struct_address = struct_ptr as usize;
@@ -2120,14 +1884,8 @@ fn bindgen_test_layout_rte_eth_fdir_masks() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<rte_eth_fdir_masks>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_fdir_masks>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_eth_fdir_masks>() };
             let struct_ptr = &struct_instance as *const rte_eth_fdir_masks;
             let field_ptr = std::ptr::addr_of!(struct_instance.ipv6_mask);
             let struct_address = struct_ptr as usize;
@@ -2145,14 +1903,8 @@ fn bindgen_test_layout_rte_eth_fdir_masks() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<rte_eth_fdir_masks>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_fdir_masks>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_eth_fdir_masks>() };
             let struct_ptr = &struct_instance as *const rte_eth_fdir_masks;
             let field_ptr = std::ptr::addr_of!(struct_instance.src_port_mask);
             let struct_address = struct_ptr as usize;
@@ -2170,14 +1922,8 @@ fn bindgen_test_layout_rte_eth_fdir_masks() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<rte_eth_fdir_masks>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_fdir_masks>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_eth_fdir_masks>() };
             let struct_ptr = &struct_instance as *const rte_eth_fdir_masks;
             let field_ptr = std::ptr::addr_of!(struct_instance.dst_port_mask);
             let struct_address = struct_ptr as usize;
@@ -2195,14 +1941,8 @@ fn bindgen_test_layout_rte_eth_fdir_masks() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<rte_eth_fdir_masks>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_fdir_masks>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_eth_fdir_masks>() };
             let struct_ptr = &struct_instance as *const rte_eth_fdir_masks;
             let field_ptr =
                 std::ptr::addr_of!(struct_instance.mac_addr_byte_mask);
@@ -2221,14 +1961,8 @@ fn bindgen_test_layout_rte_eth_fdir_masks() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<rte_eth_fdir_masks>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_fdir_masks>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_eth_fdir_masks>() };
             let struct_ptr = &struct_instance as *const rte_eth_fdir_masks;
             let field_ptr = std::ptr::addr_of!(struct_instance.tunnel_id_mask);
             let struct_address = struct_ptr as usize;
@@ -2246,14 +1980,8 @@ fn bindgen_test_layout_rte_eth_fdir_masks() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<rte_eth_fdir_masks>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_fdir_masks>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_eth_fdir_masks>() };
             let struct_ptr = &struct_instance as *const rte_eth_fdir_masks;
             let field_ptr =
                 std::ptr::addr_of!(struct_instance.tunnel_type_mask);
@@ -2310,14 +2038,8 @@ fn bindgen_test_layout_rte_eth_flex_payload_cfg() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<rte_eth_flex_payload_cfg>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_flex_payload_cfg>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_eth_flex_payload_cfg>() };
             let struct_ptr =
                 &struct_instance as *const rte_eth_flex_payload_cfg;
             let field_ptr = std::ptr::addr_of!(struct_instance.type_);
@@ -2336,14 +2058,8 @@ fn bindgen_test_layout_rte_eth_flex_payload_cfg() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<rte_eth_flex_payload_cfg>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_flex_payload_cfg>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_eth_flex_payload_cfg>() };
             let struct_ptr =
                 &struct_instance as *const rte_eth_flex_payload_cfg;
             let field_ptr = std::ptr::addr_of!(struct_instance.src_offset);
@@ -2397,14 +2113,8 @@ fn bindgen_test_layout_rte_eth_fdir_flex_mask() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<rte_eth_fdir_flex_mask>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_fdir_flex_mask>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_eth_fdir_flex_mask>() };
             let struct_ptr = &struct_instance as *const rte_eth_fdir_flex_mask;
             let field_ptr = std::ptr::addr_of!(struct_instance.flow_type);
             let struct_address = struct_ptr as usize;
@@ -2422,14 +2132,8 @@ fn bindgen_test_layout_rte_eth_fdir_flex_mask() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<rte_eth_fdir_flex_mask>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_fdir_flex_mask>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_eth_fdir_flex_mask>() };
             let struct_ptr = &struct_instance as *const rte_eth_fdir_flex_mask;
             let field_ptr = std::ptr::addr_of!(struct_instance.mask);
             let struct_address = struct_ptr as usize;
@@ -2477,14 +2181,8 @@ fn bindgen_test_layout_rte_eth_fdir_flex_conf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<rte_eth_fdir_flex_conf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_fdir_flex_conf>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_eth_fdir_flex_conf>() };
             let struct_ptr = &struct_instance as *const rte_eth_fdir_flex_conf;
             let field_ptr = std::ptr::addr_of!(struct_instance.nb_payloads);
             let struct_address = struct_ptr as usize;
@@ -2502,14 +2200,8 @@ fn bindgen_test_layout_rte_eth_fdir_flex_conf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<rte_eth_fdir_flex_conf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_fdir_flex_conf>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_eth_fdir_flex_conf>() };
             let struct_ptr = &struct_instance as *const rte_eth_fdir_flex_conf;
             let field_ptr = std::ptr::addr_of!(struct_instance.nb_flexmasks);
             let struct_address = struct_ptr as usize;
@@ -2527,14 +2219,8 @@ fn bindgen_test_layout_rte_eth_fdir_flex_conf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<rte_eth_fdir_flex_conf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_fdir_flex_conf>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_eth_fdir_flex_conf>() };
             let struct_ptr = &struct_instance as *const rte_eth_fdir_flex_conf;
             let field_ptr = std::ptr::addr_of!(struct_instance.flex_set);
             let struct_address = struct_ptr as usize;
@@ -2552,14 +2238,8 @@ fn bindgen_test_layout_rte_eth_fdir_flex_conf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<rte_eth_fdir_flex_conf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_fdir_flex_conf>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_eth_fdir_flex_conf>() };
             let struct_ptr = &struct_instance as *const rte_eth_fdir_flex_conf;
             let field_ptr = std::ptr::addr_of!(struct_instance.flex_mask);
             let struct_address = struct_ptr as usize;
@@ -2622,11 +2302,8 @@ fn bindgen_test_layout_rte_fdir_conf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_fdir_conf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_fdir_conf>(buffer)
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_fdir_conf>() };
             let struct_ptr = &struct_instance as *const rte_fdir_conf;
             let field_ptr = std::ptr::addr_of!(struct_instance.mode);
             let struct_address = struct_ptr as usize;
@@ -2644,11 +2321,8 @@ fn bindgen_test_layout_rte_fdir_conf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_fdir_conf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_fdir_conf>(buffer)
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_fdir_conf>() };
             let struct_ptr = &struct_instance as *const rte_fdir_conf;
             let field_ptr = std::ptr::addr_of!(struct_instance.pballoc);
             let struct_address = struct_ptr as usize;
@@ -2666,11 +2340,8 @@ fn bindgen_test_layout_rte_fdir_conf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_fdir_conf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_fdir_conf>(buffer)
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_fdir_conf>() };
             let struct_ptr = &struct_instance as *const rte_fdir_conf;
             let field_ptr = std::ptr::addr_of!(struct_instance.status);
             let struct_address = struct_ptr as usize;
@@ -2688,11 +2359,8 @@ fn bindgen_test_layout_rte_fdir_conf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_fdir_conf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_fdir_conf>(buffer)
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_fdir_conf>() };
             let struct_ptr = &struct_instance as *const rte_fdir_conf;
             let field_ptr = std::ptr::addr_of!(struct_instance.drop_queue);
             let struct_address = struct_ptr as usize;
@@ -2710,11 +2378,8 @@ fn bindgen_test_layout_rte_fdir_conf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_fdir_conf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_fdir_conf>(buffer)
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_fdir_conf>() };
             let struct_ptr = &struct_instance as *const rte_fdir_conf;
             let field_ptr = std::ptr::addr_of!(struct_instance.mask);
             let struct_address = struct_ptr as usize;
@@ -2732,11 +2397,8 @@ fn bindgen_test_layout_rte_fdir_conf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_fdir_conf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_fdir_conf>(buffer)
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_fdir_conf>() };
             let struct_ptr = &struct_instance as *const rte_fdir_conf;
             let field_ptr = std::ptr::addr_of!(struct_instance.flex_conf);
             let struct_address = struct_ptr as usize;
@@ -2790,11 +2452,8 @@ fn bindgen_test_layout_rte_intr_conf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_intr_conf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_intr_conf>(buffer)
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_intr_conf>() };
             let struct_ptr = &struct_instance as *const rte_intr_conf;
             let field_ptr = std::ptr::addr_of!(struct_instance.lsc);
             let struct_address = struct_ptr as usize;
@@ -2812,11 +2471,8 @@ fn bindgen_test_layout_rte_intr_conf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_intr_conf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_intr_conf>(buffer)
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_intr_conf>() };
             let struct_ptr = &struct_instance as *const rte_intr_conf;
             let field_ptr = std::ptr::addr_of!(struct_instance.rxq);
             let struct_address = struct_ptr as usize;
@@ -2897,15 +2553,8 @@ fn bindgen_test_layout_rte_eth_conf__bindgen_ty_1() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<rte_eth_conf__bindgen_ty_1>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<
-                    [u8; STRUCT_SIZE],
-                    rte_eth_conf__bindgen_ty_1,
-                >(buffer)
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_eth_conf__bindgen_ty_1>() };
             let struct_ptr =
                 &struct_instance as *const rte_eth_conf__bindgen_ty_1;
             let field_ptr = std::ptr::addr_of!(struct_instance.rss_conf);
@@ -2924,15 +2573,8 @@ fn bindgen_test_layout_rte_eth_conf__bindgen_ty_1() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<rte_eth_conf__bindgen_ty_1>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<
-                    [u8; STRUCT_SIZE],
-                    rte_eth_conf__bindgen_ty_1,
-                >(buffer)
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_eth_conf__bindgen_ty_1>() };
             let struct_ptr =
                 &struct_instance as *const rte_eth_conf__bindgen_ty_1;
             let field_ptr = std::ptr::addr_of!(struct_instance.vmdq_dcb_conf);
@@ -2951,15 +2593,8 @@ fn bindgen_test_layout_rte_eth_conf__bindgen_ty_1() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<rte_eth_conf__bindgen_ty_1>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<
-                    [u8; STRUCT_SIZE],
-                    rte_eth_conf__bindgen_ty_1,
-                >(buffer)
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_eth_conf__bindgen_ty_1>() };
             let struct_ptr =
                 &struct_instance as *const rte_eth_conf__bindgen_ty_1;
             let field_ptr = std::ptr::addr_of!(struct_instance.dcb_rx_conf);
@@ -2978,15 +2613,8 @@ fn bindgen_test_layout_rte_eth_conf__bindgen_ty_1() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<rte_eth_conf__bindgen_ty_1>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<
-                    [u8; STRUCT_SIZE],
-                    rte_eth_conf__bindgen_ty_1,
-                >(buffer)
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_eth_conf__bindgen_ty_1>() };
             let struct_ptr =
                 &struct_instance as *const rte_eth_conf__bindgen_ty_1;
             let field_ptr = std::ptr::addr_of!(struct_instance.vmdq_rx_conf);
@@ -3058,11 +2686,7 @@ fn bindgen_test_layout_rte_eth_conf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_eth_conf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_conf>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<rte_eth_conf>() };
             let struct_ptr = &struct_instance as *const rte_eth_conf;
             let field_ptr = std::ptr::addr_of!(struct_instance.link_speeds);
             let struct_address = struct_ptr as usize;
@@ -3080,11 +2704,7 @@ fn bindgen_test_layout_rte_eth_conf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_eth_conf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_conf>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<rte_eth_conf>() };
             let struct_ptr = &struct_instance as *const rte_eth_conf;
             let field_ptr = std::ptr::addr_of!(struct_instance.rxmode);
             let struct_address = struct_ptr as usize;
@@ -3102,11 +2722,7 @@ fn bindgen_test_layout_rte_eth_conf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_eth_conf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_conf>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<rte_eth_conf>() };
             let struct_ptr = &struct_instance as *const rte_eth_conf;
             let field_ptr = std::ptr::addr_of!(struct_instance.txmode);
             let struct_address = struct_ptr as usize;
@@ -3124,11 +2740,7 @@ fn bindgen_test_layout_rte_eth_conf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_eth_conf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_conf>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<rte_eth_conf>() };
             let struct_ptr = &struct_instance as *const rte_eth_conf;
             let field_ptr = std::ptr::addr_of!(struct_instance.lpbk_mode);
             let struct_address = struct_ptr as usize;
@@ -3146,11 +2758,7 @@ fn bindgen_test_layout_rte_eth_conf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_eth_conf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_conf>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<rte_eth_conf>() };
             let struct_ptr = &struct_instance as *const rte_eth_conf;
             let field_ptr = std::ptr::addr_of!(struct_instance.rx_adv_conf);
             let struct_address = struct_ptr as usize;
@@ -3168,11 +2776,7 @@ fn bindgen_test_layout_rte_eth_conf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_eth_conf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_conf>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<rte_eth_conf>() };
             let struct_ptr = &struct_instance as *const rte_eth_conf;
             let field_ptr = std::ptr::addr_of!(struct_instance.tx_adv_conf);
             let struct_address = struct_ptr as usize;
@@ -3190,11 +2794,7 @@ fn bindgen_test_layout_rte_eth_conf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_eth_conf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_conf>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<rte_eth_conf>() };
             let struct_ptr = &struct_instance as *const rte_eth_conf;
             let field_ptr =
                 std::ptr::addr_of!(struct_instance.dcb_capability_en);
@@ -3213,11 +2813,7 @@ fn bindgen_test_layout_rte_eth_conf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_eth_conf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_conf>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<rte_eth_conf>() };
             let struct_ptr = &struct_instance as *const rte_eth_conf;
             let field_ptr = std::ptr::addr_of!(struct_instance.fdir_conf);
             let struct_address = struct_ptr as usize;
@@ -3235,11 +2831,7 @@ fn bindgen_test_layout_rte_eth_conf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_eth_conf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_conf>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<rte_eth_conf>() };
             let struct_ptr = &struct_instance as *const rte_eth_conf;
             let field_ptr = std::ptr::addr_of!(struct_instance.intr_conf);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/layout_kni_mbuf.rs
+++ b/tests/expectations/tests/layout_kni_mbuf.rs
@@ -46,11 +46,7 @@ fn bindgen_test_layout_rte_kni_mbuf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_kni_mbuf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_kni_mbuf>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<rte_kni_mbuf>() };
             let struct_ptr = &struct_instance as *const rte_kni_mbuf;
             let field_ptr = std::ptr::addr_of!(struct_instance.buf_addr);
             let struct_address = struct_ptr as usize;
@@ -68,11 +64,7 @@ fn bindgen_test_layout_rte_kni_mbuf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_kni_mbuf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_kni_mbuf>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<rte_kni_mbuf>() };
             let struct_ptr = &struct_instance as *const rte_kni_mbuf;
             let field_ptr = std::ptr::addr_of!(struct_instance.buf_physaddr);
             let struct_address = struct_ptr as usize;
@@ -90,11 +82,7 @@ fn bindgen_test_layout_rte_kni_mbuf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_kni_mbuf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_kni_mbuf>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<rte_kni_mbuf>() };
             let struct_ptr = &struct_instance as *const rte_kni_mbuf;
             let field_ptr = std::ptr::addr_of!(struct_instance.pad0);
             let struct_address = struct_ptr as usize;
@@ -112,11 +100,7 @@ fn bindgen_test_layout_rte_kni_mbuf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_kni_mbuf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_kni_mbuf>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<rte_kni_mbuf>() };
             let struct_ptr = &struct_instance as *const rte_kni_mbuf;
             let field_ptr = std::ptr::addr_of!(struct_instance.data_off);
             let struct_address = struct_ptr as usize;
@@ -134,11 +118,7 @@ fn bindgen_test_layout_rte_kni_mbuf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_kni_mbuf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_kni_mbuf>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<rte_kni_mbuf>() };
             let struct_ptr = &struct_instance as *const rte_kni_mbuf;
             let field_ptr = std::ptr::addr_of!(struct_instance.pad1);
             let struct_address = struct_ptr as usize;
@@ -156,11 +136,7 @@ fn bindgen_test_layout_rte_kni_mbuf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_kni_mbuf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_kni_mbuf>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<rte_kni_mbuf>() };
             let struct_ptr = &struct_instance as *const rte_kni_mbuf;
             let field_ptr = std::ptr::addr_of!(struct_instance.nb_segs);
             let struct_address = struct_ptr as usize;
@@ -178,11 +154,7 @@ fn bindgen_test_layout_rte_kni_mbuf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_kni_mbuf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_kni_mbuf>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<rte_kni_mbuf>() };
             let struct_ptr = &struct_instance as *const rte_kni_mbuf;
             let field_ptr = std::ptr::addr_of!(struct_instance.pad4);
             let struct_address = struct_ptr as usize;
@@ -200,11 +172,7 @@ fn bindgen_test_layout_rte_kni_mbuf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_kni_mbuf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_kni_mbuf>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<rte_kni_mbuf>() };
             let struct_ptr = &struct_instance as *const rte_kni_mbuf;
             let field_ptr = std::ptr::addr_of!(struct_instance.ol_flags);
             let struct_address = struct_ptr as usize;
@@ -222,11 +190,7 @@ fn bindgen_test_layout_rte_kni_mbuf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_kni_mbuf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_kni_mbuf>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<rte_kni_mbuf>() };
             let struct_ptr = &struct_instance as *const rte_kni_mbuf;
             let field_ptr = std::ptr::addr_of!(struct_instance.pad2);
             let struct_address = struct_ptr as usize;
@@ -244,11 +208,7 @@ fn bindgen_test_layout_rte_kni_mbuf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_kni_mbuf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_kni_mbuf>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<rte_kni_mbuf>() };
             let struct_ptr = &struct_instance as *const rte_kni_mbuf;
             let field_ptr = std::ptr::addr_of!(struct_instance.pkt_len);
             let struct_address = struct_ptr as usize;
@@ -266,11 +226,7 @@ fn bindgen_test_layout_rte_kni_mbuf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_kni_mbuf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_kni_mbuf>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<rte_kni_mbuf>() };
             let struct_ptr = &struct_instance as *const rte_kni_mbuf;
             let field_ptr = std::ptr::addr_of!(struct_instance.data_len);
             let struct_address = struct_ptr as usize;
@@ -288,11 +244,7 @@ fn bindgen_test_layout_rte_kni_mbuf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_kni_mbuf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_kni_mbuf>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<rte_kni_mbuf>() };
             let struct_ptr = &struct_instance as *const rte_kni_mbuf;
             let field_ptr = std::ptr::addr_of!(struct_instance.pad3);
             let struct_address = struct_ptr as usize;
@@ -310,11 +262,7 @@ fn bindgen_test_layout_rte_kni_mbuf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_kni_mbuf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_kni_mbuf>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<rte_kni_mbuf>() };
             let struct_ptr = &struct_instance as *const rte_kni_mbuf;
             let field_ptr = std::ptr::addr_of!(struct_instance.pool);
             let struct_address = struct_ptr as usize;
@@ -332,11 +280,7 @@ fn bindgen_test_layout_rte_kni_mbuf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_kni_mbuf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_kni_mbuf>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<rte_kni_mbuf>() };
             let struct_ptr = &struct_instance as *const rte_kni_mbuf;
             let field_ptr = std::ptr::addr_of!(struct_instance.next);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/layout_kni_mbuf.rs
+++ b/tests/expectations/tests/layout_kni_mbuf.rs
@@ -45,9 +45,18 @@ fn bindgen_test_layout_rte_kni_mbuf() {
         concat!("Alignment of ", stringify!(rte_kni_mbuf))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_kni_mbuf>())).buf_addr as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_kni_mbuf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_kni_mbuf>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const rte_kni_mbuf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.buf_addr);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -58,9 +67,18 @@ fn bindgen_test_layout_rte_kni_mbuf() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_kni_mbuf>())).buf_physaddr as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_kni_mbuf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_kni_mbuf>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const rte_kni_mbuf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.buf_physaddr);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         8usize,
         concat!(
@@ -71,8 +89,18 @@ fn bindgen_test_layout_rte_kni_mbuf() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_kni_mbuf>())).pad0 as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_kni_mbuf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_kni_mbuf>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const rte_kni_mbuf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.pad0);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         16usize,
         concat!(
@@ -83,9 +111,18 @@ fn bindgen_test_layout_rte_kni_mbuf() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_kni_mbuf>())).data_off as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_kni_mbuf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_kni_mbuf>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const rte_kni_mbuf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.data_off);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         18usize,
         concat!(
@@ -96,8 +133,18 @@ fn bindgen_test_layout_rte_kni_mbuf() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_kni_mbuf>())).pad1 as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_kni_mbuf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_kni_mbuf>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const rte_kni_mbuf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.pad1);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         20usize,
         concat!(
@@ -108,9 +155,18 @@ fn bindgen_test_layout_rte_kni_mbuf() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_kni_mbuf>())).nb_segs as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_kni_mbuf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_kni_mbuf>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const rte_kni_mbuf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.nb_segs);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         22usize,
         concat!(
@@ -121,8 +177,18 @@ fn bindgen_test_layout_rte_kni_mbuf() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_kni_mbuf>())).pad4 as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_kni_mbuf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_kni_mbuf>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const rte_kni_mbuf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.pad4);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         23usize,
         concat!(
@@ -133,9 +199,18 @@ fn bindgen_test_layout_rte_kni_mbuf() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_kni_mbuf>())).ol_flags as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_kni_mbuf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_kni_mbuf>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const rte_kni_mbuf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.ol_flags);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         24usize,
         concat!(
@@ -146,8 +221,18 @@ fn bindgen_test_layout_rte_kni_mbuf() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_kni_mbuf>())).pad2 as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_kni_mbuf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_kni_mbuf>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const rte_kni_mbuf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.pad2);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         32usize,
         concat!(
@@ -158,9 +243,18 @@ fn bindgen_test_layout_rte_kni_mbuf() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_kni_mbuf>())).pkt_len as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_kni_mbuf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_kni_mbuf>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const rte_kni_mbuf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.pkt_len);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         36usize,
         concat!(
@@ -171,9 +265,18 @@ fn bindgen_test_layout_rte_kni_mbuf() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_kni_mbuf>())).data_len as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_kni_mbuf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_kni_mbuf>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const rte_kni_mbuf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.data_len);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         40usize,
         concat!(
@@ -184,8 +287,18 @@ fn bindgen_test_layout_rte_kni_mbuf() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_kni_mbuf>())).pad3 as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_kni_mbuf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_kni_mbuf>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const rte_kni_mbuf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.pad3);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         64usize,
         concat!(
@@ -196,8 +309,18 @@ fn bindgen_test_layout_rte_kni_mbuf() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_kni_mbuf>())).pool as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_kni_mbuf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_kni_mbuf>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const rte_kni_mbuf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.pool);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         72usize,
         concat!(
@@ -208,8 +331,18 @@ fn bindgen_test_layout_rte_kni_mbuf() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_kni_mbuf>())).next as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_kni_mbuf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_kni_mbuf>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const rte_kni_mbuf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.next);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         80usize,
         concat!(

--- a/tests/expectations/tests/layout_large_align_field.rs
+++ b/tests/expectations/tests/layout_large_align_field.rs
@@ -77,11 +77,7 @@ fn bindgen_test_layout_ip_frag() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<ip_frag>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], ip_frag>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<ip_frag>() };
             let struct_ptr = &struct_instance as *const ip_frag;
             let field_ptr = std::ptr::addr_of!(struct_instance.ofs);
             let struct_address = struct_ptr as usize;
@@ -99,11 +95,7 @@ fn bindgen_test_layout_ip_frag() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<ip_frag>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], ip_frag>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<ip_frag>() };
             let struct_ptr = &struct_instance as *const ip_frag;
             let field_ptr = std::ptr::addr_of!(struct_instance.len);
             let struct_address = struct_ptr as usize;
@@ -121,11 +113,7 @@ fn bindgen_test_layout_ip_frag() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<ip_frag>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], ip_frag>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<ip_frag>() };
             let struct_ptr = &struct_instance as *const ip_frag;
             let field_ptr = std::ptr::addr_of!(struct_instance.mb);
             let struct_address = struct_ptr as usize;
@@ -176,11 +164,7 @@ fn bindgen_test_layout_ip_frag_key() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<ip_frag_key>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], ip_frag_key>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<ip_frag_key>() };
             let struct_ptr = &struct_instance as *const ip_frag_key;
             let field_ptr = std::ptr::addr_of!(struct_instance.src_dst);
             let struct_address = struct_ptr as usize;
@@ -198,11 +182,7 @@ fn bindgen_test_layout_ip_frag_key() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<ip_frag_key>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], ip_frag_key>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<ip_frag_key>() };
             let struct_ptr = &struct_instance as *const ip_frag_key;
             let field_ptr = std::ptr::addr_of!(struct_instance.id);
             let struct_address = struct_ptr as usize;
@@ -220,11 +200,7 @@ fn bindgen_test_layout_ip_frag_key() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<ip_frag_key>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], ip_frag_key>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<ip_frag_key>() };
             let struct_ptr = &struct_instance as *const ip_frag_key;
             let field_ptr = std::ptr::addr_of!(struct_instance.key_len);
             let struct_address = struct_ptr as usize;
@@ -282,15 +258,8 @@ fn bindgen_test_layout_ip_frag_pkt__bindgen_ty_1() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<ip_frag_pkt__bindgen_ty_1>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<
-                    [u8; STRUCT_SIZE],
-                    ip_frag_pkt__bindgen_ty_1,
-                >(buffer)
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<ip_frag_pkt__bindgen_ty_1>() };
             let struct_ptr =
                 &struct_instance as *const ip_frag_pkt__bindgen_ty_1;
             let field_ptr = std::ptr::addr_of!(struct_instance.tqe_next);
@@ -309,15 +278,8 @@ fn bindgen_test_layout_ip_frag_pkt__bindgen_ty_1() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<ip_frag_pkt__bindgen_ty_1>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<
-                    [u8; STRUCT_SIZE],
-                    ip_frag_pkt__bindgen_ty_1,
-                >(buffer)
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<ip_frag_pkt__bindgen_ty_1>() };
             let struct_ptr =
                 &struct_instance as *const ip_frag_pkt__bindgen_ty_1;
             let field_ptr = std::ptr::addr_of!(struct_instance.tqe_prev);
@@ -358,11 +320,7 @@ fn bindgen_test_layout_ip_frag_pkt() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<ip_frag_pkt>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], ip_frag_pkt>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<ip_frag_pkt>() };
             let struct_ptr = &struct_instance as *const ip_frag_pkt;
             let field_ptr = std::ptr::addr_of!(struct_instance.lru);
             let struct_address = struct_ptr as usize;
@@ -380,11 +338,7 @@ fn bindgen_test_layout_ip_frag_pkt() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<ip_frag_pkt>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], ip_frag_pkt>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<ip_frag_pkt>() };
             let struct_ptr = &struct_instance as *const ip_frag_pkt;
             let field_ptr = std::ptr::addr_of!(struct_instance.key);
             let struct_address = struct_ptr as usize;
@@ -402,11 +356,7 @@ fn bindgen_test_layout_ip_frag_pkt() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<ip_frag_pkt>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], ip_frag_pkt>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<ip_frag_pkt>() };
             let struct_ptr = &struct_instance as *const ip_frag_pkt;
             let field_ptr = std::ptr::addr_of!(struct_instance.start);
             let struct_address = struct_ptr as usize;
@@ -424,11 +374,7 @@ fn bindgen_test_layout_ip_frag_pkt() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<ip_frag_pkt>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], ip_frag_pkt>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<ip_frag_pkt>() };
             let struct_ptr = &struct_instance as *const ip_frag_pkt;
             let field_ptr = std::ptr::addr_of!(struct_instance.total_size);
             let struct_address = struct_ptr as usize;
@@ -446,11 +392,7 @@ fn bindgen_test_layout_ip_frag_pkt() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<ip_frag_pkt>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], ip_frag_pkt>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<ip_frag_pkt>() };
             let struct_ptr = &struct_instance as *const ip_frag_pkt;
             let field_ptr = std::ptr::addr_of!(struct_instance.frag_size);
             let struct_address = struct_ptr as usize;
@@ -468,11 +410,7 @@ fn bindgen_test_layout_ip_frag_pkt() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<ip_frag_pkt>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], ip_frag_pkt>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<ip_frag_pkt>() };
             let struct_ptr = &struct_instance as *const ip_frag_pkt;
             let field_ptr = std::ptr::addr_of!(struct_instance.last_idx);
             let struct_address = struct_ptr as usize;
@@ -490,11 +428,7 @@ fn bindgen_test_layout_ip_frag_pkt() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<ip_frag_pkt>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], ip_frag_pkt>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<ip_frag_pkt>() };
             let struct_ptr = &struct_instance as *const ip_frag_pkt;
             let field_ptr = std::ptr::addr_of!(struct_instance.frags);
             let struct_address = struct_ptr as usize;
@@ -540,11 +474,7 @@ fn bindgen_test_layout_ip_pkt_list() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<ip_pkt_list>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], ip_pkt_list>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<ip_pkt_list>() };
             let struct_ptr = &struct_instance as *const ip_pkt_list;
             let field_ptr = std::ptr::addr_of!(struct_instance.tqh_first);
             let struct_address = struct_ptr as usize;
@@ -562,11 +492,7 @@ fn bindgen_test_layout_ip_pkt_list() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<ip_pkt_list>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], ip_pkt_list>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<ip_pkt_list>() };
             let struct_ptr = &struct_instance as *const ip_pkt_list;
             let field_ptr = std::ptr::addr_of!(struct_instance.tqh_last);
             let struct_address = struct_ptr as usize;
@@ -624,13 +550,8 @@ fn bindgen_test_layout_ip_frag_tbl_stat() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<ip_frag_tbl_stat>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], ip_frag_tbl_stat>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<ip_frag_tbl_stat>() };
             let struct_ptr = &struct_instance as *const ip_frag_tbl_stat;
             let field_ptr = std::ptr::addr_of!(struct_instance.find_num);
             let struct_address = struct_ptr as usize;
@@ -648,13 +569,8 @@ fn bindgen_test_layout_ip_frag_tbl_stat() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<ip_frag_tbl_stat>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], ip_frag_tbl_stat>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<ip_frag_tbl_stat>() };
             let struct_ptr = &struct_instance as *const ip_frag_tbl_stat;
             let field_ptr = std::ptr::addr_of!(struct_instance.add_num);
             let struct_address = struct_ptr as usize;
@@ -672,13 +588,8 @@ fn bindgen_test_layout_ip_frag_tbl_stat() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<ip_frag_tbl_stat>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], ip_frag_tbl_stat>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<ip_frag_tbl_stat>() };
             let struct_ptr = &struct_instance as *const ip_frag_tbl_stat;
             let field_ptr = std::ptr::addr_of!(struct_instance.del_num);
             let struct_address = struct_ptr as usize;
@@ -696,13 +607,8 @@ fn bindgen_test_layout_ip_frag_tbl_stat() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<ip_frag_tbl_stat>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], ip_frag_tbl_stat>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<ip_frag_tbl_stat>() };
             let struct_ptr = &struct_instance as *const ip_frag_tbl_stat;
             let field_ptr = std::ptr::addr_of!(struct_instance.reuse_num);
             let struct_address = struct_ptr as usize;
@@ -720,13 +626,8 @@ fn bindgen_test_layout_ip_frag_tbl_stat() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<ip_frag_tbl_stat>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], ip_frag_tbl_stat>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<ip_frag_tbl_stat>() };
             let struct_ptr = &struct_instance as *const ip_frag_tbl_stat;
             let field_ptr = std::ptr::addr_of!(struct_instance.fail_total);
             let struct_address = struct_ptr as usize;
@@ -744,13 +645,8 @@ fn bindgen_test_layout_ip_frag_tbl_stat() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<ip_frag_tbl_stat>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], ip_frag_tbl_stat>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<ip_frag_tbl_stat>() };
             let struct_ptr = &struct_instance as *const ip_frag_tbl_stat;
             let field_ptr = std::ptr::addr_of!(struct_instance.fail_nospace);
             let struct_address = struct_ptr as usize;
@@ -818,13 +714,8 @@ fn bindgen_test_layout_rte_ip_frag_tbl() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_ip_frag_tbl>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_ip_frag_tbl>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_ip_frag_tbl>() };
             let struct_ptr = &struct_instance as *const rte_ip_frag_tbl;
             let field_ptr = std::ptr::addr_of!(struct_instance.max_cycles);
             let struct_address = struct_ptr as usize;
@@ -842,13 +733,8 @@ fn bindgen_test_layout_rte_ip_frag_tbl() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_ip_frag_tbl>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_ip_frag_tbl>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_ip_frag_tbl>() };
             let struct_ptr = &struct_instance as *const rte_ip_frag_tbl;
             let field_ptr = std::ptr::addr_of!(struct_instance.entry_mask);
             let struct_address = struct_ptr as usize;
@@ -866,13 +752,8 @@ fn bindgen_test_layout_rte_ip_frag_tbl() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_ip_frag_tbl>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_ip_frag_tbl>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_ip_frag_tbl>() };
             let struct_ptr = &struct_instance as *const rte_ip_frag_tbl;
             let field_ptr = std::ptr::addr_of!(struct_instance.max_entries);
             let struct_address = struct_ptr as usize;
@@ -890,13 +771,8 @@ fn bindgen_test_layout_rte_ip_frag_tbl() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_ip_frag_tbl>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_ip_frag_tbl>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_ip_frag_tbl>() };
             let struct_ptr = &struct_instance as *const rte_ip_frag_tbl;
             let field_ptr = std::ptr::addr_of!(struct_instance.use_entries);
             let struct_address = struct_ptr as usize;
@@ -914,13 +790,8 @@ fn bindgen_test_layout_rte_ip_frag_tbl() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_ip_frag_tbl>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_ip_frag_tbl>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_ip_frag_tbl>() };
             let struct_ptr = &struct_instance as *const rte_ip_frag_tbl;
             let field_ptr = std::ptr::addr_of!(struct_instance.bucket_entries);
             let struct_address = struct_ptr as usize;
@@ -938,13 +809,8 @@ fn bindgen_test_layout_rte_ip_frag_tbl() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_ip_frag_tbl>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_ip_frag_tbl>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_ip_frag_tbl>() };
             let struct_ptr = &struct_instance as *const rte_ip_frag_tbl;
             let field_ptr = std::ptr::addr_of!(struct_instance.nb_entries);
             let struct_address = struct_ptr as usize;
@@ -962,13 +828,8 @@ fn bindgen_test_layout_rte_ip_frag_tbl() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_ip_frag_tbl>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_ip_frag_tbl>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_ip_frag_tbl>() };
             let struct_ptr = &struct_instance as *const rte_ip_frag_tbl;
             let field_ptr = std::ptr::addr_of!(struct_instance.nb_buckets);
             let struct_address = struct_ptr as usize;
@@ -986,13 +847,8 @@ fn bindgen_test_layout_rte_ip_frag_tbl() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_ip_frag_tbl>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_ip_frag_tbl>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_ip_frag_tbl>() };
             let struct_ptr = &struct_instance as *const rte_ip_frag_tbl;
             let field_ptr = std::ptr::addr_of!(struct_instance.last);
             let struct_address = struct_ptr as usize;
@@ -1010,13 +866,8 @@ fn bindgen_test_layout_rte_ip_frag_tbl() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_ip_frag_tbl>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_ip_frag_tbl>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_ip_frag_tbl>() };
             let struct_ptr = &struct_instance as *const rte_ip_frag_tbl;
             let field_ptr = std::ptr::addr_of!(struct_instance.lru);
             let struct_address = struct_ptr as usize;
@@ -1034,13 +885,8 @@ fn bindgen_test_layout_rte_ip_frag_tbl() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_ip_frag_tbl>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_ip_frag_tbl>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_ip_frag_tbl>() };
             let struct_ptr = &struct_instance as *const rte_ip_frag_tbl;
             let field_ptr = std::ptr::addr_of!(struct_instance.stat);
             let struct_address = struct_ptr as usize;
@@ -1058,13 +904,8 @@ fn bindgen_test_layout_rte_ip_frag_tbl() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_ip_frag_tbl>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_ip_frag_tbl>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_ip_frag_tbl>() };
             let struct_ptr = &struct_instance as *const rte_ip_frag_tbl;
             let field_ptr = std::ptr::addr_of!(struct_instance.pkt);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/layout_large_align_field.rs
+++ b/tests/expectations/tests/layout_large_align_field.rs
@@ -76,7 +76,19 @@ fn bindgen_test_layout_ip_frag() {
         concat!("Alignment of ", stringify!(ip_frag))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<ip_frag>())).ofs as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<ip_frag>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], ip_frag>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const ip_frag;
+            let field_ptr = std::ptr::addr_of!(struct_instance.ofs);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!(
             "Offset of field: ",
@@ -86,7 +98,19 @@ fn bindgen_test_layout_ip_frag() {
         )
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<ip_frag>())).len as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<ip_frag>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], ip_frag>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const ip_frag;
+            let field_ptr = std::ptr::addr_of!(struct_instance.len);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         2usize,
         concat!(
             "Offset of field: ",
@@ -96,7 +120,19 @@ fn bindgen_test_layout_ip_frag() {
         )
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<ip_frag>())).mb as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<ip_frag>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], ip_frag>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const ip_frag;
+            let field_ptr = std::ptr::addr_of!(struct_instance.mb);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         8usize,
         concat!(
             "Offset of field: ",
@@ -139,8 +175,18 @@ fn bindgen_test_layout_ip_frag_key() {
         concat!("Alignment of ", stringify!(ip_frag_key))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<ip_frag_key>())).src_dst as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<ip_frag_key>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], ip_frag_key>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const ip_frag_key;
+            let field_ptr = std::ptr::addr_of!(struct_instance.src_dst);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -151,8 +197,18 @@ fn bindgen_test_layout_ip_frag_key() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<ip_frag_key>())).id as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<ip_frag_key>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], ip_frag_key>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const ip_frag_key;
+            let field_ptr = std::ptr::addr_of!(struct_instance.id);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         32usize,
         concat!(
@@ -163,8 +219,18 @@ fn bindgen_test_layout_ip_frag_key() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<ip_frag_key>())).key_len as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<ip_frag_key>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], ip_frag_key>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const ip_frag_key;
+            let field_ptr = std::ptr::addr_of!(struct_instance.key_len);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         36usize,
         concat!(
@@ -215,9 +281,23 @@ fn bindgen_test_layout_ip_frag_pkt__bindgen_ty_1() {
         concat!("Alignment of ", stringify!(ip_frag_pkt__bindgen_ty_1))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<ip_frag_pkt__bindgen_ty_1>())).tqe_next
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<ip_frag_pkt__bindgen_ty_1>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<
+                    [u8; STRUCT_SIZE],
+                    ip_frag_pkt__bindgen_ty_1,
+                >(buffer)
+            };
+            let struct_ptr =
+                &struct_instance as *const ip_frag_pkt__bindgen_ty_1;
+            let field_ptr = std::ptr::addr_of!(struct_instance.tqe_next);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -228,9 +308,23 @@ fn bindgen_test_layout_ip_frag_pkt__bindgen_ty_1() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<ip_frag_pkt__bindgen_ty_1>())).tqe_prev
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<ip_frag_pkt__bindgen_ty_1>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<
+                    [u8; STRUCT_SIZE],
+                    ip_frag_pkt__bindgen_ty_1,
+                >(buffer)
+            };
+            let struct_ptr =
+                &struct_instance as *const ip_frag_pkt__bindgen_ty_1;
+            let field_ptr = std::ptr::addr_of!(struct_instance.tqe_prev);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         8usize,
         concat!(
@@ -263,8 +357,18 @@ fn bindgen_test_layout_ip_frag_pkt() {
         concat!("Alignment of ", stringify!(ip_frag_pkt))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<ip_frag_pkt>())).lru as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<ip_frag_pkt>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], ip_frag_pkt>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const ip_frag_pkt;
+            let field_ptr = std::ptr::addr_of!(struct_instance.lru);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -275,8 +379,18 @@ fn bindgen_test_layout_ip_frag_pkt() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<ip_frag_pkt>())).key as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<ip_frag_pkt>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], ip_frag_pkt>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const ip_frag_pkt;
+            let field_ptr = std::ptr::addr_of!(struct_instance.key);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         16usize,
         concat!(
@@ -287,8 +401,18 @@ fn bindgen_test_layout_ip_frag_pkt() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<ip_frag_pkt>())).start as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<ip_frag_pkt>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], ip_frag_pkt>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const ip_frag_pkt;
+            let field_ptr = std::ptr::addr_of!(struct_instance.start);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         56usize,
         concat!(
@@ -299,9 +423,18 @@ fn bindgen_test_layout_ip_frag_pkt() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<ip_frag_pkt>())).total_size as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<ip_frag_pkt>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], ip_frag_pkt>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const ip_frag_pkt;
+            let field_ptr = std::ptr::addr_of!(struct_instance.total_size);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         64usize,
         concat!(
@@ -312,9 +445,18 @@ fn bindgen_test_layout_ip_frag_pkt() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<ip_frag_pkt>())).frag_size as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<ip_frag_pkt>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], ip_frag_pkt>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const ip_frag_pkt;
+            let field_ptr = std::ptr::addr_of!(struct_instance.frag_size);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         68usize,
         concat!(
@@ -325,9 +467,18 @@ fn bindgen_test_layout_ip_frag_pkt() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<ip_frag_pkt>())).last_idx as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<ip_frag_pkt>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], ip_frag_pkt>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const ip_frag_pkt;
+            let field_ptr = std::ptr::addr_of!(struct_instance.last_idx);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         72usize,
         concat!(
@@ -338,8 +489,18 @@ fn bindgen_test_layout_ip_frag_pkt() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<ip_frag_pkt>())).frags as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<ip_frag_pkt>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], ip_frag_pkt>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const ip_frag_pkt;
+            let field_ptr = std::ptr::addr_of!(struct_instance.frags);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         80usize,
         concat!(
@@ -378,9 +539,18 @@ fn bindgen_test_layout_ip_pkt_list() {
         concat!("Alignment of ", stringify!(ip_pkt_list))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<ip_pkt_list>())).tqh_first as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<ip_pkt_list>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], ip_pkt_list>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const ip_pkt_list;
+            let field_ptr = std::ptr::addr_of!(struct_instance.tqh_first);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -391,9 +561,18 @@ fn bindgen_test_layout_ip_pkt_list() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<ip_pkt_list>())).tqh_last as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<ip_pkt_list>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], ip_pkt_list>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const ip_pkt_list;
+            let field_ptr = std::ptr::addr_of!(struct_instance.tqh_last);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         8usize,
         concat!(
@@ -444,9 +623,20 @@ fn bindgen_test_layout_ip_frag_tbl_stat() {
         concat!("Alignment of ", stringify!(ip_frag_tbl_stat))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<ip_frag_tbl_stat>())).find_num as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<ip_frag_tbl_stat>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], ip_frag_tbl_stat>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const ip_frag_tbl_stat;
+            let field_ptr = std::ptr::addr_of!(struct_instance.find_num);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -457,9 +647,20 @@ fn bindgen_test_layout_ip_frag_tbl_stat() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<ip_frag_tbl_stat>())).add_num as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<ip_frag_tbl_stat>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], ip_frag_tbl_stat>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const ip_frag_tbl_stat;
+            let field_ptr = std::ptr::addr_of!(struct_instance.add_num);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         8usize,
         concat!(
@@ -470,9 +671,20 @@ fn bindgen_test_layout_ip_frag_tbl_stat() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<ip_frag_tbl_stat>())).del_num as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<ip_frag_tbl_stat>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], ip_frag_tbl_stat>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const ip_frag_tbl_stat;
+            let field_ptr = std::ptr::addr_of!(struct_instance.del_num);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         16usize,
         concat!(
@@ -483,9 +695,20 @@ fn bindgen_test_layout_ip_frag_tbl_stat() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<ip_frag_tbl_stat>())).reuse_num as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<ip_frag_tbl_stat>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], ip_frag_tbl_stat>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const ip_frag_tbl_stat;
+            let field_ptr = std::ptr::addr_of!(struct_instance.reuse_num);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         24usize,
         concat!(
@@ -496,9 +719,20 @@ fn bindgen_test_layout_ip_frag_tbl_stat() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<ip_frag_tbl_stat>())).fail_total as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<ip_frag_tbl_stat>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], ip_frag_tbl_stat>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const ip_frag_tbl_stat;
+            let field_ptr = std::ptr::addr_of!(struct_instance.fail_total);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         32usize,
         concat!(
@@ -509,9 +743,20 @@ fn bindgen_test_layout_ip_frag_tbl_stat() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<ip_frag_tbl_stat>())).fail_nospace
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<ip_frag_tbl_stat>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], ip_frag_tbl_stat>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const ip_frag_tbl_stat;
+            let field_ptr = std::ptr::addr_of!(struct_instance.fail_nospace);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         40usize,
         concat!(
@@ -572,9 +817,20 @@ fn bindgen_test_layout_rte_ip_frag_tbl() {
         concat!("Alignment of ", stringify!(rte_ip_frag_tbl))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_ip_frag_tbl>())).max_cycles as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_ip_frag_tbl>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_ip_frag_tbl>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const rte_ip_frag_tbl;
+            let field_ptr = std::ptr::addr_of!(struct_instance.max_cycles);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -585,9 +841,20 @@ fn bindgen_test_layout_rte_ip_frag_tbl() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_ip_frag_tbl>())).entry_mask as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_ip_frag_tbl>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_ip_frag_tbl>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const rte_ip_frag_tbl;
+            let field_ptr = std::ptr::addr_of!(struct_instance.entry_mask);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         8usize,
         concat!(
@@ -598,9 +865,20 @@ fn bindgen_test_layout_rte_ip_frag_tbl() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_ip_frag_tbl>())).max_entries as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_ip_frag_tbl>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_ip_frag_tbl>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const rte_ip_frag_tbl;
+            let field_ptr = std::ptr::addr_of!(struct_instance.max_entries);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         12usize,
         concat!(
@@ -611,9 +889,20 @@ fn bindgen_test_layout_rte_ip_frag_tbl() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_ip_frag_tbl>())).use_entries as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_ip_frag_tbl>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_ip_frag_tbl>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const rte_ip_frag_tbl;
+            let field_ptr = std::ptr::addr_of!(struct_instance.use_entries);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         16usize,
         concat!(
@@ -624,9 +913,20 @@ fn bindgen_test_layout_rte_ip_frag_tbl() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_ip_frag_tbl>())).bucket_entries
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_ip_frag_tbl>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_ip_frag_tbl>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const rte_ip_frag_tbl;
+            let field_ptr = std::ptr::addr_of!(struct_instance.bucket_entries);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         20usize,
         concat!(
@@ -637,9 +937,20 @@ fn bindgen_test_layout_rte_ip_frag_tbl() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_ip_frag_tbl>())).nb_entries as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_ip_frag_tbl>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_ip_frag_tbl>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const rte_ip_frag_tbl;
+            let field_ptr = std::ptr::addr_of!(struct_instance.nb_entries);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         24usize,
         concat!(
@@ -650,9 +961,20 @@ fn bindgen_test_layout_rte_ip_frag_tbl() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_ip_frag_tbl>())).nb_buckets as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_ip_frag_tbl>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_ip_frag_tbl>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const rte_ip_frag_tbl;
+            let field_ptr = std::ptr::addr_of!(struct_instance.nb_buckets);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         28usize,
         concat!(
@@ -663,9 +985,20 @@ fn bindgen_test_layout_rte_ip_frag_tbl() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_ip_frag_tbl>())).last as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_ip_frag_tbl>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_ip_frag_tbl>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const rte_ip_frag_tbl;
+            let field_ptr = std::ptr::addr_of!(struct_instance.last);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         32usize,
         concat!(
@@ -676,8 +1009,20 @@ fn bindgen_test_layout_rte_ip_frag_tbl() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_ip_frag_tbl>())).lru as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_ip_frag_tbl>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_ip_frag_tbl>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const rte_ip_frag_tbl;
+            let field_ptr = std::ptr::addr_of!(struct_instance.lru);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         40usize,
         concat!(
@@ -688,9 +1033,20 @@ fn bindgen_test_layout_rte_ip_frag_tbl() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_ip_frag_tbl>())).stat as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_ip_frag_tbl>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_ip_frag_tbl>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const rte_ip_frag_tbl;
+            let field_ptr = std::ptr::addr_of!(struct_instance.stat);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         64usize,
         concat!(
@@ -701,8 +1057,20 @@ fn bindgen_test_layout_rte_ip_frag_tbl() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_ip_frag_tbl>())).pkt as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_ip_frag_tbl>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_ip_frag_tbl>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const rte_ip_frag_tbl;
+            let field_ptr = std::ptr::addr_of!(struct_instance.pkt);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         128usize,
         concat!(

--- a/tests/expectations/tests/layout_mbuf.rs
+++ b/tests/expectations/tests/layout_mbuf.rs
@@ -117,8 +117,18 @@ fn bindgen_test_layout_rte_atomic16_t() {
         concat!("Alignment of ", stringify!(rte_atomic16_t))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_atomic16_t>())).cnt as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_atomic16_t>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_atomic16_t>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const rte_atomic16_t;
+            let field_ptr = std::ptr::addr_of!(struct_instance.cnt);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -201,32 +211,6 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_1() {
         ::std::mem::align_of::<rte_mbuf__bindgen_ty_1>(),
         2usize,
         concat!("Alignment of ", stringify!(rte_mbuf__bindgen_ty_1))
-    );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_mbuf__bindgen_ty_1>())).refcnt_atomic
-                as *const _ as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mbuf__bindgen_ty_1),
-            "::",
-            stringify!(refcnt_atomic)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_mbuf__bindgen_ty_1>())).refcnt
-                as *const _ as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mbuf__bindgen_ty_1),
-            "::",
-            stringify!(refcnt)
-        )
     );
 }
 impl Default for rte_mbuf__bindgen_ty_1 {
@@ -421,19 +405,6 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_2() {
         4usize,
         concat!("Alignment of ", stringify!(rte_mbuf__bindgen_ty_2))
     );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_mbuf__bindgen_ty_2>())).packet_type
-                as *const _ as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mbuf__bindgen_ty_2),
-            "::",
-            stringify!(packet_type)
-        )
-    );
 }
 impl Default for rte_mbuf__bindgen_ty_2 {
     fn default() -> Self {
@@ -480,8 +451,8 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindg
 ) {
     assert_eq ! (:: std :: mem :: size_of :: < rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1 > () , 4usize , concat ! ("Size of: " , stringify ! (rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1)));
     assert_eq ! (:: std :: mem :: align_of :: < rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1 > () , 2usize , concat ! ("Alignment of " , stringify ! (rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1)));
-    assert_eq ! (unsafe { & (* (:: std :: ptr :: null :: < rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1 > ())) . hash as * const _ as usize } , 0usize , concat ! ("Offset of field: " , stringify ! (rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1) , "::" , stringify ! (hash)));
-    assert_eq ! (unsafe { & (* (:: std :: ptr :: null :: < rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1 > ())) . id as * const _ as usize } , 2usize , concat ! ("Offset of field: " , stringify ! (rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1) , "::" , stringify ! (id)));
+    assert_eq ! ({ const STRUCT_SIZE : usize = std :: mem :: size_of :: < rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1 > () ; let buffer = [0u8 ; STRUCT_SIZE] ; let struct_instance = unsafe { std :: mem :: transmute :: < [u8 ; STRUCT_SIZE] , rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1 > (buffer) } ; let struct_ptr = & struct_instance as * const rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1 ; let field_ptr = std :: ptr :: addr_of ! (struct_instance . hash) ; let struct_address = struct_ptr as usize ; let field_address = field_ptr as usize ; std :: mem :: forget (struct_instance) ; field_address . checked_sub (struct_address) . unwrap () } , 0usize , concat ! ("Offset of field: " , stringify ! (rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1) , "::" , stringify ! (hash)));
+    assert_eq ! ({ const STRUCT_SIZE : usize = std :: mem :: size_of :: < rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1 > () ; let buffer = [0u8 ; STRUCT_SIZE] ; let struct_instance = unsafe { std :: mem :: transmute :: < [u8 ; STRUCT_SIZE] , rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1 > (buffer) } ; let struct_ptr = & struct_instance as * const rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1 ; let field_ptr = std :: ptr :: addr_of ! (struct_instance . id) ; let struct_address = struct_ptr as usize ; let field_address = field_ptr as usize ; std :: mem :: forget (struct_instance) ; field_address . checked_sub (struct_address) . unwrap () } , 2usize , concat ! ("Offset of field: " , stringify ! (rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1) , "::" , stringify ! (id)));
 }
 #[test]
 fn bindgen_test_layout_rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1() {
@@ -502,21 +473,6 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1() {
         concat!(
             "Alignment of ",
             stringify!(rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<
-                rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1,
-            >()))
-            .lo as *const _ as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1),
-            "::",
-            stringify!(lo)
         )
     );
 }
@@ -548,9 +504,23 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_3__bindgen_ty_1() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_mbuf__bindgen_ty_3__bindgen_ty_1>())).hi
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<rte_mbuf__bindgen_ty_3__bindgen_ty_1>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<
+                    [u8; STRUCT_SIZE],
+                    rte_mbuf__bindgen_ty_3__bindgen_ty_1,
+                >(buffer)
+            };
+            let struct_ptr =
+                &struct_instance as *const rte_mbuf__bindgen_ty_3__bindgen_ty_1;
+            let field_ptr = std::ptr::addr_of!(struct_instance.hi);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         4usize,
         concat!(
@@ -595,9 +565,23 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_3__bindgen_ty_2() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_mbuf__bindgen_ty_3__bindgen_ty_2>())).lo
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<rte_mbuf__bindgen_ty_3__bindgen_ty_2>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<
+                    [u8; STRUCT_SIZE],
+                    rte_mbuf__bindgen_ty_3__bindgen_ty_2,
+                >(buffer)
+            };
+            let struct_ptr =
+                &struct_instance as *const rte_mbuf__bindgen_ty_3__bindgen_ty_2;
+            let field_ptr = std::ptr::addr_of!(struct_instance.lo);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -608,9 +592,23 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_3__bindgen_ty_2() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_mbuf__bindgen_ty_3__bindgen_ty_2>())).hi
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<rte_mbuf__bindgen_ty_3__bindgen_ty_2>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<
+                    [u8; STRUCT_SIZE],
+                    rte_mbuf__bindgen_ty_3__bindgen_ty_2,
+                >(buffer)
+            };
+            let struct_ptr =
+                &struct_instance as *const rte_mbuf__bindgen_ty_3__bindgen_ty_2;
+            let field_ptr = std::ptr::addr_of!(struct_instance.hi);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         4usize,
         concat!(
@@ -632,58 +630,6 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_3() {
         ::std::mem::align_of::<rte_mbuf__bindgen_ty_3>(),
         4usize,
         concat!("Alignment of ", stringify!(rte_mbuf__bindgen_ty_3))
-    );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_mbuf__bindgen_ty_3>())).rss as *const _
-                as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mbuf__bindgen_ty_3),
-            "::",
-            stringify!(rss)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_mbuf__bindgen_ty_3>())).fdir as *const _
-                as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mbuf__bindgen_ty_3),
-            "::",
-            stringify!(fdir)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_mbuf__bindgen_ty_3>())).sched as *const _
-                as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mbuf__bindgen_ty_3),
-            "::",
-            stringify!(sched)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_mbuf__bindgen_ty_3>())).usr as *const _
-                as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mbuf__bindgen_ty_3),
-            "::",
-            stringify!(usr)
-        )
     );
 }
 impl Default for rte_mbuf__bindgen_ty_3 {
@@ -714,32 +660,6 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_4() {
         ::std::mem::align_of::<rte_mbuf__bindgen_ty_4>(),
         8usize,
         concat!("Alignment of ", stringify!(rte_mbuf__bindgen_ty_4))
-    );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_mbuf__bindgen_ty_4>())).userdata
-                as *const _ as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mbuf__bindgen_ty_4),
-            "::",
-            stringify!(userdata)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_mbuf__bindgen_ty_4>())).udata64
-                as *const _ as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mbuf__bindgen_ty_4),
-            "::",
-            stringify!(udata64)
-        )
     );
 }
 impl Default for rte_mbuf__bindgen_ty_4 {
@@ -915,19 +835,6 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_5() {
         8usize,
         concat!("Alignment of ", stringify!(rte_mbuf__bindgen_ty_5))
     );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_mbuf__bindgen_ty_5>())).tx_offload
-                as *const _ as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mbuf__bindgen_ty_5),
-            "::",
-            stringify!(tx_offload)
-        )
-    );
 }
 impl Default for rte_mbuf__bindgen_ty_5 {
     fn default() -> Self {
@@ -951,8 +858,18 @@ fn bindgen_test_layout_rte_mbuf() {
         concat!("Alignment of ", stringify!(rte_mbuf))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_mbuf>())).cacheline0 as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_mbuf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_mbuf>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const rte_mbuf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.cacheline0);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -963,8 +880,18 @@ fn bindgen_test_layout_rte_mbuf() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_mbuf>())).buf_addr as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_mbuf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_mbuf>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const rte_mbuf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.buf_addr);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -975,9 +902,18 @@ fn bindgen_test_layout_rte_mbuf() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_mbuf>())).buf_physaddr as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_mbuf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_mbuf>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const rte_mbuf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.buf_physaddr);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         8usize,
         concat!(
@@ -988,8 +924,18 @@ fn bindgen_test_layout_rte_mbuf() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_mbuf>())).buf_len as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_mbuf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_mbuf>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const rte_mbuf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.buf_len);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         16usize,
         concat!(
@@ -1000,8 +946,18 @@ fn bindgen_test_layout_rte_mbuf() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_mbuf>())).rearm_data as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_mbuf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_mbuf>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const rte_mbuf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.rearm_data);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         18usize,
         concat!(
@@ -1012,8 +968,18 @@ fn bindgen_test_layout_rte_mbuf() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_mbuf>())).data_off as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_mbuf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_mbuf>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const rte_mbuf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.data_off);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         18usize,
         concat!(
@@ -1024,8 +990,18 @@ fn bindgen_test_layout_rte_mbuf() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_mbuf>())).nb_segs as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_mbuf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_mbuf>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const rte_mbuf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.nb_segs);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         22usize,
         concat!(
@@ -1036,8 +1012,18 @@ fn bindgen_test_layout_rte_mbuf() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_mbuf>())).port as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_mbuf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_mbuf>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const rte_mbuf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.port);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         23usize,
         concat!(
@@ -1048,8 +1034,18 @@ fn bindgen_test_layout_rte_mbuf() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_mbuf>())).ol_flags as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_mbuf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_mbuf>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const rte_mbuf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.ol_flags);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         24usize,
         concat!(
@@ -1060,9 +1056,19 @@ fn bindgen_test_layout_rte_mbuf() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_mbuf>())).rx_descriptor_fields1
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_mbuf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_mbuf>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const rte_mbuf;
+            let field_ptr =
+                std::ptr::addr_of!(struct_instance.rx_descriptor_fields1);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         32usize,
         concat!(
@@ -1073,8 +1079,18 @@ fn bindgen_test_layout_rte_mbuf() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_mbuf>())).pkt_len as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_mbuf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_mbuf>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const rte_mbuf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.pkt_len);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         36usize,
         concat!(
@@ -1085,8 +1101,18 @@ fn bindgen_test_layout_rte_mbuf() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_mbuf>())).data_len as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_mbuf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_mbuf>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const rte_mbuf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.data_len);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         40usize,
         concat!(
@@ -1097,8 +1123,18 @@ fn bindgen_test_layout_rte_mbuf() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_mbuf>())).vlan_tci as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_mbuf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_mbuf>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const rte_mbuf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.vlan_tci);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         42usize,
         concat!(
@@ -1109,8 +1145,18 @@ fn bindgen_test_layout_rte_mbuf() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_mbuf>())).hash as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_mbuf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_mbuf>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const rte_mbuf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.hash);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         44usize,
         concat!(
@@ -1121,8 +1167,18 @@ fn bindgen_test_layout_rte_mbuf() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_mbuf>())).seqn as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_mbuf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_mbuf>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const rte_mbuf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.seqn);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         52usize,
         concat!(
@@ -1133,9 +1189,18 @@ fn bindgen_test_layout_rte_mbuf() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_mbuf>())).vlan_tci_outer as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_mbuf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_mbuf>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const rte_mbuf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.vlan_tci_outer);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         56usize,
         concat!(
@@ -1146,8 +1211,18 @@ fn bindgen_test_layout_rte_mbuf() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_mbuf>())).cacheline1 as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_mbuf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_mbuf>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const rte_mbuf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.cacheline1);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         64usize,
         concat!(
@@ -1158,8 +1233,18 @@ fn bindgen_test_layout_rte_mbuf() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_mbuf>())).pool as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_mbuf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_mbuf>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const rte_mbuf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.pool);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         72usize,
         concat!(
@@ -1170,8 +1255,18 @@ fn bindgen_test_layout_rte_mbuf() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_mbuf>())).next as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_mbuf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_mbuf>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const rte_mbuf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.next);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         80usize,
         concat!(
@@ -1182,8 +1277,18 @@ fn bindgen_test_layout_rte_mbuf() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_mbuf>())).priv_size as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_mbuf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_mbuf>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const rte_mbuf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.priv_size);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         96usize,
         concat!(
@@ -1194,8 +1299,18 @@ fn bindgen_test_layout_rte_mbuf() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_mbuf>())).timesync as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_mbuf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_mbuf>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const rte_mbuf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.timesync);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         98usize,
         concat!(

--- a/tests/expectations/tests/layout_mbuf.rs
+++ b/tests/expectations/tests/layout_mbuf.rs
@@ -118,11 +118,8 @@ fn bindgen_test_layout_rte_atomic16_t() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_atomic16_t>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_atomic16_t>(buffer)
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_atomic16_t>() };
             let struct_ptr = &struct_instance as *const rte_atomic16_t;
             let field_ptr = std::ptr::addr_of!(struct_instance.cnt);
             let struct_address = struct_ptr as usize;
@@ -451,8 +448,8 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindg
 ) {
     assert_eq ! (:: std :: mem :: size_of :: < rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1 > () , 4usize , concat ! ("Size of: " , stringify ! (rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1)));
     assert_eq ! (:: std :: mem :: align_of :: < rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1 > () , 2usize , concat ! ("Alignment of " , stringify ! (rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1)));
-    assert_eq ! ({ const STRUCT_SIZE : usize = std :: mem :: size_of :: < rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1 > () ; let buffer = [0u8 ; STRUCT_SIZE] ; let struct_instance = unsafe { std :: mem :: transmute :: < [u8 ; STRUCT_SIZE] , rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1 > (buffer) } ; let struct_ptr = & struct_instance as * const rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1 ; let field_ptr = std :: ptr :: addr_of ! (struct_instance . hash) ; let struct_address = struct_ptr as usize ; let field_address = field_ptr as usize ; std :: mem :: forget (struct_instance) ; field_address . checked_sub (struct_address) . unwrap () } , 0usize , concat ! ("Offset of field: " , stringify ! (rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1) , "::" , stringify ! (hash)));
-    assert_eq ! ({ const STRUCT_SIZE : usize = std :: mem :: size_of :: < rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1 > () ; let buffer = [0u8 ; STRUCT_SIZE] ; let struct_instance = unsafe { std :: mem :: transmute :: < [u8 ; STRUCT_SIZE] , rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1 > (buffer) } ; let struct_ptr = & struct_instance as * const rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1 ; let field_ptr = std :: ptr :: addr_of ! (struct_instance . id) ; let struct_address = struct_ptr as usize ; let field_address = field_ptr as usize ; std :: mem :: forget (struct_instance) ; field_address . checked_sub (struct_address) . unwrap () } , 2usize , concat ! ("Offset of field: " , stringify ! (rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1) , "::" , stringify ! (id)));
+    assert_eq ! ({ let struct_instance = unsafe { std :: mem :: zeroed :: < rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1 > () } ; let struct_ptr = & struct_instance as * const rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1 ; let field_ptr = std :: ptr :: addr_of ! (struct_instance . hash) ; let struct_address = struct_ptr as usize ; let field_address = field_ptr as usize ; std :: mem :: forget (struct_instance) ; field_address . checked_sub (struct_address) . unwrap () } , 0usize , concat ! ("Offset of field: " , stringify ! (rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1) , "::" , stringify ! (hash)));
+    assert_eq ! ({ let struct_instance = unsafe { std :: mem :: zeroed :: < rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1 > () } ; let struct_ptr = & struct_instance as * const rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1 ; let field_ptr = std :: ptr :: addr_of ! (struct_instance . id) ; let struct_address = struct_ptr as usize ; let field_address = field_ptr as usize ; std :: mem :: forget (struct_instance) ; field_address . checked_sub (struct_address) . unwrap () } , 2usize , concat ! ("Offset of field: " , stringify ! (rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1) , "::" , stringify ! (id)));
 }
 #[test]
 fn bindgen_test_layout_rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1() {
@@ -505,14 +502,8 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_3__bindgen_ty_1() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<rte_mbuf__bindgen_ty_3__bindgen_ty_1>();
-            let buffer = [0u8; STRUCT_SIZE];
             let struct_instance = unsafe {
-                std::mem::transmute::<
-                    [u8; STRUCT_SIZE],
-                    rte_mbuf__bindgen_ty_3__bindgen_ty_1,
-                >(buffer)
+                std::mem::zeroed::<rte_mbuf__bindgen_ty_3__bindgen_ty_1>()
             };
             let struct_ptr =
                 &struct_instance as *const rte_mbuf__bindgen_ty_3__bindgen_ty_1;
@@ -566,14 +557,8 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_3__bindgen_ty_2() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<rte_mbuf__bindgen_ty_3__bindgen_ty_2>();
-            let buffer = [0u8; STRUCT_SIZE];
             let struct_instance = unsafe {
-                std::mem::transmute::<
-                    [u8; STRUCT_SIZE],
-                    rte_mbuf__bindgen_ty_3__bindgen_ty_2,
-                >(buffer)
+                std::mem::zeroed::<rte_mbuf__bindgen_ty_3__bindgen_ty_2>()
             };
             let struct_ptr =
                 &struct_instance as *const rte_mbuf__bindgen_ty_3__bindgen_ty_2;
@@ -593,14 +578,8 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_3__bindgen_ty_2() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<rte_mbuf__bindgen_ty_3__bindgen_ty_2>();
-            let buffer = [0u8; STRUCT_SIZE];
             let struct_instance = unsafe {
-                std::mem::transmute::<
-                    [u8; STRUCT_SIZE],
-                    rte_mbuf__bindgen_ty_3__bindgen_ty_2,
-                >(buffer)
+                std::mem::zeroed::<rte_mbuf__bindgen_ty_3__bindgen_ty_2>()
             };
             let struct_ptr =
                 &struct_instance as *const rte_mbuf__bindgen_ty_3__bindgen_ty_2;
@@ -859,11 +838,7 @@ fn bindgen_test_layout_rte_mbuf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_mbuf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_mbuf>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<rte_mbuf>() };
             let struct_ptr = &struct_instance as *const rte_mbuf;
             let field_ptr = std::ptr::addr_of!(struct_instance.cacheline0);
             let struct_address = struct_ptr as usize;
@@ -881,11 +856,7 @@ fn bindgen_test_layout_rte_mbuf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_mbuf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_mbuf>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<rte_mbuf>() };
             let struct_ptr = &struct_instance as *const rte_mbuf;
             let field_ptr = std::ptr::addr_of!(struct_instance.buf_addr);
             let struct_address = struct_ptr as usize;
@@ -903,11 +874,7 @@ fn bindgen_test_layout_rte_mbuf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_mbuf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_mbuf>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<rte_mbuf>() };
             let struct_ptr = &struct_instance as *const rte_mbuf;
             let field_ptr = std::ptr::addr_of!(struct_instance.buf_physaddr);
             let struct_address = struct_ptr as usize;
@@ -925,11 +892,7 @@ fn bindgen_test_layout_rte_mbuf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_mbuf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_mbuf>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<rte_mbuf>() };
             let struct_ptr = &struct_instance as *const rte_mbuf;
             let field_ptr = std::ptr::addr_of!(struct_instance.buf_len);
             let struct_address = struct_ptr as usize;
@@ -947,11 +910,7 @@ fn bindgen_test_layout_rte_mbuf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_mbuf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_mbuf>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<rte_mbuf>() };
             let struct_ptr = &struct_instance as *const rte_mbuf;
             let field_ptr = std::ptr::addr_of!(struct_instance.rearm_data);
             let struct_address = struct_ptr as usize;
@@ -969,11 +928,7 @@ fn bindgen_test_layout_rte_mbuf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_mbuf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_mbuf>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<rte_mbuf>() };
             let struct_ptr = &struct_instance as *const rte_mbuf;
             let field_ptr = std::ptr::addr_of!(struct_instance.data_off);
             let struct_address = struct_ptr as usize;
@@ -991,11 +946,7 @@ fn bindgen_test_layout_rte_mbuf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_mbuf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_mbuf>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<rte_mbuf>() };
             let struct_ptr = &struct_instance as *const rte_mbuf;
             let field_ptr = std::ptr::addr_of!(struct_instance.nb_segs);
             let struct_address = struct_ptr as usize;
@@ -1013,11 +964,7 @@ fn bindgen_test_layout_rte_mbuf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_mbuf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_mbuf>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<rte_mbuf>() };
             let struct_ptr = &struct_instance as *const rte_mbuf;
             let field_ptr = std::ptr::addr_of!(struct_instance.port);
             let struct_address = struct_ptr as usize;
@@ -1035,11 +982,7 @@ fn bindgen_test_layout_rte_mbuf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_mbuf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_mbuf>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<rte_mbuf>() };
             let struct_ptr = &struct_instance as *const rte_mbuf;
             let field_ptr = std::ptr::addr_of!(struct_instance.ol_flags);
             let struct_address = struct_ptr as usize;
@@ -1057,11 +1000,7 @@ fn bindgen_test_layout_rte_mbuf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_mbuf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_mbuf>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<rte_mbuf>() };
             let struct_ptr = &struct_instance as *const rte_mbuf;
             let field_ptr =
                 std::ptr::addr_of!(struct_instance.rx_descriptor_fields1);
@@ -1080,11 +1019,7 @@ fn bindgen_test_layout_rte_mbuf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_mbuf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_mbuf>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<rte_mbuf>() };
             let struct_ptr = &struct_instance as *const rte_mbuf;
             let field_ptr = std::ptr::addr_of!(struct_instance.pkt_len);
             let struct_address = struct_ptr as usize;
@@ -1102,11 +1037,7 @@ fn bindgen_test_layout_rte_mbuf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_mbuf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_mbuf>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<rte_mbuf>() };
             let struct_ptr = &struct_instance as *const rte_mbuf;
             let field_ptr = std::ptr::addr_of!(struct_instance.data_len);
             let struct_address = struct_ptr as usize;
@@ -1124,11 +1055,7 @@ fn bindgen_test_layout_rte_mbuf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_mbuf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_mbuf>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<rte_mbuf>() };
             let struct_ptr = &struct_instance as *const rte_mbuf;
             let field_ptr = std::ptr::addr_of!(struct_instance.vlan_tci);
             let struct_address = struct_ptr as usize;
@@ -1146,11 +1073,7 @@ fn bindgen_test_layout_rte_mbuf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_mbuf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_mbuf>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<rte_mbuf>() };
             let struct_ptr = &struct_instance as *const rte_mbuf;
             let field_ptr = std::ptr::addr_of!(struct_instance.hash);
             let struct_address = struct_ptr as usize;
@@ -1168,11 +1091,7 @@ fn bindgen_test_layout_rte_mbuf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_mbuf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_mbuf>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<rte_mbuf>() };
             let struct_ptr = &struct_instance as *const rte_mbuf;
             let field_ptr = std::ptr::addr_of!(struct_instance.seqn);
             let struct_address = struct_ptr as usize;
@@ -1190,11 +1109,7 @@ fn bindgen_test_layout_rte_mbuf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_mbuf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_mbuf>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<rte_mbuf>() };
             let struct_ptr = &struct_instance as *const rte_mbuf;
             let field_ptr = std::ptr::addr_of!(struct_instance.vlan_tci_outer);
             let struct_address = struct_ptr as usize;
@@ -1212,11 +1127,7 @@ fn bindgen_test_layout_rte_mbuf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_mbuf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_mbuf>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<rte_mbuf>() };
             let struct_ptr = &struct_instance as *const rte_mbuf;
             let field_ptr = std::ptr::addr_of!(struct_instance.cacheline1);
             let struct_address = struct_ptr as usize;
@@ -1234,11 +1145,7 @@ fn bindgen_test_layout_rte_mbuf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_mbuf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_mbuf>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<rte_mbuf>() };
             let struct_ptr = &struct_instance as *const rte_mbuf;
             let field_ptr = std::ptr::addr_of!(struct_instance.pool);
             let struct_address = struct_ptr as usize;
@@ -1256,11 +1163,7 @@ fn bindgen_test_layout_rte_mbuf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_mbuf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_mbuf>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<rte_mbuf>() };
             let struct_ptr = &struct_instance as *const rte_mbuf;
             let field_ptr = std::ptr::addr_of!(struct_instance.next);
             let struct_address = struct_ptr as usize;
@@ -1278,11 +1181,7 @@ fn bindgen_test_layout_rte_mbuf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_mbuf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_mbuf>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<rte_mbuf>() };
             let struct_ptr = &struct_instance as *const rte_mbuf;
             let field_ptr = std::ptr::addr_of!(struct_instance.priv_size);
             let struct_address = struct_ptr as usize;
@@ -1300,11 +1199,7 @@ fn bindgen_test_layout_rte_mbuf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_mbuf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_mbuf>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<rte_mbuf>() };
             let struct_ptr = &struct_instance as *const rte_mbuf;
             let field_ptr = std::ptr::addr_of!(struct_instance.timesync);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/layout_mbuf_1_0.rs
+++ b/tests/expectations/tests/layout_mbuf_1_0.rs
@@ -161,11 +161,8 @@ fn bindgen_test_layout_rte_atomic16_t() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_atomic16_t>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_atomic16_t>(buffer)
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_atomic16_t>() };
             let struct_ptr = &struct_instance as *const rte_atomic16_t;
             let field_ptr = std::ptr::addr_of!(struct_instance.cnt);
             let struct_address = struct_ptr as usize;
@@ -502,8 +499,8 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindg
 ) {
     assert_eq ! (:: std :: mem :: size_of :: < rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1 > () , 4usize , concat ! ("Size of: " , stringify ! (rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1)));
     assert_eq ! (:: std :: mem :: align_of :: < rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1 > () , 2usize , concat ! ("Alignment of " , stringify ! (rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1)));
-    assert_eq ! ({ const STRUCT_SIZE : usize = std :: mem :: size_of :: < rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1 > () ; let buffer = [0u8 ; STRUCT_SIZE] ; let struct_instance = unsafe { std :: mem :: transmute :: < [u8 ; STRUCT_SIZE] , rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1 > (buffer) } ; let struct_ptr = & struct_instance as * const rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1 ; let field_ptr = std :: ptr :: addr_of ! (struct_instance . hash) ; let struct_address = struct_ptr as usize ; let field_address = field_ptr as usize ; std :: mem :: forget (struct_instance) ; field_address . checked_sub (struct_address) . unwrap () } , 0usize , concat ! ("Offset of field: " , stringify ! (rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1) , "::" , stringify ! (hash)));
-    assert_eq ! ({ const STRUCT_SIZE : usize = std :: mem :: size_of :: < rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1 > () ; let buffer = [0u8 ; STRUCT_SIZE] ; let struct_instance = unsafe { std :: mem :: transmute :: < [u8 ; STRUCT_SIZE] , rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1 > (buffer) } ; let struct_ptr = & struct_instance as * const rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1 ; let field_ptr = std :: ptr :: addr_of ! (struct_instance . id) ; let struct_address = struct_ptr as usize ; let field_address = field_ptr as usize ; std :: mem :: forget (struct_instance) ; field_address . checked_sub (struct_address) . unwrap () } , 2usize , concat ! ("Offset of field: " , stringify ! (rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1) , "::" , stringify ! (id)));
+    assert_eq ! ({ let struct_instance = unsafe { std :: mem :: zeroed :: < rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1 > () } ; let struct_ptr = & struct_instance as * const rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1 ; let field_ptr = std :: ptr :: addr_of ! (struct_instance . hash) ; let struct_address = struct_ptr as usize ; let field_address = field_ptr as usize ; std :: mem :: forget (struct_instance) ; field_address . checked_sub (struct_address) . unwrap () } , 0usize , concat ! ("Offset of field: " , stringify ! (rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1) , "::" , stringify ! (hash)));
+    assert_eq ! ({ let struct_instance = unsafe { std :: mem :: zeroed :: < rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1 > () } ; let struct_ptr = & struct_instance as * const rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1 ; let field_ptr = std :: ptr :: addr_of ! (struct_instance . id) ; let struct_address = struct_ptr as usize ; let field_address = field_ptr as usize ; std :: mem :: forget (struct_instance) ; field_address . checked_sub (struct_address) . unwrap () } , 2usize , concat ! ("Offset of field: " , stringify ! (rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1) , "::" , stringify ! (id)));
 }
 impl Clone
     for rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1
@@ -559,14 +556,8 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_3__bindgen_ty_1() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<rte_mbuf__bindgen_ty_3__bindgen_ty_1>();
-            let buffer = [0u8; STRUCT_SIZE];
             let struct_instance = unsafe {
-                std::mem::transmute::<
-                    [u8; STRUCT_SIZE],
-                    rte_mbuf__bindgen_ty_3__bindgen_ty_1,
-                >(buffer)
+                std::mem::zeroed::<rte_mbuf__bindgen_ty_3__bindgen_ty_1>()
             };
             let struct_ptr =
                 &struct_instance as *const rte_mbuf__bindgen_ty_3__bindgen_ty_1;
@@ -616,14 +607,8 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_3__bindgen_ty_2() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<rte_mbuf__bindgen_ty_3__bindgen_ty_2>();
-            let buffer = [0u8; STRUCT_SIZE];
             let struct_instance = unsafe {
-                std::mem::transmute::<
-                    [u8; STRUCT_SIZE],
-                    rte_mbuf__bindgen_ty_3__bindgen_ty_2,
-                >(buffer)
+                std::mem::zeroed::<rte_mbuf__bindgen_ty_3__bindgen_ty_2>()
             };
             let struct_ptr =
                 &struct_instance as *const rte_mbuf__bindgen_ty_3__bindgen_ty_2;
@@ -643,14 +628,8 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_3__bindgen_ty_2() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<rte_mbuf__bindgen_ty_3__bindgen_ty_2>();
-            let buffer = [0u8; STRUCT_SIZE];
             let struct_instance = unsafe {
-                std::mem::transmute::<
-                    [u8; STRUCT_SIZE],
-                    rte_mbuf__bindgen_ty_3__bindgen_ty_2,
-                >(buffer)
+                std::mem::zeroed::<rte_mbuf__bindgen_ty_3__bindgen_ty_2>()
             };
             let struct_ptr =
                 &struct_instance as *const rte_mbuf__bindgen_ty_3__bindgen_ty_2;
@@ -905,11 +884,7 @@ fn bindgen_test_layout_rte_mbuf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_mbuf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_mbuf>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<rte_mbuf>() };
             let struct_ptr = &struct_instance as *const rte_mbuf;
             let field_ptr = std::ptr::addr_of!(struct_instance.cacheline0);
             let struct_address = struct_ptr as usize;
@@ -927,11 +902,7 @@ fn bindgen_test_layout_rte_mbuf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_mbuf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_mbuf>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<rte_mbuf>() };
             let struct_ptr = &struct_instance as *const rte_mbuf;
             let field_ptr = std::ptr::addr_of!(struct_instance.buf_addr);
             let struct_address = struct_ptr as usize;
@@ -949,11 +920,7 @@ fn bindgen_test_layout_rte_mbuf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_mbuf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_mbuf>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<rte_mbuf>() };
             let struct_ptr = &struct_instance as *const rte_mbuf;
             let field_ptr = std::ptr::addr_of!(struct_instance.buf_physaddr);
             let struct_address = struct_ptr as usize;
@@ -971,11 +938,7 @@ fn bindgen_test_layout_rte_mbuf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_mbuf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_mbuf>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<rte_mbuf>() };
             let struct_ptr = &struct_instance as *const rte_mbuf;
             let field_ptr = std::ptr::addr_of!(struct_instance.buf_len);
             let struct_address = struct_ptr as usize;
@@ -993,11 +956,7 @@ fn bindgen_test_layout_rte_mbuf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_mbuf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_mbuf>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<rte_mbuf>() };
             let struct_ptr = &struct_instance as *const rte_mbuf;
             let field_ptr = std::ptr::addr_of!(struct_instance.rearm_data);
             let struct_address = struct_ptr as usize;
@@ -1015,11 +974,7 @@ fn bindgen_test_layout_rte_mbuf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_mbuf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_mbuf>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<rte_mbuf>() };
             let struct_ptr = &struct_instance as *const rte_mbuf;
             let field_ptr = std::ptr::addr_of!(struct_instance.data_off);
             let struct_address = struct_ptr as usize;
@@ -1037,11 +992,7 @@ fn bindgen_test_layout_rte_mbuf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_mbuf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_mbuf>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<rte_mbuf>() };
             let struct_ptr = &struct_instance as *const rte_mbuf;
             let field_ptr = std::ptr::addr_of!(struct_instance.nb_segs);
             let struct_address = struct_ptr as usize;
@@ -1059,11 +1010,7 @@ fn bindgen_test_layout_rte_mbuf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_mbuf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_mbuf>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<rte_mbuf>() };
             let struct_ptr = &struct_instance as *const rte_mbuf;
             let field_ptr = std::ptr::addr_of!(struct_instance.port);
             let struct_address = struct_ptr as usize;
@@ -1081,11 +1028,7 @@ fn bindgen_test_layout_rte_mbuf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_mbuf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_mbuf>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<rte_mbuf>() };
             let struct_ptr = &struct_instance as *const rte_mbuf;
             let field_ptr = std::ptr::addr_of!(struct_instance.ol_flags);
             let struct_address = struct_ptr as usize;
@@ -1103,11 +1046,7 @@ fn bindgen_test_layout_rte_mbuf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_mbuf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_mbuf>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<rte_mbuf>() };
             let struct_ptr = &struct_instance as *const rte_mbuf;
             let field_ptr =
                 std::ptr::addr_of!(struct_instance.rx_descriptor_fields1);
@@ -1126,11 +1065,7 @@ fn bindgen_test_layout_rte_mbuf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_mbuf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_mbuf>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<rte_mbuf>() };
             let struct_ptr = &struct_instance as *const rte_mbuf;
             let field_ptr = std::ptr::addr_of!(struct_instance.pkt_len);
             let struct_address = struct_ptr as usize;
@@ -1148,11 +1083,7 @@ fn bindgen_test_layout_rte_mbuf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_mbuf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_mbuf>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<rte_mbuf>() };
             let struct_ptr = &struct_instance as *const rte_mbuf;
             let field_ptr = std::ptr::addr_of!(struct_instance.data_len);
             let struct_address = struct_ptr as usize;
@@ -1170,11 +1101,7 @@ fn bindgen_test_layout_rte_mbuf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_mbuf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_mbuf>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<rte_mbuf>() };
             let struct_ptr = &struct_instance as *const rte_mbuf;
             let field_ptr = std::ptr::addr_of!(struct_instance.vlan_tci);
             let struct_address = struct_ptr as usize;
@@ -1192,11 +1119,7 @@ fn bindgen_test_layout_rte_mbuf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_mbuf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_mbuf>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<rte_mbuf>() };
             let struct_ptr = &struct_instance as *const rte_mbuf;
             let field_ptr = std::ptr::addr_of!(struct_instance.hash);
             let struct_address = struct_ptr as usize;
@@ -1214,11 +1137,7 @@ fn bindgen_test_layout_rte_mbuf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_mbuf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_mbuf>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<rte_mbuf>() };
             let struct_ptr = &struct_instance as *const rte_mbuf;
             let field_ptr = std::ptr::addr_of!(struct_instance.seqn);
             let struct_address = struct_ptr as usize;
@@ -1236,11 +1155,7 @@ fn bindgen_test_layout_rte_mbuf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_mbuf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_mbuf>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<rte_mbuf>() };
             let struct_ptr = &struct_instance as *const rte_mbuf;
             let field_ptr = std::ptr::addr_of!(struct_instance.vlan_tci_outer);
             let struct_address = struct_ptr as usize;
@@ -1258,11 +1173,7 @@ fn bindgen_test_layout_rte_mbuf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_mbuf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_mbuf>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<rte_mbuf>() };
             let struct_ptr = &struct_instance as *const rte_mbuf;
             let field_ptr = std::ptr::addr_of!(struct_instance.cacheline1);
             let struct_address = struct_ptr as usize;
@@ -1280,11 +1191,7 @@ fn bindgen_test_layout_rte_mbuf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_mbuf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_mbuf>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<rte_mbuf>() };
             let struct_ptr = &struct_instance as *const rte_mbuf;
             let field_ptr = std::ptr::addr_of!(struct_instance.pool);
             let struct_address = struct_ptr as usize;
@@ -1302,11 +1209,7 @@ fn bindgen_test_layout_rte_mbuf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_mbuf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_mbuf>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<rte_mbuf>() };
             let struct_ptr = &struct_instance as *const rte_mbuf;
             let field_ptr = std::ptr::addr_of!(struct_instance.next);
             let struct_address = struct_ptr as usize;
@@ -1324,11 +1227,7 @@ fn bindgen_test_layout_rte_mbuf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_mbuf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_mbuf>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<rte_mbuf>() };
             let struct_ptr = &struct_instance as *const rte_mbuf;
             let field_ptr = std::ptr::addr_of!(struct_instance.priv_size);
             let struct_address = struct_ptr as usize;
@@ -1346,11 +1245,7 @@ fn bindgen_test_layout_rte_mbuf() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_mbuf>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_mbuf>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<rte_mbuf>() };
             let struct_ptr = &struct_instance as *const rte_mbuf;
             let field_ptr = std::ptr::addr_of!(struct_instance.timesync);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/layout_mbuf_1_0.rs
+++ b/tests/expectations/tests/layout_mbuf_1_0.rs
@@ -160,8 +160,18 @@ fn bindgen_test_layout_rte_atomic16_t() {
         concat!("Alignment of ", stringify!(rte_atomic16_t))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_atomic16_t>())).cnt as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_atomic16_t>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_atomic16_t>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const rte_atomic16_t;
+            let field_ptr = std::ptr::addr_of!(struct_instance.cnt);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -250,32 +260,6 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_1() {
         ::std::mem::align_of::<rte_mbuf__bindgen_ty_1>(),
         2usize,
         concat!("Alignment of ", stringify!(rte_mbuf__bindgen_ty_1))
-    );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_mbuf__bindgen_ty_1>())).refcnt_atomic
-                as *const _ as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mbuf__bindgen_ty_1),
-            "::",
-            stringify!(refcnt_atomic)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_mbuf__bindgen_ty_1>())).refcnt
-                as *const _ as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mbuf__bindgen_ty_1),
-            "::",
-            stringify!(refcnt)
-        )
     );
 }
 impl Clone for rte_mbuf__bindgen_ty_1 {
@@ -473,19 +457,6 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_2() {
         4usize,
         concat!("Alignment of ", stringify!(rte_mbuf__bindgen_ty_2))
     );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_mbuf__bindgen_ty_2>())).packet_type
-                as *const _ as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mbuf__bindgen_ty_2),
-            "::",
-            stringify!(packet_type)
-        )
-    );
 }
 impl Clone for rte_mbuf__bindgen_ty_2 {
     fn clone(&self) -> Self {
@@ -531,8 +502,8 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindg
 ) {
     assert_eq ! (:: std :: mem :: size_of :: < rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1 > () , 4usize , concat ! ("Size of: " , stringify ! (rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1)));
     assert_eq ! (:: std :: mem :: align_of :: < rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1 > () , 2usize , concat ! ("Alignment of " , stringify ! (rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1)));
-    assert_eq ! (unsafe { & (* (:: std :: ptr :: null :: < rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1 > ())) . hash as * const _ as usize } , 0usize , concat ! ("Offset of field: " , stringify ! (rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1) , "::" , stringify ! (hash)));
-    assert_eq ! (unsafe { & (* (:: std :: ptr :: null :: < rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1 > ())) . id as * const _ as usize } , 2usize , concat ! ("Offset of field: " , stringify ! (rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1) , "::" , stringify ! (id)));
+    assert_eq ! ({ const STRUCT_SIZE : usize = std :: mem :: size_of :: < rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1 > () ; let buffer = [0u8 ; STRUCT_SIZE] ; let struct_instance = unsafe { std :: mem :: transmute :: < [u8 ; STRUCT_SIZE] , rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1 > (buffer) } ; let struct_ptr = & struct_instance as * const rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1 ; let field_ptr = std :: ptr :: addr_of ! (struct_instance . hash) ; let struct_address = struct_ptr as usize ; let field_address = field_ptr as usize ; std :: mem :: forget (struct_instance) ; field_address . checked_sub (struct_address) . unwrap () } , 0usize , concat ! ("Offset of field: " , stringify ! (rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1) , "::" , stringify ! (hash)));
+    assert_eq ! ({ const STRUCT_SIZE : usize = std :: mem :: size_of :: < rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1 > () ; let buffer = [0u8 ; STRUCT_SIZE] ; let struct_instance = unsafe { std :: mem :: transmute :: < [u8 ; STRUCT_SIZE] , rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1 > (buffer) } ; let struct_ptr = & struct_instance as * const rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1 ; let field_ptr = std :: ptr :: addr_of ! (struct_instance . id) ; let struct_address = struct_ptr as usize ; let field_address = field_ptr as usize ; std :: mem :: forget (struct_instance) ; field_address . checked_sub (struct_address) . unwrap () } , 2usize , concat ! ("Offset of field: " , stringify ! (rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1) , "::" , stringify ! (id)));
 }
 impl Clone
     for rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1
@@ -562,21 +533,6 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1() {
             stringify!(rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1)
         )
     );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<
-                rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1,
-            >()))
-            .lo as *const _ as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1),
-            "::",
-            stringify!(lo)
-        )
-    );
 }
 impl Clone for rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1 {
     fn clone(&self) -> Self {
@@ -602,9 +558,23 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_3__bindgen_ty_1() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_mbuf__bindgen_ty_3__bindgen_ty_1>())).hi
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<rte_mbuf__bindgen_ty_3__bindgen_ty_1>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<
+                    [u8; STRUCT_SIZE],
+                    rte_mbuf__bindgen_ty_3__bindgen_ty_1,
+                >(buffer)
+            };
+            let struct_ptr =
+                &struct_instance as *const rte_mbuf__bindgen_ty_3__bindgen_ty_1;
+            let field_ptr = std::ptr::addr_of!(struct_instance.hi);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         4usize,
         concat!(
@@ -645,9 +615,23 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_3__bindgen_ty_2() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_mbuf__bindgen_ty_3__bindgen_ty_2>())).lo
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<rte_mbuf__bindgen_ty_3__bindgen_ty_2>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<
+                    [u8; STRUCT_SIZE],
+                    rte_mbuf__bindgen_ty_3__bindgen_ty_2,
+                >(buffer)
+            };
+            let struct_ptr =
+                &struct_instance as *const rte_mbuf__bindgen_ty_3__bindgen_ty_2;
+            let field_ptr = std::ptr::addr_of!(struct_instance.lo);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -658,9 +642,23 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_3__bindgen_ty_2() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_mbuf__bindgen_ty_3__bindgen_ty_2>())).hi
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<rte_mbuf__bindgen_ty_3__bindgen_ty_2>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<
+                    [u8; STRUCT_SIZE],
+                    rte_mbuf__bindgen_ty_3__bindgen_ty_2,
+                >(buffer)
+            };
+            let struct_ptr =
+                &struct_instance as *const rte_mbuf__bindgen_ty_3__bindgen_ty_2;
+            let field_ptr = std::ptr::addr_of!(struct_instance.hi);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         4usize,
         concat!(
@@ -688,58 +686,6 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_3() {
         4usize,
         concat!("Alignment of ", stringify!(rte_mbuf__bindgen_ty_3))
     );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_mbuf__bindgen_ty_3>())).rss as *const _
-                as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mbuf__bindgen_ty_3),
-            "::",
-            stringify!(rss)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_mbuf__bindgen_ty_3>())).fdir as *const _
-                as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mbuf__bindgen_ty_3),
-            "::",
-            stringify!(fdir)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_mbuf__bindgen_ty_3>())).sched as *const _
-                as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mbuf__bindgen_ty_3),
-            "::",
-            stringify!(sched)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_mbuf__bindgen_ty_3>())).usr as *const _
-                as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mbuf__bindgen_ty_3),
-            "::",
-            stringify!(usr)
-        )
-    );
 }
 impl Clone for rte_mbuf__bindgen_ty_3 {
     fn clone(&self) -> Self {
@@ -766,32 +712,6 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_4() {
         ::std::mem::align_of::<rte_mbuf__bindgen_ty_4>(),
         8usize,
         concat!("Alignment of ", stringify!(rte_mbuf__bindgen_ty_4))
-    );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_mbuf__bindgen_ty_4>())).userdata
-                as *const _ as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mbuf__bindgen_ty_4),
-            "::",
-            stringify!(userdata)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_mbuf__bindgen_ty_4>())).udata64
-                as *const _ as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mbuf__bindgen_ty_4),
-            "::",
-            stringify!(udata64)
-        )
     );
 }
 impl Clone for rte_mbuf__bindgen_ty_4 {
@@ -970,19 +890,6 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_5() {
         8usize,
         concat!("Alignment of ", stringify!(rte_mbuf__bindgen_ty_5))
     );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_mbuf__bindgen_ty_5>())).tx_offload
-                as *const _ as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mbuf__bindgen_ty_5),
-            "::",
-            stringify!(tx_offload)
-        )
-    );
 }
 impl Clone for rte_mbuf__bindgen_ty_5 {
     fn clone(&self) -> Self {
@@ -997,8 +904,18 @@ fn bindgen_test_layout_rte_mbuf() {
         concat!("Size of: ", stringify!(rte_mbuf))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_mbuf>())).cacheline0 as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_mbuf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_mbuf>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const rte_mbuf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.cacheline0);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -1009,8 +926,18 @@ fn bindgen_test_layout_rte_mbuf() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_mbuf>())).buf_addr as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_mbuf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_mbuf>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const rte_mbuf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.buf_addr);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -1021,9 +948,18 @@ fn bindgen_test_layout_rte_mbuf() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_mbuf>())).buf_physaddr as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_mbuf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_mbuf>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const rte_mbuf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.buf_physaddr);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         8usize,
         concat!(
@@ -1034,8 +970,18 @@ fn bindgen_test_layout_rte_mbuf() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_mbuf>())).buf_len as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_mbuf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_mbuf>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const rte_mbuf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.buf_len);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         16usize,
         concat!(
@@ -1046,8 +992,18 @@ fn bindgen_test_layout_rte_mbuf() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_mbuf>())).rearm_data as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_mbuf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_mbuf>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const rte_mbuf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.rearm_data);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         18usize,
         concat!(
@@ -1058,8 +1014,18 @@ fn bindgen_test_layout_rte_mbuf() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_mbuf>())).data_off as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_mbuf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_mbuf>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const rte_mbuf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.data_off);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         18usize,
         concat!(
@@ -1070,8 +1036,18 @@ fn bindgen_test_layout_rte_mbuf() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_mbuf>())).nb_segs as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_mbuf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_mbuf>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const rte_mbuf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.nb_segs);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         22usize,
         concat!(
@@ -1082,8 +1058,18 @@ fn bindgen_test_layout_rte_mbuf() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_mbuf>())).port as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_mbuf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_mbuf>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const rte_mbuf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.port);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         23usize,
         concat!(
@@ -1094,8 +1080,18 @@ fn bindgen_test_layout_rte_mbuf() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_mbuf>())).ol_flags as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_mbuf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_mbuf>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const rte_mbuf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.ol_flags);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         24usize,
         concat!(
@@ -1106,9 +1102,19 @@ fn bindgen_test_layout_rte_mbuf() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_mbuf>())).rx_descriptor_fields1
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_mbuf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_mbuf>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const rte_mbuf;
+            let field_ptr =
+                std::ptr::addr_of!(struct_instance.rx_descriptor_fields1);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         32usize,
         concat!(
@@ -1119,8 +1125,18 @@ fn bindgen_test_layout_rte_mbuf() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_mbuf>())).pkt_len as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_mbuf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_mbuf>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const rte_mbuf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.pkt_len);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         36usize,
         concat!(
@@ -1131,8 +1147,18 @@ fn bindgen_test_layout_rte_mbuf() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_mbuf>())).data_len as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_mbuf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_mbuf>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const rte_mbuf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.data_len);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         40usize,
         concat!(
@@ -1143,8 +1169,18 @@ fn bindgen_test_layout_rte_mbuf() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_mbuf>())).vlan_tci as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_mbuf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_mbuf>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const rte_mbuf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.vlan_tci);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         42usize,
         concat!(
@@ -1155,8 +1191,18 @@ fn bindgen_test_layout_rte_mbuf() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_mbuf>())).hash as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_mbuf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_mbuf>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const rte_mbuf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.hash);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         44usize,
         concat!(
@@ -1167,8 +1213,18 @@ fn bindgen_test_layout_rte_mbuf() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_mbuf>())).seqn as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_mbuf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_mbuf>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const rte_mbuf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.seqn);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         52usize,
         concat!(
@@ -1179,9 +1235,18 @@ fn bindgen_test_layout_rte_mbuf() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_mbuf>())).vlan_tci_outer as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_mbuf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_mbuf>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const rte_mbuf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.vlan_tci_outer);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         56usize,
         concat!(
@@ -1192,8 +1257,18 @@ fn bindgen_test_layout_rte_mbuf() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_mbuf>())).cacheline1 as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_mbuf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_mbuf>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const rte_mbuf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.cacheline1);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         64usize,
         concat!(
@@ -1204,8 +1279,18 @@ fn bindgen_test_layout_rte_mbuf() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_mbuf>())).pool as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_mbuf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_mbuf>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const rte_mbuf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.pool);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         72usize,
         concat!(
@@ -1216,8 +1301,18 @@ fn bindgen_test_layout_rte_mbuf() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_mbuf>())).next as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_mbuf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_mbuf>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const rte_mbuf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.next);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         80usize,
         concat!(
@@ -1228,8 +1323,18 @@ fn bindgen_test_layout_rte_mbuf() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_mbuf>())).priv_size as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_mbuf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_mbuf>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const rte_mbuf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.priv_size);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         96usize,
         concat!(
@@ -1240,8 +1345,18 @@ fn bindgen_test_layout_rte_mbuf() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_mbuf>())).timesync as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_mbuf>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_mbuf>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const rte_mbuf;
+            let field_ptr = std::ptr::addr_of!(struct_instance.timesync);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         98usize,
         concat!(

--- a/tests/expectations/tests/libclang-9/call-conv-field.rs
+++ b/tests/expectations/tests/libclang-9/call-conv-field.rs
@@ -30,14 +30,8 @@ fn bindgen_test_layout_JNINativeInterface_() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<JNINativeInterface_>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], JNINativeInterface_>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<JNINativeInterface_>() };
             let struct_ptr = &struct_instance as *const JNINativeInterface_;
             let field_ptr = std::ptr::addr_of!(struct_instance.GetVersion);
             let struct_address = struct_ptr as usize;
@@ -55,14 +49,8 @@ fn bindgen_test_layout_JNINativeInterface_() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<JNINativeInterface_>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], JNINativeInterface_>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<JNINativeInterface_>() };
             let struct_ptr = &struct_instance as *const JNINativeInterface_;
             let field_ptr = std::ptr::addr_of!(struct_instance.__hack);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/libclang-9/call-conv-field.rs
+++ b/tests/expectations/tests/libclang-9/call-conv-field.rs
@@ -29,9 +29,21 @@ fn bindgen_test_layout_JNINativeInterface_() {
         concat!("Alignment of ", stringify!(JNINativeInterface_))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<JNINativeInterface_>())).GetVersion
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<JNINativeInterface_>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], JNINativeInterface_>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const JNINativeInterface_;
+            let field_ptr = std::ptr::addr_of!(struct_instance.GetVersion);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -42,9 +54,21 @@ fn bindgen_test_layout_JNINativeInterface_() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<JNINativeInterface_>())).__hack as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<JNINativeInterface_>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], JNINativeInterface_>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const JNINativeInterface_;
+            let field_ptr = std::ptr::addr_of!(struct_instance.__hack);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         8usize,
         concat!(

--- a/tests/expectations/tests/libclang-9/class.rs
+++ b/tests/expectations/tests/libclang-9/class.rs
@@ -55,10 +55,7 @@ fn bindgen_test_layout_C() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<C>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance =
-                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], C>(buffer) };
+            let struct_instance = unsafe { std::mem::zeroed::<C>() };
             let struct_ptr = &struct_instance as *const C;
             let field_ptr = std::ptr::addr_of!(struct_instance.a);
             let struct_address = struct_ptr as usize;
@@ -71,10 +68,7 @@ fn bindgen_test_layout_C() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<C>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance =
-                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], C>(buffer) };
+            let struct_instance = unsafe { std::mem::zeroed::<C>() };
             let struct_ptr = &struct_instance as *const C;
             let field_ptr = std::ptr::addr_of!(struct_instance.big_array);
             let struct_address = struct_ptr as usize;
@@ -120,14 +114,8 @@ fn bindgen_test_layout_C_with_zero_length_array() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<C_with_zero_length_array>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], C_with_zero_length_array>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<C_with_zero_length_array>() };
             let struct_ptr =
                 &struct_instance as *const C_with_zero_length_array;
             let field_ptr = std::ptr::addr_of!(struct_instance.a);
@@ -146,14 +134,8 @@ fn bindgen_test_layout_C_with_zero_length_array() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<C_with_zero_length_array>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], C_with_zero_length_array>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<C_with_zero_length_array>() };
             let struct_ptr =
                 &struct_instance as *const C_with_zero_length_array;
             let field_ptr = std::ptr::addr_of!(struct_instance.big_array);
@@ -172,14 +154,8 @@ fn bindgen_test_layout_C_with_zero_length_array() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<C_with_zero_length_array>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], C_with_zero_length_array>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<C_with_zero_length_array>() };
             let struct_ptr =
                 &struct_instance as *const C_with_zero_length_array;
             let field_ptr =
@@ -227,15 +203,8 @@ fn bindgen_test_layout_C_with_zero_length_array_2() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<C_with_zero_length_array_2>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<
-                    [u8; STRUCT_SIZE],
-                    C_with_zero_length_array_2,
-                >(buffer)
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<C_with_zero_length_array_2>() };
             let struct_ptr =
                 &struct_instance as *const C_with_zero_length_array_2;
             let field_ptr = std::ptr::addr_of!(struct_instance.a);
@@ -254,15 +223,8 @@ fn bindgen_test_layout_C_with_zero_length_array_2() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<C_with_zero_length_array_2>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<
-                    [u8; STRUCT_SIZE],
-                    C_with_zero_length_array_2,
-                >(buffer)
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<C_with_zero_length_array_2>() };
             let struct_ptr =
                 &struct_instance as *const C_with_zero_length_array_2;
             let field_ptr =
@@ -301,14 +263,8 @@ fn bindgen_test_layout_C_with_incomplete_array() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<C_with_incomplete_array>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], C_with_incomplete_array>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<C_with_incomplete_array>() };
             let struct_ptr = &struct_instance as *const C_with_incomplete_array;
             let field_ptr = std::ptr::addr_of!(struct_instance.a);
             let struct_address = struct_ptr as usize;
@@ -326,14 +282,8 @@ fn bindgen_test_layout_C_with_incomplete_array() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<C_with_incomplete_array>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], C_with_incomplete_array>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<C_with_incomplete_array>() };
             let struct_ptr = &struct_instance as *const C_with_incomplete_array;
             let field_ptr = std::ptr::addr_of!(struct_instance.big_array);
             let struct_address = struct_ptr as usize;
@@ -351,14 +301,8 @@ fn bindgen_test_layout_C_with_incomplete_array() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<C_with_incomplete_array>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], C_with_incomplete_array>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<C_with_incomplete_array>() };
             let struct_ptr = &struct_instance as *const C_with_incomplete_array;
             let field_ptr =
                 std::ptr::addr_of!(struct_instance.incomplete_array);
@@ -405,15 +349,8 @@ fn bindgen_test_layout_C_with_incomplete_array_2() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<C_with_incomplete_array_2>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<
-                    [u8; STRUCT_SIZE],
-                    C_with_incomplete_array_2,
-                >(buffer)
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<C_with_incomplete_array_2>() };
             let struct_ptr =
                 &struct_instance as *const C_with_incomplete_array_2;
             let field_ptr = std::ptr::addr_of!(struct_instance.a);
@@ -432,15 +369,8 @@ fn bindgen_test_layout_C_with_incomplete_array_2() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<C_with_incomplete_array_2>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<
-                    [u8; STRUCT_SIZE],
-                    C_with_incomplete_array_2,
-                >(buffer)
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<C_with_incomplete_array_2>() };
             let struct_ptr =
                 &struct_instance as *const C_with_incomplete_array_2;
             let field_ptr =
@@ -486,15 +416,9 @@ fn bindgen_test_layout_C_with_zero_length_array_and_incomplete_array() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<
-                C_with_zero_length_array_and_incomplete_array,
-            >();
-            let buffer = [0u8; STRUCT_SIZE];
             let struct_instance = unsafe {
-                std::mem::transmute::<
-                    [u8; STRUCT_SIZE],
-                    C_with_zero_length_array_and_incomplete_array,
-                >(buffer)
+                std::mem::zeroed::<C_with_zero_length_array_and_incomplete_array>(
+                )
             };
             let struct_ptr = &struct_instance
                 as *const C_with_zero_length_array_and_incomplete_array;
@@ -514,15 +438,9 @@ fn bindgen_test_layout_C_with_zero_length_array_and_incomplete_array() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<
-                C_with_zero_length_array_and_incomplete_array,
-            >();
-            let buffer = [0u8; STRUCT_SIZE];
             let struct_instance = unsafe {
-                std::mem::transmute::<
-                    [u8; STRUCT_SIZE],
-                    C_with_zero_length_array_and_incomplete_array,
-                >(buffer)
+                std::mem::zeroed::<C_with_zero_length_array_and_incomplete_array>(
+                )
             };
             let struct_ptr = &struct_instance
                 as *const C_with_zero_length_array_and_incomplete_array;
@@ -542,15 +460,9 @@ fn bindgen_test_layout_C_with_zero_length_array_and_incomplete_array() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<
-                C_with_zero_length_array_and_incomplete_array,
-            >();
-            let buffer = [0u8; STRUCT_SIZE];
             let struct_instance = unsafe {
-                std::mem::transmute::<
-                    [u8; STRUCT_SIZE],
-                    C_with_zero_length_array_and_incomplete_array,
-                >(buffer)
+                std::mem::zeroed::<C_with_zero_length_array_and_incomplete_array>(
+                )
             };
             let struct_ptr = &struct_instance
                 as *const C_with_zero_length_array_and_incomplete_array;
@@ -571,15 +483,9 @@ fn bindgen_test_layout_C_with_zero_length_array_and_incomplete_array() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<
-                C_with_zero_length_array_and_incomplete_array,
-            >();
-            let buffer = [0u8; STRUCT_SIZE];
             let struct_instance = unsafe {
-                std::mem::transmute::<
-                    [u8; STRUCT_SIZE],
-                    C_with_zero_length_array_and_incomplete_array,
-                >(buffer)
+                std::mem::zeroed::<C_with_zero_length_array_and_incomplete_array>(
+                )
             };
             let struct_ptr = &struct_instance
                 as *const C_with_zero_length_array_and_incomplete_array;
@@ -637,15 +543,10 @@ fn bindgen_test_layout_C_with_zero_length_array_and_incomplete_array_2() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<
-                C_with_zero_length_array_and_incomplete_array_2,
-            >();
-            let buffer = [0u8; STRUCT_SIZE];
             let struct_instance = unsafe {
-                std::mem::transmute::<
-                    [u8; STRUCT_SIZE],
+                std::mem::zeroed::<
                     C_with_zero_length_array_and_incomplete_array_2,
-                >(buffer)
+                >()
             };
             let struct_ptr = &struct_instance
                 as *const C_with_zero_length_array_and_incomplete_array_2;
@@ -665,15 +566,10 @@ fn bindgen_test_layout_C_with_zero_length_array_and_incomplete_array_2() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<
-                C_with_zero_length_array_and_incomplete_array_2,
-            >();
-            let buffer = [0u8; STRUCT_SIZE];
             let struct_instance = unsafe {
-                std::mem::transmute::<
-                    [u8; STRUCT_SIZE],
+                std::mem::zeroed::<
                     C_with_zero_length_array_and_incomplete_array_2,
-                >(buffer)
+                >()
             };
             let struct_ptr = &struct_instance
                 as *const C_with_zero_length_array_and_incomplete_array_2;
@@ -694,15 +590,10 @@ fn bindgen_test_layout_C_with_zero_length_array_and_incomplete_array_2() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<
-                C_with_zero_length_array_and_incomplete_array_2,
-            >();
-            let buffer = [0u8; STRUCT_SIZE];
             let struct_instance = unsafe {
-                std::mem::transmute::<
-                    [u8; STRUCT_SIZE],
+                std::mem::zeroed::<
                     C_with_zero_length_array_and_incomplete_array_2,
-                >(buffer)
+                >()
             };
             let struct_ptr = &struct_instance
                 as *const C_with_zero_length_array_and_incomplete_array_2;
@@ -741,11 +632,7 @@ fn bindgen_test_layout_WithDtor() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<WithDtor>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], WithDtor>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<WithDtor>() };
             let struct_ptr = &struct_instance as *const WithDtor;
             let field_ptr = std::ptr::addr_of!(struct_instance.b);
             let struct_address = struct_ptr as usize;
@@ -781,15 +668,8 @@ fn bindgen_test_layout_IncompleteArrayNonCopiable() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<IncompleteArrayNonCopiable>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<
-                    [u8; STRUCT_SIZE],
-                    IncompleteArrayNonCopiable,
-                >(buffer)
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<IncompleteArrayNonCopiable>() };
             let struct_ptr =
                 &struct_instance as *const IncompleteArrayNonCopiable;
             let field_ptr = std::ptr::addr_of!(struct_instance.whatever);
@@ -808,15 +688,8 @@ fn bindgen_test_layout_IncompleteArrayNonCopiable() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<IncompleteArrayNonCopiable>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<
-                    [u8; STRUCT_SIZE],
-                    IncompleteArrayNonCopiable,
-                >(buffer)
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<IncompleteArrayNonCopiable>() };
             let struct_ptr =
                 &struct_instance as *const IncompleteArrayNonCopiable;
             let field_ptr =
@@ -891,11 +764,7 @@ fn bindgen_test_layout_WithUnion() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<WithUnion>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], WithUnion>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<WithUnion>() };
             let struct_ptr = &struct_instance as *const WithUnion;
             let field_ptr = std::ptr::addr_of!(struct_instance.data);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/libclang-9/class.rs
+++ b/tests/expectations/tests/libclang-9/class.rs
@@ -54,12 +54,34 @@ fn bindgen_test_layout_C() {
         concat!("Alignment of ", stringify!(C))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<C>())).a as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<C>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance =
+                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], C>(buffer) };
+            let struct_ptr = &struct_instance as *const C;
+            let field_ptr = std::ptr::addr_of!(struct_instance.a);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!("Offset of field: ", stringify!(C), "::", stringify!(a))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<C>())).big_array as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<C>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance =
+                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], C>(buffer) };
+            let struct_ptr = &struct_instance as *const C;
+            let field_ptr = std::ptr::addr_of!(struct_instance.big_array);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         4usize,
         concat!(
             "Offset of field: ",
@@ -97,9 +119,22 @@ fn bindgen_test_layout_C_with_zero_length_array() {
         concat!("Alignment of ", stringify!(C_with_zero_length_array))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<C_with_zero_length_array>())).a as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<C_with_zero_length_array>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], C_with_zero_length_array>(
+                    buffer,
+                )
+            };
+            let struct_ptr =
+                &struct_instance as *const C_with_zero_length_array;
+            let field_ptr = std::ptr::addr_of!(struct_instance.a);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -110,9 +145,22 @@ fn bindgen_test_layout_C_with_zero_length_array() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<C_with_zero_length_array>())).big_array
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<C_with_zero_length_array>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], C_with_zero_length_array>(
+                    buffer,
+                )
+            };
+            let struct_ptr =
+                &struct_instance as *const C_with_zero_length_array;
+            let field_ptr = std::ptr::addr_of!(struct_instance.big_array);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         4usize,
         concat!(
@@ -123,9 +171,23 @@ fn bindgen_test_layout_C_with_zero_length_array() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<C_with_zero_length_array>()))
-                .zero_length_array as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<C_with_zero_length_array>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], C_with_zero_length_array>(
+                    buffer,
+                )
+            };
+            let struct_ptr =
+                &struct_instance as *const C_with_zero_length_array;
+            let field_ptr =
+                std::ptr::addr_of!(struct_instance.zero_length_array);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         37usize,
         concat!(
@@ -164,9 +226,23 @@ fn bindgen_test_layout_C_with_zero_length_array_2() {
         concat!("Alignment of ", stringify!(C_with_zero_length_array_2))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<C_with_zero_length_array_2>())).a as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<C_with_zero_length_array_2>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<
+                    [u8; STRUCT_SIZE],
+                    C_with_zero_length_array_2,
+                >(buffer)
+            };
+            let struct_ptr =
+                &struct_instance as *const C_with_zero_length_array_2;
+            let field_ptr = std::ptr::addr_of!(struct_instance.a);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -177,9 +253,24 @@ fn bindgen_test_layout_C_with_zero_length_array_2() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<C_with_zero_length_array_2>()))
-                .zero_length_array as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<C_with_zero_length_array_2>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<
+                    [u8; STRUCT_SIZE],
+                    C_with_zero_length_array_2,
+                >(buffer)
+            };
+            let struct_ptr =
+                &struct_instance as *const C_with_zero_length_array_2;
+            let field_ptr =
+                std::ptr::addr_of!(struct_instance.zero_length_array);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         4usize,
         concat!(
@@ -209,9 +300,21 @@ fn bindgen_test_layout_C_with_incomplete_array() {
         concat!("Alignment of ", stringify!(C_with_incomplete_array))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<C_with_incomplete_array>())).a as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<C_with_incomplete_array>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], C_with_incomplete_array>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const C_with_incomplete_array;
+            let field_ptr = std::ptr::addr_of!(struct_instance.a);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -222,9 +325,21 @@ fn bindgen_test_layout_C_with_incomplete_array() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<C_with_incomplete_array>())).big_array
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<C_with_incomplete_array>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], C_with_incomplete_array>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const C_with_incomplete_array;
+            let field_ptr = std::ptr::addr_of!(struct_instance.big_array);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         4usize,
         concat!(
@@ -235,9 +350,22 @@ fn bindgen_test_layout_C_with_incomplete_array() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<C_with_incomplete_array>())).incomplete_array
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<C_with_incomplete_array>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], C_with_incomplete_array>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const C_with_incomplete_array;
+            let field_ptr =
+                std::ptr::addr_of!(struct_instance.incomplete_array);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         37usize,
         concat!(
@@ -276,9 +404,23 @@ fn bindgen_test_layout_C_with_incomplete_array_2() {
         concat!("Alignment of ", stringify!(C_with_incomplete_array_2))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<C_with_incomplete_array_2>())).a as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<C_with_incomplete_array_2>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<
+                    [u8; STRUCT_SIZE],
+                    C_with_incomplete_array_2,
+                >(buffer)
+            };
+            let struct_ptr =
+                &struct_instance as *const C_with_incomplete_array_2;
+            let field_ptr = std::ptr::addr_of!(struct_instance.a);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -289,9 +431,24 @@ fn bindgen_test_layout_C_with_incomplete_array_2() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<C_with_incomplete_array_2>()))
-                .incomplete_array as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<C_with_incomplete_array_2>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<
+                    [u8; STRUCT_SIZE],
+                    C_with_incomplete_array_2,
+                >(buffer)
+            };
+            let struct_ptr =
+                &struct_instance as *const C_with_incomplete_array_2;
+            let field_ptr =
+                std::ptr::addr_of!(struct_instance.incomplete_array);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         4usize,
         concat!(
@@ -328,11 +485,24 @@ fn bindgen_test_layout_C_with_zero_length_array_and_incomplete_array() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<
                 C_with_zero_length_array_and_incomplete_array,
-            >()))
-            .a as *const _ as usize
+            >();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<
+                    [u8; STRUCT_SIZE],
+                    C_with_zero_length_array_and_incomplete_array,
+                >(buffer)
+            };
+            let struct_ptr = &struct_instance
+                as *const C_with_zero_length_array_and_incomplete_array;
+            let field_ptr = std::ptr::addr_of!(struct_instance.a);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -343,11 +513,24 @@ fn bindgen_test_layout_C_with_zero_length_array_and_incomplete_array() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<
                 C_with_zero_length_array_and_incomplete_array,
-            >()))
-            .big_array as *const _ as usize
+            >();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<
+                    [u8; STRUCT_SIZE],
+                    C_with_zero_length_array_and_incomplete_array,
+                >(buffer)
+            };
+            let struct_ptr = &struct_instance
+                as *const C_with_zero_length_array_and_incomplete_array;
+            let field_ptr = std::ptr::addr_of!(struct_instance.big_array);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         4usize,
         concat!(
@@ -358,11 +541,25 @@ fn bindgen_test_layout_C_with_zero_length_array_and_incomplete_array() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<
                 C_with_zero_length_array_and_incomplete_array,
-            >()))
-            .zero_length_array as *const _ as usize
+            >();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<
+                    [u8; STRUCT_SIZE],
+                    C_with_zero_length_array_and_incomplete_array,
+                >(buffer)
+            };
+            let struct_ptr = &struct_instance
+                as *const C_with_zero_length_array_and_incomplete_array;
+            let field_ptr =
+                std::ptr::addr_of!(struct_instance.zero_length_array);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         37usize,
         concat!(
@@ -373,11 +570,25 @@ fn bindgen_test_layout_C_with_zero_length_array_and_incomplete_array() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<
                 C_with_zero_length_array_and_incomplete_array,
-            >()))
-            .incomplete_array as *const _ as usize
+            >();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<
+                    [u8; STRUCT_SIZE],
+                    C_with_zero_length_array_and_incomplete_array,
+                >(buffer)
+            };
+            let struct_ptr = &struct_instance
+                as *const C_with_zero_length_array_and_incomplete_array;
+            let field_ptr =
+                std::ptr::addr_of!(struct_instance.incomplete_array);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         37usize,
         concat!(
@@ -425,11 +636,24 @@ fn bindgen_test_layout_C_with_zero_length_array_and_incomplete_array_2() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<
                 C_with_zero_length_array_and_incomplete_array_2,
-            >()))
-            .a as *const _ as usize
+            >();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<
+                    [u8; STRUCT_SIZE],
+                    C_with_zero_length_array_and_incomplete_array_2,
+                >(buffer)
+            };
+            let struct_ptr = &struct_instance
+                as *const C_with_zero_length_array_and_incomplete_array_2;
+            let field_ptr = std::ptr::addr_of!(struct_instance.a);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -440,11 +664,25 @@ fn bindgen_test_layout_C_with_zero_length_array_and_incomplete_array_2() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<
                 C_with_zero_length_array_and_incomplete_array_2,
-            >()))
-            .zero_length_array as *const _ as usize
+            >();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<
+                    [u8; STRUCT_SIZE],
+                    C_with_zero_length_array_and_incomplete_array_2,
+                >(buffer)
+            };
+            let struct_ptr = &struct_instance
+                as *const C_with_zero_length_array_and_incomplete_array_2;
+            let field_ptr =
+                std::ptr::addr_of!(struct_instance.zero_length_array);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         4usize,
         concat!(
@@ -455,11 +693,25 @@ fn bindgen_test_layout_C_with_zero_length_array_and_incomplete_array_2() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<
                 C_with_zero_length_array_and_incomplete_array_2,
-            >()))
-            .incomplete_array as *const _ as usize
+            >();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<
+                    [u8; STRUCT_SIZE],
+                    C_with_zero_length_array_and_incomplete_array_2,
+                >(buffer)
+            };
+            let struct_ptr = &struct_instance
+                as *const C_with_zero_length_array_and_incomplete_array_2;
+            let field_ptr =
+                std::ptr::addr_of!(struct_instance.incomplete_array);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         4usize,
         concat!(
@@ -488,7 +740,19 @@ fn bindgen_test_layout_WithDtor() {
         concat!("Alignment of ", stringify!(WithDtor))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<WithDtor>())).b as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<WithDtor>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], WithDtor>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const WithDtor;
+            let field_ptr = std::ptr::addr_of!(struct_instance.b);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!(
             "Offset of field: ",
@@ -516,9 +780,23 @@ fn bindgen_test_layout_IncompleteArrayNonCopiable() {
         concat!("Alignment of ", stringify!(IncompleteArrayNonCopiable))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<IncompleteArrayNonCopiable>())).whatever
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<IncompleteArrayNonCopiable>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<
+                    [u8; STRUCT_SIZE],
+                    IncompleteArrayNonCopiable,
+                >(buffer)
+            };
+            let struct_ptr =
+                &struct_instance as *const IncompleteArrayNonCopiable;
+            let field_ptr = std::ptr::addr_of!(struct_instance.whatever);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -529,9 +807,24 @@ fn bindgen_test_layout_IncompleteArrayNonCopiable() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<IncompleteArrayNonCopiable>()))
-                .incomplete_array as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<IncompleteArrayNonCopiable>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<
+                    [u8; STRUCT_SIZE],
+                    IncompleteArrayNonCopiable,
+                >(buffer)
+            };
+            let struct_ptr =
+                &struct_instance as *const IncompleteArrayNonCopiable;
+            let field_ptr =
+                std::ptr::addr_of!(struct_instance.incomplete_array);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         8usize,
         concat!(
@@ -569,16 +862,6 @@ fn bindgen_test_layout_Union() {
         4usize,
         concat!("Alignment of ", stringify!(Union))
     );
-    assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Union>())).d as *const _ as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(Union), "::", stringify!(d))
-    );
-    assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Union>())).i as *const _ as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(Union), "::", stringify!(i))
-    );
 }
 impl Default for Union {
     fn default() -> Self {
@@ -607,8 +890,18 @@ fn bindgen_test_layout_WithUnion() {
         concat!("Alignment of ", stringify!(WithUnion))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<WithUnion>())).data as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<WithUnion>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], WithUnion>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const WithUnion;
+            let field_ptr = std::ptr::addr_of!(struct_instance.data);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(

--- a/tests/expectations/tests/libclang-9/class_1_0.rs
+++ b/tests/expectations/tests/libclang-9/class_1_0.rs
@@ -97,12 +97,34 @@ fn bindgen_test_layout_C() {
         concat!("Alignment of ", stringify!(C))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<C>())).a as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<C>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance =
+                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], C>(buffer) };
+            let struct_ptr = &struct_instance as *const C;
+            let field_ptr = std::ptr::addr_of!(struct_instance.a);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!("Offset of field: ", stringify!(C), "::", stringify!(a))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<C>())).big_array as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<C>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance =
+                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], C>(buffer) };
+            let struct_ptr = &struct_instance as *const C;
+            let field_ptr = std::ptr::addr_of!(struct_instance.big_array);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         4usize,
         concat!(
             "Offset of field: ",
@@ -150,9 +172,22 @@ fn bindgen_test_layout_C_with_zero_length_array() {
         concat!("Alignment of ", stringify!(C_with_zero_length_array))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<C_with_zero_length_array>())).a as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<C_with_zero_length_array>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], C_with_zero_length_array>(
+                    buffer,
+                )
+            };
+            let struct_ptr =
+                &struct_instance as *const C_with_zero_length_array;
+            let field_ptr = std::ptr::addr_of!(struct_instance.a);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -163,9 +198,22 @@ fn bindgen_test_layout_C_with_zero_length_array() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<C_with_zero_length_array>())).big_array
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<C_with_zero_length_array>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], C_with_zero_length_array>(
+                    buffer,
+                )
+            };
+            let struct_ptr =
+                &struct_instance as *const C_with_zero_length_array;
+            let field_ptr = std::ptr::addr_of!(struct_instance.big_array);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         4usize,
         concat!(
@@ -176,9 +224,23 @@ fn bindgen_test_layout_C_with_zero_length_array() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<C_with_zero_length_array>()))
-                .zero_length_array as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<C_with_zero_length_array>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], C_with_zero_length_array>(
+                    buffer,
+                )
+            };
+            let struct_ptr =
+                &struct_instance as *const C_with_zero_length_array;
+            let field_ptr =
+                std::ptr::addr_of!(struct_instance.zero_length_array);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         37usize,
         concat!(
@@ -217,9 +279,23 @@ fn bindgen_test_layout_C_with_zero_length_array_2() {
         concat!("Alignment of ", stringify!(C_with_zero_length_array_2))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<C_with_zero_length_array_2>())).a as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<C_with_zero_length_array_2>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<
+                    [u8; STRUCT_SIZE],
+                    C_with_zero_length_array_2,
+                >(buffer)
+            };
+            let struct_ptr =
+                &struct_instance as *const C_with_zero_length_array_2;
+            let field_ptr = std::ptr::addr_of!(struct_instance.a);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -230,9 +306,24 @@ fn bindgen_test_layout_C_with_zero_length_array_2() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<C_with_zero_length_array_2>()))
-                .zero_length_array as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<C_with_zero_length_array_2>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<
+                    [u8; STRUCT_SIZE],
+                    C_with_zero_length_array_2,
+                >(buffer)
+            };
+            let struct_ptr =
+                &struct_instance as *const C_with_zero_length_array_2;
+            let field_ptr =
+                std::ptr::addr_of!(struct_instance.zero_length_array);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         4usize,
         concat!(
@@ -262,9 +353,21 @@ fn bindgen_test_layout_C_with_incomplete_array() {
         concat!("Alignment of ", stringify!(C_with_incomplete_array))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<C_with_incomplete_array>())).a as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<C_with_incomplete_array>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], C_with_incomplete_array>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const C_with_incomplete_array;
+            let field_ptr = std::ptr::addr_of!(struct_instance.a);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -275,9 +378,21 @@ fn bindgen_test_layout_C_with_incomplete_array() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<C_with_incomplete_array>())).big_array
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<C_with_incomplete_array>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], C_with_incomplete_array>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const C_with_incomplete_array;
+            let field_ptr = std::ptr::addr_of!(struct_instance.big_array);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         4usize,
         concat!(
@@ -288,9 +403,22 @@ fn bindgen_test_layout_C_with_incomplete_array() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<C_with_incomplete_array>())).incomplete_array
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<C_with_incomplete_array>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], C_with_incomplete_array>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const C_with_incomplete_array;
+            let field_ptr =
+                std::ptr::addr_of!(struct_instance.incomplete_array);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         37usize,
         concat!(
@@ -329,9 +457,23 @@ fn bindgen_test_layout_C_with_incomplete_array_2() {
         concat!("Alignment of ", stringify!(C_with_incomplete_array_2))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<C_with_incomplete_array_2>())).a as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<C_with_incomplete_array_2>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<
+                    [u8; STRUCT_SIZE],
+                    C_with_incomplete_array_2,
+                >(buffer)
+            };
+            let struct_ptr =
+                &struct_instance as *const C_with_incomplete_array_2;
+            let field_ptr = std::ptr::addr_of!(struct_instance.a);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -342,9 +484,24 @@ fn bindgen_test_layout_C_with_incomplete_array_2() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<C_with_incomplete_array_2>()))
-                .incomplete_array as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<C_with_incomplete_array_2>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<
+                    [u8; STRUCT_SIZE],
+                    C_with_incomplete_array_2,
+                >(buffer)
+            };
+            let struct_ptr =
+                &struct_instance as *const C_with_incomplete_array_2;
+            let field_ptr =
+                std::ptr::addr_of!(struct_instance.incomplete_array);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         4usize,
         concat!(
@@ -381,11 +538,24 @@ fn bindgen_test_layout_C_with_zero_length_array_and_incomplete_array() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<
                 C_with_zero_length_array_and_incomplete_array,
-            >()))
-            .a as *const _ as usize
+            >();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<
+                    [u8; STRUCT_SIZE],
+                    C_with_zero_length_array_and_incomplete_array,
+                >(buffer)
+            };
+            let struct_ptr = &struct_instance
+                as *const C_with_zero_length_array_and_incomplete_array;
+            let field_ptr = std::ptr::addr_of!(struct_instance.a);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -396,11 +566,24 @@ fn bindgen_test_layout_C_with_zero_length_array_and_incomplete_array() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<
                 C_with_zero_length_array_and_incomplete_array,
-            >()))
-            .big_array as *const _ as usize
+            >();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<
+                    [u8; STRUCT_SIZE],
+                    C_with_zero_length_array_and_incomplete_array,
+                >(buffer)
+            };
+            let struct_ptr = &struct_instance
+                as *const C_with_zero_length_array_and_incomplete_array;
+            let field_ptr = std::ptr::addr_of!(struct_instance.big_array);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         4usize,
         concat!(
@@ -411,11 +594,25 @@ fn bindgen_test_layout_C_with_zero_length_array_and_incomplete_array() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<
                 C_with_zero_length_array_and_incomplete_array,
-            >()))
-            .zero_length_array as *const _ as usize
+            >();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<
+                    [u8; STRUCT_SIZE],
+                    C_with_zero_length_array_and_incomplete_array,
+                >(buffer)
+            };
+            let struct_ptr = &struct_instance
+                as *const C_with_zero_length_array_and_incomplete_array;
+            let field_ptr =
+                std::ptr::addr_of!(struct_instance.zero_length_array);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         37usize,
         concat!(
@@ -426,11 +623,25 @@ fn bindgen_test_layout_C_with_zero_length_array_and_incomplete_array() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<
                 C_with_zero_length_array_and_incomplete_array,
-            >()))
-            .incomplete_array as *const _ as usize
+            >();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<
+                    [u8; STRUCT_SIZE],
+                    C_with_zero_length_array_and_incomplete_array,
+                >(buffer)
+            };
+            let struct_ptr = &struct_instance
+                as *const C_with_zero_length_array_and_incomplete_array;
+            let field_ptr =
+                std::ptr::addr_of!(struct_instance.incomplete_array);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         37usize,
         concat!(
@@ -478,11 +689,24 @@ fn bindgen_test_layout_C_with_zero_length_array_and_incomplete_array_2() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<
                 C_with_zero_length_array_and_incomplete_array_2,
-            >()))
-            .a as *const _ as usize
+            >();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<
+                    [u8; STRUCT_SIZE],
+                    C_with_zero_length_array_and_incomplete_array_2,
+                >(buffer)
+            };
+            let struct_ptr = &struct_instance
+                as *const C_with_zero_length_array_and_incomplete_array_2;
+            let field_ptr = std::ptr::addr_of!(struct_instance.a);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -493,11 +717,25 @@ fn bindgen_test_layout_C_with_zero_length_array_and_incomplete_array_2() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<
                 C_with_zero_length_array_and_incomplete_array_2,
-            >()))
-            .zero_length_array as *const _ as usize
+            >();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<
+                    [u8; STRUCT_SIZE],
+                    C_with_zero_length_array_and_incomplete_array_2,
+                >(buffer)
+            };
+            let struct_ptr = &struct_instance
+                as *const C_with_zero_length_array_and_incomplete_array_2;
+            let field_ptr =
+                std::ptr::addr_of!(struct_instance.zero_length_array);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         4usize,
         concat!(
@@ -508,11 +746,25 @@ fn bindgen_test_layout_C_with_zero_length_array_and_incomplete_array_2() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<
                 C_with_zero_length_array_and_incomplete_array_2,
-            >()))
-            .incomplete_array as *const _ as usize
+            >();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<
+                    [u8; STRUCT_SIZE],
+                    C_with_zero_length_array_and_incomplete_array_2,
+                >(buffer)
+            };
+            let struct_ptr = &struct_instance
+                as *const C_with_zero_length_array_and_incomplete_array_2;
+            let field_ptr =
+                std::ptr::addr_of!(struct_instance.incomplete_array);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         4usize,
         concat!(
@@ -541,7 +793,19 @@ fn bindgen_test_layout_WithDtor() {
         concat!("Alignment of ", stringify!(WithDtor))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<WithDtor>())).b as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<WithDtor>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], WithDtor>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const WithDtor;
+            let field_ptr = std::ptr::addr_of!(struct_instance.b);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!(
             "Offset of field: ",
@@ -569,9 +833,23 @@ fn bindgen_test_layout_IncompleteArrayNonCopiable() {
         concat!("Alignment of ", stringify!(IncompleteArrayNonCopiable))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<IncompleteArrayNonCopiable>())).whatever
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<IncompleteArrayNonCopiable>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<
+                    [u8; STRUCT_SIZE],
+                    IncompleteArrayNonCopiable,
+                >(buffer)
+            };
+            let struct_ptr =
+                &struct_instance as *const IncompleteArrayNonCopiable;
+            let field_ptr = std::ptr::addr_of!(struct_instance.whatever);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -582,9 +860,24 @@ fn bindgen_test_layout_IncompleteArrayNonCopiable() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<IncompleteArrayNonCopiable>()))
-                .incomplete_array as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<IncompleteArrayNonCopiable>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<
+                    [u8; STRUCT_SIZE],
+                    IncompleteArrayNonCopiable,
+                >(buffer)
+            };
+            let struct_ptr =
+                &struct_instance as *const IncompleteArrayNonCopiable;
+            let field_ptr =
+                std::ptr::addr_of!(struct_instance.incomplete_array);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         8usize,
         concat!(
@@ -623,16 +916,6 @@ fn bindgen_test_layout_Union() {
         4usize,
         concat!("Alignment of ", stringify!(Union))
     );
-    assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Union>())).d as *const _ as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(Union), "::", stringify!(d))
-    );
-    assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Union>())).i as *const _ as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(Union), "::", stringify!(i))
-    );
 }
 impl Clone for Union {
     fn clone(&self) -> Self {
@@ -657,8 +940,18 @@ fn bindgen_test_layout_WithUnion() {
         concat!("Alignment of ", stringify!(WithUnion))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<WithUnion>())).data as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<WithUnion>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], WithUnion>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const WithUnion;
+            let field_ptr = std::ptr::addr_of!(struct_instance.data);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(

--- a/tests/expectations/tests/libclang-9/class_1_0.rs
+++ b/tests/expectations/tests/libclang-9/class_1_0.rs
@@ -98,10 +98,7 @@ fn bindgen_test_layout_C() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<C>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance =
-                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], C>(buffer) };
+            let struct_instance = unsafe { std::mem::zeroed::<C>() };
             let struct_ptr = &struct_instance as *const C;
             let field_ptr = std::ptr::addr_of!(struct_instance.a);
             let struct_address = struct_ptr as usize;
@@ -114,10 +111,7 @@ fn bindgen_test_layout_C() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<C>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance =
-                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], C>(buffer) };
+            let struct_instance = unsafe { std::mem::zeroed::<C>() };
             let struct_ptr = &struct_instance as *const C;
             let field_ptr = std::ptr::addr_of!(struct_instance.big_array);
             let struct_address = struct_ptr as usize;
@@ -173,14 +167,8 @@ fn bindgen_test_layout_C_with_zero_length_array() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<C_with_zero_length_array>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], C_with_zero_length_array>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<C_with_zero_length_array>() };
             let struct_ptr =
                 &struct_instance as *const C_with_zero_length_array;
             let field_ptr = std::ptr::addr_of!(struct_instance.a);
@@ -199,14 +187,8 @@ fn bindgen_test_layout_C_with_zero_length_array() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<C_with_zero_length_array>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], C_with_zero_length_array>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<C_with_zero_length_array>() };
             let struct_ptr =
                 &struct_instance as *const C_with_zero_length_array;
             let field_ptr = std::ptr::addr_of!(struct_instance.big_array);
@@ -225,14 +207,8 @@ fn bindgen_test_layout_C_with_zero_length_array() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<C_with_zero_length_array>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], C_with_zero_length_array>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<C_with_zero_length_array>() };
             let struct_ptr =
                 &struct_instance as *const C_with_zero_length_array;
             let field_ptr =
@@ -280,15 +256,8 @@ fn bindgen_test_layout_C_with_zero_length_array_2() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<C_with_zero_length_array_2>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<
-                    [u8; STRUCT_SIZE],
-                    C_with_zero_length_array_2,
-                >(buffer)
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<C_with_zero_length_array_2>() };
             let struct_ptr =
                 &struct_instance as *const C_with_zero_length_array_2;
             let field_ptr = std::ptr::addr_of!(struct_instance.a);
@@ -307,15 +276,8 @@ fn bindgen_test_layout_C_with_zero_length_array_2() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<C_with_zero_length_array_2>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<
-                    [u8; STRUCT_SIZE],
-                    C_with_zero_length_array_2,
-                >(buffer)
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<C_with_zero_length_array_2>() };
             let struct_ptr =
                 &struct_instance as *const C_with_zero_length_array_2;
             let field_ptr =
@@ -354,14 +316,8 @@ fn bindgen_test_layout_C_with_incomplete_array() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<C_with_incomplete_array>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], C_with_incomplete_array>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<C_with_incomplete_array>() };
             let struct_ptr = &struct_instance as *const C_with_incomplete_array;
             let field_ptr = std::ptr::addr_of!(struct_instance.a);
             let struct_address = struct_ptr as usize;
@@ -379,14 +335,8 @@ fn bindgen_test_layout_C_with_incomplete_array() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<C_with_incomplete_array>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], C_with_incomplete_array>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<C_with_incomplete_array>() };
             let struct_ptr = &struct_instance as *const C_with_incomplete_array;
             let field_ptr = std::ptr::addr_of!(struct_instance.big_array);
             let struct_address = struct_ptr as usize;
@@ -404,14 +354,8 @@ fn bindgen_test_layout_C_with_incomplete_array() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<C_with_incomplete_array>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], C_with_incomplete_array>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<C_with_incomplete_array>() };
             let struct_ptr = &struct_instance as *const C_with_incomplete_array;
             let field_ptr =
                 std::ptr::addr_of!(struct_instance.incomplete_array);
@@ -458,15 +402,8 @@ fn bindgen_test_layout_C_with_incomplete_array_2() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<C_with_incomplete_array_2>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<
-                    [u8; STRUCT_SIZE],
-                    C_with_incomplete_array_2,
-                >(buffer)
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<C_with_incomplete_array_2>() };
             let struct_ptr =
                 &struct_instance as *const C_with_incomplete_array_2;
             let field_ptr = std::ptr::addr_of!(struct_instance.a);
@@ -485,15 +422,8 @@ fn bindgen_test_layout_C_with_incomplete_array_2() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<C_with_incomplete_array_2>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<
-                    [u8; STRUCT_SIZE],
-                    C_with_incomplete_array_2,
-                >(buffer)
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<C_with_incomplete_array_2>() };
             let struct_ptr =
                 &struct_instance as *const C_with_incomplete_array_2;
             let field_ptr =
@@ -539,15 +469,9 @@ fn bindgen_test_layout_C_with_zero_length_array_and_incomplete_array() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<
-                C_with_zero_length_array_and_incomplete_array,
-            >();
-            let buffer = [0u8; STRUCT_SIZE];
             let struct_instance = unsafe {
-                std::mem::transmute::<
-                    [u8; STRUCT_SIZE],
-                    C_with_zero_length_array_and_incomplete_array,
-                >(buffer)
+                std::mem::zeroed::<C_with_zero_length_array_and_incomplete_array>(
+                )
             };
             let struct_ptr = &struct_instance
                 as *const C_with_zero_length_array_and_incomplete_array;
@@ -567,15 +491,9 @@ fn bindgen_test_layout_C_with_zero_length_array_and_incomplete_array() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<
-                C_with_zero_length_array_and_incomplete_array,
-            >();
-            let buffer = [0u8; STRUCT_SIZE];
             let struct_instance = unsafe {
-                std::mem::transmute::<
-                    [u8; STRUCT_SIZE],
-                    C_with_zero_length_array_and_incomplete_array,
-                >(buffer)
+                std::mem::zeroed::<C_with_zero_length_array_and_incomplete_array>(
+                )
             };
             let struct_ptr = &struct_instance
                 as *const C_with_zero_length_array_and_incomplete_array;
@@ -595,15 +513,9 @@ fn bindgen_test_layout_C_with_zero_length_array_and_incomplete_array() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<
-                C_with_zero_length_array_and_incomplete_array,
-            >();
-            let buffer = [0u8; STRUCT_SIZE];
             let struct_instance = unsafe {
-                std::mem::transmute::<
-                    [u8; STRUCT_SIZE],
-                    C_with_zero_length_array_and_incomplete_array,
-                >(buffer)
+                std::mem::zeroed::<C_with_zero_length_array_and_incomplete_array>(
+                )
             };
             let struct_ptr = &struct_instance
                 as *const C_with_zero_length_array_and_incomplete_array;
@@ -624,15 +536,9 @@ fn bindgen_test_layout_C_with_zero_length_array_and_incomplete_array() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<
-                C_with_zero_length_array_and_incomplete_array,
-            >();
-            let buffer = [0u8; STRUCT_SIZE];
             let struct_instance = unsafe {
-                std::mem::transmute::<
-                    [u8; STRUCT_SIZE],
-                    C_with_zero_length_array_and_incomplete_array,
-                >(buffer)
+                std::mem::zeroed::<C_with_zero_length_array_and_incomplete_array>(
+                )
             };
             let struct_ptr = &struct_instance
                 as *const C_with_zero_length_array_and_incomplete_array;
@@ -690,15 +596,10 @@ fn bindgen_test_layout_C_with_zero_length_array_and_incomplete_array_2() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<
-                C_with_zero_length_array_and_incomplete_array_2,
-            >();
-            let buffer = [0u8; STRUCT_SIZE];
             let struct_instance = unsafe {
-                std::mem::transmute::<
-                    [u8; STRUCT_SIZE],
+                std::mem::zeroed::<
                     C_with_zero_length_array_and_incomplete_array_2,
-                >(buffer)
+                >()
             };
             let struct_ptr = &struct_instance
                 as *const C_with_zero_length_array_and_incomplete_array_2;
@@ -718,15 +619,10 @@ fn bindgen_test_layout_C_with_zero_length_array_and_incomplete_array_2() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<
-                C_with_zero_length_array_and_incomplete_array_2,
-            >();
-            let buffer = [0u8; STRUCT_SIZE];
             let struct_instance = unsafe {
-                std::mem::transmute::<
-                    [u8; STRUCT_SIZE],
+                std::mem::zeroed::<
                     C_with_zero_length_array_and_incomplete_array_2,
-                >(buffer)
+                >()
             };
             let struct_ptr = &struct_instance
                 as *const C_with_zero_length_array_and_incomplete_array_2;
@@ -747,15 +643,10 @@ fn bindgen_test_layout_C_with_zero_length_array_and_incomplete_array_2() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<
-                C_with_zero_length_array_and_incomplete_array_2,
-            >();
-            let buffer = [0u8; STRUCT_SIZE];
             let struct_instance = unsafe {
-                std::mem::transmute::<
-                    [u8; STRUCT_SIZE],
+                std::mem::zeroed::<
                     C_with_zero_length_array_and_incomplete_array_2,
-                >(buffer)
+                >()
             };
             let struct_ptr = &struct_instance
                 as *const C_with_zero_length_array_and_incomplete_array_2;
@@ -794,11 +685,7 @@ fn bindgen_test_layout_WithDtor() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<WithDtor>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], WithDtor>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<WithDtor>() };
             let struct_ptr = &struct_instance as *const WithDtor;
             let field_ptr = std::ptr::addr_of!(struct_instance.b);
             let struct_address = struct_ptr as usize;
@@ -834,15 +721,8 @@ fn bindgen_test_layout_IncompleteArrayNonCopiable() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<IncompleteArrayNonCopiable>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<
-                    [u8; STRUCT_SIZE],
-                    IncompleteArrayNonCopiable,
-                >(buffer)
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<IncompleteArrayNonCopiable>() };
             let struct_ptr =
                 &struct_instance as *const IncompleteArrayNonCopiable;
             let field_ptr = std::ptr::addr_of!(struct_instance.whatever);
@@ -861,15 +741,8 @@ fn bindgen_test_layout_IncompleteArrayNonCopiable() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<IncompleteArrayNonCopiable>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<
-                    [u8; STRUCT_SIZE],
-                    IncompleteArrayNonCopiable,
-                >(buffer)
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<IncompleteArrayNonCopiable>() };
             let struct_ptr =
                 &struct_instance as *const IncompleteArrayNonCopiable;
             let field_ptr =
@@ -941,11 +814,7 @@ fn bindgen_test_layout_WithUnion() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<WithUnion>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], WithUnion>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<WithUnion>() };
             let struct_ptr = &struct_instance as *const WithUnion;
             let field_ptr = std::ptr::addr_of!(struct_instance.data);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/libclang-9/derive-hash-struct-with-incomplete-array.rs
+++ b/tests/expectations/tests/libclang-9/derive-hash-struct-with-incomplete-array.rs
@@ -55,11 +55,7 @@ fn bindgen_test_layout_test() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<test>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], test>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<test>() };
             let struct_ptr = &struct_instance as *const test;
             let field_ptr = std::ptr::addr_of!(struct_instance.a);
             let struct_address = struct_ptr as usize;
@@ -72,11 +68,7 @@ fn bindgen_test_layout_test() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<test>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], test>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<test>() };
             let struct_ptr = &struct_instance as *const test;
             let field_ptr =
                 std::ptr::addr_of!(struct_instance.zero_length_array);
@@ -114,11 +106,7 @@ fn bindgen_test_layout_test2() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<test2>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], test2>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<test2>() };
             let struct_ptr = &struct_instance as *const test2;
             let field_ptr = std::ptr::addr_of!(struct_instance.a);
             let struct_address = struct_ptr as usize;
@@ -131,11 +119,7 @@ fn bindgen_test_layout_test2() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<test2>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], test2>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<test2>() };
             let struct_ptr = &struct_instance as *const test2;
             let field_ptr =
                 std::ptr::addr_of!(struct_instance.incomplete_array);
@@ -174,11 +158,7 @@ fn bindgen_test_layout_test3() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<test3>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], test3>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<test3>() };
             let struct_ptr = &struct_instance as *const test3;
             let field_ptr = std::ptr::addr_of!(struct_instance.a);
             let struct_address = struct_ptr as usize;
@@ -191,11 +171,7 @@ fn bindgen_test_layout_test3() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<test3>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], test3>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<test3>() };
             let struct_ptr = &struct_instance as *const test3;
             let field_ptr =
                 std::ptr::addr_of!(struct_instance.zero_length_array);
@@ -214,11 +190,7 @@ fn bindgen_test_layout_test3() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<test3>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], test3>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<test3>() };
             let struct_ptr = &struct_instance as *const test3;
             let field_ptr =
                 std::ptr::addr_of!(struct_instance.incomplete_array);

--- a/tests/expectations/tests/libclang-9/derive-hash-struct-with-incomplete-array.rs
+++ b/tests/expectations/tests/libclang-9/derive-hash-struct-with-incomplete-array.rs
@@ -54,14 +54,36 @@ fn bindgen_test_layout_test() {
         concat!("Alignment of ", stringify!(test))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<test>())).a as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<test>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], test>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const test;
+            let field_ptr = std::ptr::addr_of!(struct_instance.a);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!("Offset of field: ", stringify!(test), "::", stringify!(a))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<test>())).zero_length_array as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<test>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], test>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const test;
+            let field_ptr =
+                std::ptr::addr_of!(struct_instance.zero_length_array);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         4usize,
         concat!(
@@ -91,14 +113,36 @@ fn bindgen_test_layout_test2() {
         concat!("Alignment of ", stringify!(test2))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<test2>())).a as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<test2>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], test2>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const test2;
+            let field_ptr = std::ptr::addr_of!(struct_instance.a);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!("Offset of field: ", stringify!(test2), "::", stringify!(a))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<test2>())).incomplete_array as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<test2>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], test2>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const test2;
+            let field_ptr =
+                std::ptr::addr_of!(struct_instance.incomplete_array);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         4usize,
         concat!(
@@ -129,14 +173,36 @@ fn bindgen_test_layout_test3() {
         concat!("Alignment of ", stringify!(test3))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<test3>())).a as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<test3>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], test3>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const test3;
+            let field_ptr = std::ptr::addr_of!(struct_instance.a);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!("Offset of field: ", stringify!(test3), "::", stringify!(a))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<test3>())).zero_length_array as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<test3>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], test3>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const test3;
+            let field_ptr =
+                std::ptr::addr_of!(struct_instance.zero_length_array);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         4usize,
         concat!(
@@ -147,9 +213,19 @@ fn bindgen_test_layout_test3() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<test3>())).incomplete_array as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<test3>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], test3>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const test3;
+            let field_ptr =
+                std::ptr::addr_of!(struct_instance.incomplete_array);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         4usize,
         concat!(

--- a/tests/expectations/tests/libclang-9/incomplete-array-padding.rs
+++ b/tests/expectations/tests/libclang-9/incomplete-array-padding.rs
@@ -141,7 +141,19 @@ fn bindgen_test_layout_foo() {
         concat!("Alignment of ", stringify!(foo))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<foo>())).b as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<foo>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], foo>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const foo;
+            let field_ptr = std::ptr::addr_of!(struct_instance.b);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         8usize,
         concat!("Offset of field: ", stringify!(foo), "::", stringify!(b))
     );

--- a/tests/expectations/tests/libclang-9/incomplete-array-padding.rs
+++ b/tests/expectations/tests/libclang-9/incomplete-array-padding.rs
@@ -142,11 +142,7 @@ fn bindgen_test_layout_foo() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<foo>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], foo>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<foo>() };
             let struct_ptr = &struct_instance as *const foo;
             let field_ptr = std::ptr::addr_of!(struct_instance.b);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/libclang-9/issue-643-inner-struct.rs
+++ b/tests/expectations/tests/libclang-9/issue-643-inner-struct.rs
@@ -62,11 +62,8 @@ fn bindgen_test_layout_rte_ring_prod() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_ring_prod>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_ring_prod>(buffer)
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_ring_prod>() };
             let struct_ptr = &struct_instance as *const rte_ring_prod;
             let field_ptr = std::ptr::addr_of!(struct_instance.watermark);
             let struct_address = struct_ptr as usize;
@@ -102,11 +99,8 @@ fn bindgen_test_layout_rte_ring_cons() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_ring_cons>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_ring_cons>(buffer)
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<rte_ring_cons>() };
             let struct_ptr = &struct_instance as *const rte_ring_cons;
             let field_ptr = std::ptr::addr_of!(struct_instance.sc_dequeue);
             let struct_address = struct_ptr as usize;
@@ -137,11 +131,7 @@ fn bindgen_test_layout_rte_ring() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_ring>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_ring>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<rte_ring>() };
             let struct_ptr = &struct_instance as *const rte_ring;
             let field_ptr = std::ptr::addr_of!(struct_instance.memzone);
             let struct_address = struct_ptr as usize;
@@ -159,11 +149,7 @@ fn bindgen_test_layout_rte_ring() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_ring>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_ring>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<rte_ring>() };
             let struct_ptr = &struct_instance as *const rte_ring;
             let field_ptr = std::ptr::addr_of!(struct_instance.prod);
             let struct_address = struct_ptr as usize;
@@ -181,11 +167,7 @@ fn bindgen_test_layout_rte_ring() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_ring>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_ring>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<rte_ring>() };
             let struct_ptr = &struct_instance as *const rte_ring;
             let field_ptr = std::ptr::addr_of!(struct_instance.cons);
             let struct_address = struct_ptr as usize;
@@ -203,11 +185,7 @@ fn bindgen_test_layout_rte_ring() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_ring>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_ring>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<rte_ring>() };
             let struct_ptr = &struct_instance as *const rte_ring;
             let field_ptr = std::ptr::addr_of!(struct_instance.ring);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/libclang-9/issue-643-inner-struct.rs
+++ b/tests/expectations/tests/libclang-9/issue-643-inner-struct.rs
@@ -61,9 +61,18 @@ fn bindgen_test_layout_rte_ring_prod() {
         concat!("Alignment of ", stringify!(rte_ring_prod))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_ring_prod>())).watermark as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_ring_prod>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_ring_prod>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const rte_ring_prod;
+            let field_ptr = std::ptr::addr_of!(struct_instance.watermark);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -92,9 +101,18 @@ fn bindgen_test_layout_rte_ring_cons() {
         concat!("Alignment of ", stringify!(rte_ring_cons))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_ring_cons>())).sc_dequeue as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_ring_cons>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_ring_cons>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const rte_ring_cons;
+            let field_ptr = std::ptr::addr_of!(struct_instance.sc_dequeue);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -118,8 +136,18 @@ fn bindgen_test_layout_rte_ring() {
         concat!("Alignment of ", stringify!(rte_ring))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_ring>())).memzone as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_ring>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_ring>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const rte_ring;
+            let field_ptr = std::ptr::addr_of!(struct_instance.memzone);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -130,8 +158,18 @@ fn bindgen_test_layout_rte_ring() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_ring>())).prod as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_ring>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_ring>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const rte_ring;
+            let field_ptr = std::ptr::addr_of!(struct_instance.prod);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         8usize,
         concat!(
@@ -142,8 +180,18 @@ fn bindgen_test_layout_rte_ring() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_ring>())).cons as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_ring>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_ring>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const rte_ring;
+            let field_ptr = std::ptr::addr_of!(struct_instance.cons);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         12usize,
         concat!(
@@ -154,8 +202,18 @@ fn bindgen_test_layout_rte_ring() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_ring>())).ring as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_ring>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_ring>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const rte_ring;
+            let field_ptr = std::ptr::addr_of!(struct_instance.ring);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         16usize,
         concat!(

--- a/tests/expectations/tests/libclang-9/layout_align.rs
+++ b/tests/expectations/tests/libclang-9/layout_align.rs
@@ -148,8 +148,18 @@ fn bindgen_test_layout_rte_kni_fifo() {
         concat!("Alignment of ", stringify!(rte_kni_fifo))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_kni_fifo>())).write as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_kni_fifo>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_kni_fifo>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const rte_kni_fifo;
+            let field_ptr = std::ptr::addr_of!(struct_instance.write);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -160,8 +170,18 @@ fn bindgen_test_layout_rte_kni_fifo() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_kni_fifo>())).read as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_kni_fifo>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_kni_fifo>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const rte_kni_fifo;
+            let field_ptr = std::ptr::addr_of!(struct_instance.read);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         4usize,
         concat!(
@@ -172,8 +192,18 @@ fn bindgen_test_layout_rte_kni_fifo() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_kni_fifo>())).len as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_kni_fifo>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_kni_fifo>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const rte_kni_fifo;
+            let field_ptr = std::ptr::addr_of!(struct_instance.len);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         8usize,
         concat!(
@@ -184,9 +214,18 @@ fn bindgen_test_layout_rte_kni_fifo() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_kni_fifo>())).elem_size as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_kni_fifo>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_kni_fifo>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const rte_kni_fifo;
+            let field_ptr = std::ptr::addr_of!(struct_instance.elem_size);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         12usize,
         concat!(
@@ -197,8 +236,18 @@ fn bindgen_test_layout_rte_kni_fifo() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_kni_fifo>())).buffer as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_kni_fifo>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_kni_fifo>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const rte_kni_fifo;
+            let field_ptr = std::ptr::addr_of!(struct_instance.buffer);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         16usize,
         concat!(
@@ -241,9 +290,18 @@ fn bindgen_test_layout_rte_eth_link() {
         concat!("Alignment of ", stringify!(rte_eth_link))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<rte_eth_link>())).link_speed as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<rte_eth_link>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_link>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const rte_eth_link;
+            let field_ptr = std::ptr::addr_of!(struct_instance.link_speed);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(

--- a/tests/expectations/tests/libclang-9/layout_align.rs
+++ b/tests/expectations/tests/libclang-9/layout_align.rs
@@ -149,11 +149,7 @@ fn bindgen_test_layout_rte_kni_fifo() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_kni_fifo>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_kni_fifo>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<rte_kni_fifo>() };
             let struct_ptr = &struct_instance as *const rte_kni_fifo;
             let field_ptr = std::ptr::addr_of!(struct_instance.write);
             let struct_address = struct_ptr as usize;
@@ -171,11 +167,7 @@ fn bindgen_test_layout_rte_kni_fifo() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_kni_fifo>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_kni_fifo>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<rte_kni_fifo>() };
             let struct_ptr = &struct_instance as *const rte_kni_fifo;
             let field_ptr = std::ptr::addr_of!(struct_instance.read);
             let struct_address = struct_ptr as usize;
@@ -193,11 +185,7 @@ fn bindgen_test_layout_rte_kni_fifo() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_kni_fifo>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_kni_fifo>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<rte_kni_fifo>() };
             let struct_ptr = &struct_instance as *const rte_kni_fifo;
             let field_ptr = std::ptr::addr_of!(struct_instance.len);
             let struct_address = struct_ptr as usize;
@@ -215,11 +203,7 @@ fn bindgen_test_layout_rte_kni_fifo() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_kni_fifo>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_kni_fifo>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<rte_kni_fifo>() };
             let struct_ptr = &struct_instance as *const rte_kni_fifo;
             let field_ptr = std::ptr::addr_of!(struct_instance.elem_size);
             let struct_address = struct_ptr as usize;
@@ -237,11 +221,7 @@ fn bindgen_test_layout_rte_kni_fifo() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_kni_fifo>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_kni_fifo>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<rte_kni_fifo>() };
             let struct_ptr = &struct_instance as *const rte_kni_fifo;
             let field_ptr = std::ptr::addr_of!(struct_instance.buffer);
             let struct_address = struct_ptr as usize;
@@ -291,11 +271,7 @@ fn bindgen_test_layout_rte_eth_link() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<rte_eth_link>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], rte_eth_link>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<rte_eth_link>() };
             let struct_ptr = &struct_instance as *const rte_eth_link;
             let field_ptr = std::ptr::addr_of!(struct_instance.link_speed);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/libclang-9/type_alias_template_specialized.rs
+++ b/tests/expectations/tests/libclang-9/type_alias_template_specialized.rs
@@ -24,11 +24,7 @@ fn bindgen_test_layout_Rooted() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<Rooted>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], Rooted>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<Rooted>() };
             let struct_ptr = &struct_instance as *const Rooted;
             let field_ptr = std::ptr::addr_of!(struct_instance.ptr);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/libclang-9/type_alias_template_specialized.rs
+++ b/tests/expectations/tests/libclang-9/type_alias_template_specialized.rs
@@ -23,7 +23,19 @@ fn bindgen_test_layout_Rooted() {
         concat!("Alignment of ", stringify!(Rooted))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Rooted>())).ptr as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<Rooted>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], Rooted>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const Rooted;
+            let field_ptr = std::ptr::addr_of!(struct_instance.ptr);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/libclang-9/zero-sized-array.rs
+++ b/tests/expectations/tests/libclang-9/zero-sized-array.rs
@@ -55,11 +55,8 @@ fn bindgen_test_layout_ZeroSizedArray() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<ZeroSizedArray>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], ZeroSizedArray>(buffer)
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<ZeroSizedArray>() };
             let struct_ptr = &struct_instance as *const ZeroSizedArray;
             let field_ptr = std::ptr::addr_of!(struct_instance.arr);
             let struct_address = struct_ptr as usize;
@@ -96,14 +93,8 @@ fn bindgen_test_layout_ContainsZeroSizedArray() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<ContainsZeroSizedArray>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], ContainsZeroSizedArray>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<ContainsZeroSizedArray>() };
             let struct_ptr = &struct_instance as *const ContainsZeroSizedArray;
             let field_ptr = std::ptr::addr_of!(struct_instance.zsa);
             let struct_address = struct_ptr as usize;
@@ -160,14 +151,8 @@ fn bindgen_test_layout_DynamicallySizedArray() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<DynamicallySizedArray>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], DynamicallySizedArray>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<DynamicallySizedArray>() };
             let struct_ptr = &struct_instance as *const DynamicallySizedArray;
             let field_ptr = std::ptr::addr_of!(struct_instance.arr);
             let struct_address = struct_ptr as usize;
@@ -204,15 +189,8 @@ fn bindgen_test_layout_ContainsDynamicallySizedArray() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<ContainsDynamicallySizedArray>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<
-                    [u8; STRUCT_SIZE],
-                    ContainsDynamicallySizedArray,
-                >(buffer)
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<ContainsDynamicallySizedArray>() };
             let struct_ptr =
                 &struct_instance as *const ContainsDynamicallySizedArray;
             let field_ptr = std::ptr::addr_of!(struct_instance.dsa);

--- a/tests/expectations/tests/libclang-9/zero-sized-array.rs
+++ b/tests/expectations/tests/libclang-9/zero-sized-array.rs
@@ -54,8 +54,18 @@ fn bindgen_test_layout_ZeroSizedArray() {
         concat!("Alignment of ", stringify!(ZeroSizedArray))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<ZeroSizedArray>())).arr as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<ZeroSizedArray>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], ZeroSizedArray>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const ZeroSizedArray;
+            let field_ptr = std::ptr::addr_of!(struct_instance.arr);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -85,9 +95,21 @@ fn bindgen_test_layout_ContainsZeroSizedArray() {
         concat!("Alignment of ", stringify!(ContainsZeroSizedArray))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<ContainsZeroSizedArray>())).zsa as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<ContainsZeroSizedArray>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], ContainsZeroSizedArray>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const ContainsZeroSizedArray;
+            let field_ptr = std::ptr::addr_of!(struct_instance.zsa);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -137,9 +159,21 @@ fn bindgen_test_layout_DynamicallySizedArray() {
         concat!("Alignment of ", stringify!(DynamicallySizedArray))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<DynamicallySizedArray>())).arr as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<DynamicallySizedArray>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], DynamicallySizedArray>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const DynamicallySizedArray;
+            let field_ptr = std::ptr::addr_of!(struct_instance.arr);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -169,9 +203,23 @@ fn bindgen_test_layout_ContainsDynamicallySizedArray() {
         concat!("Alignment of ", stringify!(ContainsDynamicallySizedArray))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<ContainsDynamicallySizedArray>())).dsa
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<ContainsDynamicallySizedArray>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<
+                    [u8; STRUCT_SIZE],
+                    ContainsDynamicallySizedArray,
+                >(buffer)
+            };
+            let struct_ptr =
+                &struct_instance as *const ContainsDynamicallySizedArray;
+            let field_ptr = std::ptr::addr_of!(struct_instance.dsa);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(

--- a/tests/expectations/tests/long_double.rs
+++ b/tests/expectations/tests/long_double.rs
@@ -24,7 +24,19 @@ fn bindgen_test_layout_foo() {
         concat!("Alignment of ", stringify!(foo))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<foo>())).bar as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<foo>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], foo>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const foo;
+            let field_ptr = std::ptr::addr_of!(struct_instance.bar);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar))
     );

--- a/tests/expectations/tests/long_double.rs
+++ b/tests/expectations/tests/long_double.rs
@@ -25,11 +25,7 @@ fn bindgen_test_layout_foo() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<foo>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], foo>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<foo>() };
             let struct_ptr = &struct_instance as *const foo;
             let field_ptr = std::ptr::addr_of!(struct_instance.bar);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/msvc-no-usr.rs
+++ b/tests/expectations/tests/msvc-no-usr.rs
@@ -25,10 +25,7 @@ fn bindgen_test_layout_A() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<A>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance =
-                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], A>(buffer) };
+            let struct_instance = unsafe { std::mem::zeroed::<A>() };
             let struct_ptr = &struct_instance as *const A;
             let field_ptr = std::ptr::addr_of!(struct_instance.foo);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/msvc-no-usr.rs
+++ b/tests/expectations/tests/msvc-no-usr.rs
@@ -24,7 +24,18 @@ fn bindgen_test_layout_A() {
         concat!("Alignment of ", stringify!(A))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<A>())).foo as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<A>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance =
+                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], A>(buffer) };
+            let struct_ptr = &struct_instance as *const A;
+            let field_ptr = std::ptr::addr_of!(struct_instance.foo);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!("Offset of field: ", stringify!(A), "::", stringify!(foo))
     );

--- a/tests/expectations/tests/mutable.rs
+++ b/tests/expectations/tests/mutable.rs
@@ -25,10 +25,7 @@ fn bindgen_test_layout_C() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<C>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance =
-                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], C>(buffer) };
+            let struct_instance = unsafe { std::mem::zeroed::<C>() };
             let struct_ptr = &struct_instance as *const C;
             let field_ptr = std::ptr::addr_of!(struct_instance.m_member);
             let struct_address = struct_ptr as usize;
@@ -46,10 +43,7 @@ fn bindgen_test_layout_C() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<C>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance =
-                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], C>(buffer) };
+            let struct_instance = unsafe { std::mem::zeroed::<C>() };
             let struct_ptr = &struct_instance as *const C;
             let field_ptr = std::ptr::addr_of!(struct_instance.m_other);
             let struct_address = struct_ptr as usize;
@@ -85,11 +79,7 @@ fn bindgen_test_layout_NonCopiable() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<NonCopiable>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], NonCopiable>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<NonCopiable>() };
             let struct_ptr = &struct_instance as *const NonCopiable;
             let field_ptr = std::ptr::addr_of!(struct_instance.m_member);
             let struct_address = struct_ptr as usize;
@@ -131,14 +121,8 @@ fn bindgen_test_layout_NonCopiableWithNonCopiableMutableMember() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<NonCopiableWithNonCopiableMutableMember>();
-            let buffer = [0u8; STRUCT_SIZE];
             let struct_instance = unsafe {
-                std::mem::transmute::<
-                    [u8; STRUCT_SIZE],
-                    NonCopiableWithNonCopiableMutableMember,
-                >(buffer)
+                std::mem::zeroed::<NonCopiableWithNonCopiableMutableMember>()
             };
             let struct_ptr = &struct_instance
                 as *const NonCopiableWithNonCopiableMutableMember;

--- a/tests/expectations/tests/mutable.rs
+++ b/tests/expectations/tests/mutable.rs
@@ -24,7 +24,18 @@ fn bindgen_test_layout_C() {
         concat!("Alignment of ", stringify!(C))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<C>())).m_member as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<C>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance =
+                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], C>(buffer) };
+            let struct_ptr = &struct_instance as *const C;
+            let field_ptr = std::ptr::addr_of!(struct_instance.m_member);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!(
             "Offset of field: ",
@@ -34,7 +45,18 @@ fn bindgen_test_layout_C() {
         )
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<C>())).m_other as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<C>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance =
+                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], C>(buffer) };
+            let struct_ptr = &struct_instance as *const C;
+            let field_ptr = std::ptr::addr_of!(struct_instance.m_other);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         4usize,
         concat!(
             "Offset of field: ",
@@ -62,9 +84,18 @@ fn bindgen_test_layout_NonCopiable() {
         concat!("Alignment of ", stringify!(NonCopiable))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<NonCopiable>())).m_member as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<NonCopiable>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], NonCopiable>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const NonCopiable;
+            let field_ptr = std::ptr::addr_of!(struct_instance.m_member);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -99,9 +130,23 @@ fn bindgen_test_layout_NonCopiableWithNonCopiableMutableMember() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<NonCopiableWithNonCopiableMutableMember>()))
-                .m_member as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<NonCopiableWithNonCopiableMutableMember>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<
+                    [u8; STRUCT_SIZE],
+                    NonCopiableWithNonCopiableMutableMember,
+                >(buffer)
+            };
+            let struct_ptr = &struct_instance
+                as *const NonCopiableWithNonCopiableMutableMember;
+            let field_ptr = std::ptr::addr_of!(struct_instance.m_member);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(

--- a/tests/expectations/tests/namespace.rs
+++ b/tests/expectations/tests/namespace.rs
@@ -44,7 +44,19 @@ pub mod root {
                 concat!("Alignment of ", stringify!(A))
             );
             assert_eq!(
-                unsafe { &(*(::std::ptr::null::<A>())).b as *const _ as usize },
+                {
+                    const STRUCT_SIZE: usize = std::mem::size_of::<A>();
+                    let buffer = [0u8; STRUCT_SIZE];
+                    let struct_instance = unsafe {
+                        std::mem::transmute::<[u8; STRUCT_SIZE], A>(buffer)
+                    };
+                    let struct_ptr = &struct_instance as *const A;
+                    let field_ptr = std::ptr::addr_of!(struct_instance.b);
+                    let struct_address = struct_ptr as usize;
+                    let field_address = field_ptr as usize;
+                    std::mem::forget(struct_instance);
+                    field_address.checked_sub(struct_address).unwrap()
+                },
                 0usize,
                 concat!(
                     "Offset of field: ",

--- a/tests/expectations/tests/namespace.rs
+++ b/tests/expectations/tests/namespace.rs
@@ -45,11 +45,7 @@ pub mod root {
             );
             assert_eq!(
                 {
-                    const STRUCT_SIZE: usize = std::mem::size_of::<A>();
-                    let buffer = [0u8; STRUCT_SIZE];
-                    let struct_instance = unsafe {
-                        std::mem::transmute::<[u8; STRUCT_SIZE], A>(buffer)
-                    };
+                    let struct_instance = unsafe { std::mem::zeroed::<A>() };
                     let struct_ptr = &struct_instance as *const A;
                     let field_ptr = std::ptr::addr_of!(struct_instance.b);
                     let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/nested.rs
+++ b/tests/expectations/tests/nested.rs
@@ -23,7 +23,19 @@ fn bindgen_test_layout_Calc() {
         concat!("Alignment of ", stringify!(Calc))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Calc>())).w as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<Calc>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], Calc>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const Calc;
+            let field_ptr = std::ptr::addr_of!(struct_instance.w);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!("Offset of field: ", stringify!(Calc), "::", stringify!(w))
     );
@@ -70,8 +82,18 @@ fn bindgen_test_layout_Test_Size() {
         concat!("Alignment of ", stringify!(Test_Size))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<Test_Size>())).mWidth as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<Test_Size>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], Test_Size>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const Test_Size;
+            let field_ptr = std::ptr::addr_of!(struct_instance.mWidth);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -82,8 +104,18 @@ fn bindgen_test_layout_Test_Size() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<Test_Size>())).mHeight as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<Test_Size>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], Test_Size>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const Test_Size;
+            let field_ptr = std::ptr::addr_of!(struct_instance.mHeight);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         4usize,
         concat!(

--- a/tests/expectations/tests/nested.rs
+++ b/tests/expectations/tests/nested.rs
@@ -24,11 +24,7 @@ fn bindgen_test_layout_Calc() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<Calc>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], Calc>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<Calc>() };
             let struct_ptr = &struct_instance as *const Calc;
             let field_ptr = std::ptr::addr_of!(struct_instance.w);
             let struct_address = struct_ptr as usize;
@@ -83,11 +79,7 @@ fn bindgen_test_layout_Test_Size() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<Test_Size>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], Test_Size>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<Test_Size>() };
             let struct_ptr = &struct_instance as *const Test_Size;
             let field_ptr = std::ptr::addr_of!(struct_instance.mWidth);
             let struct_address = struct_ptr as usize;
@@ -105,11 +97,7 @@ fn bindgen_test_layout_Test_Size() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<Test_Size>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], Test_Size>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<Test_Size>() };
             let struct_ptr = &struct_instance as *const Test_Size;
             let field_ptr = std::ptr::addr_of!(struct_instance.mHeight);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/nested_within_namespace.rs
+++ b/tests/expectations/tests/nested_within_namespace.rs
@@ -35,8 +35,20 @@ pub mod root {
                 concat!("Alignment of ", stringify!(Bar_Baz))
             );
             assert_eq!(
-                unsafe {
-                    &(*(::std::ptr::null::<Bar_Baz>())).foo as *const _ as usize
+                {
+                    const STRUCT_SIZE: usize = std::mem::size_of::<Bar_Baz>();
+                    let buffer = [0u8; STRUCT_SIZE];
+                    let struct_instance = unsafe {
+                        std::mem::transmute::<[u8; STRUCT_SIZE], Bar_Baz>(
+                            buffer,
+                        )
+                    };
+                    let struct_ptr = &struct_instance as *const Bar_Baz;
+                    let field_ptr = std::ptr::addr_of!(struct_instance.foo);
+                    let struct_address = struct_ptr as usize;
+                    let field_address = field_ptr as usize;
+                    std::mem::forget(struct_instance);
+                    field_address.checked_sub(struct_address).unwrap()
                 },
                 0usize,
                 concat!(
@@ -60,8 +72,18 @@ pub mod root {
                 concat!("Alignment of ", stringify!(Bar))
             );
             assert_eq!(
-                unsafe {
-                    &(*(::std::ptr::null::<Bar>())).foo as *const _ as usize
+                {
+                    const STRUCT_SIZE: usize = std::mem::size_of::<Bar>();
+                    let buffer = [0u8; STRUCT_SIZE];
+                    let struct_instance = unsafe {
+                        std::mem::transmute::<[u8; STRUCT_SIZE], Bar>(buffer)
+                    };
+                    let struct_ptr = &struct_instance as *const Bar;
+                    let field_ptr = std::ptr::addr_of!(struct_instance.foo);
+                    let struct_address = struct_ptr as usize;
+                    let field_address = field_ptr as usize;
+                    std::mem::forget(struct_instance);
+                    field_address.checked_sub(struct_address).unwrap()
                 },
                 0usize,
                 concat!(
@@ -90,8 +112,18 @@ pub mod root {
                 concat!("Alignment of ", stringify!(Baz))
             );
             assert_eq!(
-                unsafe {
-                    &(*(::std::ptr::null::<Baz>())).baz as *const _ as usize
+                {
+                    const STRUCT_SIZE: usize = std::mem::size_of::<Baz>();
+                    let buffer = [0u8; STRUCT_SIZE];
+                    let struct_instance = unsafe {
+                        std::mem::transmute::<[u8; STRUCT_SIZE], Baz>(buffer)
+                    };
+                    let struct_ptr = &struct_instance as *const Baz;
+                    let field_ptr = std::ptr::addr_of!(struct_instance.baz);
+                    let struct_address = struct_ptr as usize;
+                    let field_address = field_ptr as usize;
+                    std::mem::forget(struct_instance);
+                    field_address.checked_sub(struct_address).unwrap()
                 },
                 0usize,
                 concat!(

--- a/tests/expectations/tests/nested_within_namespace.rs
+++ b/tests/expectations/tests/nested_within_namespace.rs
@@ -36,13 +36,8 @@ pub mod root {
             );
             assert_eq!(
                 {
-                    const STRUCT_SIZE: usize = std::mem::size_of::<Bar_Baz>();
-                    let buffer = [0u8; STRUCT_SIZE];
-                    let struct_instance = unsafe {
-                        std::mem::transmute::<[u8; STRUCT_SIZE], Bar_Baz>(
-                            buffer,
-                        )
-                    };
+                    let struct_instance =
+                        unsafe { std::mem::zeroed::<Bar_Baz>() };
                     let struct_ptr = &struct_instance as *const Bar_Baz;
                     let field_ptr = std::ptr::addr_of!(struct_instance.foo);
                     let struct_address = struct_ptr as usize;
@@ -73,11 +68,7 @@ pub mod root {
             );
             assert_eq!(
                 {
-                    const STRUCT_SIZE: usize = std::mem::size_of::<Bar>();
-                    let buffer = [0u8; STRUCT_SIZE];
-                    let struct_instance = unsafe {
-                        std::mem::transmute::<[u8; STRUCT_SIZE], Bar>(buffer)
-                    };
+                    let struct_instance = unsafe { std::mem::zeroed::<Bar>() };
                     let struct_ptr = &struct_instance as *const Bar;
                     let field_ptr = std::ptr::addr_of!(struct_instance.foo);
                     let struct_address = struct_ptr as usize;
@@ -113,11 +104,7 @@ pub mod root {
             );
             assert_eq!(
                 {
-                    const STRUCT_SIZE: usize = std::mem::size_of::<Baz>();
-                    let buffer = [0u8; STRUCT_SIZE];
-                    let struct_instance = unsafe {
-                        std::mem::transmute::<[u8; STRUCT_SIZE], Baz>(buffer)
-                    };
+                    let struct_instance = unsafe { std::mem::zeroed::<Baz>() };
                     let struct_ptr = &struct_instance as *const Baz;
                     let field_ptr = std::ptr::addr_of!(struct_instance.baz);
                     let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/no-comments.rs
+++ b/tests/expectations/tests/no-comments.rs
@@ -23,7 +23,19 @@ fn bindgen_test_layout_Foo() {
         concat!("Alignment of ", stringify!(Foo))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Foo>())).s as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<Foo>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], Foo>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const Foo;
+            let field_ptr = std::ptr::addr_of!(struct_instance.s);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!("Offset of field: ", stringify!(Foo), "::", stringify!(s))
     );

--- a/tests/expectations/tests/no-comments.rs
+++ b/tests/expectations/tests/no-comments.rs
@@ -24,11 +24,7 @@ fn bindgen_test_layout_Foo() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<Foo>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], Foo>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<Foo>() };
             let struct_ptr = &struct_instance as *const Foo;
             let field_ptr = std::ptr::addr_of!(struct_instance.s);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/no-derive-debug.rs
+++ b/tests/expectations/tests/no-derive-debug.rs
@@ -33,11 +33,7 @@ fn bindgen_test_layout_bar() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<bar>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], bar>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<bar>() };
             let struct_ptr = &struct_instance as *const bar;
             let field_ptr = std::ptr::addr_of!(struct_instance.foo);
             let struct_address = struct_ptr as usize;
@@ -50,11 +46,7 @@ fn bindgen_test_layout_bar() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<bar>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], bar>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<bar>() };
             let struct_ptr = &struct_instance as *const bar;
             let field_ptr = std::ptr::addr_of!(struct_instance.baz);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/no-derive-debug.rs
+++ b/tests/expectations/tests/no-derive-debug.rs
@@ -32,12 +32,36 @@ fn bindgen_test_layout_bar() {
         concat!("Alignment of ", stringify!(bar))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<bar>())).foo as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<bar>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], bar>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const bar;
+            let field_ptr = std::ptr::addr_of!(struct_instance.foo);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!("Offset of field: ", stringify!(bar), "::", stringify!(foo))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<bar>())).baz as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<bar>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], bar>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const bar;
+            let field_ptr = std::ptr::addr_of!(struct_instance.baz);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         4usize,
         concat!("Offset of field: ", stringify!(bar), "::", stringify!(baz))
     );

--- a/tests/expectations/tests/no-derive-default.rs
+++ b/tests/expectations/tests/no-derive-default.rs
@@ -33,11 +33,7 @@ fn bindgen_test_layout_bar() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<bar>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], bar>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<bar>() };
             let struct_ptr = &struct_instance as *const bar;
             let field_ptr = std::ptr::addr_of!(struct_instance.foo);
             let struct_address = struct_ptr as usize;
@@ -50,11 +46,7 @@ fn bindgen_test_layout_bar() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<bar>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], bar>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<bar>() };
             let struct_ptr = &struct_instance as *const bar;
             let field_ptr = std::ptr::addr_of!(struct_instance.baz);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/no-derive-default.rs
+++ b/tests/expectations/tests/no-derive-default.rs
@@ -32,12 +32,36 @@ fn bindgen_test_layout_bar() {
         concat!("Alignment of ", stringify!(bar))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<bar>())).foo as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<bar>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], bar>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const bar;
+            let field_ptr = std::ptr::addr_of!(struct_instance.foo);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!("Offset of field: ", stringify!(bar), "::", stringify!(foo))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<bar>())).baz as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<bar>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], bar>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const bar;
+            let field_ptr = std::ptr::addr_of!(struct_instance.baz);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         4usize,
         concat!("Offset of field: ", stringify!(bar), "::", stringify!(baz))
     );

--- a/tests/expectations/tests/no-hash-allowlisted.rs
+++ b/tests/expectations/tests/no-hash-allowlisted.rs
@@ -24,11 +24,7 @@ fn bindgen_test_layout_NoHash() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<NoHash>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], NoHash>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<NoHash>() };
             let struct_ptr = &struct_instance as *const NoHash;
             let field_ptr = std::ptr::addr_of!(struct_instance.i);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/no-hash-allowlisted.rs
+++ b/tests/expectations/tests/no-hash-allowlisted.rs
@@ -23,7 +23,19 @@ fn bindgen_test_layout_NoHash() {
         concat!("Alignment of ", stringify!(NoHash))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<NoHash>())).i as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<NoHash>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], NoHash>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const NoHash;
+            let field_ptr = std::ptr::addr_of!(struct_instance.i);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!("Offset of field: ", stringify!(NoHash), "::", stringify!(i))
     );

--- a/tests/expectations/tests/no-partialeq-allowlisted.rs
+++ b/tests/expectations/tests/no-partialeq-allowlisted.rs
@@ -23,8 +23,18 @@ fn bindgen_test_layout_NoPartialEq() {
         concat!("Alignment of ", stringify!(NoPartialEq))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<NoPartialEq>())).i as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<NoPartialEq>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], NoPartialEq>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const NoPartialEq;
+            let field_ptr = std::ptr::addr_of!(struct_instance.i);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(

--- a/tests/expectations/tests/no-partialeq-allowlisted.rs
+++ b/tests/expectations/tests/no-partialeq-allowlisted.rs
@@ -24,11 +24,7 @@ fn bindgen_test_layout_NoPartialEq() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<NoPartialEq>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], NoPartialEq>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<NoPartialEq>() };
             let struct_ptr = &struct_instance as *const NoPartialEq;
             let field_ptr = std::ptr::addr_of!(struct_instance.i);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/no-recursive-allowlisting.rs
+++ b/tests/expectations/tests/no-recursive-allowlisting.rs
@@ -26,11 +26,7 @@ fn bindgen_test_layout_Foo() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<Foo>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], Foo>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<Foo>() };
             let struct_ptr = &struct_instance as *const Foo;
             let field_ptr = std::ptr::addr_of!(struct_instance.baz);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/no-recursive-allowlisting.rs
+++ b/tests/expectations/tests/no-recursive-allowlisting.rs
@@ -25,7 +25,19 @@ fn bindgen_test_layout_Foo() {
         concat!("Alignment of ", stringify!(Foo))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Foo>())).baz as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<Foo>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], Foo>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const Foo;
+            let field_ptr = std::ptr::addr_of!(struct_instance.baz);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!("Offset of field: ", stringify!(Foo), "::", stringify!(baz))
     );

--- a/tests/expectations/tests/no-std.rs
+++ b/tests/expectations/tests/no-std.rs
@@ -31,11 +31,7 @@ fn bindgen_test_layout_foo() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<foo>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], foo>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<foo>() };
             let struct_ptr = &struct_instance as *const foo;
             let field_ptr = std::ptr::addr_of!(struct_instance.a);
             let struct_address = struct_ptr as usize;
@@ -48,11 +44,7 @@ fn bindgen_test_layout_foo() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<foo>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], foo>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<foo>() };
             let struct_ptr = &struct_instance as *const foo;
             let field_ptr = std::ptr::addr_of!(struct_instance.b);
             let struct_address = struct_ptr as usize;
@@ -65,11 +57,7 @@ fn bindgen_test_layout_foo() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<foo>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], foo>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<foo>() };
             let struct_ptr = &struct_instance as *const foo;
             let field_ptr = std::ptr::addr_of!(struct_instance.bar);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/no-std.rs
+++ b/tests/expectations/tests/no-std.rs
@@ -30,17 +30,53 @@ fn bindgen_test_layout_foo() {
         concat!("Alignment of ", stringify!(foo))
     );
     assert_eq!(
-        unsafe { &(*(::core::ptr::null::<foo>())).a as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<foo>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], foo>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const foo;
+            let field_ptr = std::ptr::addr_of!(struct_instance.a);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!("Offset of field: ", stringify!(foo), "::", stringify!(a))
     );
     assert_eq!(
-        unsafe { &(*(::core::ptr::null::<foo>())).b as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<foo>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], foo>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const foo;
+            let field_ptr = std::ptr::addr_of!(struct_instance.b);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         4usize,
         concat!("Offset of field: ", stringify!(foo), "::", stringify!(b))
     );
     assert_eq!(
-        unsafe { &(*(::core::ptr::null::<foo>())).bar as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<foo>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], foo>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const foo;
+            let field_ptr = std::ptr::addr_of!(struct_instance.bar);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         8usize,
         concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar))
     );

--- a/tests/expectations/tests/no_copy_allowlisted.rs
+++ b/tests/expectations/tests/no_copy_allowlisted.rs
@@ -23,7 +23,19 @@ fn bindgen_test_layout_NoCopy() {
         concat!("Alignment of ", stringify!(NoCopy))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<NoCopy>())).i as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<NoCopy>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], NoCopy>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const NoCopy;
+            let field_ptr = std::ptr::addr_of!(struct_instance.i);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!("Offset of field: ", stringify!(NoCopy), "::", stringify!(i))
     );

--- a/tests/expectations/tests/no_copy_allowlisted.rs
+++ b/tests/expectations/tests/no_copy_allowlisted.rs
@@ -24,11 +24,7 @@ fn bindgen_test_layout_NoCopy() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<NoCopy>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], NoCopy>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<NoCopy>() };
             let struct_ptr = &struct_instance as *const NoCopy;
             let field_ptr = std::ptr::addr_of!(struct_instance.i);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/no_debug_allowlisted.rs
+++ b/tests/expectations/tests/no_debug_allowlisted.rs
@@ -23,7 +23,19 @@ fn bindgen_test_layout_NoDebug() {
         concat!("Alignment of ", stringify!(NoDebug))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<NoDebug>())).i as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<NoDebug>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], NoDebug>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const NoDebug;
+            let field_ptr = std::ptr::addr_of!(struct_instance.i);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/no_debug_allowlisted.rs
+++ b/tests/expectations/tests/no_debug_allowlisted.rs
@@ -24,11 +24,7 @@ fn bindgen_test_layout_NoDebug() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<NoDebug>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], NoDebug>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<NoDebug>() };
             let struct_ptr = &struct_instance as *const NoDebug;
             let field_ptr = std::ptr::addr_of!(struct_instance.i);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/no_default_allowlisted.rs
+++ b/tests/expectations/tests/no_default_allowlisted.rs
@@ -24,11 +24,7 @@ fn bindgen_test_layout_NoDefault() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<NoDefault>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], NoDefault>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<NoDefault>() };
             let struct_ptr = &struct_instance as *const NoDefault;
             let field_ptr = std::ptr::addr_of!(struct_instance.i);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/no_default_allowlisted.rs
+++ b/tests/expectations/tests/no_default_allowlisted.rs
@@ -23,7 +23,19 @@ fn bindgen_test_layout_NoDefault() {
         concat!("Alignment of ", stringify!(NoDefault))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<NoDefault>())).i as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<NoDefault>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], NoDefault>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const NoDefault;
+            let field_ptr = std::ptr::addr_of!(struct_instance.i);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/non-type-params.rs
+++ b/tests/expectations/tests/non-type-params.rs
@@ -27,9 +27,18 @@ fn bindgen_test_layout_UsesArray() {
         concat!("Alignment of ", stringify!(UsesArray))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<UsesArray>())).array_char_16 as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<UsesArray>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], UsesArray>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const UsesArray;
+            let field_ptr = std::ptr::addr_of!(struct_instance.array_char_16);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -40,9 +49,18 @@ fn bindgen_test_layout_UsesArray() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<UsesArray>())).array_bool_8 as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<UsesArray>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], UsesArray>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const UsesArray;
+            let field_ptr = std::ptr::addr_of!(struct_instance.array_bool_8);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         16usize,
         concat!(
@@ -53,9 +71,18 @@ fn bindgen_test_layout_UsesArray() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<UsesArray>())).array_int_4 as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<UsesArray>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], UsesArray>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const UsesArray;
+            let field_ptr = std::ptr::addr_of!(struct_instance.array_int_4);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         24usize,
         concat!(

--- a/tests/expectations/tests/non-type-params.rs
+++ b/tests/expectations/tests/non-type-params.rs
@@ -28,11 +28,7 @@ fn bindgen_test_layout_UsesArray() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<UsesArray>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], UsesArray>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<UsesArray>() };
             let struct_ptr = &struct_instance as *const UsesArray;
             let field_ptr = std::ptr::addr_of!(struct_instance.array_char_16);
             let struct_address = struct_ptr as usize;
@@ -50,11 +46,7 @@ fn bindgen_test_layout_UsesArray() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<UsesArray>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], UsesArray>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<UsesArray>() };
             let struct_ptr = &struct_instance as *const UsesArray;
             let field_ptr = std::ptr::addr_of!(struct_instance.array_bool_8);
             let struct_address = struct_ptr as usize;
@@ -72,11 +64,7 @@ fn bindgen_test_layout_UsesArray() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<UsesArray>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], UsesArray>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<UsesArray>() };
             let struct_ptr = &struct_instance as *const UsesArray;
             let field_ptr = std::ptr::addr_of!(struct_instance.array_int_4);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/objc_interface_type.rs
+++ b/tests/expectations/tests/objc_interface_type.rs
@@ -46,11 +46,7 @@ fn bindgen_test_layout_FooStruct() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<FooStruct>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], FooStruct>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<FooStruct>() };
             let struct_ptr = &struct_instance as *const FooStruct;
             let field_ptr = std::ptr::addr_of!(struct_instance.foo);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/objc_interface_type.rs
+++ b/tests/expectations/tests/objc_interface_type.rs
@@ -45,8 +45,18 @@ fn bindgen_test_layout_FooStruct() {
         concat!("Alignment of ", stringify!(FooStruct))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<FooStruct>())).foo as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<FooStruct>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], FooStruct>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const FooStruct;
+            let field_ptr = std::ptr::addr_of!(struct_instance.foo);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(

--- a/tests/expectations/tests/opaque-template-inst-member-2.rs
+++ b/tests/expectations/tests/opaque-template-inst-member-2.rs
@@ -32,9 +32,21 @@ fn bindgen_test_layout_ContainsOpaqueTemplate() {
         concat!("Alignment of ", stringify!(ContainsOpaqueTemplate))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<ContainsOpaqueTemplate>())).mBlah as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<ContainsOpaqueTemplate>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], ContainsOpaqueTemplate>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const ContainsOpaqueTemplate;
+            let field_ptr = std::ptr::addr_of!(struct_instance.mBlah);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -45,9 +57,21 @@ fn bindgen_test_layout_ContainsOpaqueTemplate() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<ContainsOpaqueTemplate>())).mBaz as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<ContainsOpaqueTemplate>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], ContainsOpaqueTemplate>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const ContainsOpaqueTemplate;
+            let field_ptr = std::ptr::addr_of!(struct_instance.mBaz);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         4usize,
         concat!(
@@ -78,9 +102,21 @@ fn bindgen_test_layout_InheritsOpaqueTemplate() {
         concat!("Alignment of ", stringify!(InheritsOpaqueTemplate))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<InheritsOpaqueTemplate>())).wow as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<InheritsOpaqueTemplate>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], InheritsOpaqueTemplate>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const InheritsOpaqueTemplate;
+            let field_ptr = std::ptr::addr_of!(struct_instance.wow);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         8usize,
         concat!(

--- a/tests/expectations/tests/opaque-template-inst-member-2.rs
+++ b/tests/expectations/tests/opaque-template-inst-member-2.rs
@@ -33,14 +33,8 @@ fn bindgen_test_layout_ContainsOpaqueTemplate() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<ContainsOpaqueTemplate>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], ContainsOpaqueTemplate>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<ContainsOpaqueTemplate>() };
             let struct_ptr = &struct_instance as *const ContainsOpaqueTemplate;
             let field_ptr = std::ptr::addr_of!(struct_instance.mBlah);
             let struct_address = struct_ptr as usize;
@@ -58,14 +52,8 @@ fn bindgen_test_layout_ContainsOpaqueTemplate() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<ContainsOpaqueTemplate>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], ContainsOpaqueTemplate>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<ContainsOpaqueTemplate>() };
             let struct_ptr = &struct_instance as *const ContainsOpaqueTemplate;
             let field_ptr = std::ptr::addr_of!(struct_instance.mBaz);
             let struct_address = struct_ptr as usize;
@@ -103,14 +91,8 @@ fn bindgen_test_layout_InheritsOpaqueTemplate() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<InheritsOpaqueTemplate>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], InheritsOpaqueTemplate>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<InheritsOpaqueTemplate>() };
             let struct_ptr = &struct_instance as *const InheritsOpaqueTemplate;
             let field_ptr = std::ptr::addr_of!(struct_instance.wow);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/opaque-template-inst-member.rs
+++ b/tests/expectations/tests/opaque-template-inst-member.rs
@@ -31,14 +31,8 @@ fn bindgen_test_layout_ContainsOpaqueTemplate() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<ContainsOpaqueTemplate>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], ContainsOpaqueTemplate>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<ContainsOpaqueTemplate>() };
             let struct_ptr = &struct_instance as *const ContainsOpaqueTemplate;
             let field_ptr = std::ptr::addr_of!(struct_instance.mBlah);
             let struct_address = struct_ptr as usize;
@@ -56,14 +50,8 @@ fn bindgen_test_layout_ContainsOpaqueTemplate() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<ContainsOpaqueTemplate>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], ContainsOpaqueTemplate>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<ContainsOpaqueTemplate>() };
             let struct_ptr = &struct_instance as *const ContainsOpaqueTemplate;
             let field_ptr = std::ptr::addr_of!(struct_instance.mBaz);
             let struct_address = struct_ptr as usize;
@@ -115,14 +103,8 @@ fn bindgen_test_layout_InheritsOpaqueTemplate() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<InheritsOpaqueTemplate>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], InheritsOpaqueTemplate>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<InheritsOpaqueTemplate>() };
             let struct_ptr = &struct_instance as *const InheritsOpaqueTemplate;
             let field_ptr = std::ptr::addr_of!(struct_instance.wow);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/opaque-template-inst-member.rs
+++ b/tests/expectations/tests/opaque-template-inst-member.rs
@@ -30,9 +30,21 @@ fn bindgen_test_layout_ContainsOpaqueTemplate() {
         concat!("Alignment of ", stringify!(ContainsOpaqueTemplate))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<ContainsOpaqueTemplate>())).mBlah as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<ContainsOpaqueTemplate>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], ContainsOpaqueTemplate>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const ContainsOpaqueTemplate;
+            let field_ptr = std::ptr::addr_of!(struct_instance.mBlah);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -43,9 +55,21 @@ fn bindgen_test_layout_ContainsOpaqueTemplate() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<ContainsOpaqueTemplate>())).mBaz as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<ContainsOpaqueTemplate>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], ContainsOpaqueTemplate>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const ContainsOpaqueTemplate;
+            let field_ptr = std::ptr::addr_of!(struct_instance.mBaz);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         404usize,
         concat!(
@@ -90,9 +114,21 @@ fn bindgen_test_layout_InheritsOpaqueTemplate() {
         concat!("Alignment of ", stringify!(InheritsOpaqueTemplate))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<InheritsOpaqueTemplate>())).wow as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<InheritsOpaqueTemplate>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], InheritsOpaqueTemplate>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const InheritsOpaqueTemplate;
+            let field_ptr = std::ptr::addr_of!(struct_instance.wow);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         408usize,
         concat!(

--- a/tests/expectations/tests/opaque-template-instantiation-namespaced.rs
+++ b/tests/expectations/tests/opaque-template-instantiation-namespaced.rs
@@ -46,8 +46,18 @@ pub mod root {
                 concat!("Alignment of ", stringify!(Foo))
             );
             assert_eq!(
-                unsafe {
-                    &(*(::std::ptr::null::<Foo>())).c as *const _ as usize
+                {
+                    const STRUCT_SIZE: usize = std::mem::size_of::<Foo>();
+                    let buffer = [0u8; STRUCT_SIZE];
+                    let struct_instance = unsafe {
+                        std::mem::transmute::<[u8; STRUCT_SIZE], Foo>(buffer)
+                    };
+                    let struct_ptr = &struct_instance as *const Foo;
+                    let field_ptr = std::ptr::addr_of!(struct_instance.c);
+                    let struct_address = struct_ptr as usize;
+                    let field_address = field_ptr as usize;
+                    std::mem::forget(struct_instance);
+                    field_address.checked_sub(struct_address).unwrap()
                 },
                 0usize,
                 concat!(
@@ -76,8 +86,18 @@ pub mod root {
                 concat!("Alignment of ", stringify!(Bar))
             );
             assert_eq!(
-                unsafe {
-                    &(*(::std::ptr::null::<Bar>())).i as *const _ as usize
+                {
+                    const STRUCT_SIZE: usize = std::mem::size_of::<Bar>();
+                    let buffer = [0u8; STRUCT_SIZE];
+                    let struct_instance = unsafe {
+                        std::mem::transmute::<[u8; STRUCT_SIZE], Bar>(buffer)
+                    };
+                    let struct_ptr = &struct_instance as *const Bar;
+                    let field_ptr = std::ptr::addr_of!(struct_instance.i);
+                    let struct_address = struct_ptr as usize;
+                    let field_address = field_ptr as usize;
+                    std::mem::forget(struct_instance);
+                    field_address.checked_sub(struct_address).unwrap()
                 },
                 0usize,
                 concat!(
@@ -106,9 +126,24 @@ pub mod root {
                 concat!("Alignment of ", stringify!(ContainsInstantiation))
             );
             assert_eq!(
-                unsafe {
-                    &(*(::std::ptr::null::<ContainsInstantiation>())).not_opaque
-                        as *const _ as usize
+                {
+                    const STRUCT_SIZE: usize =
+                        std::mem::size_of::<ContainsInstantiation>();
+                    let buffer = [0u8; STRUCT_SIZE];
+                    let struct_instance = unsafe {
+                        std::mem::transmute::<
+                            [u8; STRUCT_SIZE],
+                            ContainsInstantiation,
+                        >(buffer)
+                    };
+                    let struct_ptr =
+                        &struct_instance as *const ContainsInstantiation;
+                    let field_ptr =
+                        std::ptr::addr_of!(struct_instance.not_opaque);
+                    let struct_address = struct_ptr as usize;
+                    let field_address = field_ptr as usize;
+                    std::mem::forget(struct_instance);
+                    field_address.checked_sub(struct_address).unwrap()
                 },
                 0usize,
                 concat!(
@@ -149,9 +184,23 @@ pub mod root {
                 )
             );
             assert_eq!(
-                unsafe {
-                    &(*(::std::ptr::null::<ContainsOpaqueInstantiation>()))
-                        .opaque as *const _ as usize
+                {
+                    const STRUCT_SIZE: usize =
+                        std::mem::size_of::<ContainsOpaqueInstantiation>();
+                    let buffer = [0u8; STRUCT_SIZE];
+                    let struct_instance = unsafe {
+                        std::mem::transmute::<
+                            [u8; STRUCT_SIZE],
+                            ContainsOpaqueInstantiation,
+                        >(buffer)
+                    };
+                    let struct_ptr =
+                        &struct_instance as *const ContainsOpaqueInstantiation;
+                    let field_ptr = std::ptr::addr_of!(struct_instance.opaque);
+                    let struct_address = struct_ptr as usize;
+                    let field_address = field_ptr as usize;
+                    std::mem::forget(struct_instance);
+                    field_address.checked_sub(struct_address).unwrap()
                 },
                 0usize,
                 concat!(

--- a/tests/expectations/tests/opaque-template-instantiation-namespaced.rs
+++ b/tests/expectations/tests/opaque-template-instantiation-namespaced.rs
@@ -47,11 +47,7 @@ pub mod root {
             );
             assert_eq!(
                 {
-                    const STRUCT_SIZE: usize = std::mem::size_of::<Foo>();
-                    let buffer = [0u8; STRUCT_SIZE];
-                    let struct_instance = unsafe {
-                        std::mem::transmute::<[u8; STRUCT_SIZE], Foo>(buffer)
-                    };
+                    let struct_instance = unsafe { std::mem::zeroed::<Foo>() };
                     let struct_ptr = &struct_instance as *const Foo;
                     let field_ptr = std::ptr::addr_of!(struct_instance.c);
                     let struct_address = struct_ptr as usize;
@@ -87,11 +83,7 @@ pub mod root {
             );
             assert_eq!(
                 {
-                    const STRUCT_SIZE: usize = std::mem::size_of::<Bar>();
-                    let buffer = [0u8; STRUCT_SIZE];
-                    let struct_instance = unsafe {
-                        std::mem::transmute::<[u8; STRUCT_SIZE], Bar>(buffer)
-                    };
+                    let struct_instance = unsafe { std::mem::zeroed::<Bar>() };
                     let struct_ptr = &struct_instance as *const Bar;
                     let field_ptr = std::ptr::addr_of!(struct_instance.i);
                     let struct_address = struct_ptr as usize;
@@ -127,15 +119,8 @@ pub mod root {
             );
             assert_eq!(
                 {
-                    const STRUCT_SIZE: usize =
-                        std::mem::size_of::<ContainsInstantiation>();
-                    let buffer = [0u8; STRUCT_SIZE];
-                    let struct_instance = unsafe {
-                        std::mem::transmute::<
-                            [u8; STRUCT_SIZE],
-                            ContainsInstantiation,
-                        >(buffer)
-                    };
+                    let struct_instance =
+                        unsafe { std::mem::zeroed::<ContainsInstantiation>() };
                     let struct_ptr =
                         &struct_instance as *const ContainsInstantiation;
                     let field_ptr =
@@ -185,14 +170,8 @@ pub mod root {
             );
             assert_eq!(
                 {
-                    const STRUCT_SIZE: usize =
-                        std::mem::size_of::<ContainsOpaqueInstantiation>();
-                    let buffer = [0u8; STRUCT_SIZE];
                     let struct_instance = unsafe {
-                        std::mem::transmute::<
-                            [u8; STRUCT_SIZE],
-                            ContainsOpaqueInstantiation,
-                        >(buffer)
+                        std::mem::zeroed::<ContainsOpaqueInstantiation>()
                     };
                     let struct_ptr =
                         &struct_instance as *const ContainsOpaqueInstantiation;

--- a/tests/expectations/tests/opaque-template-instantiation.rs
+++ b/tests/expectations/tests/opaque-template-instantiation.rs
@@ -39,14 +39,8 @@ fn bindgen_test_layout_ContainsInstantiation() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<ContainsInstantiation>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], ContainsInstantiation>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<ContainsInstantiation>() };
             let struct_ptr = &struct_instance as *const ContainsInstantiation;
             let field_ptr = std::ptr::addr_of!(struct_instance.not_opaque);
             let struct_address = struct_ptr as usize;
@@ -91,15 +85,8 @@ fn bindgen_test_layout_ContainsOpaqueInstantiation() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<ContainsOpaqueInstantiation>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<
-                    [u8; STRUCT_SIZE],
-                    ContainsOpaqueInstantiation,
-                >(buffer)
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<ContainsOpaqueInstantiation>() };
             let struct_ptr =
                 &struct_instance as *const ContainsOpaqueInstantiation;
             let field_ptr = std::ptr::addr_of!(struct_instance.opaque);

--- a/tests/expectations/tests/opaque-template-instantiation.rs
+++ b/tests/expectations/tests/opaque-template-instantiation.rs
@@ -38,9 +38,21 @@ fn bindgen_test_layout_ContainsInstantiation() {
         concat!("Alignment of ", stringify!(ContainsInstantiation))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<ContainsInstantiation>())).not_opaque
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<ContainsInstantiation>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], ContainsInstantiation>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const ContainsInstantiation;
+            let field_ptr = std::ptr::addr_of!(struct_instance.not_opaque);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -78,9 +90,23 @@ fn bindgen_test_layout_ContainsOpaqueInstantiation() {
         concat!("Alignment of ", stringify!(ContainsOpaqueInstantiation))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<ContainsOpaqueInstantiation>())).opaque
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<ContainsOpaqueInstantiation>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<
+                    [u8; STRUCT_SIZE],
+                    ContainsOpaqueInstantiation,
+                >(buffer)
+            };
+            let struct_ptr =
+                &struct_instance as *const ContainsOpaqueInstantiation;
+            let field_ptr = std::ptr::addr_of!(struct_instance.opaque);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(

--- a/tests/expectations/tests/opaque_in_struct.rs
+++ b/tests/expectations/tests/opaque_in_struct.rs
@@ -43,8 +43,18 @@ fn bindgen_test_layout_container() {
         concat!("Alignment of ", stringify!(container))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<container>())).contained as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<container>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], container>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const container;
+            let field_ptr = std::ptr::addr_of!(struct_instance.contained);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(

--- a/tests/expectations/tests/opaque_in_struct.rs
+++ b/tests/expectations/tests/opaque_in_struct.rs
@@ -44,11 +44,7 @@ fn bindgen_test_layout_container() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<container>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], container>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<container>() };
             let struct_ptr = &struct_instance as *const container;
             let field_ptr = std::ptr::addr_of!(struct_instance.contained);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/opaque_pointer.rs
+++ b/tests/expectations/tests/opaque_pointer.rs
@@ -51,9 +51,18 @@ fn bindgen_test_layout_WithOpaquePtr() {
         concat!("Alignment of ", stringify!(WithOpaquePtr))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<WithOpaquePtr>())).whatever as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<WithOpaquePtr>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], WithOpaquePtr>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const WithOpaquePtr;
+            let field_ptr = std::ptr::addr_of!(struct_instance.whatever);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -64,8 +73,18 @@ fn bindgen_test_layout_WithOpaquePtr() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<WithOpaquePtr>())).other as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<WithOpaquePtr>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], WithOpaquePtr>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const WithOpaquePtr;
+            let field_ptr = std::ptr::addr_of!(struct_instance.other);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         8usize,
         concat!(
@@ -76,8 +95,18 @@ fn bindgen_test_layout_WithOpaquePtr() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<WithOpaquePtr>())).t as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<WithOpaquePtr>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], WithOpaquePtr>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const WithOpaquePtr;
+            let field_ptr = std::ptr::addr_of!(struct_instance.t);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         12usize,
         concat!(

--- a/tests/expectations/tests/opaque_pointer.rs
+++ b/tests/expectations/tests/opaque_pointer.rs
@@ -52,11 +52,8 @@ fn bindgen_test_layout_WithOpaquePtr() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<WithOpaquePtr>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], WithOpaquePtr>(buffer)
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<WithOpaquePtr>() };
             let struct_ptr = &struct_instance as *const WithOpaquePtr;
             let field_ptr = std::ptr::addr_of!(struct_instance.whatever);
             let struct_address = struct_ptr as usize;
@@ -74,11 +71,8 @@ fn bindgen_test_layout_WithOpaquePtr() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<WithOpaquePtr>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], WithOpaquePtr>(buffer)
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<WithOpaquePtr>() };
             let struct_ptr = &struct_instance as *const WithOpaquePtr;
             let field_ptr = std::ptr::addr_of!(struct_instance.other);
             let struct_address = struct_ptr as usize;
@@ -96,11 +90,8 @@ fn bindgen_test_layout_WithOpaquePtr() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<WithOpaquePtr>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], WithOpaquePtr>(buffer)
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<WithOpaquePtr>() };
             let struct_ptr = &struct_instance as *const WithOpaquePtr;
             let field_ptr = std::ptr::addr_of!(struct_instance.t);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/packed-n-with-padding.rs
+++ b/tests/expectations/tests/packed-n-with-padding.rs
@@ -26,22 +26,70 @@ fn bindgen_test_layout_Packed() {
         concat!("Alignment of ", stringify!(Packed))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Packed>())).a as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<Packed>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], Packed>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const Packed;
+            let field_ptr = std::ptr::addr_of!(struct_instance.a);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!("Offset of field: ", stringify!(Packed), "::", stringify!(a))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Packed>())).b as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<Packed>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], Packed>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const Packed;
+            let field_ptr = std::ptr::addr_of!(struct_instance.b);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         2usize,
         concat!("Offset of field: ", stringify!(Packed), "::", stringify!(b))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Packed>())).c as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<Packed>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], Packed>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const Packed;
+            let field_ptr = std::ptr::addr_of!(struct_instance.c);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         4usize,
         concat!("Offset of field: ", stringify!(Packed), "::", stringify!(c))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Packed>())).d as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<Packed>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], Packed>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const Packed;
+            let field_ptr = std::ptr::addr_of!(struct_instance.d);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         6usize,
         concat!("Offset of field: ", stringify!(Packed), "::", stringify!(d))
     );

--- a/tests/expectations/tests/packed-n-with-padding.rs
+++ b/tests/expectations/tests/packed-n-with-padding.rs
@@ -27,11 +27,7 @@ fn bindgen_test_layout_Packed() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<Packed>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], Packed>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<Packed>() };
             let struct_ptr = &struct_instance as *const Packed;
             let field_ptr = std::ptr::addr_of!(struct_instance.a);
             let struct_address = struct_ptr as usize;
@@ -44,11 +40,7 @@ fn bindgen_test_layout_Packed() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<Packed>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], Packed>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<Packed>() };
             let struct_ptr = &struct_instance as *const Packed;
             let field_ptr = std::ptr::addr_of!(struct_instance.b);
             let struct_address = struct_ptr as usize;
@@ -61,11 +53,7 @@ fn bindgen_test_layout_Packed() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<Packed>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], Packed>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<Packed>() };
             let struct_ptr = &struct_instance as *const Packed;
             let field_ptr = std::ptr::addr_of!(struct_instance.c);
             let struct_address = struct_ptr as usize;
@@ -78,11 +66,7 @@ fn bindgen_test_layout_Packed() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<Packed>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], Packed>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<Packed>() };
             let struct_ptr = &struct_instance as *const Packed;
             let field_ptr = std::ptr::addr_of!(struct_instance.d);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/private.rs
+++ b/tests/expectations/tests/private.rs
@@ -25,9 +25,18 @@ fn bindgen_test_layout_HasPrivate() {
         concat!("Alignment of ", stringify!(HasPrivate))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<HasPrivate>())).mNotPrivate as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<HasPrivate>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], HasPrivate>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const HasPrivate;
+            let field_ptr = std::ptr::addr_of!(struct_instance.mNotPrivate);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -38,9 +47,18 @@ fn bindgen_test_layout_HasPrivate() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<HasPrivate>())).mIsPrivate as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<HasPrivate>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], HasPrivate>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const HasPrivate;
+            let field_ptr = std::ptr::addr_of!(struct_instance.mIsPrivate);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         4usize,
         concat!(
@@ -71,9 +89,18 @@ fn bindgen_test_layout_VeryPrivate() {
         concat!("Alignment of ", stringify!(VeryPrivate))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<VeryPrivate>())).mIsPrivate as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<VeryPrivate>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], VeryPrivate>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const VeryPrivate;
+            let field_ptr = std::ptr::addr_of!(struct_instance.mIsPrivate);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -84,9 +111,18 @@ fn bindgen_test_layout_VeryPrivate() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<VeryPrivate>())).mIsAlsoPrivate as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<VeryPrivate>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], VeryPrivate>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const VeryPrivate;
+            let field_ptr = std::ptr::addr_of!(struct_instance.mIsAlsoPrivate);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         4usize,
         concat!(
@@ -118,9 +154,20 @@ fn bindgen_test_layout_ContradictPrivate() {
         concat!("Alignment of ", stringify!(ContradictPrivate))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<ContradictPrivate>())).mNotPrivate
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<ContradictPrivate>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], ContradictPrivate>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const ContradictPrivate;
+            let field_ptr = std::ptr::addr_of!(struct_instance.mNotPrivate);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -131,9 +178,20 @@ fn bindgen_test_layout_ContradictPrivate() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<ContradictPrivate>())).mIsPrivate as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<ContradictPrivate>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], ContradictPrivate>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const ContradictPrivate;
+            let field_ptr = std::ptr::addr_of!(struct_instance.mIsPrivate);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         4usize,
         concat!(

--- a/tests/expectations/tests/private.rs
+++ b/tests/expectations/tests/private.rs
@@ -26,11 +26,7 @@ fn bindgen_test_layout_HasPrivate() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<HasPrivate>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], HasPrivate>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<HasPrivate>() };
             let struct_ptr = &struct_instance as *const HasPrivate;
             let field_ptr = std::ptr::addr_of!(struct_instance.mNotPrivate);
             let struct_address = struct_ptr as usize;
@@ -48,11 +44,7 @@ fn bindgen_test_layout_HasPrivate() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<HasPrivate>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], HasPrivate>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<HasPrivate>() };
             let struct_ptr = &struct_instance as *const HasPrivate;
             let field_ptr = std::ptr::addr_of!(struct_instance.mIsPrivate);
             let struct_address = struct_ptr as usize;
@@ -90,11 +82,7 @@ fn bindgen_test_layout_VeryPrivate() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<VeryPrivate>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], VeryPrivate>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<VeryPrivate>() };
             let struct_ptr = &struct_instance as *const VeryPrivate;
             let field_ptr = std::ptr::addr_of!(struct_instance.mIsPrivate);
             let struct_address = struct_ptr as usize;
@@ -112,11 +100,7 @@ fn bindgen_test_layout_VeryPrivate() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<VeryPrivate>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], VeryPrivate>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<VeryPrivate>() };
             let struct_ptr = &struct_instance as *const VeryPrivate;
             let field_ptr = std::ptr::addr_of!(struct_instance.mIsAlsoPrivate);
             let struct_address = struct_ptr as usize;
@@ -155,13 +139,8 @@ fn bindgen_test_layout_ContradictPrivate() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<ContradictPrivate>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], ContradictPrivate>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<ContradictPrivate>() };
             let struct_ptr = &struct_instance as *const ContradictPrivate;
             let field_ptr = std::ptr::addr_of!(struct_instance.mNotPrivate);
             let struct_address = struct_ptr as usize;
@@ -179,13 +158,8 @@ fn bindgen_test_layout_ContradictPrivate() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<ContradictPrivate>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], ContradictPrivate>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<ContradictPrivate>() };
             let struct_ptr = &struct_instance as *const ContradictPrivate;
             let field_ptr = std::ptr::addr_of!(struct_instance.mIsPrivate);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/private_fields.rs
+++ b/tests/expectations/tests/private_fields.rs
@@ -111,11 +111,7 @@ fn bindgen_test_layout_PubPriv() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<PubPriv>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], PubPriv>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<PubPriv>() };
             let struct_ptr = &struct_instance as *const PubPriv;
             let field_ptr = std::ptr::addr_of!(struct_instance.x);
             let struct_address = struct_ptr as usize;
@@ -133,11 +129,7 @@ fn bindgen_test_layout_PubPriv() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<PubPriv>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], PubPriv>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<PubPriv>() };
             let struct_ptr = &struct_instance as *const PubPriv;
             let field_ptr = std::ptr::addr_of!(struct_instance.y);
             let struct_address = struct_ptr as usize;
@@ -371,11 +363,7 @@ fn bindgen_test_layout_Base() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<Base>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], Base>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<Base>() };
             let struct_ptr = &struct_instance as *const Base;
             let field_ptr = std::ptr::addr_of!(struct_instance.member);
             let struct_address = struct_ptr as usize;
@@ -453,15 +441,8 @@ fn bindgen_test_layout_WithAnonStruct__bindgen_ty_1() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<WithAnonStruct__bindgen_ty_1>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<
-                    [u8; STRUCT_SIZE],
-                    WithAnonStruct__bindgen_ty_1,
-                >(buffer)
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<WithAnonStruct__bindgen_ty_1>() };
             let struct_ptr =
                 &struct_instance as *const WithAnonStruct__bindgen_ty_1;
             let field_ptr = std::ptr::addr_of!(struct_instance.a);
@@ -498,15 +479,8 @@ fn bindgen_test_layout_WithAnonStruct__bindgen_ty_2() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<WithAnonStruct__bindgen_ty_2>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<
-                    [u8; STRUCT_SIZE],
-                    WithAnonStruct__bindgen_ty_2,
-                >(buffer)
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<WithAnonStruct__bindgen_ty_2>() };
             let struct_ptr =
                 &struct_instance as *const WithAnonStruct__bindgen_ty_2;
             let field_ptr = std::ptr::addr_of!(struct_instance.b);

--- a/tests/expectations/tests/private_fields.rs
+++ b/tests/expectations/tests/private_fields.rs
@@ -110,7 +110,19 @@ fn bindgen_test_layout_PubPriv() {
         concat!("Alignment of ", stringify!(PubPriv))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<PubPriv>())).x as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<PubPriv>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], PubPriv>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const PubPriv;
+            let field_ptr = std::ptr::addr_of!(struct_instance.x);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!(
             "Offset of field: ",
@@ -120,7 +132,19 @@ fn bindgen_test_layout_PubPriv() {
         )
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<PubPriv>())).y as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<PubPriv>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], PubPriv>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const PubPriv;
+            let field_ptr = std::ptr::addr_of!(struct_instance.y);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         4usize,
         concat!(
             "Offset of field: ",
@@ -346,7 +370,19 @@ fn bindgen_test_layout_Base() {
         concat!("Alignment of ", stringify!(Base))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Base>())).member as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<Base>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], Base>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const Base;
+            let field_ptr = std::ptr::addr_of!(struct_instance.member);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!(
             "Offset of field: ",
@@ -416,9 +452,23 @@ fn bindgen_test_layout_WithAnonStruct__bindgen_ty_1() {
         concat!("Alignment of ", stringify!(WithAnonStruct__bindgen_ty_1))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<WithAnonStruct__bindgen_ty_1>())).a
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<WithAnonStruct__bindgen_ty_1>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<
+                    [u8; STRUCT_SIZE],
+                    WithAnonStruct__bindgen_ty_1,
+                >(buffer)
+            };
+            let struct_ptr =
+                &struct_instance as *const WithAnonStruct__bindgen_ty_1;
+            let field_ptr = std::ptr::addr_of!(struct_instance.a);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -447,9 +497,23 @@ fn bindgen_test_layout_WithAnonStruct__bindgen_ty_2() {
         concat!("Alignment of ", stringify!(WithAnonStruct__bindgen_ty_2))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<WithAnonStruct__bindgen_ty_2>())).b
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<WithAnonStruct__bindgen_ty_2>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<
+                    [u8; STRUCT_SIZE],
+                    WithAnonStruct__bindgen_ty_2,
+                >(buffer)
+            };
+            let struct_ptr =
+                &struct_instance as *const WithAnonStruct__bindgen_ty_2;
+            let field_ptr = std::ptr::addr_of!(struct_instance.b);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(

--- a/tests/expectations/tests/reparented_replacement.rs
+++ b/tests/expectations/tests/reparented_replacement.rs
@@ -31,8 +31,18 @@ pub mod root {
                 concat!("Alignment of ", stringify!(Bar))
             );
             assert_eq!(
-                unsafe {
-                    &(*(::std::ptr::null::<Bar>())).bazz as *const _ as usize
+                {
+                    const STRUCT_SIZE: usize = std::mem::size_of::<Bar>();
+                    let buffer = [0u8; STRUCT_SIZE];
+                    let struct_instance = unsafe {
+                        std::mem::transmute::<[u8; STRUCT_SIZE], Bar>(buffer)
+                    };
+                    let struct_ptr = &struct_instance as *const Bar;
+                    let field_ptr = std::ptr::addr_of!(struct_instance.bazz);
+                    let struct_address = struct_ptr as usize;
+                    let field_address = field_ptr as usize;
+                    std::mem::forget(struct_instance);
+                    field_address.checked_sub(struct_address).unwrap()
                 },
                 0usize,
                 concat!(

--- a/tests/expectations/tests/reparented_replacement.rs
+++ b/tests/expectations/tests/reparented_replacement.rs
@@ -32,11 +32,7 @@ pub mod root {
             );
             assert_eq!(
                 {
-                    const STRUCT_SIZE: usize = std::mem::size_of::<Bar>();
-                    let buffer = [0u8; STRUCT_SIZE];
-                    let struct_instance = unsafe {
-                        std::mem::transmute::<[u8; STRUCT_SIZE], Bar>(buffer)
-                    };
+                    let struct_instance = unsafe { std::mem::zeroed::<Bar>() };
                     let struct_ptr = &struct_instance as *const Bar;
                     let field_ptr = std::ptr::addr_of!(struct_instance.bazz);
                     let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/replace_use.rs
+++ b/tests/expectations/tests/replace_use.rs
@@ -29,7 +29,19 @@ fn bindgen_test_layout_Test() {
         concat!("Alignment of ", stringify!(Test))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Test>())).a as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<Test>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], Test>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const Test;
+            let field_ptr = std::ptr::addr_of!(struct_instance.a);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!("Offset of field: ", stringify!(Test), "::", stringify!(a))
     );

--- a/tests/expectations/tests/replace_use.rs
+++ b/tests/expectations/tests/replace_use.rs
@@ -30,11 +30,7 @@ fn bindgen_test_layout_Test() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<Test>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], Test>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<Test>() };
             let struct_ptr = &struct_instance as *const Test;
             let field_ptr = std::ptr::addr_of!(struct_instance.a);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/repr-align.rs
+++ b/tests/expectations/tests/repr-align.rs
@@ -27,10 +27,7 @@ fn bindgen_test_layout_a() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<a>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance =
-                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], a>(buffer) };
+            let struct_instance = unsafe { std::mem::zeroed::<a>() };
             let struct_ptr = &struct_instance as *const a;
             let field_ptr = std::ptr::addr_of!(struct_instance.b);
             let struct_address = struct_ptr as usize;
@@ -43,10 +40,7 @@ fn bindgen_test_layout_a() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<a>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance =
-                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], a>(buffer) };
+            let struct_instance = unsafe { std::mem::zeroed::<a>() };
             let struct_ptr = &struct_instance as *const a;
             let field_ptr = std::ptr::addr_of!(struct_instance.c);
             let struct_address = struct_ptr as usize;
@@ -79,10 +73,7 @@ fn bindgen_test_layout_b() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<b>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance =
-                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], b>(buffer) };
+            let struct_instance = unsafe { std::mem::zeroed::<b>() };
             let struct_ptr = &struct_instance as *const b;
             let field_ptr = std::ptr::addr_of!(struct_instance.b);
             let struct_address = struct_ptr as usize;
@@ -95,10 +86,7 @@ fn bindgen_test_layout_b() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<b>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance =
-                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], b>(buffer) };
+            let struct_instance = unsafe { std::mem::zeroed::<b>() };
             let struct_ptr = &struct_instance as *const b;
             let field_ptr = std::ptr::addr_of!(struct_instance.c);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/repr-align.rs
+++ b/tests/expectations/tests/repr-align.rs
@@ -26,12 +26,34 @@ fn bindgen_test_layout_a() {
         concat!("Alignment of ", stringify!(a))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<a>())).b as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<a>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance =
+                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], a>(buffer) };
+            let struct_ptr = &struct_instance as *const a;
+            let field_ptr = std::ptr::addr_of!(struct_instance.b);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!("Offset of field: ", stringify!(a), "::", stringify!(b))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<a>())).c as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<a>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance =
+                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], a>(buffer) };
+            let struct_ptr = &struct_instance as *const a;
+            let field_ptr = std::ptr::addr_of!(struct_instance.c);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         4usize,
         concat!("Offset of field: ", stringify!(a), "::", stringify!(c))
     );
@@ -56,12 +78,34 @@ fn bindgen_test_layout_b() {
         concat!("Alignment of ", stringify!(b))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<b>())).b as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<b>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance =
+                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], b>(buffer) };
+            let struct_ptr = &struct_instance as *const b;
+            let field_ptr = std::ptr::addr_of!(struct_instance.b);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!("Offset of field: ", stringify!(b), "::", stringify!(b))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<b>())).c as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<b>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance =
+                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], b>(buffer) };
+            let struct_ptr = &struct_instance as *const b;
+            let field_ptr = std::ptr::addr_of!(struct_instance.c);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         4usize,
         concat!("Offset of field: ", stringify!(b), "::", stringify!(c))
     );

--- a/tests/expectations/tests/same_struct_name_in_different_namespaces.rs
+++ b/tests/expectations/tests/same_struct_name_in_different_namespaces.rs
@@ -29,8 +29,18 @@ fn bindgen_test_layout_JS_shadow_Zone() {
         concat!("Alignment of ", stringify!(JS_shadow_Zone))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<JS_shadow_Zone>())).x as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<JS_shadow_Zone>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], JS_shadow_Zone>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const JS_shadow_Zone;
+            let field_ptr = std::ptr::addr_of!(struct_instance.x);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -41,8 +51,18 @@ fn bindgen_test_layout_JS_shadow_Zone() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<JS_shadow_Zone>())).y as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<JS_shadow_Zone>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], JS_shadow_Zone>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const JS_shadow_Zone;
+            let field_ptr = std::ptr::addr_of!(struct_instance.y);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         4usize,
         concat!(

--- a/tests/expectations/tests/same_struct_name_in_different_namespaces.rs
+++ b/tests/expectations/tests/same_struct_name_in_different_namespaces.rs
@@ -30,11 +30,8 @@ fn bindgen_test_layout_JS_shadow_Zone() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<JS_shadow_Zone>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], JS_shadow_Zone>(buffer)
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<JS_shadow_Zone>() };
             let struct_ptr = &struct_instance as *const JS_shadow_Zone;
             let field_ptr = std::ptr::addr_of!(struct_instance.x);
             let struct_address = struct_ptr as usize;
@@ -52,11 +49,8 @@ fn bindgen_test_layout_JS_shadow_Zone() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<JS_shadow_Zone>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], JS_shadow_Zone>(buffer)
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<JS_shadow_Zone>() };
             let struct_ptr = &struct_instance as *const JS_shadow_Zone;
             let field_ptr = std::ptr::addr_of!(struct_instance.y);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/sentry-defined-multiple-times.rs
+++ b/tests/expectations/tests/sentry-defined-multiple-times.rs
@@ -40,9 +40,19 @@ pub mod root {
                 concat!("Alignment of ", stringify!(sentry))
             );
             assert_eq!(
-                unsafe {
-                    &(*(::std::ptr::null::<sentry>())).i_am_plain_sentry
-                        as *const _ as usize
+                {
+                    const STRUCT_SIZE: usize = std::mem::size_of::<sentry>();
+                    let buffer = [0u8; STRUCT_SIZE];
+                    let struct_instance = unsafe {
+                        std::mem::transmute::<[u8; STRUCT_SIZE], sentry>(buffer)
+                    };
+                    let struct_ptr = &struct_instance as *const sentry;
+                    let field_ptr =
+                        std::ptr::addr_of!(struct_instance.i_am_plain_sentry);
+                    let struct_address = struct_ptr as usize;
+                    let field_address = field_ptr as usize;
+                    std::mem::forget(struct_instance);
+                    field_address.checked_sub(struct_address).unwrap()
                 },
                 0usize,
                 concat!(
@@ -89,10 +99,25 @@ pub mod root {
                 concat!("Alignment of ", stringify!(NotTemplateWrapper_sentry))
             );
             assert_eq!(
-                unsafe {
-                    &(*(::std::ptr::null::<NotTemplateWrapper_sentry>()))
-                        .i_am_not_template_wrapper_sentry
-                        as *const _ as usize
+                {
+                    const STRUCT_SIZE: usize =
+                        std::mem::size_of::<NotTemplateWrapper_sentry>();
+                    let buffer = [0u8; STRUCT_SIZE];
+                    let struct_instance = unsafe {
+                        std::mem::transmute::<
+                            [u8; STRUCT_SIZE],
+                            NotTemplateWrapper_sentry,
+                        >(buffer)
+                    };
+                    let struct_ptr =
+                        &struct_instance as *const NotTemplateWrapper_sentry;
+                    let field_ptr = std::ptr::addr_of!(
+                        struct_instance.i_am_not_template_wrapper_sentry
+                    );
+                    let struct_address = struct_ptr as usize;
+                    let field_address = field_ptr as usize;
+                    std::mem::forget(struct_instance);
+                    field_address.checked_sub(struct_address).unwrap()
                 },
                 0usize,
                 concat!(
@@ -132,10 +157,25 @@ pub mod root {
                 )
             );
             assert_eq!(
-                unsafe {
-                    &(*(::std::ptr::null::<InlineNotTemplateWrapper_sentry>()))
-                        .i_am_inline_not_template_wrapper_sentry
-                        as *const _ as usize
+                {
+                    const STRUCT_SIZE: usize =
+                        std::mem::size_of::<InlineNotTemplateWrapper_sentry>();
+                    let buffer = [0u8; STRUCT_SIZE];
+                    let struct_instance = unsafe {
+                        std::mem::transmute::<
+                            [u8; STRUCT_SIZE],
+                            InlineNotTemplateWrapper_sentry,
+                        >(buffer)
+                    };
+                    let struct_ptr = &struct_instance
+                        as *const InlineNotTemplateWrapper_sentry;
+                    let field_ptr = std::ptr::addr_of!(
+                        struct_instance.i_am_inline_not_template_wrapper_sentry
+                    );
+                    let struct_address = struct_ptr as usize;
+                    let field_address = field_ptr as usize;
+                    std::mem::forget(struct_instance);
+                    field_address.checked_sub(struct_address).unwrap()
                 },
                 0usize,
                 concat!(
@@ -239,12 +279,26 @@ pub mod root {
                 )
             );
             assert_eq!(
-                unsafe {
-                    &(*(::std::ptr::null::<
+                {
+                    const STRUCT_SIZE: usize = std::mem::size_of::<
                         OuterDoubleWrapper_InnerDoubleWrapper_sentry,
-                    >()))
-                    .i_am_double_wrapper_sentry as *const _
-                        as usize
+                    >();
+                    let buffer = [0u8; STRUCT_SIZE];
+                    let struct_instance = unsafe {
+                        std::mem::transmute::<
+                            [u8; STRUCT_SIZE],
+                            OuterDoubleWrapper_InnerDoubleWrapper_sentry,
+                        >(buffer)
+                    };
+                    let struct_ptr = &struct_instance
+                        as *const OuterDoubleWrapper_InnerDoubleWrapper_sentry;
+                    let field_ptr = std::ptr::addr_of!(
+                        struct_instance.i_am_double_wrapper_sentry
+                    );
+                    let struct_address = struct_ptr as usize;
+                    let field_address = field_ptr as usize;
+                    std::mem::forget(struct_instance);
+                    field_address.checked_sub(struct_address).unwrap()
                 },
                 0usize,
                 concat!(
@@ -275,7 +329,7 @@ pub mod root {
         ) {
             assert_eq ! (:: std :: mem :: size_of :: < OuterDoubleInlineWrapper_InnerDoubleInlineWrapper_sentry > () , 4usize , concat ! ("Size of: " , stringify ! (OuterDoubleInlineWrapper_InnerDoubleInlineWrapper_sentry)));
             assert_eq ! (:: std :: mem :: align_of :: < OuterDoubleInlineWrapper_InnerDoubleInlineWrapper_sentry > () , 4usize , concat ! ("Alignment of " , stringify ! (OuterDoubleInlineWrapper_InnerDoubleInlineWrapper_sentry)));
-            assert_eq ! (unsafe { & (* (:: std :: ptr :: null :: < OuterDoubleInlineWrapper_InnerDoubleInlineWrapper_sentry > ())) . i_am_double_wrapper_inline_sentry as * const _ as usize } , 0usize , concat ! ("Offset of field: " , stringify ! (OuterDoubleInlineWrapper_InnerDoubleInlineWrapper_sentry) , "::" , stringify ! (i_am_double_wrapper_inline_sentry)));
+            assert_eq ! ({ const STRUCT_SIZE : usize = std :: mem :: size_of :: < OuterDoubleInlineWrapper_InnerDoubleInlineWrapper_sentry > () ; let buffer = [0u8 ; STRUCT_SIZE] ; let struct_instance = unsafe { std :: mem :: transmute :: < [u8 ; STRUCT_SIZE] , OuterDoubleInlineWrapper_InnerDoubleInlineWrapper_sentry > (buffer) } ; let struct_ptr = & struct_instance as * const OuterDoubleInlineWrapper_InnerDoubleInlineWrapper_sentry ; let field_ptr = std :: ptr :: addr_of ! (struct_instance . i_am_double_wrapper_inline_sentry) ; let struct_address = struct_ptr as usize ; let field_address = field_ptr as usize ; std :: mem :: forget (struct_instance) ; field_address . checked_sub (struct_address) . unwrap () } , 0usize , concat ! ("Offset of field: " , stringify ! (OuterDoubleInlineWrapper_InnerDoubleInlineWrapper_sentry) , "::" , stringify ! (i_am_double_wrapper_inline_sentry)));
         }
         #[test]
         fn bindgen_test_layout_OuterDoubleInlineWrapper_InnerDoubleInlineWrapper(
@@ -347,9 +401,20 @@ pub mod root {
             concat!("Alignment of ", stringify!(sentry))
         );
         assert_eq!(
-            unsafe {
-                &(*(::std::ptr::null::<sentry>())).i_am_outside_namespace_sentry
-                    as *const _ as usize
+            {
+                const STRUCT_SIZE: usize = std::mem::size_of::<sentry>();
+                let buffer = [0u8; STRUCT_SIZE];
+                let struct_instance = unsafe {
+                    std::mem::transmute::<[u8; STRUCT_SIZE], sentry>(buffer)
+                };
+                let struct_ptr = &struct_instance as *const sentry;
+                let field_ptr = std::ptr::addr_of!(
+                    struct_instance.i_am_outside_namespace_sentry
+                );
+                let struct_address = struct_ptr as usize;
+                let field_address = field_ptr as usize;
+                std::mem::forget(struct_instance);
+                field_address.checked_sub(struct_address).unwrap()
             },
             0usize,
             concat!(

--- a/tests/expectations/tests/sentry-defined-multiple-times.rs
+++ b/tests/expectations/tests/sentry-defined-multiple-times.rs
@@ -41,11 +41,8 @@ pub mod root {
             );
             assert_eq!(
                 {
-                    const STRUCT_SIZE: usize = std::mem::size_of::<sentry>();
-                    let buffer = [0u8; STRUCT_SIZE];
-                    let struct_instance = unsafe {
-                        std::mem::transmute::<[u8; STRUCT_SIZE], sentry>(buffer)
-                    };
+                    let struct_instance =
+                        unsafe { std::mem::zeroed::<sentry>() };
                     let struct_ptr = &struct_instance as *const sentry;
                     let field_ptr =
                         std::ptr::addr_of!(struct_instance.i_am_plain_sentry);
@@ -100,14 +97,8 @@ pub mod root {
             );
             assert_eq!(
                 {
-                    const STRUCT_SIZE: usize =
-                        std::mem::size_of::<NotTemplateWrapper_sentry>();
-                    let buffer = [0u8; STRUCT_SIZE];
                     let struct_instance = unsafe {
-                        std::mem::transmute::<
-                            [u8; STRUCT_SIZE],
-                            NotTemplateWrapper_sentry,
-                        >(buffer)
+                        std::mem::zeroed::<NotTemplateWrapper_sentry>()
                     };
                     let struct_ptr =
                         &struct_instance as *const NotTemplateWrapper_sentry;
@@ -158,14 +149,8 @@ pub mod root {
             );
             assert_eq!(
                 {
-                    const STRUCT_SIZE: usize =
-                        std::mem::size_of::<InlineNotTemplateWrapper_sentry>();
-                    let buffer = [0u8; STRUCT_SIZE];
                     let struct_instance = unsafe {
-                        std::mem::transmute::<
-                            [u8; STRUCT_SIZE],
-                            InlineNotTemplateWrapper_sentry,
-                        >(buffer)
+                        std::mem::zeroed::<InlineNotTemplateWrapper_sentry>()
                     };
                     let struct_ptr = &struct_instance
                         as *const InlineNotTemplateWrapper_sentry;
@@ -280,15 +265,10 @@ pub mod root {
             );
             assert_eq!(
                 {
-                    const STRUCT_SIZE: usize = std::mem::size_of::<
-                        OuterDoubleWrapper_InnerDoubleWrapper_sentry,
-                    >();
-                    let buffer = [0u8; STRUCT_SIZE];
                     let struct_instance = unsafe {
-                        std::mem::transmute::<
-                            [u8; STRUCT_SIZE],
+                        std::mem::zeroed::<
                             OuterDoubleWrapper_InnerDoubleWrapper_sentry,
-                        >(buffer)
+                        >()
                     };
                     let struct_ptr = &struct_instance
                         as *const OuterDoubleWrapper_InnerDoubleWrapper_sentry;
@@ -329,7 +309,7 @@ pub mod root {
         ) {
             assert_eq ! (:: std :: mem :: size_of :: < OuterDoubleInlineWrapper_InnerDoubleInlineWrapper_sentry > () , 4usize , concat ! ("Size of: " , stringify ! (OuterDoubleInlineWrapper_InnerDoubleInlineWrapper_sentry)));
             assert_eq ! (:: std :: mem :: align_of :: < OuterDoubleInlineWrapper_InnerDoubleInlineWrapper_sentry > () , 4usize , concat ! ("Alignment of " , stringify ! (OuterDoubleInlineWrapper_InnerDoubleInlineWrapper_sentry)));
-            assert_eq ! ({ const STRUCT_SIZE : usize = std :: mem :: size_of :: < OuterDoubleInlineWrapper_InnerDoubleInlineWrapper_sentry > () ; let buffer = [0u8 ; STRUCT_SIZE] ; let struct_instance = unsafe { std :: mem :: transmute :: < [u8 ; STRUCT_SIZE] , OuterDoubleInlineWrapper_InnerDoubleInlineWrapper_sentry > (buffer) } ; let struct_ptr = & struct_instance as * const OuterDoubleInlineWrapper_InnerDoubleInlineWrapper_sentry ; let field_ptr = std :: ptr :: addr_of ! (struct_instance . i_am_double_wrapper_inline_sentry) ; let struct_address = struct_ptr as usize ; let field_address = field_ptr as usize ; std :: mem :: forget (struct_instance) ; field_address . checked_sub (struct_address) . unwrap () } , 0usize , concat ! ("Offset of field: " , stringify ! (OuterDoubleInlineWrapper_InnerDoubleInlineWrapper_sentry) , "::" , stringify ! (i_am_double_wrapper_inline_sentry)));
+            assert_eq ! ({ let struct_instance = unsafe { std :: mem :: zeroed :: < OuterDoubleInlineWrapper_InnerDoubleInlineWrapper_sentry > () } ; let struct_ptr = & struct_instance as * const OuterDoubleInlineWrapper_InnerDoubleInlineWrapper_sentry ; let field_ptr = std :: ptr :: addr_of ! (struct_instance . i_am_double_wrapper_inline_sentry) ; let struct_address = struct_ptr as usize ; let field_address = field_ptr as usize ; std :: mem :: forget (struct_instance) ; field_address . checked_sub (struct_address) . unwrap () } , 0usize , concat ! ("Offset of field: " , stringify ! (OuterDoubleInlineWrapper_InnerDoubleInlineWrapper_sentry) , "::" , stringify ! (i_am_double_wrapper_inline_sentry)));
         }
         #[test]
         fn bindgen_test_layout_OuterDoubleInlineWrapper_InnerDoubleInlineWrapper(
@@ -402,11 +382,7 @@ pub mod root {
         );
         assert_eq!(
             {
-                const STRUCT_SIZE: usize = std::mem::size_of::<sentry>();
-                let buffer = [0u8; STRUCT_SIZE];
-                let struct_instance = unsafe {
-                    std::mem::transmute::<[u8; STRUCT_SIZE], sentry>(buffer)
-                };
+                let struct_instance = unsafe { std::mem::zeroed::<sentry>() };
                 let struct_ptr = &struct_instance as *const sentry;
                 let field_ptr = std::ptr::addr_of!(
                     struct_instance.i_am_outside_namespace_sentry

--- a/tests/expectations/tests/size_t_is_usize.rs
+++ b/tests/expectations/tests/size_t_is_usize.rs
@@ -25,17 +25,50 @@ fn bindgen_test_layout_A() {
         concat!("Alignment of ", stringify!(A))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<A>())).len as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<A>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance =
+                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], A>(buffer) };
+            let struct_ptr = &struct_instance as *const A;
+            let field_ptr = std::ptr::addr_of!(struct_instance.len);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!("Offset of field: ", stringify!(A), "::", stringify!(len))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<A>())).offset as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<A>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance =
+                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], A>(buffer) };
+            let struct_ptr = &struct_instance as *const A;
+            let field_ptr = std::ptr::addr_of!(struct_instance.offset);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         8usize,
         concat!("Offset of field: ", stringify!(A), "::", stringify!(offset))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<A>())).next as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<A>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance =
+                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], A>(buffer) };
+            let struct_ptr = &struct_instance as *const A;
+            let field_ptr = std::ptr::addr_of!(struct_instance.next);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         16usize,
         concat!("Offset of field: ", stringify!(A), "::", stringify!(next))
     );

--- a/tests/expectations/tests/size_t_is_usize.rs
+++ b/tests/expectations/tests/size_t_is_usize.rs
@@ -26,10 +26,7 @@ fn bindgen_test_layout_A() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<A>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance =
-                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], A>(buffer) };
+            let struct_instance = unsafe { std::mem::zeroed::<A>() };
             let struct_ptr = &struct_instance as *const A;
             let field_ptr = std::ptr::addr_of!(struct_instance.len);
             let struct_address = struct_ptr as usize;
@@ -42,10 +39,7 @@ fn bindgen_test_layout_A() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<A>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance =
-                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], A>(buffer) };
+            let struct_instance = unsafe { std::mem::zeroed::<A>() };
             let struct_ptr = &struct_instance as *const A;
             let field_ptr = std::ptr::addr_of!(struct_instance.offset);
             let struct_address = struct_ptr as usize;
@@ -58,10 +52,7 @@ fn bindgen_test_layout_A() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<A>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance =
-                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], A>(buffer) };
+            let struct_instance = unsafe { std::mem::zeroed::<A>() };
             let struct_ptr = &struct_instance as *const A;
             let field_ptr = std::ptr::addr_of!(struct_instance.next);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/size_t_template.rs
+++ b/tests/expectations/tests/size_t_template.rs
@@ -23,7 +23,18 @@ fn bindgen_test_layout_C() {
         concat!("Alignment of ", stringify!(C))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<C>())).arr as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<C>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance =
+                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], C>(buffer) };
+            let struct_ptr = &struct_instance as *const C;
+            let field_ptr = std::ptr::addr_of!(struct_instance.arr);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!("Offset of field: ", stringify!(C), "::", stringify!(arr))
     );

--- a/tests/expectations/tests/size_t_template.rs
+++ b/tests/expectations/tests/size_t_template.rs
@@ -24,10 +24,7 @@ fn bindgen_test_layout_C() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<C>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance =
-                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], C>(buffer) };
+            let struct_instance = unsafe { std::mem::zeroed::<C>() };
             let struct_ptr = &struct_instance as *const C;
             let field_ptr = std::ptr::addr_of!(struct_instance.arr);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/struct_containing_forward_declared_struct.rs
+++ b/tests/expectations/tests/struct_containing_forward_declared_struct.rs
@@ -23,7 +23,18 @@ fn bindgen_test_layout_a() {
         concat!("Alignment of ", stringify!(a))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<a>())).val_a as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<a>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance =
+                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], a>(buffer) };
+            let struct_ptr = &struct_instance as *const a;
+            let field_ptr = std::ptr::addr_of!(struct_instance.val_a);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!("Offset of field: ", stringify!(a), "::", stringify!(val_a))
     );
@@ -55,7 +66,18 @@ fn bindgen_test_layout_b() {
         concat!("Alignment of ", stringify!(b))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<b>())).val_b as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<b>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance =
+                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], b>(buffer) };
+            let struct_ptr = &struct_instance as *const b;
+            let field_ptr = std::ptr::addr_of!(struct_instance.val_b);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!("Offset of field: ", stringify!(b), "::", stringify!(val_b))
     );

--- a/tests/expectations/tests/struct_containing_forward_declared_struct.rs
+++ b/tests/expectations/tests/struct_containing_forward_declared_struct.rs
@@ -24,10 +24,7 @@ fn bindgen_test_layout_a() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<a>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance =
-                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], a>(buffer) };
+            let struct_instance = unsafe { std::mem::zeroed::<a>() };
             let struct_ptr = &struct_instance as *const a;
             let field_ptr = std::ptr::addr_of!(struct_instance.val_a);
             let struct_address = struct_ptr as usize;
@@ -67,10 +64,7 @@ fn bindgen_test_layout_b() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<b>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance =
-                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], b>(buffer) };
+            let struct_instance = unsafe { std::mem::zeroed::<b>() };
             let struct_ptr = &struct_instance as *const b;
             let field_ptr = std::ptr::addr_of!(struct_instance.val_b);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/struct_typedef.rs
+++ b/tests/expectations/tests/struct_typedef.rs
@@ -24,14 +24,8 @@ fn bindgen_test_layout_typedef_named_struct() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<typedef_named_struct>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], typedef_named_struct>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<typedef_named_struct>() };
             let struct_ptr = &struct_instance as *const typedef_named_struct;
             let field_ptr = std::ptr::addr_of!(struct_instance.has_name);
             let struct_address = struct_ptr as usize;
@@ -67,11 +61,8 @@ fn bindgen_test_layout__bindgen_ty_1() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<_bindgen_ty_1>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], _bindgen_ty_1>(buffer)
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<_bindgen_ty_1>() };
             let struct_ptr = &struct_instance as *const _bindgen_ty_1;
             let field_ptr = std::ptr::addr_of!(struct_instance.no_name);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/struct_typedef.rs
+++ b/tests/expectations/tests/struct_typedef.rs
@@ -23,9 +23,21 @@ fn bindgen_test_layout_typedef_named_struct() {
         concat!("Alignment of ", stringify!(typedef_named_struct))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<typedef_named_struct>())).has_name
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<typedef_named_struct>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], typedef_named_struct>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const typedef_named_struct;
+            let field_ptr = std::ptr::addr_of!(struct_instance.has_name);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -54,9 +66,18 @@ fn bindgen_test_layout__bindgen_ty_1() {
         concat!("Alignment of ", stringify!(_bindgen_ty_1))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<_bindgen_ty_1>())).no_name as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<_bindgen_ty_1>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], _bindgen_ty_1>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const _bindgen_ty_1;
+            let field_ptr = std::ptr::addr_of!(struct_instance.no_name);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(

--- a/tests/expectations/tests/struct_typedef_ns.rs
+++ b/tests/expectations/tests/struct_typedef_ns.rs
@@ -31,14 +31,8 @@ pub mod root {
             );
             assert_eq!(
                 {
-                    const STRUCT_SIZE: usize =
-                        std::mem::size_of::<typedef_struct>();
-                    let buffer = [0u8; STRUCT_SIZE];
-                    let struct_instance = unsafe {
-                        std::mem::transmute::<[u8; STRUCT_SIZE], typedef_struct>(
-                            buffer,
-                        )
-                    };
+                    let struct_instance =
+                        unsafe { std::mem::zeroed::<typedef_struct>() };
                     let struct_ptr = &struct_instance as *const typedef_struct;
                     let field_ptr = std::ptr::addr_of!(struct_instance.foo);
                     let struct_address = struct_ptr as usize;
@@ -83,14 +77,8 @@ pub mod root {
             );
             assert_eq!(
                 {
-                    const STRUCT_SIZE: usize =
-                        std::mem::size_of::<_bindgen_ty_1>();
-                    let buffer = [0u8; STRUCT_SIZE];
-                    let struct_instance = unsafe {
-                        std::mem::transmute::<[u8; STRUCT_SIZE], _bindgen_ty_1>(
-                            buffer,
-                        )
-                    };
+                    let struct_instance =
+                        unsafe { std::mem::zeroed::<_bindgen_ty_1>() };
                     let struct_ptr = &struct_instance as *const _bindgen_ty_1;
                     let field_ptr = std::ptr::addr_of!(struct_instance.foo);
                     let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/struct_typedef_ns.rs
+++ b/tests/expectations/tests/struct_typedef_ns.rs
@@ -30,9 +30,21 @@ pub mod root {
                 concat!("Alignment of ", stringify!(typedef_struct))
             );
             assert_eq!(
-                unsafe {
-                    &(*(::std::ptr::null::<typedef_struct>())).foo as *const _
-                        as usize
+                {
+                    const STRUCT_SIZE: usize =
+                        std::mem::size_of::<typedef_struct>();
+                    let buffer = [0u8; STRUCT_SIZE];
+                    let struct_instance = unsafe {
+                        std::mem::transmute::<[u8; STRUCT_SIZE], typedef_struct>(
+                            buffer,
+                        )
+                    };
+                    let struct_ptr = &struct_instance as *const typedef_struct;
+                    let field_ptr = std::ptr::addr_of!(struct_instance.foo);
+                    let struct_address = struct_ptr as usize;
+                    let field_address = field_ptr as usize;
+                    std::mem::forget(struct_instance);
+                    field_address.checked_sub(struct_address).unwrap()
                 },
                 0usize,
                 concat!(
@@ -70,9 +82,21 @@ pub mod root {
                 concat!("Alignment of ", stringify!(_bindgen_ty_1))
             );
             assert_eq!(
-                unsafe {
-                    &(*(::std::ptr::null::<_bindgen_ty_1>())).foo as *const _
-                        as usize
+                {
+                    const STRUCT_SIZE: usize =
+                        std::mem::size_of::<_bindgen_ty_1>();
+                    let buffer = [0u8; STRUCT_SIZE];
+                    let struct_instance = unsafe {
+                        std::mem::transmute::<[u8; STRUCT_SIZE], _bindgen_ty_1>(
+                            buffer,
+                        )
+                    };
+                    let struct_ptr = &struct_instance as *const _bindgen_ty_1;
+                    let field_ptr = std::ptr::addr_of!(struct_instance.foo);
+                    let struct_address = struct_ptr as usize;
+                    let field_address = field_ptr as usize;
+                    std::mem::forget(struct_instance);
+                    field_address.checked_sub(struct_address).unwrap()
                 },
                 0usize,
                 concat!(

--- a/tests/expectations/tests/struct_with_anon_struct.rs
+++ b/tests/expectations/tests/struct_with_anon_struct.rs
@@ -30,13 +30,8 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<foo__bindgen_ty_1>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], foo__bindgen_ty_1>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<foo__bindgen_ty_1>() };
             let struct_ptr = &struct_instance as *const foo__bindgen_ty_1;
             let field_ptr = std::ptr::addr_of!(struct_instance.a);
             let struct_address = struct_ptr as usize;
@@ -54,13 +49,8 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<foo__bindgen_ty_1>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], foo__bindgen_ty_1>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<foo__bindgen_ty_1>() };
             let struct_ptr = &struct_instance as *const foo__bindgen_ty_1;
             let field_ptr = std::ptr::addr_of!(struct_instance.b);
             let struct_address = struct_ptr as usize;
@@ -91,11 +81,7 @@ fn bindgen_test_layout_foo() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<foo>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], foo>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<foo>() };
             let struct_ptr = &struct_instance as *const foo;
             let field_ptr = std::ptr::addr_of!(struct_instance.bar);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/struct_with_anon_struct.rs
+++ b/tests/expectations/tests/struct_with_anon_struct.rs
@@ -29,8 +29,20 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
         concat!("Alignment of ", stringify!(foo__bindgen_ty_1))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<foo__bindgen_ty_1>())).a as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<foo__bindgen_ty_1>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], foo__bindgen_ty_1>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const foo__bindgen_ty_1;
+            let field_ptr = std::ptr::addr_of!(struct_instance.a);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -41,8 +53,20 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<foo__bindgen_ty_1>())).b as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<foo__bindgen_ty_1>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], foo__bindgen_ty_1>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const foo__bindgen_ty_1;
+            let field_ptr = std::ptr::addr_of!(struct_instance.b);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         4usize,
         concat!(
@@ -66,7 +90,19 @@ fn bindgen_test_layout_foo() {
         concat!("Alignment of ", stringify!(foo))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<foo>())).bar as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<foo>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], foo>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const foo;
+            let field_ptr = std::ptr::addr_of!(struct_instance.bar);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar))
     );

--- a/tests/expectations/tests/struct_with_anon_struct_array.rs
+++ b/tests/expectations/tests/struct_with_anon_struct_array.rs
@@ -30,8 +30,20 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
         concat!("Alignment of ", stringify!(foo__bindgen_ty_1))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<foo__bindgen_ty_1>())).a as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<foo__bindgen_ty_1>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], foo__bindgen_ty_1>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const foo__bindgen_ty_1;
+            let field_ptr = std::ptr::addr_of!(struct_instance.a);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -42,8 +54,20 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<foo__bindgen_ty_1>())).b as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<foo__bindgen_ty_1>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], foo__bindgen_ty_1>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const foo__bindgen_ty_1;
+            let field_ptr = std::ptr::addr_of!(struct_instance.b);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         4usize,
         concat!(
@@ -73,8 +97,20 @@ fn bindgen_test_layout_foo__bindgen_ty_2() {
         concat!("Alignment of ", stringify!(foo__bindgen_ty_2))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<foo__bindgen_ty_2>())).a as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<foo__bindgen_ty_2>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], foo__bindgen_ty_2>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const foo__bindgen_ty_2;
+            let field_ptr = std::ptr::addr_of!(struct_instance.a);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -85,8 +121,20 @@ fn bindgen_test_layout_foo__bindgen_ty_2() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<foo__bindgen_ty_2>())).b as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<foo__bindgen_ty_2>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], foo__bindgen_ty_2>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const foo__bindgen_ty_2;
+            let field_ptr = std::ptr::addr_of!(struct_instance.b);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         4usize,
         concat!(
@@ -110,12 +158,36 @@ fn bindgen_test_layout_foo() {
         concat!("Alignment of ", stringify!(foo))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<foo>())).bar as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<foo>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], foo>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const foo;
+            let field_ptr = std::ptr::addr_of!(struct_instance.bar);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<foo>())).baz as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<foo>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], foo>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const foo;
+            let field_ptr = std::ptr::addr_of!(struct_instance.baz);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         16usize,
         concat!("Offset of field: ", stringify!(foo), "::", stringify!(baz))
     );

--- a/tests/expectations/tests/struct_with_anon_struct_array.rs
+++ b/tests/expectations/tests/struct_with_anon_struct_array.rs
@@ -31,13 +31,8 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<foo__bindgen_ty_1>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], foo__bindgen_ty_1>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<foo__bindgen_ty_1>() };
             let struct_ptr = &struct_instance as *const foo__bindgen_ty_1;
             let field_ptr = std::ptr::addr_of!(struct_instance.a);
             let struct_address = struct_ptr as usize;
@@ -55,13 +50,8 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<foo__bindgen_ty_1>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], foo__bindgen_ty_1>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<foo__bindgen_ty_1>() };
             let struct_ptr = &struct_instance as *const foo__bindgen_ty_1;
             let field_ptr = std::ptr::addr_of!(struct_instance.b);
             let struct_address = struct_ptr as usize;
@@ -98,13 +88,8 @@ fn bindgen_test_layout_foo__bindgen_ty_2() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<foo__bindgen_ty_2>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], foo__bindgen_ty_2>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<foo__bindgen_ty_2>() };
             let struct_ptr = &struct_instance as *const foo__bindgen_ty_2;
             let field_ptr = std::ptr::addr_of!(struct_instance.a);
             let struct_address = struct_ptr as usize;
@@ -122,13 +107,8 @@ fn bindgen_test_layout_foo__bindgen_ty_2() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<foo__bindgen_ty_2>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], foo__bindgen_ty_2>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<foo__bindgen_ty_2>() };
             let struct_ptr = &struct_instance as *const foo__bindgen_ty_2;
             let field_ptr = std::ptr::addr_of!(struct_instance.b);
             let struct_address = struct_ptr as usize;
@@ -159,11 +139,7 @@ fn bindgen_test_layout_foo() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<foo>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], foo>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<foo>() };
             let struct_ptr = &struct_instance as *const foo;
             let field_ptr = std::ptr::addr_of!(struct_instance.bar);
             let struct_address = struct_ptr as usize;
@@ -176,11 +152,7 @@ fn bindgen_test_layout_foo() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<foo>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], foo>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<foo>() };
             let struct_ptr = &struct_instance as *const foo;
             let field_ptr = std::ptr::addr_of!(struct_instance.baz);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/struct_with_anon_struct_pointer.rs
+++ b/tests/expectations/tests/struct_with_anon_struct_pointer.rs
@@ -30,13 +30,8 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<foo__bindgen_ty_1>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], foo__bindgen_ty_1>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<foo__bindgen_ty_1>() };
             let struct_ptr = &struct_instance as *const foo__bindgen_ty_1;
             let field_ptr = std::ptr::addr_of!(struct_instance.a);
             let struct_address = struct_ptr as usize;
@@ -54,13 +49,8 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<foo__bindgen_ty_1>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], foo__bindgen_ty_1>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<foo__bindgen_ty_1>() };
             let struct_ptr = &struct_instance as *const foo__bindgen_ty_1;
             let field_ptr = std::ptr::addr_of!(struct_instance.b);
             let struct_address = struct_ptr as usize;
@@ -91,11 +81,7 @@ fn bindgen_test_layout_foo() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<foo>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], foo>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<foo>() };
             let struct_ptr = &struct_instance as *const foo;
             let field_ptr = std::ptr::addr_of!(struct_instance.bar);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/struct_with_anon_struct_pointer.rs
+++ b/tests/expectations/tests/struct_with_anon_struct_pointer.rs
@@ -29,8 +29,20 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
         concat!("Alignment of ", stringify!(foo__bindgen_ty_1))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<foo__bindgen_ty_1>())).a as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<foo__bindgen_ty_1>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], foo__bindgen_ty_1>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const foo__bindgen_ty_1;
+            let field_ptr = std::ptr::addr_of!(struct_instance.a);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -41,8 +53,20 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<foo__bindgen_ty_1>())).b as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<foo__bindgen_ty_1>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], foo__bindgen_ty_1>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const foo__bindgen_ty_1;
+            let field_ptr = std::ptr::addr_of!(struct_instance.b);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         4usize,
         concat!(
@@ -66,7 +90,19 @@ fn bindgen_test_layout_foo() {
         concat!("Alignment of ", stringify!(foo))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<foo>())).bar as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<foo>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], foo>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const foo;
+            let field_ptr = std::ptr::addr_of!(struct_instance.bar);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar))
     );

--- a/tests/expectations/tests/struct_with_anon_union.rs
+++ b/tests/expectations/tests/struct_with_anon_union.rs
@@ -52,11 +52,7 @@ fn bindgen_test_layout_foo() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<foo>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], foo>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<foo>() };
             let struct_ptr = &struct_instance as *const foo;
             let field_ptr = std::ptr::addr_of!(struct_instance.bar);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/struct_with_anon_union.rs
+++ b/tests/expectations/tests/struct_with_anon_union.rs
@@ -28,30 +28,6 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
         4usize,
         concat!("Alignment of ", stringify!(foo__bindgen_ty_1))
     );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<foo__bindgen_ty_1>())).a as *const _ as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(foo__bindgen_ty_1),
-            "::",
-            stringify!(a)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<foo__bindgen_ty_1>())).b as *const _ as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(foo__bindgen_ty_1),
-            "::",
-            stringify!(b)
-        )
-    );
 }
 impl Default for foo__bindgen_ty_1 {
     fn default() -> Self {
@@ -75,7 +51,19 @@ fn bindgen_test_layout_foo() {
         concat!("Alignment of ", stringify!(foo))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<foo>())).bar as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<foo>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], foo>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const foo;
+            let field_ptr = std::ptr::addr_of!(struct_instance.bar);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar))
     );

--- a/tests/expectations/tests/struct_with_anon_union_1_0.rs
+++ b/tests/expectations/tests/struct_with_anon_union_1_0.rs
@@ -72,30 +72,6 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
         4usize,
         concat!("Alignment of ", stringify!(foo__bindgen_ty_1))
     );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<foo__bindgen_ty_1>())).a as *const _ as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(foo__bindgen_ty_1),
-            "::",
-            stringify!(a)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<foo__bindgen_ty_1>())).b as *const _ as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(foo__bindgen_ty_1),
-            "::",
-            stringify!(b)
-        )
-    );
 }
 impl Clone for foo__bindgen_ty_1 {
     fn clone(&self) -> Self {
@@ -115,7 +91,19 @@ fn bindgen_test_layout_foo() {
         concat!("Alignment of ", stringify!(foo))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<foo>())).bar as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<foo>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], foo>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const foo;
+            let field_ptr = std::ptr::addr_of!(struct_instance.bar);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar))
     );

--- a/tests/expectations/tests/struct_with_anon_union_1_0.rs
+++ b/tests/expectations/tests/struct_with_anon_union_1_0.rs
@@ -92,11 +92,7 @@ fn bindgen_test_layout_foo() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<foo>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], foo>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<foo>() };
             let struct_ptr = &struct_instance as *const foo;
             let field_ptr = std::ptr::addr_of!(struct_instance.bar);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/struct_with_anon_unnamed_struct.rs
+++ b/tests/expectations/tests/struct_with_anon_unnamed_struct.rs
@@ -29,8 +29,20 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
         concat!("Alignment of ", stringify!(foo__bindgen_ty_1))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<foo__bindgen_ty_1>())).a as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<foo__bindgen_ty_1>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], foo__bindgen_ty_1>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const foo__bindgen_ty_1;
+            let field_ptr = std::ptr::addr_of!(struct_instance.a);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -41,8 +53,20 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<foo__bindgen_ty_1>())).b as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<foo__bindgen_ty_1>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], foo__bindgen_ty_1>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const foo__bindgen_ty_1;
+            let field_ptr = std::ptr::addr_of!(struct_instance.b);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         4usize,
         concat!(

--- a/tests/expectations/tests/struct_with_anon_unnamed_struct.rs
+++ b/tests/expectations/tests/struct_with_anon_unnamed_struct.rs
@@ -30,13 +30,8 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<foo__bindgen_ty_1>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], foo__bindgen_ty_1>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<foo__bindgen_ty_1>() };
             let struct_ptr = &struct_instance as *const foo__bindgen_ty_1;
             let field_ptr = std::ptr::addr_of!(struct_instance.a);
             let struct_address = struct_ptr as usize;
@@ -54,13 +49,8 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<foo__bindgen_ty_1>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], foo__bindgen_ty_1>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<foo__bindgen_ty_1>() };
             let struct_ptr = &struct_instance as *const foo__bindgen_ty_1;
             let field_ptr = std::ptr::addr_of!(struct_instance.b);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/struct_with_anon_unnamed_union.rs
+++ b/tests/expectations/tests/struct_with_anon_unnamed_union.rs
@@ -28,30 +28,6 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
         4usize,
         concat!("Alignment of ", stringify!(foo__bindgen_ty_1))
     );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<foo__bindgen_ty_1>())).a as *const _ as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(foo__bindgen_ty_1),
-            "::",
-            stringify!(a)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<foo__bindgen_ty_1>())).b as *const _ as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(foo__bindgen_ty_1),
-            "::",
-            stringify!(b)
-        )
-    );
 }
 impl Default for foo__bindgen_ty_1 {
     fn default() -> Self {

--- a/tests/expectations/tests/struct_with_anon_unnamed_union_1_0.rs
+++ b/tests/expectations/tests/struct_with_anon_unnamed_union_1_0.rs
@@ -72,30 +72,6 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
         4usize,
         concat!("Alignment of ", stringify!(foo__bindgen_ty_1))
     );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<foo__bindgen_ty_1>())).a as *const _ as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(foo__bindgen_ty_1),
-            "::",
-            stringify!(a)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<foo__bindgen_ty_1>())).b as *const _ as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(foo__bindgen_ty_1),
-            "::",
-            stringify!(b)
-        )
-    );
 }
 impl Clone for foo__bindgen_ty_1 {
     fn clone(&self) -> Self {

--- a/tests/expectations/tests/struct_with_bitfields.rs
+++ b/tests/expectations/tests/struct_with_bitfields.rs
@@ -113,7 +113,19 @@ fn bindgen_test_layout_bitfield() {
         concat!("Alignment of ", stringify!(bitfield))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<bitfield>())).e as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<bitfield>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], bitfield>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const bitfield;
+            let field_ptr = std::ptr::addr_of!(struct_instance.e);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         4usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/struct_with_bitfields.rs
+++ b/tests/expectations/tests/struct_with_bitfields.rs
@@ -114,11 +114,7 @@ fn bindgen_test_layout_bitfield() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<bitfield>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], bitfield>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<bitfield>() };
             let struct_ptr = &struct_instance as *const bitfield;
             let field_ptr = std::ptr::addr_of!(struct_instance.e);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/struct_with_derive_debug.rs
+++ b/tests/expectations/tests/struct_with_derive_debug.rs
@@ -24,11 +24,7 @@ fn bindgen_test_layout_LittleArray() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<LittleArray>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], LittleArray>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<LittleArray>() };
             let struct_ptr = &struct_instance as *const LittleArray;
             let field_ptr = std::ptr::addr_of!(struct_instance.a);
             let struct_address = struct_ptr as usize;
@@ -64,11 +60,7 @@ fn bindgen_test_layout_BigArray() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<BigArray>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], BigArray>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<BigArray>() };
             let struct_ptr = &struct_instance as *const BigArray;
             let field_ptr = std::ptr::addr_of!(struct_instance.a);
             let struct_address = struct_ptr as usize;
@@ -113,13 +105,8 @@ fn bindgen_test_layout_WithLittleArray() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<WithLittleArray>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], WithLittleArray>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<WithLittleArray>() };
             let struct_ptr = &struct_instance as *const WithLittleArray;
             let field_ptr = std::ptr::addr_of!(struct_instance.a);
             let struct_address = struct_ptr as usize;
@@ -155,11 +142,7 @@ fn bindgen_test_layout_WithBigArray() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<WithBigArray>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], WithBigArray>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<WithBigArray>() };
             let struct_ptr = &struct_instance as *const WithBigArray;
             let field_ptr = std::ptr::addr_of!(struct_instance.a);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/struct_with_derive_debug.rs
+++ b/tests/expectations/tests/struct_with_derive_debug.rs
@@ -23,8 +23,18 @@ fn bindgen_test_layout_LittleArray() {
         concat!("Alignment of ", stringify!(LittleArray))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<LittleArray>())).a as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<LittleArray>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], LittleArray>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const LittleArray;
+            let field_ptr = std::ptr::addr_of!(struct_instance.a);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -53,7 +63,19 @@ fn bindgen_test_layout_BigArray() {
         concat!("Alignment of ", stringify!(BigArray))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<BigArray>())).a as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<BigArray>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], BigArray>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const BigArray;
+            let field_ptr = std::ptr::addr_of!(struct_instance.a);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!(
             "Offset of field: ",
@@ -90,8 +112,20 @@ fn bindgen_test_layout_WithLittleArray() {
         concat!("Alignment of ", stringify!(WithLittleArray))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<WithLittleArray>())).a as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<WithLittleArray>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], WithLittleArray>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const WithLittleArray;
+            let field_ptr = std::ptr::addr_of!(struct_instance.a);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -120,8 +154,18 @@ fn bindgen_test_layout_WithBigArray() {
         concat!("Alignment of ", stringify!(WithBigArray))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<WithBigArray>())).a as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<WithBigArray>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], WithBigArray>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const WithBigArray;
+            let field_ptr = std::ptr::addr_of!(struct_instance.a);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(

--- a/tests/expectations/tests/struct_with_large_array.rs
+++ b/tests/expectations/tests/struct_with_large_array.rs
@@ -24,10 +24,7 @@ fn bindgen_test_layout_S() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<S>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance =
-                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], S>(buffer) };
+            let struct_instance = unsafe { std::mem::zeroed::<S>() };
             let struct_ptr = &struct_instance as *const S;
             let field_ptr = std::ptr::addr_of!(struct_instance.large_array);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/struct_with_large_array.rs
+++ b/tests/expectations/tests/struct_with_large_array.rs
@@ -23,8 +23,17 @@ fn bindgen_test_layout_S() {
         concat!("Alignment of ", stringify!(S))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<S>())).large_array as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<S>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance =
+                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], S>(buffer) };
+            let struct_ptr = &struct_instance as *const S;
+            let field_ptr = std::ptr::addr_of!(struct_instance.large_array);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(

--- a/tests/expectations/tests/struct_with_nesting.rs
+++ b/tests/expectations/tests/struct_with_nesting.rs
@@ -37,9 +37,23 @@ fn bindgen_test_layout_foo__bindgen_ty_1__bindgen_ty_1() {
         concat!("Alignment of ", stringify!(foo__bindgen_ty_1__bindgen_ty_1))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<foo__bindgen_ty_1__bindgen_ty_1>())).c1
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<foo__bindgen_ty_1__bindgen_ty_1>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<
+                    [u8; STRUCT_SIZE],
+                    foo__bindgen_ty_1__bindgen_ty_1,
+                >(buffer)
+            };
+            let struct_ptr =
+                &struct_instance as *const foo__bindgen_ty_1__bindgen_ty_1;
+            let field_ptr = std::ptr::addr_of!(struct_instance.c1);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -50,9 +64,23 @@ fn bindgen_test_layout_foo__bindgen_ty_1__bindgen_ty_1() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<foo__bindgen_ty_1__bindgen_ty_1>())).c2
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<foo__bindgen_ty_1__bindgen_ty_1>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<
+                    [u8; STRUCT_SIZE],
+                    foo__bindgen_ty_1__bindgen_ty_1,
+                >(buffer)
+            };
+            let struct_ptr =
+                &struct_instance as *const foo__bindgen_ty_1__bindgen_ty_1;
+            let field_ptr = std::ptr::addr_of!(struct_instance.c2);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         2usize,
         concat!(
@@ -84,9 +112,23 @@ fn bindgen_test_layout_foo__bindgen_ty_1__bindgen_ty_2() {
         concat!("Alignment of ", stringify!(foo__bindgen_ty_1__bindgen_ty_2))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<foo__bindgen_ty_1__bindgen_ty_2>())).d1
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<foo__bindgen_ty_1__bindgen_ty_2>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<
+                    [u8; STRUCT_SIZE],
+                    foo__bindgen_ty_1__bindgen_ty_2,
+                >(buffer)
+            };
+            let struct_ptr =
+                &struct_instance as *const foo__bindgen_ty_1__bindgen_ty_2;
+            let field_ptr = std::ptr::addr_of!(struct_instance.d1);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -97,9 +139,23 @@ fn bindgen_test_layout_foo__bindgen_ty_1__bindgen_ty_2() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<foo__bindgen_ty_1__bindgen_ty_2>())).d2
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<foo__bindgen_ty_1__bindgen_ty_2>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<
+                    [u8; STRUCT_SIZE],
+                    foo__bindgen_ty_1__bindgen_ty_2,
+                >(buffer)
+            };
+            let struct_ptr =
+                &struct_instance as *const foo__bindgen_ty_1__bindgen_ty_2;
+            let field_ptr = std::ptr::addr_of!(struct_instance.d2);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         1usize,
         concat!(
@@ -110,9 +166,23 @@ fn bindgen_test_layout_foo__bindgen_ty_1__bindgen_ty_2() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<foo__bindgen_ty_1__bindgen_ty_2>())).d3
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<foo__bindgen_ty_1__bindgen_ty_2>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<
+                    [u8; STRUCT_SIZE],
+                    foo__bindgen_ty_1__bindgen_ty_2,
+                >(buffer)
+            };
+            let struct_ptr =
+                &struct_instance as *const foo__bindgen_ty_1__bindgen_ty_2;
+            let field_ptr = std::ptr::addr_of!(struct_instance.d3);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         2usize,
         concat!(
@@ -123,9 +193,23 @@ fn bindgen_test_layout_foo__bindgen_ty_1__bindgen_ty_2() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<foo__bindgen_ty_1__bindgen_ty_2>())).d4
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<foo__bindgen_ty_1__bindgen_ty_2>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<
+                    [u8; STRUCT_SIZE],
+                    foo__bindgen_ty_1__bindgen_ty_2,
+                >(buffer)
+            };
+            let struct_ptr =
+                &struct_instance as *const foo__bindgen_ty_1__bindgen_ty_2;
+            let field_ptr = std::ptr::addr_of!(struct_instance.d4);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         3usize,
         concat!(
@@ -147,18 +231,6 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
         ::std::mem::align_of::<foo__bindgen_ty_1>(),
         4usize,
         concat!("Alignment of ", stringify!(foo__bindgen_ty_1))
-    );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<foo__bindgen_ty_1>())).b as *const _ as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(foo__bindgen_ty_1),
-            "::",
-            stringify!(b)
-        )
     );
 }
 impl Default for foo__bindgen_ty_1 {
@@ -183,7 +255,19 @@ fn bindgen_test_layout_foo() {
         concat!("Alignment of ", stringify!(foo))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<foo>())).a as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<foo>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], foo>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const foo;
+            let field_ptr = std::ptr::addr_of!(struct_instance.a);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!("Offset of field: ", stringify!(foo), "::", stringify!(a))
     );

--- a/tests/expectations/tests/struct_with_nesting.rs
+++ b/tests/expectations/tests/struct_with_nesting.rs
@@ -38,14 +38,8 @@ fn bindgen_test_layout_foo__bindgen_ty_1__bindgen_ty_1() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<foo__bindgen_ty_1__bindgen_ty_1>();
-            let buffer = [0u8; STRUCT_SIZE];
             let struct_instance = unsafe {
-                std::mem::transmute::<
-                    [u8; STRUCT_SIZE],
-                    foo__bindgen_ty_1__bindgen_ty_1,
-                >(buffer)
+                std::mem::zeroed::<foo__bindgen_ty_1__bindgen_ty_1>()
             };
             let struct_ptr =
                 &struct_instance as *const foo__bindgen_ty_1__bindgen_ty_1;
@@ -65,14 +59,8 @@ fn bindgen_test_layout_foo__bindgen_ty_1__bindgen_ty_1() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<foo__bindgen_ty_1__bindgen_ty_1>();
-            let buffer = [0u8; STRUCT_SIZE];
             let struct_instance = unsafe {
-                std::mem::transmute::<
-                    [u8; STRUCT_SIZE],
-                    foo__bindgen_ty_1__bindgen_ty_1,
-                >(buffer)
+                std::mem::zeroed::<foo__bindgen_ty_1__bindgen_ty_1>()
             };
             let struct_ptr =
                 &struct_instance as *const foo__bindgen_ty_1__bindgen_ty_1;
@@ -113,14 +101,8 @@ fn bindgen_test_layout_foo__bindgen_ty_1__bindgen_ty_2() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<foo__bindgen_ty_1__bindgen_ty_2>();
-            let buffer = [0u8; STRUCT_SIZE];
             let struct_instance = unsafe {
-                std::mem::transmute::<
-                    [u8; STRUCT_SIZE],
-                    foo__bindgen_ty_1__bindgen_ty_2,
-                >(buffer)
+                std::mem::zeroed::<foo__bindgen_ty_1__bindgen_ty_2>()
             };
             let struct_ptr =
                 &struct_instance as *const foo__bindgen_ty_1__bindgen_ty_2;
@@ -140,14 +122,8 @@ fn bindgen_test_layout_foo__bindgen_ty_1__bindgen_ty_2() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<foo__bindgen_ty_1__bindgen_ty_2>();
-            let buffer = [0u8; STRUCT_SIZE];
             let struct_instance = unsafe {
-                std::mem::transmute::<
-                    [u8; STRUCT_SIZE],
-                    foo__bindgen_ty_1__bindgen_ty_2,
-                >(buffer)
+                std::mem::zeroed::<foo__bindgen_ty_1__bindgen_ty_2>()
             };
             let struct_ptr =
                 &struct_instance as *const foo__bindgen_ty_1__bindgen_ty_2;
@@ -167,14 +143,8 @@ fn bindgen_test_layout_foo__bindgen_ty_1__bindgen_ty_2() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<foo__bindgen_ty_1__bindgen_ty_2>();
-            let buffer = [0u8; STRUCT_SIZE];
             let struct_instance = unsafe {
-                std::mem::transmute::<
-                    [u8; STRUCT_SIZE],
-                    foo__bindgen_ty_1__bindgen_ty_2,
-                >(buffer)
+                std::mem::zeroed::<foo__bindgen_ty_1__bindgen_ty_2>()
             };
             let struct_ptr =
                 &struct_instance as *const foo__bindgen_ty_1__bindgen_ty_2;
@@ -194,14 +164,8 @@ fn bindgen_test_layout_foo__bindgen_ty_1__bindgen_ty_2() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<foo__bindgen_ty_1__bindgen_ty_2>();
-            let buffer = [0u8; STRUCT_SIZE];
             let struct_instance = unsafe {
-                std::mem::transmute::<
-                    [u8; STRUCT_SIZE],
-                    foo__bindgen_ty_1__bindgen_ty_2,
-                >(buffer)
+                std::mem::zeroed::<foo__bindgen_ty_1__bindgen_ty_2>()
             };
             let struct_ptr =
                 &struct_instance as *const foo__bindgen_ty_1__bindgen_ty_2;
@@ -256,11 +220,7 @@ fn bindgen_test_layout_foo() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<foo>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], foo>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<foo>() };
             let struct_ptr = &struct_instance as *const foo;
             let field_ptr = std::ptr::addr_of!(struct_instance.a);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/struct_with_nesting_1_0.rs
+++ b/tests/expectations/tests/struct_with_nesting_1_0.rs
@@ -81,9 +81,23 @@ fn bindgen_test_layout_foo__bindgen_ty_1__bindgen_ty_1() {
         concat!("Alignment of ", stringify!(foo__bindgen_ty_1__bindgen_ty_1))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<foo__bindgen_ty_1__bindgen_ty_1>())).c1
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<foo__bindgen_ty_1__bindgen_ty_1>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<
+                    [u8; STRUCT_SIZE],
+                    foo__bindgen_ty_1__bindgen_ty_1,
+                >(buffer)
+            };
+            let struct_ptr =
+                &struct_instance as *const foo__bindgen_ty_1__bindgen_ty_1;
+            let field_ptr = std::ptr::addr_of!(struct_instance.c1);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -94,9 +108,23 @@ fn bindgen_test_layout_foo__bindgen_ty_1__bindgen_ty_1() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<foo__bindgen_ty_1__bindgen_ty_1>())).c2
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<foo__bindgen_ty_1__bindgen_ty_1>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<
+                    [u8; STRUCT_SIZE],
+                    foo__bindgen_ty_1__bindgen_ty_1,
+                >(buffer)
+            };
+            let struct_ptr =
+                &struct_instance as *const foo__bindgen_ty_1__bindgen_ty_1;
+            let field_ptr = std::ptr::addr_of!(struct_instance.c2);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         2usize,
         concat!(
@@ -133,9 +161,23 @@ fn bindgen_test_layout_foo__bindgen_ty_1__bindgen_ty_2() {
         concat!("Alignment of ", stringify!(foo__bindgen_ty_1__bindgen_ty_2))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<foo__bindgen_ty_1__bindgen_ty_2>())).d1
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<foo__bindgen_ty_1__bindgen_ty_2>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<
+                    [u8; STRUCT_SIZE],
+                    foo__bindgen_ty_1__bindgen_ty_2,
+                >(buffer)
+            };
+            let struct_ptr =
+                &struct_instance as *const foo__bindgen_ty_1__bindgen_ty_2;
+            let field_ptr = std::ptr::addr_of!(struct_instance.d1);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -146,9 +188,23 @@ fn bindgen_test_layout_foo__bindgen_ty_1__bindgen_ty_2() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<foo__bindgen_ty_1__bindgen_ty_2>())).d2
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<foo__bindgen_ty_1__bindgen_ty_2>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<
+                    [u8; STRUCT_SIZE],
+                    foo__bindgen_ty_1__bindgen_ty_2,
+                >(buffer)
+            };
+            let struct_ptr =
+                &struct_instance as *const foo__bindgen_ty_1__bindgen_ty_2;
+            let field_ptr = std::ptr::addr_of!(struct_instance.d2);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         1usize,
         concat!(
@@ -159,9 +215,23 @@ fn bindgen_test_layout_foo__bindgen_ty_1__bindgen_ty_2() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<foo__bindgen_ty_1__bindgen_ty_2>())).d3
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<foo__bindgen_ty_1__bindgen_ty_2>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<
+                    [u8; STRUCT_SIZE],
+                    foo__bindgen_ty_1__bindgen_ty_2,
+                >(buffer)
+            };
+            let struct_ptr =
+                &struct_instance as *const foo__bindgen_ty_1__bindgen_ty_2;
+            let field_ptr = std::ptr::addr_of!(struct_instance.d3);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         2usize,
         concat!(
@@ -172,9 +242,23 @@ fn bindgen_test_layout_foo__bindgen_ty_1__bindgen_ty_2() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<foo__bindgen_ty_1__bindgen_ty_2>())).d4
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<foo__bindgen_ty_1__bindgen_ty_2>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<
+                    [u8; STRUCT_SIZE],
+                    foo__bindgen_ty_1__bindgen_ty_2,
+                >(buffer)
+            };
+            let struct_ptr =
+                &struct_instance as *const foo__bindgen_ty_1__bindgen_ty_2;
+            let field_ptr = std::ptr::addr_of!(struct_instance.d4);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         3usize,
         concat!(
@@ -202,18 +286,6 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
         4usize,
         concat!("Alignment of ", stringify!(foo__bindgen_ty_1))
     );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<foo__bindgen_ty_1>())).b as *const _ as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(foo__bindgen_ty_1),
-            "::",
-            stringify!(b)
-        )
-    );
 }
 impl Clone for foo__bindgen_ty_1 {
     fn clone(&self) -> Self {
@@ -233,7 +305,19 @@ fn bindgen_test_layout_foo() {
         concat!("Alignment of ", stringify!(foo))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<foo>())).a as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<foo>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], foo>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const foo;
+            let field_ptr = std::ptr::addr_of!(struct_instance.a);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!("Offset of field: ", stringify!(foo), "::", stringify!(a))
     );

--- a/tests/expectations/tests/struct_with_nesting_1_0.rs
+++ b/tests/expectations/tests/struct_with_nesting_1_0.rs
@@ -82,14 +82,8 @@ fn bindgen_test_layout_foo__bindgen_ty_1__bindgen_ty_1() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<foo__bindgen_ty_1__bindgen_ty_1>();
-            let buffer = [0u8; STRUCT_SIZE];
             let struct_instance = unsafe {
-                std::mem::transmute::<
-                    [u8; STRUCT_SIZE],
-                    foo__bindgen_ty_1__bindgen_ty_1,
-                >(buffer)
+                std::mem::zeroed::<foo__bindgen_ty_1__bindgen_ty_1>()
             };
             let struct_ptr =
                 &struct_instance as *const foo__bindgen_ty_1__bindgen_ty_1;
@@ -109,14 +103,8 @@ fn bindgen_test_layout_foo__bindgen_ty_1__bindgen_ty_1() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<foo__bindgen_ty_1__bindgen_ty_1>();
-            let buffer = [0u8; STRUCT_SIZE];
             let struct_instance = unsafe {
-                std::mem::transmute::<
-                    [u8; STRUCT_SIZE],
-                    foo__bindgen_ty_1__bindgen_ty_1,
-                >(buffer)
+                std::mem::zeroed::<foo__bindgen_ty_1__bindgen_ty_1>()
             };
             let struct_ptr =
                 &struct_instance as *const foo__bindgen_ty_1__bindgen_ty_1;
@@ -162,14 +150,8 @@ fn bindgen_test_layout_foo__bindgen_ty_1__bindgen_ty_2() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<foo__bindgen_ty_1__bindgen_ty_2>();
-            let buffer = [0u8; STRUCT_SIZE];
             let struct_instance = unsafe {
-                std::mem::transmute::<
-                    [u8; STRUCT_SIZE],
-                    foo__bindgen_ty_1__bindgen_ty_2,
-                >(buffer)
+                std::mem::zeroed::<foo__bindgen_ty_1__bindgen_ty_2>()
             };
             let struct_ptr =
                 &struct_instance as *const foo__bindgen_ty_1__bindgen_ty_2;
@@ -189,14 +171,8 @@ fn bindgen_test_layout_foo__bindgen_ty_1__bindgen_ty_2() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<foo__bindgen_ty_1__bindgen_ty_2>();
-            let buffer = [0u8; STRUCT_SIZE];
             let struct_instance = unsafe {
-                std::mem::transmute::<
-                    [u8; STRUCT_SIZE],
-                    foo__bindgen_ty_1__bindgen_ty_2,
-                >(buffer)
+                std::mem::zeroed::<foo__bindgen_ty_1__bindgen_ty_2>()
             };
             let struct_ptr =
                 &struct_instance as *const foo__bindgen_ty_1__bindgen_ty_2;
@@ -216,14 +192,8 @@ fn bindgen_test_layout_foo__bindgen_ty_1__bindgen_ty_2() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<foo__bindgen_ty_1__bindgen_ty_2>();
-            let buffer = [0u8; STRUCT_SIZE];
             let struct_instance = unsafe {
-                std::mem::transmute::<
-                    [u8; STRUCT_SIZE],
-                    foo__bindgen_ty_1__bindgen_ty_2,
-                >(buffer)
+                std::mem::zeroed::<foo__bindgen_ty_1__bindgen_ty_2>()
             };
             let struct_ptr =
                 &struct_instance as *const foo__bindgen_ty_1__bindgen_ty_2;
@@ -243,14 +213,8 @@ fn bindgen_test_layout_foo__bindgen_ty_1__bindgen_ty_2() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<foo__bindgen_ty_1__bindgen_ty_2>();
-            let buffer = [0u8; STRUCT_SIZE];
             let struct_instance = unsafe {
-                std::mem::transmute::<
-                    [u8; STRUCT_SIZE],
-                    foo__bindgen_ty_1__bindgen_ty_2,
-                >(buffer)
+                std::mem::zeroed::<foo__bindgen_ty_1__bindgen_ty_2>()
             };
             let struct_ptr =
                 &struct_instance as *const foo__bindgen_ty_1__bindgen_ty_2;
@@ -306,11 +270,7 @@ fn bindgen_test_layout_foo() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<foo>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], foo>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<foo>() };
             let struct_ptr = &struct_instance as *const foo;
             let field_ptr = std::ptr::addr_of!(struct_instance.a);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/struct_with_packing.rs
+++ b/tests/expectations/tests/struct_with_packing.rs
@@ -24,12 +24,34 @@ fn bindgen_test_layout_a() {
         concat!("Alignment of ", stringify!(a))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<a>())).b as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<a>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance =
+                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], a>(buffer) };
+            let struct_ptr = &struct_instance as *const a;
+            let field_ptr = std::ptr::addr_of!(struct_instance.b);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!("Offset of field: ", stringify!(a), "::", stringify!(b))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<a>())).c as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<a>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance =
+                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], a>(buffer) };
+            let struct_ptr = &struct_instance as *const a;
+            let field_ptr = std::ptr::addr_of!(struct_instance.c);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         1usize,
         concat!("Offset of field: ", stringify!(a), "::", stringify!(c))
     );

--- a/tests/expectations/tests/struct_with_packing.rs
+++ b/tests/expectations/tests/struct_with_packing.rs
@@ -25,10 +25,7 @@ fn bindgen_test_layout_a() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<a>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance =
-                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], a>(buffer) };
+            let struct_instance = unsafe { std::mem::zeroed::<a>() };
             let struct_ptr = &struct_instance as *const a;
             let field_ptr = std::ptr::addr_of!(struct_instance.b);
             let struct_address = struct_ptr as usize;
@@ -41,10 +38,7 @@ fn bindgen_test_layout_a() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<a>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance =
-                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], a>(buffer) };
+            let struct_instance = unsafe { std::mem::zeroed::<a>() };
             let struct_ptr = &struct_instance as *const a;
             let field_ptr = std::ptr::addr_of!(struct_instance.c);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/struct_with_struct.rs
+++ b/tests/expectations/tests/struct_with_struct.rs
@@ -29,8 +29,20 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
         concat!("Alignment of ", stringify!(foo__bindgen_ty_1))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<foo__bindgen_ty_1>())).x as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<foo__bindgen_ty_1>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], foo__bindgen_ty_1>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const foo__bindgen_ty_1;
+            let field_ptr = std::ptr::addr_of!(struct_instance.x);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -41,8 +53,20 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<foo__bindgen_ty_1>())).y as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<foo__bindgen_ty_1>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], foo__bindgen_ty_1>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const foo__bindgen_ty_1;
+            let field_ptr = std::ptr::addr_of!(struct_instance.y);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         4usize,
         concat!(
@@ -66,7 +90,19 @@ fn bindgen_test_layout_foo() {
         concat!("Alignment of ", stringify!(foo))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<foo>())).bar as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<foo>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], foo>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const foo;
+            let field_ptr = std::ptr::addr_of!(struct_instance.bar);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar))
     );

--- a/tests/expectations/tests/struct_with_struct.rs
+++ b/tests/expectations/tests/struct_with_struct.rs
@@ -30,13 +30,8 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<foo__bindgen_ty_1>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], foo__bindgen_ty_1>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<foo__bindgen_ty_1>() };
             let struct_ptr = &struct_instance as *const foo__bindgen_ty_1;
             let field_ptr = std::ptr::addr_of!(struct_instance.x);
             let struct_address = struct_ptr as usize;
@@ -54,13 +49,8 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<foo__bindgen_ty_1>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], foo__bindgen_ty_1>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<foo__bindgen_ty_1>() };
             let struct_ptr = &struct_instance as *const foo__bindgen_ty_1;
             let field_ptr = std::ptr::addr_of!(struct_instance.y);
             let struct_address = struct_ptr as usize;
@@ -91,11 +81,7 @@ fn bindgen_test_layout_foo() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<foo>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], foo>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<foo>() };
             let struct_ptr = &struct_instance as *const foo;
             let field_ptr = std::ptr::addr_of!(struct_instance.bar);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/template.rs
+++ b/tests/expectations/tests/template.rs
@@ -79,10 +79,7 @@ fn bindgen_test_layout_C() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<C>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance =
-                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], C>(buffer) };
+            let struct_instance = unsafe { std::mem::zeroed::<C>() };
             let struct_ptr = &struct_instance as *const C;
             let field_ptr = std::ptr::addr_of!(struct_instance.mB);
             let struct_address = struct_ptr as usize;
@@ -95,10 +92,7 @@ fn bindgen_test_layout_C() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<C>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance =
-                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], C>(buffer) };
+            let struct_instance = unsafe { std::mem::zeroed::<C>() };
             let struct_ptr = &struct_instance as *const C;
             let field_ptr = std::ptr::addr_of!(struct_instance.mBConstPtr);
             let struct_address = struct_ptr as usize;
@@ -116,10 +110,7 @@ fn bindgen_test_layout_C() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<C>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance =
-                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], C>(buffer) };
+            let struct_instance = unsafe { std::mem::zeroed::<C>() };
             let struct_ptr = &struct_instance as *const C;
             let field_ptr =
                 std::ptr::addr_of!(struct_instance.mBConstStructPtr);
@@ -138,10 +129,7 @@ fn bindgen_test_layout_C() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<C>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance =
-                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], C>(buffer) };
+            let struct_instance = unsafe { std::mem::zeroed::<C>() };
             let struct_ptr = &struct_instance as *const C;
             let field_ptr =
                 std::ptr::addr_of!(struct_instance.mBConstStructPtrArray);
@@ -160,10 +148,7 @@ fn bindgen_test_layout_C() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<C>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance =
-                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], C>(buffer) };
+            let struct_instance = unsafe { std::mem::zeroed::<C>() };
             let struct_ptr = &struct_instance as *const C;
             let field_ptr = std::ptr::addr_of!(struct_instance.mBConst);
             let struct_address = struct_ptr as usize;
@@ -181,10 +166,7 @@ fn bindgen_test_layout_C() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<C>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance =
-                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], C>(buffer) };
+            let struct_instance = unsafe { std::mem::zeroed::<C>() };
             let struct_ptr = &struct_instance as *const C;
             let field_ptr = std::ptr::addr_of!(struct_instance.mBVolatile);
             let struct_address = struct_ptr as usize;
@@ -202,10 +184,7 @@ fn bindgen_test_layout_C() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<C>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance =
-                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], C>(buffer) };
+            let struct_instance = unsafe { std::mem::zeroed::<C>() };
             let struct_ptr = &struct_instance as *const C;
             let field_ptr = std::ptr::addr_of!(struct_instance.mBConstBool);
             let struct_address = struct_ptr as usize;
@@ -223,10 +202,7 @@ fn bindgen_test_layout_C() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<C>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance =
-                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], C>(buffer) };
+            let struct_instance = unsafe { std::mem::zeroed::<C>() };
             let struct_ptr = &struct_instance as *const C;
             let field_ptr = std::ptr::addr_of!(struct_instance.mBConstChar);
             let struct_address = struct_ptr as usize;
@@ -244,10 +220,7 @@ fn bindgen_test_layout_C() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<C>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance =
-                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], C>(buffer) };
+            let struct_instance = unsafe { std::mem::zeroed::<C>() };
             let struct_ptr = &struct_instance as *const C;
             let field_ptr = std::ptr::addr_of!(struct_instance.mBArray);
             let struct_address = struct_ptr as usize;
@@ -265,10 +238,7 @@ fn bindgen_test_layout_C() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<C>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance =
-                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], C>(buffer) };
+            let struct_instance = unsafe { std::mem::zeroed::<C>() };
             let struct_ptr = &struct_instance as *const C;
             let field_ptr = std::ptr::addr_of!(struct_instance.mBPtrArray);
             let struct_address = struct_ptr as usize;
@@ -286,10 +256,7 @@ fn bindgen_test_layout_C() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<C>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance =
-                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], C>(buffer) };
+            let struct_instance = unsafe { std::mem::zeroed::<C>() };
             let struct_ptr = &struct_instance as *const C;
             let field_ptr = std::ptr::addr_of!(struct_instance.mBArrayPtr);
             let struct_address = struct_ptr as usize;
@@ -307,10 +274,7 @@ fn bindgen_test_layout_C() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<C>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance =
-                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], C>(buffer) };
+            let struct_instance = unsafe { std::mem::zeroed::<C>() };
             let struct_ptr = &struct_instance as *const C;
             let field_ptr = std::ptr::addr_of!(struct_instance.mBRef);
             let struct_address = struct_ptr as usize;
@@ -323,10 +287,7 @@ fn bindgen_test_layout_C() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<C>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance =
-                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], C>(buffer) };
+            let struct_instance = unsafe { std::mem::zeroed::<C>() };
             let struct_ptr = &struct_instance as *const C;
             let field_ptr = std::ptr::addr_of!(struct_instance.mBConstRef);
             let struct_address = struct_ptr as usize;
@@ -344,10 +305,7 @@ fn bindgen_test_layout_C() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<C>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance =
-                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], C>(buffer) };
+            let struct_instance = unsafe { std::mem::zeroed::<C>() };
             let struct_ptr = &struct_instance as *const C;
             let field_ptr = std::ptr::addr_of!(struct_instance.mPtrRef);
             let struct_address = struct_ptr as usize;
@@ -365,10 +323,7 @@ fn bindgen_test_layout_C() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<C>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance =
-                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], C>(buffer) };
+            let struct_instance = unsafe { std::mem::zeroed::<C>() };
             let struct_ptr = &struct_instance as *const C;
             let field_ptr = std::ptr::addr_of!(struct_instance.mArrayRef);
             let struct_address = struct_ptr as usize;
@@ -461,13 +416,8 @@ fn bindgen_test_layout_RootedContainer() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<RootedContainer>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], RootedContainer>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<RootedContainer>() };
             let struct_ptr = &struct_instance as *const RootedContainer;
             let field_ptr = std::ptr::addr_of!(struct_instance.root);
             let struct_address = struct_ptr as usize;
@@ -528,14 +478,8 @@ fn bindgen_test_layout_PODButContainsDtor() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<PODButContainsDtor>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], PODButContainsDtor>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<PODButContainsDtor>() };
             let struct_ptr = &struct_instance as *const PODButContainsDtor;
             let field_ptr = std::ptr::addr_of!(struct_instance.member);
             let struct_address = struct_ptr as usize;
@@ -586,11 +530,7 @@ fn bindgen_test_layout_POD() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<POD>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], POD>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<POD>() };
             let struct_ptr = &struct_instance as *const POD;
             let field_ptr = std::ptr::addr_of!(struct_instance.opaque_member);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/template.rs
+++ b/tests/expectations/tests/template.rs
@@ -78,13 +78,33 @@ fn bindgen_test_layout_C() {
         concat!("Alignment of ", stringify!(C))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<C>())).mB as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<C>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance =
+                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], C>(buffer) };
+            let struct_ptr = &struct_instance as *const C;
+            let field_ptr = std::ptr::addr_of!(struct_instance.mB);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!("Offset of field: ", stringify!(C), "::", stringify!(mB))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<C>())).mBConstPtr as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<C>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance =
+                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], C>(buffer) };
+            let struct_ptr = &struct_instance as *const C;
+            let field_ptr = std::ptr::addr_of!(struct_instance.mBConstPtr);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         8usize,
         concat!(
@@ -95,8 +115,18 @@ fn bindgen_test_layout_C() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<C>())).mBConstStructPtr as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<C>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance =
+                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], C>(buffer) };
+            let struct_ptr = &struct_instance as *const C;
+            let field_ptr =
+                std::ptr::addr_of!(struct_instance.mBConstStructPtr);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         16usize,
         concat!(
@@ -107,9 +137,18 @@ fn bindgen_test_layout_C() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<C>())).mBConstStructPtrArray as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<C>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance =
+                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], C>(buffer) };
+            let struct_ptr = &struct_instance as *const C;
+            let field_ptr =
+                std::ptr::addr_of!(struct_instance.mBConstStructPtrArray);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         24usize,
         concat!(
@@ -120,7 +159,18 @@ fn bindgen_test_layout_C() {
         )
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<C>())).mBConst as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<C>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance =
+                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], C>(buffer) };
+            let struct_ptr = &struct_instance as *const C;
+            let field_ptr = std::ptr::addr_of!(struct_instance.mBConst);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         32usize,
         concat!(
             "Offset of field: ",
@@ -130,8 +180,17 @@ fn bindgen_test_layout_C() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<C>())).mBVolatile as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<C>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance =
+                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], C>(buffer) };
+            let struct_ptr = &struct_instance as *const C;
+            let field_ptr = std::ptr::addr_of!(struct_instance.mBVolatile);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         36usize,
         concat!(
@@ -142,8 +201,17 @@ fn bindgen_test_layout_C() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<C>())).mBConstBool as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<C>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance =
+                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], C>(buffer) };
+            let struct_ptr = &struct_instance as *const C;
+            let field_ptr = std::ptr::addr_of!(struct_instance.mBConstBool);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         40usize,
         concat!(
@@ -154,8 +222,17 @@ fn bindgen_test_layout_C() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<C>())).mBConstChar as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<C>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance =
+                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], C>(buffer) };
+            let struct_ptr = &struct_instance as *const C;
+            let field_ptr = std::ptr::addr_of!(struct_instance.mBConstChar);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         42usize,
         concat!(
@@ -166,7 +243,18 @@ fn bindgen_test_layout_C() {
         )
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<C>())).mBArray as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<C>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance =
+                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], C>(buffer) };
+            let struct_ptr = &struct_instance as *const C;
+            let field_ptr = std::ptr::addr_of!(struct_instance.mBArray);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         44usize,
         concat!(
             "Offset of field: ",
@@ -176,8 +264,17 @@ fn bindgen_test_layout_C() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<C>())).mBPtrArray as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<C>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance =
+                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], C>(buffer) };
+            let struct_ptr = &struct_instance as *const C;
+            let field_ptr = std::ptr::addr_of!(struct_instance.mBPtrArray);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         48usize,
         concat!(
@@ -188,8 +285,17 @@ fn bindgen_test_layout_C() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<C>())).mBArrayPtr as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<C>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance =
+                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], C>(buffer) };
+            let struct_ptr = &struct_instance as *const C;
+            let field_ptr = std::ptr::addr_of!(struct_instance.mBArrayPtr);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         56usize,
         concat!(
@@ -200,13 +306,33 @@ fn bindgen_test_layout_C() {
         )
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<C>())).mBRef as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<C>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance =
+                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], C>(buffer) };
+            let struct_ptr = &struct_instance as *const C;
+            let field_ptr = std::ptr::addr_of!(struct_instance.mBRef);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         64usize,
         concat!("Offset of field: ", stringify!(C), "::", stringify!(mBRef))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<C>())).mBConstRef as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<C>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance =
+                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], C>(buffer) };
+            let struct_ptr = &struct_instance as *const C;
+            let field_ptr = std::ptr::addr_of!(struct_instance.mBConstRef);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         72usize,
         concat!(
@@ -217,7 +343,18 @@ fn bindgen_test_layout_C() {
         )
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<C>())).mPtrRef as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<C>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance =
+                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], C>(buffer) };
+            let struct_ptr = &struct_instance as *const C;
+            let field_ptr = std::ptr::addr_of!(struct_instance.mPtrRef);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         80usize,
         concat!(
             "Offset of field: ",
@@ -227,7 +364,18 @@ fn bindgen_test_layout_C() {
         )
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<C>())).mArrayRef as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<C>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance =
+                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], C>(buffer) };
+            let struct_ptr = &struct_instance as *const C;
+            let field_ptr = std::ptr::addr_of!(struct_instance.mArrayRef);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         88usize,
         concat!(
             "Offset of field: ",
@@ -312,9 +460,20 @@ fn bindgen_test_layout_RootedContainer() {
         concat!("Alignment of ", stringify!(RootedContainer))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<RootedContainer>())).root as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<RootedContainer>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], RootedContainer>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const RootedContainer;
+            let field_ptr = std::ptr::addr_of!(struct_instance.root);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -368,9 +527,21 @@ fn bindgen_test_layout_PODButContainsDtor() {
         concat!("Alignment of ", stringify!(PODButContainsDtor))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<PODButContainsDtor>())).member as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<PODButContainsDtor>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], PODButContainsDtor>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const PODButContainsDtor;
+            let field_ptr = std::ptr::addr_of!(struct_instance.member);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -414,8 +585,18 @@ fn bindgen_test_layout_POD() {
         concat!("Alignment of ", stringify!(POD))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<POD>())).opaque_member as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<POD>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], POD>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const POD;
+            let field_ptr = std::ptr::addr_of!(struct_instance.opaque_member);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(

--- a/tests/expectations/tests/test_mixed_header_and_header_contents.rs
+++ b/tests/expectations/tests/test_mixed_header_and_header_contents.rs
@@ -45,10 +45,8 @@ fn bindgen_test_layout_Test() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<Test>();
-            let buffer = [0u8; STRUCT_SIZE];
             let struct_instance =
-                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], Test>(buffer) };
+                unsafe { std::mem::zeroed::<Test>() };
             let struct_ptr = &struct_instance as *const Test;
             let field_ptr = std::ptr::addr_of!(struct_instance.ch);
             let struct_address = struct_ptr as usize;
@@ -61,10 +59,8 @@ fn bindgen_test_layout_Test() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<Test>();
-            let buffer = [0u8; STRUCT_SIZE];
             let struct_instance =
-                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], Test>(buffer) };
+                unsafe { std::mem::zeroed::<Test>() };
             let struct_ptr = &struct_instance as *const Test;
             let field_ptr = std::ptr::addr_of!(struct_instance.u);
             let struct_address = struct_ptr as usize;
@@ -77,10 +73,8 @@ fn bindgen_test_layout_Test() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<Test>();
-            let buffer = [0u8; STRUCT_SIZE];
             let struct_instance =
-                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], Test>(buffer) };
+                unsafe { std::mem::zeroed::<Test>() };
             let struct_ptr = &struct_instance as *const Test;
             let field_ptr = std::ptr::addr_of!(struct_instance.d);
             let struct_address = struct_ptr as usize;
@@ -93,10 +87,8 @@ fn bindgen_test_layout_Test() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<Test>();
-            let buffer = [0u8; STRUCT_SIZE];
             let struct_instance =
-                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], Test>(buffer) };
+                unsafe { std::mem::zeroed::<Test>() };
             let struct_ptr = &struct_instance as *const Test;
             let field_ptr = std::ptr::addr_of!(struct_instance.cch);
             let struct_address = struct_ptr as usize;
@@ -109,10 +101,8 @@ fn bindgen_test_layout_Test() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<Test>();
-            let buffer = [0u8; STRUCT_SIZE];
             let struct_instance =
-                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], Test>(buffer) };
+                unsafe { std::mem::zeroed::<Test>() };
             let struct_ptr = &struct_instance as *const Test;
             let field_ptr = std::ptr::addr_of!(struct_instance.cu);
             let struct_address = struct_ptr as usize;
@@ -125,10 +115,8 @@ fn bindgen_test_layout_Test() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<Test>();
-            let buffer = [0u8; STRUCT_SIZE];
             let struct_instance =
-                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], Test>(buffer) };
+                unsafe { std::mem::zeroed::<Test>() };
             let struct_ptr = &struct_instance as *const Test;
             let field_ptr = std::ptr::addr_of!(struct_instance.cd);
             let struct_address = struct_ptr as usize;
@@ -141,10 +129,8 @@ fn bindgen_test_layout_Test() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<Test>();
-            let buffer = [0u8; STRUCT_SIZE];
             let struct_instance =
-                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], Test>(buffer) };
+                unsafe { std::mem::zeroed::<Test>() };
             let struct_ptr = &struct_instance as *const Test;
             let field_ptr = std::ptr::addr_of!(struct_instance.Cch);
             let struct_address = struct_ptr as usize;
@@ -157,10 +143,8 @@ fn bindgen_test_layout_Test() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<Test>();
-            let buffer = [0u8; STRUCT_SIZE];
             let struct_instance =
-                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], Test>(buffer) };
+                unsafe { std::mem::zeroed::<Test>() };
             let struct_ptr = &struct_instance as *const Test;
             let field_ptr = std::ptr::addr_of!(struct_instance.Cu);
             let struct_address = struct_ptr as usize;
@@ -173,10 +157,8 @@ fn bindgen_test_layout_Test() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<Test>();
-            let buffer = [0u8; STRUCT_SIZE];
             let struct_instance =
-                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], Test>(buffer) };
+                unsafe { std::mem::zeroed::<Test>() };
             let struct_ptr = &struct_instance as *const Test;
             let field_ptr = std::ptr::addr_of!(struct_instance.Cd);
             let struct_address = struct_ptr as usize;
@@ -189,10 +171,8 @@ fn bindgen_test_layout_Test() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<Test>();
-            let buffer = [0u8; STRUCT_SIZE];
             let struct_instance =
-                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], Test>(buffer) };
+                unsafe { std::mem::zeroed::<Test>() };
             let struct_ptr = &struct_instance as *const Test;
             let field_ptr = std::ptr::addr_of!(struct_instance.Ccch);
             let struct_address = struct_ptr as usize;
@@ -210,10 +190,8 @@ fn bindgen_test_layout_Test() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<Test>();
-            let buffer = [0u8; STRUCT_SIZE];
             let struct_instance =
-                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], Test>(buffer) };
+                unsafe { std::mem::zeroed::<Test>() };
             let struct_ptr = &struct_instance as *const Test;
             let field_ptr = std::ptr::addr_of!(struct_instance.Ccu);
             let struct_address = struct_ptr as usize;
@@ -226,10 +204,8 @@ fn bindgen_test_layout_Test() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<Test>();
-            let buffer = [0u8; STRUCT_SIZE];
             let struct_instance =
-                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], Test>(buffer) };
+                unsafe { std::mem::zeroed::<Test>() };
             let struct_ptr = &struct_instance as *const Test;
             let field_ptr = std::ptr::addr_of!(struct_instance.Ccd);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/test_mixed_header_and_header_contents.rs
+++ b/tests/expectations/tests/test_mixed_header_and_header_contents.rs
@@ -44,52 +44,162 @@ fn bindgen_test_layout_Test() {
         concat!("Alignment of ", stringify!(Test))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Test>())).ch as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<Test>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance =
+                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], Test>(buffer) };
+            let struct_ptr = &struct_instance as *const Test;
+            let field_ptr = std::ptr::addr_of!(struct_instance.ch);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!("Offset of field: ", stringify!(Test), "::", stringify!(ch))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Test>())).u as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<Test>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance =
+                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], Test>(buffer) };
+            let struct_ptr = &struct_instance as *const Test;
+            let field_ptr = std::ptr::addr_of!(struct_instance.u);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         1usize,
         concat!("Offset of field: ", stringify!(Test), "::", stringify!(u))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Test>())).d as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<Test>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance =
+                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], Test>(buffer) };
+            let struct_ptr = &struct_instance as *const Test;
+            let field_ptr = std::ptr::addr_of!(struct_instance.d);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         2usize,
         concat!("Offset of field: ", stringify!(Test), "::", stringify!(d))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Test>())).cch as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<Test>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance =
+                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], Test>(buffer) };
+            let struct_ptr = &struct_instance as *const Test;
+            let field_ptr = std::ptr::addr_of!(struct_instance.cch);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         3usize,
         concat!("Offset of field: ", stringify!(Test), "::", stringify!(cch))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Test>())).cu as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<Test>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance =
+                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], Test>(buffer) };
+            let struct_ptr = &struct_instance as *const Test;
+            let field_ptr = std::ptr::addr_of!(struct_instance.cu);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         4usize,
         concat!("Offset of field: ", stringify!(Test), "::", stringify!(cu))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Test>())).cd as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<Test>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance =
+                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], Test>(buffer) };
+            let struct_ptr = &struct_instance as *const Test;
+            let field_ptr = std::ptr::addr_of!(struct_instance.cd);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         5usize,
         concat!("Offset of field: ", stringify!(Test), "::", stringify!(cd))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Test>())).Cch as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<Test>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance =
+                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], Test>(buffer) };
+            let struct_ptr = &struct_instance as *const Test;
+            let field_ptr = std::ptr::addr_of!(struct_instance.Cch);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         6usize,
         concat!("Offset of field: ", stringify!(Test), "::", stringify!(Cch))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Test>())).Cu as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<Test>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance =
+                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], Test>(buffer) };
+            let struct_ptr = &struct_instance as *const Test;
+            let field_ptr = std::ptr::addr_of!(struct_instance.Cu);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         7usize,
         concat!("Offset of field: ", stringify!(Test), "::", stringify!(Cu))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Test>())).Cd as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<Test>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance =
+                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], Test>(buffer) };
+            let struct_ptr = &struct_instance as *const Test;
+            let field_ptr = std::ptr::addr_of!(struct_instance.Cd);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         8usize,
         concat!("Offset of field: ", stringify!(Test), "::", stringify!(Cd))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Test>())).Ccch as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<Test>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance =
+                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], Test>(buffer) };
+            let struct_ptr = &struct_instance as *const Test;
+            let field_ptr = std::ptr::addr_of!(struct_instance.Ccch);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         9usize,
         concat!(
             "Offset of field: ",
@@ -99,12 +209,34 @@ fn bindgen_test_layout_Test() {
         )
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Test>())).Ccu as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<Test>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance =
+                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], Test>(buffer) };
+            let struct_ptr = &struct_instance as *const Test;
+            let field_ptr = std::ptr::addr_of!(struct_instance.Ccu);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         10usize,
         concat!("Offset of field: ", stringify!(Test), "::", stringify!(Ccu))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Test>())).Ccd as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<Test>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance =
+                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], Test>(buffer) };
+            let struct_ptr = &struct_instance as *const Test;
+            let field_ptr = std::ptr::addr_of!(struct_instance.Ccd);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         11usize,
         concat!("Offset of field: ", stringify!(Test), "::", stringify!(Ccd))
     );

--- a/tests/expectations/tests/test_multiple_header_calls_in_builder.rs
+++ b/tests/expectations/tests/test_multiple_header_calls_in_builder.rs
@@ -38,52 +38,162 @@ fn bindgen_test_layout_Test() {
         concat!("Alignment of ", stringify!(Test))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Test>())).ch as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<Test>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance =
+                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], Test>(buffer) };
+            let struct_ptr = &struct_instance as *const Test;
+            let field_ptr = std::ptr::addr_of!(struct_instance.ch);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!("Offset of field: ", stringify!(Test), "::", stringify!(ch))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Test>())).u as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<Test>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance =
+                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], Test>(buffer) };
+            let struct_ptr = &struct_instance as *const Test;
+            let field_ptr = std::ptr::addr_of!(struct_instance.u);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         1usize,
         concat!("Offset of field: ", stringify!(Test), "::", stringify!(u))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Test>())).d as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<Test>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance =
+                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], Test>(buffer) };
+            let struct_ptr = &struct_instance as *const Test;
+            let field_ptr = std::ptr::addr_of!(struct_instance.d);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         2usize,
         concat!("Offset of field: ", stringify!(Test), "::", stringify!(d))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Test>())).cch as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<Test>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance =
+                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], Test>(buffer) };
+            let struct_ptr = &struct_instance as *const Test;
+            let field_ptr = std::ptr::addr_of!(struct_instance.cch);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         3usize,
         concat!("Offset of field: ", stringify!(Test), "::", stringify!(cch))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Test>())).cu as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<Test>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance =
+                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], Test>(buffer) };
+            let struct_ptr = &struct_instance as *const Test;
+            let field_ptr = std::ptr::addr_of!(struct_instance.cu);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         4usize,
         concat!("Offset of field: ", stringify!(Test), "::", stringify!(cu))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Test>())).cd as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<Test>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance =
+                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], Test>(buffer) };
+            let struct_ptr = &struct_instance as *const Test;
+            let field_ptr = std::ptr::addr_of!(struct_instance.cd);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         5usize,
         concat!("Offset of field: ", stringify!(Test), "::", stringify!(cd))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Test>())).Cch as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<Test>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance =
+                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], Test>(buffer) };
+            let struct_ptr = &struct_instance as *const Test;
+            let field_ptr = std::ptr::addr_of!(struct_instance.Cch);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         6usize,
         concat!("Offset of field: ", stringify!(Test), "::", stringify!(Cch))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Test>())).Cu as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<Test>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance =
+                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], Test>(buffer) };
+            let struct_ptr = &struct_instance as *const Test;
+            let field_ptr = std::ptr::addr_of!(struct_instance.Cu);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         7usize,
         concat!("Offset of field: ", stringify!(Test), "::", stringify!(Cu))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Test>())).Cd as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<Test>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance =
+                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], Test>(buffer) };
+            let struct_ptr = &struct_instance as *const Test;
+            let field_ptr = std::ptr::addr_of!(struct_instance.Cd);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         8usize,
         concat!("Offset of field: ", stringify!(Test), "::", stringify!(Cd))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Test>())).Ccch as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<Test>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance =
+                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], Test>(buffer) };
+            let struct_ptr = &struct_instance as *const Test;
+            let field_ptr = std::ptr::addr_of!(struct_instance.Ccch);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         9usize,
         concat!(
             "Offset of field: ",
@@ -93,12 +203,34 @@ fn bindgen_test_layout_Test() {
         )
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Test>())).Ccu as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<Test>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance =
+                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], Test>(buffer) };
+            let struct_ptr = &struct_instance as *const Test;
+            let field_ptr = std::ptr::addr_of!(struct_instance.Ccu);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         10usize,
         concat!("Offset of field: ", stringify!(Test), "::", stringify!(Ccu))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Test>())).Ccd as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<Test>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance =
+                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], Test>(buffer) };
+            let struct_ptr = &struct_instance as *const Test;
+            let field_ptr = std::ptr::addr_of!(struct_instance.Ccd);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         11usize,
         concat!("Offset of field: ", stringify!(Test), "::", stringify!(Ccd))
     );

--- a/tests/expectations/tests/test_multiple_header_calls_in_builder.rs
+++ b/tests/expectations/tests/test_multiple_header_calls_in_builder.rs
@@ -39,10 +39,8 @@ fn bindgen_test_layout_Test() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<Test>();
-            let buffer = [0u8; STRUCT_SIZE];
             let struct_instance =
-                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], Test>(buffer) };
+                unsafe { std::mem::zeroed::<Test>() };
             let struct_ptr = &struct_instance as *const Test;
             let field_ptr = std::ptr::addr_of!(struct_instance.ch);
             let struct_address = struct_ptr as usize;
@@ -55,10 +53,8 @@ fn bindgen_test_layout_Test() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<Test>();
-            let buffer = [0u8; STRUCT_SIZE];
             let struct_instance =
-                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], Test>(buffer) };
+                unsafe { std::mem::zeroed::<Test>() };
             let struct_ptr = &struct_instance as *const Test;
             let field_ptr = std::ptr::addr_of!(struct_instance.u);
             let struct_address = struct_ptr as usize;
@@ -71,10 +67,8 @@ fn bindgen_test_layout_Test() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<Test>();
-            let buffer = [0u8; STRUCT_SIZE];
             let struct_instance =
-                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], Test>(buffer) };
+                unsafe { std::mem::zeroed::<Test>() };
             let struct_ptr = &struct_instance as *const Test;
             let field_ptr = std::ptr::addr_of!(struct_instance.d);
             let struct_address = struct_ptr as usize;
@@ -87,10 +81,8 @@ fn bindgen_test_layout_Test() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<Test>();
-            let buffer = [0u8; STRUCT_SIZE];
             let struct_instance =
-                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], Test>(buffer) };
+                unsafe { std::mem::zeroed::<Test>() };
             let struct_ptr = &struct_instance as *const Test;
             let field_ptr = std::ptr::addr_of!(struct_instance.cch);
             let struct_address = struct_ptr as usize;
@@ -103,10 +95,8 @@ fn bindgen_test_layout_Test() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<Test>();
-            let buffer = [0u8; STRUCT_SIZE];
             let struct_instance =
-                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], Test>(buffer) };
+                unsafe { std::mem::zeroed::<Test>() };
             let struct_ptr = &struct_instance as *const Test;
             let field_ptr = std::ptr::addr_of!(struct_instance.cu);
             let struct_address = struct_ptr as usize;
@@ -119,10 +109,8 @@ fn bindgen_test_layout_Test() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<Test>();
-            let buffer = [0u8; STRUCT_SIZE];
             let struct_instance =
-                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], Test>(buffer) };
+                unsafe { std::mem::zeroed::<Test>() };
             let struct_ptr = &struct_instance as *const Test;
             let field_ptr = std::ptr::addr_of!(struct_instance.cd);
             let struct_address = struct_ptr as usize;
@@ -135,10 +123,8 @@ fn bindgen_test_layout_Test() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<Test>();
-            let buffer = [0u8; STRUCT_SIZE];
             let struct_instance =
-                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], Test>(buffer) };
+                unsafe { std::mem::zeroed::<Test>() };
             let struct_ptr = &struct_instance as *const Test;
             let field_ptr = std::ptr::addr_of!(struct_instance.Cch);
             let struct_address = struct_ptr as usize;
@@ -151,10 +137,8 @@ fn bindgen_test_layout_Test() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<Test>();
-            let buffer = [0u8; STRUCT_SIZE];
             let struct_instance =
-                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], Test>(buffer) };
+                unsafe { std::mem::zeroed::<Test>() };
             let struct_ptr = &struct_instance as *const Test;
             let field_ptr = std::ptr::addr_of!(struct_instance.Cu);
             let struct_address = struct_ptr as usize;
@@ -167,10 +151,8 @@ fn bindgen_test_layout_Test() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<Test>();
-            let buffer = [0u8; STRUCT_SIZE];
             let struct_instance =
-                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], Test>(buffer) };
+                unsafe { std::mem::zeroed::<Test>() };
             let struct_ptr = &struct_instance as *const Test;
             let field_ptr = std::ptr::addr_of!(struct_instance.Cd);
             let struct_address = struct_ptr as usize;
@@ -183,10 +165,8 @@ fn bindgen_test_layout_Test() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<Test>();
-            let buffer = [0u8; STRUCT_SIZE];
             let struct_instance =
-                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], Test>(buffer) };
+                unsafe { std::mem::zeroed::<Test>() };
             let struct_ptr = &struct_instance as *const Test;
             let field_ptr = std::ptr::addr_of!(struct_instance.Ccch);
             let struct_address = struct_ptr as usize;
@@ -204,10 +184,8 @@ fn bindgen_test_layout_Test() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<Test>();
-            let buffer = [0u8; STRUCT_SIZE];
             let struct_instance =
-                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], Test>(buffer) };
+                unsafe { std::mem::zeroed::<Test>() };
             let struct_ptr = &struct_instance as *const Test;
             let field_ptr = std::ptr::addr_of!(struct_instance.Ccu);
             let struct_address = struct_ptr as usize;
@@ -220,10 +198,8 @@ fn bindgen_test_layout_Test() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<Test>();
-            let buffer = [0u8; STRUCT_SIZE];
             let struct_instance =
-                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], Test>(buffer) };
+                unsafe { std::mem::zeroed::<Test>() };
             let struct_ptr = &struct_instance as *const Test;
             let field_ptr = std::ptr::addr_of!(struct_instance.Ccd);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/timex.rs
+++ b/tests/expectations/tests/timex.rs
@@ -112,11 +112,7 @@ fn bindgen_test_layout_timex() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<timex>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], timex>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<timex>() };
             let struct_ptr = &struct_instance as *const timex;
             let field_ptr = std::ptr::addr_of!(struct_instance.tai);
             let struct_address = struct_ptr as usize;
@@ -163,11 +159,7 @@ fn bindgen_test_layout_timex_named() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<timex_named>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], timex_named>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<timex_named>() };
             let struct_ptr = &struct_instance as *const timex_named;
             let field_ptr = std::ptr::addr_of!(struct_instance.tai);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/timex.rs
+++ b/tests/expectations/tests/timex.rs
@@ -111,7 +111,19 @@ fn bindgen_test_layout_timex() {
         concat!("Alignment of ", stringify!(timex))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<timex>())).tai as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<timex>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], timex>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const timex;
+            let field_ptr = std::ptr::addr_of!(struct_instance.tai);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!(
             "Offset of field: ",
@@ -150,8 +162,18 @@ fn bindgen_test_layout_timex_named() {
         concat!("Alignment of ", stringify!(timex_named))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<timex_named>())).tai as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<timex_named>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], timex_named>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const timex_named;
+            let field_ptr = std::ptr::addr_of!(struct_instance.tai);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(

--- a/tests/expectations/tests/type-referenced-by-allowlisted-function.rs
+++ b/tests/expectations/tests/type-referenced-by-allowlisted-function.rs
@@ -23,8 +23,18 @@ fn bindgen_test_layout_dl_phdr_info() {
         concat!("Alignment of ", stringify!(dl_phdr_info))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<dl_phdr_info>())).x as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<dl_phdr_info>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], dl_phdr_info>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const dl_phdr_info;
+            let field_ptr = std::ptr::addr_of!(struct_instance.x);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(

--- a/tests/expectations/tests/type-referenced-by-allowlisted-function.rs
+++ b/tests/expectations/tests/type-referenced-by-allowlisted-function.rs
@@ -24,11 +24,7 @@ fn bindgen_test_layout_dl_phdr_info() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<dl_phdr_info>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], dl_phdr_info>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<dl_phdr_info>() };
             let struct_ptr = &struct_instance as *const dl_phdr_info;
             let field_ptr = std::ptr::addr_of!(struct_instance.x);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/typeref.rs
+++ b/tests/expectations/tests/typeref.rs
@@ -23,9 +23,21 @@ fn bindgen_test_layout_mozilla_FragmentOrURL() {
         concat!("Alignment of ", stringify!(mozilla_FragmentOrURL))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<mozilla_FragmentOrURL>())).mIsLocalRef
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<mozilla_FragmentOrURL>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], mozilla_FragmentOrURL>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const mozilla_FragmentOrURL;
+            let field_ptr = std::ptr::addr_of!(struct_instance.mIsLocalRef);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -99,7 +111,19 @@ fn bindgen_test_layout_Bar() {
         concat!("Alignment of ", stringify!(Bar))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Bar>())).mFoo as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<Bar>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], Bar>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const Bar;
+            let field_ptr = std::ptr::addr_of!(struct_instance.mFoo);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!("Offset of field: ", stringify!(Bar), "::", stringify!(mFoo))
     );
@@ -130,7 +154,19 @@ fn bindgen_test_layout_nsFoo() {
         concat!("Alignment of ", stringify!(nsFoo))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<nsFoo>())).mBar as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<nsFoo>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], nsFoo>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const nsFoo;
+            let field_ptr = std::ptr::addr_of!(struct_instance.mBar);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/typeref.rs
+++ b/tests/expectations/tests/typeref.rs
@@ -24,14 +24,8 @@ fn bindgen_test_layout_mozilla_FragmentOrURL() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<mozilla_FragmentOrURL>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], mozilla_FragmentOrURL>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<mozilla_FragmentOrURL>() };
             let struct_ptr = &struct_instance as *const mozilla_FragmentOrURL;
             let field_ptr = std::ptr::addr_of!(struct_instance.mIsLocalRef);
             let struct_address = struct_ptr as usize;
@@ -112,11 +106,7 @@ fn bindgen_test_layout_Bar() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<Bar>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], Bar>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<Bar>() };
             let struct_ptr = &struct_instance as *const Bar;
             let field_ptr = std::ptr::addr_of!(struct_instance.mFoo);
             let struct_address = struct_ptr as usize;
@@ -155,11 +145,7 @@ fn bindgen_test_layout_nsFoo() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<nsFoo>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], nsFoo>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<nsFoo>() };
             let struct_ptr = &struct_instance as *const nsFoo;
             let field_ptr = std::ptr::addr_of!(struct_instance.mBar);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/typeref_1_0.rs
+++ b/tests/expectations/tests/typeref_1_0.rs
@@ -66,9 +66,21 @@ fn bindgen_test_layout_mozilla_FragmentOrURL() {
         concat!("Alignment of ", stringify!(mozilla_FragmentOrURL))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<mozilla_FragmentOrURL>())).mIsLocalRef
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<mozilla_FragmentOrURL>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], mozilla_FragmentOrURL>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const mozilla_FragmentOrURL;
+            let field_ptr = std::ptr::addr_of!(struct_instance.mIsLocalRef);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -137,7 +149,19 @@ fn bindgen_test_layout_Bar() {
         concat!("Alignment of ", stringify!(Bar))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Bar>())).mFoo as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<Bar>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], Bar>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const Bar;
+            let field_ptr = std::ptr::addr_of!(struct_instance.mFoo);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!("Offset of field: ", stringify!(Bar), "::", stringify!(mFoo))
     );
@@ -174,7 +198,19 @@ fn bindgen_test_layout_nsFoo() {
         concat!("Alignment of ", stringify!(nsFoo))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<nsFoo>())).mBar as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<nsFoo>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], nsFoo>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const nsFoo;
+            let field_ptr = std::ptr::addr_of!(struct_instance.mBar);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/typeref_1_0.rs
+++ b/tests/expectations/tests/typeref_1_0.rs
@@ -67,14 +67,8 @@ fn bindgen_test_layout_mozilla_FragmentOrURL() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<mozilla_FragmentOrURL>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], mozilla_FragmentOrURL>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<mozilla_FragmentOrURL>() };
             let struct_ptr = &struct_instance as *const mozilla_FragmentOrURL;
             let field_ptr = std::ptr::addr_of!(struct_instance.mIsLocalRef);
             let struct_address = struct_ptr as usize;
@@ -150,11 +144,7 @@ fn bindgen_test_layout_Bar() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<Bar>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], Bar>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<Bar>() };
             let struct_ptr = &struct_instance as *const Bar;
             let field_ptr = std::ptr::addr_of!(struct_instance.mFoo);
             let struct_address = struct_ptr as usize;
@@ -199,11 +189,7 @@ fn bindgen_test_layout_nsFoo() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<nsFoo>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], nsFoo>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<nsFoo>() };
             let struct_ptr = &struct_instance as *const nsFoo;
             let field_ptr = std::ptr::addr_of!(struct_instance.mBar);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/underscore.rs
+++ b/tests/expectations/tests/underscore.rs
@@ -25,11 +25,7 @@ fn bindgen_test_layout_ptr_t() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<ptr_t>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], ptr_t>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<ptr_t>() };
             let struct_ptr = &struct_instance as *const ptr_t;
             let field_ptr = std::ptr::addr_of!(struct_instance.__);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/underscore.rs
+++ b/tests/expectations/tests/underscore.rs
@@ -24,7 +24,19 @@ fn bindgen_test_layout_ptr_t() {
         concat!("Alignment of ", stringify!(ptr_t))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<ptr_t>())).__ as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<ptr_t>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], ptr_t>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const ptr_t;
+            let field_ptr = std::ptr::addr_of!(struct_instance.__);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!("Offset of field: ", stringify!(ptr_t), "::", stringify!(__))
     );

--- a/tests/expectations/tests/union-align.rs
+++ b/tests/expectations/tests/union-align.rs
@@ -23,11 +23,6 @@ fn bindgen_test_layout_Bar() {
         16usize,
         concat!("Alignment of ", stringify!(Bar))
     );
-    assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Bar>())).foo as *const _ as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(Bar), "::", stringify!(foo))
-    );
 }
 impl Default for Bar {
     fn default() -> Self {
@@ -55,11 +50,6 @@ fn bindgen_test_layout_Baz() {
         ::std::mem::align_of::<Baz>(),
         16usize,
         concat!("Alignment of ", stringify!(Baz))
-    );
-    assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Baz>())).bar as *const _ as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(Baz), "::", stringify!(bar))
     );
 }
 impl Default for Baz {

--- a/tests/expectations/tests/union-in-ns.rs
+++ b/tests/expectations/tests/union-in-ns.rs
@@ -26,16 +26,6 @@ pub mod root {
             4usize,
             concat!("Alignment of ", stringify!(bar))
         );
-        assert_eq!(
-            unsafe { &(*(::std::ptr::null::<bar>())).baz as *const _ as usize },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(bar),
-                "::",
-                stringify!(baz)
-            )
-        );
     }
     impl Default for bar {
         fn default() -> Self {

--- a/tests/expectations/tests/union-in-ns_1_0.rs
+++ b/tests/expectations/tests/union-in-ns_1_0.rs
@@ -73,16 +73,6 @@ pub mod root {
             4usize,
             concat!("Alignment of ", stringify!(bar))
         );
-        assert_eq!(
-            unsafe { &(*(::std::ptr::null::<bar>())).baz as *const _ as usize },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(bar),
-                "::",
-                stringify!(baz)
-            )
-        );
     }
     impl Clone for bar {
         fn clone(&self) -> Self {

--- a/tests/expectations/tests/union_dtor.rs
+++ b/tests/expectations/tests/union_dtor.rs
@@ -22,30 +22,6 @@ fn bindgen_test_layout_UnionWithDtor() {
         8usize,
         concat!("Alignment of ", stringify!(UnionWithDtor))
     );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<UnionWithDtor>())).mFoo as *const _ as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(UnionWithDtor),
-            "::",
-            stringify!(mFoo)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<UnionWithDtor>())).mBar as *const _ as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(UnionWithDtor),
-            "::",
-            stringify!(mBar)
-        )
-    );
 }
 extern "C" {
     #[link_name = "\u{1}_ZN13UnionWithDtorD1Ev"]

--- a/tests/expectations/tests/union_dtor_1_0.rs
+++ b/tests/expectations/tests/union_dtor_1_0.rs
@@ -67,30 +67,6 @@ fn bindgen_test_layout_UnionWithDtor() {
         8usize,
         concat!("Alignment of ", stringify!(UnionWithDtor))
     );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<UnionWithDtor>())).mFoo as *const _ as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(UnionWithDtor),
-            "::",
-            stringify!(mFoo)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<UnionWithDtor>())).mBar as *const _ as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(UnionWithDtor),
-            "::",
-            stringify!(mBar)
-        )
-    );
 }
 extern "C" {
     #[link_name = "\u{1}_ZN13UnionWithDtorD1Ev"]

--- a/tests/expectations/tests/union_fields.rs
+++ b/tests/expectations/tests/union_fields.rs
@@ -24,43 +24,6 @@ fn bindgen_test_layout_nsStyleUnion() {
         8usize,
         concat!("Alignment of ", stringify!(nsStyleUnion))
     );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<nsStyleUnion>())).mInt as *const _ as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(nsStyleUnion),
-            "::",
-            stringify!(mInt)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<nsStyleUnion>())).mFloat as *const _ as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(nsStyleUnion),
-            "::",
-            stringify!(mFloat)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<nsStyleUnion>())).mPointer as *const _
-                as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(nsStyleUnion),
-            "::",
-            stringify!(mPointer)
-        )
-    );
 }
 impl Default for nsStyleUnion {
     fn default() -> Self {

--- a/tests/expectations/tests/union_fields_1_0.rs
+++ b/tests/expectations/tests/union_fields_1_0.rs
@@ -68,43 +68,6 @@ fn bindgen_test_layout_nsStyleUnion() {
         8usize,
         concat!("Alignment of ", stringify!(nsStyleUnion))
     );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<nsStyleUnion>())).mInt as *const _ as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(nsStyleUnion),
-            "::",
-            stringify!(mInt)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<nsStyleUnion>())).mFloat as *const _ as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(nsStyleUnion),
-            "::",
-            stringify!(mFloat)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<nsStyleUnion>())).mPointer as *const _
-                as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(nsStyleUnion),
-            "::",
-            stringify!(mPointer)
-        )
-    );
 }
 impl Clone for nsStyleUnion {
     fn clone(&self) -> Self {

--- a/tests/expectations/tests/union_with_anon_struct.rs
+++ b/tests/expectations/tests/union_with_anon_struct.rs
@@ -30,13 +30,8 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<foo__bindgen_ty_1>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], foo__bindgen_ty_1>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<foo__bindgen_ty_1>() };
             let struct_ptr = &struct_instance as *const foo__bindgen_ty_1;
             let field_ptr = std::ptr::addr_of!(struct_instance.a);
             let struct_address = struct_ptr as usize;
@@ -54,13 +49,8 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<foo__bindgen_ty_1>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], foo__bindgen_ty_1>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<foo__bindgen_ty_1>() };
             let struct_ptr = &struct_instance as *const foo__bindgen_ty_1;
             let field_ptr = std::ptr::addr_of!(struct_instance.b);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/union_with_anon_struct.rs
+++ b/tests/expectations/tests/union_with_anon_struct.rs
@@ -29,8 +29,20 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
         concat!("Alignment of ", stringify!(foo__bindgen_ty_1))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<foo__bindgen_ty_1>())).a as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<foo__bindgen_ty_1>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], foo__bindgen_ty_1>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const foo__bindgen_ty_1;
+            let field_ptr = std::ptr::addr_of!(struct_instance.a);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -41,8 +53,20 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<foo__bindgen_ty_1>())).b as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<foo__bindgen_ty_1>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], foo__bindgen_ty_1>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const foo__bindgen_ty_1;
+            let field_ptr = std::ptr::addr_of!(struct_instance.b);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         4usize,
         concat!(
@@ -64,11 +88,6 @@ fn bindgen_test_layout_foo() {
         ::std::mem::align_of::<foo>(),
         4usize,
         concat!("Alignment of ", stringify!(foo))
-    );
-    assert_eq!(
-        unsafe { &(*(::std::ptr::null::<foo>())).bar as *const _ as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar))
     );
 }
 impl Default for foo {

--- a/tests/expectations/tests/union_with_anon_struct_1_0.rs
+++ b/tests/expectations/tests/union_with_anon_struct_1_0.rs
@@ -74,13 +74,8 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<foo__bindgen_ty_1>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], foo__bindgen_ty_1>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<foo__bindgen_ty_1>() };
             let struct_ptr = &struct_instance as *const foo__bindgen_ty_1;
             let field_ptr = std::ptr::addr_of!(struct_instance.a);
             let struct_address = struct_ptr as usize;
@@ -98,13 +93,8 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<foo__bindgen_ty_1>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], foo__bindgen_ty_1>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<foo__bindgen_ty_1>() };
             let struct_ptr = &struct_instance as *const foo__bindgen_ty_1;
             let field_ptr = std::ptr::addr_of!(struct_instance.b);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/union_with_anon_struct_1_0.rs
+++ b/tests/expectations/tests/union_with_anon_struct_1_0.rs
@@ -73,8 +73,20 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
         concat!("Alignment of ", stringify!(foo__bindgen_ty_1))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<foo__bindgen_ty_1>())).a as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<foo__bindgen_ty_1>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], foo__bindgen_ty_1>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const foo__bindgen_ty_1;
+            let field_ptr = std::ptr::addr_of!(struct_instance.a);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -85,8 +97,20 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<foo__bindgen_ty_1>())).b as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<foo__bindgen_ty_1>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], foo__bindgen_ty_1>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const foo__bindgen_ty_1;
+            let field_ptr = std::ptr::addr_of!(struct_instance.b);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         4usize,
         concat!(
@@ -113,11 +137,6 @@ fn bindgen_test_layout_foo() {
         ::std::mem::align_of::<foo>(),
         4usize,
         concat!("Alignment of ", stringify!(foo))
-    );
-    assert_eq!(
-        unsafe { &(*(::std::ptr::null::<foo>())).bar as *const _ as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar))
     );
 }
 impl Clone for foo {

--- a/tests/expectations/tests/union_with_anon_struct_bitfield.rs
+++ b/tests/expectations/tests/union_with_anon_struct_bitfield.rs
@@ -174,11 +174,6 @@ fn bindgen_test_layout_foo() {
         4usize,
         concat!("Alignment of ", stringify!(foo))
     );
-    assert_eq!(
-        unsafe { &(*(::std::ptr::null::<foo>())).a as *const _ as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(a))
-    );
 }
 impl Default for foo {
     fn default() -> Self {

--- a/tests/expectations/tests/union_with_anon_struct_bitfield_1_0.rs
+++ b/tests/expectations/tests/union_with_anon_struct_bitfield_1_0.rs
@@ -223,11 +223,6 @@ fn bindgen_test_layout_foo() {
         4usize,
         concat!("Alignment of ", stringify!(foo))
     );
-    assert_eq!(
-        unsafe { &(*(::std::ptr::null::<foo>())).a as *const _ as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(a))
-    );
 }
 impl Clone for foo {
     fn clone(&self) -> Self {

--- a/tests/expectations/tests/union_with_anon_union.rs
+++ b/tests/expectations/tests/union_with_anon_union.rs
@@ -28,30 +28,6 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
         4usize,
         concat!("Alignment of ", stringify!(foo__bindgen_ty_1))
     );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<foo__bindgen_ty_1>())).a as *const _ as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(foo__bindgen_ty_1),
-            "::",
-            stringify!(a)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<foo__bindgen_ty_1>())).b as *const _ as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(foo__bindgen_ty_1),
-            "::",
-            stringify!(b)
-        )
-    );
 }
 impl Default for foo__bindgen_ty_1 {
     fn default() -> Self {
@@ -73,11 +49,6 @@ fn bindgen_test_layout_foo() {
         ::std::mem::align_of::<foo>(),
         4usize,
         concat!("Alignment of ", stringify!(foo))
-    );
-    assert_eq!(
-        unsafe { &(*(::std::ptr::null::<foo>())).bar as *const _ as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar))
     );
 }
 impl Default for foo {

--- a/tests/expectations/tests/union_with_anon_union_1_0.rs
+++ b/tests/expectations/tests/union_with_anon_union_1_0.rs
@@ -73,30 +73,6 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
         4usize,
         concat!("Alignment of ", stringify!(foo__bindgen_ty_1))
     );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<foo__bindgen_ty_1>())).a as *const _ as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(foo__bindgen_ty_1),
-            "::",
-            stringify!(a)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<foo__bindgen_ty_1>())).b as *const _ as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(foo__bindgen_ty_1),
-            "::",
-            stringify!(b)
-        )
-    );
 }
 impl Clone for foo__bindgen_ty_1 {
     fn clone(&self) -> Self {
@@ -114,11 +90,6 @@ fn bindgen_test_layout_foo() {
         ::std::mem::align_of::<foo>(),
         4usize,
         concat!("Alignment of ", stringify!(foo))
-    );
-    assert_eq!(
-        unsafe { &(*(::std::ptr::null::<foo>())).bar as *const _ as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar))
     );
 }
 impl Clone for foo {

--- a/tests/expectations/tests/union_with_anon_unnamed_struct.rs
+++ b/tests/expectations/tests/union_with_anon_unnamed_struct.rs
@@ -33,14 +33,8 @@ fn bindgen_test_layout_pixel__bindgen_ty_1() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<pixel__bindgen_ty_1>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], pixel__bindgen_ty_1>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<pixel__bindgen_ty_1>() };
             let struct_ptr = &struct_instance as *const pixel__bindgen_ty_1;
             let field_ptr = std::ptr::addr_of!(struct_instance.r);
             let struct_address = struct_ptr as usize;
@@ -58,14 +52,8 @@ fn bindgen_test_layout_pixel__bindgen_ty_1() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<pixel__bindgen_ty_1>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], pixel__bindgen_ty_1>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<pixel__bindgen_ty_1>() };
             let struct_ptr = &struct_instance as *const pixel__bindgen_ty_1;
             let field_ptr = std::ptr::addr_of!(struct_instance.g);
             let struct_address = struct_ptr as usize;
@@ -83,14 +71,8 @@ fn bindgen_test_layout_pixel__bindgen_ty_1() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<pixel__bindgen_ty_1>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], pixel__bindgen_ty_1>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<pixel__bindgen_ty_1>() };
             let struct_ptr = &struct_instance as *const pixel__bindgen_ty_1;
             let field_ptr = std::ptr::addr_of!(struct_instance.b);
             let struct_address = struct_ptr as usize;
@@ -108,14 +90,8 @@ fn bindgen_test_layout_pixel__bindgen_ty_1() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<pixel__bindgen_ty_1>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], pixel__bindgen_ty_1>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<pixel__bindgen_ty_1>() };
             let struct_ptr = &struct_instance as *const pixel__bindgen_ty_1;
             let field_ptr = std::ptr::addr_of!(struct_instance.a);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/union_with_anon_unnamed_struct.rs
+++ b/tests/expectations/tests/union_with_anon_unnamed_struct.rs
@@ -32,9 +32,21 @@ fn bindgen_test_layout_pixel__bindgen_ty_1() {
         concat!("Alignment of ", stringify!(pixel__bindgen_ty_1))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<pixel__bindgen_ty_1>())).r as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<pixel__bindgen_ty_1>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], pixel__bindgen_ty_1>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const pixel__bindgen_ty_1;
+            let field_ptr = std::ptr::addr_of!(struct_instance.r);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -45,9 +57,21 @@ fn bindgen_test_layout_pixel__bindgen_ty_1() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<pixel__bindgen_ty_1>())).g as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<pixel__bindgen_ty_1>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], pixel__bindgen_ty_1>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const pixel__bindgen_ty_1;
+            let field_ptr = std::ptr::addr_of!(struct_instance.g);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         1usize,
         concat!(
@@ -58,9 +82,21 @@ fn bindgen_test_layout_pixel__bindgen_ty_1() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<pixel__bindgen_ty_1>())).b as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<pixel__bindgen_ty_1>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], pixel__bindgen_ty_1>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const pixel__bindgen_ty_1;
+            let field_ptr = std::ptr::addr_of!(struct_instance.b);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         2usize,
         concat!(
@@ -71,9 +107,21 @@ fn bindgen_test_layout_pixel__bindgen_ty_1() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<pixel__bindgen_ty_1>())).a as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<pixel__bindgen_ty_1>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], pixel__bindgen_ty_1>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const pixel__bindgen_ty_1;
+            let field_ptr = std::ptr::addr_of!(struct_instance.a);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         3usize,
         concat!(
@@ -95,16 +143,6 @@ fn bindgen_test_layout_pixel() {
         ::std::mem::align_of::<pixel>(),
         4usize,
         concat!("Alignment of ", stringify!(pixel))
-    );
-    assert_eq!(
-        unsafe { &(*(::std::ptr::null::<pixel>())).rgba as *const _ as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(pixel),
-            "::",
-            stringify!(rgba)
-        )
     );
 }
 impl Default for pixel {

--- a/tests/expectations/tests/union_with_anon_unnamed_struct_1_0.rs
+++ b/tests/expectations/tests/union_with_anon_unnamed_struct_1_0.rs
@@ -77,14 +77,8 @@ fn bindgen_test_layout_pixel__bindgen_ty_1() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<pixel__bindgen_ty_1>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], pixel__bindgen_ty_1>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<pixel__bindgen_ty_1>() };
             let struct_ptr = &struct_instance as *const pixel__bindgen_ty_1;
             let field_ptr = std::ptr::addr_of!(struct_instance.r);
             let struct_address = struct_ptr as usize;
@@ -102,14 +96,8 @@ fn bindgen_test_layout_pixel__bindgen_ty_1() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<pixel__bindgen_ty_1>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], pixel__bindgen_ty_1>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<pixel__bindgen_ty_1>() };
             let struct_ptr = &struct_instance as *const pixel__bindgen_ty_1;
             let field_ptr = std::ptr::addr_of!(struct_instance.g);
             let struct_address = struct_ptr as usize;
@@ -127,14 +115,8 @@ fn bindgen_test_layout_pixel__bindgen_ty_1() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<pixel__bindgen_ty_1>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], pixel__bindgen_ty_1>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<pixel__bindgen_ty_1>() };
             let struct_ptr = &struct_instance as *const pixel__bindgen_ty_1;
             let field_ptr = std::ptr::addr_of!(struct_instance.b);
             let struct_address = struct_ptr as usize;
@@ -152,14 +134,8 @@ fn bindgen_test_layout_pixel__bindgen_ty_1() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize =
-                std::mem::size_of::<pixel__bindgen_ty_1>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], pixel__bindgen_ty_1>(
-                    buffer,
-                )
-            };
+            let struct_instance =
+                unsafe { std::mem::zeroed::<pixel__bindgen_ty_1>() };
             let struct_ptr = &struct_instance as *const pixel__bindgen_ty_1;
             let field_ptr = std::ptr::addr_of!(struct_instance.a);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/union_with_anon_unnamed_struct_1_0.rs
+++ b/tests/expectations/tests/union_with_anon_unnamed_struct_1_0.rs
@@ -76,9 +76,21 @@ fn bindgen_test_layout_pixel__bindgen_ty_1() {
         concat!("Alignment of ", stringify!(pixel__bindgen_ty_1))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<pixel__bindgen_ty_1>())).r as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<pixel__bindgen_ty_1>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], pixel__bindgen_ty_1>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const pixel__bindgen_ty_1;
+            let field_ptr = std::ptr::addr_of!(struct_instance.r);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -89,9 +101,21 @@ fn bindgen_test_layout_pixel__bindgen_ty_1() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<pixel__bindgen_ty_1>())).g as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<pixel__bindgen_ty_1>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], pixel__bindgen_ty_1>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const pixel__bindgen_ty_1;
+            let field_ptr = std::ptr::addr_of!(struct_instance.g);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         1usize,
         concat!(
@@ -102,9 +126,21 @@ fn bindgen_test_layout_pixel__bindgen_ty_1() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<pixel__bindgen_ty_1>())).b as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<pixel__bindgen_ty_1>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], pixel__bindgen_ty_1>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const pixel__bindgen_ty_1;
+            let field_ptr = std::ptr::addr_of!(struct_instance.b);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         2usize,
         concat!(
@@ -115,9 +151,21 @@ fn bindgen_test_layout_pixel__bindgen_ty_1() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<pixel__bindgen_ty_1>())).a as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize =
+                std::mem::size_of::<pixel__bindgen_ty_1>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], pixel__bindgen_ty_1>(
+                    buffer,
+                )
+            };
+            let struct_ptr = &struct_instance as *const pixel__bindgen_ty_1;
+            let field_ptr = std::ptr::addr_of!(struct_instance.a);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         3usize,
         concat!(
@@ -144,16 +192,6 @@ fn bindgen_test_layout_pixel() {
         ::std::mem::align_of::<pixel>(),
         4usize,
         concat!("Alignment of ", stringify!(pixel))
-    );
-    assert_eq!(
-        unsafe { &(*(::std::ptr::null::<pixel>())).rgba as *const _ as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(pixel),
-            "::",
-            stringify!(rgba)
-        )
     );
 }
 impl Clone for pixel {

--- a/tests/expectations/tests/union_with_anon_unnamed_union.rs
+++ b/tests/expectations/tests/union_with_anon_unnamed_union.rs
@@ -29,30 +29,6 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
         2usize,
         concat!("Alignment of ", stringify!(foo__bindgen_ty_1))
     );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<foo__bindgen_ty_1>())).b as *const _ as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(foo__bindgen_ty_1),
-            "::",
-            stringify!(b)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<foo__bindgen_ty_1>())).c as *const _ as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(foo__bindgen_ty_1),
-            "::",
-            stringify!(c)
-        )
-    );
 }
 impl Default for foo__bindgen_ty_1 {
     fn default() -> Self {
@@ -74,11 +50,6 @@ fn bindgen_test_layout_foo() {
         ::std::mem::align_of::<foo>(),
         4usize,
         concat!("Alignment of ", stringify!(foo))
-    );
-    assert_eq!(
-        unsafe { &(*(::std::ptr::null::<foo>())).a as *const _ as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(a))
     );
 }
 impl Default for foo {

--- a/tests/expectations/tests/union_with_anon_unnamed_union_1_0.rs
+++ b/tests/expectations/tests/union_with_anon_unnamed_union_1_0.rs
@@ -74,30 +74,6 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
         2usize,
         concat!("Alignment of ", stringify!(foo__bindgen_ty_1))
     );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<foo__bindgen_ty_1>())).b as *const _ as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(foo__bindgen_ty_1),
-            "::",
-            stringify!(b)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<foo__bindgen_ty_1>())).c as *const _ as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(foo__bindgen_ty_1),
-            "::",
-            stringify!(c)
-        )
-    );
 }
 impl Clone for foo__bindgen_ty_1 {
     fn clone(&self) -> Self {
@@ -115,11 +91,6 @@ fn bindgen_test_layout_foo() {
         ::std::mem::align_of::<foo>(),
         4usize,
         concat!("Alignment of ", stringify!(foo))
-    );
-    assert_eq!(
-        unsafe { &(*(::std::ptr::null::<foo>())).a as *const _ as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(a))
     );
 }
 impl Clone for foo {

--- a/tests/expectations/tests/union_with_big_member.rs
+++ b/tests/expectations/tests/union_with_big_member.rs
@@ -23,30 +23,6 @@ fn bindgen_test_layout_WithBigArray() {
         4usize,
         concat!("Alignment of ", stringify!(WithBigArray))
     );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<WithBigArray>())).a as *const _ as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(WithBigArray),
-            "::",
-            stringify!(a)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<WithBigArray>())).b as *const _ as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(WithBigArray),
-            "::",
-            stringify!(b)
-        )
-    );
 }
 impl Default for WithBigArray {
     fn default() -> Self {
@@ -75,30 +51,6 @@ fn bindgen_test_layout_WithBigArray2() {
         4usize,
         concat!("Alignment of ", stringify!(WithBigArray2))
     );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<WithBigArray2>())).a as *const _ as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(WithBigArray2),
-            "::",
-            stringify!(a)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<WithBigArray2>())).b as *const _ as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(WithBigArray2),
-            "::",
-            stringify!(b)
-        )
-    );
 }
 impl Default for WithBigArray2 {
     fn default() -> Self {
@@ -126,30 +78,6 @@ fn bindgen_test_layout_WithBigMember() {
         ::std::mem::align_of::<WithBigMember>(),
         4usize,
         concat!("Alignment of ", stringify!(WithBigMember))
-    );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<WithBigMember>())).a as *const _ as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(WithBigMember),
-            "::",
-            stringify!(a)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<WithBigMember>())).b as *const _ as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(WithBigMember),
-            "::",
-            stringify!(b)
-        )
     );
 }
 impl Default for WithBigMember {

--- a/tests/expectations/tests/union_with_big_member_1_0.rs
+++ b/tests/expectations/tests/union_with_big_member_1_0.rs
@@ -67,30 +67,6 @@ fn bindgen_test_layout_WithBigArray() {
         4usize,
         concat!("Alignment of ", stringify!(WithBigArray))
     );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<WithBigArray>())).a as *const _ as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(WithBigArray),
-            "::",
-            stringify!(a)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<WithBigArray>())).b as *const _ as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(WithBigArray),
-            "::",
-            stringify!(b)
-        )
-    );
 }
 impl Clone for WithBigArray {
     fn clone(&self) -> Self {
@@ -125,30 +101,6 @@ fn bindgen_test_layout_WithBigArray2() {
         4usize,
         concat!("Alignment of ", stringify!(WithBigArray2))
     );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<WithBigArray2>())).a as *const _ as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(WithBigArray2),
-            "::",
-            stringify!(a)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<WithBigArray2>())).b as *const _ as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(WithBigArray2),
-            "::",
-            stringify!(b)
-        )
-    );
 }
 impl Clone for WithBigArray2 {
     fn clone(&self) -> Self {
@@ -173,30 +125,6 @@ fn bindgen_test_layout_WithBigMember() {
         ::std::mem::align_of::<WithBigMember>(),
         4usize,
         concat!("Alignment of ", stringify!(WithBigMember))
-    );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<WithBigMember>())).a as *const _ as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(WithBigMember),
-            "::",
-            stringify!(a)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<WithBigMember>())).b as *const _ as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(WithBigMember),
-            "::",
-            stringify!(b)
-        )
     );
 }
 impl Clone for WithBigMember {

--- a/tests/expectations/tests/union_with_nesting.rs
+++ b/tests/expectations/tests/union_with_nesting.rs
@@ -35,32 +35,6 @@ fn bindgen_test_layout_foo__bindgen_ty_1__bindgen_ty_1() {
         2usize,
         concat!("Alignment of ", stringify!(foo__bindgen_ty_1__bindgen_ty_1))
     );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<foo__bindgen_ty_1__bindgen_ty_1>())).b1
-                as *const _ as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(foo__bindgen_ty_1__bindgen_ty_1),
-            "::",
-            stringify!(b1)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<foo__bindgen_ty_1__bindgen_ty_1>())).b2
-                as *const _ as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(foo__bindgen_ty_1__bindgen_ty_1),
-            "::",
-            stringify!(b2)
-        )
-    );
 }
 impl Default for foo__bindgen_ty_1__bindgen_ty_1 {
     fn default() -> Self {
@@ -88,32 +62,6 @@ fn bindgen_test_layout_foo__bindgen_ty_1__bindgen_ty_2() {
         ::std::mem::align_of::<foo__bindgen_ty_1__bindgen_ty_2>(),
         2usize,
         concat!("Alignment of ", stringify!(foo__bindgen_ty_1__bindgen_ty_2))
-    );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<foo__bindgen_ty_1__bindgen_ty_2>())).c1
-                as *const _ as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(foo__bindgen_ty_1__bindgen_ty_2),
-            "::",
-            stringify!(c1)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<foo__bindgen_ty_1__bindgen_ty_2>())).c2
-                as *const _ as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(foo__bindgen_ty_1__bindgen_ty_2),
-            "::",
-            stringify!(c2)
-        )
     );
 }
 impl Default for foo__bindgen_ty_1__bindgen_ty_2 {
@@ -158,11 +106,6 @@ fn bindgen_test_layout_foo() {
         ::std::mem::align_of::<foo>(),
         4usize,
         concat!("Alignment of ", stringify!(foo))
-    );
-    assert_eq!(
-        unsafe { &(*(::std::ptr::null::<foo>())).a as *const _ as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(a))
     );
 }
 impl Default for foo {

--- a/tests/expectations/tests/union_with_nesting_1_0.rs
+++ b/tests/expectations/tests/union_with_nesting_1_0.rs
@@ -80,32 +80,6 @@ fn bindgen_test_layout_foo__bindgen_ty_1__bindgen_ty_1() {
         2usize,
         concat!("Alignment of ", stringify!(foo__bindgen_ty_1__bindgen_ty_1))
     );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<foo__bindgen_ty_1__bindgen_ty_1>())).b1
-                as *const _ as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(foo__bindgen_ty_1__bindgen_ty_1),
-            "::",
-            stringify!(b1)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<foo__bindgen_ty_1__bindgen_ty_1>())).b2
-                as *const _ as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(foo__bindgen_ty_1__bindgen_ty_1),
-            "::",
-            stringify!(b2)
-        )
-    );
 }
 impl Clone for foo__bindgen_ty_1__bindgen_ty_1 {
     fn clone(&self) -> Self {
@@ -130,32 +104,6 @@ fn bindgen_test_layout_foo__bindgen_ty_1__bindgen_ty_2() {
         ::std::mem::align_of::<foo__bindgen_ty_1__bindgen_ty_2>(),
         2usize,
         concat!("Alignment of ", stringify!(foo__bindgen_ty_1__bindgen_ty_2))
-    );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<foo__bindgen_ty_1__bindgen_ty_2>())).c1
-                as *const _ as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(foo__bindgen_ty_1__bindgen_ty_2),
-            "::",
-            stringify!(c1)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<foo__bindgen_ty_1__bindgen_ty_2>())).c2
-                as *const _ as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(foo__bindgen_ty_1__bindgen_ty_2),
-            "::",
-            stringify!(c2)
-        )
     );
 }
 impl Clone for foo__bindgen_ty_1__bindgen_ty_2 {
@@ -192,11 +140,6 @@ fn bindgen_test_layout_foo() {
         ::std::mem::align_of::<foo>(),
         4usize,
         concat!("Alignment of ", stringify!(foo))
-    );
-    assert_eq!(
-        unsafe { &(*(::std::ptr::null::<foo>())).a as *const _ as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(a))
     );
 }
 impl Clone for foo {

--- a/tests/expectations/tests/unknown_attr.rs
+++ b/tests/expectations/tests/unknown_attr.rs
@@ -27,11 +27,7 @@ fn bindgen_test_layout_max_align_t() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<max_align_t>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], max_align_t>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<max_align_t>() };
             let struct_ptr = &struct_instance as *const max_align_t;
             let field_ptr =
                 std::ptr::addr_of!(struct_instance.__clang_max_align_nonce1);
@@ -50,11 +46,7 @@ fn bindgen_test_layout_max_align_t() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<max_align_t>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], max_align_t>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<max_align_t>() };
             let struct_ptr = &struct_instance as *const max_align_t;
             let field_ptr =
                 std::ptr::addr_of!(struct_instance.__clang_max_align_nonce2);

--- a/tests/expectations/tests/unknown_attr.rs
+++ b/tests/expectations/tests/unknown_attr.rs
@@ -26,9 +26,19 @@ fn bindgen_test_layout_max_align_t() {
         concat!("Alignment of ", stringify!(max_align_t))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<max_align_t>())).__clang_max_align_nonce1
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<max_align_t>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], max_align_t>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const max_align_t;
+            let field_ptr =
+                std::ptr::addr_of!(struct_instance.__clang_max_align_nonce1);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -39,9 +49,19 @@ fn bindgen_test_layout_max_align_t() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<max_align_t>())).__clang_max_align_nonce2
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<max_align_t>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], max_align_t>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const max_align_t;
+            let field_ptr =
+                std::ptr::addr_of!(struct_instance.__clang_max_align_nonce2);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         16usize,
         concat!(

--- a/tests/expectations/tests/use-core.rs
+++ b/tests/expectations/tests/use-core.rs
@@ -27,17 +27,53 @@ fn bindgen_test_layout_foo() {
         concat!("Alignment of ", stringify!(foo))
     );
     assert_eq!(
-        unsafe { &(*(::core::ptr::null::<foo>())).a as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<foo>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], foo>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const foo;
+            let field_ptr = std::ptr::addr_of!(struct_instance.a);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!("Offset of field: ", stringify!(foo), "::", stringify!(a))
     );
     assert_eq!(
-        unsafe { &(*(::core::ptr::null::<foo>())).b as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<foo>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], foo>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const foo;
+            let field_ptr = std::ptr::addr_of!(struct_instance.b);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         4usize,
         concat!("Offset of field: ", stringify!(foo), "::", stringify!(b))
     );
     assert_eq!(
-        unsafe { &(*(::core::ptr::null::<foo>())).bar as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<foo>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], foo>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const foo;
+            let field_ptr = std::ptr::addr_of!(struct_instance.bar);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         8usize,
         concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar))
     );
@@ -68,30 +104,6 @@ fn bindgen_test_layout__bindgen_ty_1() {
         ::core::mem::align_of::<_bindgen_ty_1>(),
         8usize,
         concat!("Alignment of ", stringify!(_bindgen_ty_1))
-    );
-    assert_eq!(
-        unsafe {
-            &(*(::core::ptr::null::<_bindgen_ty_1>())).bar as *const _ as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(_bindgen_ty_1),
-            "::",
-            stringify!(bar)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            &(*(::core::ptr::null::<_bindgen_ty_1>())).baz as *const _ as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(_bindgen_ty_1),
-            "::",
-            stringify!(baz)
-        )
     );
 }
 impl Default for _bindgen_ty_1 {

--- a/tests/expectations/tests/use-core.rs
+++ b/tests/expectations/tests/use-core.rs
@@ -28,11 +28,7 @@ fn bindgen_test_layout_foo() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<foo>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], foo>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<foo>() };
             let struct_ptr = &struct_instance as *const foo;
             let field_ptr = std::ptr::addr_of!(struct_instance.a);
             let struct_address = struct_ptr as usize;
@@ -45,11 +41,7 @@ fn bindgen_test_layout_foo() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<foo>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], foo>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<foo>() };
             let struct_ptr = &struct_instance as *const foo;
             let field_ptr = std::ptr::addr_of!(struct_instance.b);
             let struct_address = struct_ptr as usize;
@@ -62,11 +54,7 @@ fn bindgen_test_layout_foo() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<foo>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], foo>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<foo>() };
             let struct_ptr = &struct_instance as *const foo;
             let field_ptr = std::ptr::addr_of!(struct_instance.bar);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/use-core_1_0.rs
+++ b/tests/expectations/tests/use-core_1_0.rs
@@ -71,11 +71,7 @@ fn bindgen_test_layout_foo() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<foo>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], foo>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<foo>() };
             let struct_ptr = &struct_instance as *const foo;
             let field_ptr = std::ptr::addr_of!(struct_instance.a);
             let struct_address = struct_ptr as usize;
@@ -88,11 +84,7 @@ fn bindgen_test_layout_foo() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<foo>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], foo>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<foo>() };
             let struct_ptr = &struct_instance as *const foo;
             let field_ptr = std::ptr::addr_of!(struct_instance.b);
             let struct_address = struct_ptr as usize;
@@ -105,11 +97,7 @@ fn bindgen_test_layout_foo() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<foo>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], foo>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<foo>() };
             let struct_ptr = &struct_instance as *const foo;
             let field_ptr = std::ptr::addr_of!(struct_instance.bar);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/use-core_1_0.rs
+++ b/tests/expectations/tests/use-core_1_0.rs
@@ -70,17 +70,53 @@ fn bindgen_test_layout_foo() {
         concat!("Alignment of ", stringify!(foo))
     );
     assert_eq!(
-        unsafe { &(*(::core::ptr::null::<foo>())).a as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<foo>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], foo>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const foo;
+            let field_ptr = std::ptr::addr_of!(struct_instance.a);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!("Offset of field: ", stringify!(foo), "::", stringify!(a))
     );
     assert_eq!(
-        unsafe { &(*(::core::ptr::null::<foo>())).b as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<foo>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], foo>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const foo;
+            let field_ptr = std::ptr::addr_of!(struct_instance.b);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         4usize,
         concat!("Offset of field: ", stringify!(foo), "::", stringify!(b))
     );
     assert_eq!(
-        unsafe { &(*(::core::ptr::null::<foo>())).bar as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<foo>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], foo>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const foo;
+            let field_ptr = std::ptr::addr_of!(struct_instance.bar);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         8usize,
         concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar))
     );
@@ -117,30 +153,6 @@ fn bindgen_test_layout__bindgen_ty_1() {
         ::core::mem::align_of::<_bindgen_ty_1>(),
         8usize,
         concat!("Alignment of ", stringify!(_bindgen_ty_1))
-    );
-    assert_eq!(
-        unsafe {
-            &(*(::core::ptr::null::<_bindgen_ty_1>())).bar as *const _ as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(_bindgen_ty_1),
-            "::",
-            stringify!(bar)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            &(*(::core::ptr::null::<_bindgen_ty_1>())).baz as *const _ as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(_bindgen_ty_1),
-            "::",
-            stringify!(baz)
-        )
     );
 }
 impl Clone for _bindgen_ty_1 {

--- a/tests/expectations/tests/var-tracing.rs
+++ b/tests/expectations/tests/var-tracing.rs
@@ -24,11 +24,7 @@ fn bindgen_test_layout_Bar() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<Bar>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], Bar>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<Bar>() };
             let struct_ptr = &struct_instance as *const Bar;
             let field_ptr = std::ptr::addr_of!(struct_instance.m_baz);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/var-tracing.rs
+++ b/tests/expectations/tests/var-tracing.rs
@@ -23,7 +23,19 @@ fn bindgen_test_layout_Bar() {
         concat!("Alignment of ", stringify!(Bar))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Bar>())).m_baz as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<Bar>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], Bar>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const Bar;
+            let field_ptr = std::ptr::addr_of!(struct_instance.m_baz);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/vector.rs
+++ b/tests/expectations/tests/vector.rs
@@ -24,11 +24,7 @@ fn bindgen_test_layout_foo() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<foo>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], foo>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<foo>() };
             let struct_ptr = &struct_instance as *const foo;
             let field_ptr = std::ptr::addr_of!(struct_instance.mMember);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/vector.rs
+++ b/tests/expectations/tests/vector.rs
@@ -23,7 +23,19 @@ fn bindgen_test_layout_foo() {
         concat!("Alignment of ", stringify!(foo))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<foo>())).mMember as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<foo>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], foo>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const foo;
+            let field_ptr = std::ptr::addr_of!(struct_instance.mMember);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/virtual_inheritance.rs
+++ b/tests/expectations/tests/virtual_inheritance.rs
@@ -23,7 +23,18 @@ fn bindgen_test_layout_A() {
         concat!("Alignment of ", stringify!(A))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<A>())).foo as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<A>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance =
+                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], A>(buffer) };
+            let struct_ptr = &struct_instance as *const A;
+            let field_ptr = std::ptr::addr_of!(struct_instance.foo);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         0usize,
         concat!("Offset of field: ", stringify!(A), "::", stringify!(foo))
     );
@@ -49,7 +60,18 @@ fn bindgen_test_layout_B() {
         concat!("Alignment of ", stringify!(B))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<B>())).bar as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<B>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance =
+                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], B>(buffer) };
+            let struct_ptr = &struct_instance as *const B;
+            let field_ptr = std::ptr::addr_of!(struct_instance.bar);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         8usize,
         concat!("Offset of field: ", stringify!(B), "::", stringify!(bar))
     );
@@ -84,7 +106,18 @@ fn bindgen_test_layout_C() {
         concat!("Alignment of ", stringify!(C))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<C>())).baz as *const _ as usize },
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<C>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance =
+                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], C>(buffer) };
+            let struct_ptr = &struct_instance as *const C;
+            let field_ptr = std::ptr::addr_of!(struct_instance.baz);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
+        },
         8usize,
         concat!("Offset of field: ", stringify!(C), "::", stringify!(baz))
     );

--- a/tests/expectations/tests/virtual_inheritance.rs
+++ b/tests/expectations/tests/virtual_inheritance.rs
@@ -24,10 +24,7 @@ fn bindgen_test_layout_A() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<A>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance =
-                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], A>(buffer) };
+            let struct_instance = unsafe { std::mem::zeroed::<A>() };
             let struct_ptr = &struct_instance as *const A;
             let field_ptr = std::ptr::addr_of!(struct_instance.foo);
             let struct_address = struct_ptr as usize;
@@ -61,10 +58,7 @@ fn bindgen_test_layout_B() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<B>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance =
-                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], B>(buffer) };
+            let struct_instance = unsafe { std::mem::zeroed::<B>() };
             let struct_ptr = &struct_instance as *const B;
             let field_ptr = std::ptr::addr_of!(struct_instance.bar);
             let struct_address = struct_ptr as usize;
@@ -107,10 +101,7 @@ fn bindgen_test_layout_C() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<C>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance =
-                unsafe { std::mem::transmute::<[u8; STRUCT_SIZE], C>(buffer) };
+            let struct_instance = unsafe { std::mem::zeroed::<C>() };
             let struct_ptr = &struct_instance as *const C;
             let field_ptr = std::ptr::addr_of!(struct_instance.baz);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/weird_bitfields.rs
+++ b/tests/expectations/tests/weird_bitfields.rs
@@ -132,9 +132,19 @@ fn bindgen_test_layout_Weird() {
         concat!("Alignment of ", stringify!(Weird))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<Weird>())).mStrokeDasharrayLength as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<Weird>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], Weird>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const Weird;
+            let field_ptr =
+                std::ptr::addr_of!(struct_instance.mStrokeDasharrayLength);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -145,8 +155,18 @@ fn bindgen_test_layout_Weird() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<Weird>())).mClipRule as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<Weird>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], Weird>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const Weird;
+            let field_ptr = std::ptr::addr_of!(struct_instance.mClipRule);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         8usize,
         concat!(
@@ -157,9 +177,19 @@ fn bindgen_test_layout_Weird() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<Weird>())).mColorInterpolation as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<Weird>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], Weird>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const Weird;
+            let field_ptr =
+                std::ptr::addr_of!(struct_instance.mColorInterpolation);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         9usize,
         concat!(
@@ -170,9 +200,19 @@ fn bindgen_test_layout_Weird() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<Weird>())).mColorInterpolationFilters
-                as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<Weird>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], Weird>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const Weird;
+            let field_ptr =
+                std::ptr::addr_of!(struct_instance.mColorInterpolationFilters);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         10usize,
         concat!(
@@ -183,8 +223,18 @@ fn bindgen_test_layout_Weird() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<Weird>())).mFillRule as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<Weird>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], Weird>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const Weird;
+            let field_ptr = std::ptr::addr_of!(struct_instance.mFillRule);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         11usize,
         concat!(
@@ -195,9 +245,18 @@ fn bindgen_test_layout_Weird() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<Weird>())).mImageRendering as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<Weird>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], Weird>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const Weird;
+            let field_ptr = std::ptr::addr_of!(struct_instance.mImageRendering);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         12usize,
         concat!(
@@ -208,8 +267,18 @@ fn bindgen_test_layout_Weird() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<Weird>())).mPaintOrder as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<Weird>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], Weird>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const Weird;
+            let field_ptr = std::ptr::addr_of!(struct_instance.mPaintOrder);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         13usize,
         concat!(
@@ -220,9 +289,18 @@ fn bindgen_test_layout_Weird() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<Weird>())).mShapeRendering as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<Weird>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], Weird>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const Weird;
+            let field_ptr = std::ptr::addr_of!(struct_instance.mShapeRendering);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         14usize,
         concat!(
@@ -233,9 +311,18 @@ fn bindgen_test_layout_Weird() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<Weird>())).mStrokeLinecap as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<Weird>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], Weird>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const Weird;
+            let field_ptr = std::ptr::addr_of!(struct_instance.mStrokeLinecap);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         15usize,
         concat!(
@@ -246,9 +333,18 @@ fn bindgen_test_layout_Weird() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<Weird>())).mStrokeLinejoin as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<Weird>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], Weird>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const Weird;
+            let field_ptr = std::ptr::addr_of!(struct_instance.mStrokeLinejoin);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         16usize,
         concat!(
@@ -259,8 +355,18 @@ fn bindgen_test_layout_Weird() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<Weird>())).mTextAnchor as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<Weird>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], Weird>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const Weird;
+            let field_ptr = std::ptr::addr_of!(struct_instance.mTextAnchor);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         17usize,
         concat!(
@@ -271,9 +377,18 @@ fn bindgen_test_layout_Weird() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<Weird>())).mTextRendering as *const _
-                as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<Weird>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], Weird>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const Weird;
+            let field_ptr = std::ptr::addr_of!(struct_instance.mTextRendering);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         18usize,
         concat!(

--- a/tests/expectations/tests/weird_bitfields.rs
+++ b/tests/expectations/tests/weird_bitfields.rs
@@ -133,11 +133,7 @@ fn bindgen_test_layout_Weird() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<Weird>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], Weird>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<Weird>() };
             let struct_ptr = &struct_instance as *const Weird;
             let field_ptr =
                 std::ptr::addr_of!(struct_instance.mStrokeDasharrayLength);
@@ -156,11 +152,7 @@ fn bindgen_test_layout_Weird() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<Weird>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], Weird>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<Weird>() };
             let struct_ptr = &struct_instance as *const Weird;
             let field_ptr = std::ptr::addr_of!(struct_instance.mClipRule);
             let struct_address = struct_ptr as usize;
@@ -178,11 +170,7 @@ fn bindgen_test_layout_Weird() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<Weird>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], Weird>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<Weird>() };
             let struct_ptr = &struct_instance as *const Weird;
             let field_ptr =
                 std::ptr::addr_of!(struct_instance.mColorInterpolation);
@@ -201,11 +189,7 @@ fn bindgen_test_layout_Weird() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<Weird>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], Weird>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<Weird>() };
             let struct_ptr = &struct_instance as *const Weird;
             let field_ptr =
                 std::ptr::addr_of!(struct_instance.mColorInterpolationFilters);
@@ -224,11 +208,7 @@ fn bindgen_test_layout_Weird() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<Weird>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], Weird>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<Weird>() };
             let struct_ptr = &struct_instance as *const Weird;
             let field_ptr = std::ptr::addr_of!(struct_instance.mFillRule);
             let struct_address = struct_ptr as usize;
@@ -246,11 +226,7 @@ fn bindgen_test_layout_Weird() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<Weird>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], Weird>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<Weird>() };
             let struct_ptr = &struct_instance as *const Weird;
             let field_ptr = std::ptr::addr_of!(struct_instance.mImageRendering);
             let struct_address = struct_ptr as usize;
@@ -268,11 +244,7 @@ fn bindgen_test_layout_Weird() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<Weird>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], Weird>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<Weird>() };
             let struct_ptr = &struct_instance as *const Weird;
             let field_ptr = std::ptr::addr_of!(struct_instance.mPaintOrder);
             let struct_address = struct_ptr as usize;
@@ -290,11 +262,7 @@ fn bindgen_test_layout_Weird() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<Weird>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], Weird>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<Weird>() };
             let struct_ptr = &struct_instance as *const Weird;
             let field_ptr = std::ptr::addr_of!(struct_instance.mShapeRendering);
             let struct_address = struct_ptr as usize;
@@ -312,11 +280,7 @@ fn bindgen_test_layout_Weird() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<Weird>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], Weird>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<Weird>() };
             let struct_ptr = &struct_instance as *const Weird;
             let field_ptr = std::ptr::addr_of!(struct_instance.mStrokeLinecap);
             let struct_address = struct_ptr as usize;
@@ -334,11 +298,7 @@ fn bindgen_test_layout_Weird() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<Weird>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], Weird>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<Weird>() };
             let struct_ptr = &struct_instance as *const Weird;
             let field_ptr = std::ptr::addr_of!(struct_instance.mStrokeLinejoin);
             let struct_address = struct_ptr as usize;
@@ -356,11 +316,7 @@ fn bindgen_test_layout_Weird() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<Weird>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], Weird>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<Weird>() };
             let struct_ptr = &struct_instance as *const Weird;
             let field_ptr = std::ptr::addr_of!(struct_instance.mTextAnchor);
             let struct_address = struct_ptr as usize;
@@ -378,11 +334,7 @@ fn bindgen_test_layout_Weird() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<Weird>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], Weird>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<Weird>() };
             let struct_ptr = &struct_instance as *const Weird;
             let field_ptr = std::ptr::addr_of!(struct_instance.mTextRendering);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/zero-size-array-align.rs
+++ b/tests/expectations/tests/zero-size-array-align.rs
@@ -56,11 +56,7 @@ fn bindgen_test_layout_dm_deps() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<dm_deps>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], dm_deps>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<dm_deps>() };
             let struct_ptr = &struct_instance as *const dm_deps;
             let field_ptr = std::ptr::addr_of!(struct_instance.count);
             let struct_address = struct_ptr as usize;
@@ -78,11 +74,7 @@ fn bindgen_test_layout_dm_deps() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<dm_deps>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], dm_deps>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<dm_deps>() };
             let struct_ptr = &struct_instance as *const dm_deps;
             let field_ptr = std::ptr::addr_of!(struct_instance.filler);
             let struct_address = struct_ptr as usize;
@@ -100,11 +92,7 @@ fn bindgen_test_layout_dm_deps() {
     );
     assert_eq!(
         {
-            const STRUCT_SIZE: usize = std::mem::size_of::<dm_deps>();
-            let buffer = [0u8; STRUCT_SIZE];
-            let struct_instance = unsafe {
-                std::mem::transmute::<[u8; STRUCT_SIZE], dm_deps>(buffer)
-            };
+            let struct_instance = unsafe { std::mem::zeroed::<dm_deps>() };
             let struct_ptr = &struct_instance as *const dm_deps;
             let field_ptr = std::ptr::addr_of!(struct_instance.device);
             let struct_address = struct_ptr as usize;

--- a/tests/expectations/tests/zero-size-array-align.rs
+++ b/tests/expectations/tests/zero-size-array-align.rs
@@ -55,8 +55,18 @@ fn bindgen_test_layout_dm_deps() {
         concat!("Alignment of ", stringify!(dm_deps))
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<dm_deps>())).count as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<dm_deps>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], dm_deps>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const dm_deps;
+            let field_ptr = std::ptr::addr_of!(struct_instance.count);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         0usize,
         concat!(
@@ -67,8 +77,18 @@ fn bindgen_test_layout_dm_deps() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<dm_deps>())).filler as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<dm_deps>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], dm_deps>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const dm_deps;
+            let field_ptr = std::ptr::addr_of!(struct_instance.filler);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         4usize,
         concat!(
@@ -79,8 +99,18 @@ fn bindgen_test_layout_dm_deps() {
         )
     );
     assert_eq!(
-        unsafe {
-            &(*(::std::ptr::null::<dm_deps>())).device as *const _ as usize
+        {
+            const STRUCT_SIZE: usize = std::mem::size_of::<dm_deps>();
+            let buffer = [0u8; STRUCT_SIZE];
+            let struct_instance = unsafe {
+                std::mem::transmute::<[u8; STRUCT_SIZE], dm_deps>(buffer)
+            };
+            let struct_ptr = &struct_instance as *const dm_deps;
+            let field_ptr = std::ptr::addr_of!(struct_instance.device);
+            let struct_address = struct_ptr as usize;
+            let field_address = field_ptr as usize;
+            std::mem::forget(struct_instance);
+            field_address.checked_sub(struct_address).unwrap()
         },
         8usize,
         concat!(


### PR DESCRIPTION
 - Replaced dereferencing of null ptr with
   zero bit pattern + transmute + std::ptr::addr_of!
   to avoid UB. It affects only checks of fields offsets
 - Overwritten expected with BINDGEN_OVERWRITE_EXPECTED=1
 - Overwritten test_multiple_header_calls_in_builder and test_mixed_header_and_header_contents
   manually because https://github.com/rust-lang/rust-bindgen/issues/2054
 - Do not check the layout for repr(C) unions
 - Do not call the destructor of tmp struct to avoid other UB
 
 Close #1651 
 

Note: This way is not ideal (see the latest comments in related issue). Zero bit pattern can be replaces with manual initialization of the fields, but I have no time to investigate how to do it when
1. The item is a struct contains other structs.
2. The item is a union.

However, I think this way is good enough, because there no UB anymore. The only one unsafe block with transmute will not cause an UB, because all C types allows zero bit pattern. Anyway, it's better than current implementation with UB and warnings.

Any feedback or commits are appreciated. Thanks.