### PR TITLE
Layout test should pass clippy borrow_as_ptr lint

### DIFF
--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -2192,7 +2192,7 @@ impl CodeGenerator for CompInfo {
                                         quote! {
                                             assert_eq!(
                                                 unsafe {
-                                                    &(*(::#prefix::ptr::null::<#canonical_ident>())).#field_name as *const _ as usize
+                                                    ::#prefix::ptr::addr_of!((*(::#prefix::ptr::null::<#canonical_ident>())).#field_name) as usize
                                                 },
                                                 #field_offset,
                                                 concat!("Offset of field: ", stringify!(#canonical_ident), "::", stringify!(#field_name))

--- a/tests/expectations/tests/16-byte-alignment.rs
+++ b/tests/expectations/tests/16-byte-alignment.rs
@@ -44,9 +44,12 @@ fn bindgen_test_layout_rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1>(
-            )))
-            .dport as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<
+                    rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1,
+                >()))
+                .dport
+            ) as usize
         },
         0usize,
         concat!(
@@ -58,9 +61,12 @@ fn bindgen_test_layout_rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1>(
-            )))
-            .sport as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<
+                    rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1,
+                >()))
+                .sport
+            ) as usize
         },
         2usize,
         concat!(
@@ -85,8 +91,10 @@ fn bindgen_test_layout_rte_ipv4_tuple__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_ipv4_tuple__bindgen_ty_1>())).sctp_tag
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_ipv4_tuple__bindgen_ty_1>()))
+                    .sctp_tag
+            ) as usize
         },
         0usize,
         concat!(
@@ -120,8 +128,9 @@ fn bindgen_test_layout_rte_ipv4_tuple() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_ipv4_tuple>())).src_addr as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_ipv4_tuple>())).src_addr
+            ) as usize
         },
         0usize,
         concat!(
@@ -133,8 +142,9 @@ fn bindgen_test_layout_rte_ipv4_tuple() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_ipv4_tuple>())).dst_addr as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_ipv4_tuple>())).dst_addr
+            ) as usize
         },
         4usize,
         concat!(
@@ -193,9 +203,12 @@ fn bindgen_test_layout_rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1>(
-            )))
-            .dport as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<
+                    rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1,
+                >()))
+                .dport
+            ) as usize
         },
         0usize,
         concat!(
@@ -207,9 +220,12 @@ fn bindgen_test_layout_rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1>(
-            )))
-            .sport as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<
+                    rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1,
+                >()))
+                .sport
+            ) as usize
         },
         2usize,
         concat!(
@@ -234,8 +250,10 @@ fn bindgen_test_layout_rte_ipv6_tuple__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_ipv6_tuple__bindgen_ty_1>())).sctp_tag
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_ipv6_tuple__bindgen_ty_1>()))
+                    .sctp_tag
+            ) as usize
         },
         0usize,
         concat!(
@@ -269,8 +287,9 @@ fn bindgen_test_layout_rte_ipv6_tuple() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_ipv6_tuple>())).src_addr as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_ipv6_tuple>())).src_addr
+            ) as usize
         },
         0usize,
         concat!(
@@ -282,8 +301,9 @@ fn bindgen_test_layout_rte_ipv6_tuple() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_ipv6_tuple>())).dst_addr as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_ipv6_tuple>())).dst_addr
+            ) as usize
         },
         16usize,
         concat!(
@@ -324,7 +344,8 @@ fn bindgen_test_layout_rte_thash_tuple() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_thash_tuple>())).v4 as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<rte_thash_tuple>())).v4)
+                as usize
         },
         0usize,
         concat!(
@@ -336,7 +357,8 @@ fn bindgen_test_layout_rte_thash_tuple() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_thash_tuple>())).v6 as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<rte_thash_tuple>())).v6)
+                as usize
         },
         0usize,
         concat!(

--- a/tests/expectations/tests/16-byte-alignment_1_0.rs
+++ b/tests/expectations/tests/16-byte-alignment_1_0.rs
@@ -89,9 +89,12 @@ fn bindgen_test_layout_rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1>(
-            )))
-            .dport as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<
+                    rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1,
+                >()))
+                .dport
+            ) as usize
         },
         0usize,
         concat!(
@@ -103,9 +106,12 @@ fn bindgen_test_layout_rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1>(
-            )))
-            .sport as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<
+                    rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1,
+                >()))
+                .sport
+            ) as usize
         },
         2usize,
         concat!(
@@ -135,8 +141,10 @@ fn bindgen_test_layout_rte_ipv4_tuple__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_ipv4_tuple__bindgen_ty_1>())).sctp_tag
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_ipv4_tuple__bindgen_ty_1>()))
+                    .sctp_tag
+            ) as usize
         },
         0usize,
         concat!(
@@ -166,8 +174,9 @@ fn bindgen_test_layout_rte_ipv4_tuple() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_ipv4_tuple>())).src_addr as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_ipv4_tuple>())).src_addr
+            ) as usize
         },
         0usize,
         concat!(
@@ -179,8 +188,9 @@ fn bindgen_test_layout_rte_ipv4_tuple() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_ipv4_tuple>())).dst_addr as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_ipv4_tuple>())).dst_addr
+            ) as usize
         },
         4usize,
         concat!(
@@ -237,9 +247,12 @@ fn bindgen_test_layout_rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1>(
-            )))
-            .dport as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<
+                    rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1,
+                >()))
+                .dport
+            ) as usize
         },
         0usize,
         concat!(
@@ -251,9 +264,12 @@ fn bindgen_test_layout_rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1>(
-            )))
-            .sport as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<
+                    rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1,
+                >()))
+                .sport
+            ) as usize
         },
         2usize,
         concat!(
@@ -283,8 +299,10 @@ fn bindgen_test_layout_rte_ipv6_tuple__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_ipv6_tuple__bindgen_ty_1>())).sctp_tag
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_ipv6_tuple__bindgen_ty_1>()))
+                    .sctp_tag
+            ) as usize
         },
         0usize,
         concat!(
@@ -314,8 +332,9 @@ fn bindgen_test_layout_rte_ipv6_tuple() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_ipv6_tuple>())).src_addr as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_ipv6_tuple>())).src_addr
+            ) as usize
         },
         0usize,
         concat!(
@@ -327,8 +346,9 @@ fn bindgen_test_layout_rte_ipv6_tuple() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_ipv6_tuple>())).dst_addr as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_ipv6_tuple>())).dst_addr
+            ) as usize
         },
         16usize,
         concat!(
@@ -360,7 +380,8 @@ fn bindgen_test_layout_rte_thash_tuple() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_thash_tuple>())).v4 as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<rte_thash_tuple>())).v4)
+                as usize
         },
         0usize,
         concat!(
@@ -372,7 +393,8 @@ fn bindgen_test_layout_rte_thash_tuple() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_thash_tuple>())).v6 as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<rte_thash_tuple>())).v6)
+                as usize
         },
         0usize,
         concat!(

--- a/tests/expectations/tests/accessors.rs
+++ b/tests/expectations/tests/accessors.rs
@@ -30,8 +30,9 @@ fn bindgen_test_layout_SomeAccessors() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<SomeAccessors>())).mNoAccessor as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<SomeAccessors>())).mNoAccessor
+            ) as usize
         },
         0usize,
         concat!(
@@ -43,8 +44,9 @@ fn bindgen_test_layout_SomeAccessors() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<SomeAccessors>())).mBothAccessors as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<SomeAccessors>())).mBothAccessors
+            ) as usize
         },
         4usize,
         concat!(
@@ -56,8 +58,9 @@ fn bindgen_test_layout_SomeAccessors() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<SomeAccessors>())).mUnsafeAccessors
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<SomeAccessors>())).mUnsafeAccessors
+            ) as usize
         },
         8usize,
         concat!(
@@ -69,8 +72,9 @@ fn bindgen_test_layout_SomeAccessors() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<SomeAccessors>())).mImmutableAccessor
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<SomeAccessors>())).mImmutableAccessor
+            ) as usize
         },
         12usize,
         concat!(
@@ -126,8 +130,9 @@ fn bindgen_test_layout_AllAccessors() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<AllAccessors>())).mBothAccessors as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<AllAccessors>())).mBothAccessors
+            ) as usize
         },
         0usize,
         concat!(
@@ -139,8 +144,9 @@ fn bindgen_test_layout_AllAccessors() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<AllAccessors>())).mAlsoBothAccessors
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<AllAccessors>())).mAlsoBothAccessors
+            ) as usize
         },
         4usize,
         concat!(
@@ -190,8 +196,9 @@ fn bindgen_test_layout_AllUnsafeAccessors() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<AllUnsafeAccessors>())).mBothAccessors
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<AllUnsafeAccessors>())).mBothAccessors
+            ) as usize
         },
         0usize,
         concat!(
@@ -203,8 +210,10 @@ fn bindgen_test_layout_AllUnsafeAccessors() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<AllUnsafeAccessors>())).mAlsoBothAccessors
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<AllUnsafeAccessors>()))
+                    .mAlsoBothAccessors
+            ) as usize
         },
         4usize,
         concat!(
@@ -263,8 +272,9 @@ fn bindgen_test_layout_ContradictAccessors() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<ContradictAccessors>())).mBothAccessors
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<ContradictAccessors>())).mBothAccessors
+            ) as usize
         },
         0usize,
         concat!(
@@ -276,8 +286,9 @@ fn bindgen_test_layout_ContradictAccessors() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<ContradictAccessors>())).mNoAccessors
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<ContradictAccessors>())).mNoAccessors
+            ) as usize
         },
         4usize,
         concat!(
@@ -289,8 +300,9 @@ fn bindgen_test_layout_ContradictAccessors() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<ContradictAccessors>())).mUnsafeAccessors
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<ContradictAccessors>())).mUnsafeAccessors
+            ) as usize
         },
         8usize,
         concat!(
@@ -302,8 +314,10 @@ fn bindgen_test_layout_ContradictAccessors() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<ContradictAccessors>())).mImmutableAccessor
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<ContradictAccessors>()))
+                    .mImmutableAccessor
+            ) as usize
         },
         12usize,
         concat!(
@@ -358,7 +372,8 @@ fn bindgen_test_layout_Replaced() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<Replaced>())).mAccessor as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<Replaced>())).mAccessor)
+                as usize
         },
         0usize,
         concat!(
@@ -399,7 +414,8 @@ fn bindgen_test_layout_Wrapper() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<Wrapper>())).mReplaced as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<Wrapper>())).mReplaced)
+                as usize
         },
         0usize,
         concat!(

--- a/tests/expectations/tests/allowlist-file.rs
+++ b/tests/expectations/tests/allowlist-file.rs
@@ -70,8 +70,10 @@ fn bindgen_test_layout_StructWithAllowlistedDefinition() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<StructWithAllowlistedDefinition>())).other
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<StructWithAllowlistedDefinition>()))
+                    .other
+            ) as usize
         },
         0usize,
         concat!(
@@ -110,8 +112,9 @@ fn bindgen_test_layout_StructWithAllowlistedFwdDecl() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<StructWithAllowlistedFwdDecl>())).b
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<StructWithAllowlistedFwdDecl>())).b
+            ) as usize
         },
         0usize,
         concat!(
@@ -141,7 +144,8 @@ fn bindgen_test_layout_AllowlistMe() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<AllowlistMe>())).foo as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<AllowlistMe>())).foo)
+                as usize
         },
         0usize,
         concat!(

--- a/tests/expectations/tests/allowlist-namespaces.rs
+++ b/tests/expectations/tests/allowlist-namespaces.rs
@@ -53,7 +53,8 @@ pub mod root {
             );
             assert_eq!(
                 unsafe {
-                    &(*(::std::ptr::null::<Test>())).helper as *const _ as usize
+                    ::std::ptr::addr_of!((*(::std::ptr::null::<Test>())).helper)
+                        as usize
                 },
                 0usize,
                 concat!(

--- a/tests/expectations/tests/allowlisted-item-references-no-hash.rs
+++ b/tests/expectations/tests/allowlisted-item-references-no-hash.rs
@@ -42,7 +42,8 @@ fn bindgen_test_layout_AllowlistMe() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<AllowlistMe>())).a as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<AllowlistMe>())).a)
+                as usize
         },
         0usize,
         concat!(

--- a/tests/expectations/tests/allowlisted-item-references-no-partialeq.rs
+++ b/tests/expectations/tests/allowlisted-item-references-no-partialeq.rs
@@ -42,7 +42,8 @@ fn bindgen_test_layout_AllowlistMe() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<AllowlistMe>())).a as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<AllowlistMe>())).a)
+                as usize
         },
         0usize,
         concat!(

--- a/tests/expectations/tests/allowlisted_item_references_no_copy.rs
+++ b/tests/expectations/tests/allowlisted_item_references_no_copy.rs
@@ -42,7 +42,8 @@ fn bindgen_test_layout_AllowlistMe() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<AllowlistMe>())).a as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<AllowlistMe>())).a)
+                as usize
         },
         0usize,
         concat!(

--- a/tests/expectations/tests/annotation_hide.rs
+++ b/tests/expectations/tests/annotation_hide.rs
@@ -44,7 +44,8 @@ fn bindgen_test_layout_NotAnnotated() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<NotAnnotated>())).f as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<NotAnnotated>())).f)
+                as usize
         },
         0usize,
         concat!(

--- a/tests/expectations/tests/anon-fields-prefix.rs
+++ b/tests/expectations/tests/anon-fields-prefix.rs
@@ -33,8 +33,9 @@ fn bindgen_test_layout_color__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<color__bindgen_ty_1>())).r as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<color__bindgen_ty_1>())).r
+            ) as usize
         },
         0usize,
         concat!(
@@ -46,8 +47,9 @@ fn bindgen_test_layout_color__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<color__bindgen_ty_1>())).g as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<color__bindgen_ty_1>())).g
+            ) as usize
         },
         1usize,
         concat!(
@@ -59,8 +61,9 @@ fn bindgen_test_layout_color__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<color__bindgen_ty_1>())).b as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<color__bindgen_ty_1>())).b
+            ) as usize
         },
         2usize,
         concat!(
@@ -92,8 +95,9 @@ fn bindgen_test_layout_color__bindgen_ty_2() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<color__bindgen_ty_2>())).y as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<color__bindgen_ty_2>())).y
+            ) as usize
         },
         0usize,
         concat!(
@@ -105,8 +109,9 @@ fn bindgen_test_layout_color__bindgen_ty_2() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<color__bindgen_ty_2>())).u as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<color__bindgen_ty_2>())).u
+            ) as usize
         },
         1usize,
         concat!(
@@ -118,8 +123,9 @@ fn bindgen_test_layout_color__bindgen_ty_2() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<color__bindgen_ty_2>())).v as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<color__bindgen_ty_2>())).v
+            ) as usize
         },
         2usize,
         concat!(
@@ -143,7 +149,9 @@ fn bindgen_test_layout_color() {
         concat!("Alignment of ", stringify!(color))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<color>())).v3 as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<color>())).v3) as usize
+        },
         0usize,
         concat!("Offset of field: ", stringify!(color), "::", stringify!(v3))
     );

--- a/tests/expectations/tests/anon_enum.rs
+++ b/tests/expectations/tests/anon_enum.rs
@@ -30,12 +30,16 @@ fn bindgen_test_layout_Test() {
         concat!("Alignment of ", stringify!(Test))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Test>())).foo as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<Test>())).foo) as usize
+        },
         0usize,
         concat!("Offset of field: ", stringify!(Test), "::", stringify!(foo))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Test>())).bar as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<Test>())).bar) as usize
+        },
         4usize,
         concat!("Offset of field: ", stringify!(Test), "::", stringify!(bar))
     );

--- a/tests/expectations/tests/anon_struct_in_union.rs
+++ b/tests/expectations/tests/anon_struct_in_union.rs
@@ -34,8 +34,9 @@ fn bindgen_test_layout_s__bindgen_ty_1_inner() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<s__bindgen_ty_1_inner>())).b as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<s__bindgen_ty_1_inner>())).b
+            ) as usize
         },
         0usize,
         concat!(
@@ -60,8 +61,9 @@ fn bindgen_test_layout_s__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<s__bindgen_ty_1>())).field as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<s__bindgen_ty_1>())).field
+            ) as usize
         },
         0usize,
         concat!(
@@ -94,7 +96,9 @@ fn bindgen_test_layout_s() {
         concat!("Alignment of ", stringify!(s))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<s>())).u as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<s>())).u) as usize
+        },
         0usize,
         concat!("Offset of field: ", stringify!(s), "::", stringify!(u))
     );

--- a/tests/expectations/tests/anon_struct_in_union_1_0.rs
+++ b/tests/expectations/tests/anon_struct_in_union_1_0.rs
@@ -78,8 +78,9 @@ fn bindgen_test_layout_s__bindgen_ty_1_inner() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<s__bindgen_ty_1_inner>())).b as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<s__bindgen_ty_1_inner>())).b
+            ) as usize
         },
         0usize,
         concat!(
@@ -109,8 +110,9 @@ fn bindgen_test_layout_s__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<s__bindgen_ty_1>())).field as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<s__bindgen_ty_1>())).field
+            ) as usize
         },
         0usize,
         concat!(
@@ -139,7 +141,9 @@ fn bindgen_test_layout_s() {
         concat!("Alignment of ", stringify!(s))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<s>())).u as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<s>())).u) as usize
+        },
         0usize,
         concat!("Offset of field: ", stringify!(s), "::", stringify!(u))
     );

--- a/tests/expectations/tests/array-of-zero-sized-types.rs
+++ b/tests/expectations/tests/array-of-zero-sized-types.rs
@@ -45,8 +45,9 @@ fn bindgen_test_layout_HasArrayOfEmpty() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<HasArrayOfEmpty>())).empties as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<HasArrayOfEmpty>())).empties
+            ) as usize
         },
         0usize,
         concat!(

--- a/tests/expectations/tests/bindgen-union-inside-namespace.rs
+++ b/tests/expectations/tests/bindgen-union-inside-namespace.rs
@@ -79,7 +79,8 @@ pub mod root {
             );
             assert_eq!(
                 unsafe {
-                    &(*(::std::ptr::null::<Bar>())).foo as *const _ as usize
+                    ::std::ptr::addr_of!((*(::std::ptr::null::<Bar>())).foo)
+                        as usize
                 },
                 0usize,
                 concat!(
@@ -91,7 +92,8 @@ pub mod root {
             );
             assert_eq!(
                 unsafe {
-                    &(*(::std::ptr::null::<Bar>())).bar as *const _ as usize
+                    ::std::ptr::addr_of!((*(::std::ptr::null::<Bar>())).bar)
+                        as usize
                 },
                 0usize,
                 concat!(

--- a/tests/expectations/tests/bitfield-linux-32.rs
+++ b/tests/expectations/tests/bitfield-linux-32.rs
@@ -111,7 +111,9 @@ fn bindgen_test_layout_Test() {
         concat!("Alignment of ", stringify!(Test))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Test>())).foo as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<Test>())).foo) as usize
+        },
         0usize,
         concat!("Offset of field: ", stringify!(Test), "::", stringify!(foo))
     );

--- a/tests/expectations/tests/bitfield_align.rs
+++ b/tests/expectations/tests/bitfield_align.rs
@@ -113,12 +113,16 @@ fn bindgen_test_layout_A() {
         concat!("Alignment of ", stringify!(A))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<A>())).x as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<A>())).x) as usize
+        },
         0usize,
         concat!("Offset of field: ", stringify!(A), "::", stringify!(x))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<A>())).y as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<A>())).y) as usize
+        },
         3usize,
         concat!("Offset of field: ", stringify!(A), "::", stringify!(y))
     );
@@ -398,12 +402,16 @@ fn bindgen_test_layout_C() {
         concat!("Alignment of ", stringify!(C))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<C>())).x as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<C>())).x) as usize
+        },
         0usize,
         concat!("Offset of field: ", stringify!(C), "::", stringify!(x))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<C>())).baz as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<C>())).baz) as usize
+        },
         4usize,
         concat!("Offset of field: ", stringify!(C), "::", stringify!(baz))
     );
@@ -695,7 +703,9 @@ fn bindgen_test_layout_Date3() {
         concat!("Alignment of ", stringify!(Date3))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Date3>())).byte as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<Date3>())).byte) as usize
+        },
         3usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/blocklist-and-impl-debug.rs
+++ b/tests/expectations/tests/blocklist-and-impl-debug.rs
@@ -26,8 +26,9 @@ fn bindgen_test_layout_ShouldManuallyImplDebug() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<ShouldManuallyImplDebug>())).a as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<ShouldManuallyImplDebug>())).a
+            ) as usize
         },
         0usize,
         concat!(

--- a/tests/expectations/tests/blocklist-file.rs
+++ b/tests/expectations/tests/blocklist-file.rs
@@ -26,7 +26,8 @@ fn bindgen_test_layout_SizedIntegers() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<SizedIntegers>())).x as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<SizedIntegers>())).x)
+                as usize
         },
         0usize,
         concat!(
@@ -38,7 +39,8 @@ fn bindgen_test_layout_SizedIntegers() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<SizedIntegers>())).y as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<SizedIntegers>())).y)
+                as usize
         },
         2usize,
         concat!(
@@ -50,7 +52,8 @@ fn bindgen_test_layout_SizedIntegers() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<SizedIntegers>())).z as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<SizedIntegers>())).z)
+                as usize
         },
         4usize,
         concat!(
@@ -80,8 +83,9 @@ fn bindgen_test_layout_StructWithBlocklistedFwdDecl() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<StructWithBlocklistedFwdDecl>())).b
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<StructWithBlocklistedFwdDecl>())).b
+            ) as usize
         },
         0usize,
         concat!(

--- a/tests/expectations/tests/blocks-signature.rs
+++ b/tests/expectations/tests/blocks-signature.rs
@@ -49,8 +49,9 @@ fn bindgen_test_layout_contains_block_pointers() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<contains_block_pointers>())).val as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<contains_block_pointers>())).val
+            ) as usize
         },
         0usize,
         concat!(
@@ -62,8 +63,9 @@ fn bindgen_test_layout_contains_block_pointers() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<contains_block_pointers>())).ptr_val
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<contains_block_pointers>())).ptr_val
+            ) as usize
         },
         8usize,
         concat!(

--- a/tests/expectations/tests/blocks.rs
+++ b/tests/expectations/tests/blocks.rs
@@ -48,8 +48,9 @@ fn bindgen_test_layout_contains_block_pointers() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<contains_block_pointers>())).val as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<contains_block_pointers>())).val
+            ) as usize
         },
         0usize,
         concat!(
@@ -61,8 +62,9 @@ fn bindgen_test_layout_contains_block_pointers() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<contains_block_pointers>())).ptr_val
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<contains_block_pointers>())).ptr_val
+            ) as usize
         },
         8usize,
         concat!(

--- a/tests/expectations/tests/c_naming.rs
+++ b/tests/expectations/tests/c_naming.rs
@@ -23,7 +23,9 @@ fn bindgen_test_layout_struct_a() {
         concat!("Alignment of ", stringify!(struct_a))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<struct_a>())).a as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<struct_a>())).a) as usize
+        },
         0usize,
         concat!(
             "Offset of field: ",
@@ -53,7 +55,9 @@ fn bindgen_test_layout_union_b() {
         concat!("Alignment of ", stringify!(union_b))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<union_b>())).a as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<union_b>())).a) as usize
+        },
         0usize,
         concat!(
             "Offset of field: ",
@@ -63,7 +67,9 @@ fn bindgen_test_layout_union_b() {
         )
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<union_b>())).b as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<union_b>())).b) as usize
+        },
         0usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/canonical-types.rs
+++ b/tests/expectations/tests/canonical-types.rs
@@ -178,7 +178,8 @@ fn bindgen_test_layout_ClassAInner() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<ClassAInner>())).x as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<ClassAInner>())).x)
+                as usize
         },
         0usize,
         concat!(
@@ -217,7 +218,8 @@ fn bindgen_test_layout_ClassCInnerA() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<ClassCInnerA>())).member as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<ClassCInnerA>())).member)
+                as usize
         },
         0usize,
         concat!(
@@ -256,7 +258,8 @@ fn bindgen_test_layout_ClassCInnerB() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<ClassCInnerB>())).cache as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<ClassCInnerB>())).cache)
+                as usize
         },
         0usize,
         concat!(

--- a/tests/expectations/tests/char.rs
+++ b/tests/expectations/tests/char.rs
@@ -37,52 +37,72 @@ fn bindgen_test_layout_Test() {
         concat!("Alignment of ", stringify!(Test))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Test>())).ch as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<Test>())).ch) as usize
+        },
         0usize,
         concat!("Offset of field: ", stringify!(Test), "::", stringify!(ch))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Test>())).u as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<Test>())).u) as usize
+        },
         1usize,
         concat!("Offset of field: ", stringify!(Test), "::", stringify!(u))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Test>())).d as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<Test>())).d) as usize
+        },
         2usize,
         concat!("Offset of field: ", stringify!(Test), "::", stringify!(d))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Test>())).cch as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<Test>())).cch) as usize
+        },
         3usize,
         concat!("Offset of field: ", stringify!(Test), "::", stringify!(cch))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Test>())).cu as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<Test>())).cu) as usize
+        },
         4usize,
         concat!("Offset of field: ", stringify!(Test), "::", stringify!(cu))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Test>())).cd as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<Test>())).cd) as usize
+        },
         5usize,
         concat!("Offset of field: ", stringify!(Test), "::", stringify!(cd))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Test>())).Cch as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<Test>())).Cch) as usize
+        },
         6usize,
         concat!("Offset of field: ", stringify!(Test), "::", stringify!(Cch))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Test>())).Cu as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<Test>())).Cu) as usize
+        },
         7usize,
         concat!("Offset of field: ", stringify!(Test), "::", stringify!(Cu))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Test>())).Cd as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<Test>())).Cd) as usize
+        },
         8usize,
         concat!("Offset of field: ", stringify!(Test), "::", stringify!(Cd))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Test>())).Ccch as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<Test>())).Ccch) as usize
+        },
         9usize,
         concat!(
             "Offset of field: ",
@@ -92,12 +112,16 @@ fn bindgen_test_layout_Test() {
         )
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Test>())).Ccu as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<Test>())).Ccu) as usize
+        },
         10usize,
         concat!("Offset of field: ", stringify!(Test), "::", stringify!(Ccu))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Test>())).Ccd as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<Test>())).Ccd) as usize
+        },
         11usize,
         concat!("Offset of field: ", stringify!(Test), "::", stringify!(Ccd))
     );

--- a/tests/expectations/tests/class_nested.rs
+++ b/tests/expectations/tests/class_nested.rs
@@ -29,7 +29,8 @@ fn bindgen_test_layout_A_B() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<A_B>())).member_b as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<A_B>())).member_b)
+                as usize
         },
         0usize,
         concat!(
@@ -68,7 +69,9 @@ fn bindgen_test_layout_A() {
         concat!("Alignment of ", stringify!(A))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<A>())).member_a as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<A>())).member_a) as usize
+        },
         0usize,
         concat!(
             "Offset of field: ",
@@ -96,7 +99,9 @@ fn bindgen_test_layout_A_C() {
         concat!("Alignment of ", stringify!(A_C))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<A_C>())).baz as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<A_C>())).baz) as usize
+        },
         0usize,
         concat!("Offset of field: ", stringify!(A_C), "::", stringify!(baz))
     );
@@ -144,7 +149,9 @@ fn bindgen_test_layout_D() {
         concat!("Alignment of ", stringify!(D))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<D>())).member as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<D>())).member) as usize
+        },
         0usize,
         concat!("Offset of field: ", stringify!(D), "::", stringify!(member))
     );

--- a/tests/expectations/tests/class_no_members.rs
+++ b/tests/expectations/tests/class_no_members.rs
@@ -60,8 +60,9 @@ fn bindgen_test_layout_whatever_child_with_member() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<whatever_child_with_member>())).m_member
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<whatever_child_with_member>())).m_member
+            ) as usize
         },
         0usize,
         concat!(

--- a/tests/expectations/tests/class_use_as.rs
+++ b/tests/expectations/tests/class_use_as.rs
@@ -25,8 +25,9 @@ fn bindgen_test_layout_whatever() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<whatever>())).replacement as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<whatever>())).replacement
+            ) as usize
         },
         0usize,
         concat!(
@@ -55,7 +56,10 @@ fn bindgen_test_layout_container() {
         concat!("Alignment of ", stringify!(container))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<container>())).c as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<container>())).c)
+                as usize
+        },
         0usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/class_with_dtor.rs
+++ b/tests/expectations/tests/class_with_dtor.rs
@@ -40,8 +40,9 @@ fn bindgen_test_layout_WithoutDtor() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<WithoutDtor>())).shouldBeWithDtor as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<WithoutDtor>())).shouldBeWithDtor
+            ) as usize
         },
         0usize,
         concat!(

--- a/tests/expectations/tests/class_with_inner_struct.rs
+++ b/tests/expectations/tests/class_with_inner_struct.rs
@@ -32,7 +32,8 @@ fn bindgen_test_layout_A_Segment() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<A_Segment>())).begin as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<A_Segment>())).begin)
+                as usize
         },
         0usize,
         concat!(
@@ -44,7 +45,8 @@ fn bindgen_test_layout_A_Segment() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<A_Segment>())).end as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<A_Segment>())).end)
+                as usize
         },
         4usize,
         concat!(
@@ -74,7 +76,8 @@ fn bindgen_test_layout_A__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<A__bindgen_ty_1>())).f as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<A__bindgen_ty_1>())).f)
+                as usize
         },
         0usize,
         concat!(
@@ -113,7 +116,8 @@ fn bindgen_test_layout_A__bindgen_ty_2() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<A__bindgen_ty_2>())).d as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<A__bindgen_ty_2>())).d)
+                as usize
         },
         0usize,
         concat!(
@@ -146,13 +150,16 @@ fn bindgen_test_layout_A() {
         concat!("Alignment of ", stringify!(A))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<A>())).c as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<A>())).c) as usize
+        },
         0usize,
         concat!("Offset of field: ", stringify!(A), "::", stringify!(c))
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<A>())).named_union as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<A>())).named_union)
+                as usize
         },
         4usize,
         concat!(
@@ -197,7 +204,8 @@ fn bindgen_test_layout_B_Segment() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<B_Segment>())).begin as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<B_Segment>())).begin)
+                as usize
         },
         0usize,
         concat!(
@@ -209,7 +217,8 @@ fn bindgen_test_layout_B_Segment() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<B_Segment>())).end as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<B_Segment>())).end)
+                as usize
         },
         4usize,
         concat!(
@@ -233,7 +242,9 @@ fn bindgen_test_layout_B() {
         concat!("Alignment of ", stringify!(B))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<B>())).d as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<B>())).d) as usize
+        },
         0usize,
         concat!("Offset of field: ", stringify!(B), "::", stringify!(d))
     );
@@ -280,8 +291,9 @@ fn bindgen_test_layout_C__bindgen_ty_1__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<C__bindgen_ty_1__bindgen_ty_1>())).mX1
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<C__bindgen_ty_1__bindgen_ty_1>())).mX1
+            ) as usize
         },
         0usize,
         concat!(
@@ -293,8 +305,9 @@ fn bindgen_test_layout_C__bindgen_ty_1__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<C__bindgen_ty_1__bindgen_ty_1>())).mY1
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<C__bindgen_ty_1__bindgen_ty_1>())).mY1
+            ) as usize
         },
         4usize,
         concat!(
@@ -306,8 +319,9 @@ fn bindgen_test_layout_C__bindgen_ty_1__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<C__bindgen_ty_1__bindgen_ty_1>())).mX2
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<C__bindgen_ty_1__bindgen_ty_1>())).mX2
+            ) as usize
         },
         8usize,
         concat!(
@@ -319,8 +333,9 @@ fn bindgen_test_layout_C__bindgen_ty_1__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<C__bindgen_ty_1__bindgen_ty_1>())).mY2
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<C__bindgen_ty_1__bindgen_ty_1>())).mY2
+            ) as usize
         },
         12usize,
         concat!(
@@ -351,8 +366,10 @@ fn bindgen_test_layout_C__bindgen_ty_1__bindgen_ty_2() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<C__bindgen_ty_1__bindgen_ty_2>()))
-                .mStepSyntax as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<C__bindgen_ty_1__bindgen_ty_2>()))
+                    .mStepSyntax
+            ) as usize
         },
         0usize,
         concat!(
@@ -364,8 +381,9 @@ fn bindgen_test_layout_C__bindgen_ty_1__bindgen_ty_2() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<C__bindgen_ty_1__bindgen_ty_2>())).mSteps
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<C__bindgen_ty_1__bindgen_ty_2>())).mSteps
+            ) as usize
         },
         4usize,
         concat!(
@@ -399,8 +417,9 @@ fn bindgen_test_layout_C__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<C__bindgen_ty_1>())).mFunc as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<C__bindgen_ty_1>())).mFunc
+            ) as usize
         },
         0usize,
         concat!(
@@ -440,7 +459,8 @@ fn bindgen_test_layout_C_Segment() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<C_Segment>())).begin as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<C_Segment>())).begin)
+                as usize
         },
         0usize,
         concat!(
@@ -452,7 +472,8 @@ fn bindgen_test_layout_C_Segment() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<C_Segment>())).end as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<C_Segment>())).end)
+                as usize
         },
         4usize,
         concat!(
@@ -476,7 +497,9 @@ fn bindgen_test_layout_C() {
         concat!("Alignment of ", stringify!(C))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<C>())).d as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<C>())).d) as usize
+        },
         0usize,
         concat!("Offset of field: ", stringify!(C), "::", stringify!(d))
     );

--- a/tests/expectations/tests/class_with_inner_struct_1_0.rs
+++ b/tests/expectations/tests/class_with_inner_struct_1_0.rs
@@ -75,7 +75,8 @@ fn bindgen_test_layout_A_Segment() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<A_Segment>())).begin as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<A_Segment>())).begin)
+                as usize
         },
         0usize,
         concat!(
@@ -87,7 +88,8 @@ fn bindgen_test_layout_A_Segment() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<A_Segment>())).end as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<A_Segment>())).end)
+                as usize
         },
         4usize,
         concat!(
@@ -123,7 +125,8 @@ fn bindgen_test_layout_A__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<A__bindgen_ty_1>())).f as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<A__bindgen_ty_1>())).f)
+                as usize
         },
         0usize,
         concat!(
@@ -159,7 +162,8 @@ fn bindgen_test_layout_A__bindgen_ty_2() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<A__bindgen_ty_2>())).d as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<A__bindgen_ty_2>())).d)
+                as usize
         },
         0usize,
         concat!(
@@ -188,13 +192,16 @@ fn bindgen_test_layout_A() {
         concat!("Alignment of ", stringify!(A))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<A>())).c as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<A>())).c) as usize
+        },
         0usize,
         concat!("Offset of field: ", stringify!(A), "::", stringify!(c))
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<A>())).named_union as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<A>())).named_union)
+                as usize
         },
         4usize,
         concat!(
@@ -235,7 +242,8 @@ fn bindgen_test_layout_B_Segment() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<B_Segment>())).begin as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<B_Segment>())).begin)
+                as usize
         },
         0usize,
         concat!(
@@ -247,7 +255,8 @@ fn bindgen_test_layout_B_Segment() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<B_Segment>())).end as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<B_Segment>())).end)
+                as usize
         },
         4usize,
         concat!(
@@ -276,7 +285,9 @@ fn bindgen_test_layout_B() {
         concat!("Alignment of ", stringify!(B))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<B>())).d as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<B>())).d) as usize
+        },
         0usize,
         concat!("Offset of field: ", stringify!(B), "::", stringify!(d))
     );
@@ -329,8 +340,9 @@ fn bindgen_test_layout_C__bindgen_ty_1__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<C__bindgen_ty_1__bindgen_ty_1>())).mX1
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<C__bindgen_ty_1__bindgen_ty_1>())).mX1
+            ) as usize
         },
         0usize,
         concat!(
@@ -342,8 +354,9 @@ fn bindgen_test_layout_C__bindgen_ty_1__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<C__bindgen_ty_1__bindgen_ty_1>())).mY1
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<C__bindgen_ty_1__bindgen_ty_1>())).mY1
+            ) as usize
         },
         4usize,
         concat!(
@@ -355,8 +368,9 @@ fn bindgen_test_layout_C__bindgen_ty_1__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<C__bindgen_ty_1__bindgen_ty_1>())).mX2
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<C__bindgen_ty_1__bindgen_ty_1>())).mX2
+            ) as usize
         },
         8usize,
         concat!(
@@ -368,8 +382,9 @@ fn bindgen_test_layout_C__bindgen_ty_1__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<C__bindgen_ty_1__bindgen_ty_1>())).mY2
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<C__bindgen_ty_1__bindgen_ty_1>())).mY2
+            ) as usize
         },
         12usize,
         concat!(
@@ -405,8 +420,10 @@ fn bindgen_test_layout_C__bindgen_ty_1__bindgen_ty_2() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<C__bindgen_ty_1__bindgen_ty_2>()))
-                .mStepSyntax as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<C__bindgen_ty_1__bindgen_ty_2>()))
+                    .mStepSyntax
+            ) as usize
         },
         0usize,
         concat!(
@@ -418,8 +435,9 @@ fn bindgen_test_layout_C__bindgen_ty_1__bindgen_ty_2() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<C__bindgen_ty_1__bindgen_ty_2>())).mSteps
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<C__bindgen_ty_1__bindgen_ty_2>())).mSteps
+            ) as usize
         },
         4usize,
         concat!(
@@ -458,8 +476,9 @@ fn bindgen_test_layout_C__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<C__bindgen_ty_1>())).mFunc as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<C__bindgen_ty_1>())).mFunc
+            ) as usize
         },
         0usize,
         concat!(
@@ -495,7 +514,8 @@ fn bindgen_test_layout_C_Segment() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<C_Segment>())).begin as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<C_Segment>())).begin)
+                as usize
         },
         0usize,
         concat!(
@@ -507,7 +527,8 @@ fn bindgen_test_layout_C_Segment() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<C_Segment>())).end as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<C_Segment>())).end)
+                as usize
         },
         4usize,
         concat!(
@@ -536,7 +557,9 @@ fn bindgen_test_layout_C() {
         concat!("Alignment of ", stringify!(C))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<C>())).d as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<C>())).d) as usize
