### PR TITLE
Added support for dynamic loading of variables

### DIFF
--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -737,7 +737,15 @@ impl CodeGenerator for Var {
                 }
             );
 
-            result.push(tokens);
+            if ctx.options().dynamic_library_name.is_some() {
+                result.dynamic_items().push_var(
+                    canonical_ident,
+                    self.ty().to_rust_ty_or_opaque(ctx, &()),
+                    ctx.options().dynamic_link_require_all,
+                );
+            } else {
+                result.push(tokens);
+            }
         }
     }
 }
@@ -4144,7 +4152,7 @@ impl CodeGenerator for Function {
                 TypeKind::Void => quote! {()},
                 _ => return_item.to_rust_ty_or_opaque(ctx, &()),
             };
-            result.dynamic_items().push(
+            result.dynamic_items().push_func(
                 ident,
                 abi,
                 signature.is_variadic(),

--- a/tests/expectations/tests/dynamic_loading_variable_required.rs
+++ b/tests/expectations/tests/dynamic_loading_variable_required.rs
@@ -1,0 +1,47 @@
+#![allow(
+    dead_code,
+    non_snake_case,
+    non_camel_case_types,
+    non_upper_case_globals
+)]
+
+extern crate libloading;
+pub struct TestLib {
+    __library: ::libloading::Library,
+    pub foo: *mut ::std::os::raw::c_int,
+    pub baz: *mut *mut ::std::os::raw::c_int,
+}
+impl TestLib {
+    pub unsafe fn new<P>(path: P) -> Result<Self, ::libloading::Error>
+        where
+            P: AsRef<::std::ffi::OsStr>,
+    {
+        let library = ::libloading::Library::new(path)?;
+        Self::from_library(library)
+    }
+    pub unsafe fn from_library<L>(
+        library: L,
+    ) -> Result<Self, ::libloading::Error>
+        where
+            L: Into<::libloading::Library>,
+    {
+        let __library = library.into();
+        let foo = __library
+            .get::<*mut ::std::os::raw::c_int>(b"foo\0")
+            .map(|sym| *sym)?;
+        let baz = __library
+            .get::<*mut *mut ::std::os::raw::c_int>(b"baz\0")
+            .map(|sym| *sym)?;
+        Ok(TestLib {
+            __library,
+            foo,
+            baz,
+        })
+    }
+    pub unsafe fn get_var_foo(&self) -> *mut ::std::os::raw::c_int {
+        self.foo
+    }
+    pub unsafe fn get_var_baz(&self) -> *mut *mut ::std::os::raw::c_int {
+        self.baz
+    }
+}

--- a/tests/expectations/tests/dynamic_loading_variable_simple.rs
+++ b/tests/expectations/tests/dynamic_loading_variable_simple.rs
@@ -1,0 +1,47 @@
+#![allow(
+    dead_code,
+    non_snake_case,
+    non_camel_case_types,
+    non_upper_case_globals
+)]
+
+extern crate libloading;
+pub struct TestLib {
+    __library: ::libloading::Library,
+    pub foo: Result<*mut ::std::os::raw::c_int, ::libloading::Error>,
+    pub baz: Result<*mut *mut ::std::os::raw::c_int, ::libloading::Error>,
+}
+impl TestLib {
+    pub unsafe fn new<P>(path: P) -> Result<Self, ::libloading::Error>
+        where
+            P: AsRef<::std::ffi::OsStr>,
+    {
+        let library = ::libloading::Library::new(path)?;
+        Self::from_library(library)
+    }
+    pub unsafe fn from_library<L>(
+        library: L,
+    ) -> Result<Self, ::libloading::Error>
+        where
+            L: Into<::libloading::Library>,
+    {
+        let __library = library.into();
+        let foo = __library
+            .get::<*mut ::std::os::raw::c_int>(b"foo\0")
+            .map(|sym| *sym);
+        let baz = __library
+            .get::<*mut *mut ::std::os::raw::c_int>(b"baz\0")
+            .map(|sym| *sym);
+        Ok(TestLib {
+            __library,
+            foo,
+            baz,
+        })
+    }
+    pub unsafe fn get_var_foo(&self) -> *mut ::std::os::raw::c_int {
+        *self.foo.as_ref().expect("Expected variable, got error.")
+    }
+    pub unsafe fn get_var_baz(&self) -> *mut *mut ::std::os::raw::c_int {
+        *self.baz.as_ref().expect("Expected variable, got error.")
+    }
+}

--- a/tests/expectations/tests/dynamic_loading_variable_with_allowlist.rs
+++ b/tests/expectations/tests/dynamic_loading_variable_with_allowlist.rs
@@ -1,0 +1,47 @@
+#![allow(
+    dead_code,
+    non_snake_case,
+    non_camel_case_types,
+    non_upper_case_globals
+)]
+
+extern crate libloading;
+pub struct TestLib {
+    __library: ::libloading::Library,
+    pub foo: Result<*mut ::std::os::raw::c_int, ::libloading::Error>,
+    pub bar: Result<*mut ::std::os::raw::c_int, ::libloading::Error>,
+}
+impl TestLib {
+    pub unsafe fn new<P>(path: P) -> Result<Self, ::libloading::Error>
+        where
+            P: AsRef<::std::ffi::OsStr>,
+    {
+        let library = ::libloading::Library::new(path)?;
+        Self::from_library(library)
+    }
+    pub unsafe fn from_library<L>(
+        library: L,
+    ) -> Result<Self, ::libloading::Error>
+        where
+            L: Into<::libloading::Library>,
+    {
+        let __library = library.into();
+        let foo = __library
+            .get::<*mut ::std::os::raw::c_int>(b"foo\0")
+            .map(|sym| *sym);
+        let bar = __library
+            .get::<*mut ::std::os::raw::c_int>(b"bar\0")
+            .map(|sym| *sym);
+        Ok(TestLib {
+            __library,
+            foo,
+            bar,
+        })
+    }
+    pub unsafe fn get_var_foo(&self) -> *mut ::std::os::raw::c_int {
+        *self.foo.as_ref().expect("Expected variable, got error.")
+    }
+    pub unsafe fn get_var_bar(&self) -> *mut ::std::os::raw::c_int {
+        *self.bar.as_ref().expect("Expected variable, got error.")
+    }
+}

--- a/tests/headers/dynamic_loading_variable_required.h
+++ b/tests/headers/dynamic_loading_variable_required.h
@@ -1,0 +1,4 @@
+// bindgen-flags: --dynamic-loading TestLib --dynamic-link-require-all
+
+int foo;
+int *baz;

--- a/tests/headers/dynamic_loading_variable_simple.h
+++ b/tests/headers/dynamic_loading_variable_simple.h
@@ -1,0 +1,4 @@
+// bindgen-flags: --dynamic-loading TestLib
+
+int foo;
+int *baz;

--- a/tests/headers/dynamic_loading_variable_with_allowlist.hpp
+++ b/tests/headers/dynamic_loading_variable_with_allowlist.hpp
@@ -1,0 +1,5 @@
+// bindgen-flags: --dynamic-loading TestLib --allowlist-var foo --allowlist-var bar
+
+int foo;
+int bar;
+int baz; // should not be allowed


### PR DESCRIPTION
This expands support for dynamic loading to support dynamically loaded variables.

This PR addresses my own grievance - issue #2113. It plays nicely with  `--dynamic-link-require-all`. I tried to mirror the approach used to support dynamically loaded functions.

It's my first contribution to this project, all feedback welcome.

