### PR TITLE
Drop 'static for pub const strings

### DIFF
--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -665,10 +665,21 @@ impl CodeGenerator for Var {
                     match String::from_utf8(bytes.clone()) {
                         Ok(string) => {
                             let cstr = helpers::ast_ty::cstr_expr(string);
-                            result.push(quote! {
-                                #(#attrs)*
-                                pub const #canonical_ident : &'static #ty = #cstr ;
-                            });
+                            if ctx
+                                .options()
+                                .rust_features
+                                .static_lifetime_elision
+                            {
+                                result.push(quote! {
+                                    #(#attrs)*
+                                    pub const #canonical_ident : &#ty = #cstr ;
+                                });
+                            } else {
+                                result.push(quote! {
+                                    #(#attrs)*
+                                    pub const #canonical_ident : &'static #ty = #cstr ;
+                                });
+                            }
                         }
                         Err(..) => {
                             let bytes = helpers::ast_ty::byte_array_expr(bytes);

--- a/src/features.rs
+++ b/src/features.rs
@@ -87,8 +87,9 @@ macro_rules! rust_target_base {
         $x_macro!(
             /// Rust stable 1.0
             => Stable_1_0 => 1.0;
-            /// Rust stable 1.1
-            => Stable_1_1 => 1.1;
+            /// Rust stable 1.17
+            ///  * Static lifetime elision ([RFC 1623](https://github.com/rust-lang/rfcs/blob/master/text/1623-static.md))
+            => Stable_1_17 => 1.17;
             /// Rust stable 1.19
             ///  * Untagged unions ([RFC 1444](https://github.com/rust-lang/rfcs/blob/master/text/1444-union.md))
             => Stable_1_19 => 1.19;
@@ -191,6 +192,9 @@ macro_rules! rust_feature_def {
 // documentation for the relevant variant in the rust_target_base macro
 // definition.
 rust_feature_def!(
+    Stable_1_17 {
+        => static_lifetime_elision;
+    }
     Stable_1_19 {
         => untagged_union;
     }
@@ -249,7 +253,8 @@ mod test {
     fn target_features() {
         let f_1_0 = RustFeatures::from(RustTarget::Stable_1_0);
         assert!(
-            !f_1_0.core_ffi_c_void &&
+            !f_1_0.static_lifetime_elision &&
+                !f_1_0.core_ffi_c_void &&
                 !f_1_0.untagged_union &&
                 !f_1_0.associated_const &&
                 !f_1_0.builtin_clone_impls &&
@@ -258,7 +263,8 @@ mod test {
         );
         let f_1_21 = RustFeatures::from(RustTarget::Stable_1_21);
         assert!(
-            !f_1_21.core_ffi_c_void &&
+            f_1_21.static_lifetime_elision &&
+                !f_1_21.core_ffi_c_void &&
                 f_1_21.untagged_union &&
                 f_1_21.associated_const &&
                 f_1_21.builtin_clone_impls &&
@@ -267,7 +273,8 @@ mod test {
         );
         let f_nightly = RustFeatures::from(RustTarget::Nightly);
         assert!(
-            f_nightly.core_ffi_c_void &&
+            f_nightly.static_lifetime_elision &&
+                f_nightly.core_ffi_c_void &&
                 f_nightly.untagged_union &&
                 f_nightly.associated_const &&
                 f_nightly.builtin_clone_impls &&
@@ -286,6 +293,7 @@ mod test {
     #[test]
     fn str_to_target() {
         test_target("1.0", RustTarget::Stable_1_0);
+        test_target("1.17", RustTarget::Stable_1_17);
         test_target("1.19", RustTarget::Stable_1_19);
         test_target("1.21", RustTarget::Stable_1_21);
         test_target("1.25", RustTarget::Stable_1_25);

--- a/tests/expectations/tests/libclang-3.9/constant-evaluate.rs
+++ b/tests/expectations/tests/libclang-3.9/constant-evaluate.rs
@@ -23,5 +23,5 @@ pub const BAZ: ::std::os::raw::c_longlong = 24;
 pub const fuzz: f64 = 51.0;
 pub const BAZZ: ::std::os::raw::c_char = 53;
 pub const WAT: ::std::os::raw::c_char = 0;
-pub const bytestring: &'static [u8; 4usize] = b"Foo\0";
+pub const bytestring: &[u8; 4usize] = b"Foo\0";
 pub const NOT_UTF8: [u8; 5usize] = [240u8, 40u8, 140u8, 40u8, 0u8];

--- a/tests/expectations/tests/libclang-4/constant-evaluate.rs
+++ b/tests/expectations/tests/libclang-4/constant-evaluate.rs
@@ -21,5 +21,5 @@ pub const BAZ: ::std::os::raw::c_longlong = 24;
 pub const fuzz: f64 = 51.0;
 pub const BAZZ: ::std::os::raw::c_char = 53;
 pub const WAT: ::std::os::raw::c_char = 0;
-pub const bytestring: &'static [u8; 4usize] = b"Foo\0";
+pub const bytestring: &[u8; 4usize] = b"Foo\0";
 pub const NOT_UTF8: [u8; 5usize] = [240u8, 40u8, 140u8, 40u8, 0u8];

--- a/tests/expectations/tests/libclang-5/constant-evaluate.rs
+++ b/tests/expectations/tests/libclang-5/constant-evaluate.rs
@@ -21,5 +21,5 @@ pub const BAZ: ::std::os::raw::c_longlong = 24;
 pub const fuzz: f64 = 51.0;
 pub const BAZZ: ::std::os::raw::c_char = 53;
 pub const WAT: ::std::os::raw::c_char = 0;
-pub const bytestring: &'static [u8; 4usize] = b"Foo\0";
+pub const bytestring: &[u8; 4usize] = b"Foo\0";
 pub const NOT_UTF8: [u8; 5usize] = [240u8, 40u8, 140u8, 40u8, 0u8];

--- a/tests/expectations/tests/libclang-9/constant-evaluate.rs
+++ b/tests/expectations/tests/libclang-9/constant-evaluate.rs
@@ -21,5 +21,5 @@ pub const BAZ: ::std::os::raw::c_longlong = 24;
 pub const fuzz: f64 = 51.0;
 pub const BAZZ: ::std::os::raw::c_char = 53;
 pub const WAT: ::std::os::raw::c_char = 0;
-pub const bytestring: &'static [u8; 4usize] = b"Foo\0";
+pub const bytestring: &[u8; 4usize] = b"Foo\0";
 pub const NOT_UTF8: [u8; 5usize] = [240u8, 40u8, 140u8, 40u8, 0u8];

--- a/tests/expectations/tests/macro_const_1_0.rs
+++ b/tests/expectations/tests/macro_const_1_0.rs
@@ -5,7 +5,7 @@
     non_upper_case_globals
 )]
 
-pub const foo: &[u8; 4usize] = b"bar\0";
+pub const foo: &'static [u8; 4usize] = b"bar\0";
 pub const CHAR: u8 = 98u8;
 pub const CHARR: u8 = 0u8;
 pub const FLOAT: f64 = 5.09;

--- a/tests/headers/macro_const_1_0.h
+++ b/tests/headers/macro_const_1_0.h
@@ -1,0 +1,10 @@
+// bindgen-flags: --rust-target 1.0
+
+#define foo "bar"
+#define CHAR 'b'
+#define CHARR '\0'
+#define FLOAT 5.09f
+#define FLOAT_EXPR (5 / 1000.0f)
+#define LONG 3L
+
+#define INVALID_UTF8 "\xf0\x28\x8c\x28"


### PR DESCRIPTION
Constant and static declaration have a 'static live time by default,
that is already elided since 1.17.

Clippy complains on this kind of strings that are present in the
generated code.

This patch remove the 'static live time for those strings.

Fix #1612

Signed-off-by: Alberto Planas <aplanas@suse.com>