+        },
         0usize,
         concat!("Offset of field: ", stringify!(C), "::", stringify!(d))
     );

--- a/tests/expectations/tests/class_with_typedef.rs
+++ b/tests/expectations/tests/class_with_typedef.rs
@@ -30,27 +30,38 @@ fn bindgen_test_layout_C() {
         concat!("Alignment of ", stringify!(C))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<C>())).c as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<C>())).c) as usize
+        },
         0usize,
         concat!("Offset of field: ", stringify!(C), "::", stringify!(c))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<C>())).ptr as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<C>())).ptr) as usize
+        },
         8usize,
         concat!("Offset of field: ", stringify!(C), "::", stringify!(ptr))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<C>())).arr as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<C>())).arr) as usize
+        },
         16usize,
         concat!("Offset of field: ", stringify!(C), "::", stringify!(arr))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<C>())).d as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<C>())).d) as usize
+        },
         56usize,
         concat!("Offset of field: ", stringify!(C), "::", stringify!(d))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<C>())).other_ptr as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<C>())).other_ptr)
+                as usize
+        },
         64usize,
         concat!(
             "Offset of field: ",
@@ -122,7 +133,9 @@ fn bindgen_test_layout_D() {
         concat!("Alignment of ", stringify!(D))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<D>())).ptr as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<D>())).ptr) as usize
+        },
         72usize,
         concat!("Offset of field: ", stringify!(D), "::", stringify!(ptr))
     );

--- a/tests/expectations/tests/comment-indent.rs
+++ b/tests/expectations/tests/comment-indent.rs
@@ -82,7 +82,8 @@ pub mod root {
             );
             assert_eq!(
                 unsafe {
-                    &(*(::std::ptr::null::<Baz>())).member as *const _ as usize
+                    ::std::ptr::addr_of!((*(::std::ptr::null::<Baz>())).member)
+                        as usize
                 },
                 0usize,
                 concat!(

--- a/tests/expectations/tests/complex.rs
+++ b/tests/expectations/tests/complex.rs
@@ -30,7 +30,8 @@ fn bindgen_test_layout_TestDouble() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<TestDouble>())).mMember as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<TestDouble>())).mMember)
+                as usize
         },
         0usize,
         concat!(
@@ -60,8 +61,9 @@ fn bindgen_test_layout_TestDoublePtr() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<TestDoublePtr>())).mMember as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<TestDoublePtr>())).mMember
+            ) as usize
         },
         0usize,
         concat!(
@@ -100,7 +102,8 @@ fn bindgen_test_layout_TestFloat() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<TestFloat>())).mMember as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<TestFloat>())).mMember)
+                as usize
         },
         0usize,
         concat!(
@@ -130,8 +133,9 @@ fn bindgen_test_layout_TestFloatPtr() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<TestFloatPtr>())).mMember as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<TestFloatPtr>())).mMember
+            ) as usize
         },
         0usize,
         concat!(

--- a/tests/expectations/tests/const-const-mut-ptr.rs
+++ b/tests/expectations/tests/const-const-mut-ptr.rs
@@ -23,7 +23,9 @@ fn bindgen_test_layout_foo() {
         concat!("Alignment of ", stringify!(foo))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<foo>())).bar as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<foo>())).bar) as usize
+        },
         0usize,
         concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar))
     );

--- a/tests/expectations/tests/constified-enum-module-overflow.rs
+++ b/tests/expectations/tests/constified-enum-module-overflow.rs
@@ -34,7 +34,9 @@ fn bindgen_test_layout_A() {
         concat!("Alignment of ", stringify!(A))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<A>())).u as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<A>())).u) as usize
+        },
         0usize,
         concat!("Offset of field: ", stringify!(A), "::", stringify!(u))
     );

--- a/tests/expectations/tests/constify-all-enums.rs
+++ b/tests/expectations/tests/constify-all-enums.rs
@@ -28,8 +28,9 @@ fn bindgen_test_layout_bar() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<bar>())).this_should_work as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<bar>())).this_should_work
+            ) as usize
         },
         0usize,
         concat!(

--- a/tests/expectations/tests/constify-module-enums-basic.rs
+++ b/tests/expectations/tests/constify-module-enums-basic.rs
@@ -32,8 +32,9 @@ fn bindgen_test_layout_bar() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<bar>())).this_should_work as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<bar>())).this_should_work
+            ) as usize
         },
         0usize,
         concat!(

--- a/tests/expectations/tests/constify-module-enums-namespace.rs
+++ b/tests/expectations/tests/constify-module-enums-namespace.rs
@@ -44,8 +44,9 @@ pub mod root {
                 );
                 assert_eq!(
                     unsafe {
-                        &(*(::std::ptr::null::<bar>())).this_should_work
-                            as *const _ as usize
+                        ::std::ptr::addr_of!(
+                            (*(::std::ptr::null::<bar>())).this_should_work
+                        ) as usize
                     },
                     0usize,
                     concat!(

--- a/tests/expectations/tests/constify-module-enums-shadow-name.rs
+++ b/tests/expectations/tests/constify-module-enums-shadow-name.rs
@@ -30,7 +30,9 @@ fn bindgen_test_layout_bar() {
         concat!("Alignment of ", stringify!(bar))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<bar>())).member as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<bar>())).member) as usize
+        },
         0usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/constify-module-enums-simple-alias.rs
+++ b/tests/expectations/tests/constify-module-enums-simple-alias.rs
@@ -39,28 +39,37 @@ fn bindgen_test_layout_Bar() {
         concat!("Alignment of ", stringify!(Bar))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Bar>())).baz1 as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<Bar>())).baz1) as usize
+        },
         0usize,
         concat!("Offset of field: ", stringify!(Bar), "::", stringify!(baz1))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Bar>())).baz2 as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<Bar>())).baz2) as usize
+        },
         4usize,
         concat!("Offset of field: ", stringify!(Bar), "::", stringify!(baz2))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Bar>())).baz3 as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<Bar>())).baz3) as usize
+        },
         8usize,
         concat!("Offset of field: ", stringify!(Bar), "::", stringify!(baz3))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Bar>())).baz4 as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<Bar>())).baz4) as usize
+        },
         12usize,
         concat!("Offset of field: ", stringify!(Bar), "::", stringify!(baz4))
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<Bar>())).baz_ptr1 as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<Bar>())).baz_ptr1)
+                as usize
         },
         16usize,
         concat!(
@@ -72,7 +81,8 @@ fn bindgen_test_layout_Bar() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<Bar>())).baz_ptr2 as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<Bar>())).baz_ptr2)
+                as usize
         },
         24usize,
         concat!(
@@ -84,7 +94,8 @@ fn bindgen_test_layout_Bar() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<Bar>())).baz_ptr3 as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<Bar>())).baz_ptr3)
+                as usize
         },
         32usize,
         concat!(
@@ -96,7 +107,8 @@ fn bindgen_test_layout_Bar() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<Bar>())).baz_ptr4 as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<Bar>())).baz_ptr4)
+                as usize
         },
         40usize,
         concat!(

--- a/tests/expectations/tests/constify-module-enums-simple-nonamespace.rs
+++ b/tests/expectations/tests/constify-module-enums-simple-nonamespace.rs
@@ -29,12 +29,16 @@ fn bindgen_test_layout_Bar() {
         concat!("Alignment of ", stringify!(Bar))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Bar>())).baz1 as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<Bar>())).baz1) as usize
+        },
         0usize,
         concat!("Offset of field: ", stringify!(Bar), "::", stringify!(baz1))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Bar>())).baz2 as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<Bar>())).baz2) as usize
+        },
         8usize,
         concat!("Offset of field: ", stringify!(Bar), "::", stringify!(baz2))
     );

--- a/tests/expectations/tests/constify-module-enums-types.rs
+++ b/tests/expectations/tests/constify-module-enums-types.rs
@@ -64,7 +64,10 @@ fn bindgen_test_layout_bar() {
         concat!("Alignment of ", stringify!(bar))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<bar>())).member1 as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<bar>())).member1)
+                as usize
+        },
         0usize,
         concat!(
             "Offset of field: ",
@@ -74,7 +77,10 @@ fn bindgen_test_layout_bar() {
         )
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<bar>())).member2 as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<bar>())).member2)
+                as usize
+        },
         4usize,
         concat!(
             "Offset of field: ",
@@ -84,7 +90,10 @@ fn bindgen_test_layout_bar() {
         )
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<bar>())).member3 as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<bar>())).member3)
+                as usize
+        },
         8usize,
         concat!(
             "Offset of field: ",
@@ -94,7 +103,10 @@ fn bindgen_test_layout_bar() {
         )
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<bar>())).member4 as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<bar>())).member4)
+                as usize
+        },
         12usize,
         concat!(
             "Offset of field: ",
@@ -104,7 +116,10 @@ fn bindgen_test_layout_bar() {
         )
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<bar>())).member5 as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<bar>())).member5)
+                as usize
+        },
         16usize,
         concat!(
             "Offset of field: ",
@@ -114,7 +129,10 @@ fn bindgen_test_layout_bar() {
         )
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<bar>())).member6 as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<bar>())).member6)
+                as usize
+        },
         24usize,
         concat!(
             "Offset of field: ",
@@ -124,7 +142,10 @@ fn bindgen_test_layout_bar() {
         )
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<bar>())).member7 as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<bar>())).member7)
+                as usize
+        },
         32usize,
         concat!(
             "Offset of field: ",
@@ -134,7 +155,10 @@ fn bindgen_test_layout_bar() {
         )
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<bar>())).member8 as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<bar>())).member8)
+                as usize
+        },
         36usize,
         concat!(
             "Offset of field: ",
@@ -144,7 +168,10 @@ fn bindgen_test_layout_bar() {
         )
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<bar>())).member9 as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<bar>())).member9)
+                as usize
+        },
         40usize,
         concat!(
             "Offset of field: ",
@@ -155,7 +182,8 @@ fn bindgen_test_layout_bar() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<bar>())).member10 as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<bar>())).member10)
+                as usize
         },
         44usize,
         concat!(
@@ -193,7 +221,10 @@ fn bindgen_test_layout_Baz() {
         concat!("Alignment of ", stringify!(Baz))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Baz>())).member1 as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<Baz>())).member1)
+                as usize
+        },
         0usize,
         concat!(
             "Offset of field: ",
@@ -235,7 +266,9 @@ fn bindgen_test_layout_Bar() {
         concat!("Alignment of ", stringify!(Bar))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Bar>())).baz as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<Bar>())).baz) as usize
+        },
         0usize,
         concat!("Offset of field: ", stringify!(Bar), "::", stringify!(baz))
     );

--- a/tests/expectations/tests/contains-vs-inherits-zero-sized.rs
+++ b/tests/expectations/tests/contains-vs-inherits-zero-sized.rs
@@ -44,7 +44,9 @@ fn bindgen_test_layout_Inherits() {
         concat!("Alignment of ", stringify!(Inherits))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Inherits>())).b as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<Inherits>())).b) as usize
+        },
         0usize,
         concat!(
             "Offset of field: ",
@@ -76,7 +78,8 @@ fn bindgen_test_layout_Contains() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<Contains>())).empty as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<Contains>())).empty)
+                as usize
         },
         0usize,
         concat!(
@@ -87,7 +90,9 @@ fn bindgen_test_layout_Contains() {
         )
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Contains>())).b as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<Contains>())).b) as usize
+        },
         1usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/convert-floats.rs
+++ b/tests/expectations/tests/convert-floats.rs
@@ -34,22 +34,30 @@ fn bindgen_test_layout_foo() {
         concat!("Alignment of ", stringify!(foo))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<foo>())).bar as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<foo>())).bar) as usize
+        },
         0usize,
         concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<foo>())).baz as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<foo>())).baz) as usize
+        },
         4usize,
         concat!("Offset of field: ", stringify!(foo), "::", stringify!(baz))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<foo>())).bazz as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<foo>())).bazz) as usize
+        },
         8usize,
         concat!("Offset of field: ", stringify!(foo), "::", stringify!(bazz))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<foo>())).bazzz as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<foo>())).bazzz) as usize
+        },
         16usize,
         concat!(
             "Offset of field: ",
@@ -60,7 +68,8 @@ fn bindgen_test_layout_foo() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<foo>())).complexFloat as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<foo>())).complexFloat)
+                as usize
         },
         24usize,
         concat!(
@@ -72,7 +81,8 @@ fn bindgen_test_layout_foo() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<foo>())).complexDouble as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<foo>())).complexDouble)
+                as usize
         },
         32usize,
         concat!(

--- a/tests/expectations/tests/ctypes-prefix-path.rs
+++ b/tests/expectations/tests/ctypes-prefix-path.rs
@@ -32,17 +32,23 @@ fn bindgen_test_layout_foo() {
         concat!("Alignment of ", stringify!(foo))
     );
     assert_eq!(
-        unsafe { &(*(::core::ptr::null::<foo>())).a as *const _ as usize },
+        unsafe {
+            ::core::ptr::addr_of!((*(::core::ptr::null::<foo>())).a) as usize
+        },
         0usize,
         concat!("Offset of field: ", stringify!(foo), "::", stringify!(a))
     );
     assert_eq!(
-        unsafe { &(*(::core::ptr::null::<foo>())).b as *const _ as usize },
+        unsafe {
+            ::core::ptr::addr_of!((*(::core::ptr::null::<foo>())).b) as usize
+        },
         4usize,
         concat!("Offset of field: ", stringify!(foo), "::", stringify!(b))
     );
     assert_eq!(
-        unsafe { &(*(::core::ptr::null::<foo>())).bar as *const _ as usize },
+        unsafe {
+            ::core::ptr::addr_of!((*(::core::ptr::null::<foo>())).bar) as usize
+        },
         8usize,
         concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar))
     );

--- a/tests/expectations/tests/derive-bitfield-method-same-name.rs
+++ b/tests/expectations/tests/derive-bitfield-method-same-name.rs
@@ -115,7 +115,9 @@ fn bindgen_test_layout_Foo() {
         concat!("Alignment of ", stringify!(Foo))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Foo>())).large as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<Foo>())).large) as usize
+        },
         0usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/derive-clone.rs
+++ b/tests/expectations/tests/derive-clone.rs
@@ -25,8 +25,9 @@ fn bindgen_test_layout_ShouldDeriveClone() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<ShouldDeriveClone>())).large as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<ShouldDeriveClone>())).large
+            ) as usize
         },
         0usize,
         concat!(

--- a/tests/expectations/tests/derive-clone_1_0.rs
+++ b/tests/expectations/tests/derive-clone_1_0.rs
@@ -26,8 +26,9 @@ fn bindgen_test_layout_ShouldImplClone() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<ShouldImplClone>())).large as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<ShouldImplClone>())).large
+            ) as usize
         },
         0usize,
         concat!(

--- a/tests/expectations/tests/derive-debug-bitfield-core.rs
+++ b/tests/expectations/tests/derive-debug-bitfield-core.rs
@@ -114,7 +114,8 @@ fn bindgen_test_layout_C() {
     );
     assert_eq!(
         unsafe {
-            &(*(::core::ptr::null::<C>())).large_array as *const _ as usize
+            ::core::ptr::addr_of!((*(::core::ptr::null::<C>())).large_array)
+                as usize
         },
         4usize,
         concat!(

--- a/tests/expectations/tests/derive-debug-bitfield.rs
+++ b/tests/expectations/tests/derive-debug-bitfield.rs
@@ -112,7 +112,8 @@ fn bindgen_test_layout_C() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<C>())).large_array as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<C>())).large_array)
+                as usize
         },
         4usize,
         concat!(

--- a/tests/expectations/tests/derive-debug-function-pointer.rs
+++ b/tests/expectations/tests/derive-debug-function-pointer.rs
@@ -27,7 +27,8 @@ fn bindgen_test_layout_Nice() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<Nice>())).pointer as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<Nice>())).pointer)
+                as usize
         },
         0usize,
         concat!(
@@ -39,7 +40,8 @@ fn bindgen_test_layout_Nice() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<Nice>())).large_array as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<Nice>())).large_array)
+                as usize
         },
         8usize,
         concat!(

--- a/tests/expectations/tests/derive-debug-mangle-name.rs
+++ b/tests/expectations/tests/derive-debug-mangle-name.rs
@@ -32,8 +32,9 @@ fn bindgen_test_layout_perf_event_attr__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<perf_event_attr__bindgen_ty_1>())).b
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<perf_event_attr__bindgen_ty_1>())).b
+            ) as usize
         },
         0usize,
         concat!(
@@ -45,8 +46,9 @@ fn bindgen_test_layout_perf_event_attr__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<perf_event_attr__bindgen_ty_1>())).c
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<perf_event_attr__bindgen_ty_1>())).c
+            ) as usize
         },
         0usize,
         concat!(
@@ -85,8 +87,9 @@ fn bindgen_test_layout_perf_event_attr() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<perf_event_attr>())).type_ as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<perf_event_attr>())).type_
+            ) as usize
         },
         0usize,
         concat!(
@@ -98,7 +101,8 @@ fn bindgen_test_layout_perf_event_attr() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<perf_event_attr>())).a as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<perf_event_attr>())).a)
+                as usize
         },
         4usize,
         concat!(

--- a/tests/expectations/tests/derive-debug-opaque-template-instantiation.rs
+++ b/tests/expectations/tests/derive-debug-opaque-template-instantiation.rs
@@ -23,7 +23,8 @@ fn bindgen_test_layout_Instance() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<Instance>())).val as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<Instance>())).val)
+                as usize
         },
         0usize,
         concat!(

--- a/tests/expectations/tests/derive-debug-opaque.rs
+++ b/tests/expectations/tests/derive-debug-opaque.rs
@@ -55,7 +55,8 @@ fn bindgen_test_layout_OpaqueUser() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<OpaqueUser>())).opaque as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<OpaqueUser>())).opaque)
+                as usize
         },
         0usize,
         concat!(

--- a/tests/expectations/tests/derive-default-and-blocklist.rs
+++ b/tests/expectations/tests/derive-default-and-blocklist.rs
@@ -27,8 +27,9 @@ fn bindgen_test_layout_ShouldNotDeriveDefault() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<ShouldNotDeriveDefault>())).a as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<ShouldNotDeriveDefault>())).a
+            ) as usize
         },
         0usize,
         concat!(

--- a/tests/expectations/tests/derive-fn-ptr.rs
+++ b/tests/expectations/tests/derive-fn-ptr.rs
@@ -44,7 +44,8 @@ fn bindgen_test_layout_Foo() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<Foo>())).callback as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<Foo>())).callback)
+                as usize
         },
         0usize,
         concat!(
@@ -90,7 +91,8 @@ fn bindgen_test_layout_Bar() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<Bar>())).callback as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<Bar>())).callback)
+                as usize
         },
         0usize,
         concat!(

--- a/tests/expectations/tests/derive-hash-and-blocklist.rs
+++ b/tests/expectations/tests/derive-hash-and-blocklist.rs
@@ -26,8 +26,9 @@ fn bindgen_test_layout_ShouldNotDeriveHash() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<ShouldNotDeriveHash>())).a as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<ShouldNotDeriveHash>())).a
+            ) as usize
         },
         0usize,
         concat!(

--- a/tests/expectations/tests/derive-hash-blocklisting.rs
+++ b/tests/expectations/tests/derive-hash-blocklisting.rs
@@ -32,7 +32,8 @@ fn bindgen_test_layout_AllowlistedOne() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<AllowlistedOne>())).a as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<AllowlistedOne>())).a)
+                as usize
         },
         0usize,
         concat!(
@@ -71,7 +72,8 @@ fn bindgen_test_layout_AllowlistedTwo() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<AllowlistedTwo>())).b as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<AllowlistedTwo>())).b)
+                as usize
         },
         0usize,
         concat!(

--- a/tests/expectations/tests/derive-hash-struct-with-anon-struct-float.rs
+++ b/tests/expectations/tests/derive-hash-struct-with-anon-struct-float.rs
@@ -31,7 +31,8 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<foo__bindgen_ty_1>())).a as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<foo__bindgen_ty_1>())).a)
+                as usize
         },
         0usize,
         concat!(
@@ -43,7 +44,8 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<foo__bindgen_ty_1>())).b as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<foo__bindgen_ty_1>())).b)
+                as usize
         },
         4usize,
         concat!(
@@ -67,7 +69,9 @@ fn bindgen_test_layout_foo() {
         concat!("Alignment of ", stringify!(foo))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<foo>())).bar as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<foo>())).bar) as usize
+        },
         0usize,
         concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar))
     );

--- a/tests/expectations/tests/derive-hash-struct-with-float-array.rs
+++ b/tests/expectations/tests/derive-hash-struct-with-float-array.rs
@@ -24,7 +24,9 @@ fn bindgen_test_layout_foo() {
         concat!("Alignment of ", stringify!(foo))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<foo>())).bar as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<foo>())).bar) as usize
+        },
         0usize,
         concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar))
     );

--- a/tests/expectations/tests/derive-hash-struct-with-pointer.rs
+++ b/tests/expectations/tests/derive-hash-struct-with-pointer.rs
@@ -25,7 +25,8 @@ fn bindgen_test_layout_ConstPtrMutObj() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<ConstPtrMutObj>())).bar as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<ConstPtrMutObj>())).bar)
+                as usize
         },
         0usize,
         concat!(
@@ -64,7 +65,8 @@ fn bindgen_test_layout_MutPtrMutObj() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<MutPtrMutObj>())).bar as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<MutPtrMutObj>())).bar)
+                as usize
         },
         0usize,
         concat!(
@@ -103,7 +105,8 @@ fn bindgen_test_layout_MutPtrConstObj() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<MutPtrConstObj>())).bar as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<MutPtrConstObj>())).bar)
+                as usize
         },
         0usize,
         concat!(
@@ -142,8 +145,9 @@ fn bindgen_test_layout_ConstPtrConstObj() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<ConstPtrConstObj>())).bar as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<ConstPtrConstObj>())).bar
+            ) as usize
         },
         0usize,
         concat!(

--- a/tests/expectations/tests/derive-hash-template-inst-float.rs
+++ b/tests/expectations/tests/derive-hash-template-inst-float.rs
@@ -40,7 +40,9 @@ fn bindgen_test_layout_IntStr() {
         concat!("Alignment of ", stringify!(IntStr))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<IntStr>())).a as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<IntStr>())).a) as usize
+        },
         0usize,
         concat!("Offset of field: ", stringify!(IntStr), "::", stringify!(a))
     );
@@ -73,7 +75,9 @@ fn bindgen_test_layout_FloatStr() {
         concat!("Alignment of ", stringify!(FloatStr))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<FloatStr>())).a as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<FloatStr>())).a) as usize
+        },
         0usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/derive-partialeq-and-blocklist.rs
+++ b/tests/expectations/tests/derive-partialeq-and-blocklist.rs
@@ -27,8 +27,9 @@ fn bindgen_test_layout_ShouldNotDerivePartialEq() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<ShouldNotDerivePartialEq>())).a as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<ShouldNotDerivePartialEq>())).a
+            ) as usize
         },
         0usize,
         concat!(

--- a/tests/expectations/tests/derive-partialeq-base.rs
+++ b/tests/expectations/tests/derive-partialeq-base.rs
@@ -23,7 +23,9 @@ fn bindgen_test_layout_Base() {
         concat!("Alignment of ", stringify!(Base))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Base>())).large as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<Base>())).large) as usize
+        },
         0usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/derive-partialeq-bitfield.rs
+++ b/tests/expectations/tests/derive-partialeq-bitfield.rs
@@ -112,7 +112,8 @@ fn bindgen_test_layout_C() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<C>())).large_array as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<C>())).large_array)
+                as usize
         },
         4usize,
         concat!(

--- a/tests/expectations/tests/derive-partialeq-core.rs
+++ b/tests/expectations/tests/derive-partialeq-core.rs
@@ -26,7 +26,8 @@ fn bindgen_test_layout_C() {
     );
     assert_eq!(
         unsafe {
-            &(*(::core::ptr::null::<C>())).large_array as *const _ as usize
+            ::core::ptr::addr_of!((*(::core::ptr::null::<C>())).large_array)
+                as usize
         },
         0usize,
         concat!(

--- a/tests/expectations/tests/derive-partialeq-pointer.rs
+++ b/tests/expectations/tests/derive-partialeq-pointer.rs
@@ -23,7 +23,9 @@ fn bindgen_test_layout_Bar() {
         concat!("Alignment of ", stringify!(Bar))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Bar>())).b as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<Bar>())).b) as usize
+        },
         0usize,
         concat!("Offset of field: ", stringify!(Bar), "::", stringify!(b))
     );
@@ -109,7 +111,9 @@ fn bindgen_test_layout_a() {
         concat!("Alignment of ", stringify!(a))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<a>())).d as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<a>())).d) as usize
+        },
         0usize,
         concat!("Offset of field: ", stringify!(a), "::", stringify!(d))
     );

--- a/tests/expectations/tests/derive-partialeq-union.rs
+++ b/tests/expectations/tests/derive-partialeq-union.rs
@@ -26,8 +26,9 @@ fn bindgen_test_layout_ShouldNotDerivePartialEq() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<ShouldNotDerivePartialEq>())).a as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<ShouldNotDerivePartialEq>())).a
+            ) as usize
         },
         0usize,
         concat!(
@@ -39,8 +40,9 @@ fn bindgen_test_layout_ShouldNotDerivePartialEq() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<ShouldNotDerivePartialEq>())).b as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<ShouldNotDerivePartialEq>())).b
+            ) as usize
         },
         0usize,
         concat!(

--- a/tests/expectations/tests/derive-partialeq-union_1_0.rs
+++ b/tests/expectations/tests/derive-partialeq-union_1_0.rs
@@ -70,8 +70,9 @@ fn bindgen_test_layout_ShouldDerivePartialEq() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<ShouldDerivePartialEq>())).a as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<ShouldDerivePartialEq>())).a
+            ) as usize
         },
         0usize,
         concat!(
@@ -83,8 +84,9 @@ fn bindgen_test_layout_ShouldDerivePartialEq() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<ShouldDerivePartialEq>())).b as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<ShouldDerivePartialEq>())).b
+            ) as usize
         },
         0usize,
         concat!(

--- a/tests/expectations/tests/disable-nested-struct-naming.rs
+++ b/tests/expectations/tests/disable-nested-struct-naming.rs
@@ -46,7 +46,9 @@ fn bindgen_test_layout_bar4() {
         concat!("Alignment of ", stringify!(bar4))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<bar4>())).x4 as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<bar4>())).x4) as usize
+        },
         0usize,
         concat!("Offset of field: ", stringify!(bar4), "::", stringify!(x4))
     );
@@ -68,8 +70,9 @@ fn bindgen_test_layout_bar1__bindgen_ty_1__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<bar1__bindgen_ty_1__bindgen_ty_1>())).x3
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<bar1__bindgen_ty_1__bindgen_ty_1>())).x3
+            ) as usize
         },
         0usize,
         concat!(
@@ -81,8 +84,9 @@ fn bindgen_test_layout_bar1__bindgen_ty_1__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<bar1__bindgen_ty_1__bindgen_ty_1>())).b4
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<bar1__bindgen_ty_1__bindgen_ty_1>())).b4
+            ) as usize
         },
         4usize,
         concat!(
@@ -107,8 +111,9 @@ fn bindgen_test_layout_bar1__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<bar1__bindgen_ty_1>())).x2 as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<bar1__bindgen_ty_1>())).x2
+            ) as usize
         },
         0usize,
         concat!(
@@ -120,8 +125,9 @@ fn bindgen_test_layout_bar1__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<bar1__bindgen_ty_1>())).b3 as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<bar1__bindgen_ty_1>())).b3
+            ) as usize
         },
         4usize,
         concat!(
@@ -145,12 +151,16 @@ fn bindgen_test_layout_bar1() {
         concat!("Alignment of ", stringify!(bar1))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<bar1>())).x1 as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<bar1>())).x1) as usize
+        },
         0usize,
         concat!("Offset of field: ", stringify!(bar1), "::", stringify!(x1))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<bar1>())).b2 as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<bar1>())).b2) as usize
+        },
         4usize,
         concat!("Offset of field: ", stringify!(bar1), "::", stringify!(b2))
     );
@@ -168,7 +178,9 @@ fn bindgen_test_layout_foo() {
         concat!("Alignment of ", stringify!(foo))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<foo>())).b1 as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<foo>())).b1) as usize
+        },
         0usize,
         concat!("Offset of field: ", stringify!(foo), "::", stringify!(b1))
     );
@@ -201,7 +213,9 @@ fn bindgen_test_layout_baz() {
         concat!("Alignment of ", stringify!(baz))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<baz>())).x as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<baz>())).x) as usize
+        },
         0usize,
         concat!("Offset of field: ", stringify!(baz), "::", stringify!(x))
     );
@@ -220,8 +234,9 @@ fn bindgen_test_layout__bindgen_ty_1__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<_bindgen_ty_1__bindgen_ty_1>())).b
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<_bindgen_ty_1__bindgen_ty_1>())).b
+            ) as usize
         },
         0usize,
         concat!(
@@ -246,7 +261,8 @@ fn bindgen_test_layout__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<_bindgen_ty_1>())).anon2 as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<_bindgen_ty_1>())).anon2)
+                as usize
         },
         0usize,
         concat!(

--- a/tests/expectations/tests/disable-untagged-union.rs
+++ b/tests/expectations/tests/disable-untagged-union.rs
@@ -68,12 +68,16 @@ fn bindgen_test_layout_Foo() {
         concat!("Alignment of ", stringify!(Foo))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Foo>())).bar as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<Foo>())).bar) as usize
+        },
         0usize,
         concat!("Offset of field: ", stringify!(Foo), "::", stringify!(bar))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Foo>())).baz as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<Foo>())).baz) as usize
+        },
         0usize,
         concat!("Offset of field: ", stringify!(Foo), "::", stringify!(baz))
     );

--- a/tests/expectations/tests/do-not-derive-copy.rs
+++ b/tests/expectations/tests/do-not-derive-copy.rs
@@ -27,8 +27,9 @@ fn bindgen_test_layout_WouldBeCopyButWeAreNotDerivingCopy() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<WouldBeCopyButWeAreNotDerivingCopy>())).x
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<WouldBeCopyButWeAreNotDerivingCopy>())).x
+            ) as usize
         },
         0usize,
         concat!(

--- a/tests/expectations/tests/doggo-or-null.rs
+++ b/tests/expectations/tests/doggo-or-null.rs
@@ -23,7 +23,9 @@ fn bindgen_test_layout_Doggo() {
         concat!("Alignment of ", stringify!(Doggo))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Doggo>())).x as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<Doggo>())).x) as usize
+        },
         0usize,
         concat!("Offset of field: ", stringify!(Doggo), "::", stringify!(x))
     );

--- a/tests/expectations/tests/duplicated-namespaces-definitions.rs
+++ b/tests/expectations/tests/duplicated-namespaces-definitions.rs
@@ -32,7 +32,8 @@ pub mod root {
             );
             assert_eq!(
                 unsafe {
-                    &(*(::std::ptr::null::<Bar>())).foo as *const _ as usize
+                    ::std::ptr::addr_of!((*(::std::ptr::null::<Bar>())).foo)
+                        as usize
                 },
                 0usize,
                 concat!(
@@ -44,7 +45,8 @@ pub mod root {
             );
             assert_eq!(
                 unsafe {
-                    &(*(::std::ptr::null::<Bar>())).baz as *const _ as usize
+                    ::std::ptr::addr_of!((*(::std::ptr::null::<Bar>())).baz)
+                        as usize
                 },
                 4usize,
                 concat!(
@@ -78,7 +80,8 @@ pub mod root {
             );
             assert_eq!(
                 unsafe {
-                    &(*(::std::ptr::null::<Foo>())).ptr as *const _ as usize
+                    ::std::ptr::addr_of!((*(::std::ptr::null::<Foo>())).ptr)
+                        as usize
                 },
                 0usize,
                 concat!(

--- a/tests/expectations/tests/dynamic_loading_with_blocklist.rs
+++ b/tests/expectations/tests/dynamic_loading_with_blocklist.rs
@@ -23,7 +23,9 @@ fn bindgen_test_layout_X() {
         concat!("Alignment of ", stringify!(X))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<X>()))._x as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<X>()))._x) as usize
+        },
         0usize,
         concat!("Offset of field: ", stringify!(X), "::", stringify!(_x))
     );

--- a/tests/expectations/tests/dynamic_loading_with_class.rs
+++ b/tests/expectations/tests/dynamic_loading_with_class.rs
@@ -23,7 +23,9 @@ fn bindgen_test_layout_A() {
         concat!("Alignment of ", stringify!(A))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<A>()))._x as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<A>()))._x) as usize
+        },
         0usize,
         concat!("Offset of field: ", stringify!(A), "::", stringify!(_x))
     );

--- a/tests/expectations/tests/enum-default-bitfield.rs
+++ b/tests/expectations/tests/enum-default-bitfield.rs
@@ -54,7 +54,9 @@ fn bindgen_test_layout_foo() {
         concat!("Alignment of ", stringify!(foo))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<foo>())).member as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<foo>())).member) as usize
+        },
         0usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/enum-default-consts.rs
+++ b/tests/expectations/tests/enum-default-consts.rs
@@ -26,7 +26,9 @@ fn bindgen_test_layout_foo() {
         concat!("Alignment of ", stringify!(foo))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<foo>())).member as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<foo>())).member) as usize
+        },
         0usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/enum-default-module.rs
+++ b/tests/expectations/tests/enum-default-module.rs
@@ -28,7 +28,9 @@ fn bindgen_test_layout_foo() {
         concat!("Alignment of ", stringify!(foo))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<foo>())).member as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<foo>())).member) as usize
+        },
         0usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/enum-default-rust.rs
+++ b/tests/expectations/tests/enum-default-rust.rs
@@ -31,7 +31,9 @@ fn bindgen_test_layout_foo() {
         concat!("Alignment of ", stringify!(foo))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<foo>())).member as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<foo>())).member) as usize
+        },
         0usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/enum-no-debug-rust.rs
+++ b/tests/expectations/tests/enum-no-debug-rust.rs
@@ -31,7 +31,9 @@ fn bindgen_test_layout_foo() {
         concat!("Alignment of ", stringify!(foo))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<foo>())).member as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<foo>())).member) as usize
+        },
         0usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/enum.rs
+++ b/tests/expectations/tests/enum.rs
@@ -26,7 +26,9 @@ fn bindgen_test_layout_foo() {
         concat!("Alignment of ", stringify!(foo))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<foo>())).member as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<foo>())).member) as usize
+        },
         0usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/enum_and_vtable_mangling.rs
+++ b/tests/expectations/tests/enum_and_vtable_mangling.rs
@@ -36,7 +36,9 @@ fn bindgen_test_layout_C() {
         concat!("Alignment of ", stringify!(C))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<C>())).i as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<C>())).i) as usize
+        },
         8usize,
         concat!("Offset of field: ", stringify!(C), "::", stringify!(i))
     );

--- a/tests/expectations/tests/explicit-padding.rs
+++ b/tests/expectations/tests/explicit-padding.rs
@@ -28,7 +28,8 @@ fn bindgen_test_layout_pad_me() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<pad_me>())).first as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<pad_me>())).first)
+                as usize
         },
         0usize,
         concat!(
@@ -40,7 +41,8 @@ fn bindgen_test_layout_pad_me() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<pad_me>())).second as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<pad_me>())).second)
+                as usize
         },
         4usize,
         concat!(
@@ -52,7 +54,8 @@ fn bindgen_test_layout_pad_me() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<pad_me>())).third as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<pad_me>())).third)
+                as usize
         },
         8usize,
         concat!(
@@ -84,7 +87,8 @@ fn bindgen_test_layout_dont_pad_me() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<dont_pad_me>())).first as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<dont_pad_me>())).first)
+                as usize
         },
         0usize,
         concat!(
@@ -96,7 +100,8 @@ fn bindgen_test_layout_dont_pad_me() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<dont_pad_me>())).second as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<dont_pad_me>())).second)
+                as usize
         },
         0usize,
         concat!(
@@ -108,7 +113,8 @@ fn bindgen_test_layout_dont_pad_me() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<dont_pad_me>())).third as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<dont_pad_me>())).third)
+                as usize
         },
         0usize,
         concat!(

--- a/tests/expectations/tests/extern-const-struct.rs
+++ b/tests/expectations/tests/extern-const-struct.rs
@@ -24,7 +24,8 @@ fn bindgen_test_layout_nsFoo() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<nsFoo>())).details as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<nsFoo>())).details)
+                as usize
         },
         0usize,
         concat!(

--- a/tests/expectations/tests/forward-declaration-autoptr.rs
+++ b/tests/expectations/tests/forward-declaration-autoptr.rs
@@ -44,7 +44,8 @@ fn bindgen_test_layout_Bar() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<Bar>())).m_member as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<Bar>())).m_member)
+                as usize
         },
         0usize,
         concat!(

--- a/tests/expectations/tests/forward_declared_complex_types.rs
+++ b/tests/expectations/tests/forward_declared_complex_types.rs
@@ -46,7 +46,9 @@ fn bindgen_test_layout_Bar() {
         concat!("Alignment of ", stringify!(Bar))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Bar>())).f as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<Bar>())).f) as usize
+        },
         0usize,
         concat!("Offset of field: ", stringify!(Bar), "::", stringify!(f))
     );

--- a/tests/expectations/tests/forward_declared_complex_types_1_0.rs
+++ b/tests/expectations/tests/forward_declared_complex_types_1_0.rs
@@ -56,7 +56,9 @@ fn bindgen_test_layout_Bar() {
         concat!("Alignment of ", stringify!(Bar))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Bar>())).f as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<Bar>())).f) as usize
+        },
         0usize,
         concat!("Offset of field: ", stringify!(Bar), "::", stringify!(f))
     );

--- a/tests/expectations/tests/forward_declared_struct.rs
+++ b/tests/expectations/tests/forward_declared_struct.rs
@@ -23,7 +23,9 @@ fn bindgen_test_layout_a() {
         concat!("Alignment of ", stringify!(a))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<a>())).b as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<a>())).b) as usize
+        },
         0usize,
         concat!("Offset of field: ", stringify!(a), "::", stringify!(b))
     );
