### PR TITLE
Detect and avoid cycles when resolving items.

### DIFF
--- a/tests/expectations/tests/qualified-dependent-types.rs
+++ b/tests/expectations/tests/qualified-dependent-types.rs
@@ -1,0 +1,17 @@
+#![allow(
+    dead_code,
+    non_snake_case,
+    non_camel_case_types,
+    non_upper_case_globals
+)]
+
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct Foo {
+    pub _address: u8,
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct Bar {
+    pub _address: u8,
+}

--- a/tests/headers/qualified-dependent-types.hpp
+++ b/tests/headers/qualified-dependent-types.hpp
@@ -1,0 +1,16 @@
+// Issue #2085.
+
+template<typename T>
+struct Foo;
+
+template<typename T, typename U>
+struct Bar {};
+
+template<typename T>
+struct Bar<T, void> {
+    using BarDependent = typename Foo<T>::Dependent;
+    void method(const BarDependent &);
+};
+
+template<typename T>
+void Bar<T, void>::method(const BarDependent &) {}


### PR DESCRIPTION
These can happen in certain cases involving incomplete qualified dependent
types. To avoid looping forever, we need to check for them.

Closes #2085.

r? @emilio 