### PR TITLE
Remove fields never read

### DIFF
--- a/src/ir/context.rs
+++ b/src/ir/context.rs
@@ -364,9 +364,6 @@ pub struct BindgenContext {
 
     in_codegen: bool,
 
-    /// The clang index for parsing.
-    index: clang::Index,
-
     /// The translation unit for parsing.
     translation_unit: clang::TranslationUnit,
 
@@ -419,12 +416,6 @@ pub struct BindgenContext {
     /// This is populated when we enter codegen by `compute_cannot_derive_copy`
     /// and is always `None` before that and `Some` after.
     cannot_derive_copy: Option<HashSet<ItemId>>,
-
-    /// The set of (`ItemId`s of) types that can't derive copy in array.
-    ///
-    /// This is populated when we enter codegen by `compute_cannot_derive_copy`
-    /// and is always `None` before that and `Some` after.
-    cannot_derive_copy_in_array: Option<HashSet<ItemId>>,
 
     /// The set of (`ItemId`s of) types that can't derive hash.
     ///
@@ -569,7 +560,6 @@ If you encounter an error missing from this list, please file an issue or a PR!"
             replacements: Default::default(),
             collected_typerefs: false,
             in_codegen: false,
-            index,
             translation_unit,
             target_info,
             options,
@@ -582,7 +572,6 @@ If you encounter an error missing from this list, please file an issue or a PR!"
             cannot_derive_debug: None,
             cannot_derive_default: None,
             cannot_derive_copy: None,
-            cannot_derive_copy_in_array: None,
             cannot_derive_hash: None,
             cannot_derive_partialeq_or_partialord: None,
             sizedness: None,

--- a/src/ir/function.rs
+++ b/src/ir/function.rs
@@ -131,6 +131,11 @@ impl Function {
         self.signature
     }
 
+    /// Get this function's comment.
+    pub fn comment(&self) -> Option<&str> {
+        self.comment.as_deref()
+    }
+
     /// Get this function's kind.
     pub fn kind(&self) -> FunctionKind {
         self.kind

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1827,13 +1827,6 @@ struct BindgenOptions {
     /// Whether to time the bindgen phases.
     time_phases: bool,
 
-    /// True if we should generate constant names that are **directly** under
-    /// namespaces.
-    namespaced_constants: bool,
-
-    /// True if we should use MSVC name mangling rules.
-    msvc_mangling: bool,
-
     /// Whether we should convert float types to f32/f64 types.
     convert_floats: bool,
 
@@ -2084,8 +2077,6 @@ impl Default for BindgenOptions {
             use_core: false,
             ctypes_prefix: None,
             anon_fields_prefix: DEFAULT_ANON_FIELDS_PREFIX.into(),
-            namespaced_constants: true,
-            msvc_mangling: false,
             convert_floats: true,
             raw_lines: vec![],
             module_lines: HashMap::default(),


### PR DESCRIPTION
The CI couldn't pass due to `rustc` issued "field is never read" warnings, so I have fixed it.