@@ -46,7 +48,9 @@ fn bindgen_test_layout_c() {
         concat!("Alignment of ", stringify!(c))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<c>())).d as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<c>())).d) as usize
+        },
         0usize,
         concat!("Offset of field: ", stringify!(c), "::", stringify!(d))
     );

--- a/tests/expectations/tests/func_ptr_in_struct.rs
+++ b/tests/expectations/tests/func_ptr_in_struct.rs
@@ -33,7 +33,9 @@ fn bindgen_test_layout_Foo() {
         concat!("Alignment of ", stringify!(Foo))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Foo>())).bar as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<Foo>())).bar) as usize
+        },
         0usize,
         concat!("Offset of field: ", stringify!(Foo), "::", stringify!(bar))
     );

--- a/tests/expectations/tests/gen-destructors-neg.rs
+++ b/tests/expectations/tests/gen-destructors-neg.rs
@@ -23,7 +23,9 @@ fn bindgen_test_layout_Foo() {
         concat!("Alignment of ", stringify!(Foo))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Foo>())).bar as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<Foo>())).bar) as usize
+        },
         0usize,
         concat!("Offset of field: ", stringify!(Foo), "::", stringify!(bar))
     );

--- a/tests/expectations/tests/gen-destructors.rs
+++ b/tests/expectations/tests/gen-destructors.rs
@@ -23,7 +23,9 @@ fn bindgen_test_layout_Foo() {
         concat!("Alignment of ", stringify!(Foo))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Foo>())).bar as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<Foo>())).bar) as usize
+        },
         0usize,
         concat!("Offset of field: ", stringify!(Foo), "::", stringify!(bar))
     );

--- a/tests/expectations/tests/i128.rs
+++ b/tests/expectations/tests/i128.rs
@@ -26,7 +26,8 @@ fn bindgen_test_layout_foo() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<foo>())).my_signed as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<foo>())).my_signed)
+                as usize
         },
         0usize,
         concat!(
@@ -38,7 +39,8 @@ fn bindgen_test_layout_foo() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<foo>())).my_unsigned as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<foo>())).my_unsigned)
+                as usize
         },
         16usize,
         concat!(

--- a/tests/expectations/tests/inline_namespace.rs
+++ b/tests/expectations/tests/inline_namespace.rs
@@ -32,7 +32,10 @@ pub mod root {
             concat!("Alignment of ", stringify!(Bar))
         );
         assert_eq!(
-            unsafe { &(*(::std::ptr::null::<Bar>())).baz as *const _ as usize },
+            unsafe {
+                ::std::ptr::addr_of!((*(::std::ptr::null::<Bar>())).baz)
+                    as usize
+            },
             0usize,
             concat!(
                 "Offset of field: ",

--- a/tests/expectations/tests/inline_namespace_conservative.rs
+++ b/tests/expectations/tests/inline_namespace_conservative.rs
@@ -37,7 +37,10 @@ pub mod root {
             concat!("Alignment of ", stringify!(Bar))
         );
         assert_eq!(
-            unsafe { &(*(::std::ptr::null::<Bar>())).baz as *const _ as usize },
+            unsafe {
+                ::std::ptr::addr_of!((*(::std::ptr::null::<Bar>())).baz)
+                    as usize
+            },
             0usize,
             concat!(
                 "Offset of field: ",

--- a/tests/expectations/tests/inner_const.rs
+++ b/tests/expectations/tests/inner_const.rs
@@ -31,7 +31,9 @@ fn bindgen_test_layout_Foo() {
         concat!("Alignment of ", stringify!(Foo))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Foo>())).bar as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<Foo>())).bar) as usize
+        },
         0usize,
         concat!("Offset of field: ", stringify!(Foo), "::", stringify!(bar))
     );

--- a/tests/expectations/tests/inner_template_self.rs
+++ b/tests/expectations/tests/inner_template_self.rs
@@ -39,8 +39,9 @@ fn bindgen_test_layout_InstantiateIt() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<InstantiateIt>())).m_list as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<InstantiateIt>())).m_list
+            ) as usize
         },
         0usize,
         concat!(

--- a/tests/expectations/tests/issue-1118-using-forward-decl.rs
+++ b/tests/expectations/tests/issue-1118-using-forward-decl.rs
@@ -25,7 +25,8 @@ fn bindgen_test_layout_nsTArray_base() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<nsTArray_base>())).d as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<nsTArray_base>())).d)
+                as usize
         },
         0usize,
         concat!(
@@ -78,7 +79,8 @@ fn bindgen_test_layout_nsIContent() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<nsIContent>())).foo as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<nsIContent>())).foo)
+                as usize
         },
         0usize,
         concat!(

--- a/tests/expectations/tests/issue-1216-variadic-member.rs
+++ b/tests/expectations/tests/issue-1216-variadic-member.rs
@@ -33,7 +33,9 @@ fn bindgen_test_layout_Foo() {
         concat!("Alignment of ", stringify!(Foo))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Foo>())).f as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<Foo>())).f) as usize
+        },
         0usize,
         concat!("Offset of field: ", stringify!(Foo), "::", stringify!(f))
     );

--- a/tests/expectations/tests/issue-1281.rs
+++ b/tests/expectations/tests/issue-1281.rs
@@ -28,7 +28,9 @@ fn bindgen_test_layout_foo() {
         concat!("Alignment of ", stringify!(foo))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<foo>())).foo as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<foo>())).foo) as usize
+        },
         0usize,
         concat!("Offset of field: ", stringify!(foo), "::", stringify!(foo))
     );
@@ -46,7 +48,9 @@ fn bindgen_test_layout_bar() {
         concat!("Alignment of ", stringify!(bar))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<bar>())).u as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<bar>())).u) as usize
+        },
         0usize,
         concat!("Offset of field: ", stringify!(bar), "::", stringify!(u))
     );
@@ -70,7 +74,9 @@ fn bindgen_test_layout_baz() {
         concat!("Alignment of ", stringify!(baz))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<baz>())).f as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<baz>())).f) as usize
+        },
         0usize,
         concat!("Offset of field: ", stringify!(baz), "::", stringify!(f))
     );

--- a/tests/expectations/tests/issue-1285.rs
+++ b/tests/expectations/tests/issue-1285.rs
@@ -30,7 +30,8 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<foo__bindgen_ty_1>())).a as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<foo__bindgen_ty_1>())).a)
+                as usize
         },
         0usize,
         concat!(
@@ -42,7 +43,8 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<foo__bindgen_ty_1>())).b as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<foo__bindgen_ty_1>())).b)
+                as usize
         },
         0usize,
         concat!(
@@ -75,7 +77,9 @@ fn bindgen_test_layout_foo() {
         concat!("Alignment of ", stringify!(foo))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<foo>())).bar as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<foo>())).bar) as usize
+        },
         0usize,
         concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar))
     );

--- a/tests/expectations/tests/issue-1291.rs
+++ b/tests/expectations/tests/issue-1291.rs
@@ -38,7 +38,9 @@ fn bindgen_test_layout_RTCRay() {
         concat!("Alignment of ", stringify!(RTCRay))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<RTCRay>())).org as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<RTCRay>())).org) as usize
+        },
         0usize,
         concat!(
             "Offset of field: ",
@@ -49,7 +51,8 @@ fn bindgen_test_layout_RTCRay() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<RTCRay>())).align0 as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<RTCRay>())).align0)
+                as usize
         },
         12usize,
         concat!(
@@ -60,7 +63,9 @@ fn bindgen_test_layout_RTCRay() {
         )
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<RTCRay>())).dir as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<RTCRay>())).dir) as usize
+        },
         16usize,
         concat!(
             "Offset of field: ",
@@ -71,7 +76,8 @@ fn bindgen_test_layout_RTCRay() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<RTCRay>())).align1 as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<RTCRay>())).align1)
+                as usize
         },
         28usize,
         concat!(
@@ -83,7 +89,8 @@ fn bindgen_test_layout_RTCRay() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<RTCRay>())).tnear as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<RTCRay>())).tnear)
+                as usize
         },
         32usize,
         concat!(
@@ -94,7 +101,10 @@ fn bindgen_test_layout_RTCRay() {
         )
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<RTCRay>())).tfar as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<RTCRay>())).tfar)
+                as usize
+        },
         36usize,
         concat!(
             "Offset of field: ",
@@ -104,7 +114,10 @@ fn bindgen_test_layout_RTCRay() {
         )
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<RTCRay>())).time as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<RTCRay>())).time)
+                as usize
+        },
         40usize,
         concat!(
             "Offset of field: ",
@@ -114,7 +127,10 @@ fn bindgen_test_layout_RTCRay() {
         )
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<RTCRay>())).mask as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<RTCRay>())).mask)
+                as usize
+        },
         44usize,
         concat!(
             "Offset of field: ",
@@ -124,7 +140,9 @@ fn bindgen_test_layout_RTCRay() {
         )
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<RTCRay>())).Ng as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<RTCRay>())).Ng) as usize
+        },
         48usize,
         concat!(
             "Offset of field: ",
@@ -135,7 +153,8 @@ fn bindgen_test_layout_RTCRay() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<RTCRay>())).align2 as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<RTCRay>())).align2)
+                as usize
         },
         60usize,
         concat!(
@@ -146,18 +165,23 @@ fn bindgen_test_layout_RTCRay() {
         )
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<RTCRay>())).u as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<RTCRay>())).u) as usize
+        },
         64usize,
         concat!("Offset of field: ", stringify!(RTCRay), "::", stringify!(u))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<RTCRay>())).v as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<RTCRay>())).v) as usize
+        },
         68usize,
         concat!("Offset of field: ", stringify!(RTCRay), "::", stringify!(v))
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<RTCRay>())).geomID as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<RTCRay>())).geomID)
+                as usize
         },
         72usize,
         concat!(
@@ -169,7 +193,8 @@ fn bindgen_test_layout_RTCRay() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<RTCRay>())).primID as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<RTCRay>())).primID)
+                as usize
         },
         76usize,
         concat!(
@@ -181,7 +206,8 @@ fn bindgen_test_layout_RTCRay() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<RTCRay>())).instID as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<RTCRay>())).instID)
+                as usize
         },
         80usize,
         concat!(

--- a/tests/expectations/tests/issue-1382-rust-primitive-types.rs
+++ b/tests/expectations/tests/issue-1382-rust-primitive-types.rs
@@ -44,47 +44,65 @@ fn bindgen_test_layout_Foo() {
         concat!("Alignment of ", stringify!(Foo))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Foo>())).i8_ as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<Foo>())).i8_) as usize
+        },
         0usize,
         concat!("Offset of field: ", stringify!(Foo), "::", stringify!(i8_))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Foo>())).u8_ as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<Foo>())).u8_) as usize
+        },
         4usize,
         concat!("Offset of field: ", stringify!(Foo), "::", stringify!(u8_))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Foo>())).i16_ as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<Foo>())).i16_) as usize
+        },
         8usize,
         concat!("Offset of field: ", stringify!(Foo), "::", stringify!(i16_))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Foo>())).u16_ as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<Foo>())).u16_) as usize
+        },
         12usize,
         concat!("Offset of field: ", stringify!(Foo), "::", stringify!(u16_))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Foo>())).i32_ as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<Foo>())).i32_) as usize
+        },
         16usize,
         concat!("Offset of field: ", stringify!(Foo), "::", stringify!(i32_))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Foo>())).u32_ as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<Foo>())).u32_) as usize
+        },
         20usize,
         concat!("Offset of field: ", stringify!(Foo), "::", stringify!(u32_))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Foo>())).i64_ as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<Foo>())).i64_) as usize
+        },
         24usize,
         concat!("Offset of field: ", stringify!(Foo), "::", stringify!(i64_))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Foo>())).u64_ as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<Foo>())).u64_) as usize
+        },
         28usize,
         concat!("Offset of field: ", stringify!(Foo), "::", stringify!(u64_))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Foo>())).i128_ as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<Foo>())).i128_) as usize
+        },
         32usize,
         concat!(
             "Offset of field: ",
@@ -94,7 +112,9 @@ fn bindgen_test_layout_Foo() {
         )
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Foo>())).u128_ as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<Foo>())).u128_) as usize
+        },
         36usize,
         concat!(
             "Offset of field: ",
@@ -104,7 +124,9 @@ fn bindgen_test_layout_Foo() {
         )
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Foo>())).isize_ as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<Foo>())).isize_) as usize
+        },
         40usize,
         concat!(
             "Offset of field: ",
@@ -114,7 +136,9 @@ fn bindgen_test_layout_Foo() {
         )
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Foo>())).usize_ as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<Foo>())).usize_) as usize
+        },
         44usize,
         concat!(
             "Offset of field: ",
@@ -124,12 +148,16 @@ fn bindgen_test_layout_Foo() {
         )
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Foo>())).f32_ as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<Foo>())).f32_) as usize
+        },
         48usize,
         concat!("Offset of field: ", stringify!(Foo), "::", stringify!(f32_))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Foo>())).f64_ as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<Foo>())).f64_) as usize
+        },
         52usize,
         concat!("Offset of field: ", stringify!(Foo), "::", stringify!(f64_))
     );

--- a/tests/expectations/tests/issue-1443.rs
+++ b/tests/expectations/tests/issue-1443.rs
@@ -29,12 +29,16 @@ fn bindgen_test_layout_Bar() {
         concat!("Alignment of ", stringify!(Bar))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Bar>())).f as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<Bar>())).f) as usize
+        },
         0usize,
         concat!("Offset of field: ", stringify!(Bar), "::", stringify!(f))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Bar>())).m as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<Bar>())).m) as usize
+        },
         8usize,
         concat!("Offset of field: ", stringify!(Bar), "::", stringify!(m))
     );
@@ -67,12 +71,16 @@ fn bindgen_test_layout_Baz() {
         concat!("Alignment of ", stringify!(Baz))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Baz>())).f as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<Baz>())).f) as usize
+        },
         0usize,
         concat!("Offset of field: ", stringify!(Baz), "::", stringify!(f))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Baz>())).m as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<Baz>())).m) as usize
+        },
         8usize,
         concat!("Offset of field: ", stringify!(Baz), "::", stringify!(m))
     );
@@ -105,12 +113,16 @@ fn bindgen_test_layout_Tar() {
         concat!("Alignment of ", stringify!(Tar))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Tar>())).f as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<Tar>())).f) as usize
+        },
         0usize,
         concat!("Offset of field: ", stringify!(Tar), "::", stringify!(f))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Tar>())).m as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<Tar>())).m) as usize
+        },
         8usize,
         concat!("Offset of field: ", stringify!(Tar), "::", stringify!(m))
     );
@@ -143,12 +155,16 @@ fn bindgen_test_layout_Taz() {
         concat!("Alignment of ", stringify!(Taz))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Taz>())).f as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<Taz>())).f) as usize
+        },
         0usize,
         concat!("Offset of field: ", stringify!(Taz), "::", stringify!(f))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Taz>())).m as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<Taz>())).m) as usize
+        },
         8usize,
         concat!("Offset of field: ", stringify!(Taz), "::", stringify!(m))
     );

--- a/tests/expectations/tests/issue-1454.rs
+++ b/tests/expectations/tests/issue-1454.rs
@@ -28,7 +28,8 @@ fn bindgen_test_layout_local_type() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<local_type>())).inner as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<local_type>())).inner)
+                as usize
         },
         0usize,
         concat!(

--- a/tests/expectations/tests/issue-1498.rs
+++ b/tests/expectations/tests/issue-1498.rs
@@ -45,8 +45,9 @@ fn bindgen_test_layout_rte_memseg__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_memseg__bindgen_ty_1>())).addr
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_memseg__bindgen_ty_1>())).addr
+            ) as usize
         },
         0usize,
         concat!(
@@ -58,8 +59,9 @@ fn bindgen_test_layout_rte_memseg__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_memseg__bindgen_ty_1>())).addr_64
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_memseg__bindgen_ty_1>())).addr_64
+            ) as usize
         },
         0usize,
         concat!(
@@ -93,8 +95,9 @@ fn bindgen_test_layout_rte_memseg() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_memseg>())).phys_addr as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_memseg>())).phys_addr
+            ) as usize
         },
         0usize,
         concat!(
@@ -106,7 +109,8 @@ fn bindgen_test_layout_rte_memseg() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_memseg>())).len as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<rte_memseg>())).len)
+                as usize
         },
         16usize,
         concat!(
@@ -118,8 +122,9 @@ fn bindgen_test_layout_rte_memseg() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_memseg>())).hugepage_sz as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_memseg>())).hugepage_sz
+            ) as usize
         },
         24usize,
         concat!(
@@ -131,8 +136,9 @@ fn bindgen_test_layout_rte_memseg() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_memseg>())).socket_id as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_memseg>())).socket_id
+            ) as usize
         },
         32usize,
         concat!(
@@ -144,7 +150,8 @@ fn bindgen_test_layout_rte_memseg() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_memseg>())).nchannel as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<rte_memseg>())).nchannel)
+                as usize
         },
         36usize,
         concat!(
@@ -156,7 +163,8 @@ fn bindgen_test_layout_rte_memseg() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_memseg>())).nrank as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<rte_memseg>())).nrank)
+                as usize
         },
         40usize,
         concat!(

--- a/tests/expectations/tests/issue-1947.rs
+++ b/tests/expectations/tests/issue-1947.rs
@@ -119,7 +119,8 @@ fn bindgen_test_layout_V56AMDY() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<V56AMDY>())).MADK as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<V56AMDY>())).MADK)
+                as usize
         },
         2usize,
         concat!(
@@ -131,7 +132,8 @@ fn bindgen_test_layout_V56AMDY() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<V56AMDY>())).MABR as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<V56AMDY>())).MABR)
+                as usize
         },
         3usize,
         concat!(
@@ -143,7 +145,8 @@ fn bindgen_test_layout_V56AMDY() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<V56AMDY>()))._rB_ as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<V56AMDY>()))._rB_)
+                as usize
         },
         7usize,
         concat!(

--- a/tests/expectations/tests/issue-1977-larger-arrays.rs
+++ b/tests/expectations/tests/issue-1977-larger-arrays.rs
@@ -24,7 +24,8 @@ fn bindgen_test_layout_S() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<S>())).large_array as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<S>())).large_array)
+                as usize
         },
         0usize,
         concat!(

--- a/tests/expectations/tests/issue-1995.rs
+++ b/tests/expectations/tests/issue-1995.rs
@@ -30,7 +30,9 @@ fn bindgen_test_layout_Bar() {
         concat!("Alignment of ", stringify!(Bar))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Bar>())).baz as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<Bar>())).baz) as usize
+        },
         0usize,
         concat!("Offset of field: ", stringify!(Bar), "::", stringify!(baz))
     );

--- a/tests/expectations/tests/issue-2019.rs
+++ b/tests/expectations/tests/issue-2019.rs
@@ -23,7 +23,9 @@ fn bindgen_test_layout_A() {
         concat!("Alignment of ", stringify!(A))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<A>())).a as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<A>())).a) as usize
+        },
         0usize,
         concat!("Offset of field: ", stringify!(A), "::", stringify!(a))
     );
@@ -56,7 +58,9 @@ fn bindgen_test_layout_B() {
         concat!("Alignment of ", stringify!(B))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<B>())).b as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<B>())).b) as usize
+        },
         0usize,
         concat!("Offset of field: ", stringify!(B), "::", stringify!(b))
     );

--- a/tests/expectations/tests/issue-372.rs
+++ b/tests/expectations/tests/issue-372.rs
@@ -29,17 +29,23 @@ pub mod root {
             concat!("Alignment of ", stringify!(i))
         );
         assert_eq!(
-            unsafe { &(*(::std::ptr::null::<i>())).j as *const _ as usize },
+            unsafe {
+                ::std::ptr::addr_of!((*(::std::ptr::null::<i>())).j) as usize
+            },
             0usize,
             concat!("Offset of field: ", stringify!(i), "::", stringify!(j))
         );
         assert_eq!(
-            unsafe { &(*(::std::ptr::null::<i>())).k as *const _ as usize },
+            unsafe {
+                ::std::ptr::addr_of!((*(::std::ptr::null::<i>())).k) as usize
+            },
             8usize,
             concat!("Offset of field: ", stringify!(i), "::", stringify!(k))
         );
         assert_eq!(
-            unsafe { &(*(::std::ptr::null::<i>())).l as *const _ as usize },
+            unsafe {
+                ::std::ptr::addr_of!((*(::std::ptr::null::<i>())).l) as usize
+            },
             16usize,
             concat!("Offset of field: ", stringify!(i), "::", stringify!(l))
         );
@@ -71,7 +77,9 @@ pub mod root {
             concat!("Alignment of ", stringify!(d))
         );
         assert_eq!(
-            unsafe { &(*(::std::ptr::null::<d>())).m as *const _ as usize },
+            unsafe {
+                ::std::ptr::addr_of!((*(::std::ptr::null::<d>())).m) as usize
+            },
             0usize,
             concat!("Offset of field: ", stringify!(d), "::", stringify!(m))
         );
@@ -118,7 +126,9 @@ pub mod root {
             concat!("Alignment of ", stringify!(F))
         );
         assert_eq!(
-            unsafe { &(*(::std::ptr::null::<F>())).w as *const _ as usize },
+            unsafe {
+                ::std::ptr::addr_of!((*(::std::ptr::null::<F>())).w) as usize
+            },
             0usize,
             concat!("Offset of field: ", stringify!(F), "::", stringify!(w))
         );

--- a/tests/expectations/tests/issue-537-repr-packed-n.rs
+++ b/tests/expectations/tests/issue-537-repr-packed-n.rs
@@ -27,7 +27,8 @@ fn bindgen_test_layout_AlignedToOne() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<AlignedToOne>())).i as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<AlignedToOne>())).i)
+                as usize
         },
         0usize,
         concat!(
@@ -58,7 +59,8 @@ fn bindgen_test_layout_AlignedToTwo() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<AlignedToTwo>())).i as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<AlignedToTwo>())).i)
+                as usize
         },
         0usize,
         concat!(
@@ -92,7 +94,8 @@ fn bindgen_test_layout_PackedToOne() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<PackedToOne>())).x as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<PackedToOne>())).x)
+                as usize
         },
         0usize,
         concat!(
@@ -104,7 +107,8 @@ fn bindgen_test_layout_PackedToOne() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<PackedToOne>())).y as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<PackedToOne>())).y)
+                as usize
         },
         4usize,
         concat!(
@@ -136,7 +140,8 @@ fn bindgen_test_layout_PackedToTwo() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<PackedToTwo>())).x as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<PackedToTwo>())).x)
+                as usize
         },
         0usize,
         concat!(
@@ -148,7 +153,8 @@ fn bindgen_test_layout_PackedToTwo() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<PackedToTwo>())).y as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<PackedToTwo>())).y)
+                as usize
         },
         4usize,
         concat!(

--- a/tests/expectations/tests/issue-537.rs
+++ b/tests/expectations/tests/issue-537.rs
@@ -26,7 +26,8 @@ fn bindgen_test_layout_AlignedToOne() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<AlignedToOne>())).i as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<AlignedToOne>())).i)
+                as usize
         },
         0usize,
         concat!(
@@ -58,7 +59,8 @@ fn bindgen_test_layout_AlignedToTwo() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<AlignedToTwo>())).i as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<AlignedToTwo>())).i)
+                as usize
         },
         0usize,
         concat!(
@@ -92,7 +94,8 @@ fn bindgen_test_layout_PackedToOne() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<PackedToOne>())).x as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<PackedToOne>())).x)
+                as usize
         },
         0usize,
         concat!(
@@ -104,7 +107,8 @@ fn bindgen_test_layout_PackedToOne() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<PackedToOne>())).y as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<PackedToOne>())).y)
+                as usize
         },
         4usize,
         concat!(
@@ -138,7 +142,8 @@ fn bindgen_test_layout_PackedToTwo() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<PackedToTwo>())).x as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<PackedToTwo>())).x)
+                as usize
         },
         0usize,
         concat!(
@@ -150,7 +155,8 @@ fn bindgen_test_layout_PackedToTwo() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<PackedToTwo>())).y as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<PackedToTwo>())).y)
+                as usize
         },
         4usize,
         concat!(

--- a/tests/expectations/tests/issue-573-layout-test-failures.rs
+++ b/tests/expectations/tests/issue-573-layout-test-failures.rs
@@ -29,7 +29,8 @@ fn bindgen_test_layout_AutoIdVector() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<AutoIdVector>())).ar as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<AutoIdVector>())).ar)
+                as usize
         },
         0usize,
         concat!(

--- a/tests/expectations/tests/issue-574-assertion-failure-in-codegen.rs
+++ b/tests/expectations/tests/issue-574-assertion-failure-in-codegen.rs
@@ -29,7 +29,8 @@ fn bindgen_test_layout__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<_bindgen_ty_1>())).ar as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<_bindgen_ty_1>())).ar)
+                as usize
         },
         0usize,
         concat!(

--- a/tests/expectations/tests/issue-584-stylo-template-analysis-panic.rs
+++ b/tests/expectations/tests/issue-584-stylo-template-analysis-panic.rs
@@ -62,7 +62,9 @@ fn bindgen_test_layout_g() {
         concat!("Alignment of ", stringify!(g))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<g>())).h as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<g>())).h) as usize
+        },
         0usize,
         concat!("Offset of field: ", stringify!(g), "::", stringify!(h))
     );

--- a/tests/expectations/tests/issue-639-typedef-anon-field.rs
+++ b/tests/expectations/tests/issue-639-typedef-anon-field.rs
@@ -28,7 +28,10 @@ fn bindgen_test_layout_Foo_Bar() {
         concat!("Alignment of ", stringify!(Foo_Bar))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Foo_Bar>())).abc as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<Foo_Bar>())).abc)
+                as usize
+        },
         0usize,
         concat!(
             "Offset of field: ",
@@ -51,7 +54,9 @@ fn bindgen_test_layout_Foo() {
         concat!("Alignment of ", stringify!(Foo))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Foo>())).bar as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<Foo>())).bar) as usize
+        },
         0usize,
         concat!("Offset of field: ", stringify!(Foo), "::", stringify!(bar))
     );
@@ -79,7 +84,10 @@ fn bindgen_test_layout_Baz_Bar() {
         concat!("Alignment of ", stringify!(Baz_Bar))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Baz_Bar>())).abc as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<Baz_Bar>())).abc)
+                as usize
+        },
         0usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/issue-648-derive-debug-with-padding.rs
+++ b/tests/expectations/tests/issue-648-derive-debug-with-padding.rs
@@ -26,7 +26,9 @@ fn bindgen_test_layout_NoDebug() {
         concat!("Alignment of ", stringify!(NoDebug))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<NoDebug>())).c as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<NoDebug>())).c) as usize
+        },
         0usize,
         concat!(
             "Offset of field: ",
@@ -75,8 +77,9 @@ fn bindgen_test_layout_ShouldDeriveDebugButDoesNot() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<ShouldDeriveDebugButDoesNot>())).c
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<ShouldDeriveDebugButDoesNot>())).c
+            ) as usize
         },
         0usize,
         concat!(
@@ -88,8 +91,9 @@ fn bindgen_test_layout_ShouldDeriveDebugButDoesNot() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<ShouldDeriveDebugButDoesNot>())).d
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<ShouldDeriveDebugButDoesNot>())).d
+            ) as usize
         },
         32usize,
         concat!(

--- a/tests/expectations/tests/issue-674-1.rs
+++ b/tests/expectations/tests/issue-674-1.rs
@@ -38,8 +38,9 @@ pub mod root {
         );
         assert_eq!(
             unsafe {
-                &(*(::std::ptr::null::<CapturingContentInfo>())).a as *const _
-                    as usize
+                ::std::ptr::addr_of!(
+                    (*(::std::ptr::null::<CapturingContentInfo>())).a
+                ) as usize
             },
             0usize,
             concat!(

--- a/tests/expectations/tests/issue-674-2.rs
+++ b/tests/expectations/tests/issue-674-2.rs
@@ -37,7 +37,9 @@ pub mod root {
             concat!("Alignment of ", stringify!(c))
         );
         assert_eq!(
-            unsafe { &(*(::std::ptr::null::<c>())).b as *const _ as usize },
+            unsafe {
+                ::std::ptr::addr_of!((*(::std::ptr::null::<c>())).b) as usize
+            },
             0usize,
             concat!("Offset of field: ", stringify!(c), "::", stringify!(b))
         );
@@ -60,7 +62,9 @@ pub mod root {
             concat!("Alignment of ", stringify!(B))
         );
         assert_eq!(
-            unsafe { &(*(::std::ptr::null::<B>())).a as *const _ as usize },
+            unsafe {
+                ::std::ptr::addr_of!((*(::std::ptr::null::<B>())).a) as usize
+            },
             0usize,
             concat!("Offset of field: ", stringify!(B), "::", stringify!(a))
         );

--- a/tests/expectations/tests/issue-674-3.rs
+++ b/tests/expectations/tests/issue-674-3.rs
@@ -33,7 +33,9 @@ pub mod root {
             concat!("Alignment of ", stringify!(a))
         );
         assert_eq!(
-            unsafe { &(*(::std::ptr::null::<a>())).b as *const _ as usize },
+            unsafe {
+                ::std::ptr::addr_of!((*(::std::ptr::null::<a>())).b) as usize
+            },
             0usize,
             concat!("Offset of field: ", stringify!(a), "::", stringify!(b))
         );
@@ -57,7 +59,8 @@ pub mod root {
         );
         assert_eq!(
             unsafe {
-                &(*(::std::ptr::null::<nsCSSValue>())).c as *const _ as usize
+                ::std::ptr::addr_of!((*(::std::ptr::null::<nsCSSValue>())).c)
+                    as usize
             },
             0usize,
             concat!(

--- a/tests/expectations/tests/issue-801-opaque-sloppiness.rs
+++ b/tests/expectations/tests/issue-801-opaque-sloppiness.rs
@@ -51,7 +51,9 @@ fn bindgen_test_layout_C() {
         concat!("Alignment of ", stringify!(C))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<C>())).b as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<C>())).b) as usize
+        },
         0usize,
         concat!("Offset of field: ", stringify!(C), "::", stringify!(b))
     );

--- a/tests/expectations/tests/issue-807-opaque-types-methods-being-generated.rs
+++ b/tests/expectations/tests/issue-807-opaque-types-methods-being-generated.rs
@@ -121,8 +121,9 @@ fn bindgen_test_layout_Allowlisted() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<Allowlisted>())).some_member as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<Allowlisted>())).some_member
+            ) as usize
         },
         0usize,
         concat!(

--- a/tests/expectations/tests/issue-944-derive-copy-and-blocklisting.rs
+++ b/tests/expectations/tests/issue-944-derive-copy-and-blocklisting.rs
@@ -26,7 +26,8 @@ fn bindgen_test_layout_ShouldNotBeCopy() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<ShouldNotBeCopy>())).a as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<ShouldNotBeCopy>())).a)
+                as usize
         },
         0usize,
         concat!(

--- a/tests/expectations/tests/jsval_layout_opaque.rs
+++ b/tests/expectations/tests/jsval_layout_opaque.rs
@@ -295,8 +295,7 @@ fn bindgen_test_layout_jsval_layout__bindgen_ty_2__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<jsval_layout__bindgen_ty_2__bindgen_ty_1>()))
-                .i32_ as *const _ as usize
+            :: std :: ptr :: addr_of ! ((* (:: std :: ptr :: null :: < jsval_layout__bindgen_ty_2__bindgen_ty_1 > ())) . i32_) as usize
         },
         0usize,
         concat!(
@@ -308,8 +307,7 @@ fn bindgen_test_layout_jsval_layout__bindgen_ty_2__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<jsval_layout__bindgen_ty_2__bindgen_ty_1>()))
-                .u32_ as *const _ as usize
+            :: std :: ptr :: addr_of ! ((* (:: std :: ptr :: null :: < jsval_layout__bindgen_ty_2__bindgen_ty_1 > ())) . u32_) as usize
         },
         0usize,
         concat!(
@@ -321,8 +319,7 @@ fn bindgen_test_layout_jsval_layout__bindgen_ty_2__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<jsval_layout__bindgen_ty_2__bindgen_ty_1>()))
-                .why as *const _ as usize
+            :: std :: ptr :: addr_of ! ((* (:: std :: ptr :: null :: < jsval_layout__bindgen_ty_2__bindgen_ty_1 > ())) . why) as usize
         },
         0usize,
         concat!(
@@ -356,8 +353,9 @@ fn bindgen_test_layout_jsval_layout__bindgen_ty_2() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<jsval_layout__bindgen_ty_2>())).payload
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<jsval_layout__bindgen_ty_2>())).payload
+            ) as usize
         },
         0usize,
         concat!(
@@ -391,7 +389,8 @@ fn bindgen_test_layout_jsval_layout() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<jsval_layout>())).asBits as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<jsval_layout>())).asBits)
+                as usize
         },
         0usize,
         concat!(
@@ -403,8 +402,9 @@ fn bindgen_test_layout_jsval_layout() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<jsval_layout>())).debugView as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<jsval_layout>())).debugView
+            ) as usize
         },
         0usize,
         concat!(
@@ -416,7 +416,8 @@ fn bindgen_test_layout_jsval_layout() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<jsval_layout>())).s as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<jsval_layout>())).s)
+                as usize
         },
         0usize,
         concat!(
@@ -428,8 +429,9 @@ fn bindgen_test_layout_jsval_layout() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<jsval_layout>())).asDouble as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<jsval_layout>())).asDouble
+            ) as usize
         },
         0usize,
         concat!(
@@ -441,7 +443,8 @@ fn bindgen_test_layout_jsval_layout() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<jsval_layout>())).asPtr as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<jsval_layout>())).asPtr)
+                as usize
         },
         0usize,
         concat!(
@@ -453,7 +456,8 @@ fn bindgen_test_layout_jsval_layout() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<jsval_layout>())).asWord as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<jsval_layout>())).asWord)
+                as usize
         },
         0usize,
         concat!(
@@ -465,8 +469,9 @@ fn bindgen_test_layout_jsval_layout() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<jsval_layout>())).asUIntPtr as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<jsval_layout>())).asUIntPtr
+            ) as usize
         },
         0usize,
         concat!(
@@ -504,7 +509,9 @@ fn bindgen_test_layout_Value() {
         concat!("Alignment of ", stringify!(Value))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Value>())).data as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<Value>())).data) as usize
+        },
         0usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/jsval_layout_opaque_1_0.rs
+++ b/tests/expectations/tests/jsval_layout_opaque_1_0.rs
@@ -345,8 +345,7 @@ fn bindgen_test_layout_jsval_layout__bindgen_ty_2__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<jsval_layout__bindgen_ty_2__bindgen_ty_1>()))
-                .i32_ as *const _ as usize
+            :: std :: ptr :: addr_of ! ((* (:: std :: ptr :: null :: < jsval_layout__bindgen_ty_2__bindgen_ty_1 > ())) . i32_) as usize
         },
         0usize,
         concat!(
@@ -358,8 +357,7 @@ fn bindgen_test_layout_jsval_layout__bindgen_ty_2__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<jsval_layout__bindgen_ty_2__bindgen_ty_1>()))
-                .u32_ as *const _ as usize
+            :: std :: ptr :: addr_of ! ((* (:: std :: ptr :: null :: < jsval_layout__bindgen_ty_2__bindgen_ty_1 > ())) . u32_) as usize
         },
         0usize,
         concat!(
@@ -371,8 +369,7 @@ fn bindgen_test_layout_jsval_layout__bindgen_ty_2__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<jsval_layout__bindgen_ty_2__bindgen_ty_1>()))
-                .why as *const _ as usize
+            :: std :: ptr :: addr_of ! ((* (:: std :: ptr :: null :: < jsval_layout__bindgen_ty_2__bindgen_ty_1 > ())) . why) as usize
         },
         0usize,
         concat!(
@@ -402,8 +399,9 @@ fn bindgen_test_layout_jsval_layout__bindgen_ty_2() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<jsval_layout__bindgen_ty_2>())).payload
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<jsval_layout__bindgen_ty_2>())).payload
+            ) as usize
         },
         0usize,
         concat!(
@@ -433,7 +431,8 @@ fn bindgen_test_layout_jsval_layout() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<jsval_layout>())).asBits as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<jsval_layout>())).asBits)
+                as usize
         },
         0usize,
         concat!(
@@ -445,8 +444,9 @@ fn bindgen_test_layout_jsval_layout() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<jsval_layout>())).debugView as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<jsval_layout>())).debugView
+            ) as usize
         },
         0usize,
         concat!(
@@ -458,7 +458,8 @@ fn bindgen_test_layout_jsval_layout() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<jsval_layout>())).s as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<jsval_layout>())).s)
+                as usize
         },
         0usize,
         concat!(
@@ -470,8 +471,9 @@ fn bindgen_test_layout_jsval_layout() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<jsval_layout>())).asDouble as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<jsval_layout>())).asDouble
+            ) as usize
         },
         0usize,
         concat!(
@@ -483,7 +485,8 @@ fn bindgen_test_layout_jsval_layout() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<jsval_layout>())).asPtr as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<jsval_layout>())).asPtr)
+                as usize
         },
         0usize,
         concat!(
@@ -495,7 +498,8 @@ fn bindgen_test_layout_jsval_layout() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<jsval_layout>())).asWord as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<jsval_layout>())).asWord)
+                as usize
         },
         0usize,
         concat!(
@@ -507,8 +511,9 @@ fn bindgen_test_layout_jsval_layout() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<jsval_layout>())).asUIntPtr as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<jsval_layout>())).asUIntPtr
+            ) as usize
         },
         0usize,
         concat!(
@@ -542,7 +547,9 @@ fn bindgen_test_layout_Value() {
         concat!("Alignment of ", stringify!(Value))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Value>())).data as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<Value>())).data) as usize
+        },
         0usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/layout_arp.rs
