### PR TITLE
Allow fully-qualified derives

### DIFF
--- a/bindgen-integration/build.rs
+++ b/bindgen-integration/build.rs
@@ -128,7 +128,7 @@ impl ParseCallbacks for MacroCallback {
             ]
         } else if name == "MyOrderedEnum" {
             vec![
-                "PartialOrd".into(),
+                "std::cmp::PartialOrd".into(),
             ]
         } else {
             vec![]

--- a/src/codegen/helpers.rs
+++ b/src/codegen/helpers.rs
@@ -30,7 +30,7 @@ pub mod attributes {
         let which_ones = which_ones
             .iter()
             .cloned()
-            .map(|one| Ident::new(one, Span::call_site()));
+            .map(|one| TokenStream::from_str(one).expect("derive to be valid"));
         quote! {
             #[derive( #( #which_ones ),* )]
         }


### PR DESCRIPTION
Adding a custom derive like "serde::Deserialize" results in a panic complaining
that it is not a valid Ident. Derive params are not identifiers, so treat it as
a token stream instead.

Relates to  #1089