### PR TITLE
Add note about RVO in cpp.md

### DIFF
--- a/book/src/cpp.md
+++ b/book/src/cpp.md
@@ -71,3 +71,8 @@ cannot translate into Rust:
   generate undefined behaviour. See
   [the tracking issue for exceptions](https://github.com/rust-lang/rust-bindgen/issues/1208)
   for more details.
+  
+* Return value optimization. C++ compilers will in certain circumstances optimize functions
+  returning a struct type value to instead take an extra hidden argument that refers
+  to the return value struct. `bindgen` cannot necessarily know about this optimization and
+  thus at present `bindgen`-interfaces for these kinds of functions are invalid. 


### PR DESCRIPTION
`bindgen`'s inability to currently support RVO should be noted in C++ bindings generation document.

The issue is complex and definitely not easily summarised but better to still mention something about it than leave it out. Optionally the cpp.md could also link to Issue #778.