### PR TITLE
Allow modifying macro tokens at parse time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ csmith-fuzzing/platform.info
 
 # Backups of test cases from C-Reduce
 **/*.orig
+
+.*sw?

--- a/.gitignore
+++ b/.gitignore
@@ -17,5 +17,3 @@ csmith-fuzzing/platform.info
 
 # Backups of test cases from C-Reduce
 **/*.orig
-
-.*sw?

--- a/src/callbacks.rs
+++ b/src/callbacks.rs
@@ -4,6 +4,7 @@ pub use crate::ir::analysis::DeriveTrait;
 pub use crate::ir::derive::CanDerive as ImplementsTrait;
 pub use crate::ir::enum_ty::{EnumVariantCustomBehavior, EnumVariantValue};
 pub use crate::ir::int::IntKind;
+use cexpr::token::Token;
 use std::fmt;
 use std::panic::UnwindSafe;
 
@@ -29,6 +30,10 @@ pub trait ParseCallbacks: fmt::Debug + UnwindSafe {
     /// This function will be run on every macro that is identified.
     fn will_parse_macro(&self, _name: &str) -> MacroParsingBehavior {
         MacroParsingBehavior::Default
+    }
+
+    /// This function allows changing the tokens in a macro defintion
+    fn modify_macro(&self, _name: &str, _tokens: &mut [Token]) {
     }
 
     /// The integer kind an integer macro should have, given a name and the

--- a/src/callbacks.rs
+++ b/src/callbacks.rs
@@ -4,8 +4,8 @@ pub use crate::ir::analysis::DeriveTrait;
 pub use crate::ir::derive::CanDerive as ImplementsTrait;
 pub use crate::ir::enum_ty::{EnumVariantCustomBehavior, EnumVariantValue};
 pub use crate::ir::int::IntKind;
-pub use cexpr::token::Token;
 pub use cexpr::token::Kind as TokenKind;
+pub use cexpr::token::Token;
 use std::fmt;
 use std::panic::UnwindSafe;
 
@@ -34,8 +34,7 @@ pub trait ParseCallbacks: fmt::Debug + UnwindSafe {
     }
 
     /// This function allows changing the tokens in a macro defintion
-    fn modify_macro(&self, _name: &str, _tokens: &mut Vec<Token>) {
-    }
+    fn modify_macro(&self, _name: &str, _tokens: &mut Vec<Token>) {}
 
     /// The integer kind an integer macro should have, given a name and the
     /// value of that macro, or `None` if you want the default to be chosen.

--- a/src/callbacks.rs
+++ b/src/callbacks.rs
@@ -5,6 +5,7 @@ pub use crate::ir::derive::CanDerive as ImplementsTrait;
 pub use crate::ir::enum_ty::{EnumVariantCustomBehavior, EnumVariantValue};
 pub use crate::ir::int::IntKind;
 pub use cexpr::token::Token;
+pub use cexpr::token::Kind as TokenKind;
 use std::fmt;
 use std::panic::UnwindSafe;
 

--- a/src/callbacks.rs
+++ b/src/callbacks.rs
@@ -34,7 +34,7 @@ pub trait ParseCallbacks: fmt::Debug + UnwindSafe {
     }
 
     /// This function allows changing the tokens in a macro defintion
-    fn modify_macro(&self, _name: &str, _tokens: &mut [Token]) {
+    fn modify_macro(&self, _name: &str, _tokens: &mut Vec<Token>) {
     }
 
     /// The integer kind an integer macro should have, given a name and the

--- a/src/callbacks.rs
+++ b/src/callbacks.rs
@@ -4,7 +4,7 @@ pub use crate::ir::analysis::DeriveTrait;
 pub use crate::ir::derive::CanDerive as ImplementsTrait;
 pub use crate::ir::enum_ty::{EnumVariantCustomBehavior, EnumVariantValue};
 pub use crate::ir::int::IntKind;
-use cexpr::token::Token;
+pub use cexpr::token::Token;
 use std::fmt;
 use std::panic::UnwindSafe;
 

--- a/src/ir/var.rs
+++ b/src/ir/var.rs
@@ -220,7 +220,7 @@ impl ClangSubItemParser for Var {
                     handle_function_macro(&cursor, &tokens, callbacks)?;
                 }
 
-                let value = parse_macro(ctx, &tokens);
+                let value = parse_macro(ctx, &cursor.spelling(), &tokens);
 
                 let (id, value) = match value {
                     Some(v) => v,
@@ -387,6 +387,7 @@ impl ClangSubItemParser for Var {
 /// Try and parse a macro using all the macros parsed until now.
 fn parse_macro(
     ctx: &BindgenContext,
+    name: &str,
     tokens: &[ClangToken],
 ) -> Option<(Vec<u8>, cexpr::expr::EvalResult)> {
     use cexpr::expr;
@@ -395,6 +396,10 @@ fn parse_macro(
         .iter()
         .filter_map(ClangToken::as_cexpr_token)
         .collect();
+
+    if let Some(callbacks) = ctx.parse_callbacks() {
+        callbacks.modify_macro(name, &mut cexpr_tokens);
+    }
 
     let parser = expr::IdentifierParser::new(ctx.parsed_macros());
 


### PR DESCRIPTION
This pull requests adds a callback to ParseCallbacks that enables users to mangle the tokens on a macro definition. The goal is to allow custom "sanitization" of macros to enable generation of rust code.

In my use case, I have a few header files that define (a few hundred) macros such as:

```
#define FLAG_BITS            8:10
#define FLAG_FOO            0x1
#define FLAG_BAR            0x2
#define FLAG_FOOBAR    0x4
```

Currently, bindgen, rightly, ignores `FLAG_BITS` since the meaning of that definition is application specific. In my case, the side effect is that I lose the information about how much to shift bits around.

This pull request allows programmers to define a `modify_macro` callback that enables inspecting the Tokens of a given macro definition and sanitize it for bindgen to be able to generate rust code for it.

In my use case, the callback translates the three tokens `8` `:` `10` into `(8 << 16) | 10`. A value I can use in my rust code to determine the location of the bits.