### PR TITLE
Ignore test inputs/outputs for Github Linguist

### DIFF
--- a/bindgen-integration/.gitattributes
+++ b/bindgen-integration/.gitattributes
@@ -1,0 +1,4 @@
+# Tell Github Linguist to avoid counting these C and C++ test inputs toward
+# statistics.
+*.h -linguist-detectable
+*.cc -linguist-detectable

--- a/tests/.gitattributes
+++ b/tests/.gitattributes
@@ -1,0 +1,4 @@
+# Tell Github Linguist to avoid counting these C and C++ test inputs toward
+# statistics.
+*.h -linguist-detectable
+*.hpp -linguist-detectable

--- a/tests/expectations/tests/.gitattributes
+++ b/tests/expectations/tests/.gitattributes
@@ -1,0 +1,2 @@
+# Prevent Github Linguist from counting generated files in statistics.
+*.rs linguist-generated


### PR DESCRIPTION
I noticed that Github interprets `rust-bindgen` as a C++ project, due to the many C++ input headers. I find this misleading and undesirable.

![screen shot from pinned repository](https://user-images.githubusercontent.com/74288/171614841-901298d0-b381-4094-a0f0-5addb7d02586.png)

The use of `.gitattributes` for Github's Linguist is described in [`linguist/docs/overrides.md`](https://github.com/github/linguist/blob/02ffab2d4df3034c05fd7b2e8bf0a2fd31c0452d/docs/overrides.md).

The changes in this PR are certainly debatable; if they are not loved, I am happy to withdraw them.