### PR TITLE
Fix Debug not being derived for Rust enumerations anymore by default

### DIFF
--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -3000,7 +3000,7 @@ impl CodeGenerator for Enum {
 
         if !variation.is_const() {
             let mut derives = derives_of_item(item, ctx);
-            // For backwards compat, enums always derive Clone/Eq/PartialEq/Hash, even
+            // For backwards compat, enums always derive Debug/Clone/Eq/PartialEq/Hash, even
             // if we don't generate those by default.
             derives.insert(
                 DerivableTraits::CLONE |
@@ -3009,6 +3009,9 @@ impl CodeGenerator for Enum {
                     DerivableTraits::PARTIAL_EQ |
                     DerivableTraits::EQ,
             );
+            if variation.is_rust() {
+                derives.insert(DerivableTraits::DEBUG);
+            }
             let derives: Vec<_> = derives.into();
             attrs.push(attributes::derives(&derives));
         }

--- a/tests/expectations/tests/enum-default-rust.rs
+++ b/tests/expectations/tests/enum-default-rust.rs
@@ -63,7 +63,7 @@ pub mod Neg {
 }
 #[repr(u32)]
 /// <div rustbindgen nodebug></div>
-#[derive(Copy, Clone, Hash, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum NoDebug {
     NoDebug1 = 0,
     NoDebug2 = 1,


### PR DESCRIPTION
`bindgen` used to derive `Debug` by default for all rustified enumerations, even if no-derive-debug was specified. This change restores that behaviour.

Fixes #2076