### PR TITLE
add custom derives callback

### DIFF
--- a/bindgen-integration/build.rs
+++ b/bindgen-integration/build.rs
@@ -119,6 +119,17 @@ impl ParseCallbacks for MacroCallback {
             }
         }
     }
+
+    // Test the "custom derives" capability by adding `PartialEq` to the `Test` struct.
+    fn add_derives(&self, name: &str) -> Vec<String> {
+        if name == "Test" {
+            vec![
+                "PartialEq".into(),
+            ]
+        } else {
+            vec![]
+        }
+    }
 }
 
 impl Drop for MacroCallback {

--- a/bindgen-integration/src/lib.rs
+++ b/bindgen-integration/src/lib.rs
@@ -267,3 +267,12 @@ fn test_homogeneous_aggregate_float_union() {
         assert_eq!([1., 2., 3., 4.], coord.v)
     }
 }
+
+#[test]
+fn test_custom_derive() {
+    // The `add_derives` callback should have added `#[derive(PartialEq)]`
+    // to the `Test` struct. If it didn't, this will fail to compile.
+    let test1 = unsafe { bindings::Test::new(5) };
+    let test2 = unsafe { bindings::Test::new(6) };
+    assert_ne!(test1, test2);
+}

--- a/src/callbacks.rs
+++ b/src/callbacks.rs
@@ -95,4 +95,12 @@ pub trait ParseCallbacks: fmt::Debug + UnwindSafe {
     ) -> Option<ImplementsTrait> {
         None
     }
+
+    /// Provide a list of custom derive attributes.
+    ///
+    /// If no additional attributes are wanted, this function should return an
+    /// empty `Vec`.
+    fn add_derives(&self, _name: &str) -> Vec<String> {
+        vec![]
+    }
 }

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -1997,6 +1997,15 @@ impl CodeGenerator for CompInfo {
         let mut derives: Vec<_> = derivable_traits.into();
         derives.extend(item.annotations().derives().iter().map(String::as_str));
 
+        // The custom derives callback may return a list of derive attributes;
+        // add them to the end of the list.
+        let custom_derives;
+        if let Some(cb) = &ctx.options().parse_callbacks {
+            custom_derives = cb.add_derives(&canonical_name);
+            // In most cases this will be a no-op, since custom_derives will be empty.
+            derives.extend(custom_derives.iter().map(|s| s.as_str()));
+        };
+
         if !derives.is_empty() {
             attributes.push(attributes::derives(&derives))
         }


### PR DESCRIPTION
This callback allows us to specify arbitrary derive attributes for each named struct. This is useful for adding things that can't easily be implemented separately, such as `serde::Deserialize` or `zerocopy::FromBytes`.

This addresses the easiest cases of #1089.

There aren't any tests yet-- I'm not sure what the best way would be to test this, since it can't be reduced to a command line.