+++ b/tests/expectations/tests/layout_arp.rs
@@ -42,8 +42,9 @@ fn bindgen_test_layout_ether_addr() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<ether_addr>())).addr_bytes as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<ether_addr>())).addr_bytes
+            ) as usize
         },
         0usize,
         concat!(
@@ -81,7 +82,8 @@ fn bindgen_test_layout_arp_ipv4() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<arp_ipv4>())).arp_sha as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<arp_ipv4>())).arp_sha)
+                as usize
         },
         0usize,
         concat!(
@@ -93,7 +95,8 @@ fn bindgen_test_layout_arp_ipv4() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<arp_ipv4>())).arp_sip as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<arp_ipv4>())).arp_sip)
+                as usize
         },
         6usize,
         concat!(
@@ -105,7 +108,8 @@ fn bindgen_test_layout_arp_ipv4() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<arp_ipv4>())).arp_tha as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<arp_ipv4>())).arp_tha)
+                as usize
         },
         10usize,
         concat!(
@@ -117,7 +121,8 @@ fn bindgen_test_layout_arp_ipv4() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<arp_ipv4>())).arp_tip as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<arp_ipv4>())).arp_tip)
+                as usize
         },
         16usize,
         concat!(
@@ -153,7 +158,8 @@ fn bindgen_test_layout_arp_hdr() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<arp_hdr>())).arp_hrd as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<arp_hdr>())).arp_hrd)
+                as usize
         },
         0usize,
         concat!(
@@ -165,7 +171,8 @@ fn bindgen_test_layout_arp_hdr() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<arp_hdr>())).arp_pro as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<arp_hdr>())).arp_pro)
+                as usize
         },
         2usize,
         concat!(
@@ -177,7 +184,8 @@ fn bindgen_test_layout_arp_hdr() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<arp_hdr>())).arp_hln as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<arp_hdr>())).arp_hln)
+                as usize
         },
         4usize,
         concat!(
@@ -189,7 +197,8 @@ fn bindgen_test_layout_arp_hdr() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<arp_hdr>())).arp_pln as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<arp_hdr>())).arp_pln)
+                as usize
         },
         5usize,
         concat!(
@@ -201,7 +210,8 @@ fn bindgen_test_layout_arp_hdr() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<arp_hdr>())).arp_op as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<arp_hdr>())).arp_op)
+                as usize
         },
         6usize,
         concat!(
@@ -213,7 +223,8 @@ fn bindgen_test_layout_arp_hdr() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<arp_hdr>())).arp_data as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<arp_hdr>())).arp_data)
+                as usize
         },
         8usize,
         concat!(

--- a/tests/expectations/tests/layout_array.rs
+++ b/tests/expectations/tests/layout_array.rs
@@ -81,8 +81,9 @@ fn bindgen_test_layout_rte_mempool_ops() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_mempool_ops>())).name as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_mempool_ops>())).name
+            ) as usize
         },
         0usize,
         concat!(
@@ -94,8 +95,9 @@ fn bindgen_test_layout_rte_mempool_ops() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_mempool_ops>())).alloc as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_mempool_ops>())).alloc
+            ) as usize
         },
         32usize,
         concat!(
@@ -107,8 +109,9 @@ fn bindgen_test_layout_rte_mempool_ops() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_mempool_ops>())).free as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_mempool_ops>())).free
+            ) as usize
         },
         40usize,
         concat!(
@@ -120,8 +123,9 @@ fn bindgen_test_layout_rte_mempool_ops() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_mempool_ops>())).enqueue as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_mempool_ops>())).enqueue
+            ) as usize
         },
         48usize,
         concat!(
@@ -133,8 +137,9 @@ fn bindgen_test_layout_rte_mempool_ops() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_mempool_ops>())).dequeue as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_mempool_ops>())).dequeue
+            ) as usize
         },
         56usize,
         concat!(
@@ -146,8 +151,9 @@ fn bindgen_test_layout_rte_mempool_ops() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_mempool_ops>())).get_count as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_mempool_ops>())).get_count
+            ) as usize
         },
         64usize,
         concat!(
@@ -198,8 +204,9 @@ fn bindgen_test_layout_rte_spinlock_t() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_spinlock_t>())).locked as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_spinlock_t>())).locked
+            ) as usize
         },
         0usize,
         concat!(
@@ -243,8 +250,9 @@ fn bindgen_test_layout_rte_mempool_ops_table() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_mempool_ops_table>())).sl as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_mempool_ops_table>())).sl
+            ) as usize
         },
         0usize,
         concat!(
@@ -256,8 +264,9 @@ fn bindgen_test_layout_rte_mempool_ops_table() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_mempool_ops_table>())).num_ops
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_mempool_ops_table>())).num_ops
+            ) as usize
         },
         4usize,
         concat!(
@@ -269,8 +278,9 @@ fn bindgen_test_layout_rte_mempool_ops_table() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_mempool_ops_table>())).ops as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_mempool_ops_table>())).ops
+            ) as usize
         },
         64usize,
         concat!(
@@ -319,8 +329,9 @@ fn bindgen_test_layout_malloc_heap__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<malloc_heap__bindgen_ty_1>())).lh_first
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<malloc_heap__bindgen_ty_1>())).lh_first
+            ) as usize
         },
         0usize,
         concat!(
@@ -354,7 +365,8 @@ fn bindgen_test_layout_malloc_heap() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<malloc_heap>())).lock as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<malloc_heap>())).lock)
+                as usize
         },
         0usize,
         concat!(
@@ -366,8 +378,9 @@ fn bindgen_test_layout_malloc_heap() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<malloc_heap>())).free_head as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<malloc_heap>())).free_head
+            ) as usize
         },
         8usize,
         concat!(
@@ -379,8 +392,9 @@ fn bindgen_test_layout_malloc_heap() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<malloc_heap>())).alloc_count as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<malloc_heap>())).alloc_count
+            ) as usize
         },
         112usize,
         concat!(
@@ -392,8 +406,9 @@ fn bindgen_test_layout_malloc_heap() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<malloc_heap>())).total_size as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<malloc_heap>())).total_size
+            ) as usize
         },
         120usize,
         concat!(

--- a/tests/expectations/tests/layout_array_too_long.rs
+++ b/tests/expectations/tests/layout_array_too_long.rs
@@ -46,7 +46,10 @@ fn bindgen_test_layout_ip_frag() {
         concat!("Alignment of ", stringify!(ip_frag))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<ip_frag>())).ofs as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<ip_frag>())).ofs)
+                as usize
+        },
         0usize,
         concat!(
             "Offset of field: ",
@@ -56,7 +59,10 @@ fn bindgen_test_layout_ip_frag() {
         )
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<ip_frag>())).len as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<ip_frag>())).len)
+                as usize
+        },
         2usize,
         concat!(
             "Offset of field: ",
@@ -66,7 +72,9 @@ fn bindgen_test_layout_ip_frag() {
         )
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<ip_frag>())).mb as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<ip_frag>())).mb) as usize
+        },
         8usize,
         concat!(
             "Offset of field: ",
@@ -110,7 +118,8 @@ fn bindgen_test_layout_ip_frag_key() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<ip_frag_key>())).src_dst as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<ip_frag_key>())).src_dst)
+                as usize
         },
         0usize,
         concat!(
@@ -122,7 +131,8 @@ fn bindgen_test_layout_ip_frag_key() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<ip_frag_key>())).id as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<ip_frag_key>())).id)
+                as usize
         },
         32usize,
         concat!(
@@ -134,7 +144,8 @@ fn bindgen_test_layout_ip_frag_key() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<ip_frag_key>())).key_len as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<ip_frag_key>())).key_len)
+                as usize
         },
         36usize,
         concat!(
@@ -186,8 +197,9 @@ fn bindgen_test_layout_ip_frag_pkt__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<ip_frag_pkt__bindgen_ty_1>())).tqe_next
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<ip_frag_pkt__bindgen_ty_1>())).tqe_next
+            ) as usize
         },
         0usize,
         concat!(
@@ -199,8 +211,9 @@ fn bindgen_test_layout_ip_frag_pkt__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<ip_frag_pkt__bindgen_ty_1>())).tqe_prev
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<ip_frag_pkt__bindgen_ty_1>())).tqe_prev
+            ) as usize
         },
         8usize,
         concat!(
@@ -234,7 +247,8 @@ fn bindgen_test_layout_ip_frag_pkt() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<ip_frag_pkt>())).lru as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<ip_frag_pkt>())).lru)
+                as usize
         },
         0usize,
         concat!(
@@ -246,7 +260,8 @@ fn bindgen_test_layout_ip_frag_pkt() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<ip_frag_pkt>())).key as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<ip_frag_pkt>())).key)
+                as usize
         },
         16usize,
         concat!(
@@ -258,7 +273,8 @@ fn bindgen_test_layout_ip_frag_pkt() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<ip_frag_pkt>())).start as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<ip_frag_pkt>())).start)
+                as usize
         },
         56usize,
         concat!(
@@ -270,8 +286,9 @@ fn bindgen_test_layout_ip_frag_pkt() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<ip_frag_pkt>())).total_size as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<ip_frag_pkt>())).total_size
+            ) as usize
         },
         64usize,
         concat!(
@@ -283,8 +300,9 @@ fn bindgen_test_layout_ip_frag_pkt() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<ip_frag_pkt>())).frag_size as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<ip_frag_pkt>())).frag_size
+            ) as usize
         },
         68usize,
         concat!(
@@ -296,8 +314,9 @@ fn bindgen_test_layout_ip_frag_pkt() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<ip_frag_pkt>())).last_idx as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<ip_frag_pkt>())).last_idx
+            ) as usize
         },
         72usize,
         concat!(
@@ -309,7 +328,8 @@ fn bindgen_test_layout_ip_frag_pkt() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<ip_frag_pkt>())).frags as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<ip_frag_pkt>())).frags)
+                as usize
         },
         80usize,
         concat!(

--- a/tests/expectations/tests/layout_cmdline_token.rs
+++ b/tests/expectations/tests/layout_cmdline_token.rs
@@ -27,8 +27,9 @@ fn bindgen_test_layout_cmdline_token_hdr() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<cmdline_token_hdr>())).ops as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<cmdline_token_hdr>())).ops
+            ) as usize
         },
         0usize,
         concat!(
@@ -40,8 +41,9 @@ fn bindgen_test_layout_cmdline_token_hdr() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<cmdline_token_hdr>())).offset as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<cmdline_token_hdr>())).offset
+            ) as usize
         },
         8usize,
         concat!(
@@ -131,8 +133,9 @@ fn bindgen_test_layout_cmdline_token_ops() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<cmdline_token_ops>())).parse as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<cmdline_token_ops>())).parse
+            ) as usize
         },
         0usize,
         concat!(
@@ -144,8 +147,9 @@ fn bindgen_test_layout_cmdline_token_ops() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<cmdline_token_ops>())).complete_get_nb
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<cmdline_token_ops>())).complete_get_nb
+            ) as usize
         },
         8usize,
         concat!(
@@ -157,8 +161,9 @@ fn bindgen_test_layout_cmdline_token_ops() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<cmdline_token_ops>())).complete_get_elt
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<cmdline_token_ops>())).complete_get_elt
+            ) as usize
         },
         16usize,
         concat!(
@@ -170,8 +175,9 @@ fn bindgen_test_layout_cmdline_token_ops() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<cmdline_token_ops>())).get_help as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<cmdline_token_ops>())).get_help
+            ) as usize
         },
         24usize,
         concat!(
@@ -213,8 +219,9 @@ fn bindgen_test_layout_cmdline_token_num_data() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<cmdline_token_num_data>())).type_ as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<cmdline_token_num_data>())).type_
+            ) as usize
         },
         0usize,
         concat!(
@@ -254,8 +261,9 @@ fn bindgen_test_layout_cmdline_token_num() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<cmdline_token_num>())).hdr as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<cmdline_token_num>())).hdr
+            ) as usize
         },
         0usize,
         concat!(
@@ -267,8 +275,9 @@ fn bindgen_test_layout_cmdline_token_num() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<cmdline_token_num>())).num_data as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<cmdline_token_num>())).num_data
+            ) as usize
         },
         16usize,
         concat!(

--- a/tests/expectations/tests/layout_eth_conf.rs
+++ b/tests/expectations/tests/layout_eth_conf.rs
@@ -172,8 +172,9 @@ fn bindgen_test_layout_rte_eth_rxmode() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_rxmode>())).mq_mode as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_rxmode>())).mq_mode
+            ) as usize
         },
         0usize,
         concat!(
@@ -185,8 +186,9 @@ fn bindgen_test_layout_rte_eth_rxmode() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_rxmode>())).max_rx_pkt_len
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_rxmode>())).max_rx_pkt_len
+            ) as usize
         },
         4usize,
         concat!(
@@ -198,8 +200,9 @@ fn bindgen_test_layout_rte_eth_rxmode() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_rxmode>())).split_hdr_size
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_rxmode>())).split_hdr_size
+            ) as usize
         },
         8usize,
         concat!(
@@ -437,8 +440,9 @@ fn bindgen_test_layout_rte_eth_txmode() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_txmode>())).mq_mode as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_txmode>())).mq_mode
+            ) as usize
         },
         0usize,
         concat!(
@@ -450,7 +454,8 @@ fn bindgen_test_layout_rte_eth_txmode() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_txmode>())).pvid as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<rte_eth_txmode>())).pvid)
+                as usize
         },
         4usize,
         concat!(
@@ -575,8 +580,9 @@ fn bindgen_test_layout_rte_eth_rss_conf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_rss_conf>())).rss_key as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_rss_conf>())).rss_key
+            ) as usize
         },
         0usize,
         concat!(
@@ -588,8 +594,9 @@ fn bindgen_test_layout_rte_eth_rss_conf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_rss_conf>())).rss_key_len as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_rss_conf>())).rss_key_len
+            ) as usize
         },
         8usize,
         concat!(
@@ -601,8 +608,9 @@ fn bindgen_test_layout_rte_eth_rss_conf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_rss_conf>())).rss_hf as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_rss_conf>())).rss_hf
+            ) as usize
         },
         16usize,
         concat!(
@@ -695,8 +703,10 @@ fn bindgen_test_layout_rte_eth_vmdq_dcb_conf__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_vmdq_dcb_conf__bindgen_ty_1>()))
-                .vlan_id as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_vmdq_dcb_conf__bindgen_ty_1>()))
+                    .vlan_id
+            ) as usize
         },
         0usize,
         concat!(
@@ -708,8 +718,10 @@ fn bindgen_test_layout_rte_eth_vmdq_dcb_conf__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_vmdq_dcb_conf__bindgen_ty_1>()))
-                .pools as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_vmdq_dcb_conf__bindgen_ty_1>()))
+                    .pools
+            ) as usize
         },
         8usize,
         concat!(
@@ -734,8 +746,9 @@ fn bindgen_test_layout_rte_eth_vmdq_dcb_conf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_vmdq_dcb_conf>())).nb_queue_pools
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_vmdq_dcb_conf>())).nb_queue_pools
+            ) as usize
         },
         0usize,
         concat!(
@@ -747,8 +760,10 @@ fn bindgen_test_layout_rte_eth_vmdq_dcb_conf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_vmdq_dcb_conf>()))
-                .enable_default_pool as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_vmdq_dcb_conf>()))
+                    .enable_default_pool
+            ) as usize
         },
         4usize,
         concat!(
@@ -760,8 +775,9 @@ fn bindgen_test_layout_rte_eth_vmdq_dcb_conf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_vmdq_dcb_conf>())).default_pool
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_vmdq_dcb_conf>())).default_pool
+            ) as usize
         },
         5usize,
         concat!(
@@ -773,8 +789,9 @@ fn bindgen_test_layout_rte_eth_vmdq_dcb_conf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_vmdq_dcb_conf>())).nb_pool_maps
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_vmdq_dcb_conf>())).nb_pool_maps
+            ) as usize
         },
         6usize,
         concat!(
@@ -786,8 +803,9 @@ fn bindgen_test_layout_rte_eth_vmdq_dcb_conf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_vmdq_dcb_conf>())).pool_map
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_vmdq_dcb_conf>())).pool_map
+            ) as usize
         },
         8usize,
         concat!(
@@ -799,8 +817,9 @@ fn bindgen_test_layout_rte_eth_vmdq_dcb_conf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_vmdq_dcb_conf>())).dcb_tc as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_vmdq_dcb_conf>())).dcb_tc
+            ) as usize
         },
         1032usize,
         concat!(
@@ -842,8 +861,9 @@ fn bindgen_test_layout_rte_eth_dcb_rx_conf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_dcb_rx_conf>())).nb_tcs as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_dcb_rx_conf>())).nb_tcs
+            ) as usize
         },
         0usize,
         concat!(
@@ -855,8 +875,9 @@ fn bindgen_test_layout_rte_eth_dcb_rx_conf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_dcb_rx_conf>())).dcb_tc as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_dcb_rx_conf>())).dcb_tc
+            ) as usize
         },
         4usize,
         concat!(
@@ -898,8 +919,10 @@ fn bindgen_test_layout_rte_eth_vmdq_dcb_tx_conf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_vmdq_dcb_tx_conf>())).nb_queue_pools
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_vmdq_dcb_tx_conf>()))
+                    .nb_queue_pools
+            ) as usize
         },
         0usize,
         concat!(
@@ -911,8 +934,9 @@ fn bindgen_test_layout_rte_eth_vmdq_dcb_tx_conf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_vmdq_dcb_tx_conf>())).dcb_tc
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_vmdq_dcb_tx_conf>())).dcb_tc
+            ) as usize
         },
         4usize,
         concat!(
@@ -954,8 +978,9 @@ fn bindgen_test_layout_rte_eth_dcb_tx_conf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_dcb_tx_conf>())).nb_tcs as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_dcb_tx_conf>())).nb_tcs
+            ) as usize
         },
         0usize,
         concat!(
@@ -967,8 +992,9 @@ fn bindgen_test_layout_rte_eth_dcb_tx_conf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_dcb_tx_conf>())).dcb_tc as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_dcb_tx_conf>())).dcb_tc
+            ) as usize
         },
         4usize,
         concat!(
@@ -1008,8 +1034,9 @@ fn bindgen_test_layout_rte_eth_vmdq_tx_conf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_vmdq_tx_conf>())).nb_queue_pools
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_vmdq_tx_conf>())).nb_queue_pools
+            ) as usize
         },
         0usize,
         concat!(
@@ -1072,8 +1099,10 @@ fn bindgen_test_layout_rte_eth_vmdq_rx_conf__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_vmdq_rx_conf__bindgen_ty_1>()))
-                .vlan_id as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_vmdq_rx_conf__bindgen_ty_1>()))
+                    .vlan_id
+            ) as usize
         },
         0usize,
         concat!(
@@ -1085,8 +1114,10 @@ fn bindgen_test_layout_rte_eth_vmdq_rx_conf__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_vmdq_rx_conf__bindgen_ty_1>())).pools
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_vmdq_rx_conf__bindgen_ty_1>()))
+                    .pools
+            ) as usize
         },
         8usize,
         concat!(
@@ -1111,8 +1142,9 @@ fn bindgen_test_layout_rte_eth_vmdq_rx_conf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_vmdq_rx_conf>())).nb_queue_pools
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_vmdq_rx_conf>())).nb_queue_pools
+            ) as usize
         },
         0usize,
         concat!(
@@ -1124,8 +1156,10 @@ fn bindgen_test_layout_rte_eth_vmdq_rx_conf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_vmdq_rx_conf>())).enable_default_pool
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_vmdq_rx_conf>()))
+                    .enable_default_pool
+            ) as usize
         },
         4usize,
         concat!(
@@ -1137,8 +1171,9 @@ fn bindgen_test_layout_rte_eth_vmdq_rx_conf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_vmdq_rx_conf>())).default_pool
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_vmdq_rx_conf>())).default_pool
+            ) as usize
         },
         5usize,
         concat!(
@@ -1150,8 +1185,10 @@ fn bindgen_test_layout_rte_eth_vmdq_rx_conf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_vmdq_rx_conf>())).enable_loop_back
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_vmdq_rx_conf>()))
+                    .enable_loop_back
+            ) as usize
         },
         6usize,
         concat!(
@@ -1163,8 +1200,9 @@ fn bindgen_test_layout_rte_eth_vmdq_rx_conf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_vmdq_rx_conf>())).nb_pool_maps
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_vmdq_rx_conf>())).nb_pool_maps
+            ) as usize
         },
         7usize,
         concat!(
@@ -1176,8 +1214,9 @@ fn bindgen_test_layout_rte_eth_vmdq_rx_conf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_vmdq_rx_conf>())).rx_mode as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_vmdq_rx_conf>())).rx_mode
+            ) as usize
         },
         8usize,
         concat!(
@@ -1189,8 +1228,9 @@ fn bindgen_test_layout_rte_eth_vmdq_rx_conf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_vmdq_rx_conf>())).pool_map
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_vmdq_rx_conf>())).pool_map
+            ) as usize
         },
         16usize,
         concat!(
@@ -1277,8 +1317,9 @@ fn bindgen_test_layout_rte_eth_ipv4_flow() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_ipv4_flow>())).src_ip as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_ipv4_flow>())).src_ip
+            ) as usize
         },
         0usize,
         concat!(
@@ -1290,8 +1331,9 @@ fn bindgen_test_layout_rte_eth_ipv4_flow() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_ipv4_flow>())).dst_ip as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_ipv4_flow>())).dst_ip
+            ) as usize
         },
         4usize,
         concat!(
@@ -1303,8 +1345,9 @@ fn bindgen_test_layout_rte_eth_ipv4_flow() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_ipv4_flow>())).tos as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_ipv4_flow>())).tos
+            ) as usize
         },
         8usize,
         concat!(
@@ -1316,8 +1359,9 @@ fn bindgen_test_layout_rte_eth_ipv4_flow() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_ipv4_flow>())).ttl as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_ipv4_flow>())).ttl
+            ) as usize
         },
         9usize,
         concat!(
@@ -1329,8 +1373,9 @@ fn bindgen_test_layout_rte_eth_ipv4_flow() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_ipv4_flow>())).proto as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_ipv4_flow>())).proto
+            ) as usize
         },
         10usize,
         concat!(
@@ -1370,8 +1415,9 @@ fn bindgen_test_layout_rte_eth_ipv6_flow() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_ipv6_flow>())).src_ip as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_ipv6_flow>())).src_ip
+            ) as usize
         },
         0usize,
         concat!(
@@ -1383,8 +1429,9 @@ fn bindgen_test_layout_rte_eth_ipv6_flow() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_ipv6_flow>())).dst_ip as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_ipv6_flow>())).dst_ip
+            ) as usize
         },
         16usize,
         concat!(
@@ -1396,8 +1443,9 @@ fn bindgen_test_layout_rte_eth_ipv6_flow() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_ipv6_flow>())).tc as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_ipv6_flow>())).tc
+            ) as usize
         },
         32usize,
         concat!(
@@ -1409,8 +1457,9 @@ fn bindgen_test_layout_rte_eth_ipv6_flow() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_ipv6_flow>())).proto as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_ipv6_flow>())).proto
+            ) as usize
         },
         33usize,
         concat!(
@@ -1422,8 +1471,9 @@ fn bindgen_test_layout_rte_eth_ipv6_flow() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_ipv6_flow>())).hop_limits as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_ipv6_flow>())).hop_limits
+            ) as usize
         },
         34usize,
         concat!(
@@ -1472,8 +1522,9 @@ fn bindgen_test_layout_rte_eth_fdir_masks() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_fdir_masks>())).vlan_tci_mask
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_fdir_masks>())).vlan_tci_mask
+            ) as usize
         },
         0usize,
         concat!(
@@ -1485,8 +1536,9 @@ fn bindgen_test_layout_rte_eth_fdir_masks() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_fdir_masks>())).ipv4_mask as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_fdir_masks>())).ipv4_mask
+            ) as usize
         },
         4usize,
         concat!(
@@ -1498,8 +1550,9 @@ fn bindgen_test_layout_rte_eth_fdir_masks() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_fdir_masks>())).ipv6_mask as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_fdir_masks>())).ipv6_mask
+            ) as usize
         },
         16usize,
         concat!(
@@ -1511,8 +1564,9 @@ fn bindgen_test_layout_rte_eth_fdir_masks() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_fdir_masks>())).src_port_mask
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_fdir_masks>())).src_port_mask
+            ) as usize
         },
         52usize,
         concat!(
@@ -1524,8 +1578,9 @@ fn bindgen_test_layout_rte_eth_fdir_masks() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_fdir_masks>())).dst_port_mask
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_fdir_masks>())).dst_port_mask
+            ) as usize
         },
         54usize,
         concat!(
@@ -1537,8 +1592,10 @@ fn bindgen_test_layout_rte_eth_fdir_masks() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_fdir_masks>())).mac_addr_byte_mask
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_fdir_masks>()))
+                    .mac_addr_byte_mask
+            ) as usize
         },
         56usize,
         concat!(
@@ -1550,8 +1607,9 @@ fn bindgen_test_layout_rte_eth_fdir_masks() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_fdir_masks>())).tunnel_id_mask
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_fdir_masks>())).tunnel_id_mask
+            ) as usize
         },
         60usize,
         concat!(
@@ -1563,8 +1621,9 @@ fn bindgen_test_layout_rte_eth_fdir_masks() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_fdir_masks>())).tunnel_type_mask
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_fdir_masks>())).tunnel_type_mask
+            ) as usize
         },
         64usize,
         concat!(
@@ -1609,8 +1668,9 @@ fn bindgen_test_layout_rte_eth_flex_payload_cfg() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_flex_payload_cfg>())).type_
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_flex_payload_cfg>())).type_
+            ) as usize
         },
         0usize,
         concat!(
@@ -1622,8 +1682,9 @@ fn bindgen_test_layout_rte_eth_flex_payload_cfg() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_flex_payload_cfg>())).src_offset
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_flex_payload_cfg>())).src_offset
+            ) as usize
         },
         4usize,
         concat!(
@@ -1665,8 +1726,9 @@ fn bindgen_test_layout_rte_eth_fdir_flex_mask() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_fdir_flex_mask>())).flow_type
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_fdir_flex_mask>())).flow_type
+            ) as usize
         },
         0usize,
         concat!(
@@ -1678,8 +1740,9 @@ fn bindgen_test_layout_rte_eth_fdir_flex_mask() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_fdir_flex_mask>())).mask as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_fdir_flex_mask>())).mask
+            ) as usize
         },
         2usize,
         concat!(
@@ -1716,8 +1779,9 @@ fn bindgen_test_layout_rte_eth_fdir_flex_conf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_fdir_flex_conf>())).nb_payloads
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_fdir_flex_conf>())).nb_payloads
+            ) as usize
         },
         0usize,
         concat!(
@@ -1729,8 +1793,9 @@ fn bindgen_test_layout_rte_eth_fdir_flex_conf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_fdir_flex_conf>())).nb_flexmasks
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_fdir_flex_conf>())).nb_flexmasks
+            ) as usize
         },
         2usize,
         concat!(
@@ -1742,8 +1807,9 @@ fn bindgen_test_layout_rte_eth_fdir_flex_conf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_fdir_flex_conf>())).flex_set
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_fdir_flex_conf>())).flex_set
+            ) as usize
         },
         4usize,
         concat!(
@@ -1755,8 +1821,9 @@ fn bindgen_test_layout_rte_eth_fdir_flex_conf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_fdir_flex_conf>())).flex_mask
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_fdir_flex_conf>())).flex_mask
+            ) as usize
         },
         292usize,
         concat!(
@@ -1808,7 +1875,8 @@ fn bindgen_test_layout_rte_fdir_conf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_fdir_conf>())).mode as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<rte_fdir_conf>())).mode)
+                as usize
         },
         0usize,
         concat!(
@@ -1820,8 +1888,9 @@ fn bindgen_test_layout_rte_fdir_conf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_fdir_conf>())).pballoc as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_fdir_conf>())).pballoc
+            ) as usize
         },
         4usize,
         concat!(
@@ -1833,8 +1902,9 @@ fn bindgen_test_layout_rte_fdir_conf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_fdir_conf>())).status as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_fdir_conf>())).status
+            ) as usize
         },
         8usize,
         concat!(
@@ -1846,8 +1916,9 @@ fn bindgen_test_layout_rte_fdir_conf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_fdir_conf>())).drop_queue as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_fdir_conf>())).drop_queue
+            ) as usize
         },
         12usize,
         concat!(
@@ -1859,7 +1930,8 @@ fn bindgen_test_layout_rte_fdir_conf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_fdir_conf>())).mask as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<rte_fdir_conf>())).mask)
+                as usize
         },
         16usize,
         concat!(
@@ -1871,8 +1943,9 @@ fn bindgen_test_layout_rte_fdir_conf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_fdir_conf>())).flex_conf as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_fdir_conf>())).flex_conf
+            ) as usize
         },
         84usize,
         concat!(
@@ -1915,7 +1988,8 @@ fn bindgen_test_layout_rte_intr_conf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_intr_conf>())).lsc as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<rte_intr_conf>())).lsc)
+                as usize
         },
         0usize,
         concat!(
@@ -1927,7 +2001,8 @@ fn bindgen_test_layout_rte_intr_conf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_intr_conf>())).rxq as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<rte_intr_conf>())).rxq)
+                as usize
         },
         2usize,
         concat!(
@@ -1997,8 +2072,9 @@ fn bindgen_test_layout_rte_eth_conf__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_conf__bindgen_ty_1>())).rss_conf
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_conf__bindgen_ty_1>())).rss_conf
+            ) as usize
         },
         0usize,
         concat!(
@@ -2010,8 +2086,10 @@ fn bindgen_test_layout_rte_eth_conf__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_conf__bindgen_ty_1>())).vmdq_dcb_conf
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_conf__bindgen_ty_1>()))
+                    .vmdq_dcb_conf
+            ) as usize
         },
         24usize,
         concat!(
@@ -2023,8 +2101,10 @@ fn bindgen_test_layout_rte_eth_conf__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_conf__bindgen_ty_1>())).dcb_rx_conf
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_conf__bindgen_ty_1>()))
+                    .dcb_rx_conf
+            ) as usize
         },
         1064usize,
         concat!(
@@ -2036,8 +2116,10 @@ fn bindgen_test_layout_rte_eth_conf__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_conf__bindgen_ty_1>())).vmdq_rx_conf
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_conf__bindgen_ty_1>()))
+                    .vmdq_rx_conf
+            ) as usize
         },
         1080usize,
         concat!(
@@ -2078,8 +2160,10 @@ fn bindgen_test_layout_rte_eth_conf__bindgen_ty_2() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_conf__bindgen_ty_2>()))
-                .vmdq_dcb_tx_conf as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_conf__bindgen_ty_2>()))
+                    .vmdq_dcb_tx_conf
+            ) as usize
         },
         0usize,
         concat!(
@@ -2091,8 +2175,10 @@ fn bindgen_test_layout_rte_eth_conf__bindgen_ty_2() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_conf__bindgen_ty_2>())).dcb_tx_conf
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_conf__bindgen_ty_2>()))
+                    .dcb_tx_conf
+            ) as usize
         },
         0usize,
         concat!(
@@ -2104,8 +2190,10 @@ fn bindgen_test_layout_rte_eth_conf__bindgen_ty_2() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_conf__bindgen_ty_2>())).vmdq_tx_conf
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_conf__bindgen_ty_2>()))
+                    .vmdq_tx_conf
+            ) as usize
         },
         0usize,
         concat!(
@@ -2139,8 +2227,9 @@ fn bindgen_test_layout_rte_eth_conf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_conf>())).link_speeds as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_conf>())).link_speeds
+            ) as usize
         },
         0usize,
         concat!(
@@ -2152,7 +2241,8 @@ fn bindgen_test_layout_rte_eth_conf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_conf>())).rxmode as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<rte_eth_conf>())).rxmode)
+                as usize
         },
         4usize,
         concat!(
@@ -2164,7 +2254,8 @@ fn bindgen_test_layout_rte_eth_conf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_conf>())).txmode as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<rte_eth_conf>())).txmode)
+                as usize
         },
         16usize,
         concat!(
@@ -2176,8 +2267,9 @@ fn bindgen_test_layout_rte_eth_conf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_conf>())).lpbk_mode as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_conf>())).lpbk_mode
+            ) as usize
         },
         24usize,
         concat!(
@@ -2189,8 +2281,9 @@ fn bindgen_test_layout_rte_eth_conf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_conf>())).rx_adv_conf as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_conf>())).rx_adv_conf
+            ) as usize
         },
         32usize,
         concat!(
@@ -2202,8 +2295,9 @@ fn bindgen_test_layout_rte_eth_conf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_conf>())).tx_adv_conf as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_conf>())).tx_adv_conf
+            ) as usize
         },
         2152usize,
         concat!(
@@ -2215,8 +2309,9 @@ fn bindgen_test_layout_rte_eth_conf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_conf>())).dcb_capability_en
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_conf>())).dcb_capability_en
+            ) as usize
         },
         2164usize,
         concat!(
@@ -2228,8 +2323,9 @@ fn bindgen_test_layout_rte_eth_conf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_conf>())).fdir_conf as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_conf>())).fdir_conf
+            ) as usize
         },
         2168usize,
         concat!(
@@ -2241,8 +2337,9 @@ fn bindgen_test_layout_rte_eth_conf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_conf>())).intr_conf as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_conf>())).intr_conf
+            ) as usize
         },
         2940usize,
         concat!(

--- a/tests/expectations/tests/layout_eth_conf_1_0.rs
+++ b/tests/expectations/tests/layout_eth_conf_1_0.rs
@@ -215,8 +215,9 @@ fn bindgen_test_layout_rte_eth_rxmode() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_rxmode>())).mq_mode as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_rxmode>())).mq_mode
+            ) as usize
         },
         0usize,
         concat!(
@@ -228,8 +229,9 @@ fn bindgen_test_layout_rte_eth_rxmode() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_rxmode>())).max_rx_pkt_len
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_rxmode>())).max_rx_pkt_len
+            ) as usize
         },
         4usize,
         concat!(
@@ -241,8 +243,9 @@ fn bindgen_test_layout_rte_eth_rxmode() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_rxmode>())).split_hdr_size
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_rxmode>())).split_hdr_size
+            ) as usize
         },
         8usize,
         concat!(
@@ -485,8 +488,9 @@ fn bindgen_test_layout_rte_eth_txmode() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_txmode>())).mq_mode as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_txmode>())).mq_mode
+            ) as usize
         },
         0usize,
         concat!(
@@ -498,7 +502,8 @@ fn bindgen_test_layout_rte_eth_txmode() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_txmode>())).pvid as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<rte_eth_txmode>())).pvid)
+                as usize
         },
         4usize,
         concat!(
@@ -628,8 +633,9 @@ fn bindgen_test_layout_rte_eth_rss_conf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_rss_conf>())).rss_key as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_rss_conf>())).rss_key
+            ) as usize
         },
         0usize,
         concat!(
@@ -641,8 +647,9 @@ fn bindgen_test_layout_rte_eth_rss_conf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_rss_conf>())).rss_key_len as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_rss_conf>())).rss_key_len
+            ) as usize
         },
         8usize,
         concat!(
@@ -654,8 +661,9 @@ fn bindgen_test_layout_rte_eth_rss_conf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_rss_conf>())).rss_hf as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_rss_conf>())).rss_hf
+            ) as usize
         },
         16usize,
         concat!(
@@ -753,8 +761,10 @@ fn bindgen_test_layout_rte_eth_vmdq_dcb_conf__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_vmdq_dcb_conf__bindgen_ty_1>()))
-                .vlan_id as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_vmdq_dcb_conf__bindgen_ty_1>()))
+                    .vlan_id
+            ) as usize
         },
         0usize,
         concat!(
@@ -766,8 +776,10 @@ fn bindgen_test_layout_rte_eth_vmdq_dcb_conf__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_vmdq_dcb_conf__bindgen_ty_1>()))
-                .pools as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_vmdq_dcb_conf__bindgen_ty_1>()))
+                    .pools
+            ) as usize
         },
         8usize,
         concat!(
@@ -797,8 +809,9 @@ fn bindgen_test_layout_rte_eth_vmdq_dcb_conf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_vmdq_dcb_conf>())).nb_queue_pools
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_vmdq_dcb_conf>())).nb_queue_pools
+            ) as usize
         },
         0usize,
         concat!(
@@ -810,8 +823,10 @@ fn bindgen_test_layout_rte_eth_vmdq_dcb_conf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_vmdq_dcb_conf>()))
-                .enable_default_pool as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_vmdq_dcb_conf>()))
+                    .enable_default_pool
+            ) as usize
         },
         4usize,
         concat!(
@@ -823,8 +838,9 @@ fn bindgen_test_layout_rte_eth_vmdq_dcb_conf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_vmdq_dcb_conf>())).default_pool
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_vmdq_dcb_conf>())).default_pool
+            ) as usize
         },
         5usize,
         concat!(
@@ -836,8 +852,9 @@ fn bindgen_test_layout_rte_eth_vmdq_dcb_conf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_vmdq_dcb_conf>())).nb_pool_maps
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_vmdq_dcb_conf>())).nb_pool_maps
+            ) as usize
         },
         6usize,
         concat!(
@@ -849,8 +866,9 @@ fn bindgen_test_layout_rte_eth_vmdq_dcb_conf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_vmdq_dcb_conf>())).pool_map
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_vmdq_dcb_conf>())).pool_map
+            ) as usize
         },
         8usize,
         concat!(
@@ -862,8 +880,9 @@ fn bindgen_test_layout_rte_eth_vmdq_dcb_conf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_vmdq_dcb_conf>())).dcb_tc as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_vmdq_dcb_conf>())).dcb_tc
+            ) as usize
         },
         1032usize,
         concat!(
@@ -910,8 +929,9 @@ fn bindgen_test_layout_rte_eth_dcb_rx_conf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_dcb_rx_conf>())).nb_tcs as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_dcb_rx_conf>())).nb_tcs
+            ) as usize
         },
         0usize,
         concat!(
@@ -923,8 +943,9 @@ fn bindgen_test_layout_rte_eth_dcb_rx_conf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_dcb_rx_conf>())).dcb_tc as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_dcb_rx_conf>())).dcb_tc
+            ) as usize
         },
         4usize,
         concat!(
@@ -971,8 +992,10 @@ fn bindgen_test_layout_rte_eth_vmdq_dcb_tx_conf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_vmdq_dcb_tx_conf>())).nb_queue_pools
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_vmdq_dcb_tx_conf>()))
+                    .nb_queue_pools
+            ) as usize
         },
         0usize,
         concat!(
@@ -984,8 +1007,9 @@ fn bindgen_test_layout_rte_eth_vmdq_dcb_tx_conf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_vmdq_dcb_tx_conf>())).dcb_tc
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_vmdq_dcb_tx_conf>())).dcb_tc
+            ) as usize
         },
         4usize,
         concat!(
@@ -1032,8 +1056,9 @@ fn bindgen_test_layout_rte_eth_dcb_tx_conf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_dcb_tx_conf>())).nb_tcs as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_dcb_tx_conf>())).nb_tcs
+            ) as usize
         },
         0usize,
         concat!(
@@ -1045,8 +1070,9 @@ fn bindgen_test_layout_rte_eth_dcb_tx_conf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_dcb_tx_conf>())).dcb_tc as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_dcb_tx_conf>())).dcb_tc
+            ) as usize
         },
         4usize,
         concat!(
@@ -1091,8 +1117,9 @@ fn bindgen_test_layout_rte_eth_vmdq_tx_conf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_vmdq_tx_conf>())).nb_queue_pools
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_vmdq_tx_conf>())).nb_queue_pools
+            ) as usize
         },
         0usize,
         concat!(
@@ -1160,8 +1187,10 @@ fn bindgen_test_layout_rte_eth_vmdq_rx_conf__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_vmdq_rx_conf__bindgen_ty_1>()))
-                .vlan_id as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_vmdq_rx_conf__bindgen_ty_1>()))
+                    .vlan_id
+            ) as usize
         },
         0usize,
         concat!(
@@ -1173,8 +1202,10 @@ fn bindgen_test_layout_rte_eth_vmdq_rx_conf__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_vmdq_rx_conf__bindgen_ty_1>())).pools
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_vmdq_rx_conf__bindgen_ty_1>()))
+                    .pools
+            ) as usize
         },
         8usize,
         concat!(
@@ -1204,8 +1235,9 @@ fn bindgen_test_layout_rte_eth_vmdq_rx_conf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_vmdq_rx_conf>())).nb_queue_pools
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_vmdq_rx_conf>())).nb_queue_pools
+            ) as usize
         },
         0usize,
         concat!(
@@ -1217,8 +1249,10 @@ fn bindgen_test_layout_rte_eth_vmdq_rx_conf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_vmdq_rx_conf>())).enable_default_pool
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_vmdq_rx_conf>()))
+                    .enable_default_pool
+            ) as usize
         },
         4usize,
         concat!(
@@ -1230,8 +1264,9 @@ fn bindgen_test_layout_rte_eth_vmdq_rx_conf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_vmdq_rx_conf>())).default_pool
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_vmdq_rx_conf>())).default_pool
+            ) as usize
         },
         5usize,
         concat!(
@@ -1243,8 +1278,10 @@ fn bindgen_test_layout_rte_eth_vmdq_rx_conf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_vmdq_rx_conf>())).enable_loop_back
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_vmdq_rx_conf>()))
+                    .enable_loop_back
+            ) as usize
         },
         6usize,
         concat!(
@@ -1256,8 +1293,9 @@ fn bindgen_test_layout_rte_eth_vmdq_rx_conf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_vmdq_rx_conf>())).nb_pool_maps
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_vmdq_rx_conf>())).nb_pool_maps
+            ) as usize
         },
         7usize,
         concat!(
@@ -1269,8 +1307,9 @@ fn bindgen_test_layout_rte_eth_vmdq_rx_conf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_vmdq_rx_conf>())).rx_mode as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_vmdq_rx_conf>())).rx_mode
+            ) as usize
         },
         8usize,
         concat!(
@@ -1282,8 +1321,9 @@ fn bindgen_test_layout_rte_eth_vmdq_rx_conf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_vmdq_rx_conf>())).pool_map
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_vmdq_rx_conf>())).pool_map
+            ) as usize
         },
         16usize,
         concat!(
@@ -1375,8 +1415,9 @@ fn bindgen_test_layout_rte_eth_ipv4_flow() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_ipv4_flow>())).src_ip as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_ipv4_flow>())).src_ip
+            ) as usize
         },
         0usize,
         concat!(
@@ -1388,8 +1429,9 @@ fn bindgen_test_layout_rte_eth_ipv4_flow() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_ipv4_flow>())).dst_ip as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_ipv4_flow>())).dst_ip
+            ) as usize
         },
         4usize,
         concat!(
@@ -1401,8 +1443,9 @@ fn bindgen_test_layout_rte_eth_ipv4_flow() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_ipv4_flow>())).tos as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_ipv4_flow>())).tos
+            ) as usize
         },
         8usize,
         concat!(
@@ -1414,8 +1457,9 @@ fn bindgen_test_layout_rte_eth_ipv4_flow() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_ipv4_flow>())).ttl as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_ipv4_flow>())).ttl
+            ) as usize
         },
         9usize,
         concat!(
@@ -1427,8 +1471,9 @@ fn bindgen_test_layout_rte_eth_ipv4_flow() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_ipv4_flow>())).proto as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_ipv4_flow>())).proto
+            ) as usize
         },
         10usize,
         concat!(
@@ -1473,8 +1518,9 @@ fn bindgen_test_layout_rte_eth_ipv6_flow() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_ipv6_flow>())).src_ip as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_ipv6_flow>())).src_ip
+            ) as usize
         },
         0usize,
         concat!(
@@ -1486,8 +1532,9 @@ fn bindgen_test_layout_rte_eth_ipv6_flow() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_ipv6_flow>())).dst_ip as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_ipv6_flow>())).dst_ip
+            ) as usize
         },
         16usize,
         concat!(
@@ -1499,8 +1546,9 @@ fn bindgen_test_layout_rte_eth_ipv6_flow() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_ipv6_flow>())).tc as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_ipv6_flow>())).tc
+            ) as usize
         },
         32usize,
         concat!(
@@ -1512,8 +1560,9 @@ fn bindgen_test_layout_rte_eth_ipv6_flow() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_ipv6_flow>())).proto as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_ipv6_flow>())).proto
+            ) as usize
         },
         33usize,
         concat!(
@@ -1525,8 +1574,9 @@ fn bindgen_test_layout_rte_eth_ipv6_flow() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_ipv6_flow>())).hop_limits as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_ipv6_flow>())).hop_limits
+            ) as usize
         },
         34usize,
         concat!(
@@ -1580,8 +1630,9 @@ fn bindgen_test_layout_rte_eth_fdir_masks() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_fdir_masks>())).vlan_tci_mask
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_fdir_masks>())).vlan_tci_mask
+            ) as usize
         },
         0usize,
         concat!(
@@ -1593,8 +1644,9 @@ fn bindgen_test_layout_rte_eth_fdir_masks() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_fdir_masks>())).ipv4_mask as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_fdir_masks>())).ipv4_mask
+            ) as usize
         },
         4usize,
         concat!(
@@ -1606,8 +1658,9 @@ fn bindgen_test_layout_rte_eth_fdir_masks() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_fdir_masks>())).ipv6_mask as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_fdir_masks>())).ipv6_mask
+            ) as usize
         },
         16usize,
         concat!(
@@ -1619,8 +1672,9 @@ fn bindgen_test_layout_rte_eth_fdir_masks() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_fdir_masks>())).src_port_mask
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_fdir_masks>())).src_port_mask
+            ) as usize
         },
         52usize,
         concat!(
@@ -1632,8 +1686,9 @@ fn bindgen_test_layout_rte_eth_fdir_masks() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_fdir_masks>())).dst_port_mask
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_fdir_masks>())).dst_port_mask
+            ) as usize
         },
         54usize,
         concat!(
@@ -1645,8 +1700,10 @@ fn bindgen_test_layout_rte_eth_fdir_masks() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_fdir_masks>())).mac_addr_byte_mask
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_fdir_masks>()))
+                    .mac_addr_byte_mask
+            ) as usize
         },
         56usize,
         concat!(
@@ -1658,8 +1715,9 @@ fn bindgen_test_layout_rte_eth_fdir_masks() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_fdir_masks>())).tunnel_id_mask
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_fdir_masks>())).tunnel_id_mask
+            ) as usize
         },
         60usize,
         concat!(
@@ -1671,8 +1729,9 @@ fn bindgen_test_layout_rte_eth_fdir_masks() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_fdir_masks>())).tunnel_type_mask
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_fdir_masks>())).tunnel_type_mask
+            ) as usize
         },
         64usize,
         concat!(
@@ -1722,8 +1781,9 @@ fn bindgen_test_layout_rte_eth_flex_payload_cfg() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_flex_payload_cfg>())).type_
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_flex_payload_cfg>())).type_
+            ) as usize
         },
         0usize,
         concat!(
@@ -1735,8 +1795,9 @@ fn bindgen_test_layout_rte_eth_flex_payload_cfg() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_flex_payload_cfg>())).src_offset
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_flex_payload_cfg>())).src_offset
+            ) as usize
         },
         4usize,
         concat!(
@@ -1783,8 +1844,9 @@ fn bindgen_test_layout_rte_eth_fdir_flex_mask() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_fdir_flex_mask>())).flow_type
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_fdir_flex_mask>())).flow_type
+            ) as usize
         },
         0usize,
         concat!(
@@ -1796,8 +1858,9 @@ fn bindgen_test_layout_rte_eth_fdir_flex_mask() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_fdir_flex_mask>())).mask as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_fdir_flex_mask>())).mask
+            ) as usize
         },
         2usize,
         concat!(
@@ -1839,8 +1902,9 @@ fn bindgen_test_layout_rte_eth_fdir_flex_conf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_fdir_flex_conf>())).nb_payloads
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_fdir_flex_conf>())).nb_payloads
+            ) as usize
         },
         0usize,
         concat!(
@@ -1852,8 +1916,9 @@ fn bindgen_test_layout_rte_eth_fdir_flex_conf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_fdir_flex_conf>())).nb_flexmasks
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_fdir_flex_conf>())).nb_flexmasks
+            ) as usize
         },
         2usize,
         concat!(
@@ -1865,8 +1930,9 @@ fn bindgen_test_layout_rte_eth_fdir_flex_conf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_fdir_flex_conf>())).flex_set
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_fdir_flex_conf>())).flex_set
+            ) as usize
         },
         4usize,
         concat!(
@@ -1878,8 +1944,9 @@ fn bindgen_test_layout_rte_eth_fdir_flex_conf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_fdir_flex_conf>())).flex_mask
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_fdir_flex_conf>())).flex_mask
+            ) as usize
         },
         292usize,
         concat!(
@@ -1936,7 +2003,8 @@ fn bindgen_test_layout_rte_fdir_conf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_fdir_conf>())).mode as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<rte_fdir_conf>())).mode)
+                as usize
         },
         0usize,
         concat!(
@@ -1948,8 +2016,9 @@ fn bindgen_test_layout_rte_fdir_conf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_fdir_conf>())).pballoc as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_fdir_conf>())).pballoc
+            ) as usize
         },
         4usize,
         concat!(
@@ -1961,8 +2030,9 @@ fn bindgen_test_layout_rte_fdir_conf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_fdir_conf>())).status as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_fdir_conf>())).status
+            ) as usize
         },
         8usize,
         concat!(
@@ -1974,8 +2044,9 @@ fn bindgen_test_layout_rte_fdir_conf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_fdir_conf>())).drop_queue as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_fdir_conf>())).drop_queue
+            ) as usize
         },
         12usize,
         concat!(
@@ -1987,7 +2058,8 @@ fn bindgen_test_layout_rte_fdir_conf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_fdir_conf>())).mask as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<rte_fdir_conf>())).mask)
+                as usize
         },
         16usize,
         concat!(
@@ -1999,8 +2071,9 @@ fn bindgen_test_layout_rte_fdir_conf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_fdir_conf>())).flex_conf as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_fdir_conf>())).flex_conf
+            ) as usize
         },
         84usize,
         concat!(
@@ -2048,7 +2121,8 @@ fn bindgen_test_layout_rte_intr_conf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_intr_conf>())).lsc as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<rte_intr_conf>())).lsc)
+                as usize
         },
         0usize,
         concat!(
@@ -2060,7 +2134,8 @@ fn bindgen_test_layout_rte_intr_conf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_intr_conf>())).rxq as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<rte_intr_conf>())).rxq)
+                as usize
         },
         2usize,
         concat!(
@@ -2135,8 +2210,9 @@ fn bindgen_test_layout_rte_eth_conf__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_conf__bindgen_ty_1>())).rss_conf
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_conf__bindgen_ty_1>())).rss_conf
+            ) as usize
         },
         0usize,
         concat!(
@@ -2148,8 +2224,10 @@ fn bindgen_test_layout_rte_eth_conf__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_conf__bindgen_ty_1>())).vmdq_dcb_conf
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_conf__bindgen_ty_1>()))
+                    .vmdq_dcb_conf
+            ) as usize
         },
         24usize,
         concat!(
@@ -2161,8 +2239,10 @@ fn bindgen_test_layout_rte_eth_conf__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_conf__bindgen_ty_1>())).dcb_rx_conf
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_conf__bindgen_ty_1>()))
+                    .dcb_rx_conf
+            ) as usize
         },
         1064usize,
         concat!(
@@ -2174,8 +2254,10 @@ fn bindgen_test_layout_rte_eth_conf__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_conf__bindgen_ty_1>())).vmdq_rx_conf
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_conf__bindgen_ty_1>()))
+                    .vmdq_rx_conf
+            ) as usize
         },
         1080usize,
         concat!(
@@ -2222,8 +2304,10 @@ fn bindgen_test_layout_rte_eth_conf__bindgen_ty_2() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_conf__bindgen_ty_2>()))
-                .vmdq_dcb_tx_conf as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_conf__bindgen_ty_2>()))
+                    .vmdq_dcb_tx_conf
+            ) as usize
         },
         0usize,
         concat!(
@@ -2235,8 +2319,10 @@ fn bindgen_test_layout_rte_eth_conf__bindgen_ty_2() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_conf__bindgen_ty_2>())).dcb_tx_conf
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_conf__bindgen_ty_2>()))
+                    .dcb_tx_conf
+            ) as usize
         },
         0usize,
         concat!(
@@ -2248,8 +2334,10 @@ fn bindgen_test_layout_rte_eth_conf__bindgen_ty_2() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_conf__bindgen_ty_2>())).vmdq_tx_conf
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_conf__bindgen_ty_2>()))
+                    .vmdq_tx_conf
+            ) as usize
         },
         0usize,
         concat!(
@@ -2279,8 +2367,9 @@ fn bindgen_test_layout_rte_eth_conf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_conf>())).link_speeds as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_conf>())).link_speeds
+            ) as usize
         },
         0usize,
         concat!(
@@ -2292,7 +2381,8 @@ fn bindgen_test_layout_rte_eth_conf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_conf>())).rxmode as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<rte_eth_conf>())).rxmode)
+                as usize
         },
         4usize,
         concat!(
@@ -2304,7 +2394,8 @@ fn bindgen_test_layout_rte_eth_conf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_conf>())).txmode as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<rte_eth_conf>())).txmode)
+                as usize
         },
         16usize,
         concat!(
@@ -2316,8 +2407,9 @@ fn bindgen_test_layout_rte_eth_conf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_conf>())).lpbk_mode as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_conf>())).lpbk_mode
+            ) as usize
         },
         24usize,
         concat!(
@@ -2329,8 +2421,9 @@ fn bindgen_test_layout_rte_eth_conf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_conf>())).rx_adv_conf as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_conf>())).rx_adv_conf
+            ) as usize
         },
         32usize,
         concat!(
@@ -2342,8 +2435,9 @@ fn bindgen_test_layout_rte_eth_conf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_conf>())).tx_adv_conf as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_conf>())).tx_adv_conf
+            ) as usize
         },
         2152usize,
         concat!(
@@ -2355,8 +2449,9 @@ fn bindgen_test_layout_rte_eth_conf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_conf>())).dcb_capability_en
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_conf>())).dcb_capability_en
+            ) as usize
         },
         2164usize,
         concat!(
@@ -2368,8 +2463,9 @@ fn bindgen_test_layout_rte_eth_conf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_conf>())).fdir_conf as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_conf>())).fdir_conf
+            ) as usize
         },
         2168usize,
         concat!(
@@ -2381,8 +2477,9 @@ fn bindgen_test_layout_rte_eth_conf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_conf>())).intr_conf as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_conf>())).intr_conf
+            ) as usize
         },
         2940usize,
         concat!(

--- a/tests/expectations/tests/layout_kni_mbuf.rs
+++ b/tests/expectations/tests/layout_kni_mbuf.rs
@@ -46,8 +46,9 @@ fn bindgen_test_layout_rte_kni_mbuf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_kni_mbuf>())).buf_addr as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_kni_mbuf>())).buf_addr
+            ) as usize
         },
         0usize,
         concat!(
@@ -59,8 +60,9 @@ fn bindgen_test_layout_rte_kni_mbuf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_kni_mbuf>())).buf_physaddr as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_kni_mbuf>())).buf_physaddr
+            ) as usize
         },
         8usize,
         concat!(
@@ -72,7 +74,8 @@ fn bindgen_test_layout_rte_kni_mbuf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_kni_mbuf>())).pad0 as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<rte_kni_mbuf>())).pad0)
+                as usize
         },
         16usize,
         concat!(
@@ -84,8 +87,9 @@ fn bindgen_test_layout_rte_kni_mbuf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_kni_mbuf>())).data_off as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_kni_mbuf>())).data_off
+            ) as usize
         },
         18usize,
         concat!(
@@ -97,7 +101,8 @@ fn bindgen_test_layout_rte_kni_mbuf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_kni_mbuf>())).pad1 as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<rte_kni_mbuf>())).pad1)
+                as usize
         },
         20usize,
         concat!(
@@ -109,8 +114,9 @@ fn bindgen_test_layout_rte_kni_mbuf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_kni_mbuf>())).nb_segs as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_kni_mbuf>())).nb_segs
+            ) as usize
         },
         22usize,
         concat!(
@@ -122,7 +128,8 @@ fn bindgen_test_layout_rte_kni_mbuf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_kni_mbuf>())).pad4 as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<rte_kni_mbuf>())).pad4)
+                as usize
         },
         23usize,
         concat!(
@@ -134,8 +141,9 @@ fn bindgen_test_layout_rte_kni_mbuf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_kni_mbuf>())).ol_flags as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_kni_mbuf>())).ol_flags
+            ) as usize
         },
         24usize,
         concat!(
@@ -147,7 +155,8 @@ fn bindgen_test_layout_rte_kni_mbuf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_kni_mbuf>())).pad2 as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<rte_kni_mbuf>())).pad2)
+                as usize
         },
         32usize,
         concat!(
@@ -159,8 +168,9 @@ fn bindgen_test_layout_rte_kni_mbuf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_kni_mbuf>())).pkt_len as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_kni_mbuf>())).pkt_len
+            ) as usize
         },
         36usize,
         concat!(
@@ -172,8 +182,9 @@ fn bindgen_test_layout_rte_kni_mbuf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_kni_mbuf>())).data_len as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_kni_mbuf>())).data_len
+            ) as usize
         },
         40usize,
         concat!(
@@ -185,7 +196,8 @@ fn bindgen_test_layout_rte_kni_mbuf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_kni_mbuf>())).pad3 as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<rte_kni_mbuf>())).pad3)
+                as usize
         },
         64usize,
         concat!(
@@ -197,7 +209,8 @@ fn bindgen_test_layout_rte_kni_mbuf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_kni_mbuf>())).pool as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<rte_kni_mbuf>())).pool)
+                as usize
         },
         72usize,
         concat!(
@@ -209,7 +222,8 @@ fn bindgen_test_layout_rte_kni_mbuf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_kni_mbuf>())).next as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<rte_kni_mbuf>())).next)
+                as usize
         },
         80usize,
         concat!(

--- a/tests/expectations/tests/layout_large_align_field.rs
+++ b/tests/expectations/tests/layout_large_align_field.rs
@@ -76,7 +76,10 @@ fn bindgen_test_layout_ip_frag() {
         concat!("Alignment of ", stringify!(ip_frag))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<ip_frag>())).ofs as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<ip_frag>())).ofs)
