### PR TITLE
Implement #710, must-use for types.

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -19,6 +19,7 @@
     - [Preventing the Derivation of `Copy` and `Clone`](./nocopy.md)
     - [Preventing the Derivation of `Debug`](./nodebug.md)
     - [Preventing the Derivation of `Default`](./nodefault.md)
+    - [Annotating types with `#[must-use]`](./must-use-types.md)
 - [Generating Bindings to C++](./cpp.md)
 - [Generating Bindings to Objective-c](./objc.md)
 - [Using Unions](./using-unions.md)

--- a/book/src/must-use-types.md
+++ b/book/src/must-use-types.md
@@ -1,0 +1,27 @@
+# Annotating types with `#[must-use]`
+
+`bindgen` can be instructed to annotate certain types with 
+[`#[must_use]`](https://doc.rust-lang.org/reference/attributes/diagnostics.html#the-must_use-attribute).
+
+Some libraries have a common error type, returned by lots of their functions, 
+which needs to be checked after every call. In these cases it's useful to add `#[must_use]` to this type, so the Rust
+compiler emits a warning when the check is missing.
+### Library
+
+* [`bindgen::Builder::must_use_type`](https://docs.rs/bindgen/latest/bindgen/struct.Builder.html#method.must_use_type)
+
+### Command Line
+
+* `--must-use-type <regex>`
+
+### Annotations
+
+```c
+/** <div rustbindgen mustusetype></div> */
+struct ErrorType {
+    // ...
+};
+
+...
+```
+

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -2023,7 +2023,8 @@ impl CodeGenerator for CompInfo {
             attributes.push(attributes::derives(&derives))
         }
 
-        if item.annotations().must_use_type() || ctx.must_use_type_by_name(item) {
+        if item.annotations().must_use_type() || ctx.must_use_type_by_name(item)
+        {
             attributes.push(attributes::must_use());
         }
 
@@ -3000,6 +3001,11 @@ impl CodeGenerator for Enum {
 
         if let Some(comment) = item.comment(ctx) {
             attrs.push(attributes::doc(comment));
+        }
+
+        if item.annotations().must_use_type() || ctx.must_use_type_by_name(item)
+        {
+            attrs.push(attributes::must_use());
         }
 
         if !variation.is_const() {

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -2023,7 +2023,7 @@ impl CodeGenerator for CompInfo {
             attributes.push(attributes::derives(&derives))
         }
 
-        if ctx.must_use_type_by_name(item) {
+        if item.annotations().must_use_type() || ctx.must_use_type_by_name(item) {
             attributes.push(attributes::must_use());
         }
 

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -2023,6 +2023,10 @@ impl CodeGenerator for CompInfo {
             attributes.push(attributes::derives(&derives))
         }
 
+        if ctx.must_use_type_by_name(item) {
+            attributes.push(attributes::must_use());
+        }
+
         let mut tokens = if is_union && struct_layout.is_rust_union() {
             quote! {
                 #( #attributes )*

--- a/src/ir/annotations.rs
+++ b/src/ir/annotations.rs
@@ -42,6 +42,8 @@ pub struct Annotations {
     disallow_debug: bool,
     /// Manually disable deriving/implement default on this type.
     disallow_default: bool,
+    /// Whether to add a #[must_use] annotation to this type.
+    must_use_type: bool,
     /// Whether fields should be marked as private or not. You can set this on
     /// structs (it will apply to all the fields), or individual fields.
     private_fields: Option<bool>,
@@ -84,6 +86,7 @@ impl Default for Annotations {
             disallow_copy: false,
             disallow_debug: false,
             disallow_default: false,
+            must_use_type: false,
             private_fields: None,
             accessor_kind: None,
             constify_enum_variant: false,
@@ -163,6 +166,11 @@ impl Annotations {
         self.disallow_default
     }
 
+    /// Should this type get a `#[must_use]` annotation?
+    pub fn must_use_type(&self) -> bool {
+        self.must_use_type
+    }
+
     /// Should the fields be private?
     pub fn private_fields(&self) -> Option<bool> {
         self.private_fields
@@ -190,6 +198,7 @@ impl Annotations {
                     "nocopy" => self.disallow_copy = true,
                     "nodebug" => self.disallow_debug = true,
                     "nodefault" => self.disallow_default = true,
+                    "mustusetype" => self.must_use_type = true,
                     "replaces" => {
                         self.use_instead_of = Some(
                             attr.value.split("::").map(Into::into).collect(),

--- a/src/ir/context.rs
+++ b/src/ir/context.rs
@@ -2663,6 +2663,12 @@ If you encounter an error missing from this list, please file an issue or a PR!"
         let name = item.path_for_allowlisting(self)[1..].join("::");
         self.options().no_hash_types.matches(&name)
     }
+
+    /// Check if `--must-use-type` flag is enabled for this item.
+    pub fn must_use_type_by_name(&self, item: &Item) -> bool {
+        let name = item.path_for_allowlisting(self)[1..].join("::");
+        self.options().must_use_types.matches(&name)
+    }
 }
 
 /// A builder struct for configuring item resolution options.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -317,6 +317,7 @@ impl Builder {
             (&self.options.no_debug_types, "--no-debug"),
             (&self.options.no_default_types, "--no-default"),
             (&self.options.no_hash_types, "--no-hash"),
+            (&self.options.must_use_types, "--must-use-type"),
         ];
 
         for (set, flag) in regex_sets {
@@ -1588,6 +1589,13 @@ impl Builder {
         self
     }
 
+    /// Add `#[must_use]` for the given type. Regular
+    /// expressions are supported.
+    pub fn must_use_type<T: Into<String>>(mut self, arg: T) -> Builder {
+        self.options.must_use_types.insert(arg.into());
+        self
+    }
+
     /// Set whether `arr[size]` should be treated as `*mut T` or `*mut [T; size]` (same for mut)
     pub fn array_pointers_in_arguments(mut self, doit: bool) -> Self {
         self.options.array_pointers_in_arguments = doit;
@@ -1928,6 +1936,9 @@ struct BindgenOptions {
     /// The set of types that we should not derive `Hash` for.
     no_hash_types: RegexSet,
 
+    /// The set of types that we should be annotated with `#[must_use]`.
+    must_use_types: RegexSet,
+
     /// Decide if C arrays should be regular pointers in rust or array pointers
     array_pointers_in_arguments: bool,
 
@@ -1986,6 +1997,7 @@ impl BindgenOptions {
             &mut self.no_debug_types,
             &mut self.no_default_types,
             &mut self.no_hash_types,
+            &mut self.must_use_types,
         ];
         let record_matches = self.record_matches;
         for regex_set in &mut regex_sets {
@@ -2090,6 +2102,7 @@ impl Default for BindgenOptions {
             no_debug_types: Default::default(),
             no_default_types: Default::default(),
             no_hash_types: Default::default(),
+            must_use_types: Default::default(),
             array_pointers_in_arguments: false,
             wasm_import_module_name: None,
             dynamic_library_name: None,

--- a/src/options.rs
+++ b/src/options.rs
@@ -486,6 +486,13 @@ where
                 .takes_value(true)
                 .multiple(true)
                 .number_of_values(1),
+            Arg::with_name("must-use-type")
+                .long("must-use-type")
+                .help("Add #[must_use] annotation to types matching <regex>.")
+                .value_name("regex")
+                .takes_value(true)
+                .multiple(true)
+                .number_of_values(1),
             Arg::with_name("enable-function-attribute-detection")
                 .long("enable-function-attribute-detection")
                 .help(
@@ -940,6 +947,12 @@ where
     if let Some(no_hash) = matches.values_of("no-hash") {
         for regex in no_hash {
             builder = builder.no_hash(regex);
+        }
+    }
+    
+    if let Some(must_use_type) = matches.values_of("must-use-type") {
+        for regex in must_use_type {
+            builder = builder.must_use_type(regex);
         }
     }
 

--- a/src/options.rs
+++ b/src/options.rs
@@ -949,7 +949,7 @@ where
             builder = builder.no_hash(regex);
         }
     }
-    
+
     if let Some(must_use_type) = matches.values_of("must-use-type") {
         for regex in must_use_type {
             builder = builder.must_use_type(regex);

--- a/tests/expectations/tests/issue-710-must-use-type.rs
+++ b/tests/expectations/tests/issue-710-must-use-type.rs
@@ -1,0 +1,18 @@
+#![allow(
+    dead_code,
+    non_snake_case,
+    non_camel_case_types,
+    non_upper_case_globals
+)]
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+#[must_use]
+pub struct MyType {
+    _unused: [u8; 0],
+}
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct OtherType {
+    _unused: [u8; 0],
+}

--- a/tests/expectations/tests/issue-710-must-use-type.rs
+++ b/tests/expectations/tests/issue-710-must-use-type.rs
@@ -8,11 +8,18 @@
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 #[must_use]
-pub struct MyType {
+pub struct A {
+    _unused: [u8; 0],
+}
+/// <div rustbindgen mustusetype></div>
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+#[must_use]
+pub struct B {
     _unused: [u8; 0],
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
-pub struct OtherType {
+pub struct C {
     _unused: [u8; 0],
 }

--- a/tests/headers/issue-710-must-use-type.h
+++ b/tests/headers/issue-710-must-use-type.h
@@ -1,5 +1,8 @@
-// bindgen-flags: --must-use-type MyType
+// bindgen-flags: --must-use-type A
 
-struct MyType;
+struct A;
 
-struct OtherType;
+/** <div rustbindgen mustusetype></div> */
+struct B;
+
+struct C;

--- a/tests/headers/issue-710-must-use-type.h
+++ b/tests/headers/issue-710-must-use-type.h
@@ -1,0 +1,5 @@
+// bindgen-flags: --must-use-type MyType
+
+struct MyType;
+
+struct OtherType;


### PR DESCRIPTION
This PR adds an option to generate `#[must_use]` annotations as described in #710.