### PR TITLE
Fix wrong panic!() argument type (quote it)

### DIFF
--- a/book/src/tutorial-5.md
+++ b/book/src/tutorial-5.md
@@ -61,7 +61,7 @@ mod tests {
             // Finish the compression stream.
             let result = BZ2_bzCompressEnd(&mut stream as *mut _);
             match result {
-                r if r == (BZ_PARAM_ERROR as _) => panic!(BZ_PARAM_ERROR),
+                r if r == (BZ_PARAM_ERROR as _) => panic!("BZ_PARAM_ERROR"),
                 r if r == (BZ_OK as _) => {},
                 r => panic!("Unknown return value = {}", r),
             }


### PR DESCRIPTION
The "sanity test" example contains one `panic!()` with wrong argument type (`i32` instead of string literal) that produces warning on recent rust compilers:

```
arning: panic message is not a string literal
  --> src/lib.rs:52:59
   |
52 |                 r if r == (BZ_PARAM_ERROR as _) => panic!(BZ_PARAM_ERROR),
   |                                                           ^^^^^^^^^^^^^^
   |
   = note: `#[warn(non_fmt_panics)]` on by default
   = note: this usage of panic!() is deprecated; it will be a hard error in Rust 2021
   = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2021/panic-macro-consistency.html>
help: add a "{}" format string to Display the message
   |
52 |                 r if r == (BZ_PARAM_ERROR as _) => panic!("{}", BZ_PARAM_ERROR),
   |                                                           +++++
help: or use std::panic::panic_any instead
   |
52 |                 r if r == (BZ_PARAM_ERROR as _) => std::panic::panic_any(BZ_PARAM_ERROR),
   |                                                    ~~~~~~~~~~~~~~~~~~~~~
```
Here is provided trivial fix - quoting it as is done in other places of this example.