+                as usize
+        },
         0usize,
         concat!(
             "Offset of field: ",
@@ -86,7 +89,10 @@ fn bindgen_test_layout_ip_frag() {
         )
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<ip_frag>())).len as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<ip_frag>())).len)
+                as usize
+        },
         2usize,
         concat!(
             "Offset of field: ",
@@ -96,7 +102,9 @@ fn bindgen_test_layout_ip_frag() {
         )
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<ip_frag>())).mb as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<ip_frag>())).mb) as usize
+        },
         8usize,
         concat!(
             "Offset of field: ",
@@ -140,7 +148,8 @@ fn bindgen_test_layout_ip_frag_key() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<ip_frag_key>())).src_dst as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<ip_frag_key>())).src_dst)
+                as usize
         },
         0usize,
         concat!(
@@ -152,7 +161,8 @@ fn bindgen_test_layout_ip_frag_key() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<ip_frag_key>())).id as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<ip_frag_key>())).id)
+                as usize
         },
         32usize,
         concat!(
@@ -164,7 +174,8 @@ fn bindgen_test_layout_ip_frag_key() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<ip_frag_key>())).key_len as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<ip_frag_key>())).key_len)
+                as usize
         },
         36usize,
         concat!(
@@ -216,8 +227,9 @@ fn bindgen_test_layout_ip_frag_pkt__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<ip_frag_pkt__bindgen_ty_1>())).tqe_next
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<ip_frag_pkt__bindgen_ty_1>())).tqe_next
+            ) as usize
         },
         0usize,
         concat!(
@@ -229,8 +241,9 @@ fn bindgen_test_layout_ip_frag_pkt__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<ip_frag_pkt__bindgen_ty_1>())).tqe_prev
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<ip_frag_pkt__bindgen_ty_1>())).tqe_prev
+            ) as usize
         },
         8usize,
         concat!(
@@ -264,7 +277,8 @@ fn bindgen_test_layout_ip_frag_pkt() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<ip_frag_pkt>())).lru as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<ip_frag_pkt>())).lru)
+                as usize
         },
         0usize,
         concat!(
@@ -276,7 +290,8 @@ fn bindgen_test_layout_ip_frag_pkt() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<ip_frag_pkt>())).key as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<ip_frag_pkt>())).key)
+                as usize
         },
         16usize,
         concat!(
@@ -288,7 +303,8 @@ fn bindgen_test_layout_ip_frag_pkt() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<ip_frag_pkt>())).start as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<ip_frag_pkt>())).start)
+                as usize
         },
         56usize,
         concat!(
@@ -300,8 +316,9 @@ fn bindgen_test_layout_ip_frag_pkt() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<ip_frag_pkt>())).total_size as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<ip_frag_pkt>())).total_size
+            ) as usize
         },
         64usize,
         concat!(
@@ -313,8 +330,9 @@ fn bindgen_test_layout_ip_frag_pkt() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<ip_frag_pkt>())).frag_size as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<ip_frag_pkt>())).frag_size
+            ) as usize
         },
         68usize,
         concat!(
@@ -326,8 +344,9 @@ fn bindgen_test_layout_ip_frag_pkt() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<ip_frag_pkt>())).last_idx as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<ip_frag_pkt>())).last_idx
+            ) as usize
         },
         72usize,
         concat!(
@@ -339,7 +358,8 @@ fn bindgen_test_layout_ip_frag_pkt() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<ip_frag_pkt>())).frags as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<ip_frag_pkt>())).frags)
+                as usize
         },
         80usize,
         concat!(
@@ -379,8 +399,9 @@ fn bindgen_test_layout_ip_pkt_list() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<ip_pkt_list>())).tqh_first as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<ip_pkt_list>())).tqh_first
+            ) as usize
         },
         0usize,
         concat!(
@@ -392,8 +413,9 @@ fn bindgen_test_layout_ip_pkt_list() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<ip_pkt_list>())).tqh_last as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<ip_pkt_list>())).tqh_last
+            ) as usize
         },
         8usize,
         concat!(
@@ -445,8 +467,9 @@ fn bindgen_test_layout_ip_frag_tbl_stat() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<ip_frag_tbl_stat>())).find_num as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<ip_frag_tbl_stat>())).find_num
+            ) as usize
         },
         0usize,
         concat!(
@@ -458,8 +481,9 @@ fn bindgen_test_layout_ip_frag_tbl_stat() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<ip_frag_tbl_stat>())).add_num as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<ip_frag_tbl_stat>())).add_num
+            ) as usize
         },
         8usize,
         concat!(
@@ -471,8 +495,9 @@ fn bindgen_test_layout_ip_frag_tbl_stat() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<ip_frag_tbl_stat>())).del_num as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<ip_frag_tbl_stat>())).del_num
+            ) as usize
         },
         16usize,
         concat!(
@@ -484,8 +509,9 @@ fn bindgen_test_layout_ip_frag_tbl_stat() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<ip_frag_tbl_stat>())).reuse_num as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<ip_frag_tbl_stat>())).reuse_num
+            ) as usize
         },
         24usize,
         concat!(
@@ -497,8 +523,9 @@ fn bindgen_test_layout_ip_frag_tbl_stat() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<ip_frag_tbl_stat>())).fail_total as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<ip_frag_tbl_stat>())).fail_total
+            ) as usize
         },
         32usize,
         concat!(
@@ -510,8 +537,9 @@ fn bindgen_test_layout_ip_frag_tbl_stat() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<ip_frag_tbl_stat>())).fail_nospace
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<ip_frag_tbl_stat>())).fail_nospace
+            ) as usize
         },
         40usize,
         concat!(
@@ -573,8 +601,9 @@ fn bindgen_test_layout_rte_ip_frag_tbl() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_ip_frag_tbl>())).max_cycles as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_ip_frag_tbl>())).max_cycles
+            ) as usize
         },
         0usize,
         concat!(
@@ -586,8 +615,9 @@ fn bindgen_test_layout_rte_ip_frag_tbl() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_ip_frag_tbl>())).entry_mask as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_ip_frag_tbl>())).entry_mask
+            ) as usize
         },
         8usize,
         concat!(
@@ -599,8 +629,9 @@ fn bindgen_test_layout_rte_ip_frag_tbl() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_ip_frag_tbl>())).max_entries as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_ip_frag_tbl>())).max_entries
+            ) as usize
         },
         12usize,
         concat!(
@@ -612,8 +643,9 @@ fn bindgen_test_layout_rte_ip_frag_tbl() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_ip_frag_tbl>())).use_entries as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_ip_frag_tbl>())).use_entries
+            ) as usize
         },
         16usize,
         concat!(
@@ -625,8 +657,9 @@ fn bindgen_test_layout_rte_ip_frag_tbl() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_ip_frag_tbl>())).bucket_entries
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_ip_frag_tbl>())).bucket_entries
+            ) as usize
         },
         20usize,
         concat!(
@@ -638,8 +671,9 @@ fn bindgen_test_layout_rte_ip_frag_tbl() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_ip_frag_tbl>())).nb_entries as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_ip_frag_tbl>())).nb_entries
+            ) as usize
         },
         24usize,
         concat!(
@@ -651,8 +685,9 @@ fn bindgen_test_layout_rte_ip_frag_tbl() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_ip_frag_tbl>())).nb_buckets as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_ip_frag_tbl>())).nb_buckets
+            ) as usize
         },
         28usize,
         concat!(
@@ -664,8 +699,9 @@ fn bindgen_test_layout_rte_ip_frag_tbl() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_ip_frag_tbl>())).last as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_ip_frag_tbl>())).last
+            ) as usize
         },
         32usize,
         concat!(
@@ -677,7 +713,8 @@ fn bindgen_test_layout_rte_ip_frag_tbl() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_ip_frag_tbl>())).lru as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<rte_ip_frag_tbl>())).lru)
+                as usize
         },
         40usize,
         concat!(
@@ -689,8 +726,9 @@ fn bindgen_test_layout_rte_ip_frag_tbl() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_ip_frag_tbl>())).stat as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_ip_frag_tbl>())).stat
+            ) as usize
         },
         64usize,
         concat!(
@@ -702,7 +740,8 @@ fn bindgen_test_layout_rte_ip_frag_tbl() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_ip_frag_tbl>())).pkt as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<rte_ip_frag_tbl>())).pkt)
+                as usize
         },
         128usize,
         concat!(

--- a/tests/expectations/tests/layout_mbuf.rs
+++ b/tests/expectations/tests/layout_mbuf.rs
@@ -118,7 +118,8 @@ fn bindgen_test_layout_rte_atomic16_t() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_atomic16_t>())).cnt as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<rte_atomic16_t>())).cnt)
+                as usize
         },
         0usize,
         concat!(
@@ -204,8 +205,9 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_mbuf__bindgen_ty_1>())).refcnt_atomic
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_mbuf__bindgen_ty_1>())).refcnt_atomic
+            ) as usize
         },
         0usize,
         concat!(
@@ -217,8 +219,9 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_mbuf__bindgen_ty_1>())).refcnt
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_mbuf__bindgen_ty_1>())).refcnt
+            ) as usize
         },
         0usize,
         concat!(
@@ -423,8 +426,9 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_2() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_mbuf__bindgen_ty_2>())).packet_type
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_mbuf__bindgen_ty_2>())).packet_type
+            ) as usize
         },
         0usize,
         concat!(
@@ -480,8 +484,8 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindg
 ) {
     assert_eq ! (:: std :: mem :: size_of :: < rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1 > () , 4usize , concat ! ("Size of: " , stringify ! (rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1)));
     assert_eq ! (:: std :: mem :: align_of :: < rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1 > () , 2usize , concat ! ("Alignment of " , stringify ! (rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1)));
-    assert_eq ! (unsafe { & (* (:: std :: ptr :: null :: < rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1 > ())) . hash as * const _ as usize } , 0usize , concat ! ("Offset of field: " , stringify ! (rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1) , "::" , stringify ! (hash)));
-    assert_eq ! (unsafe { & (* (:: std :: ptr :: null :: < rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1 > ())) . id as * const _ as usize } , 2usize , concat ! ("Offset of field: " , stringify ! (rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1) , "::" , stringify ! (id)));
+    assert_eq ! (unsafe { :: std :: ptr :: addr_of ! ((* (:: std :: ptr :: null :: < rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1 > ())) . hash) as usize } , 0usize , concat ! ("Offset of field: " , stringify ! (rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1) , "::" , stringify ! (hash)));
+    assert_eq ! (unsafe { :: std :: ptr :: addr_of ! ((* (:: std :: ptr :: null :: < rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1 > ())) . id) as usize } , 2usize , concat ! ("Offset of field: " , stringify ! (rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1) , "::" , stringify ! (id)));
 }
 #[test]
 fn bindgen_test_layout_rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1() {
@@ -506,10 +510,12 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<
-                rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1,
-            >()))
-            .lo as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<
+                    rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1,
+                >()))
+                .lo
+            ) as usize
         },
         0usize,
         concat!(
@@ -549,8 +555,10 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_3__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_mbuf__bindgen_ty_3__bindgen_ty_1>())).hi
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_mbuf__bindgen_ty_3__bindgen_ty_1>()))
+                    .hi
+            ) as usize
         },
         4usize,
         concat!(
@@ -596,8 +604,10 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_3__bindgen_ty_2() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_mbuf__bindgen_ty_3__bindgen_ty_2>())).lo
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_mbuf__bindgen_ty_3__bindgen_ty_2>()))
+                    .lo
+            ) as usize
         },
         0usize,
         concat!(
@@ -609,8 +619,10 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_3__bindgen_ty_2() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_mbuf__bindgen_ty_3__bindgen_ty_2>())).hi
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_mbuf__bindgen_ty_3__bindgen_ty_2>()))
+                    .hi
+            ) as usize
         },
         4usize,
         concat!(
@@ -635,8 +647,9 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_3() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_mbuf__bindgen_ty_3>())).rss as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_mbuf__bindgen_ty_3>())).rss
+            ) as usize
         },
         0usize,
         concat!(
@@ -648,8 +661,9 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_3() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_mbuf__bindgen_ty_3>())).fdir as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_mbuf__bindgen_ty_3>())).fdir
+            ) as usize
         },
         0usize,
         concat!(
@@ -661,8 +675,9 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_3() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_mbuf__bindgen_ty_3>())).sched as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_mbuf__bindgen_ty_3>())).sched
+            ) as usize
         },
         0usize,
         concat!(
@@ -674,8 +689,9 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_3() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_mbuf__bindgen_ty_3>())).usr as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_mbuf__bindgen_ty_3>())).usr
+            ) as usize
         },
         0usize,
         concat!(
@@ -717,8 +733,9 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_4() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_mbuf__bindgen_ty_4>())).userdata
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_mbuf__bindgen_ty_4>())).userdata
+            ) as usize
         },
         0usize,
         concat!(
@@ -730,8 +747,9 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_4() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_mbuf__bindgen_ty_4>())).udata64
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_mbuf__bindgen_ty_4>())).udata64
+            ) as usize
         },
         0usize,
         concat!(
@@ -917,8 +935,9 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_5() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_mbuf__bindgen_ty_5>())).tx_offload
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_mbuf__bindgen_ty_5>())).tx_offload
+            ) as usize
         },
         0usize,
         concat!(
@@ -952,7 +971,8 @@ fn bindgen_test_layout_rte_mbuf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_mbuf>())).cacheline0 as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<rte_mbuf>())).cacheline0)
+                as usize
         },
         0usize,
         concat!(
@@ -964,7 +984,8 @@ fn bindgen_test_layout_rte_mbuf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_mbuf>())).buf_addr as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<rte_mbuf>())).buf_addr)
+                as usize
         },
         0usize,
         concat!(
@@ -976,8 +997,9 @@ fn bindgen_test_layout_rte_mbuf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_mbuf>())).buf_physaddr as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_mbuf>())).buf_physaddr
+            ) as usize
         },
         8usize,
         concat!(
@@ -989,7 +1011,8 @@ fn bindgen_test_layout_rte_mbuf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_mbuf>())).buf_len as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<rte_mbuf>())).buf_len)
+                as usize
         },
         16usize,
         concat!(
@@ -1001,7 +1024,8 @@ fn bindgen_test_layout_rte_mbuf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_mbuf>())).rearm_data as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<rte_mbuf>())).rearm_data)
+                as usize
         },
         18usize,
         concat!(
@@ -1013,7 +1037,8 @@ fn bindgen_test_layout_rte_mbuf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_mbuf>())).data_off as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<rte_mbuf>())).data_off)
+                as usize
         },
         18usize,
         concat!(
@@ -1025,7 +1050,8 @@ fn bindgen_test_layout_rte_mbuf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_mbuf>())).nb_segs as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<rte_mbuf>())).nb_segs)
+                as usize
         },
         22usize,
         concat!(
@@ -1037,7 +1063,8 @@ fn bindgen_test_layout_rte_mbuf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_mbuf>())).port as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<rte_mbuf>())).port)
+                as usize
         },
         23usize,
         concat!(
@@ -1049,7 +1076,8 @@ fn bindgen_test_layout_rte_mbuf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_mbuf>())).ol_flags as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<rte_mbuf>())).ol_flags)
+                as usize
         },
         24usize,
         concat!(
@@ -1061,8 +1089,9 @@ fn bindgen_test_layout_rte_mbuf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_mbuf>())).rx_descriptor_fields1
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_mbuf>())).rx_descriptor_fields1
+            ) as usize
         },
         32usize,
         concat!(
@@ -1074,7 +1103,8 @@ fn bindgen_test_layout_rte_mbuf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_mbuf>())).pkt_len as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<rte_mbuf>())).pkt_len)
+                as usize
         },
         36usize,
         concat!(
@@ -1086,7 +1116,8 @@ fn bindgen_test_layout_rte_mbuf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_mbuf>())).data_len as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<rte_mbuf>())).data_len)
+                as usize
         },
         40usize,
         concat!(
@@ -1098,7 +1129,8 @@ fn bindgen_test_layout_rte_mbuf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_mbuf>())).vlan_tci as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<rte_mbuf>())).vlan_tci)
+                as usize
         },
         42usize,
         concat!(
@@ -1110,7 +1142,8 @@ fn bindgen_test_layout_rte_mbuf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_mbuf>())).hash as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<rte_mbuf>())).hash)
+                as usize
         },
         44usize,
         concat!(
@@ -1122,7 +1155,8 @@ fn bindgen_test_layout_rte_mbuf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_mbuf>())).seqn as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<rte_mbuf>())).seqn)
+                as usize
         },
         52usize,
         concat!(
@@ -1134,8 +1168,9 @@ fn bindgen_test_layout_rte_mbuf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_mbuf>())).vlan_tci_outer as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_mbuf>())).vlan_tci_outer
+            ) as usize
         },
         56usize,
         concat!(
@@ -1147,7 +1182,8 @@ fn bindgen_test_layout_rte_mbuf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_mbuf>())).cacheline1 as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<rte_mbuf>())).cacheline1)
+                as usize
         },
         64usize,
         concat!(
@@ -1159,7 +1195,8 @@ fn bindgen_test_layout_rte_mbuf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_mbuf>())).pool as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<rte_mbuf>())).pool)
+                as usize
         },
         72usize,
         concat!(
@@ -1171,7 +1208,8 @@ fn bindgen_test_layout_rte_mbuf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_mbuf>())).next as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<rte_mbuf>())).next)
+                as usize
         },
         80usize,
         concat!(
@@ -1183,7 +1221,8 @@ fn bindgen_test_layout_rte_mbuf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_mbuf>())).priv_size as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<rte_mbuf>())).priv_size)
+                as usize
         },
         96usize,
         concat!(
@@ -1195,7 +1234,8 @@ fn bindgen_test_layout_rte_mbuf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_mbuf>())).timesync as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<rte_mbuf>())).timesync)
+                as usize
         },
         98usize,
         concat!(

--- a/tests/expectations/tests/layout_mbuf_1_0.rs
+++ b/tests/expectations/tests/layout_mbuf_1_0.rs
@@ -161,7 +161,8 @@ fn bindgen_test_layout_rte_atomic16_t() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_atomic16_t>())).cnt as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<rte_atomic16_t>())).cnt)
+                as usize
         },
         0usize,
         concat!(
@@ -253,8 +254,9 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_mbuf__bindgen_ty_1>())).refcnt_atomic
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_mbuf__bindgen_ty_1>())).refcnt_atomic
+            ) as usize
         },
         0usize,
         concat!(
@@ -266,8 +268,9 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_mbuf__bindgen_ty_1>())).refcnt
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_mbuf__bindgen_ty_1>())).refcnt
+            ) as usize
         },
         0usize,
         concat!(
@@ -475,8 +478,9 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_2() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_mbuf__bindgen_ty_2>())).packet_type
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_mbuf__bindgen_ty_2>())).packet_type
+            ) as usize
         },
         0usize,
         concat!(
@@ -531,8 +535,8 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindg
 ) {
     assert_eq ! (:: std :: mem :: size_of :: < rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1 > () , 4usize , concat ! ("Size of: " , stringify ! (rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1)));
     assert_eq ! (:: std :: mem :: align_of :: < rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1 > () , 2usize , concat ! ("Alignment of " , stringify ! (rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1)));
-    assert_eq ! (unsafe { & (* (:: std :: ptr :: null :: < rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1 > ())) . hash as * const _ as usize } , 0usize , concat ! ("Offset of field: " , stringify ! (rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1) , "::" , stringify ! (hash)));
-    assert_eq ! (unsafe { & (* (:: std :: ptr :: null :: < rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1 > ())) . id as * const _ as usize } , 2usize , concat ! ("Offset of field: " , stringify ! (rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1) , "::" , stringify ! (id)));
+    assert_eq ! (unsafe { :: std :: ptr :: addr_of ! ((* (:: std :: ptr :: null :: < rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1 > ())) . hash) as usize } , 0usize , concat ! ("Offset of field: " , stringify ! (rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1) , "::" , stringify ! (hash)));
+    assert_eq ! (unsafe { :: std :: ptr :: addr_of ! ((* (:: std :: ptr :: null :: < rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1 > ())) . id) as usize } , 2usize , concat ! ("Offset of field: " , stringify ! (rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1) , "::" , stringify ! (id)));
 }
 impl Clone
     for rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1
