### PR TITLE
 implement clone on builder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,6 +40,7 @@ dependencies = [
  "clang-sys",
  "clap",
  "diff",
+ "dyn-clone",
  "env_logger",
  "lazy_static",
  "lazycell",
@@ -106,6 +107,12 @@ name = "diff"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e25ea47919b1560c4e3b7fe0aaab9becf5b84a10325ddf7db0f0ba5e1026499"
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee2626afccd7561a06cf1367e2950c4718ea04565e20fb5029b6c7d8ad09abcf"
 
 [[package]]
 name = "either"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ cexpr = "0.6"
 # This kinda sucks: https://github.com/rust-lang/cargo/issues/1982
 clap = { version = "2", optional = true }
 clang-sys = { version = "1", features = ["clang_6_0"] }
+dyn-clone = "1"
 lazycell = "1"
 lazy_static = "1"
 peeking_take_while = "0.1.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ cexpr = "0.6"
 # This kinda sucks: https://github.com/rust-lang/cargo/issues/1982
 clap = { version = "2", optional = true }
 clang-sys = { version = "1", features = ["clang_6_0"] }
-dyn-clone = "1"
+dyn-clone = { version = "1", optional = true }
 lazycell = "1"
 lazy_static = "1"
 peeking_take_while = "0.1.2"
@@ -72,6 +72,8 @@ version = "0.4"
 
 [features]
 default = ["logging", "clap", "runtime", "which-rustfmt"]
+# Implement the `Clone` trait on `bindgen::Builder`
+builder-clone = ["dyn-clone"]
 logging = ["env_logger", "log"]
 static = ["clang-sys/static"]
 runtime = ["clang-sys/runtime"]

--- a/src/callbacks.rs
+++ b/src/callbacks.rs
@@ -25,8 +25,93 @@ impl Default for MacroParsingBehavior {
 
 /// A trait to allow configuring different kinds of types in different
 /// situations.
+#[cfg(not(feature = "builder-clone"))]
+pub trait ParseCallbacks: fmt::Debug + UnwindSafe {
+    /// This function will be run on every macro that is identified.
+    fn will_parse_macro(&self, _name: &str) -> MacroParsingBehavior {
+        MacroParsingBehavior::Default
+    }
+
+    /// The integer kind an integer macro should have, given a name and the
+    /// value of that macro, or `None` if you want the default to be chosen.
+    fn int_macro(&self, _name: &str, _value: i64) -> Option<IntKind> {
+        None
+    }
+
+    /// This will be run on every string macro. The callback cannot influence the further
+    /// treatment of the macro, but may use the value to generate additional code or configuration.
+    fn str_macro(&self, _name: &str, _value: &[u8]) {}
+
+    /// This will be run on every function-like macro. The callback cannot
+    /// influence the further treatment of the macro, but may use the value to
+    /// generate additional code or configuration.
+    ///
+    /// The first parameter represents the name and argument list (including the
+    /// parentheses) of the function-like macro. The second parameter represents
+    /// the expansion of the macro as a sequence of tokens.
+    fn func_macro(&self, _name: &str, _value: &[&[u8]]) {}
+
+    /// This function should return whether, given an enum variant
+    /// name, and value, this enum variant will forcibly be a constant.
+    fn enum_variant_behavior(
+        &self,
+        _enum_name: Option<&str>,
+        _original_variant_name: &str,
+        _variant_value: EnumVariantValue,
+    ) -> Option<EnumVariantCustomBehavior> {
+        None
+    }
+
+    /// Allows to rename an enum variant, replacing `_original_variant_name`.
+    fn enum_variant_name(
+        &self,
+        _enum_name: Option<&str>,
+        _original_variant_name: &str,
+        _variant_value: EnumVariantValue,
+    ) -> Option<String> {
+        None
+    }
+
+    /// Allows to rename an item, replacing `_original_item_name`.
+    fn item_name(&self, _original_item_name: &str) -> Option<String> {
+        None
+    }
+
+    /// This will be called on every file inclusion, with the full path of the included file.
+    fn include_file(&self, _filename: &str) {}
+
+    /// This will be called to determine whether a particular blocklisted type
+    /// implements a trait or not. This will be used to implement traits on
+    /// other types containing the blocklisted type.
+    ///
+    /// * `None`: use the default behavior
+    /// * `Some(ImplementsTrait::Yes)`: `_name` implements `_derive_trait`
+    /// * `Some(ImplementsTrait::Manually)`: any type including `_name` can't
+    ///   derive `_derive_trait` but can implemented it manually
+    /// * `Some(ImplementsTrait::No)`: `_name` doesn't implement `_derive_trait`
+    fn blocklisted_type_implements_trait(
+        &self,
+        _name: &str,
+        _derive_trait: DeriveTrait,
+    ) -> Option<ImplementsTrait> {
+        None
+    }
+
+    /// Provide a list of custom derive attributes.
+    ///
+    /// If no additional attributes are wanted, this function should return an
+    /// empty `Vec`.
+    fn add_derives(&self, _name: &str) -> Vec<String> {
+        vec![]
+    }
+}
+
+/// The same trait as above, but clonable so that it can be included as a
+/// field in Builder when the builder-clone feature is enabled such that
+/// Builder implements Clone.
+#[cfg(feature = "builder-clone")]
 pub trait ParseCallbacks:
-          fmt::Debug + UnwindSafe + dyn_clone::DynClone
+    fmt::Debug + UnwindSafe + dyn_clone::DynClone
 {
     /// This function will be run on every macro that is identified.
     fn will_parse_macro(&self, _name: &str) -> MacroParsingBehavior {
@@ -107,4 +192,5 @@ pub trait ParseCallbacks:
     }
 }
 
+#[cfg(feature = "builder-clone")]
 dyn_clone::clone_trait_object!(ParseCallbacks);

--- a/src/callbacks.rs
+++ b/src/callbacks.rs
@@ -25,7 +25,7 @@ impl Default for MacroParsingBehavior {
 
 /// A trait to allow configuring different kinds of types in different
 /// situations.
-pub trait ParseCallbacks: fmt::Debug + UnwindSafe {
+pub trait ParseCallbacks: fmt::Debug + UnwindSafe + dyn_clone::DynClone {
     /// This function will be run on every macro that is identified.
     fn will_parse_macro(&self, _name: &str) -> MacroParsingBehavior {
         MacroParsingBehavior::Default
@@ -104,3 +104,5 @@ pub trait ParseCallbacks: fmt::Debug + UnwindSafe {
         vec![]
     }
 }
+
+dyn_clone::clone_trait_object!(ParseCallbacks);

--- a/src/callbacks.rs
+++ b/src/callbacks.rs
@@ -25,7 +25,9 @@ impl Default for MacroParsingBehavior {
 
 /// A trait to allow configuring different kinds of types in different
 /// situations.
-pub trait ParseCallbacks: fmt::Debug + UnwindSafe + dyn_clone::DynClone {
+pub trait ParseCallbacks:
+          fmt::Debug + UnwindSafe + dyn_clone::DynClone
+{
     /// This function will be run on every macro that is identified.
     fn will_parse_macro(&self, _name: &str) -> MacroParsingBehavior {
         MacroParsingBehavior::Default

--- a/src/clang.rs
+++ b/src/clang.rs
@@ -1687,6 +1687,7 @@ impl Drop for Diagnostic {
 }
 
 /// A file which has not been saved to disk.
+#[derive(Clone)]
 pub struct UnsavedFile {
     x: CXUnsavedFile,
     /// The name of the unsaved file. Kept here to avoid leaving dangling pointers in

--- a/src/deps.rs
+++ b/src/deps.rs
@@ -1,7 +1,7 @@
 /// Generating build depfiles from parsed bindings.
 use std::{collections::BTreeSet, path::PathBuf};
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub(crate) struct DepfileSpec {
     pub output_module: String,
     pub depfile_path: PathBuf,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -219,7 +219,8 @@ impl Default for CodegenConfig {
 /// End-users of the crate may need to set the `BINDGEN_EXTRA_CLANG_ARGS` environment variable to
 /// add additional arguments. For example, to build against a different sysroot a user could set
 /// `BINDGEN_EXTRA_CLANG_ARGS` to `--sysroot=/path/to/sysroot`.
-#[derive(Clone, Debug, Default)]
+#[cfg_attr(feature = "builder-clone", derive(Clone))]
+#[derive(Debug, Default)]
 pub struct Builder {
     options: BindgenOptions,
     input_headers: Vec<String>,
@@ -1663,7 +1664,8 @@ impl Builder {
 }
 
 /// Configuration options for generated bindings.
-#[derive(Clone, Debug)]
+#[cfg_attr(feature = "builder-clone", derive(Clone))]
+#[derive(Debug)]
 struct BindgenOptions {
     /// The set of types that have been blocklisted and should not appear
     /// anywhere in the generated code.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -219,7 +219,7 @@ impl Default for CodegenConfig {
 /// End-users of the crate may need to set the `BINDGEN_EXTRA_CLANG_ARGS` environment variable to
 /// add additional arguments. For example, to build against a different sysroot a user could set
 /// `BINDGEN_EXTRA_CLANG_ARGS` to `--sysroot=/path/to/sysroot`.
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct Builder {
     options: BindgenOptions,
     input_headers: Vec<String>,
@@ -1663,7 +1663,7 @@ impl Builder {
 }
 
 /// Configuration options for generated bindings.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 struct BindgenOptions {
     /// The set of types that have been blocklisted and should not appear
     /// anywhere in the generated code.
@@ -2656,7 +2656,7 @@ fn get_target_dependent_env_var(var: &str) -> Option<String> {
 ///     .parse_callbacks(Box::new(bindgen::CargoCallbacks))
 ///     .generate();
 /// ```
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct CargoCallbacks;
 
 impl callbacks::ParseCallbacks for CargoCallbacks {

--- a/src/regex_set.rs
+++ b/src/regex_set.rs
@@ -4,7 +4,7 @@ use regex::RegexSet as RxSet;
 use std::cell::Cell;
 
 /// A dynamic set of regular expressions.
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct RegexSet {
     items: Vec<String>,
     /// Whether any of the items in the set was ever matched. The length of this

--- a/tests/parse_callbacks/mod.rs
+++ b/tests/parse_callbacks/mod.rs
@@ -1,6 +1,6 @@
 use bindgen::callbacks::*;
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 struct EnumVariantRename;
 
 impl ParseCallbacks for EnumVariantRename {
@@ -14,7 +14,7 @@ impl ParseCallbacks for EnumVariantRename {
     }
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 struct BlocklistedTypeImplementsTrait;
 
 impl ParseCallbacks for BlocklistedTypeImplementsTrait {


### PR DESCRIPTION
Implements `Clone` on `Builder` (and all of the types included within it). Most were straightforward and I simply added derive Clone on the structs, except for the boxed `ParseCallbacks` since it is a trait. I have used the `dyn-clone` crate to make this work, provided that the underlying type implementing the trait implements Clone itself.

Notably, this does mean that any type used to implement `ParseCallbacks` that does not implement `Clone` would cause a compilation failure, although I imagine in most cases it should be a simple matter of adding `#[derive(Clone)]` to the type. Every example I've seen uses a unit struct for the `ParseCallbacks` implementation, so I guess it would be very easy to fix, but it would nonetheless be a breaking change since code that previously worked would fail to compile after this change until a Clone implementation is added to the type implementing `ParseCallbacks`. 

The changes made to the parse callbacks tests illustrate the simple fix that would need to be made to client code: https://github.com/rust-lang/rust-bindgen/commit/97fed5531db5ec2e55426f2fe2262e1c3de0d40c

Closes #2132
