### PR TITLE
context: Escape the try keyword properly

### DIFF
--- a/src/ir/context.rs
+++ b/src/ir/context.rs
@@ -845,7 +845,7 @@ If you encounter an error missing from this list, please file an issue or a PR!"
                     "macro" | "match" | "mod" | "move" | "mut" | "offsetof" |
                     "override" | "priv" | "proc" | "pub" | "pure" | "ref" |
                     "return" | "Self" | "self" | "sizeof" | "static" |
-                    "struct" | "super" | "trait" | "true" | "type" | "typeof" |
+                    "struct" | "super" | "trait" | "true" | "try" | "type" | "typeof" |
                     "unsafe" | "unsized" | "use" | "virtual" | "where" |
                     "while" | "yield" | "str" | "bool" | "f32" | "f64" |
                     "usize" | "isize" | "u128" | "i128" | "u64" | "i64" |

--- a/tests/expectations/tests/keywords.rs
+++ b/tests/expectations/tests/keywords.rs
@@ -146,6 +146,10 @@ extern "C" {
     pub static mut true_: ::std::os::raw::c_int;
 }
 extern "C" {
+    #[link_name = "\u{1}try"]
+    pub static mut try_: ::std::os::raw::c_int;
+}
+extern "C" {
     #[link_name = "\u{1}type"]
     pub static mut type_: ::std::os::raw::c_int;
 }

--- a/tests/headers/keywords.h
+++ b/tests/headers/keywords.h
@@ -34,6 +34,7 @@ int Self;
 int super;
 int trait;
 int true;
+int try;
 int type;
 int unsafe;
 int use;


### PR DESCRIPTION
When trying to compile redbpf, there are errors because the code contains the try keyword