### PR TITLE
Add support for `vectorcall` ABI

### DIFF
--- a/src/features.rs
+++ b/src/features.rs
@@ -129,6 +129,7 @@ macro_rules! rust_target_base {
             => Stable_1_47 => 1.47;
             /// Nightly rust
             ///  * `thiscall` calling convention ([Tracking issue](https://github.com/rust-lang/rust/issues/42202))
+            ///  * `vectorcall` calling convention (no tracking issue)
             => Nightly => nightly;
         );
     }
@@ -234,6 +235,7 @@ rust_feature_def!(
     }
     Nightly {
         => thiscall_abi;
+        => vectorcall_abi;
     }
 );
 
@@ -259,7 +261,8 @@ mod test {
                 !f_1_0.associated_const &&
                 !f_1_0.builtin_clone_impls &&
                 !f_1_0.repr_align &&
-                !f_1_0.thiscall_abi
+                !f_1_0.thiscall_abi &&
+                !f_1_0.vectorcall_abi
         );
         let f_1_21 = RustFeatures::from(RustTarget::Stable_1_21);
         assert!(
@@ -269,7 +272,8 @@ mod test {
                 f_1_21.associated_const &&
                 f_1_21.builtin_clone_impls &&
                 !f_1_21.repr_align &&
-                !f_1_21.thiscall_abi
+                !f_1_21.thiscall_abi &&
+                !f_1_21.vectorcall_abi
         );
         let f_nightly = RustFeatures::from(RustTarget::Nightly);
         assert!(
@@ -280,7 +284,8 @@ mod test {
                 f_nightly.builtin_clone_impls &&
                 f_nightly.maybe_uninit &&
                 f_nightly.repr_align &&
-                f_nightly.thiscall_abi
+                f_nightly.thiscall_abi &&
+                f_nightly.vectorcall_abi
         );
     }
 

--- a/src/ir/function.rs
+++ b/src/ir/function.rs
@@ -181,6 +181,8 @@ pub enum Abi {
     Fastcall,
     /// The "thiscall" ABI.
     ThisCall,
+    /// The "vectorcall" ABI.
+    Vectorcall,
     /// The "aapcs" ABI.
     Aapcs,
     /// The "win64" ABI.
@@ -203,6 +205,7 @@ impl quote::ToTokens for Abi {
             Abi::Stdcall => quote! { "stdcall" },
             Abi::Fastcall => quote! { "fastcall" },
             Abi::ThisCall => quote! { "thiscall" },
+            Abi::Vectorcall => quote! { "vectorcall" },
             Abi::Aapcs => quote! { "aapcs" },
             Abi::Win64 => quote! { "win64" },
             Abi::Unknown(cc) => panic!(
@@ -241,6 +244,7 @@ fn get_abi(cc: CXCallingConv) -> Abi {
         CXCallingConv_X86StdCall => Abi::Stdcall,
         CXCallingConv_X86FastCall => Abi::Fastcall,
         CXCallingConv_X86ThisCall => Abi::ThisCall,
+        CXCallingConv_X86VectorCall => Abi::Vectorcall,
         CXCallingConv_AAPCS => Abi::Aapcs,
         CXCallingConv_X86_64Win64 => Abi::Win64,
         other => Abi::Unknown(other),

--- a/tests/expectations/tests/win32-vectorcall-1_0.rs
+++ b/tests/expectations/tests/win32-vectorcall-1_0.rs
@@ -1,0 +1,6 @@
+#![allow(
+    dead_code,
+    non_snake_case,
+    non_camel_case_types,
+    non_upper_case_globals
+)]

--- a/tests/expectations/tests/win32-vectorcall-nightly.rs
+++ b/tests/expectations/tests/win32-vectorcall-nightly.rs
@@ -1,0 +1,16 @@
+#![allow(
+    dead_code,
+    non_snake_case,
+    non_camel_case_types,
+    non_upper_case_globals
+)]
+#![cfg(feature = "nightly")]
+#![feature(abi_vectorcall)]
+
+extern "vectorcall" {
+    #[link_name = "\u{1}test_vectorcall@@16"]
+    pub fn test_vectorcall(
+        a: ::std::os::raw::c_int,
+        b: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}

--- a/tests/headers/win32-vectorcall-1_0.h
+++ b/tests/headers/win32-vectorcall-1_0.h
@@ -1,0 +1,3 @@
+// bindgen-flags: --rust-target 1.0 -- --target=x86_64-pc-windows-msvc
+
+int __vectorcall test_vectorcall(int a, int b);

--- a/tests/headers/win32-vectorcall-nightly.h
+++ b/tests/headers/win32-vectorcall-nightly.h
@@ -1,0 +1,3 @@
+// bindgen-flags: --rust-target nightly --raw-line '#![cfg(feature = "nightly")]' --raw-line '#![feature(abi_vectorcall)]' -- --target=x86_64-pc-windows-msvc
+
+int __vectorcall test_vectorcall(int a, int b);


### PR DESCRIPTION
Adds support for the `vectorcall` ABI on x86_64 platforms. I have mostly
followed the implementation of the `thiscall` ABI. Similar to `thiscall`,
`vectorcall` is feature-gated and only available on nightly. There is no
tracking issue for the `abi_vectorcall` feature (not sure why).

r? @emilio 