@@ -564,10 +568,12 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<
-                rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1,
-            >()))
-            .lo as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<
+                    rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1,
+                >()))
+                .lo
+            ) as usize
         },
         0usize,
         concat!(
@@ -603,8 +609,10 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_3__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_mbuf__bindgen_ty_3__bindgen_ty_1>())).hi
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_mbuf__bindgen_ty_3__bindgen_ty_1>()))
+                    .hi
+            ) as usize
         },
         4usize,
         concat!(
@@ -646,8 +654,10 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_3__bindgen_ty_2() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_mbuf__bindgen_ty_3__bindgen_ty_2>())).lo
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_mbuf__bindgen_ty_3__bindgen_ty_2>()))
+                    .lo
+            ) as usize
         },
         0usize,
         concat!(
@@ -659,8 +669,10 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_3__bindgen_ty_2() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_mbuf__bindgen_ty_3__bindgen_ty_2>())).hi
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_mbuf__bindgen_ty_3__bindgen_ty_2>()))
+                    .hi
+            ) as usize
         },
         4usize,
         concat!(
@@ -690,8 +702,9 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_3() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_mbuf__bindgen_ty_3>())).rss as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_mbuf__bindgen_ty_3>())).rss
+            ) as usize
         },
         0usize,
         concat!(
@@ -703,8 +716,9 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_3() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_mbuf__bindgen_ty_3>())).fdir as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_mbuf__bindgen_ty_3>())).fdir
+            ) as usize
         },
         0usize,
         concat!(
@@ -716,8 +730,9 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_3() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_mbuf__bindgen_ty_3>())).sched as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_mbuf__bindgen_ty_3>())).sched
+            ) as usize
         },
         0usize,
         concat!(
@@ -729,8 +744,9 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_3() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_mbuf__bindgen_ty_3>())).usr as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_mbuf__bindgen_ty_3>())).usr
+            ) as usize
         },
         0usize,
         concat!(
@@ -769,8 +785,9 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_4() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_mbuf__bindgen_ty_4>())).userdata
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_mbuf__bindgen_ty_4>())).userdata
+            ) as usize
         },
         0usize,
         concat!(
@@ -782,8 +799,9 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_4() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_mbuf__bindgen_ty_4>())).udata64
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_mbuf__bindgen_ty_4>())).udata64
+            ) as usize
         },
         0usize,
         concat!(
@@ -972,8 +990,9 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_5() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_mbuf__bindgen_ty_5>())).tx_offload
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_mbuf__bindgen_ty_5>())).tx_offload
+            ) as usize
         },
         0usize,
         concat!(
@@ -998,7 +1017,8 @@ fn bindgen_test_layout_rte_mbuf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_mbuf>())).cacheline0 as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<rte_mbuf>())).cacheline0)
+                as usize
         },
         0usize,
         concat!(
@@ -1010,7 +1030,8 @@ fn bindgen_test_layout_rte_mbuf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_mbuf>())).buf_addr as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<rte_mbuf>())).buf_addr)
+                as usize
         },
         0usize,
         concat!(
@@ -1022,8 +1043,9 @@ fn bindgen_test_layout_rte_mbuf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_mbuf>())).buf_physaddr as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_mbuf>())).buf_physaddr
+            ) as usize
         },
         8usize,
         concat!(
@@ -1035,7 +1057,8 @@ fn bindgen_test_layout_rte_mbuf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_mbuf>())).buf_len as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<rte_mbuf>())).buf_len)
+                as usize
         },
         16usize,
         concat!(
@@ -1047,7 +1070,8 @@ fn bindgen_test_layout_rte_mbuf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_mbuf>())).rearm_data as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<rte_mbuf>())).rearm_data)
+                as usize
         },
         18usize,
         concat!(
@@ -1059,7 +1083,8 @@ fn bindgen_test_layout_rte_mbuf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_mbuf>())).data_off as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<rte_mbuf>())).data_off)
+                as usize
         },
         18usize,
         concat!(
@@ -1071,7 +1096,8 @@ fn bindgen_test_layout_rte_mbuf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_mbuf>())).nb_segs as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<rte_mbuf>())).nb_segs)
+                as usize
         },
         22usize,
         concat!(
@@ -1083,7 +1109,8 @@ fn bindgen_test_layout_rte_mbuf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_mbuf>())).port as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<rte_mbuf>())).port)
+                as usize
         },
         23usize,
         concat!(
@@ -1095,7 +1122,8 @@ fn bindgen_test_layout_rte_mbuf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_mbuf>())).ol_flags as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<rte_mbuf>())).ol_flags)
+                as usize
         },
         24usize,
         concat!(
@@ -1107,8 +1135,9 @@ fn bindgen_test_layout_rte_mbuf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_mbuf>())).rx_descriptor_fields1
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_mbuf>())).rx_descriptor_fields1
+            ) as usize
         },
         32usize,
         concat!(
@@ -1120,7 +1149,8 @@ fn bindgen_test_layout_rte_mbuf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_mbuf>())).pkt_len as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<rte_mbuf>())).pkt_len)
+                as usize
         },
         36usize,
         concat!(
@@ -1132,7 +1162,8 @@ fn bindgen_test_layout_rte_mbuf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_mbuf>())).data_len as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<rte_mbuf>())).data_len)
+                as usize
         },
         40usize,
         concat!(
@@ -1144,7 +1175,8 @@ fn bindgen_test_layout_rte_mbuf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_mbuf>())).vlan_tci as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<rte_mbuf>())).vlan_tci)
+                as usize
         },
         42usize,
         concat!(
@@ -1156,7 +1188,8 @@ fn bindgen_test_layout_rte_mbuf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_mbuf>())).hash as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<rte_mbuf>())).hash)
+                as usize
         },
         44usize,
         concat!(
@@ -1168,7 +1201,8 @@ fn bindgen_test_layout_rte_mbuf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_mbuf>())).seqn as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<rte_mbuf>())).seqn)
+                as usize
         },
         52usize,
         concat!(
@@ -1180,8 +1214,9 @@ fn bindgen_test_layout_rte_mbuf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_mbuf>())).vlan_tci_outer as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_mbuf>())).vlan_tci_outer
+            ) as usize
         },
         56usize,
         concat!(
@@ -1193,7 +1228,8 @@ fn bindgen_test_layout_rte_mbuf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_mbuf>())).cacheline1 as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<rte_mbuf>())).cacheline1)
+                as usize
         },
         64usize,
         concat!(
@@ -1205,7 +1241,8 @@ fn bindgen_test_layout_rte_mbuf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_mbuf>())).pool as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<rte_mbuf>())).pool)
+                as usize
         },
         72usize,
         concat!(
@@ -1217,7 +1254,8 @@ fn bindgen_test_layout_rte_mbuf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_mbuf>())).next as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<rte_mbuf>())).next)
+                as usize
         },
         80usize,
         concat!(
@@ -1229,7 +1267,8 @@ fn bindgen_test_layout_rte_mbuf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_mbuf>())).priv_size as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<rte_mbuf>())).priv_size)
+                as usize
         },
         96usize,
         concat!(
@@ -1241,7 +1280,8 @@ fn bindgen_test_layout_rte_mbuf() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_mbuf>())).timesync as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<rte_mbuf>())).timesync)
+                as usize
         },
         98usize,
         concat!(

--- a/tests/expectations/tests/libclang-9/call-conv-field.rs
+++ b/tests/expectations/tests/libclang-9/call-conv-field.rs
@@ -30,8 +30,9 @@ fn bindgen_test_layout_JNINativeInterface_() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<JNINativeInterface_>())).GetVersion
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<JNINativeInterface_>())).GetVersion
+            ) as usize
         },
         0usize,
         concat!(
@@ -43,8 +44,9 @@ fn bindgen_test_layout_JNINativeInterface_() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<JNINativeInterface_>())).__hack as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<JNINativeInterface_>())).__hack
+            ) as usize
         },
         8usize,
         concat!(

--- a/tests/expectations/tests/libclang-9/class.rs
+++ b/tests/expectations/tests/libclang-9/class.rs
@@ -54,12 +54,17 @@ fn bindgen_test_layout_C() {
         concat!("Alignment of ", stringify!(C))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<C>())).a as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<C>())).a) as usize
+        },
         0usize,
         concat!("Offset of field: ", stringify!(C), "::", stringify!(a))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<C>())).big_array as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<C>())).big_array)
+                as usize
+        },
         4usize,
         concat!(
             "Offset of field: ",
@@ -98,8 +103,9 @@ fn bindgen_test_layout_C_with_zero_length_array() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<C_with_zero_length_array>())).a as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<C_with_zero_length_array>())).a
+            ) as usize
         },
         0usize,
         concat!(
@@ -111,8 +117,9 @@ fn bindgen_test_layout_C_with_zero_length_array() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<C_with_zero_length_array>())).big_array
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<C_with_zero_length_array>())).big_array
+            ) as usize
         },
         4usize,
         concat!(
@@ -124,8 +131,10 @@ fn bindgen_test_layout_C_with_zero_length_array() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<C_with_zero_length_array>()))
-                .zero_length_array as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<C_with_zero_length_array>()))
+                    .zero_length_array
+            ) as usize
         },
         37usize,
         concat!(
@@ -165,8 +174,9 @@ fn bindgen_test_layout_C_with_zero_length_array_2() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<C_with_zero_length_array_2>())).a as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<C_with_zero_length_array_2>())).a
+            ) as usize
         },
         0usize,
         concat!(
@@ -178,8 +188,10 @@ fn bindgen_test_layout_C_with_zero_length_array_2() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<C_with_zero_length_array_2>()))
-                .zero_length_array as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<C_with_zero_length_array_2>()))
+                    .zero_length_array
+            ) as usize
         },
         4usize,
         concat!(
@@ -210,8 +222,9 @@ fn bindgen_test_layout_C_with_incomplete_array() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<C_with_incomplete_array>())).a as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<C_with_incomplete_array>())).a
+            ) as usize
         },
         0usize,
         concat!(
@@ -223,8 +236,9 @@ fn bindgen_test_layout_C_with_incomplete_array() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<C_with_incomplete_array>())).big_array
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<C_with_incomplete_array>())).big_array
+            ) as usize
         },
         4usize,
         concat!(
@@ -236,8 +250,10 @@ fn bindgen_test_layout_C_with_incomplete_array() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<C_with_incomplete_array>())).incomplete_array
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<C_with_incomplete_array>()))
+                    .incomplete_array
+            ) as usize
         },
         37usize,
         concat!(
@@ -277,8 +293,9 @@ fn bindgen_test_layout_C_with_incomplete_array_2() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<C_with_incomplete_array_2>())).a as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<C_with_incomplete_array_2>())).a
+            ) as usize
         },
         0usize,
         concat!(
@@ -290,8 +307,10 @@ fn bindgen_test_layout_C_with_incomplete_array_2() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<C_with_incomplete_array_2>()))
-                .incomplete_array as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<C_with_incomplete_array_2>()))
+                    .incomplete_array
+            ) as usize
         },
         4usize,
         concat!(
@@ -329,10 +348,12 @@ fn bindgen_test_layout_C_with_zero_length_array_and_incomplete_array() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<
-                C_with_zero_length_array_and_incomplete_array,
-            >()))
-            .a as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<
+                    C_with_zero_length_array_and_incomplete_array,
+                >()))
+                .a
+            ) as usize
         },
         0usize,
         concat!(
@@ -344,10 +365,12 @@ fn bindgen_test_layout_C_with_zero_length_array_and_incomplete_array() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<
-                C_with_zero_length_array_and_incomplete_array,
-            >()))
-            .big_array as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<
+                    C_with_zero_length_array_and_incomplete_array,
+                >()))
+                .big_array
+            ) as usize
         },
         4usize,
         concat!(
@@ -359,10 +382,12 @@ fn bindgen_test_layout_C_with_zero_length_array_and_incomplete_array() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<
-                C_with_zero_length_array_and_incomplete_array,
-            >()))
-            .zero_length_array as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<
+                    C_with_zero_length_array_and_incomplete_array,
+                >()))
+                .zero_length_array
+            ) as usize
         },
         37usize,
         concat!(
@@ -374,10 +399,12 @@ fn bindgen_test_layout_C_with_zero_length_array_and_incomplete_array() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<
-                C_with_zero_length_array_and_incomplete_array,
-            >()))
-            .incomplete_array as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<
+                    C_with_zero_length_array_and_incomplete_array,
+                >()))
+                .incomplete_array
+            ) as usize
         },
         37usize,
         concat!(
@@ -426,10 +453,12 @@ fn bindgen_test_layout_C_with_zero_length_array_and_incomplete_array_2() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<
-                C_with_zero_length_array_and_incomplete_array_2,
-            >()))
-            .a as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<
+                    C_with_zero_length_array_and_incomplete_array_2,
+                >()))
+                .a
+            ) as usize
         },
         0usize,
         concat!(
@@ -441,10 +470,12 @@ fn bindgen_test_layout_C_with_zero_length_array_and_incomplete_array_2() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<
-                C_with_zero_length_array_and_incomplete_array_2,
-            >()))
-            .zero_length_array as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<
+                    C_with_zero_length_array_and_incomplete_array_2,
+                >()))
+                .zero_length_array
+            ) as usize
         },
         4usize,
         concat!(
@@ -456,10 +487,12 @@ fn bindgen_test_layout_C_with_zero_length_array_and_incomplete_array_2() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<
-                C_with_zero_length_array_and_incomplete_array_2,
-            >()))
-            .incomplete_array as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<
+                    C_with_zero_length_array_and_incomplete_array_2,
+                >()))
+                .incomplete_array
+            ) as usize
         },
         4usize,
         concat!(
@@ -488,7 +521,9 @@ fn bindgen_test_layout_WithDtor() {
         concat!("Alignment of ", stringify!(WithDtor))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<WithDtor>())).b as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<WithDtor>())).b) as usize
+        },
         0usize,
         concat!(
             "Offset of field: ",
@@ -517,8 +552,9 @@ fn bindgen_test_layout_IncompleteArrayNonCopiable() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<IncompleteArrayNonCopiable>())).whatever
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<IncompleteArrayNonCopiable>())).whatever
+            ) as usize
         },
         0usize,
         concat!(
@@ -530,8 +566,10 @@ fn bindgen_test_layout_IncompleteArrayNonCopiable() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<IncompleteArrayNonCopiable>()))
-                .incomplete_array as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<IncompleteArrayNonCopiable>()))
+                    .incomplete_array
+            ) as usize
         },
         8usize,
         concat!(
@@ -570,12 +608,16 @@ fn bindgen_test_layout_Union() {
         concat!("Alignment of ", stringify!(Union))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Union>())).d as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<Union>())).d) as usize
+        },
         0usize,
         concat!("Offset of field: ", stringify!(Union), "::", stringify!(d))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Union>())).i as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<Union>())).i) as usize
+        },
         0usize,
         concat!("Offset of field: ", stringify!(Union), "::", stringify!(i))
     );
@@ -608,7 +650,8 @@ fn bindgen_test_layout_WithUnion() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<WithUnion>())).data as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<WithUnion>())).data)
+                as usize
         },
         0usize,
         concat!(

--- a/tests/expectations/tests/libclang-9/class_1_0.rs
+++ b/tests/expectations/tests/libclang-9/class_1_0.rs
@@ -97,12 +97,17 @@ fn bindgen_test_layout_C() {
         concat!("Alignment of ", stringify!(C))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<C>())).a as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<C>())).a) as usize
+        },
         0usize,
         concat!("Offset of field: ", stringify!(C), "::", stringify!(a))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<C>())).big_array as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<C>())).big_array)
+                as usize
+        },
         4usize,
         concat!(
             "Offset of field: ",
@@ -151,8 +156,9 @@ fn bindgen_test_layout_C_with_zero_length_array() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<C_with_zero_length_array>())).a as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<C_with_zero_length_array>())).a
+            ) as usize
         },
         0usize,
         concat!(
@@ -164,8 +170,9 @@ fn bindgen_test_layout_C_with_zero_length_array() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<C_with_zero_length_array>())).big_array
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<C_with_zero_length_array>())).big_array
+            ) as usize
         },
         4usize,
         concat!(
@@ -177,8 +184,10 @@ fn bindgen_test_layout_C_with_zero_length_array() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<C_with_zero_length_array>()))
-                .zero_length_array as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<C_with_zero_length_array>()))
+                    .zero_length_array
+            ) as usize
         },
         37usize,
         concat!(
@@ -218,8 +227,9 @@ fn bindgen_test_layout_C_with_zero_length_array_2() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<C_with_zero_length_array_2>())).a as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<C_with_zero_length_array_2>())).a
+            ) as usize
         },
         0usize,
         concat!(
@@ -231,8 +241,10 @@ fn bindgen_test_layout_C_with_zero_length_array_2() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<C_with_zero_length_array_2>()))
-                .zero_length_array as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<C_with_zero_length_array_2>()))
+                    .zero_length_array
+            ) as usize
         },
         4usize,
         concat!(
@@ -263,8 +275,9 @@ fn bindgen_test_layout_C_with_incomplete_array() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<C_with_incomplete_array>())).a as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<C_with_incomplete_array>())).a
+            ) as usize
         },
         0usize,
         concat!(
@@ -276,8 +289,9 @@ fn bindgen_test_layout_C_with_incomplete_array() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<C_with_incomplete_array>())).big_array
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<C_with_incomplete_array>())).big_array
+            ) as usize
         },
         4usize,
         concat!(
@@ -289,8 +303,10 @@ fn bindgen_test_layout_C_with_incomplete_array() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<C_with_incomplete_array>())).incomplete_array
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<C_with_incomplete_array>()))
+                    .incomplete_array
+            ) as usize
         },
         37usize,
         concat!(
@@ -330,8 +346,9 @@ fn bindgen_test_layout_C_with_incomplete_array_2() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<C_with_incomplete_array_2>())).a as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<C_with_incomplete_array_2>())).a
+            ) as usize
         },
         0usize,
         concat!(
@@ -343,8 +360,10 @@ fn bindgen_test_layout_C_with_incomplete_array_2() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<C_with_incomplete_array_2>()))
-                .incomplete_array as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<C_with_incomplete_array_2>()))
+                    .incomplete_array
+            ) as usize
         },
         4usize,
         concat!(
@@ -382,10 +401,12 @@ fn bindgen_test_layout_C_with_zero_length_array_and_incomplete_array() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<
-                C_with_zero_length_array_and_incomplete_array,
-            >()))
-            .a as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<
+                    C_with_zero_length_array_and_incomplete_array,
+                >()))
+                .a
+            ) as usize
         },
         0usize,
         concat!(
@@ -397,10 +418,12 @@ fn bindgen_test_layout_C_with_zero_length_array_and_incomplete_array() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<
-                C_with_zero_length_array_and_incomplete_array,
-            >()))
-            .big_array as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<
+                    C_with_zero_length_array_and_incomplete_array,
+                >()))
+                .big_array
+            ) as usize
         },
         4usize,
         concat!(
@@ -412,10 +435,12 @@ fn bindgen_test_layout_C_with_zero_length_array_and_incomplete_array() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<
-                C_with_zero_length_array_and_incomplete_array,
-            >()))
-            .zero_length_array as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<
+                    C_with_zero_length_array_and_incomplete_array,
+                >()))
+                .zero_length_array
+            ) as usize
         },
         37usize,
         concat!(
@@ -427,10 +452,12 @@ fn bindgen_test_layout_C_with_zero_length_array_and_incomplete_array() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<
-                C_with_zero_length_array_and_incomplete_array,
-            >()))
-            .incomplete_array as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<
+                    C_with_zero_length_array_and_incomplete_array,
+                >()))
+                .incomplete_array
+            ) as usize
         },
         37usize,
         concat!(
@@ -479,10 +506,12 @@ fn bindgen_test_layout_C_with_zero_length_array_and_incomplete_array_2() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<
-                C_with_zero_length_array_and_incomplete_array_2,
-            >()))
-            .a as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<
+                    C_with_zero_length_array_and_incomplete_array_2,
+                >()))
+                .a
+            ) as usize
         },
         0usize,
         concat!(
@@ -494,10 +523,12 @@ fn bindgen_test_layout_C_with_zero_length_array_and_incomplete_array_2() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<
-                C_with_zero_length_array_and_incomplete_array_2,
-            >()))
-            .zero_length_array as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<
+                    C_with_zero_length_array_and_incomplete_array_2,
+                >()))
+                .zero_length_array
+            ) as usize
         },
         4usize,
         concat!(
@@ -509,10 +540,12 @@ fn bindgen_test_layout_C_with_zero_length_array_and_incomplete_array_2() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<
-                C_with_zero_length_array_and_incomplete_array_2,
-            >()))
-            .incomplete_array as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<
+                    C_with_zero_length_array_and_incomplete_array_2,
+                >()))
+                .incomplete_array
+            ) as usize
         },
         4usize,
         concat!(
@@ -541,7 +574,9 @@ fn bindgen_test_layout_WithDtor() {
         concat!("Alignment of ", stringify!(WithDtor))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<WithDtor>())).b as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<WithDtor>())).b) as usize
+        },
         0usize,
         concat!(
             "Offset of field: ",
@@ -570,8 +605,9 @@ fn bindgen_test_layout_IncompleteArrayNonCopiable() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<IncompleteArrayNonCopiable>())).whatever
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<IncompleteArrayNonCopiable>())).whatever
+            ) as usize
         },
         0usize,
         concat!(
@@ -583,8 +619,10 @@ fn bindgen_test_layout_IncompleteArrayNonCopiable() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<IncompleteArrayNonCopiable>()))
-                .incomplete_array as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<IncompleteArrayNonCopiable>()))
+                    .incomplete_array
+            ) as usize
         },
         8usize,
         concat!(
@@ -624,12 +662,16 @@ fn bindgen_test_layout_Union() {
         concat!("Alignment of ", stringify!(Union))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Union>())).d as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<Union>())).d) as usize
+        },
         0usize,
         concat!("Offset of field: ", stringify!(Union), "::", stringify!(d))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Union>())).i as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<Union>())).i) as usize
+        },
         0usize,
         concat!("Offset of field: ", stringify!(Union), "::", stringify!(i))
     );
@@ -658,7 +700,8 @@ fn bindgen_test_layout_WithUnion() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<WithUnion>())).data as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<WithUnion>())).data)
+                as usize
         },
         0usize,
         concat!(

--- a/tests/expectations/tests/libclang-9/derive-hash-struct-with-incomplete-array.rs
+++ b/tests/expectations/tests/libclang-9/derive-hash-struct-with-incomplete-array.rs
@@ -54,14 +54,17 @@ fn bindgen_test_layout_test() {
         concat!("Alignment of ", stringify!(test))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<test>())).a as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<test>())).a) as usize
+        },
         0usize,
         concat!("Offset of field: ", stringify!(test), "::", stringify!(a))
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<test>())).zero_length_array as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<test>())).zero_length_array
+            ) as usize
         },
         4usize,
         concat!(
@@ -91,14 +94,17 @@ fn bindgen_test_layout_test2() {
         concat!("Alignment of ", stringify!(test2))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<test2>())).a as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<test2>())).a) as usize
+        },
         0usize,
         concat!("Offset of field: ", stringify!(test2), "::", stringify!(a))
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<test2>())).incomplete_array as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<test2>())).incomplete_array
+            ) as usize
         },
         4usize,
         concat!(
@@ -129,14 +135,17 @@ fn bindgen_test_layout_test3() {
         concat!("Alignment of ", stringify!(test3))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<test3>())).a as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<test3>())).a) as usize
+        },
         0usize,
         concat!("Offset of field: ", stringify!(test3), "::", stringify!(a))
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<test3>())).zero_length_array as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<test3>())).zero_length_array
+            ) as usize
         },
         4usize,
         concat!(
@@ -148,8 +157,9 @@ fn bindgen_test_layout_test3() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<test3>())).incomplete_array as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<test3>())).incomplete_array
+            ) as usize
         },
         4usize,
         concat!(

--- a/tests/expectations/tests/libclang-9/incomplete-array-padding.rs
+++ b/tests/expectations/tests/libclang-9/incomplete-array-padding.rs
@@ -141,7 +141,9 @@ fn bindgen_test_layout_foo() {
         concat!("Alignment of ", stringify!(foo))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<foo>())).b as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<foo>())).b) as usize
+        },
         8usize,
         concat!("Offset of field: ", stringify!(foo), "::", stringify!(b))
     );

--- a/tests/expectations/tests/libclang-9/issue-643-inner-struct.rs
+++ b/tests/expectations/tests/libclang-9/issue-643-inner-struct.rs
@@ -62,8 +62,9 @@ fn bindgen_test_layout_rte_ring_prod() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_ring_prod>())).watermark as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_ring_prod>())).watermark
+            ) as usize
         },
         0usize,
         concat!(
@@ -93,8 +94,9 @@ fn bindgen_test_layout_rte_ring_cons() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_ring_cons>())).sc_dequeue as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_ring_cons>())).sc_dequeue
+            ) as usize
         },
         0usize,
         concat!(
@@ -119,7 +121,8 @@ fn bindgen_test_layout_rte_ring() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_ring>())).memzone as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<rte_ring>())).memzone)
+                as usize
         },
         0usize,
         concat!(
@@ -131,7 +134,8 @@ fn bindgen_test_layout_rte_ring() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_ring>())).prod as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<rte_ring>())).prod)
+                as usize
         },
         8usize,
         concat!(
@@ -143,7 +147,8 @@ fn bindgen_test_layout_rte_ring() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_ring>())).cons as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<rte_ring>())).cons)
+                as usize
         },
         12usize,
         concat!(
@@ -155,7 +160,8 @@ fn bindgen_test_layout_rte_ring() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_ring>())).ring as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<rte_ring>())).ring)
+                as usize
         },
         16usize,
         concat!(

--- a/tests/expectations/tests/libclang-9/layout_align.rs
+++ b/tests/expectations/tests/libclang-9/layout_align.rs
@@ -149,7 +149,8 @@ fn bindgen_test_layout_rte_kni_fifo() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_kni_fifo>())).write as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<rte_kni_fifo>())).write)
+                as usize
         },
         0usize,
         concat!(
@@ -161,7 +162,8 @@ fn bindgen_test_layout_rte_kni_fifo() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_kni_fifo>())).read as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<rte_kni_fifo>())).read)
+                as usize
         },
         4usize,
         concat!(
@@ -173,7 +175,8 @@ fn bindgen_test_layout_rte_kni_fifo() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_kni_fifo>())).len as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<rte_kni_fifo>())).len)
+                as usize
         },
         8usize,
         concat!(
@@ -185,8 +188,9 @@ fn bindgen_test_layout_rte_kni_fifo() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_kni_fifo>())).elem_size as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_kni_fifo>())).elem_size
+            ) as usize
         },
         12usize,
         concat!(
@@ -198,7 +202,8 @@ fn bindgen_test_layout_rte_kni_fifo() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_kni_fifo>())).buffer as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<rte_kni_fifo>())).buffer)
+                as usize
         },
         16usize,
         concat!(
@@ -242,8 +247,9 @@ fn bindgen_test_layout_rte_eth_link() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<rte_eth_link>())).link_speed as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<rte_eth_link>())).link_speed
+            ) as usize
         },
         0usize,
         concat!(

--- a/tests/expectations/tests/libclang-9/type_alias_template_specialized.rs
+++ b/tests/expectations/tests/libclang-9/type_alias_template_specialized.rs
@@ -23,7 +23,9 @@ fn bindgen_test_layout_Rooted() {
         concat!("Alignment of ", stringify!(Rooted))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Rooted>())).ptr as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<Rooted>())).ptr) as usize
+        },
         0usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/libclang-9/zero-sized-array.rs
+++ b/tests/expectations/tests/libclang-9/zero-sized-array.rs
@@ -55,7 +55,8 @@ fn bindgen_test_layout_ZeroSizedArray() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<ZeroSizedArray>())).arr as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<ZeroSizedArray>())).arr)
+                as usize
         },
         0usize,
         concat!(
@@ -86,8 +87,9 @@ fn bindgen_test_layout_ContainsZeroSizedArray() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<ContainsZeroSizedArray>())).zsa as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<ContainsZeroSizedArray>())).zsa
+            ) as usize
         },
         0usize,
         concat!(
@@ -138,8 +140,9 @@ fn bindgen_test_layout_DynamicallySizedArray() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<DynamicallySizedArray>())).arr as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<DynamicallySizedArray>())).arr
+            ) as usize
         },
         0usize,
         concat!(
@@ -170,8 +173,9 @@ fn bindgen_test_layout_ContainsDynamicallySizedArray() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<ContainsDynamicallySizedArray>())).dsa
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<ContainsDynamicallySizedArray>())).dsa
+            ) as usize
         },
         0usize,
         concat!(

--- a/tests/expectations/tests/long_double.rs
+++ b/tests/expectations/tests/long_double.rs
@@ -24,7 +24,9 @@ fn bindgen_test_layout_foo() {
         concat!("Alignment of ", stringify!(foo))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<foo>())).bar as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<foo>())).bar) as usize
+        },
         0usize,
         concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar))
     );

--- a/tests/expectations/tests/msvc-no-usr.rs
+++ b/tests/expectations/tests/msvc-no-usr.rs
@@ -24,7 +24,9 @@ fn bindgen_test_layout_A() {
         concat!("Alignment of ", stringify!(A))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<A>())).foo as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<A>())).foo) as usize
+        },
         0usize,
         concat!("Offset of field: ", stringify!(A), "::", stringify!(foo))
     );

--- a/tests/expectations/tests/mutable.rs
+++ b/tests/expectations/tests/mutable.rs
@@ -24,7 +24,9 @@ fn bindgen_test_layout_C() {
         concat!("Alignment of ", stringify!(C))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<C>())).m_member as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<C>())).m_member) as usize
+        },
         0usize,
         concat!(
             "Offset of field: ",
@@ -34,7 +36,9 @@ fn bindgen_test_layout_C() {
         )
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<C>())).m_other as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<C>())).m_other) as usize
+        },
         4usize,
         concat!(
             "Offset of field: ",
@@ -63,8 +67,9 @@ fn bindgen_test_layout_NonCopiable() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<NonCopiable>())).m_member as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<NonCopiable>())).m_member
+            ) as usize
         },
         0usize,
         concat!(
@@ -100,8 +105,11 @@ fn bindgen_test_layout_NonCopiableWithNonCopiableMutableMember() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<NonCopiableWithNonCopiableMutableMember>()))
-                .m_member as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<NonCopiableWithNonCopiableMutableMember>(
+                )))
+                .m_member
+            ) as usize
         },
         0usize,
         concat!(

--- a/tests/expectations/tests/namespace.rs
+++ b/tests/expectations/tests/namespace.rs
@@ -44,7 +44,10 @@ pub mod root {
                 concat!("Alignment of ", stringify!(A))
             );
             assert_eq!(
-                unsafe { &(*(::std::ptr::null::<A>())).b as *const _ as usize },
+                unsafe {
+                    ::std::ptr::addr_of!((*(::std::ptr::null::<A>())).b)
+                        as usize
+                },
                 0usize,
                 concat!(
                     "Offset of field: ",

--- a/tests/expectations/tests/nested.rs
+++ b/tests/expectations/tests/nested.rs
@@ -23,7 +23,9 @@ fn bindgen_test_layout_Calc() {
         concat!("Alignment of ", stringify!(Calc))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Calc>())).w as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<Calc>())).w) as usize
+        },
         0usize,
         concat!("Offset of field: ", stringify!(Calc), "::", stringify!(w))
     );
@@ -71,7 +73,8 @@ fn bindgen_test_layout_Test_Size() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<Test_Size>())).mWidth as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<Test_Size>())).mWidth)
+                as usize
         },
         0usize,
         concat!(
@@ -83,7 +86,8 @@ fn bindgen_test_layout_Test_Size() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<Test_Size>())).mHeight as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<Test_Size>())).mHeight)
+                as usize
         },
         4usize,
         concat!(

--- a/tests/expectations/tests/nested_within_namespace.rs
+++ b/tests/expectations/tests/nested_within_namespace.rs
@@ -36,7 +36,8 @@ pub mod root {
             );
             assert_eq!(
                 unsafe {
-                    &(*(::std::ptr::null::<Bar_Baz>())).foo as *const _ as usize
+                    ::std::ptr::addr_of!((*(::std::ptr::null::<Bar_Baz>())).foo)
+                        as usize
                 },
                 0usize,
                 concat!(
@@ -61,7 +62,8 @@ pub mod root {
             );
             assert_eq!(
                 unsafe {
-                    &(*(::std::ptr::null::<Bar>())).foo as *const _ as usize
+                    ::std::ptr::addr_of!((*(::std::ptr::null::<Bar>())).foo)
+                        as usize
                 },
                 0usize,
                 concat!(
@@ -91,7 +93,8 @@ pub mod root {
             );
             assert_eq!(
                 unsafe {
-                    &(*(::std::ptr::null::<Baz>())).baz as *const _ as usize
+                    ::std::ptr::addr_of!((*(::std::ptr::null::<Baz>())).baz)
+                        as usize
                 },
                 0usize,
                 concat!(

--- a/tests/expectations/tests/no-comments.rs
+++ b/tests/expectations/tests/no-comments.rs
@@ -23,7 +23,9 @@ fn bindgen_test_layout_Foo() {
         concat!("Alignment of ", stringify!(Foo))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Foo>())).s as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<Foo>())).s) as usize
+        },
         0usize,
         concat!("Offset of field: ", stringify!(Foo), "::", stringify!(s))
     );

--- a/tests/expectations/tests/no-derive-debug.rs
+++ b/tests/expectations/tests/no-derive-debug.rs
@@ -32,12 +32,16 @@ fn bindgen_test_layout_bar() {
         concat!("Alignment of ", stringify!(bar))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<bar>())).foo as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<bar>())).foo) as usize
+        },
         0usize,
         concat!("Offset of field: ", stringify!(bar), "::", stringify!(foo))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<bar>())).baz as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<bar>())).baz) as usize
+        },
         4usize,
         concat!("Offset of field: ", stringify!(bar), "::", stringify!(baz))
     );

--- a/tests/expectations/tests/no-derive-default.rs
+++ b/tests/expectations/tests/no-derive-default.rs
@@ -32,12 +32,16 @@ fn bindgen_test_layout_bar() {
         concat!("Alignment of ", stringify!(bar))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<bar>())).foo as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<bar>())).foo) as usize
+        },
         0usize,
         concat!("Offset of field: ", stringify!(bar), "::", stringify!(foo))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<bar>())).baz as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<bar>())).baz) as usize
+        },
         4usize,
         concat!("Offset of field: ", stringify!(bar), "::", stringify!(baz))
     );

--- a/tests/expectations/tests/no-hash-allowlisted.rs
+++ b/tests/expectations/tests/no-hash-allowlisted.rs
@@ -23,7 +23,9 @@ fn bindgen_test_layout_NoHash() {
         concat!("Alignment of ", stringify!(NoHash))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<NoHash>())).i as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<NoHash>())).i) as usize
+        },
         0usize,
         concat!("Offset of field: ", stringify!(NoHash), "::", stringify!(i))
     );

--- a/tests/expectations/tests/no-partialeq-allowlisted.rs
+++ b/tests/expectations/tests/no-partialeq-allowlisted.rs
@@ -24,7 +24,8 @@ fn bindgen_test_layout_NoPartialEq() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<NoPartialEq>())).i as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<NoPartialEq>())).i)
+                as usize
         },
         0usize,
         concat!(

--- a/tests/expectations/tests/no-recursive-allowlisting.rs
+++ b/tests/expectations/tests/no-recursive-allowlisting.rs
@@ -25,7 +25,9 @@ fn bindgen_test_layout_Foo() {
         concat!("Alignment of ", stringify!(Foo))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Foo>())).baz as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<Foo>())).baz) as usize
+        },
         0usize,
         concat!("Offset of field: ", stringify!(Foo), "::", stringify!(baz))
     );

--- a/tests/expectations/tests/no-std.rs
+++ b/tests/expectations/tests/no-std.rs
@@ -30,17 +30,23 @@ fn bindgen_test_layout_foo() {
         concat!("Alignment of ", stringify!(foo))
     );
     assert_eq!(
-        unsafe { &(*(::core::ptr::null::<foo>())).a as *const _ as usize },
+        unsafe {
+            ::core::ptr::addr_of!((*(::core::ptr::null::<foo>())).a) as usize
+        },
         0usize,
         concat!("Offset of field: ", stringify!(foo), "::", stringify!(a))
     );
     assert_eq!(
-        unsafe { &(*(::core::ptr::null::<foo>())).b as *const _ as usize },
+        unsafe {
+            ::core::ptr::addr_of!((*(::core::ptr::null::<foo>())).b) as usize
+        },
         4usize,
         concat!("Offset of field: ", stringify!(foo), "::", stringify!(b))
     );
     assert_eq!(
-        unsafe { &(*(::core::ptr::null::<foo>())).bar as *const _ as usize },
+        unsafe {
+            ::core::ptr::addr_of!((*(::core::ptr::null::<foo>())).bar) as usize
+        },
         8usize,
         concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar))
     );

