### PR TITLE
Add --blocklist-file option

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -247,8 +247,8 @@ See [./csmith-fuzzing/README.md](./csmith-fuzzing/README.md) for details.
 
 The `tests/quickchecking` crate generates property tests for `bindgen`.
 From the crate's directory you can run the tests with `cargo run`. For details
-on additional configuration including how to preserve / inspect the generated 
-property tests, see 
+on additional configuration including how to preserve / inspect the generated
+property tests, see
 [./tests/quickchecking/README.md](./tests/quickchecking/README.md).
 
 ## Code Overview
@@ -298,6 +298,8 @@ looking at. Here is a summary of the IR types and their relationships:
             * Its type's `ItemId`
             * Optionally, a mangled name
             * Optionally, a value
+    * An optional `clang::SourceLocation` that holds the first source code
+      location where the `Item` was encountered.
 
 The IR forms a graph of interconnected and inter-referencing types and
 functions. The `ir::traversal` module provides IR graph traversal

--- a/book/src/blocklisting.md
+++ b/book/src/blocklisting.md
@@ -2,8 +2,7 @@
 
 If you need to provide your own custom translation of some type (for example,
 because you need to wrap one of its fields in an `UnsafeCell`), you can
-explicitly blocklist
- generation of its definition. Uses of the blocklisted type
+explicitly blocklist generation of its definition. Uses of the blocklisted type
 will still appear in other types' definitions. (If you don't want the type to
 appear in the bindings at
 all, [make it opaque](./opaque.md) instead of
@@ -13,13 +12,24 @@ Blocklisted types are pessimistically assumed not to be able to `derive` any
 traits, which can transitively affect other types' ability to `derive` traits or
 not.
 
+The `blocklist-file` option also allows the blocklisting of all items from a
+particular path regex, for example to block all types defined in system headers
+that are transitively included.
+
 ### Library
 
