### PR TITLE
Use annotations on enumerations

### DIFF
--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -3000,16 +3000,26 @@ impl CodeGenerator for Enum {
 
         if !variation.is_const() {
             let mut derives = derives_of_item(item, ctx);
-            // For backwards compat, enums always derive Clone/Eq/PartialEq/Hash, even
+            // For backwards compat, enums always derive Debug/Clone/Eq/PartialEq/Hash, even
             // if we don't generate those by default.
+            if !item.annotations().disallow_debug() {
+                derives.insert(DerivableTraits::DEBUG);
+            }
+            if !item.annotations().disallow_copy() {
+                derives.insert(DerivableTraits::COPY);
+            }
             derives.insert(
                 DerivableTraits::CLONE |
-                    DerivableTraits::COPY |
                     DerivableTraits::HASH |
                     DerivableTraits::PARTIAL_EQ |
                     DerivableTraits::EQ,
             );
-            let derives: Vec<_> = derives.into();
+            let mut derives: Vec<_> = derives.into();
+            for derive in item.annotations().derives().iter() {
+                if !derives.contains(&derive.as_str()) {
+                    derives.push(&derive);
+                }
+            }
             attrs.push(attributes::derives(&derives));
         }
 

--- a/tests/expectations/tests/enum-default-bitfield.rs
+++ b/tests/expectations/tests/enum-default-bitfield.rs
@@ -149,3 +149,39 @@ impl ::std::ops::BitAndAssign for NoDebug {
 /// <div rustbindgen nodebug></div>
 #[derive(Copy, Clone, Hash, PartialEq, Eq)]
 pub struct NoDebug(pub ::std::os::raw::c_uint);
+impl Debug {
+    pub const Debug1: Debug = Debug(0);
+}
+impl Debug {
+    pub const Debug2: Debug = Debug(1);
+}
+impl ::std::ops::BitOr<Debug> for Debug {
+    type Output = Self;
+    #[inline]
+    fn bitor(self, other: Self) -> Self {
+        Debug(self.0 | other.0)
+    }
+}
+impl ::std::ops::BitOrAssign for Debug {
+    #[inline]
+    fn bitor_assign(&mut self, rhs: Debug) {
+        self.0 |= rhs.0;
+    }
+}
+impl ::std::ops::BitAnd<Debug> for Debug {
+    type Output = Self;
+    #[inline]
+    fn bitand(self, other: Self) -> Self {
+        Debug(self.0 & other.0)
+    }
+}
+impl ::std::ops::BitAndAssign for Debug {
+    #[inline]
+    fn bitand_assign(&mut self, rhs: Debug) {
+        self.0 &= rhs.0;
+    }
+}
+#[repr(transparent)]
+/// <div rustbindgen derive="Debug"></div>
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub struct Debug(pub ::std::os::raw::c_uint);

--- a/tests/expectations/tests/enum-default-consts.rs
+++ b/tests/expectations/tests/enum-default-consts.rs
@@ -57,3 +57,7 @@ pub const NoDebug_NoDebug1: NoDebug = 0;
 pub const NoDebug_NoDebug2: NoDebug = 1;
 /// <div rustbindgen nodebug></div>
 pub type NoDebug = ::std::os::raw::c_uint;
+pub const Debug_Debug1: Debug = 0;
+pub const Debug_Debug2: Debug = 1;
+/// <div rustbindgen derive="Debug"></div>
+pub type Debug = ::std::os::raw::c_uint;

--- a/tests/expectations/tests/enum-default-module.rs
+++ b/tests/expectations/tests/enum-default-module.rs
@@ -63,3 +63,9 @@ pub mod NoDebug {
     pub const NoDebug1: Type = 0;
     pub const NoDebug2: Type = 1;
 }
+pub mod Debug {
+    /// <div rustbindgen derive="Debug"></div>
+    pub type Type = ::std::os::raw::c_uint;
+    pub const Debug1: Type = 0;
+    pub const Debug2: Type = 1;
+}

--- a/tests/expectations/tests/enum-default-rust.rs
+++ b/tests/expectations/tests/enum-default-rust.rs
@@ -68,3 +68,10 @@ pub enum NoDebug {
     NoDebug1 = 0,
     NoDebug2 = 1,
 }
+#[repr(u32)]
+/// <div rustbindgen derive="Debug"></div>
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum Debug {
+    Debug1 = 0,
+    Debug2 = 1,
+}

--- a/tests/expectations/tests/enum-no-debug-rust.rs
+++ b/tests/expectations/tests/enum-no-debug-rust.rs
@@ -1,0 +1,77 @@
+#![allow(
+    dead_code,
+    non_snake_case,
+    non_camel_case_types,
+    non_upper_case_globals
+)]
+
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct foo {
+    pub member: foo__bindgen_ty_1,
+}
+pub const foo_FOO_A: foo__bindgen_ty_1 = foo__bindgen_ty_1::FOO_A;
+pub const foo_FOO_B: foo__bindgen_ty_1 = foo__bindgen_ty_1::FOO_B;
+#[repr(u32)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum foo__bindgen_ty_1 {
+    FOO_A = 0,
+    FOO_B = 1,
+}
+#[test]
+fn bindgen_test_layout_foo() {
+    assert_eq!(
+        ::std::mem::size_of::<foo>(),
+        4usize,
+        concat!("Size of: ", stringify!(foo))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<foo>(),
+        4usize,
+        concat!("Alignment of ", stringify!(foo))
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<foo>())).member as *const _ as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(foo),
+            "::",
+            stringify!(member)
+        )
+    );
+}
+impl Default for foo {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+#[repr(u32)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum Foo {
+    Bar = 0,
+    Qux = 1,
+}
+pub mod Neg {
+    pub type Type = ::std::os::raw::c_int;
+    pub const MinusOne: Type = -1;
+    pub const One: Type = 1;
+}
+#[repr(u32)]
+/// <div rustbindgen nodebug></div>
+#[derive(Copy, Clone, Hash, PartialEq, Eq)]
+pub enum NoDebug {
+    NoDebug1 = 0,
+    NoDebug2 = 1,
+}
+#[repr(u32)]
+/// <div rustbindgen derive="Debug"></div>
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum Debug {
+    Debug1 = 0,
+    Debug2 = 1,
+}

--- a/tests/expectations/tests/enum.rs
+++ b/tests/expectations/tests/enum.rs
@@ -55,3 +55,7 @@ pub const NoDebug_NoDebug1: NoDebug = 0;
 pub const NoDebug_NoDebug2: NoDebug = 1;
 /// <div rustbindgen nodebug></div>
 pub type NoDebug = ::std::os::raw::c_uint;
+pub const Debug_Debug1: Debug = 0;
+pub const Debug_Debug2: Debug = 1;
+/// <div rustbindgen derive="Debug"></div>
+pub type Debug = ::std::os::raw::c_uint;

--- a/tests/headers/enum-no-debug-rust.h
+++ b/tests/headers/enum-no-debug-rust.h
@@ -1,0 +1,3 @@
+// bindgen-flags: --no-derive-debug --default-enum-style=rust --constified-enum-module=Neg
+
+#include "enum.h"

--- a/tests/headers/enum.h
+++ b/tests/headers/enum.h
@@ -23,3 +23,9 @@ enum NoDebug {
     NoDebug1,
     NoDebug2,
 };
+
+/** <div rustbindgen derive="Debug"></div> */
+enum Debug {
+    Debug1,
+    Debug2,
+};


### PR DESCRIPTION
This enables users to add additional derives, or prevent deriving traits.

Fixes #2076