### PR TITLE
Fix warnings on tests

### DIFF
--- a/.github/workflows/bindgen.yml
+++ b/.github/workflows/bindgen.yml
@@ -35,6 +35,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: clippy
+          args: -- --cfg test
 
   msrv:
     runs-on: ubuntu-latest

--- a/src/ir/analysis/mod.rs
+++ b/src/ir/analysis/mod.rs
@@ -281,9 +281,13 @@ mod tests {
         fn reverse(&self) -> Graph {
             let mut reversed = Graph::default();
             for (node, edges) in self.0.iter() {
-                reversed.0.entry(*node).or_insert(vec![]);
+                reversed.0.entry(*node).or_insert_with(Vec::new);
                 for referent in edges.iter() {
-                    reversed.0.entry(*referent).or_insert(vec![]).push(*node);
+                    reversed
+                        .0
+                        .entry(*referent)
+                        .or_insert_with(Vec::new)
+                        .push(*node);
                 }
             }
             reversed
@@ -306,8 +310,8 @@ mod tests {
             let reversed = graph.reverse();
             ReachableFrom {
                 reachable: Default::default(),
-                graph: graph,
-                reversed: reversed,
+                graph,
+                reversed,
             }
         }
 
@@ -328,7 +332,7 @@ mod tests {
             let original_size = self
                 .reachable
                 .entry(node)
-                .or_insert(HashSet::default())
+                .or_insert_with(HashSet::default)
                 .len();
 
             for sub_node in self.graph.0[&node].iter() {
@@ -337,7 +341,7 @@ mod tests {
                 let sub_reachable = self
                     .reachable
                     .entry(*sub_node)
-                    .or_insert(HashSet::default())
+                    .or_insert_with(HashSet::default)
                     .clone();
 
                 for transitive in sub_reachable {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2691,9 +2691,7 @@ fn commandline_flag_unit_test_function() {
     .map(|&x| x.into())
     .collect::<Vec<String>>();
 
-    assert!(test_cases
-        .iter()
-        .all(|ref x| command_line_flags.contains(x),));
+    assert!(test_cases.iter().all(|x| command_line_flags.contains(x)));
 
     //Test 2
     let bindings = crate::builder()
@@ -2718,9 +2716,7 @@ fn commandline_flag_unit_test_function() {
     .collect::<Vec<String>>();
     println!("{:?}", command_line_flags);
 
-    assert!(test_cases
-        .iter()
-        .all(|ref x| command_line_flags.contains(x),));
+    assert!(test_cases.iter().all(|x| command_line_flags.contains(x)));
 }
 
 #[test]


### PR DESCRIPTION
I forgot to fix some warnings in `cfg(test)` in #2111 because they can't seen on CI, but I found them by running `cargo clippy -- --cfg test` and fixed.