+* [`bindgen::Builder::blocklist_file`](https://docs.rs/bindgen/latest/bindgen/struct.Builder.html#method.blocklist_file)
+* [`bindgen::Builder::blocklist_function`](https://docs.rs/bindgen/latest/bindgen/struct.Builder.html#method.blocklist_function)
+* [`bindgen::Builder::blocklist_item`](https://docs.rs/bindgen/latest/bindgen/struct.Builder.html#method.blocklist_item)
 * [`bindgen::Builder::blocklist_type`](https://docs.rs/bindgen/latest/bindgen/struct.Builder.html#method.blocklist_type)
 
 ### Command Line
 
+* `--blocklist-file <path>`
+* `--blocklist-function <function>`
+* `--blocklist-item <item>`
 * `--blocklist-type <type>`
+
 
 ### Annotations
 

--- a/src/clang.rs
+++ b/src/clang.rs
@@ -1401,6 +1401,12 @@ impl fmt::Display for SourceLocation {
     }
 }
 
+impl fmt::Debug for SourceLocation {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self)
+    }
+}
+
 /// A comment in the source text.
 ///
 /// Comments are sort of parsed by Clang, and have a tree structure.

--- a/src/ir/item.rs
+++ b/src/ir/item.rs
@@ -641,11 +641,13 @@ impl Item {
             return true;
         }
 
-        if let Some(location) = &self.location {
-            let (file, _, _, _) = location.location();
-            if let Some(filename) = file.name() {
-                if ctx.options().blocklisted_files.matches(&filename) {
-                    return true;
+        if !ctx.options().blocklisted_files.is_empty() {
+            if let Some(location) = &self.location {
+                let (file, _, _, _) = location.location();
+                if let Some(filename) = file.name() {
+                    if ctx.options().blocklisted_files.matches(&filename) {
+                        return true;
+                    }
                 }
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -308,6 +308,7 @@ impl Builder {
             (&self.options.blocklisted_types, "--blocklist-type"),
             (&self.options.blocklisted_functions, "--blocklist-function"),
             (&self.options.blocklisted_items, "--blocklist-item"),
+            (&self.options.blocklisted_files, "--blocklist-file"),
             (&self.options.opaque_types, "--opaque-type"),
             (&self.options.allowlisted_functions, "--allowlist-function"),
             (&self.options.allowlisted_types, "--allowlist-type"),
@@ -818,6 +819,13 @@ impl Builder {
     /// [regex](https://docs.rs/regex/*/regex/) docs
     pub fn blocklist_item<T: AsRef<str>>(mut self, arg: T) -> Builder {
         self.options.blocklisted_items.insert(arg);
+        self
+    }
+
+    /// Hide any contents of the given file from the generated bindings,
+    /// regardless of whether it's a type, function, module etc.
+    pub fn blocklist_file<T: AsRef<str>>(mut self, arg: T) -> Builder {
+        self.options.blocklisted_files.insert(arg);
         self
     }
 
@@ -1669,6 +1677,10 @@ struct BindgenOptions {
     /// blocklisted and should not appear in the generated code.
     blocklisted_items: RegexSet,
 
+    /// The set of files whose contents should be blocklisted and should not
+    /// appear in the generated code.
+    blocklisted_files: RegexSet,
+
     /// The set of types that should be treated as opaque structures in the
     /// generated code.
     opaque_types: RegexSet,
@@ -1982,6 +1994,7 @@ impl BindgenOptions {
             &mut self.blocklisted_types,
             &mut self.blocklisted_functions,
             &mut self.blocklisted_items,
+            &mut self.blocklisted_files,
             &mut self.opaque_types,
             &mut self.bitfield_enums,
             &mut self.constified_enums,
@@ -2029,6 +2042,7 @@ impl Default for BindgenOptions {
             blocklisted_types: Default::default(),
             blocklisted_functions: Default::default(),
             blocklisted_items: Default::default(),
+            blocklisted_files: Default::default(),
             opaque_types: Default::default(),
             rustfmt_path: Default::default(),
             depfile: Default::default(),

--- a/src/options.rs
+++ b/src/options.rs
@@ -164,6 +164,14 @@ where
                 .takes_value(true)
                 .multiple(true)
                 .number_of_values(1),
+            Arg::with_name("blocklist-file")
+                .alias("blacklist-file")
+                .long("blocklist-file")
+                .help("Mark all contents of <path> as hidden.")
+                .value_name("path")
+                .takes_value(true)
+                .multiple(true)
+                .number_of_values(1),
             Arg::with_name("no-layout-tests")
                 .long("no-layout-tests")
                 .help("Avoid generating layout tests for any type."),
@@ -627,6 +635,12 @@ where
     if let Some(hidden_identifiers) = matches.values_of("blocklist-item") {
         for id in hidden_identifiers {
             builder = builder.blocklist_item(id);
+        }
+    }
+
+    if let Some(hidden_files) = matches.values_of("blocklist-file") {
+        for file in hidden_files {
+            builder = builder.blocklist_file(file);
         }
     }
 

--- a/tests/expectations/tests/blocklist-file.rs
+++ b/tests/expectations/tests/blocklist-file.rs
@@ -61,3 +61,34 @@ fn bindgen_test_layout_SizedIntegers() {
         )
     );
 }
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct StructWithBlocklistedFwdDecl {
+    pub b: u8,
+}
+#[test]
+fn bindgen_test_layout_StructWithBlocklistedFwdDecl() {
+    assert_eq!(
+        ::std::mem::size_of::<StructWithBlocklistedFwdDecl>(),
+        1usize,
+        concat!("Size of: ", stringify!(StructWithBlocklistedFwdDecl))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<StructWithBlocklistedFwdDecl>(),
+        1usize,
+        concat!("Alignment of ", stringify!(StructWithBlocklistedFwdDecl))
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<StructWithBlocklistedFwdDecl>())).b
+                as *const _ as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(StructWithBlocklistedFwdDecl),
+            "::",
+            stringify!(b)
+        )
+    );
+}

--- a/tests/expectations/tests/blocklist-file.rs
+++ b/tests/expectations/tests/blocklist-file.rs
@@ -1,0 +1,63 @@
+#![allow(
+    dead_code,
+    non_snake_case,
+    non_camel_case_types,
+    non_upper_case_globals
+)]
+
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct SizedIntegers {
+    pub x: u8,
+    pub y: u16,
+    pub z: u32,
+}
+#[test]
+fn bindgen_test_layout_SizedIntegers() {
+    assert_eq!(
+        ::std::mem::size_of::<SizedIntegers>(),
+        8usize,
+        concat!("Size of: ", stringify!(SizedIntegers))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<SizedIntegers>(),
+        4usize,
+        concat!("Alignment of ", stringify!(SizedIntegers))
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<SizedIntegers>())).x as *const _ as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(SizedIntegers),
+            "::",
+            stringify!(x)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<SizedIntegers>())).y as *const _ as usize
+        },
+        2usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(SizedIntegers),
+            "::",
+            stringify!(y)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            &(*(::std::ptr::null::<SizedIntegers>())).z as *const _ as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(SizedIntegers),
+            "::",
+            stringify!(z)
+        )
+    );
+}

