### PR TITLE
Derive from any other trait only when deriving from Copy

### DIFF
--- a/tests/expectations/tests/packed-vtable.rs
+++ b/tests/expectations/tests/packed-vtable.rs
@@ -9,7 +9,6 @@
 #[repr(C)]
 pub struct PackedVtable__bindgen_vtable(::std::os::raw::c_void);
 #[repr(C, packed)]
-#[derive(Debug)]
 pub struct PackedVtable {
     pub vtable_: *const PackedVtable__bindgen_vtable,
 }


### PR DESCRIPTION
It's impossible to #[derive] from any other trait when not deriving from
Copy when using the newest Rust nightly. Any attempt to do that results
in the following error:

```
error: `#[derive]` can't be used on a `#[repr(packed)]` struct that does not derive Copy (error E0133)
```

Fixes: #2083
Signed-off-by: Michal Rostecki <vadorovsky@gmail.com>