### PR TITLE
Enables blocklisting of Objective-C methods

### DIFF
--- a/book/src/objc.md
+++ b/book/src/objc.md
@@ -32,6 +32,8 @@ methods found in `NSObject`.
 In order to initialize a class `Foo`, you will have to do something like `let
 foo = Foo(Foo::alloc().initWithStuff())`.
 
+To blocklist an Objective-C method, you should add the bindgen generated method
+path (e.g. `IFoo::method` or `IFoo::class_method`) as a blocklist item.
 
 ## Supported Features
 

--- a/tests/expectations/tests/objc_blocklist.rs
+++ b/tests/expectations/tests/objc_blocklist.rs
@@ -1,0 +1,42 @@
+#![allow(
+    dead_code,
+    non_snake_case,
+    non_camel_case_types,
+    non_upper_case_globals
+)]
+#![cfg(target_os = "macos")]
+
+#[macro_use]
+extern crate objc;
+#[allow(non_camel_case_types)]
+pub type id = *mut objc::runtime::Object;
+#[repr(transparent)]
+#[derive(Debug, Copy, Clone)]
+pub struct SomeClass(pub id);
+impl std::ops::Deref for SomeClass {
+    type Target = objc::runtime::Object;
+    fn deref(&self) -> &Self::Target {
+        unsafe { &*self.0 }
+    }
+}
+unsafe impl objc::Message for SomeClass {}
+impl SomeClass {
+    pub fn alloc() -> Self {
+        Self(unsafe { msg_send!(class!(SomeClass), alloc) })
+    }
+}
+impl ISomeClass for SomeClass {}
+pub trait ISomeClass: Sized + std::ops::Deref {
+    unsafe fn ambiguouslyBlockedMethod(&self)
+    where
+        <Self as std::ops::Deref>::Target: objc::Message + Sized,
+    {
+        msg_send!(*self, ambiguouslyBlockedMethod)
+    }
+    unsafe fn instanceMethod(&self)
+    where
+        <Self as std::ops::Deref>::Target: objc::Message + Sized,
+    {
+        msg_send!(*self, instanceMethod)
+    }
+}

--- a/tests/headers/objc_blocklist.h
+++ b/tests/headers/objc_blocklist.h
@@ -1,0 +1,9 @@
+// bindgen-flags: --objc-extern-crate --blocklist-item ISomeClass::class_ambiguouslyBlockedMethod --blocklist-item ISomeClass::blockedInstanceMethod -- -x objective-c
+// bindgen-osx-only
+
+@interface SomeClass
++ (void)ambiguouslyBlockedMethod;
+- (void)ambiguouslyBlockedMethod;
+- (void)instanceMethod;
+- (void)blockedInstanceMethod;
+@end


### PR DESCRIPTION
This PR adds the ability to blocklist Objective-C methods using --blocklist-item. The path format that's matched against is `ItemPath:: rustMethodName`.

The Rust method name is used over the Objective-C name, as it is needed to deal with the ambiguity when class and instance methods share the same name.