--- a/tests/headers/blocklist-file.hpp
+++ b/tests/headers/blocklist-file.hpp
@@ -1,5 +1,8 @@
 // bindgen-flags: --blocklist-file ".*/blocklisted/file.*" -- -Itests/headers
 
+// Forward declaration of struct that's defined in a blocklisted file.
+struct StructWithBlocklistedDefinition;
+
 #include "blocklisted/file.hpp"
 #include "blocklisted/fake-stdint.h"
 
@@ -7,4 +10,9 @@ struct SizedIntegers {
     uint8_t x;
     uint16_t y;
     uint32_t z;
+};
+
+// Actual definition of struct that has a forward declaration in a blocklisted file.
+struct StructWithBlocklistedFwdDecl {
+    uint8_t b;
 };

--- a/tests/headers/blocklist-file.hpp
+++ b/tests/headers/blocklist-file.hpp
@@ -1,0 +1,10 @@
+// bindgen-flags: --blocklist-file ".*/blocklisted/file.*" -- -Itests/headers
+
+#include "blocklisted/file.hpp"
+#include "blocklisted/fake-stdint.h"
+
+struct SizedIntegers {
+    uint8_t x;
+    uint16_t y;
+    uint32_t z;
+};

--- a/tests/headers/blocklisted/fake-stdint.h
+++ b/tests/headers/blocklisted/fake-stdint.h
@@ -1,0 +1,7 @@
+// <stdint.h>-like types get special treatment even when blocklisted.
+typedef signed char      int8_t;
+typedef unsigned char    uint8_t;
+typedef signed short     int16_t;
+typedef unsigned short   uint16_t;
+typedef signed int       int32_t;
+typedef unsigned int     uint32_t;

--- a/tests/headers/blocklisted/file.hpp
+++ b/tests/headers/blocklisted/file.hpp
@@ -1,0 +1,19 @@
+void SomeFunction();
+extern int someVar;
+#define SOME_DEFUN 123
+
+class someClass {
+  void somePrivateMethod();
+public:
+  void somePublicMethod(int foo);
+};
+
+extern "C" void ExternFunction();
+
+namespace foo {
+  void NamespacedFunction();
+}
+
+namespace bar {
+  void NamespacedFunction();
+}

--- a/tests/headers/blocklisted/file.hpp
+++ b/tests/headers/blocklisted/file.hpp
@@ -17,3 +17,10 @@ namespace foo {
 namespace bar {
   void NamespacedFunction();
 }
+
+
+struct StructWithBlocklistedFwdDecl;
+
+struct StructWithBlocklistedDefinition {
+    StructWithBlocklistedFwdDecl* other;
+};


### PR DESCRIPTION
Update Item to hold a `clang::SourceLocation` and use this to allow
blocklisting based on filename.

The existing code has a special case that always maps <stdint.h> integer
types to corresponding Rust integer types, even if the C types are
blocklisted.  To match this special case behaviour, also treat these
C <stdint.h> types as being eligible for derived Copy/Clone/Debug
traits.

Fixes #2096