### PR TITLE
Fix some clippy warnings

### DIFF
--- a/.github/workflows/bindgen.yml
+++ b/.github/workflows/bindgen.yml
@@ -35,7 +35,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: -- --cfg test
+          args: --tests
 
   msrv:
     runs-on: ubuntu-latest

--- a/build.rs
+++ b/build.rs
@@ -85,6 +85,6 @@ fn main() {
     );
     println!(
         "cargo:rerun-if-env-changed=BINDGEN_EXTRA_CLANG_ARGS_{}",
-        std::env::var("TARGET").unwrap().replace("-", "_")
+        std::env::var("TARGET").unwrap().replace('-', "_")
     );
 }

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -4078,9 +4078,7 @@ fn objc_method_codegen(
 
     let body = if method.is_class_method() {
         let class_name = ctx.rust_ident(
-            class_name
-                .expect("Generating a class method without class name?")
-                .to_owned(),
+            class_name.expect("Generating a class method without class name?"),
         );
         quote! {
             msg_send!(class!(#class_name), #methods_and_args)

--- a/src/ir/context.rs
+++ b/src/ir/context.rs
@@ -597,7 +597,7 @@ If you encounter an error missing from this list, please file an issue or a PR!"
     /// Returns the pointer width to use for the target for the current
     /// translation.
     pub fn target_pointer_size(&self) -> usize {
-        return self.target_info.pointer_width / 8;
+        self.target_info.pointer_width / 8
     }
 
     /// Get the stack of partially parsed types that we are in the middle of
@@ -836,9 +836,9 @@ If you encounter an error missing from this list, please file an issue or a PR!"
             )
         {
             let mut s = name.to_owned();
-            s = s.replace("@", "_");
-            s = s.replace("?", "_");
-            s = s.replace("$", "_");
+            s = s.replace('@', "_");
+            s = s.replace('?', "_");
+            s = s.replace('$', "_");
             s.push('_');
             return Cow::Owned(s);
         }

--- a/src/ir/item.rs
+++ b/src/ir/item.rs
@@ -1894,7 +1894,7 @@ impl ClangItemParser for Item {
 
         // See tests/headers/const_tparam.hpp and
         // tests/headers/variadic_tname.hpp.
-        let name = ty_spelling.replace("const ", "").replace(".", "");
+        let name = ty_spelling.replace("const ", "").replace('.', "");
 
         let id = with_id.unwrap_or_else(|| ctx.next_item_id());
         let item = Item::new(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2714,7 +2714,7 @@ fn get_target_dependent_env_var(var: &str) -> Option<String> {
             return Some(v);
         }
         if let Ok(v) =
-            env::var(&format!("{}_{}", var, target.replace("-", "_")))
+            env::var(&format!("{}_{}", var, target.replace('-', "_")))
         {
             return Some(v);
         }


### PR DESCRIPTION
The Github Actions flow is showing "Unchanged files with check annotations" for each PR. This PR can mechanically remove some of those warnings, and avoid some of the rest by [an improved invocation of `clippy`](https://github.com/rust-lang/rust-clippy/issues/1436#issuecomment-462059561).