--- a/tests/expectations/tests/no_copy_allowlisted.rs
+++ b/tests/expectations/tests/no_copy_allowlisted.rs
@@ -23,7 +23,9 @@ fn bindgen_test_layout_NoCopy() {
         concat!("Alignment of ", stringify!(NoCopy))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<NoCopy>())).i as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<NoCopy>())).i) as usize
+        },
         0usize,
         concat!("Offset of field: ", stringify!(NoCopy), "::", stringify!(i))
     );

--- a/tests/expectations/tests/no_debug_allowlisted.rs
+++ b/tests/expectations/tests/no_debug_allowlisted.rs
@@ -23,7 +23,9 @@ fn bindgen_test_layout_NoDebug() {
         concat!("Alignment of ", stringify!(NoDebug))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<NoDebug>())).i as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<NoDebug>())).i) as usize
+        },
         0usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/no_default_allowlisted.rs
+++ b/tests/expectations/tests/no_default_allowlisted.rs
@@ -23,7 +23,10 @@ fn bindgen_test_layout_NoDefault() {
         concat!("Alignment of ", stringify!(NoDefault))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<NoDefault>())).i as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<NoDefault>())).i)
+                as usize
+        },
         0usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/non-type-params.rs
+++ b/tests/expectations/tests/non-type-params.rs
@@ -28,8 +28,9 @@ fn bindgen_test_layout_UsesArray() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<UsesArray>())).array_char_16 as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<UsesArray>())).array_char_16
+            ) as usize
         },
         0usize,
         concat!(
@@ -41,8 +42,9 @@ fn bindgen_test_layout_UsesArray() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<UsesArray>())).array_bool_8 as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<UsesArray>())).array_bool_8
+            ) as usize
         },
         16usize,
         concat!(
@@ -54,8 +56,9 @@ fn bindgen_test_layout_UsesArray() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<UsesArray>())).array_int_4 as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<UsesArray>())).array_int_4
+            ) as usize
         },
         24usize,
         concat!(

--- a/tests/expectations/tests/objc_interface_type.rs
+++ b/tests/expectations/tests/objc_interface_type.rs
@@ -45,7 +45,8 @@ fn bindgen_test_layout_FooStruct() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<FooStruct>())).foo as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<FooStruct>())).foo)
+                as usize
         },
         0usize,
         concat!(

--- a/tests/expectations/tests/opaque-template-inst-member-2.rs
+++ b/tests/expectations/tests/opaque-template-inst-member-2.rs
@@ -33,8 +33,9 @@ fn bindgen_test_layout_ContainsOpaqueTemplate() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<ContainsOpaqueTemplate>())).mBlah as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<ContainsOpaqueTemplate>())).mBlah
+            ) as usize
         },
         0usize,
         concat!(
@@ -46,8 +47,9 @@ fn bindgen_test_layout_ContainsOpaqueTemplate() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<ContainsOpaqueTemplate>())).mBaz as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<ContainsOpaqueTemplate>())).mBaz
+            ) as usize
         },
         4usize,
         concat!(
@@ -79,8 +81,9 @@ fn bindgen_test_layout_InheritsOpaqueTemplate() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<InheritsOpaqueTemplate>())).wow as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<InheritsOpaqueTemplate>())).wow
+            ) as usize
         },
         8usize,
         concat!(

--- a/tests/expectations/tests/opaque-template-inst-member.rs
+++ b/tests/expectations/tests/opaque-template-inst-member.rs
@@ -31,8 +31,9 @@ fn bindgen_test_layout_ContainsOpaqueTemplate() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<ContainsOpaqueTemplate>())).mBlah as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<ContainsOpaqueTemplate>())).mBlah
+            ) as usize
         },
         0usize,
         concat!(
@@ -44,8 +45,9 @@ fn bindgen_test_layout_ContainsOpaqueTemplate() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<ContainsOpaqueTemplate>())).mBaz as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<ContainsOpaqueTemplate>())).mBaz
+            ) as usize
         },
         404usize,
         concat!(
@@ -91,8 +93,9 @@ fn bindgen_test_layout_InheritsOpaqueTemplate() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<InheritsOpaqueTemplate>())).wow as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<InheritsOpaqueTemplate>())).wow
+            ) as usize
         },
         408usize,
         concat!(

--- a/tests/expectations/tests/opaque-template-instantiation-namespaced.rs
+++ b/tests/expectations/tests/opaque-template-instantiation-namespaced.rs
@@ -47,7 +47,8 @@ pub mod root {
             );
             assert_eq!(
                 unsafe {
-                    &(*(::std::ptr::null::<Foo>())).c as *const _ as usize
+                    ::std::ptr::addr_of!((*(::std::ptr::null::<Foo>())).c)
+                        as usize
                 },
                 0usize,
                 concat!(
@@ -77,7 +78,8 @@ pub mod root {
             );
             assert_eq!(
                 unsafe {
-                    &(*(::std::ptr::null::<Bar>())).i as *const _ as usize
+                    ::std::ptr::addr_of!((*(::std::ptr::null::<Bar>())).i)
+                        as usize
                 },
                 0usize,
                 concat!(
@@ -107,8 +109,10 @@ pub mod root {
             );
             assert_eq!(
                 unsafe {
-                    &(*(::std::ptr::null::<ContainsInstantiation>())).not_opaque
-                        as *const _ as usize
+                    ::std::ptr::addr_of!(
+                        (*(::std::ptr::null::<ContainsInstantiation>()))
+                            .not_opaque
+                    ) as usize
                 },
                 0usize,
                 concat!(
@@ -150,8 +154,10 @@ pub mod root {
             );
             assert_eq!(
                 unsafe {
-                    &(*(::std::ptr::null::<ContainsOpaqueInstantiation>()))
-                        .opaque as *const _ as usize
+                    ::std::ptr::addr_of!(
+                        (*(::std::ptr::null::<ContainsOpaqueInstantiation>()))
+                            .opaque
+                    ) as usize
                 },
                 0usize,
                 concat!(

--- a/tests/expectations/tests/opaque-template-instantiation.rs
+++ b/tests/expectations/tests/opaque-template-instantiation.rs
@@ -39,8 +39,9 @@ fn bindgen_test_layout_ContainsInstantiation() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<ContainsInstantiation>())).not_opaque
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<ContainsInstantiation>())).not_opaque
+            ) as usize
         },
         0usize,
         concat!(
@@ -79,8 +80,9 @@ fn bindgen_test_layout_ContainsOpaqueInstantiation() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<ContainsOpaqueInstantiation>())).opaque
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<ContainsOpaqueInstantiation>())).opaque
+            ) as usize
         },
         0usize,
         concat!(

--- a/tests/expectations/tests/opaque_in_struct.rs
+++ b/tests/expectations/tests/opaque_in_struct.rs
@@ -44,7 +44,8 @@ fn bindgen_test_layout_container() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<container>())).contained as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<container>())).contained)
+                as usize
         },
         0usize,
         concat!(

--- a/tests/expectations/tests/opaque_pointer.rs
+++ b/tests/expectations/tests/opaque_pointer.rs
@@ -52,8 +52,9 @@ fn bindgen_test_layout_WithOpaquePtr() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<WithOpaquePtr>())).whatever as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<WithOpaquePtr>())).whatever
+            ) as usize
         },
         0usize,
         concat!(
@@ -65,7 +66,8 @@ fn bindgen_test_layout_WithOpaquePtr() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<WithOpaquePtr>())).other as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<WithOpaquePtr>())).other)
+                as usize
         },
         8usize,
         concat!(
@@ -77,7 +79,8 @@ fn bindgen_test_layout_WithOpaquePtr() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<WithOpaquePtr>())).t as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<WithOpaquePtr>())).t)
+                as usize
         },
         12usize,
         concat!(

--- a/tests/expectations/tests/packed-n-with-padding.rs
+++ b/tests/expectations/tests/packed-n-with-padding.rs
@@ -26,22 +26,30 @@ fn bindgen_test_layout_Packed() {
         concat!("Alignment of ", stringify!(Packed))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Packed>())).a as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<Packed>())).a) as usize
+        },
         0usize,
         concat!("Offset of field: ", stringify!(Packed), "::", stringify!(a))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Packed>())).b as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<Packed>())).b) as usize
+        },
         2usize,
         concat!("Offset of field: ", stringify!(Packed), "::", stringify!(b))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Packed>())).c as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<Packed>())).c) as usize
+        },
         4usize,
         concat!("Offset of field: ", stringify!(Packed), "::", stringify!(c))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Packed>())).d as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<Packed>())).d) as usize
+        },
         6usize,
         concat!("Offset of field: ", stringify!(Packed), "::", stringify!(d))
     );

--- a/tests/expectations/tests/private.rs
+++ b/tests/expectations/tests/private.rs
@@ -26,8 +26,9 @@ fn bindgen_test_layout_HasPrivate() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<HasPrivate>())).mNotPrivate as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<HasPrivate>())).mNotPrivate
+            ) as usize
         },
         0usize,
         concat!(
@@ -39,8 +40,9 @@ fn bindgen_test_layout_HasPrivate() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<HasPrivate>())).mIsPrivate as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<HasPrivate>())).mIsPrivate
+            ) as usize
         },
         4usize,
         concat!(
@@ -72,8 +74,9 @@ fn bindgen_test_layout_VeryPrivate() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<VeryPrivate>())).mIsPrivate as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<VeryPrivate>())).mIsPrivate
+            ) as usize
         },
         0usize,
         concat!(
@@ -85,8 +88,9 @@ fn bindgen_test_layout_VeryPrivate() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<VeryPrivate>())).mIsAlsoPrivate as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<VeryPrivate>())).mIsAlsoPrivate
+            ) as usize
         },
         4usize,
         concat!(
@@ -119,8 +123,9 @@ fn bindgen_test_layout_ContradictPrivate() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<ContradictPrivate>())).mNotPrivate
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<ContradictPrivate>())).mNotPrivate
+            ) as usize
         },
         0usize,
         concat!(
@@ -132,8 +137,9 @@ fn bindgen_test_layout_ContradictPrivate() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<ContradictPrivate>())).mIsPrivate as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<ContradictPrivate>())).mIsPrivate
+            ) as usize
         },
         4usize,
         concat!(

--- a/tests/expectations/tests/private_fields.rs
+++ b/tests/expectations/tests/private_fields.rs
@@ -110,7 +110,9 @@ fn bindgen_test_layout_PubPriv() {
         concat!("Alignment of ", stringify!(PubPriv))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<PubPriv>())).x as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<PubPriv>())).x) as usize
+        },
         0usize,
         concat!(
             "Offset of field: ",
@@ -120,7 +122,9 @@ fn bindgen_test_layout_PubPriv() {
         )
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<PubPriv>())).y as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<PubPriv>())).y) as usize
+        },
         4usize,
         concat!(
             "Offset of field: ",
@@ -346,7 +350,10 @@ fn bindgen_test_layout_Base() {
         concat!("Alignment of ", stringify!(Base))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Base>())).member as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<Base>())).member)
+                as usize
+        },
         0usize,
         concat!(
             "Offset of field: ",
@@ -417,8 +424,9 @@ fn bindgen_test_layout_WithAnonStruct__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<WithAnonStruct__bindgen_ty_1>())).a
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<WithAnonStruct__bindgen_ty_1>())).a
+            ) as usize
         },
         0usize,
         concat!(
@@ -448,8 +456,9 @@ fn bindgen_test_layout_WithAnonStruct__bindgen_ty_2() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<WithAnonStruct__bindgen_ty_2>())).b
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<WithAnonStruct__bindgen_ty_2>())).b
+            ) as usize
         },
         0usize,
         concat!(

--- a/tests/expectations/tests/reparented_replacement.rs
+++ b/tests/expectations/tests/reparented_replacement.rs
@@ -32,7 +32,8 @@ pub mod root {
             );
             assert_eq!(
                 unsafe {
-                    &(*(::std::ptr::null::<Bar>())).bazz as *const _ as usize
+                    ::std::ptr::addr_of!((*(::std::ptr::null::<Bar>())).bazz)
+                        as usize
                 },
                 0usize,
                 concat!(

--- a/tests/expectations/tests/replace_use.rs
+++ b/tests/expectations/tests/replace_use.rs
@@ -29,7 +29,9 @@ fn bindgen_test_layout_Test() {
         concat!("Alignment of ", stringify!(Test))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Test>())).a as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<Test>())).a) as usize
+        },
         0usize,
         concat!("Offset of field: ", stringify!(Test), "::", stringify!(a))
     );

--- a/tests/expectations/tests/repr-align.rs
+++ b/tests/expectations/tests/repr-align.rs
@@ -26,12 +26,16 @@ fn bindgen_test_layout_a() {
         concat!("Alignment of ", stringify!(a))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<a>())).b as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<a>())).b) as usize
+        },
         0usize,
         concat!("Offset of field: ", stringify!(a), "::", stringify!(b))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<a>())).c as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<a>())).c) as usize
+        },
         4usize,
         concat!("Offset of field: ", stringify!(a), "::", stringify!(c))
     );
@@ -56,12 +60,16 @@ fn bindgen_test_layout_b() {
         concat!("Alignment of ", stringify!(b))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<b>())).b as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<b>())).b) as usize
+        },
         0usize,
         concat!("Offset of field: ", stringify!(b), "::", stringify!(b))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<b>())).c as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<b>())).c) as usize
+        },
         4usize,
         concat!("Offset of field: ", stringify!(b), "::", stringify!(c))
     );

--- a/tests/expectations/tests/same_struct_name_in_different_namespaces.rs
+++ b/tests/expectations/tests/same_struct_name_in_different_namespaces.rs
@@ -30,7 +30,8 @@ fn bindgen_test_layout_JS_shadow_Zone() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<JS_shadow_Zone>())).x as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<JS_shadow_Zone>())).x)
+                as usize
         },
         0usize,
         concat!(
@@ -42,7 +43,8 @@ fn bindgen_test_layout_JS_shadow_Zone() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<JS_shadow_Zone>())).y as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<JS_shadow_Zone>())).y)
+                as usize
         },
         4usize,
         concat!(

--- a/tests/expectations/tests/sentry-defined-multiple-times.rs
+++ b/tests/expectations/tests/sentry-defined-multiple-times.rs
@@ -41,8 +41,9 @@ pub mod root {
             );
             assert_eq!(
                 unsafe {
-                    &(*(::std::ptr::null::<sentry>())).i_am_plain_sentry
-                        as *const _ as usize
+                    ::std::ptr::addr_of!(
+                        (*(::std::ptr::null::<sentry>())).i_am_plain_sentry
+                    ) as usize
                 },
                 0usize,
                 concat!(
@@ -90,9 +91,10 @@ pub mod root {
             );
             assert_eq!(
                 unsafe {
-                    &(*(::std::ptr::null::<NotTemplateWrapper_sentry>()))
-                        .i_am_not_template_wrapper_sentry
-                        as *const _ as usize
+                    ::std::ptr::addr_of!(
+                        (*(::std::ptr::null::<NotTemplateWrapper_sentry>()))
+                            .i_am_not_template_wrapper_sentry
+                    ) as usize
                 },
                 0usize,
                 concat!(
@@ -133,9 +135,11 @@ pub mod root {
             );
             assert_eq!(
                 unsafe {
-                    &(*(::std::ptr::null::<InlineNotTemplateWrapper_sentry>()))
+                    ::std::ptr::addr_of!(
+                        (*(::std::ptr::null::<InlineNotTemplateWrapper_sentry>(
+                        )))
                         .i_am_inline_not_template_wrapper_sentry
-                        as *const _ as usize
+                    ) as usize
                 },
                 0usize,
                 concat!(
@@ -240,11 +244,12 @@ pub mod root {
             );
             assert_eq!(
                 unsafe {
-                    &(*(::std::ptr::null::<
-                        OuterDoubleWrapper_InnerDoubleWrapper_sentry,
-                    >()))
-                    .i_am_double_wrapper_sentry as *const _
-                        as usize
+                    ::std::ptr::addr_of!(
+                        (*(::std::ptr::null::<
+                            OuterDoubleWrapper_InnerDoubleWrapper_sentry,
+                        >()))
+                        .i_am_double_wrapper_sentry
+                    ) as usize
                 },
                 0usize,
                 concat!(
@@ -275,7 +280,7 @@ pub mod root {
         ) {
             assert_eq ! (:: std :: mem :: size_of :: < OuterDoubleInlineWrapper_InnerDoubleInlineWrapper_sentry > () , 4usize , concat ! ("Size of: " , stringify ! (OuterDoubleInlineWrapper_InnerDoubleInlineWrapper_sentry)));
             assert_eq ! (:: std :: mem :: align_of :: < OuterDoubleInlineWrapper_InnerDoubleInlineWrapper_sentry > () , 4usize , concat ! ("Alignment of " , stringify ! (OuterDoubleInlineWrapper_InnerDoubleInlineWrapper_sentry)));
-            assert_eq ! (unsafe { & (* (:: std :: ptr :: null :: < OuterDoubleInlineWrapper_InnerDoubleInlineWrapper_sentry > ())) . i_am_double_wrapper_inline_sentry as * const _ as usize } , 0usize , concat ! ("Offset of field: " , stringify ! (OuterDoubleInlineWrapper_InnerDoubleInlineWrapper_sentry) , "::" , stringify ! (i_am_double_wrapper_inline_sentry)));
+            assert_eq ! (unsafe { :: std :: ptr :: addr_of ! ((* (:: std :: ptr :: null :: < OuterDoubleInlineWrapper_InnerDoubleInlineWrapper_sentry > ())) . i_am_double_wrapper_inline_sentry) as usize } , 0usize , concat ! ("Offset of field: " , stringify ! (OuterDoubleInlineWrapper_InnerDoubleInlineWrapper_sentry) , "::" , stringify ! (i_am_double_wrapper_inline_sentry)));
         }
         #[test]
         fn bindgen_test_layout_OuterDoubleInlineWrapper_InnerDoubleInlineWrapper(
@@ -348,8 +353,10 @@ pub mod root {
         );
         assert_eq!(
             unsafe {
-                &(*(::std::ptr::null::<sentry>())).i_am_outside_namespace_sentry
-                    as *const _ as usize
+                ::std::ptr::addr_of!(
+                    (*(::std::ptr::null::<sentry>()))
+                        .i_am_outside_namespace_sentry
+                ) as usize
             },
             0usize,
             concat!(

--- a/tests/expectations/tests/size_t_is_usize.rs
+++ b/tests/expectations/tests/size_t_is_usize.rs
@@ -25,17 +25,23 @@ fn bindgen_test_layout_A() {
         concat!("Alignment of ", stringify!(A))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<A>())).len as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<A>())).len) as usize
+        },
         0usize,
         concat!("Offset of field: ", stringify!(A), "::", stringify!(len))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<A>())).offset as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<A>())).offset) as usize
+        },
         8usize,
         concat!("Offset of field: ", stringify!(A), "::", stringify!(offset))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<A>())).next as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<A>())).next) as usize
+        },
         16usize,
         concat!("Offset of field: ", stringify!(A), "::", stringify!(next))
     );

--- a/tests/expectations/tests/size_t_template.rs
+++ b/tests/expectations/tests/size_t_template.rs
@@ -23,7 +23,9 @@ fn bindgen_test_layout_C() {
         concat!("Alignment of ", stringify!(C))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<C>())).arr as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<C>())).arr) as usize
+        },
         0usize,
         concat!("Offset of field: ", stringify!(C), "::", stringify!(arr))
     );

--- a/tests/expectations/tests/struct_containing_forward_declared_struct.rs
+++ b/tests/expectations/tests/struct_containing_forward_declared_struct.rs
@@ -23,7 +23,9 @@ fn bindgen_test_layout_a() {
         concat!("Alignment of ", stringify!(a))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<a>())).val_a as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<a>())).val_a) as usize
+        },
         0usize,
         concat!("Offset of field: ", stringify!(a), "::", stringify!(val_a))
     );
@@ -55,7 +57,9 @@ fn bindgen_test_layout_b() {
         concat!("Alignment of ", stringify!(b))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<b>())).val_b as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<b>())).val_b) as usize
+        },
         0usize,
         concat!("Offset of field: ", stringify!(b), "::", stringify!(val_b))
     );

--- a/tests/expectations/tests/struct_typedef.rs
+++ b/tests/expectations/tests/struct_typedef.rs
@@ -24,8 +24,9 @@ fn bindgen_test_layout_typedef_named_struct() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<typedef_named_struct>())).has_name
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<typedef_named_struct>())).has_name
+            ) as usize
         },
         0usize,
         concat!(
@@ -55,8 +56,9 @@ fn bindgen_test_layout__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<_bindgen_ty_1>())).no_name as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<_bindgen_ty_1>())).no_name
+            ) as usize
         },
         0usize,
         concat!(

--- a/tests/expectations/tests/struct_typedef_ns.rs
+++ b/tests/expectations/tests/struct_typedef_ns.rs
@@ -31,8 +31,9 @@ pub mod root {
             );
             assert_eq!(
                 unsafe {
-                    &(*(::std::ptr::null::<typedef_struct>())).foo as *const _
-                        as usize
+                    ::std::ptr::addr_of!(
+                        (*(::std::ptr::null::<typedef_struct>())).foo
+                    ) as usize
                 },
                 0usize,
                 concat!(
@@ -71,8 +72,9 @@ pub mod root {
             );
             assert_eq!(
                 unsafe {
-                    &(*(::std::ptr::null::<_bindgen_ty_1>())).foo as *const _
-                        as usize
+                    ::std::ptr::addr_of!(
+                        (*(::std::ptr::null::<_bindgen_ty_1>())).foo
+                    ) as usize
                 },
                 0usize,
                 concat!(

--- a/tests/expectations/tests/struct_with_anon_struct.rs
+++ b/tests/expectations/tests/struct_with_anon_struct.rs
@@ -30,7 +30,8 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<foo__bindgen_ty_1>())).a as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<foo__bindgen_ty_1>())).a)
+                as usize
         },
         0usize,
         concat!(
@@ -42,7 +43,8 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<foo__bindgen_ty_1>())).b as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<foo__bindgen_ty_1>())).b)
+                as usize
         },
         4usize,
         concat!(
@@ -66,7 +68,9 @@ fn bindgen_test_layout_foo() {
         concat!("Alignment of ", stringify!(foo))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<foo>())).bar as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<foo>())).bar) as usize
+        },
         0usize,
         concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar))
     );

--- a/tests/expectations/tests/struct_with_anon_struct_array.rs
+++ b/tests/expectations/tests/struct_with_anon_struct_array.rs
@@ -31,7 +31,8 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<foo__bindgen_ty_1>())).a as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<foo__bindgen_ty_1>())).a)
+                as usize
         },
         0usize,
         concat!(
@@ -43,7 +44,8 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<foo__bindgen_ty_1>())).b as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<foo__bindgen_ty_1>())).b)
+                as usize
         },
         4usize,
         concat!(
@@ -74,7 +76,8 @@ fn bindgen_test_layout_foo__bindgen_ty_2() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<foo__bindgen_ty_2>())).a as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<foo__bindgen_ty_2>())).a)
+                as usize
         },
         0usize,
         concat!(
@@ -86,7 +89,8 @@ fn bindgen_test_layout_foo__bindgen_ty_2() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<foo__bindgen_ty_2>())).b as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<foo__bindgen_ty_2>())).b)
+                as usize
         },
         4usize,
         concat!(
@@ -110,12 +114,16 @@ fn bindgen_test_layout_foo() {
         concat!("Alignment of ", stringify!(foo))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<foo>())).bar as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<foo>())).bar) as usize
+        },
         0usize,
         concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<foo>())).baz as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<foo>())).baz) as usize
+        },
         16usize,
         concat!("Offset of field: ", stringify!(foo), "::", stringify!(baz))
     );

--- a/tests/expectations/tests/struct_with_anon_struct_pointer.rs
+++ b/tests/expectations/tests/struct_with_anon_struct_pointer.rs
@@ -30,7 +30,8 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<foo__bindgen_ty_1>())).a as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<foo__bindgen_ty_1>())).a)
+                as usize
         },
         0usize,
         concat!(
@@ -42,7 +43,8 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<foo__bindgen_ty_1>())).b as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<foo__bindgen_ty_1>())).b)
+                as usize
         },
         4usize,
         concat!(
@@ -66,7 +68,9 @@ fn bindgen_test_layout_foo() {
         concat!("Alignment of ", stringify!(foo))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<foo>())).bar as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<foo>())).bar) as usize
+        },
         0usize,
         concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar))
     );

--- a/tests/expectations/tests/struct_with_anon_union.rs
+++ b/tests/expectations/tests/struct_with_anon_union.rs
@@ -30,7 +30,8 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<foo__bindgen_ty_1>())).a as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<foo__bindgen_ty_1>())).a)
+                as usize
         },
         0usize,
         concat!(
@@ -42,7 +43,8 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<foo__bindgen_ty_1>())).b as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<foo__bindgen_ty_1>())).b)
+                as usize
         },
         0usize,
         concat!(
@@ -75,7 +77,9 @@ fn bindgen_test_layout_foo() {
         concat!("Alignment of ", stringify!(foo))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<foo>())).bar as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<foo>())).bar) as usize
+        },
         0usize,
         concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar))
     );

--- a/tests/expectations/tests/struct_with_anon_union_1_0.rs
+++ b/tests/expectations/tests/struct_with_anon_union_1_0.rs
@@ -74,7 +74,8 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<foo__bindgen_ty_1>())).a as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<foo__bindgen_ty_1>())).a)
+                as usize
         },
         0usize,
         concat!(
@@ -86,7 +87,8 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<foo__bindgen_ty_1>())).b as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<foo__bindgen_ty_1>())).b)
+                as usize
         },
         0usize,
         concat!(
@@ -115,7 +117,9 @@ fn bindgen_test_layout_foo() {
         concat!("Alignment of ", stringify!(foo))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<foo>())).bar as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<foo>())).bar) as usize
+        },
         0usize,
         concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar))
     );

--- a/tests/expectations/tests/struct_with_anon_unnamed_struct.rs
+++ b/tests/expectations/tests/struct_with_anon_unnamed_struct.rs
@@ -30,7 +30,8 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<foo__bindgen_ty_1>())).a as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<foo__bindgen_ty_1>())).a)
+                as usize
         },
         0usize,
         concat!(
@@ -42,7 +43,8 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<foo__bindgen_ty_1>())).b as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<foo__bindgen_ty_1>())).b)
+                as usize
         },
         4usize,
         concat!(

--- a/tests/expectations/tests/struct_with_anon_unnamed_union.rs
+++ b/tests/expectations/tests/struct_with_anon_unnamed_union.rs
@@ -30,7 +30,8 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<foo__bindgen_ty_1>())).a as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<foo__bindgen_ty_1>())).a)
+                as usize
         },
         0usize,
         concat!(
@@ -42,7 +43,8 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<foo__bindgen_ty_1>())).b as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<foo__bindgen_ty_1>())).b)
+                as usize
         },
         0usize,
         concat!(

--- a/tests/expectations/tests/struct_with_anon_unnamed_union_1_0.rs
+++ b/tests/expectations/tests/struct_with_anon_unnamed_union_1_0.rs
@@ -74,7 +74,8 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<foo__bindgen_ty_1>())).a as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<foo__bindgen_ty_1>())).a)
+                as usize
         },
         0usize,
         concat!(
@@ -86,7 +87,8 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<foo__bindgen_ty_1>())).b as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<foo__bindgen_ty_1>())).b)
+                as usize
         },
         0usize,
         concat!(

--- a/tests/expectations/tests/struct_with_bitfields.rs
+++ b/tests/expectations/tests/struct_with_bitfields.rs
@@ -113,7 +113,9 @@ fn bindgen_test_layout_bitfield() {
         concat!("Alignment of ", stringify!(bitfield))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<bitfield>())).e as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<bitfield>())).e) as usize
+        },
         4usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/struct_with_derive_debug.rs
+++ b/tests/expectations/tests/struct_with_derive_debug.rs
@@ -24,7 +24,8 @@ fn bindgen_test_layout_LittleArray() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<LittleArray>())).a as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<LittleArray>())).a)
+                as usize
         },
         0usize,
         concat!(
@@ -53,7 +54,9 @@ fn bindgen_test_layout_BigArray() {
         concat!("Alignment of ", stringify!(BigArray))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<BigArray>())).a as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<BigArray>())).a) as usize
+        },
         0usize,
         concat!(
             "Offset of field: ",
@@ -91,7 +94,8 @@ fn bindgen_test_layout_WithLittleArray() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<WithLittleArray>())).a as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<WithLittleArray>())).a)
+                as usize
         },
         0usize,
         concat!(
@@ -121,7 +125,8 @@ fn bindgen_test_layout_WithBigArray() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<WithBigArray>())).a as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<WithBigArray>())).a)
+                as usize
         },
         0usize,
         concat!(

--- a/tests/expectations/tests/struct_with_large_array.rs
+++ b/tests/expectations/tests/struct_with_large_array.rs
@@ -24,7 +24,8 @@ fn bindgen_test_layout_S() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<S>())).large_array as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<S>())).large_array)
+                as usize
         },
         0usize,
         concat!(

--- a/tests/expectations/tests/struct_with_nesting.rs
+++ b/tests/expectations/tests/struct_with_nesting.rs
@@ -38,8 +38,9 @@ fn bindgen_test_layout_foo__bindgen_ty_1__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<foo__bindgen_ty_1__bindgen_ty_1>())).c1
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<foo__bindgen_ty_1__bindgen_ty_1>())).c1
+            ) as usize
         },
         0usize,
         concat!(
@@ -51,8 +52,9 @@ fn bindgen_test_layout_foo__bindgen_ty_1__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<foo__bindgen_ty_1__bindgen_ty_1>())).c2
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<foo__bindgen_ty_1__bindgen_ty_1>())).c2
+            ) as usize
         },
         2usize,
         concat!(
@@ -85,8 +87,9 @@ fn bindgen_test_layout_foo__bindgen_ty_1__bindgen_ty_2() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<foo__bindgen_ty_1__bindgen_ty_2>())).d1
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<foo__bindgen_ty_1__bindgen_ty_2>())).d1
+            ) as usize
         },
         0usize,
         concat!(
@@ -98,8 +101,9 @@ fn bindgen_test_layout_foo__bindgen_ty_1__bindgen_ty_2() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<foo__bindgen_ty_1__bindgen_ty_2>())).d2
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<foo__bindgen_ty_1__bindgen_ty_2>())).d2
+            ) as usize
         },
         1usize,
         concat!(
@@ -111,8 +115,9 @@ fn bindgen_test_layout_foo__bindgen_ty_1__bindgen_ty_2() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<foo__bindgen_ty_1__bindgen_ty_2>())).d3
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<foo__bindgen_ty_1__bindgen_ty_2>())).d3
+            ) as usize
         },
         2usize,
         concat!(
@@ -124,8 +129,9 @@ fn bindgen_test_layout_foo__bindgen_ty_1__bindgen_ty_2() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<foo__bindgen_ty_1__bindgen_ty_2>())).d4
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<foo__bindgen_ty_1__bindgen_ty_2>())).d4
+            ) as usize
         },
         3usize,
         concat!(
@@ -150,7 +156,8 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<foo__bindgen_ty_1>())).b as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<foo__bindgen_ty_1>())).b)
+                as usize
         },
         0usize,
         concat!(
@@ -183,7 +190,9 @@ fn bindgen_test_layout_foo() {
         concat!("Alignment of ", stringify!(foo))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<foo>())).a as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<foo>())).a) as usize
+        },
         0usize,
         concat!("Offset of field: ", stringify!(foo), "::", stringify!(a))
     );

--- a/tests/expectations/tests/struct_with_nesting_1_0.rs
+++ b/tests/expectations/tests/struct_with_nesting_1_0.rs
@@ -82,8 +82,9 @@ fn bindgen_test_layout_foo__bindgen_ty_1__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<foo__bindgen_ty_1__bindgen_ty_1>())).c1
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<foo__bindgen_ty_1__bindgen_ty_1>())).c1
+            ) as usize
         },
         0usize,
         concat!(
@@ -95,8 +96,9 @@ fn bindgen_test_layout_foo__bindgen_ty_1__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<foo__bindgen_ty_1__bindgen_ty_1>())).c2
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<foo__bindgen_ty_1__bindgen_ty_1>())).c2
+            ) as usize
         },
         2usize,
         concat!(
@@ -134,8 +136,9 @@ fn bindgen_test_layout_foo__bindgen_ty_1__bindgen_ty_2() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<foo__bindgen_ty_1__bindgen_ty_2>())).d1
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<foo__bindgen_ty_1__bindgen_ty_2>())).d1
+            ) as usize
         },
         0usize,
         concat!(
@@ -147,8 +150,9 @@ fn bindgen_test_layout_foo__bindgen_ty_1__bindgen_ty_2() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<foo__bindgen_ty_1__bindgen_ty_2>())).d2
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<foo__bindgen_ty_1__bindgen_ty_2>())).d2
+            ) as usize
         },
         1usize,
         concat!(
@@ -160,8 +164,9 @@ fn bindgen_test_layout_foo__bindgen_ty_1__bindgen_ty_2() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<foo__bindgen_ty_1__bindgen_ty_2>())).d3
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<foo__bindgen_ty_1__bindgen_ty_2>())).d3
+            ) as usize
         },
         2usize,
         concat!(
@@ -173,8 +178,9 @@ fn bindgen_test_layout_foo__bindgen_ty_1__bindgen_ty_2() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<foo__bindgen_ty_1__bindgen_ty_2>())).d4
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<foo__bindgen_ty_1__bindgen_ty_2>())).d4
+            ) as usize
         },
         3usize,
         concat!(
@@ -204,7 +210,8 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<foo__bindgen_ty_1>())).b as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<foo__bindgen_ty_1>())).b)
+                as usize
         },
         0usize,
         concat!(
@@ -233,7 +240,9 @@ fn bindgen_test_layout_foo() {
         concat!("Alignment of ", stringify!(foo))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<foo>())).a as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<foo>())).a) as usize
+        },
         0usize,
         concat!("Offset of field: ", stringify!(foo), "::", stringify!(a))
     );

--- a/tests/expectations/tests/struct_with_packing.rs
+++ b/tests/expectations/tests/struct_with_packing.rs
@@ -24,12 +24,16 @@ fn bindgen_test_layout_a() {
         concat!("Alignment of ", stringify!(a))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<a>())).b as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<a>())).b) as usize
+        },
         0usize,
         concat!("Offset of field: ", stringify!(a), "::", stringify!(b))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<a>())).c as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<a>())).c) as usize
+        },
         1usize,
         concat!("Offset of field: ", stringify!(a), "::", stringify!(c))
     );

--- a/tests/expectations/tests/struct_with_struct.rs
+++ b/tests/expectations/tests/struct_with_struct.rs
@@ -30,7 +30,8 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<foo__bindgen_ty_1>())).x as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<foo__bindgen_ty_1>())).x)
+                as usize
         },
         0usize,
         concat!(
@@ -42,7 +43,8 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<foo__bindgen_ty_1>())).y as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<foo__bindgen_ty_1>())).y)
+                as usize
         },
         4usize,
         concat!(
@@ -66,7 +68,9 @@ fn bindgen_test_layout_foo() {
         concat!("Alignment of ", stringify!(foo))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<foo>())).bar as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<foo>())).bar) as usize
+        },
         0usize,
         concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar))
     );

--- a/tests/expectations/tests/template.rs
+++ b/tests/expectations/tests/template.rs
@@ -79,13 +79,16 @@ fn bindgen_test_layout_C() {
         concat!("Alignment of ", stringify!(C))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<C>())).mB as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<C>())).mB) as usize
+        },
         0usize,
         concat!("Offset of field: ", stringify!(C), "::", stringify!(mB))
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<C>())).mBConstPtr as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<C>())).mBConstPtr)
+                as usize
         },
         8usize,
         concat!(
@@ -97,7 +100,8 @@ fn bindgen_test_layout_C() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<C>())).mBConstStructPtr as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<C>())).mBConstStructPtr)
+                as usize
         },
         16usize,
         concat!(
@@ -109,8 +113,9 @@ fn bindgen_test_layout_C() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<C>())).mBConstStructPtrArray as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<C>())).mBConstStructPtrArray
+            ) as usize
         },
         24usize,
         concat!(
@@ -121,7 +126,9 @@ fn bindgen_test_layout_C() {
         )
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<C>())).mBConst as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<C>())).mBConst) as usize
+        },
         32usize,
         concat!(
             "Offset of field: ",
@@ -132,7 +139,8 @@ fn bindgen_test_layout_C() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<C>())).mBVolatile as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<C>())).mBVolatile)
+                as usize
         },
         36usize,
         concat!(
@@ -144,7 +152,8 @@ fn bindgen_test_layout_C() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<C>())).mBConstBool as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<C>())).mBConstBool)
+                as usize
         },
         40usize,
         concat!(
@@ -156,7 +165,8 @@ fn bindgen_test_layout_C() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<C>())).mBConstChar as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<C>())).mBConstChar)
+                as usize
         },
         42usize,
         concat!(
@@ -167,7 +177,9 @@ fn bindgen_test_layout_C() {
         )
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<C>())).mBArray as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<C>())).mBArray) as usize
+        },
         44usize,
         concat!(
             "Offset of field: ",
@@ -178,7 +190,8 @@ fn bindgen_test_layout_C() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<C>())).mBPtrArray as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<C>())).mBPtrArray)
+                as usize
         },
         48usize,
         concat!(
@@ -190,7 +203,8 @@ fn bindgen_test_layout_C() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<C>())).mBArrayPtr as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<C>())).mBArrayPtr)
+                as usize
         },
         56usize,
         concat!(
@@ -201,13 +215,16 @@ fn bindgen_test_layout_C() {
         )
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<C>())).mBRef as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<C>())).mBRef) as usize
+        },
         64usize,
         concat!("Offset of field: ", stringify!(C), "::", stringify!(mBRef))
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<C>())).mBConstRef as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<C>())).mBConstRef)
+                as usize
         },
         72usize,
         concat!(
@@ -218,7 +235,9 @@ fn bindgen_test_layout_C() {
         )
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<C>())).mPtrRef as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<C>())).mPtrRef) as usize
+        },
         80usize,
         concat!(
             "Offset of field: ",
@@ -228,7 +247,10 @@ fn bindgen_test_layout_C() {
         )
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<C>())).mArrayRef as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<C>())).mArrayRef)
+                as usize
+        },
         88usize,
         concat!(
             "Offset of field: ",
@@ -239,7 +261,8 @@ fn bindgen_test_layout_C() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<C>())).mBConstArray as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<C>())).mBConstArray)
+                as usize
         },
         96usize,
         concat!(
@@ -326,8 +349,9 @@ fn bindgen_test_layout_RootedContainer() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<RootedContainer>())).root as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<RootedContainer>())).root
+            ) as usize
         },
         0usize,
         concat!(
@@ -382,8 +406,9 @@ fn bindgen_test_layout_PODButContainsDtor() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<PODButContainsDtor>())).member as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<PODButContainsDtor>())).member
+            ) as usize
         },
         0usize,
         concat!(
@@ -428,7 +453,8 @@ fn bindgen_test_layout_POD() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<POD>())).opaque_member as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<POD>())).opaque_member)
+                as usize
         },
         0usize,
         concat!(

--- a/tests/expectations/tests/test_mixed_header_and_header_contents.rs
+++ b/tests/expectations/tests/test_mixed_header_and_header_contents.rs
@@ -44,52 +44,72 @@ fn bindgen_test_layout_Test() {
         concat!("Alignment of ", stringify!(Test))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Test>())).ch as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<Test>())).ch) as usize
