### PR TITLE
Provide information how to link to shared objects

### DIFF
--- a/book/src/tutorial-3.md
+++ b/book/src/tutorial-3.md
@@ -7,6 +7,8 @@ bindings to `bzip2` at compile time. The resulting bindings will be written to
 `$OUT_DIR/bindings.rs` where `$OUT_DIR` is chosen by `cargo` and is something
 like `./target/debug/build/bindgen-tutorial-bzip2-sys-afc7747d7eafd720/out/`.
 
+Note that the associated shared object to `bz2` is `libbz2.so`. In general, a `lib<name>.so` should be referenced in the build file by `<name>`.
+
 ```rust,ignore
 extern crate bindgen;
 
@@ -14,6 +16,9 @@ use std::env;
 use std::path::PathBuf;
 
 fn main() {
+    // Tell cargo to look for shared libraries in the specified directory
+    println!("cargo:rustc-link-search=/path/to/lib");
+
     // Tell cargo to tell rustc to link the system bzip2
     // shared library.
     println!("cargo:rustc-link-lib=bz2");


### PR DESCRIPTION
The information is fundamental when working with shared libraries but is never explicitly mentioned. 
Without, it is very possible to get stuck trying to import `lib<name>.so` with `println!("cargo:rustc-link-lib=lib<name>");` which will not work (as it happened to me).