+        },
         0usize,
         concat!("Offset of field: ", stringify!(Test), "::", stringify!(ch))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Test>())).u as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<Test>())).u) as usize
+        },
         1usize,
         concat!("Offset of field: ", stringify!(Test), "::", stringify!(u))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Test>())).d as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<Test>())).d) as usize
+        },
         2usize,
         concat!("Offset of field: ", stringify!(Test), "::", stringify!(d))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Test>())).cch as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<Test>())).cch) as usize
+        },
         3usize,
         concat!("Offset of field: ", stringify!(Test), "::", stringify!(cch))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Test>())).cu as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<Test>())).cu) as usize
+        },
         4usize,
         concat!("Offset of field: ", stringify!(Test), "::", stringify!(cu))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Test>())).cd as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<Test>())).cd) as usize
+        },
         5usize,
         concat!("Offset of field: ", stringify!(Test), "::", stringify!(cd))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Test>())).Cch as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<Test>())).Cch) as usize
+        },
         6usize,
         concat!("Offset of field: ", stringify!(Test), "::", stringify!(Cch))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Test>())).Cu as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<Test>())).Cu) as usize
+        },
         7usize,
         concat!("Offset of field: ", stringify!(Test), "::", stringify!(Cu))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Test>())).Cd as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<Test>())).Cd) as usize
+        },
         8usize,
         concat!("Offset of field: ", stringify!(Test), "::", stringify!(Cd))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Test>())).Ccch as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<Test>())).Ccch) as usize
+        },
         9usize,
         concat!(
             "Offset of field: ",
@@ -99,12 +119,16 @@ fn bindgen_test_layout_Test() {
         )
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Test>())).Ccu as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<Test>())).Ccu) as usize
+        },
         10usize,
         concat!("Offset of field: ", stringify!(Test), "::", stringify!(Ccu))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Test>())).Ccd as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<Test>())).Ccd) as usize
+        },
         11usize,
         concat!("Offset of field: ", stringify!(Test), "::", stringify!(Ccd))
     );

--- a/tests/expectations/tests/test_multiple_header_calls_in_builder.rs
+++ b/tests/expectations/tests/test_multiple_header_calls_in_builder.rs
@@ -38,52 +38,72 @@ fn bindgen_test_layout_Test() {
         concat!("Alignment of ", stringify!(Test))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Test>())).ch as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<Test>())).ch) as usize
+        },
         0usize,
         concat!("Offset of field: ", stringify!(Test), "::", stringify!(ch))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Test>())).u as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<Test>())).u) as usize
+        },
         1usize,
         concat!("Offset of field: ", stringify!(Test), "::", stringify!(u))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Test>())).d as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<Test>())).d) as usize
+        },
         2usize,
         concat!("Offset of field: ", stringify!(Test), "::", stringify!(d))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Test>())).cch as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<Test>())).cch) as usize
+        },
         3usize,
         concat!("Offset of field: ", stringify!(Test), "::", stringify!(cch))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Test>())).cu as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<Test>())).cu) as usize
+        },
         4usize,
         concat!("Offset of field: ", stringify!(Test), "::", stringify!(cu))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Test>())).cd as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<Test>())).cd) as usize
+        },
         5usize,
         concat!("Offset of field: ", stringify!(Test), "::", stringify!(cd))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Test>())).Cch as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<Test>())).Cch) as usize
+        },
         6usize,
         concat!("Offset of field: ", stringify!(Test), "::", stringify!(Cch))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Test>())).Cu as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<Test>())).Cu) as usize
+        },
         7usize,
         concat!("Offset of field: ", stringify!(Test), "::", stringify!(Cu))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Test>())).Cd as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<Test>())).Cd) as usize
+        },
         8usize,
         concat!("Offset of field: ", stringify!(Test), "::", stringify!(Cd))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Test>())).Ccch as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<Test>())).Ccch) as usize
+        },
         9usize,
         concat!(
             "Offset of field: ",
@@ -93,12 +113,16 @@ fn bindgen_test_layout_Test() {
         )
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Test>())).Ccu as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<Test>())).Ccu) as usize
+        },
         10usize,
         concat!("Offset of field: ", stringify!(Test), "::", stringify!(Ccu))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Test>())).Ccd as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<Test>())).Ccd) as usize
+        },
         11usize,
         concat!("Offset of field: ", stringify!(Test), "::", stringify!(Ccd))
     );

--- a/tests/expectations/tests/timex.rs
+++ b/tests/expectations/tests/timex.rs
@@ -111,7 +111,9 @@ fn bindgen_test_layout_timex() {
         concat!("Alignment of ", stringify!(timex))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<timex>())).tai as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<timex>())).tai) as usize
+        },
         0usize,
         concat!(
             "Offset of field: ",
@@ -151,7 +153,8 @@ fn bindgen_test_layout_timex_named() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<timex_named>())).tai as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<timex_named>())).tai)
+                as usize
         },
         0usize,
         concat!(

--- a/tests/expectations/tests/type-referenced-by-allowlisted-function.rs
+++ b/tests/expectations/tests/type-referenced-by-allowlisted-function.rs
@@ -24,7 +24,8 @@ fn bindgen_test_layout_dl_phdr_info() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<dl_phdr_info>())).x as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<dl_phdr_info>())).x)
+                as usize
         },
         0usize,
         concat!(

--- a/tests/expectations/tests/typeref.rs
+++ b/tests/expectations/tests/typeref.rs
@@ -24,8 +24,9 @@ fn bindgen_test_layout_mozilla_FragmentOrURL() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<mozilla_FragmentOrURL>())).mIsLocalRef
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<mozilla_FragmentOrURL>())).mIsLocalRef
+            ) as usize
         },
         0usize,
         concat!(
@@ -99,7 +100,9 @@ fn bindgen_test_layout_Bar() {
         concat!("Alignment of ", stringify!(Bar))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Bar>())).mFoo as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<Bar>())).mFoo) as usize
+        },
         0usize,
         concat!("Offset of field: ", stringify!(Bar), "::", stringify!(mFoo))
     );
@@ -130,7 +133,9 @@ fn bindgen_test_layout_nsFoo() {
         concat!("Alignment of ", stringify!(nsFoo))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<nsFoo>())).mBar as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<nsFoo>())).mBar) as usize
+        },
         0usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/typeref_1_0.rs
+++ b/tests/expectations/tests/typeref_1_0.rs
@@ -67,8 +67,9 @@ fn bindgen_test_layout_mozilla_FragmentOrURL() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<mozilla_FragmentOrURL>())).mIsLocalRef
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<mozilla_FragmentOrURL>())).mIsLocalRef
+            ) as usize
         },
         0usize,
         concat!(
@@ -137,7 +138,9 @@ fn bindgen_test_layout_Bar() {
         concat!("Alignment of ", stringify!(Bar))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Bar>())).mFoo as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<Bar>())).mFoo) as usize
+        },
         0usize,
         concat!("Offset of field: ", stringify!(Bar), "::", stringify!(mFoo))
     );
@@ -174,7 +177,9 @@ fn bindgen_test_layout_nsFoo() {
         concat!("Alignment of ", stringify!(nsFoo))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<nsFoo>())).mBar as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<nsFoo>())).mBar) as usize
+        },
         0usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/underscore.rs
+++ b/tests/expectations/tests/underscore.rs
@@ -24,7 +24,9 @@ fn bindgen_test_layout_ptr_t() {
         concat!("Alignment of ", stringify!(ptr_t))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<ptr_t>())).__ as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<ptr_t>())).__) as usize
+        },
         0usize,
         concat!("Offset of field: ", stringify!(ptr_t), "::", stringify!(__))
     );

--- a/tests/expectations/tests/union-align.rs
+++ b/tests/expectations/tests/union-align.rs
@@ -24,7 +24,9 @@ fn bindgen_test_layout_Bar() {
         concat!("Alignment of ", stringify!(Bar))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Bar>())).foo as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<Bar>())).foo) as usize
+        },
         0usize,
         concat!("Offset of field: ", stringify!(Bar), "::", stringify!(foo))
     );
@@ -57,7 +59,9 @@ fn bindgen_test_layout_Baz() {
         concat!("Alignment of ", stringify!(Baz))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Baz>())).bar as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<Baz>())).bar) as usize
+        },
         0usize,
         concat!("Offset of field: ", stringify!(Baz), "::", stringify!(bar))
     );

--- a/tests/expectations/tests/union-in-ns.rs
+++ b/tests/expectations/tests/union-in-ns.rs
@@ -27,7 +27,10 @@ pub mod root {
             concat!("Alignment of ", stringify!(bar))
         );
         assert_eq!(
-            unsafe { &(*(::std::ptr::null::<bar>())).baz as *const _ as usize },
+            unsafe {
+                ::std::ptr::addr_of!((*(::std::ptr::null::<bar>())).baz)
+                    as usize
+            },
             0usize,
             concat!(
                 "Offset of field: ",

--- a/tests/expectations/tests/union-in-ns_1_0.rs
+++ b/tests/expectations/tests/union-in-ns_1_0.rs
@@ -74,7 +74,10 @@ pub mod root {
             concat!("Alignment of ", stringify!(bar))
         );
         assert_eq!(
-            unsafe { &(*(::std::ptr::null::<bar>())).baz as *const _ as usize },
+            unsafe {
+                ::std::ptr::addr_of!((*(::std::ptr::null::<bar>())).baz)
+                    as usize
+            },
             0usize,
             concat!(
                 "Offset of field: ",

--- a/tests/expectations/tests/union_dtor.rs
+++ b/tests/expectations/tests/union_dtor.rs
@@ -24,7 +24,8 @@ fn bindgen_test_layout_UnionWithDtor() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<UnionWithDtor>())).mFoo as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<UnionWithDtor>())).mFoo)
+                as usize
         },
         0usize,
         concat!(
@@ -36,7 +37,8 @@ fn bindgen_test_layout_UnionWithDtor() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<UnionWithDtor>())).mBar as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<UnionWithDtor>())).mBar)
+                as usize
         },
         0usize,
         concat!(

--- a/tests/expectations/tests/union_dtor_1_0.rs
+++ b/tests/expectations/tests/union_dtor_1_0.rs
@@ -69,7 +69,8 @@ fn bindgen_test_layout_UnionWithDtor() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<UnionWithDtor>())).mFoo as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<UnionWithDtor>())).mFoo)
+                as usize
         },
         0usize,
         concat!(
@@ -81,7 +82,8 @@ fn bindgen_test_layout_UnionWithDtor() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<UnionWithDtor>())).mBar as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<UnionWithDtor>())).mBar)
+                as usize
         },
         0usize,
         concat!(

--- a/tests/expectations/tests/union_fields.rs
+++ b/tests/expectations/tests/union_fields.rs
@@ -26,7 +26,8 @@ fn bindgen_test_layout_nsStyleUnion() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<nsStyleUnion>())).mInt as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<nsStyleUnion>())).mInt)
+                as usize
         },
         0usize,
         concat!(
@@ -38,7 +39,8 @@ fn bindgen_test_layout_nsStyleUnion() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<nsStyleUnion>())).mFloat as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<nsStyleUnion>())).mFloat)
+                as usize
         },
         0usize,
         concat!(
@@ -50,8 +52,9 @@ fn bindgen_test_layout_nsStyleUnion() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<nsStyleUnion>())).mPointer as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<nsStyleUnion>())).mPointer
+            ) as usize
         },
         0usize,
         concat!(

--- a/tests/expectations/tests/union_fields_1_0.rs
+++ b/tests/expectations/tests/union_fields_1_0.rs
@@ -70,7 +70,8 @@ fn bindgen_test_layout_nsStyleUnion() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<nsStyleUnion>())).mInt as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<nsStyleUnion>())).mInt)
+                as usize
         },
         0usize,
         concat!(
@@ -82,7 +83,8 @@ fn bindgen_test_layout_nsStyleUnion() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<nsStyleUnion>())).mFloat as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<nsStyleUnion>())).mFloat)
+                as usize
         },
         0usize,
         concat!(
@@ -94,8 +96,9 @@ fn bindgen_test_layout_nsStyleUnion() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<nsStyleUnion>())).mPointer as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<nsStyleUnion>())).mPointer
+            ) as usize
         },
         0usize,
         concat!(

--- a/tests/expectations/tests/union_with_anon_struct.rs
+++ b/tests/expectations/tests/union_with_anon_struct.rs
@@ -30,7 +30,8 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<foo__bindgen_ty_1>())).a as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<foo__bindgen_ty_1>())).a)
+                as usize
         },
         0usize,
         concat!(
@@ -42,7 +43,8 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<foo__bindgen_ty_1>())).b as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<foo__bindgen_ty_1>())).b)
+                as usize
         },
         4usize,
         concat!(
@@ -66,7 +68,9 @@ fn bindgen_test_layout_foo() {
         concat!("Alignment of ", stringify!(foo))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<foo>())).bar as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<foo>())).bar) as usize
+        },
         0usize,
         concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar))
     );

--- a/tests/expectations/tests/union_with_anon_struct_1_0.rs
+++ b/tests/expectations/tests/union_with_anon_struct_1_0.rs
@@ -74,7 +74,8 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<foo__bindgen_ty_1>())).a as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<foo__bindgen_ty_1>())).a)
+                as usize
         },
         0usize,
         concat!(
@@ -86,7 +87,8 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<foo__bindgen_ty_1>())).b as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<foo__bindgen_ty_1>())).b)
+                as usize
         },
         4usize,
         concat!(
@@ -115,7 +117,9 @@ fn bindgen_test_layout_foo() {
         concat!("Alignment of ", stringify!(foo))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<foo>())).bar as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<foo>())).bar) as usize
+        },
         0usize,
         concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar))
     );

--- a/tests/expectations/tests/union_with_anon_struct_bitfield.rs
+++ b/tests/expectations/tests/union_with_anon_struct_bitfield.rs
@@ -175,7 +175,9 @@ fn bindgen_test_layout_foo() {
         concat!("Alignment of ", stringify!(foo))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<foo>())).a as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<foo>())).a) as usize
+        },
         0usize,
         concat!("Offset of field: ", stringify!(foo), "::", stringify!(a))
     );

--- a/tests/expectations/tests/union_with_anon_struct_bitfield_1_0.rs
+++ b/tests/expectations/tests/union_with_anon_struct_bitfield_1_0.rs
@@ -224,7 +224,9 @@ fn bindgen_test_layout_foo() {
         concat!("Alignment of ", stringify!(foo))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<foo>())).a as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<foo>())).a) as usize
+        },
         0usize,
         concat!("Offset of field: ", stringify!(foo), "::", stringify!(a))
     );

--- a/tests/expectations/tests/union_with_anon_union.rs
+++ b/tests/expectations/tests/union_with_anon_union.rs
@@ -30,7 +30,8 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<foo__bindgen_ty_1>())).a as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<foo__bindgen_ty_1>())).a)
+                as usize
         },
         0usize,
         concat!(
@@ -42,7 +43,8 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<foo__bindgen_ty_1>())).b as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<foo__bindgen_ty_1>())).b)
+                as usize
         },
         0usize,
         concat!(
@@ -75,7 +77,9 @@ fn bindgen_test_layout_foo() {
         concat!("Alignment of ", stringify!(foo))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<foo>())).bar as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<foo>())).bar) as usize
+        },
         0usize,
         concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar))
     );

--- a/tests/expectations/tests/union_with_anon_union_1_0.rs
+++ b/tests/expectations/tests/union_with_anon_union_1_0.rs
@@ -75,7 +75,8 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<foo__bindgen_ty_1>())).a as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<foo__bindgen_ty_1>())).a)
+                as usize
         },
         0usize,
         concat!(
@@ -87,7 +88,8 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<foo__bindgen_ty_1>())).b as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<foo__bindgen_ty_1>())).b)
+                as usize
         },
         0usize,
         concat!(
@@ -116,7 +118,9 @@ fn bindgen_test_layout_foo() {
         concat!("Alignment of ", stringify!(foo))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<foo>())).bar as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<foo>())).bar) as usize
+        },
         0usize,
         concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar))
     );

--- a/tests/expectations/tests/union_with_anon_unnamed_struct.rs
+++ b/tests/expectations/tests/union_with_anon_unnamed_struct.rs
@@ -33,8 +33,9 @@ fn bindgen_test_layout_pixel__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<pixel__bindgen_ty_1>())).r as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<pixel__bindgen_ty_1>())).r
+            ) as usize
         },
         0usize,
         concat!(
@@ -46,8 +47,9 @@ fn bindgen_test_layout_pixel__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<pixel__bindgen_ty_1>())).g as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<pixel__bindgen_ty_1>())).g
+            ) as usize
         },
         1usize,
         concat!(
@@ -59,8 +61,9 @@ fn bindgen_test_layout_pixel__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<pixel__bindgen_ty_1>())).b as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<pixel__bindgen_ty_1>())).b
+            ) as usize
         },
         2usize,
         concat!(
@@ -72,8 +75,9 @@ fn bindgen_test_layout_pixel__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<pixel__bindgen_ty_1>())).a as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<pixel__bindgen_ty_1>())).a
+            ) as usize
         },
         3usize,
         concat!(
@@ -97,7 +101,9 @@ fn bindgen_test_layout_pixel() {
         concat!("Alignment of ", stringify!(pixel))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<pixel>())).rgba as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<pixel>())).rgba) as usize
+        },
         0usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/union_with_anon_unnamed_struct_1_0.rs
+++ b/tests/expectations/tests/union_with_anon_unnamed_struct_1_0.rs
@@ -77,8 +77,9 @@ fn bindgen_test_layout_pixel__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<pixel__bindgen_ty_1>())).r as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<pixel__bindgen_ty_1>())).r
+            ) as usize
         },
         0usize,
         concat!(
@@ -90,8 +91,9 @@ fn bindgen_test_layout_pixel__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<pixel__bindgen_ty_1>())).g as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<pixel__bindgen_ty_1>())).g
+            ) as usize
         },
         1usize,
         concat!(
@@ -103,8 +105,9 @@ fn bindgen_test_layout_pixel__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<pixel__bindgen_ty_1>())).b as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<pixel__bindgen_ty_1>())).b
+            ) as usize
         },
         2usize,
         concat!(
@@ -116,8 +119,9 @@ fn bindgen_test_layout_pixel__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<pixel__bindgen_ty_1>())).a as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<pixel__bindgen_ty_1>())).a
+            ) as usize
         },
         3usize,
         concat!(
@@ -146,7 +150,9 @@ fn bindgen_test_layout_pixel() {
         concat!("Alignment of ", stringify!(pixel))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<pixel>())).rgba as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<pixel>())).rgba) as usize
+        },
         0usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/union_with_anon_unnamed_union.rs
+++ b/tests/expectations/tests/union_with_anon_unnamed_union.rs
@@ -31,7 +31,8 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<foo__bindgen_ty_1>())).b as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<foo__bindgen_ty_1>())).b)
+                as usize
         },
         0usize,
         concat!(
@@ -43,7 +44,8 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<foo__bindgen_ty_1>())).c as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<foo__bindgen_ty_1>())).c)
+                as usize
         },
         0usize,
         concat!(
@@ -76,7 +78,9 @@ fn bindgen_test_layout_foo() {
         concat!("Alignment of ", stringify!(foo))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<foo>())).a as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<foo>())).a) as usize
+        },
         0usize,
         concat!("Offset of field: ", stringify!(foo), "::", stringify!(a))
     );

--- a/tests/expectations/tests/union_with_anon_unnamed_union_1_0.rs
+++ b/tests/expectations/tests/union_with_anon_unnamed_union_1_0.rs
@@ -76,7 +76,8 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<foo__bindgen_ty_1>())).b as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<foo__bindgen_ty_1>())).b)
+                as usize
         },
         0usize,
         concat!(
@@ -88,7 +89,8 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<foo__bindgen_ty_1>())).c as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<foo__bindgen_ty_1>())).c)
+                as usize
         },
         0usize,
         concat!(
@@ -117,7 +119,9 @@ fn bindgen_test_layout_foo() {
         concat!("Alignment of ", stringify!(foo))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<foo>())).a as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<foo>())).a) as usize
+        },
         0usize,
         concat!("Offset of field: ", stringify!(foo), "::", stringify!(a))
     );

--- a/tests/expectations/tests/union_with_big_member.rs
+++ b/tests/expectations/tests/union_with_big_member.rs
@@ -25,7 +25,8 @@ fn bindgen_test_layout_WithBigArray() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<WithBigArray>())).a as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<WithBigArray>())).a)
+                as usize
         },
         0usize,
         concat!(
@@ -37,7 +38,8 @@ fn bindgen_test_layout_WithBigArray() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<WithBigArray>())).b as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<WithBigArray>())).b)
+                as usize
         },
         0usize,
         concat!(
@@ -77,7 +79,8 @@ fn bindgen_test_layout_WithBigArray2() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<WithBigArray2>())).a as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<WithBigArray2>())).a)
+                as usize
         },
         0usize,
         concat!(
@@ -89,7 +92,8 @@ fn bindgen_test_layout_WithBigArray2() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<WithBigArray2>())).b as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<WithBigArray2>())).b)
+                as usize
         },
         0usize,
         concat!(
@@ -129,7 +133,8 @@ fn bindgen_test_layout_WithBigMember() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<WithBigMember>())).a as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<WithBigMember>())).a)
+                as usize
         },
         0usize,
         concat!(
@@ -141,7 +146,8 @@ fn bindgen_test_layout_WithBigMember() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<WithBigMember>())).b as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<WithBigMember>())).b)
+                as usize
         },
         0usize,
         concat!(

--- a/tests/expectations/tests/union_with_big_member_1_0.rs
+++ b/tests/expectations/tests/union_with_big_member_1_0.rs
@@ -69,7 +69,8 @@ fn bindgen_test_layout_WithBigArray() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<WithBigArray>())).a as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<WithBigArray>())).a)
+                as usize
         },
         0usize,
         concat!(
@@ -81,7 +82,8 @@ fn bindgen_test_layout_WithBigArray() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<WithBigArray>())).b as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<WithBigArray>())).b)
+                as usize
         },
         0usize,
         concat!(
@@ -127,7 +129,8 @@ fn bindgen_test_layout_WithBigArray2() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<WithBigArray2>())).a as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<WithBigArray2>())).a)
+                as usize
         },
         0usize,
         concat!(
@@ -139,7 +142,8 @@ fn bindgen_test_layout_WithBigArray2() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<WithBigArray2>())).b as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<WithBigArray2>())).b)
+                as usize
         },
         0usize,
         concat!(
@@ -176,7 +180,8 @@ fn bindgen_test_layout_WithBigMember() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<WithBigMember>())).a as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<WithBigMember>())).a)
+                as usize
         },
         0usize,
         concat!(
@@ -188,7 +193,8 @@ fn bindgen_test_layout_WithBigMember() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<WithBigMember>())).b as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<WithBigMember>())).b)
+                as usize
         },
         0usize,
         concat!(

--- a/tests/expectations/tests/union_with_nesting.rs
+++ b/tests/expectations/tests/union_with_nesting.rs
@@ -37,8 +37,9 @@ fn bindgen_test_layout_foo__bindgen_ty_1__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<foo__bindgen_ty_1__bindgen_ty_1>())).b1
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<foo__bindgen_ty_1__bindgen_ty_1>())).b1
+            ) as usize
         },
         0usize,
         concat!(
@@ -50,8 +51,9 @@ fn bindgen_test_layout_foo__bindgen_ty_1__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<foo__bindgen_ty_1__bindgen_ty_1>())).b2
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<foo__bindgen_ty_1__bindgen_ty_1>())).b2
+            ) as usize
         },
         0usize,
         concat!(
@@ -91,8 +93,9 @@ fn bindgen_test_layout_foo__bindgen_ty_1__bindgen_ty_2() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<foo__bindgen_ty_1__bindgen_ty_2>())).c1
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<foo__bindgen_ty_1__bindgen_ty_2>())).c1
+            ) as usize
         },
         0usize,
         concat!(
@@ -104,8 +107,9 @@ fn bindgen_test_layout_foo__bindgen_ty_1__bindgen_ty_2() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<foo__bindgen_ty_1__bindgen_ty_2>())).c2
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<foo__bindgen_ty_1__bindgen_ty_2>())).c2
+            ) as usize
         },
         0usize,
         concat!(
@@ -160,7 +164,9 @@ fn bindgen_test_layout_foo() {
         concat!("Alignment of ", stringify!(foo))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<foo>())).a as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<foo>())).a) as usize
+        },
         0usize,
         concat!("Offset of field: ", stringify!(foo), "::", stringify!(a))
     );

--- a/tests/expectations/tests/union_with_nesting_1_0.rs
+++ b/tests/expectations/tests/union_with_nesting_1_0.rs
@@ -82,8 +82,9 @@ fn bindgen_test_layout_foo__bindgen_ty_1__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<foo__bindgen_ty_1__bindgen_ty_1>())).b1
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<foo__bindgen_ty_1__bindgen_ty_1>())).b1
+            ) as usize
         },
         0usize,
         concat!(
@@ -95,8 +96,9 @@ fn bindgen_test_layout_foo__bindgen_ty_1__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<foo__bindgen_ty_1__bindgen_ty_1>())).b2
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<foo__bindgen_ty_1__bindgen_ty_1>())).b2
+            ) as usize
         },
         0usize,
         concat!(
@@ -133,8 +135,9 @@ fn bindgen_test_layout_foo__bindgen_ty_1__bindgen_ty_2() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<foo__bindgen_ty_1__bindgen_ty_2>())).c1
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<foo__bindgen_ty_1__bindgen_ty_2>())).c1
+            ) as usize
         },
         0usize,
         concat!(
@@ -146,8 +149,9 @@ fn bindgen_test_layout_foo__bindgen_ty_1__bindgen_ty_2() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<foo__bindgen_ty_1__bindgen_ty_2>())).c2
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<foo__bindgen_ty_1__bindgen_ty_2>())).c2
+            ) as usize
         },
         0usize,
         concat!(
@@ -194,7 +198,9 @@ fn bindgen_test_layout_foo() {
         concat!("Alignment of ", stringify!(foo))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<foo>())).a as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<foo>())).a) as usize
+        },
         0usize,
         concat!("Offset of field: ", stringify!(foo), "::", stringify!(a))
     );

--- a/tests/expectations/tests/unknown_attr.rs
+++ b/tests/expectations/tests/unknown_attr.rs
@@ -27,8 +27,9 @@ fn bindgen_test_layout_max_align_t() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<max_align_t>())).__clang_max_align_nonce1
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<max_align_t>())).__clang_max_align_nonce1
+            ) as usize
         },
         0usize,
         concat!(
@@ -40,8 +41,9 @@ fn bindgen_test_layout_max_align_t() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<max_align_t>())).__clang_max_align_nonce2
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<max_align_t>())).__clang_max_align_nonce2
+            ) as usize
         },
         16usize,
         concat!(

--- a/tests/expectations/tests/use-core.rs
+++ b/tests/expectations/tests/use-core.rs
@@ -27,17 +27,23 @@ fn bindgen_test_layout_foo() {
         concat!("Alignment of ", stringify!(foo))
     );
     assert_eq!(
-        unsafe { &(*(::core::ptr::null::<foo>())).a as *const _ as usize },
+        unsafe {
+            ::core::ptr::addr_of!((*(::core::ptr::null::<foo>())).a) as usize
+        },
         0usize,
         concat!("Offset of field: ", stringify!(foo), "::", stringify!(a))
     );
     assert_eq!(
-        unsafe { &(*(::core::ptr::null::<foo>())).b as *const _ as usize },
+        unsafe {
+            ::core::ptr::addr_of!((*(::core::ptr::null::<foo>())).b) as usize
+        },
         4usize,
         concat!("Offset of field: ", stringify!(foo), "::", stringify!(b))
     );
     assert_eq!(
-        unsafe { &(*(::core::ptr::null::<foo>())).bar as *const _ as usize },
+        unsafe {
+            ::core::ptr::addr_of!((*(::core::ptr::null::<foo>())).bar) as usize
+        },
         8usize,
         concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar))
     );
@@ -71,7 +77,8 @@ fn bindgen_test_layout__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::core::ptr::null::<_bindgen_ty_1>())).bar as *const _ as usize
+            ::core::ptr::addr_of!((*(::core::ptr::null::<_bindgen_ty_1>())).bar)
+                as usize
         },
         0usize,
         concat!(
@@ -83,7 +90,8 @@ fn bindgen_test_layout__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::core::ptr::null::<_bindgen_ty_1>())).baz as *const _ as usize
+            ::core::ptr::addr_of!((*(::core::ptr::null::<_bindgen_ty_1>())).baz)
+                as usize
         },
         0usize,
         concat!(

--- a/tests/expectations/tests/use-core_1_0.rs
+++ b/tests/expectations/tests/use-core_1_0.rs
@@ -70,17 +70,23 @@ fn bindgen_test_layout_foo() {
         concat!("Alignment of ", stringify!(foo))
     );
     assert_eq!(
-        unsafe { &(*(::core::ptr::null::<foo>())).a as *const _ as usize },
+        unsafe {
+            ::core::ptr::addr_of!((*(::core::ptr::null::<foo>())).a) as usize
+        },
         0usize,
         concat!("Offset of field: ", stringify!(foo), "::", stringify!(a))
     );
     assert_eq!(
-        unsafe { &(*(::core::ptr::null::<foo>())).b as *const _ as usize },
+        unsafe {
+            ::core::ptr::addr_of!((*(::core::ptr::null::<foo>())).b) as usize
+        },
         4usize,
         concat!("Offset of field: ", stringify!(foo), "::", stringify!(b))
     );
     assert_eq!(
-        unsafe { &(*(::core::ptr::null::<foo>())).bar as *const _ as usize },
+        unsafe {
+            ::core::ptr::addr_of!((*(::core::ptr::null::<foo>())).bar) as usize
+        },
         8usize,
         concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar))
     );
@@ -120,7 +126,8 @@ fn bindgen_test_layout__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::core::ptr::null::<_bindgen_ty_1>())).bar as *const _ as usize
+            ::core::ptr::addr_of!((*(::core::ptr::null::<_bindgen_ty_1>())).bar)
+                as usize
         },
         0usize,
         concat!(
@@ -132,7 +139,8 @@ fn bindgen_test_layout__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            &(*(::core::ptr::null::<_bindgen_ty_1>())).baz as *const _ as usize
+            ::core::ptr::addr_of!((*(::core::ptr::null::<_bindgen_ty_1>())).baz)
+                as usize
         },
         0usize,
         concat!(

--- a/tests/expectations/tests/var-tracing.rs
+++ b/tests/expectations/tests/var-tracing.rs
@@ -23,7 +23,9 @@ fn bindgen_test_layout_Bar() {
         concat!("Alignment of ", stringify!(Bar))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<Bar>())).m_baz as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<Bar>())).m_baz) as usize
+        },
         0usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/vector.rs
+++ b/tests/expectations/tests/vector.rs
@@ -23,7 +23,10 @@ fn bindgen_test_layout_foo() {
         concat!("Alignment of ", stringify!(foo))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<foo>())).mMember as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<foo>())).mMember)
+                as usize
+        },
         0usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/virtual_inheritance.rs
+++ b/tests/expectations/tests/virtual_inheritance.rs
@@ -23,7 +23,9 @@ fn bindgen_test_layout_A() {
         concat!("Alignment of ", stringify!(A))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<A>())).foo as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<A>())).foo) as usize
+        },
         0usize,
         concat!("Offset of field: ", stringify!(A), "::", stringify!(foo))
     );
@@ -49,7 +51,9 @@ fn bindgen_test_layout_B() {
         concat!("Alignment of ", stringify!(B))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<B>())).bar as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<B>())).bar) as usize
+        },
         8usize,
         concat!("Offset of field: ", stringify!(B), "::", stringify!(bar))
     );
@@ -84,7 +88,9 @@ fn bindgen_test_layout_C() {
         concat!("Alignment of ", stringify!(C))
     );
     assert_eq!(
-        unsafe { &(*(::std::ptr::null::<C>())).baz as *const _ as usize },
+        unsafe {
+            ::std::ptr::addr_of!((*(::std::ptr::null::<C>())).baz) as usize
+        },
         8usize,
         concat!("Offset of field: ", stringify!(C), "::", stringify!(baz))
     );

--- a/tests/expectations/tests/weird_bitfields.rs
+++ b/tests/expectations/tests/weird_bitfields.rs
@@ -133,8 +133,9 @@ fn bindgen_test_layout_Weird() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<Weird>())).mStrokeDasharrayLength as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<Weird>())).mStrokeDasharrayLength
+            ) as usize
         },
         0usize,
         concat!(
@@ -146,7 +147,8 @@ fn bindgen_test_layout_Weird() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<Weird>())).mClipRule as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<Weird>())).mClipRule)
+                as usize
         },
         8usize,
         concat!(
@@ -158,8 +160,9 @@ fn bindgen_test_layout_Weird() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<Weird>())).mColorInterpolation as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<Weird>())).mColorInterpolation
+            ) as usize
         },
         9usize,
         concat!(
@@ -171,8 +174,9 @@ fn bindgen_test_layout_Weird() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<Weird>())).mColorInterpolationFilters
-                as *const _ as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<Weird>())).mColorInterpolationFilters
+            ) as usize
         },
         10usize,
         concat!(
@@ -184,7 +188,8 @@ fn bindgen_test_layout_Weird() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<Weird>())).mFillRule as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<Weird>())).mFillRule)
+                as usize
         },
         11usize,
         concat!(
@@ -196,8 +201,9 @@ fn bindgen_test_layout_Weird() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<Weird>())).mImageRendering as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<Weird>())).mImageRendering
+            ) as usize
         },
         12usize,
         concat!(
@@ -209,7 +215,8 @@ fn bindgen_test_layout_Weird() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<Weird>())).mPaintOrder as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<Weird>())).mPaintOrder)
+                as usize
         },
         13usize,
         concat!(
@@ -221,8 +228,9 @@ fn bindgen_test_layout_Weird() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<Weird>())).mShapeRendering as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<Weird>())).mShapeRendering
+            ) as usize
         },
         14usize,
         concat!(
@@ -234,8 +242,9 @@ fn bindgen_test_layout_Weird() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<Weird>())).mStrokeLinecap as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<Weird>())).mStrokeLinecap
+            ) as usize
         },
         15usize,
         concat!(
@@ -247,8 +256,9 @@ fn bindgen_test_layout_Weird() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<Weird>())).mStrokeLinejoin as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<Weird>())).mStrokeLinejoin
+            ) as usize
         },
         16usize,
         concat!(
@@ -260,7 +270,8 @@ fn bindgen_test_layout_Weird() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<Weird>())).mTextAnchor as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<Weird>())).mTextAnchor)
+                as usize
         },
         17usize,
         concat!(
@@ -272,8 +283,9 @@ fn bindgen_test_layout_Weird() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<Weird>())).mTextRendering as *const _
-                as usize
+            ::std::ptr::addr_of!(
+                (*(::std::ptr::null::<Weird>())).mTextRendering
+            ) as usize
         },
         18usize,
         concat!(

--- a/tests/expectations/tests/zero-size-array-align.rs
+++ b/tests/expectations/tests/zero-size-array-align.rs
@@ -56,7 +56,8 @@ fn bindgen_test_layout_dm_deps() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<dm_deps>())).count as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<dm_deps>())).count)
+                as usize
         },
         0usize,
         concat!(
@@ -68,7 +69,8 @@ fn bindgen_test_layout_dm_deps() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<dm_deps>())).filler as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<dm_deps>())).filler)
+                as usize
         },
         4usize,
         concat!(
@@ -80,7 +82,8 @@ fn bindgen_test_layout_dm_deps() {
     );
     assert_eq!(
         unsafe {
-            &(*(::std::ptr::null::<dm_deps>())).device as *const _ as usize
+            ::std::ptr::addr_of!((*(::std::ptr::null::<dm_deps>())).device)
+                as usize
         },
         8usize,
         concat!(

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -557,7 +557,19 @@ fn test_mixed_header_and_header_contents() {
     ));
     let (expected, _) = rustfmt(expected.to_string());
 
-    assert_eq!(expected, actual);
+    if actual != expected {
+        println!("Generated bindings differ from expected!");
+
+        for diff in diff::lines(&actual, &expected) {
+            match diff {
+                diff::Result::Left(l) => println!("-{}", l),
+                diff::Result::Both(l, _) => println!(" {}", l),
+                diff::Result::Right(r) => println!("+{}", r),
+            }
+        }
+
+        panic!();
+    }
 }
 
 #[test]


### PR DESCRIPTION
The generated layout tests should pass the borrow_as_ptr lint.

Fixes: #2204 