### PR TITLE
codegen: tests: Put each individual field test in a function.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,6 +151,14 @@
 
 ## Security
 
+# 0.60.1
+
+Released 2022/06/06
+
+## Fixed
+
+ * Fixed stack overflow in generated tests for structs with many fields (#2219).
+
 # 0.60.0
 
 Released 2022/06/05

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,7 +30,7 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "bindgen"
-version = "0.60.0"
+version = "0.60.1"
 dependencies = [
  "bitflags",
  "cexpr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 repository = "https://github.com/rust-lang/rust-bindgen"
 documentation = "https://docs.rs/bindgen"
 homepage = "https://rust-lang.github.io/rust-bindgen/"
-version = "0.60.0"
+version = "0.60.1"
 edition = "2018"
 build = "build.rs"
 

--- a/tests/expectations/tests/16-byte-alignment.rs
+++ b/tests/expectations/tests/16-byte-alignment.rs
@@ -42,38 +42,44 @@ fn bindgen_test_layout_rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1() {
             stringify!(rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1)
         )
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<
-                rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1,
-            >::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).dport) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1),
-            "::",
-            stringify!(dport)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<
-                rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1,
-            >::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).sport) as usize - ptr as usize
-        },
-        2usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1),
-            "::",
-            stringify!(sport)
-        )
-    );
+    fn test_field_dport() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<
+                    rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1,
+                >::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).dport) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1),
+                "::",
+                stringify!(dport)
+            )
+        );
+    }
+    test_field_dport();
+    fn test_field_sport() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<
+                    rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1,
+                >::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).sport) as usize - ptr as usize
+            },
+            2usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1),
+                "::",
+                stringify!(sport)
+            )
+        );
+    }
+    test_field_sport();
 }
 #[test]
 fn bindgen_test_layout_rte_ipv4_tuple__bindgen_ty_1() {
@@ -87,22 +93,25 @@ fn bindgen_test_layout_rte_ipv4_tuple__bindgen_ty_1() {
         4usize,
         concat!("Alignment of ", stringify!(rte_ipv4_tuple__bindgen_ty_1))
     );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<rte_ipv4_tuple__bindgen_ty_1>::uninit(
-                );
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).sctp_tag) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_ipv4_tuple__bindgen_ty_1),
-            "::",
-            stringify!(sctp_tag)
-        )
-    );
+    fn test_field_sctp_tag() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<
+                    rte_ipv4_tuple__bindgen_ty_1,
+                >::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).sctp_tag) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_ipv4_tuple__bindgen_ty_1),
+                "::",
+                stringify!(sctp_tag)
+            )
+        );
+    }
+    test_field_sctp_tag();
 }
 impl Default for rte_ipv4_tuple__bindgen_ty_1 {
     fn default() -> Self {
@@ -125,34 +134,42 @@ fn bindgen_test_layout_rte_ipv4_tuple() {
         4usize,
         concat!("Alignment of ", stringify!(rte_ipv4_tuple))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_ipv4_tuple>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).src_addr) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_ipv4_tuple),
-            "::",
-            stringify!(src_addr)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_ipv4_tuple>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).dst_addr) as usize - ptr as usize
-        },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_ipv4_tuple),
-            "::",
-            stringify!(dst_addr)
-        )
-    );
+    fn test_field_src_addr() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_ipv4_tuple>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).src_addr) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_ipv4_tuple),
+                "::",
+                stringify!(src_addr)
+            )
+        );
+    }
+    test_field_src_addr();
+    fn test_field_dst_addr() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_ipv4_tuple>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).dst_addr) as usize - ptr as usize
+            },
+            4usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_ipv4_tuple),
+                "::",
+                stringify!(dst_addr)
+            )
+        );
+    }
+    test_field_dst_addr();
 }
 impl Default for rte_ipv4_tuple {
     fn default() -> Self {
@@ -200,38 +217,44 @@ fn bindgen_test_layout_rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1() {
             stringify!(rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1)
         )
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<
-                rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1,
-            >::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).dport) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1),
-            "::",
-            stringify!(dport)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<
-                rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1,
-            >::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).sport) as usize - ptr as usize
-        },
-        2usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1),
-            "::",
-            stringify!(sport)
-        )
-    );
+    fn test_field_dport() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<
+                    rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1,
+                >::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).dport) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1),
+                "::",
+                stringify!(dport)
+            )
+        );
+    }
+    test_field_dport();
+    fn test_field_sport() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<
+                    rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1,
+                >::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).sport) as usize - ptr as usize
+            },
+            2usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1),
+                "::",
+                stringify!(sport)
+            )
+        );
+    }
+    test_field_sport();
 }
 #[test]
 fn bindgen_test_layout_rte_ipv6_tuple__bindgen_ty_1() {
@@ -245,22 +268,25 @@ fn bindgen_test_layout_rte_ipv6_tuple__bindgen_ty_1() {
         4usize,
         concat!("Alignment of ", stringify!(rte_ipv6_tuple__bindgen_ty_1))
     );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<rte_ipv6_tuple__bindgen_ty_1>::uninit(
-                );
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).sctp_tag) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_ipv6_tuple__bindgen_ty_1),
-            "::",
-            stringify!(sctp_tag)
-        )
-    );
+    fn test_field_sctp_tag() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<
+                    rte_ipv6_tuple__bindgen_ty_1,
+                >::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).sctp_tag) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_ipv6_tuple__bindgen_ty_1),
+                "::",
+                stringify!(sctp_tag)
+            )
+        );
+    }
+    test_field_sctp_tag();
 }
 impl Default for rte_ipv6_tuple__bindgen_ty_1 {
     fn default() -> Self {
@@ -283,34 +309,42 @@ fn bindgen_test_layout_rte_ipv6_tuple() {
         4usize,
         concat!("Alignment of ", stringify!(rte_ipv6_tuple))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_ipv6_tuple>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).src_addr) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_ipv6_tuple),
-            "::",
-            stringify!(src_addr)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_ipv6_tuple>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).dst_addr) as usize - ptr as usize
-        },
-        16usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_ipv6_tuple),
-            "::",
-            stringify!(dst_addr)
-        )
-    );
+    fn test_field_src_addr() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_ipv6_tuple>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).src_addr) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_ipv6_tuple),
+                "::",
+                stringify!(src_addr)
+            )
+        );
+    }
+    test_field_src_addr();
+    fn test_field_dst_addr() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_ipv6_tuple>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).dst_addr) as usize - ptr as usize
+            },
+            16usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_ipv6_tuple),
+                "::",
+                stringify!(dst_addr)
+            )
+        );
+    }
+    test_field_dst_addr();
 }
 impl Default for rte_ipv6_tuple {
     fn default() -> Self {
@@ -340,34 +374,42 @@ fn bindgen_test_layout_rte_thash_tuple() {
         16usize,
         concat!("Alignment of ", stringify!(rte_thash_tuple))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_thash_tuple>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).v4) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_thash_tuple),
-            "::",
-            stringify!(v4)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_thash_tuple>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).v6) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_thash_tuple),
-            "::",
-            stringify!(v6)
-        )
-    );
+    fn test_field_v4() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_thash_tuple>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).v4) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_thash_tuple),
+                "::",
+                stringify!(v4)
+            )
+        );
+    }
+    test_field_v4();
+    fn test_field_v6() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_thash_tuple>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).v6) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_thash_tuple),
+                "::",
+                stringify!(v6)
+            )
+        );
+    }
+    test_field_v6();
 }
 impl Default for rte_thash_tuple {
     fn default() -> Self {

--- a/tests/expectations/tests/16-byte-alignment_1_0.rs
+++ b/tests/expectations/tests/16-byte-alignment_1_0.rs
@@ -87,38 +87,44 @@ fn bindgen_test_layout_rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1() {
             stringify!(rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1)
         )
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<
-                rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1,
-            >::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).dport) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1),
-            "::",
-            stringify!(dport)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<
-                rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1,
-            >::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).sport) as usize - ptr as usize
-        },
-        2usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1),
-            "::",
-            stringify!(sport)
-        )
-    );
+    fn test_field_dport() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<
+                    rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1,
+                >::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).dport) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1),
+                "::",
+                stringify!(dport)
+            )
+        );
+    }
+    test_field_dport();
+    fn test_field_sport() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<
+                    rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1,
+                >::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).sport) as usize - ptr as usize
+            },
+            2usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1),
+                "::",
+                stringify!(sport)
+            )
+        );
+    }
+    test_field_sport();
 }
 impl Clone for rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1 {
     fn clone(&self) -> Self {
@@ -137,22 +143,25 @@ fn bindgen_test_layout_rte_ipv4_tuple__bindgen_ty_1() {
         4usize,
         concat!("Alignment of ", stringify!(rte_ipv4_tuple__bindgen_ty_1))
     );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<rte_ipv4_tuple__bindgen_ty_1>::uninit(
-                );
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).sctp_tag) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_ipv4_tuple__bindgen_ty_1),
-            "::",
-            stringify!(sctp_tag)
-        )
-    );
+    fn test_field_sctp_tag() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<
+                    rte_ipv4_tuple__bindgen_ty_1,
+                >::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).sctp_tag) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_ipv4_tuple__bindgen_ty_1),
+                "::",
+                stringify!(sctp_tag)
+            )
+        );
+    }
+    test_field_sctp_tag();
 }
 impl Clone for rte_ipv4_tuple__bindgen_ty_1 {
     fn clone(&self) -> Self {
@@ -171,34 +180,42 @@ fn bindgen_test_layout_rte_ipv4_tuple() {
         4usize,
         concat!("Alignment of ", stringify!(rte_ipv4_tuple))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_ipv4_tuple>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).src_addr) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_ipv4_tuple),
-            "::",
-            stringify!(src_addr)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_ipv4_tuple>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).dst_addr) as usize - ptr as usize
-        },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_ipv4_tuple),
-            "::",
-            stringify!(dst_addr)
-        )
-    );
+    fn test_field_src_addr() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_ipv4_tuple>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).src_addr) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_ipv4_tuple),
+                "::",
+                stringify!(src_addr)
+            )
+        );
+    }
+    test_field_src_addr();
+    fn test_field_dst_addr() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_ipv4_tuple>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).dst_addr) as usize - ptr as usize
+            },
+            4usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_ipv4_tuple),
+                "::",
+                stringify!(dst_addr)
+            )
+        );
+    }
+    test_field_dst_addr();
 }
 impl Clone for rte_ipv4_tuple {
     fn clone(&self) -> Self {
@@ -244,38 +261,44 @@ fn bindgen_test_layout_rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1() {
             stringify!(rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1)
         )
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<
-                rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1,
-            >::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).dport) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1),
-            "::",
-            stringify!(dport)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<
-                rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1,
-            >::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).sport) as usize - ptr as usize
-        },
-        2usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1),
-            "::",
-            stringify!(sport)
-        )
-    );
+    fn test_field_dport() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<
+                    rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1,
+                >::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).dport) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1),
+                "::",
+                stringify!(dport)
+            )
+        );
+    }
+    test_field_dport();
+    fn test_field_sport() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<
+                    rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1,
+                >::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).sport) as usize - ptr as usize
+            },
+            2usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1),
+                "::",
+                stringify!(sport)
+            )
+        );
+    }
+    test_field_sport();
 }
 impl Clone for rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1 {
     fn clone(&self) -> Self {
@@ -294,22 +317,25 @@ fn bindgen_test_layout_rte_ipv6_tuple__bindgen_ty_1() {
         4usize,
         concat!("Alignment of ", stringify!(rte_ipv6_tuple__bindgen_ty_1))
     );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<rte_ipv6_tuple__bindgen_ty_1>::uninit(
-                );
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).sctp_tag) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_ipv6_tuple__bindgen_ty_1),
-            "::",
-            stringify!(sctp_tag)
-        )
-    );
+    fn test_field_sctp_tag() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<
+                    rte_ipv6_tuple__bindgen_ty_1,
+                >::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).sctp_tag) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_ipv6_tuple__bindgen_ty_1),
+                "::",
+                stringify!(sctp_tag)
+            )
+        );
+    }
+    test_field_sctp_tag();
 }
 impl Clone for rte_ipv6_tuple__bindgen_ty_1 {
     fn clone(&self) -> Self {
@@ -328,34 +354,42 @@ fn bindgen_test_layout_rte_ipv6_tuple() {
         4usize,
         concat!("Alignment of ", stringify!(rte_ipv6_tuple))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_ipv6_tuple>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).src_addr) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_ipv6_tuple),
-            "::",
-            stringify!(src_addr)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_ipv6_tuple>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).dst_addr) as usize - ptr as usize
-        },
-        16usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_ipv6_tuple),
-            "::",
-            stringify!(dst_addr)
-        )
-    );
+    fn test_field_src_addr() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_ipv6_tuple>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).src_addr) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_ipv6_tuple),
+                "::",
+                stringify!(src_addr)
+            )
+        );
+    }
+    test_field_src_addr();
+    fn test_field_dst_addr() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_ipv6_tuple>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).dst_addr) as usize - ptr as usize
+            },
+            16usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_ipv6_tuple),
+                "::",
+                stringify!(dst_addr)
+            )
+        );
+    }
+    test_field_dst_addr();
 }
 impl Clone for rte_ipv6_tuple {
     fn clone(&self) -> Self {
@@ -376,34 +410,42 @@ fn bindgen_test_layout_rte_thash_tuple() {
         48usize,
         concat!("Size of: ", stringify!(rte_thash_tuple))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_thash_tuple>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).v4) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_thash_tuple),
-            "::",
-            stringify!(v4)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_thash_tuple>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).v6) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_thash_tuple),
-            "::",
-            stringify!(v6)
-        )
-    );
+    fn test_field_v4() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_thash_tuple>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).v4) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_thash_tuple),
+                "::",
+                stringify!(v4)
+            )
+        );
+    }
+    test_field_v4();
+    fn test_field_v6() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_thash_tuple>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).v6) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_thash_tuple),
+                "::",
+                stringify!(v6)
+            )
+        );
+    }
+    test_field_v6();
 }
 impl Clone for rte_thash_tuple {
     fn clone(&self) -> Self {

--- a/tests/expectations/tests/accessors.rs
+++ b/tests/expectations/tests/accessors.rs
@@ -28,64 +28,77 @@ fn bindgen_test_layout_SomeAccessors() {
         4usize,
         concat!("Alignment of ", stringify!(SomeAccessors))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<SomeAccessors>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mNoAccessor) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(SomeAccessors),
-            "::",
-            stringify!(mNoAccessor)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<SomeAccessors>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mBothAccessors) as usize - ptr as usize
-        },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(SomeAccessors),
-            "::",
-            stringify!(mBothAccessors)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<SomeAccessors>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mUnsafeAccessors) as usize -
-                ptr as usize
-        },
-        8usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(SomeAccessors),
-            "::",
-            stringify!(mUnsafeAccessors)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<SomeAccessors>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mImmutableAccessor) as usize -
-                ptr as usize
-        },
-        12usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(SomeAccessors),
-            "::",
-            stringify!(mImmutableAccessor)
-        )
-    );
+    fn test_field_mNoAccessor() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<SomeAccessors>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).mNoAccessor) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(SomeAccessors),
+                "::",
+                stringify!(mNoAccessor)
+            )
+        );
+    }
+    test_field_mNoAccessor();
+    fn test_field_mBothAccessors() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<SomeAccessors>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).mBothAccessors) as usize -
+                    ptr as usize
+            },
+            4usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(SomeAccessors),
+                "::",
+                stringify!(mBothAccessors)
+            )
+        );
+    }
+    test_field_mBothAccessors();
+    fn test_field_mUnsafeAccessors() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<SomeAccessors>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).mUnsafeAccessors) as usize -
+                    ptr as usize
+            },
+            8usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(SomeAccessors),
+                "::",
+                stringify!(mUnsafeAccessors)
+            )
+        );
+    }
+    test_field_mUnsafeAccessors();
+    fn test_field_mImmutableAccessor() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<SomeAccessors>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).mImmutableAccessor) as usize -
+                    ptr as usize
+            },
+            12usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(SomeAccessors),
+                "::",
+                stringify!(mImmutableAccessor)
+            )
+        );
+    }
+    test_field_mImmutableAccessor();
 }
 impl SomeAccessors {
     #[inline]
@@ -130,35 +143,42 @@ fn bindgen_test_layout_AllAccessors() {
         4usize,
         concat!("Alignment of ", stringify!(AllAccessors))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<AllAccessors>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mBothAccessors) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(AllAccessors),
-            "::",
-            stringify!(mBothAccessors)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<AllAccessors>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mAlsoBothAccessors) as usize -
-                ptr as usize
-        },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(AllAccessors),
-            "::",
-            stringify!(mAlsoBothAccessors)
-        )
-    );
+    fn test_field_mBothAccessors() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<AllAccessors>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).mBothAccessors) as usize -
+                    ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(AllAccessors),
+                "::",
+                stringify!(mBothAccessors)
+            )
+        );
+    }
+    test_field_mBothAccessors();
+    fn test_field_mAlsoBothAccessors() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<AllAccessors>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).mAlsoBothAccessors) as usize -
+                    ptr as usize
+            },
+            4usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(AllAccessors),
+                "::",
+                stringify!(mAlsoBothAccessors)
+            )
+        );
+    }
+    test_field_mAlsoBothAccessors();
 }
 impl AllAccessors {
     #[inline]
@@ -197,37 +217,44 @@ fn bindgen_test_layout_AllUnsafeAccessors() {
         4usize,
         concat!("Alignment of ", stringify!(AllUnsafeAccessors))
     );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<AllUnsafeAccessors>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mBothAccessors) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(AllUnsafeAccessors),
-            "::",
-            stringify!(mBothAccessors)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<AllUnsafeAccessors>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mAlsoBothAccessors) as usize -
-                ptr as usize
-        },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(AllUnsafeAccessors),
-            "::",
-            stringify!(mAlsoBothAccessors)
-        )
-    );
+    fn test_field_mBothAccessors() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<AllUnsafeAccessors>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).mBothAccessors) as usize -
+                    ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(AllUnsafeAccessors),
+                "::",
+                stringify!(mBothAccessors)
+            )
+        );
+    }
+    test_field_mBothAccessors();
+    fn test_field_mAlsoBothAccessors() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<AllUnsafeAccessors>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).mAlsoBothAccessors) as usize -
+                    ptr as usize
+            },
+            4usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(AllUnsafeAccessors),
+                "::",
+                stringify!(mAlsoBothAccessors)
+            )
+        );
+    }
+    test_field_mAlsoBothAccessors();
 }
 impl AllUnsafeAccessors {
     #[inline]
@@ -275,68 +302,82 @@ fn bindgen_test_layout_ContradictAccessors() {
         4usize,
         concat!("Alignment of ", stringify!(ContradictAccessors))
     );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<ContradictAccessors>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mBothAccessors) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(ContradictAccessors),
-            "::",
-            stringify!(mBothAccessors)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<ContradictAccessors>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mNoAccessors) as usize - ptr as usize
-        },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(ContradictAccessors),
-            "::",
-            stringify!(mNoAccessors)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<ContradictAccessors>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mUnsafeAccessors) as usize -
-                ptr as usize
-        },
-        8usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(ContradictAccessors),
-            "::",
-            stringify!(mUnsafeAccessors)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<ContradictAccessors>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mImmutableAccessor) as usize -
-                ptr as usize
-        },
-        12usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(ContradictAccessors),
-            "::",
-            stringify!(mImmutableAccessor)
-        )
-    );
+    fn test_field_mBothAccessors() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<ContradictAccessors>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).mBothAccessors) as usize -
+                    ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(ContradictAccessors),
+                "::",
+                stringify!(mBothAccessors)
+            )
+        );
+    }
+    test_field_mBothAccessors();
+    fn test_field_mNoAccessors() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<ContradictAccessors>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).mNoAccessors) as usize -
+                    ptr as usize
+            },
+            4usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(ContradictAccessors),
+                "::",
+                stringify!(mNoAccessors)
+            )
+        );
+    }
+    test_field_mNoAccessors();
+    fn test_field_mUnsafeAccessors() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<ContradictAccessors>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).mUnsafeAccessors) as usize -
+                    ptr as usize
+            },
+            8usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(ContradictAccessors),
+                "::",
+                stringify!(mUnsafeAccessors)
+            )
+        );
+    }
+    test_field_mUnsafeAccessors();
+    fn test_field_mImmutableAccessor() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<ContradictAccessors>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).mImmutableAccessor) as usize -
+                    ptr as usize
+            },
+            12usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(ContradictAccessors),
+                "::",
+                stringify!(mImmutableAccessor)
+            )
+        );
+    }
+    test_field_mImmutableAccessor();
 }
 impl ContradictAccessors {
     #[inline]
@@ -380,20 +421,23 @@ fn bindgen_test_layout_Replaced() {
         4usize,
         concat!("Alignment of ", stringify!(Replaced))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Replaced>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mAccessor) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(Replaced),
-            "::",
-            stringify!(mAccessor)
-        )
-    );
+    fn test_field_mAccessor() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Replaced>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).mAccessor) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(Replaced),
+                "::",
+                stringify!(mAccessor)
+            )
+        );
+    }
+    test_field_mAccessor();
 }
 impl Replaced {
     #[inline]
@@ -423,20 +467,23 @@ fn bindgen_test_layout_Wrapper() {
         4usize,
         concat!("Alignment of ", stringify!(Wrapper))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Wrapper>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mReplaced) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(Wrapper),
-            "::",
-            stringify!(mReplaced)
-        )
-    );
+    fn test_field_mReplaced() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Wrapper>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).mReplaced) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(Wrapper),
+                "::",
+                stringify!(mReplaced)
+            )
+        );
+    }
+    test_field_mReplaced();
 }
 impl Wrapper {
     #[inline]

--- a/tests/expectations/tests/allowlist-file.rs
+++ b/tests/expectations/tests/allowlist-file.rs
@@ -68,22 +68,25 @@ fn bindgen_test_layout_StructWithAllowlistedDefinition() {
         8usize,
         concat!("Alignment of ", stringify!(StructWithAllowlistedDefinition))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<
-                StructWithAllowlistedDefinition,
-            >::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).other) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(StructWithAllowlistedDefinition),
-            "::",
-            stringify!(other)
-        )
-    );
+    fn test_field_other() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<
+                    StructWithAllowlistedDefinition,
+                >::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).other) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(StructWithAllowlistedDefinition),
+                "::",
+                stringify!(other)
+            )
+        );
+    }
+    test_field_other();
 }
 impl Default for StructWithAllowlistedDefinition {
     fn default() -> Self {
@@ -111,22 +114,25 @@ fn bindgen_test_layout_StructWithAllowlistedFwdDecl() {
         4usize,
         concat!("Alignment of ", stringify!(StructWithAllowlistedFwdDecl))
     );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<StructWithAllowlistedFwdDecl>::uninit(
-                );
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(StructWithAllowlistedFwdDecl),
-            "::",
-            stringify!(b)
-        )
-    );
+    fn test_field_b() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<
+                    StructWithAllowlistedFwdDecl,
+                >::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(StructWithAllowlistedFwdDecl),
+                "::",
+                stringify!(b)
+            )
+        );
+    }
+    test_field_b();
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
@@ -145,18 +151,21 @@ fn bindgen_test_layout_AllowlistMe() {
         4usize,
         concat!("Alignment of ", stringify!(AllowlistMe))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<AllowlistMe>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(AllowlistMe),
-            "::",
-            stringify!(foo)
-        )
-    );
+    fn test_field_foo() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<AllowlistMe>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(AllowlistMe),
+                "::",
+                stringify!(foo)
+            )
+        );
+    }
+    test_field_foo();
 }

--- a/tests/expectations/tests/allowlist-namespaces.rs
+++ b/tests/expectations/tests/allowlist-namespaces.rs
@@ -51,20 +51,24 @@ pub mod root {
                 1usize,
                 concat!("Alignment of ", stringify!(Test))
             );
-            assert_eq!(
-                unsafe {
-                    let uninit = ::std::mem::MaybeUninit::<Test>::uninit();
-                    let ptr = uninit.as_ptr();
-                    ::std::ptr::addr_of!((*ptr).helper) as usize - ptr as usize
-                },
-                0usize,
-                concat!(
-                    "Offset of field: ",
-                    stringify!(Test),
-                    "::",
-                    stringify!(helper)
-                )
-            );
+            fn test_field_helper() {
+                assert_eq!(
+                    unsafe {
+                        let uninit = ::std::mem::MaybeUninit::<Test>::uninit();
+                        let ptr = uninit.as_ptr();
+                        ::std::ptr::addr_of!((*ptr).helper) as usize -
+                            ptr as usize
+                    },
+                    0usize,
+                    concat!(
+                        "Offset of field: ",
+                        stringify!(Test),
+                        "::",
+                        stringify!(helper)
+                    )
+                );
+            }
+            test_field_helper();
         }
     }
 }

--- a/tests/expectations/tests/allowlisted-item-references-no-hash.rs
+++ b/tests/expectations/tests/allowlisted-item-references-no-hash.rs
@@ -40,18 +40,21 @@ fn bindgen_test_layout_AllowlistMe() {
         1usize,
         concat!("Alignment of ", stringify!(AllowlistMe))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<AllowlistMe>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(AllowlistMe),
-            "::",
-            stringify!(a)
-        )
-    );
+    fn test_field_a() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<AllowlistMe>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(AllowlistMe),
+                "::",
+                stringify!(a)
+            )
+        );
+    }
+    test_field_a();
 }

--- a/tests/expectations/tests/allowlisted-item-references-no-partialeq.rs
+++ b/tests/expectations/tests/allowlisted-item-references-no-partialeq.rs
@@ -40,18 +40,21 @@ fn bindgen_test_layout_AllowlistMe() {
         1usize,
         concat!("Alignment of ", stringify!(AllowlistMe))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<AllowlistMe>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(AllowlistMe),
-            "::",
-            stringify!(a)
-        )
-    );
+    fn test_field_a() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<AllowlistMe>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(AllowlistMe),
+                "::",
+                stringify!(a)
+            )
+        );
+    }
+    test_field_a();
 }

--- a/tests/expectations/tests/allowlisted_item_references_no_copy.rs
+++ b/tests/expectations/tests/allowlisted_item_references_no_copy.rs
@@ -40,18 +40,21 @@ fn bindgen_test_layout_AllowlistMe() {
         1usize,
         concat!("Alignment of ", stringify!(AllowlistMe))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<AllowlistMe>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(AllowlistMe),
-            "::",
-            stringify!(a)
-        )
-    );
+    fn test_field_a() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<AllowlistMe>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(AllowlistMe),
+                "::",
+                stringify!(a)
+            )
+        );
+    }
+    test_field_a();
 }

--- a/tests/expectations/tests/annotation_hide.rs
+++ b/tests/expectations/tests/annotation_hide.rs
@@ -42,18 +42,21 @@ fn bindgen_test_layout_NotAnnotated() {
         4usize,
         concat!("Alignment of ", stringify!(NotAnnotated))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<NotAnnotated>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).f) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(NotAnnotated),
-            "::",
-            stringify!(f)
-        )
-    );
+    fn test_field_f() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<NotAnnotated>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).f) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(NotAnnotated),
+                "::",
+                stringify!(f)
+            )
+        );
+    }
+    test_field_f();
 }

--- a/tests/expectations/tests/anon-fields-prefix.rs
+++ b/tests/expectations/tests/anon-fields-prefix.rs
@@ -31,51 +31,60 @@ fn bindgen_test_layout_color__bindgen_ty_1() {
         1usize,
         concat!("Alignment of ", stringify!(color__bindgen_ty_1))
     );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<color__bindgen_ty_1>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).r) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(color__bindgen_ty_1),
-            "::",
-            stringify!(r)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<color__bindgen_ty_1>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).g) as usize - ptr as usize
-        },
-        1usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(color__bindgen_ty_1),
-            "::",
-            stringify!(g)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<color__bindgen_ty_1>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-        },
-        2usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(color__bindgen_ty_1),
-            "::",
-            stringify!(b)
-        )
-    );
+    fn test_field_r() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<color__bindgen_ty_1>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).r) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(color__bindgen_ty_1),
+                "::",
+                stringify!(r)
+            )
+        );
+    }
+    test_field_r();
+    fn test_field_g() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<color__bindgen_ty_1>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).g) as usize - ptr as usize
+            },
+            1usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(color__bindgen_ty_1),
+                "::",
+                stringify!(g)
+            )
+        );
+    }
+    test_field_g();
+    fn test_field_b() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<color__bindgen_ty_1>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
+            },
+            2usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(color__bindgen_ty_1),
+                "::",
+                stringify!(b)
+            )
+        );
+    }
+    test_field_b();
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
@@ -96,51 +105,60 @@ fn bindgen_test_layout_color__bindgen_ty_2() {
         1usize,
         concat!("Alignment of ", stringify!(color__bindgen_ty_2))
     );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<color__bindgen_ty_2>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).y) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(color__bindgen_ty_2),
-            "::",
-            stringify!(y)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<color__bindgen_ty_2>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).u) as usize - ptr as usize
-        },
-        1usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(color__bindgen_ty_2),
-            "::",
-            stringify!(u)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<color__bindgen_ty_2>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).v) as usize - ptr as usize
-        },
-        2usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(color__bindgen_ty_2),
-            "::",
-            stringify!(v)
-        )
-    );
+    fn test_field_y() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<color__bindgen_ty_2>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).y) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(color__bindgen_ty_2),
+                "::",
+                stringify!(y)
+            )
+        );
+    }
+    test_field_y();
+    fn test_field_u() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<color__bindgen_ty_2>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).u) as usize - ptr as usize
+            },
+            1usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(color__bindgen_ty_2),
+                "::",
+                stringify!(u)
+            )
+        );
+    }
+    test_field_u();
+    fn test_field_v() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<color__bindgen_ty_2>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).v) as usize - ptr as usize
+            },
+            2usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(color__bindgen_ty_2),
+                "::",
+                stringify!(v)
+            )
+        );
+    }
+    test_field_v();
 }
 #[test]
 fn bindgen_test_layout_color() {
@@ -154,15 +172,23 @@ fn bindgen_test_layout_color() {
         1usize,
         concat!("Alignment of ", stringify!(color))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<color>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).v3) as usize - ptr as usize
-        },
-        0usize,
-        concat!("Offset of field: ", stringify!(color), "::", stringify!(v3))
-    );
+    fn test_field_v3() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<color>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).v3) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(color),
+                "::",
+                stringify!(v3)
+            )
+        );
+    }
+    test_field_v3();
 }
 impl Default for color {
     fn default() -> Self {

--- a/tests/expectations/tests/anon_enum.rs
+++ b/tests/expectations/tests/anon_enum.rs
@@ -29,24 +29,40 @@ fn bindgen_test_layout_Test() {
         4usize,
         concat!("Alignment of ", stringify!(Test))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Test>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize
-        },
-        0usize,
-        concat!("Offset of field: ", stringify!(Test), "::", stringify!(foo))
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Test>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
-        },
-        4usize,
-        concat!("Offset of field: ", stringify!(Test), "::", stringify!(bar))
-    );
+    fn test_field_foo() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Test>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(Test),
+                "::",
+                stringify!(foo)
+            )
+        );
+    }
+    test_field_foo();
+    fn test_field_bar() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Test>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
+            },
+            4usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(Test),
+                "::",
+                stringify!(bar)
+            )
+        );
+    }
+    test_field_bar();
 }
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]

--- a/tests/expectations/tests/anon_struct_in_union.rs
+++ b/tests/expectations/tests/anon_struct_in_union.rs
@@ -32,21 +32,24 @@ fn bindgen_test_layout_s__bindgen_ty_1_inner() {
         4usize,
         concat!("Alignment of ", stringify!(s__bindgen_ty_1_inner))
     );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<s__bindgen_ty_1_inner>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(s__bindgen_ty_1_inner),
-            "::",
-            stringify!(b)
-        )
-    );
+    fn test_field_b() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<s__bindgen_ty_1_inner>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(s__bindgen_ty_1_inner),
+                "::",
+                stringify!(b)
+            )
+        );
+    }
+    test_field_b();
 }
 #[test]
 fn bindgen_test_layout_s__bindgen_ty_1() {
@@ -60,20 +63,24 @@ fn bindgen_test_layout_s__bindgen_ty_1() {
         4usize,
         concat!("Alignment of ", stringify!(s__bindgen_ty_1))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<s__bindgen_ty_1>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).field) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(s__bindgen_ty_1),
-            "::",
-            stringify!(field)
-        )
-    );
+    fn test_field_field() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<s__bindgen_ty_1>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).field) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(s__bindgen_ty_1),
+                "::",
+                stringify!(field)
+            )
+        );
+    }
+    test_field_field();
 }
 impl Default for s__bindgen_ty_1 {
     fn default() -> Self {
@@ -96,15 +103,18 @@ fn bindgen_test_layout_s() {
         4usize,
         concat!("Alignment of ", stringify!(s))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<s>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).u) as usize - ptr as usize
-        },
-        0usize,
-        concat!("Offset of field: ", stringify!(s), "::", stringify!(u))
-    );
+    fn test_field_u() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<s>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).u) as usize - ptr as usize
+            },
+            0usize,
+            concat!("Offset of field: ", stringify!(s), "::", stringify!(u))
+        );
+    }
+    test_field_u();
 }
 impl Default for s {
     fn default() -> Self {

--- a/tests/expectations/tests/anon_struct_in_union_1_0.rs
+++ b/tests/expectations/tests/anon_struct_in_union_1_0.rs
@@ -76,21 +76,24 @@ fn bindgen_test_layout_s__bindgen_ty_1_inner() {
         4usize,
         concat!("Alignment of ", stringify!(s__bindgen_ty_1_inner))
     );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<s__bindgen_ty_1_inner>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(s__bindgen_ty_1_inner),
-            "::",
-            stringify!(b)
-        )
-    );
+    fn test_field_b() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<s__bindgen_ty_1_inner>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(s__bindgen_ty_1_inner),
+                "::",
+                stringify!(b)
+            )
+        );
+    }
+    test_field_b();
 }
 impl Clone for s__bindgen_ty_1_inner {
     fn clone(&self) -> Self {
@@ -109,20 +112,24 @@ fn bindgen_test_layout_s__bindgen_ty_1() {
         4usize,
         concat!("Alignment of ", stringify!(s__bindgen_ty_1))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<s__bindgen_ty_1>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).field) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(s__bindgen_ty_1),
-            "::",
-            stringify!(field)
-        )
-    );
+    fn test_field_field() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<s__bindgen_ty_1>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).field) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(s__bindgen_ty_1),
+                "::",
+                stringify!(field)
+            )
+        );
+    }
+    test_field_field();
 }
 impl Clone for s__bindgen_ty_1 {
     fn clone(&self) -> Self {
@@ -141,15 +148,18 @@ fn bindgen_test_layout_s() {
         4usize,
         concat!("Alignment of ", stringify!(s))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<s>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).u) as usize - ptr as usize
-        },
-        0usize,
-        concat!("Offset of field: ", stringify!(s), "::", stringify!(u))
-    );
+    fn test_field_u() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<s>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).u) as usize - ptr as usize
+            },
+            0usize,
+            concat!("Offset of field: ", stringify!(s), "::", stringify!(u))
+        );
+    }
+    test_field_u();
 }
 impl Clone for s {
     fn clone(&self) -> Self {

--- a/tests/expectations/tests/array-of-zero-sized-types.rs
+++ b/tests/expectations/tests/array-of-zero-sized-types.rs
@@ -43,18 +43,22 @@ fn bindgen_test_layout_HasArrayOfEmpty() {
         1usize,
         concat!("Alignment of ", stringify!(HasArrayOfEmpty))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<HasArrayOfEmpty>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).empties) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(HasArrayOfEmpty),
-            "::",
-            stringify!(empties)
-        )
-    );
+    fn test_field_empties() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<HasArrayOfEmpty>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).empties) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(HasArrayOfEmpty),
+                "::",
+                stringify!(empties)
+            )
+        );
+    }
+    test_field_empties();
 }

--- a/tests/expectations/tests/bindgen-union-inside-namespace.rs
+++ b/tests/expectations/tests/bindgen-union-inside-namespace.rs
@@ -77,34 +77,40 @@ pub mod root {
                 4usize,
                 concat!("Alignment of ", stringify!(Bar))
             );
-            assert_eq!(
-                unsafe {
-                    let uninit = ::std::mem::MaybeUninit::<Bar>::uninit();
-                    let ptr = uninit.as_ptr();
-                    ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize
-                },
-                0usize,
-                concat!(
-                    "Offset of field: ",
-                    stringify!(Bar),
-                    "::",
-                    stringify!(foo)
-                )
-            );
-            assert_eq!(
-                unsafe {
-                    let uninit = ::std::mem::MaybeUninit::<Bar>::uninit();
-                    let ptr = uninit.as_ptr();
-                    ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
-                },
-                0usize,
-                concat!(
-                    "Offset of field: ",
-                    stringify!(Bar),
-                    "::",
-                    stringify!(bar)
-                )
-            );
+            fn test_field_foo() {
+                assert_eq!(
+                    unsafe {
+                        let uninit = ::std::mem::MaybeUninit::<Bar>::uninit();
+                        let ptr = uninit.as_ptr();
+                        ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize
+                    },
+                    0usize,
+                    concat!(
+                        "Offset of field: ",
+                        stringify!(Bar),
+                        "::",
+                        stringify!(foo)
+                    )
+                );
+            }
+            test_field_foo();
+            fn test_field_bar() {
+                assert_eq!(
+                    unsafe {
+                        let uninit = ::std::mem::MaybeUninit::<Bar>::uninit();
+                        let ptr = uninit.as_ptr();
+                        ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
+                    },
+                    0usize,
+                    concat!(
+                        "Offset of field: ",
+                        stringify!(Bar),
+                        "::",
+                        stringify!(bar)
+                    )
+                );
+            }
+            test_field_bar();
         }
         impl Clone for Bar {
             fn clone(&self) -> Self {

--- a/tests/expectations/tests/bitfield-linux-32.rs
+++ b/tests/expectations/tests/bitfield-linux-32.rs
@@ -110,15 +110,23 @@ fn bindgen_test_layout_Test() {
         4usize,
         concat!("Alignment of ", stringify!(Test))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Test>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize
-        },
-        0usize,
-        concat!("Offset of field: ", stringify!(Test), "::", stringify!(foo))
-    );
+    fn test_field_foo() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Test>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(Test),
+                "::",
+                stringify!(foo)
+            )
+        );
+    }
+    test_field_foo();
 }
 impl Test {
     #[inline]

--- a/tests/expectations/tests/bitfield_align.rs
+++ b/tests/expectations/tests/bitfield_align.rs
@@ -112,24 +112,30 @@ fn bindgen_test_layout_A() {
         4usize,
         concat!("Alignment of ", stringify!(A))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<A>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize
-        },
-        0usize,
-        concat!("Offset of field: ", stringify!(A), "::", stringify!(x))
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<A>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).y) as usize - ptr as usize
-        },
-        3usize,
-        concat!("Offset of field: ", stringify!(A), "::", stringify!(y))
-    );
+    fn test_field_x() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<A>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize
+            },
+            0usize,
+            concat!("Offset of field: ", stringify!(A), "::", stringify!(x))
+        );
+    }
+    test_field_x();
+    fn test_field_y() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<A>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).y) as usize - ptr as usize
+            },
+            3usize,
+            concat!("Offset of field: ", stringify!(A), "::", stringify!(y))
+        );
+    }
+    test_field_y();
 }
 impl A {
     #[inline]
@@ -405,24 +411,30 @@ fn bindgen_test_layout_C() {
         4usize,
         concat!("Alignment of ", stringify!(C))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<C>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize
-        },
-        0usize,
-        concat!("Offset of field: ", stringify!(C), "::", stringify!(x))
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<C>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize
-        },
-        4usize,
-        concat!("Offset of field: ", stringify!(C), "::", stringify!(baz))
-    );
+    fn test_field_x() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<C>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize
+            },
+            0usize,
+            concat!("Offset of field: ", stringify!(C), "::", stringify!(x))
+        );
+    }
+    test_field_x();
+    fn test_field_baz() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<C>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize
+            },
+            4usize,
+            concat!("Offset of field: ", stringify!(C), "::", stringify!(baz))
+        );
+    }
+    test_field_baz();
 }
 impl C {
     #[inline]
@@ -710,20 +722,23 @@ fn bindgen_test_layout_Date3() {
         2usize,
         concat!("Alignment of ", stringify!(Date3))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Date3>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).byte) as usize - ptr as usize
-        },
-        3usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(Date3),
-            "::",
-            stringify!(byte)
-        )
-    );
+    fn test_field_byte() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Date3>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).byte) as usize - ptr as usize
+            },
+            3usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(Date3),
+                "::",
+                stringify!(byte)
+            )
+        );
+    }
+    test_field_byte();
 }
 impl Date3 {
     #[inline]

--- a/tests/expectations/tests/blocklist-and-impl-debug.rs
+++ b/tests/expectations/tests/blocklist-and-impl-debug.rs
@@ -24,21 +24,25 @@ fn bindgen_test_layout_ShouldManuallyImplDebug() {
         1usize,
         concat!("Alignment of ", stringify!(ShouldManuallyImplDebug))
     );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<ShouldManuallyImplDebug>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(ShouldManuallyImplDebug),
-            "::",
-            stringify!(a)
-        )
-    );
+    fn test_field_a() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<ShouldManuallyImplDebug>::uninit(
+                    );
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(ShouldManuallyImplDebug),
+                "::",
+                stringify!(a)
+            )
+        );
+    }
+    test_field_a();
 }
 impl Default for ShouldManuallyImplDebug {
     fn default() -> Self {

--- a/tests/expectations/tests/blocklist-file.rs
+++ b/tests/expectations/tests/blocklist-file.rs
@@ -24,48 +24,57 @@ fn bindgen_test_layout_SizedIntegers() {
         4usize,
         concat!("Alignment of ", stringify!(SizedIntegers))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<SizedIntegers>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(SizedIntegers),
-            "::",
-            stringify!(x)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<SizedIntegers>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).y) as usize - ptr as usize
-        },
-        2usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(SizedIntegers),
-            "::",
-            stringify!(y)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<SizedIntegers>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).z) as usize - ptr as usize
-        },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(SizedIntegers),
-            "::",
-            stringify!(z)
-        )
-    );
+    fn test_field_x() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<SizedIntegers>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(SizedIntegers),
+                "::",
+                stringify!(x)
+            )
+        );
+    }
+    test_field_x();
+    fn test_field_y() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<SizedIntegers>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).y) as usize - ptr as usize
+            },
+            2usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(SizedIntegers),
+                "::",
+                stringify!(y)
+            )
+        );
+    }
+    test_field_y();
+    fn test_field_z() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<SizedIntegers>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).z) as usize - ptr as usize
+            },
+            4usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(SizedIntegers),
+                "::",
+                stringify!(z)
+            )
+        );
+    }
+    test_field_z();
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
@@ -84,20 +93,23 @@ fn bindgen_test_layout_StructWithBlocklistedFwdDecl() {
         1usize,
         concat!("Alignment of ", stringify!(StructWithBlocklistedFwdDecl))
     );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<StructWithBlocklistedFwdDecl>::uninit(
-                );
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(StructWithBlocklistedFwdDecl),
-            "::",
-            stringify!(b)
-        )
-    );
+    fn test_field_b() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<
+                    StructWithBlocklistedFwdDecl,
+                >::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(StructWithBlocklistedFwdDecl),
+                "::",
+                stringify!(b)
+            )
+        );
+    }
+    test_field_b();
 }

--- a/tests/expectations/tests/blocks-signature.rs
+++ b/tests/expectations/tests/blocks-signature.rs
@@ -47,36 +47,44 @@ fn bindgen_test_layout_contains_block_pointers() {
         8usize,
         concat!("Alignment of ", stringify!(contains_block_pointers))
     );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<contains_block_pointers>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).val) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(contains_block_pointers),
-            "::",
-            stringify!(val)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<contains_block_pointers>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).ptr_val) as usize - ptr as usize
-        },
-        8usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(contains_block_pointers),
-            "::",
-            stringify!(ptr_val)
-        )
-    );
+    fn test_field_val() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<contains_block_pointers>::uninit(
+                    );
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).val) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(contains_block_pointers),
+                "::",
+                stringify!(val)
+            )
+        );
+    }
+    test_field_val();
+    fn test_field_ptr_val() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<contains_block_pointers>::uninit(
+                    );
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).ptr_val) as usize - ptr as usize
+            },
+            8usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(contains_block_pointers),
+                "::",
+                stringify!(ptr_val)
+            )
+        );
+    }
+    test_field_ptr_val();
 }
 impl Default for contains_block_pointers {
     fn default() -> Self {

--- a/tests/expectations/tests/blocks.rs
+++ b/tests/expectations/tests/blocks.rs
@@ -46,36 +46,44 @@ fn bindgen_test_layout_contains_block_pointers() {
         8usize,
         concat!("Alignment of ", stringify!(contains_block_pointers))
     );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<contains_block_pointers>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).val) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(contains_block_pointers),
-            "::",
-            stringify!(val)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<contains_block_pointers>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).ptr_val) as usize - ptr as usize
-        },
-        8usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(contains_block_pointers),
-            "::",
-            stringify!(ptr_val)
-        )
-    );
+    fn test_field_val() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<contains_block_pointers>::uninit(
+                    );
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).val) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(contains_block_pointers),
+                "::",
+                stringify!(val)
+            )
+        );
+    }
+    test_field_val();
+    fn test_field_ptr_val() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<contains_block_pointers>::uninit(
+                    );
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).ptr_val) as usize - ptr as usize
+            },
+            8usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(contains_block_pointers),
+                "::",
+                stringify!(ptr_val)
+            )
+        );
+    }
+    test_field_ptr_val();
 }
 impl Default for contains_block_pointers {
     fn default() -> Self {

--- a/tests/expectations/tests/c_naming.rs
+++ b/tests/expectations/tests/c_naming.rs
@@ -22,20 +22,23 @@ fn bindgen_test_layout_struct_a() {
         4usize,
         concat!("Alignment of ", stringify!(struct_a))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<struct_a>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(struct_a),
-            "::",
-            stringify!(a)
-        )
-    );
+    fn test_field_a() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<struct_a>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(struct_a),
+                "::",
+                stringify!(a)
+            )
+        );
+    }
+    test_field_a();
 }
 pub type a = *const struct_a;
 #[repr(C)]
@@ -56,34 +59,40 @@ fn bindgen_test_layout_union_b() {
         4usize,
         concat!("Alignment of ", stringify!(union_b))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<union_b>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(union_b),
-            "::",
-            stringify!(a)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<union_b>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(union_b),
-            "::",
-            stringify!(b)
-        )
-    );
+    fn test_field_a() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<union_b>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(union_b),
+                "::",
+                stringify!(a)
+            )
+        );
+    }
+    test_field_a();
+    fn test_field_b() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<union_b>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(union_b),
+                "::",
+                stringify!(b)
+            )
+        );
+    }
+    test_field_b();
 }
 impl Default for union_b {
     fn default() -> Self {

--- a/tests/expectations/tests/canonical-types.rs
+++ b/tests/expectations/tests/canonical-types.rs
@@ -176,20 +176,23 @@ fn bindgen_test_layout_ClassAInner() {
         8usize,
         concat!("Alignment of ", stringify!(ClassAInner))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<ClassAInner>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(ClassAInner),
-            "::",
-            stringify!(x)
-        )
-    );
+    fn test_field_x() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<ClassAInner>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(ClassAInner),
+                "::",
+                stringify!(x)
+            )
+        );
+    }
+    test_field_x();
 }
 impl Default for ClassAInner {
     fn default() -> Self {
@@ -217,20 +220,23 @@ fn bindgen_test_layout_ClassCInnerA() {
         8usize,
         concat!("Alignment of ", stringify!(ClassCInnerA))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<ClassCInnerA>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).member) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(ClassCInnerA),
-            "::",
-            stringify!(member)
-        )
-    );
+    fn test_field_member() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<ClassCInnerA>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).member) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(ClassCInnerA),
+                "::",
+                stringify!(member)
+            )
+        );
+    }
+    test_field_member();
 }
 impl Default for ClassCInnerA {
     fn default() -> Self {
@@ -258,20 +264,23 @@ fn bindgen_test_layout_ClassCInnerB() {
         8usize,
         concat!("Alignment of ", stringify!(ClassCInnerB))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<ClassCInnerB>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).cache) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(ClassCInnerB),
-            "::",
-            stringify!(cache)
-        )
-    );
+    fn test_field_cache() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<ClassCInnerB>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).cache) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(ClassCInnerB),
+                "::",
+                stringify!(cache)
+            )
+        );
+    }
+    test_field_cache();
 }
 impl Default for ClassCInnerB {
     fn default() -> Self {

--- a/tests/expectations/tests/char.rs
+++ b/tests/expectations/tests/char.rs
@@ -36,117 +36,198 @@ fn bindgen_test_layout_Test() {
         1usize,
         concat!("Alignment of ", stringify!(Test))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Test>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).ch) as usize - ptr as usize
-        },
-        0usize,
-        concat!("Offset of field: ", stringify!(Test), "::", stringify!(ch))
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Test>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).u) as usize - ptr as usize
-        },
-        1usize,
-        concat!("Offset of field: ", stringify!(Test), "::", stringify!(u))
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Test>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize
-        },
-        2usize,
-        concat!("Offset of field: ", stringify!(Test), "::", stringify!(d))
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Test>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).cch) as usize - ptr as usize
-        },
-        3usize,
-        concat!("Offset of field: ", stringify!(Test), "::", stringify!(cch))
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Test>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).cu) as usize - ptr as usize
-        },
-        4usize,
-        concat!("Offset of field: ", stringify!(Test), "::", stringify!(cu))
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Test>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).cd) as usize - ptr as usize
-        },
-        5usize,
-        concat!("Offset of field: ", stringify!(Test), "::", stringify!(cd))
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Test>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).Cch) as usize - ptr as usize
-        },
-        6usize,
-        concat!("Offset of field: ", stringify!(Test), "::", stringify!(Cch))
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Test>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).Cu) as usize - ptr as usize
-        },
-        7usize,
-        concat!("Offset of field: ", stringify!(Test), "::", stringify!(Cu))
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Test>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).Cd) as usize - ptr as usize
-        },
-        8usize,
-        concat!("Offset of field: ", stringify!(Test), "::", stringify!(Cd))
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Test>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).Ccch) as usize - ptr as usize
-        },
-        9usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(Test),
-            "::",
-            stringify!(Ccch)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Test>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).Ccu) as usize - ptr as usize
-        },
-        10usize,
-        concat!("Offset of field: ", stringify!(Test), "::", stringify!(Ccu))
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Test>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).Ccd) as usize - ptr as usize
-        },
-        11usize,
-        concat!("Offset of field: ", stringify!(Test), "::", stringify!(Ccd))
-    );
+    fn test_field_ch() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Test>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).ch) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(Test),
+                "::",
+                stringify!(ch)
+            )
+        );
+    }
+    test_field_ch();
+    fn test_field_u() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Test>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).u) as usize - ptr as usize
+            },
+            1usize,
+            concat!("Offset of field: ", stringify!(Test), "::", stringify!(u))
+        );
+    }
+    test_field_u();
+    fn test_field_d() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Test>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize
+            },
+            2usize,
+            concat!("Offset of field: ", stringify!(Test), "::", stringify!(d))
+        );
+    }
+    test_field_d();
+    fn test_field_cch() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Test>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).cch) as usize - ptr as usize
+            },
+            3usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(Test),
+                "::",
+                stringify!(cch)
+            )
+        );
+    }
+    test_field_cch();
+    fn test_field_cu() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Test>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).cu) as usize - ptr as usize
+            },
+            4usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(Test),
+                "::",
+                stringify!(cu)
+            )
+        );
+    }
+    test_field_cu();
+    fn test_field_cd() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Test>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).cd) as usize - ptr as usize
+            },
+            5usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(Test),
+                "::",
+                stringify!(cd)
+            )
+        );
+    }
+    test_field_cd();
+    fn test_field_Cch() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Test>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).Cch) as usize - ptr as usize
+            },
+            6usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(Test),
+                "::",
+                stringify!(Cch)
+            )
+        );
+    }
+    test_field_Cch();
+    fn test_field_Cu() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Test>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).Cu) as usize - ptr as usize
+            },
+            7usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(Test),
+                "::",
+                stringify!(Cu)
+            )
+        );
+    }
+    test_field_Cu();
+    fn test_field_Cd() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Test>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).Cd) as usize - ptr as usize
+            },
+            8usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(Test),
+                "::",
+                stringify!(Cd)
+            )
+        );
+    }
+    test_field_Cd();
+    fn test_field_Ccch() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Test>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).Ccch) as usize - ptr as usize
+            },
+            9usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(Test),
+                "::",
+                stringify!(Ccch)
+            )
+        );
+    }
+    test_field_Ccch();
+    fn test_field_Ccu() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Test>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).Ccu) as usize - ptr as usize
+            },
+            10usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(Test),
+                "::",
+                stringify!(Ccu)
+            )
+        );
+    }
+    test_field_Ccu();
+    fn test_field_Ccd() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Test>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).Ccd) as usize - ptr as usize
+            },
+            11usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(Test),
+                "::",
+                stringify!(Ccd)
+            )
+        );
+    }
+    test_field_Ccd();
 }

--- a/tests/expectations/tests/class.rs
+++ b/tests/expectations/tests/class.rs
@@ -53,29 +53,35 @@ fn bindgen_test_layout_C() {
         4usize,
         concat!("Alignment of ", stringify!(C))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<C>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
-        0usize,
-        concat!("Offset of field: ", stringify!(C), "::", stringify!(a))
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<C>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).big_array) as usize - ptr as usize
-        },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C),
-            "::",
-            stringify!(big_array)
-        )
-    );
+    fn test_field_a() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<C>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+            },
+            0usize,
+            concat!("Offset of field: ", stringify!(C), "::", stringify!(a))
+        );
+    }
+    test_field_a();
+    fn test_field_big_array() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<C>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).big_array) as usize - ptr as usize
+            },
+            4usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(C),
+                "::",
+                stringify!(big_array)
+            )
+        );
+    }
+    test_field_big_array();
 }
 impl Default for C {
     fn default() -> Self {
@@ -104,52 +110,64 @@ fn bindgen_test_layout_C_with_zero_length_array() {
         4usize,
         concat!("Alignment of ", stringify!(C_with_zero_length_array))
     );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<C_with_zero_length_array>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C_with_zero_length_array),
-            "::",
-            stringify!(a)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<C_with_zero_length_array>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).big_array) as usize - ptr as usize
-        },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C_with_zero_length_array),
-            "::",
-            stringify!(big_array)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<C_with_zero_length_array>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).zero_length_array) as usize -
-                ptr as usize
-        },
-        37usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C_with_zero_length_array),
-            "::",
-            stringify!(zero_length_array)
-        )
-    );
+    fn test_field_a() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<C_with_zero_length_array>::uninit(
+                    );
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(C_with_zero_length_array),
+                "::",
+                stringify!(a)
+            )
+        );
+    }
+    test_field_a();
+    fn test_field_big_array() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<C_with_zero_length_array>::uninit(
+                    );
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).big_array) as usize - ptr as usize
+            },
+            4usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(C_with_zero_length_array),
+                "::",
+                stringify!(big_array)
+            )
+        );
+    }
+    test_field_big_array();
+    fn test_field_zero_length_array() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<C_with_zero_length_array>::uninit(
+                    );
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).zero_length_array) as usize -
+                    ptr as usize
+            },
+            37usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(C_with_zero_length_array),
+                "::",
+                stringify!(zero_length_array)
+            )
+        );
+    }
+    test_field_zero_length_array();
 }
 impl Default for C_with_zero_length_array {
     fn default() -> Self {
@@ -178,37 +196,45 @@ fn bindgen_test_layout_C_with_zero_length_array_2() {
         4usize,
         concat!("Alignment of ", stringify!(C_with_zero_length_array_2))
     );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<C_with_zero_length_array_2>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C_with_zero_length_array_2),
-            "::",
-            stringify!(a)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<C_with_zero_length_array_2>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).zero_length_array) as usize -
-                ptr as usize
-        },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C_with_zero_length_array_2),
-            "::",
-            stringify!(zero_length_array)
-        )
-    );
+    fn test_field_a() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<
+                    C_with_zero_length_array_2,
+                >::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(C_with_zero_length_array_2),
+                "::",
+                stringify!(a)
+            )
+        );
+    }
+    test_field_a();
+    fn test_field_zero_length_array() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<
+                    C_with_zero_length_array_2,
+                >::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).zero_length_array) as usize -
+                    ptr as usize
+            },
+            4usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(C_with_zero_length_array_2),
+                "::",
+                stringify!(zero_length_array)
+            )
+        );
+    }
+    test_field_zero_length_array();
 }
 #[repr(C)]
 pub struct C_with_incomplete_array {
@@ -337,20 +363,23 @@ fn bindgen_test_layout_WithDtor() {
         4usize,
         concat!("Alignment of ", stringify!(WithDtor))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<WithDtor>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(WithDtor),
-            "::",
-            stringify!(b)
-        )
-    );
+    fn test_field_b() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<WithDtor>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(WithDtor),
+                "::",
+                stringify!(b)
+            )
+        );
+    }
+    test_field_b();
 }
 #[repr(C)]
 pub struct IncompleteArrayNonCopiable {
@@ -397,24 +426,40 @@ fn bindgen_test_layout_Union() {
         4usize,
         concat!("Alignment of ", stringify!(Union))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Union>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize
-        },
-        0usize,
-        concat!("Offset of field: ", stringify!(Union), "::", stringify!(d))
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Union>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).i) as usize - ptr as usize
-        },
-        0usize,
-        concat!("Offset of field: ", stringify!(Union), "::", stringify!(i))
-    );
+    fn test_field_d() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Union>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(Union),
+                "::",
+                stringify!(d)
+            )
+        );
+    }
+    test_field_d();
+    fn test_field_i() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Union>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).i) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(Union),
+                "::",
+                stringify!(i)
+            )
+        );
+    }
+    test_field_i();
 }
 impl Default for Union {
     fn default() -> Self {
@@ -442,20 +487,23 @@ fn bindgen_test_layout_WithUnion() {
         4usize,
         concat!("Alignment of ", stringify!(WithUnion))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<WithUnion>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).data) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(WithUnion),
-            "::",
-            stringify!(data)
-        )
-    );
+    fn test_field_data() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<WithUnion>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).data) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(WithUnion),
+                "::",
+                stringify!(data)
+            )
+        );
+    }
+    test_field_data();
 }
 impl Default for WithUnion {
     fn default() -> Self {

--- a/tests/expectations/tests/class_1_0.rs
+++ b/tests/expectations/tests/class_1_0.rs
@@ -96,29 +96,35 @@ fn bindgen_test_layout_C() {
         4usize,
         concat!("Alignment of ", stringify!(C))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<C>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
-        0usize,
-        concat!("Offset of field: ", stringify!(C), "::", stringify!(a))
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<C>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).big_array) as usize - ptr as usize
-        },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C),
-            "::",
-            stringify!(big_array)
-        )
-    );
+    fn test_field_a() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<C>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+            },
+            0usize,
+            concat!("Offset of field: ", stringify!(C), "::", stringify!(a))
+        );
+    }
+    test_field_a();
+    fn test_field_big_array() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<C>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).big_array) as usize - ptr as usize
+            },
+            4usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(C),
+                "::",
+                stringify!(big_array)
+            )
+        );
+    }
+    test_field_big_array();
 }
 impl Clone for C {
     fn clone(&self) -> Self {
@@ -157,52 +163,64 @@ fn bindgen_test_layout_C_with_zero_length_array() {
         4usize,
         concat!("Alignment of ", stringify!(C_with_zero_length_array))
     );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<C_with_zero_length_array>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C_with_zero_length_array),
-            "::",
-            stringify!(a)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<C_with_zero_length_array>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).big_array) as usize - ptr as usize
-        },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C_with_zero_length_array),
-            "::",
-            stringify!(big_array)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<C_with_zero_length_array>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).zero_length_array) as usize -
-                ptr as usize
-        },
-        37usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C_with_zero_length_array),
-            "::",
-            stringify!(zero_length_array)
-        )
-    );
+    fn test_field_a() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<C_with_zero_length_array>::uninit(
+                    );
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(C_with_zero_length_array),
+                "::",
+                stringify!(a)
+            )
+        );
+    }
+    test_field_a();
+    fn test_field_big_array() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<C_with_zero_length_array>::uninit(
+                    );
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).big_array) as usize - ptr as usize
+            },
+            4usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(C_with_zero_length_array),
+                "::",
+                stringify!(big_array)
+            )
+        );
+    }
+    test_field_big_array();
+    fn test_field_zero_length_array() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<C_with_zero_length_array>::uninit(
+                    );
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).zero_length_array) as usize -
+                    ptr as usize
+            },
+            37usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(C_with_zero_length_array),
+                "::",
+                stringify!(zero_length_array)
+            )
+        );
+    }
+    test_field_zero_length_array();
 }
 impl Default for C_with_zero_length_array {
     fn default() -> Self {
@@ -231,37 +249,45 @@ fn bindgen_test_layout_C_with_zero_length_array_2() {
         4usize,
         concat!("Alignment of ", stringify!(C_with_zero_length_array_2))
     );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<C_with_zero_length_array_2>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C_with_zero_length_array_2),
-            "::",
-            stringify!(a)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<C_with_zero_length_array_2>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).zero_length_array) as usize -
-                ptr as usize
-        },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C_with_zero_length_array_2),
-            "::",
-            stringify!(zero_length_array)
-        )
-    );
+    fn test_field_a() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<
+                    C_with_zero_length_array_2,
+                >::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(C_with_zero_length_array_2),
+                "::",
+                stringify!(a)
+            )
+        );
+    }
+    test_field_a();
+    fn test_field_zero_length_array() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<
+                    C_with_zero_length_array_2,
+                >::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).zero_length_array) as usize -
+                    ptr as usize
+            },
+            4usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(C_with_zero_length_array_2),
+                "::",
+                stringify!(zero_length_array)
+            )
+        );
+    }
+    test_field_zero_length_array();
 }
 #[repr(C)]
 pub struct C_with_incomplete_array {
@@ -390,20 +416,23 @@ fn bindgen_test_layout_WithDtor() {
         4usize,
         concat!("Alignment of ", stringify!(WithDtor))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<WithDtor>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(WithDtor),
-            "::",
-            stringify!(b)
-        )
-    );
+    fn test_field_b() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<WithDtor>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(WithDtor),
+                "::",
+                stringify!(b)
+            )
+        );
+    }
+    test_field_b();
 }
 #[repr(C)]
 pub struct IncompleteArrayNonCopiable {
@@ -451,24 +480,40 @@ fn bindgen_test_layout_Union() {
         4usize,
         concat!("Alignment of ", stringify!(Union))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Union>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize
-        },
-        0usize,
-        concat!("Offset of field: ", stringify!(Union), "::", stringify!(d))
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Union>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).i) as usize - ptr as usize
-        },
-        0usize,
-        concat!("Offset of field: ", stringify!(Union), "::", stringify!(i))
-    );
+    fn test_field_d() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Union>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(Union),
+                "::",
+                stringify!(d)
+            )
+        );
+    }
+    test_field_d();
+    fn test_field_i() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Union>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).i) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(Union),
+                "::",
+                stringify!(i)
+            )
+        );
+    }
+    test_field_i();
 }
 impl Clone for Union {
     fn clone(&self) -> Self {
@@ -492,20 +537,23 @@ fn bindgen_test_layout_WithUnion() {
         4usize,
         concat!("Alignment of ", stringify!(WithUnion))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<WithUnion>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).data) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(WithUnion),
-            "::",
-            stringify!(data)
-        )
-    );
+    fn test_field_data() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<WithUnion>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).data) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(WithUnion),
+                "::",
+                stringify!(data)
+            )
+        );
+    }
+    test_field_data();
 }
 impl Clone for WithUnion {
     fn clone(&self) -> Self {

--- a/tests/expectations/tests/class_nested.rs
+++ b/tests/expectations/tests/class_nested.rs
@@ -27,20 +27,23 @@ fn bindgen_test_layout_A_B() {
         4usize,
         concat!("Alignment of ", stringify!(A_B))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<A_B>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).member_b) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(A_B),
-            "::",
-            stringify!(member_b)
-        )
-    );
+    fn test_field_member_b() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<A_B>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).member_b) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(A_B),
+                "::",
+                stringify!(member_b)
+            )
+        );
+    }
+    test_field_member_b();
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -69,20 +72,23 @@ fn bindgen_test_layout_A() {
         4usize,
         concat!("Alignment of ", stringify!(A))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<A>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).member_a) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(A),
-            "::",
-            stringify!(member_a)
-        )
-    );
+    fn test_field_member_a() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<A>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).member_a) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(A),
+                "::",
+                stringify!(member_a)
+            )
+        );
+    }
+    test_field_member_a();
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
@@ -101,15 +107,23 @@ fn bindgen_test_layout_A_C() {
         4usize,
         concat!("Alignment of ", stringify!(A_C))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<A_C>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize
-        },
-        0usize,
-        concat!("Offset of field: ", stringify!(A_C), "::", stringify!(baz))
-    );
+    fn test_field_baz() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<A_C>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(A_C),
+                "::",
+                stringify!(baz)
+            )
+        );
+    }
+    test_field_baz();
 }
 extern "C" {
     pub static mut var: A_B;
@@ -153,15 +167,23 @@ fn bindgen_test_layout_D() {
         4usize,
         concat!("Alignment of ", stringify!(D))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<D>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).member) as usize - ptr as usize
-        },
-        0usize,
-        concat!("Offset of field: ", stringify!(D), "::", stringify!(member))
-    );
+    fn test_field_member() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<D>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).member) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(D),
+                "::",
+                stringify!(member)
+            )
+        );
+    }
+    test_field_member();
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]

--- a/tests/expectations/tests/class_no_members.rs
+++ b/tests/expectations/tests/class_no_members.rs
@@ -58,19 +58,23 @@ fn bindgen_test_layout_whatever_child_with_member() {
         4usize,
         concat!("Alignment of ", stringify!(whatever_child_with_member))
     );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<whatever_child_with_member>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).m_member) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(whatever_child_with_member),
-            "::",
-            stringify!(m_member)
-        )
-    );
+    fn test_field_m_member() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<
+                    whatever_child_with_member,
+                >::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).m_member) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(whatever_child_with_member),
+                "::",
+                stringify!(m_member)
+            )
+        );
+    }
+    test_field_m_member();
 }

--- a/tests/expectations/tests/class_use_as.rs
+++ b/tests/expectations/tests/class_use_as.rs
@@ -23,20 +23,23 @@ fn bindgen_test_layout_whatever() {
         4usize,
         concat!("Alignment of ", stringify!(whatever))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<whatever>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).replacement) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(whatever),
-            "::",
-            stringify!(replacement)
-        )
-    );
+    fn test_field_replacement() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<whatever>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).replacement) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(whatever),
+                "::",
+                stringify!(replacement)
+            )
+        );
+    }
+    test_field_replacement();
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
@@ -55,18 +58,21 @@ fn bindgen_test_layout_container() {
         4usize,
         concat!("Alignment of ", stringify!(container))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<container>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).c) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(container),
-            "::",
-            stringify!(c)
-        )
-    );
+    fn test_field_c() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<container>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).c) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(container),
+                "::",
+                stringify!(c)
+            )
+        );
+    }
+    test_field_c();
 }

--- a/tests/expectations/tests/class_with_dtor.rs
+++ b/tests/expectations/tests/class_with_dtor.rs
@@ -38,21 +38,24 @@ fn bindgen_test_layout_WithoutDtor() {
         8usize,
         concat!("Alignment of ", stringify!(WithoutDtor))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<WithoutDtor>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).shouldBeWithDtor) as usize -
-                ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(WithoutDtor),
-            "::",
-            stringify!(shouldBeWithDtor)
-        )
-    );
+    fn test_field_shouldBeWithDtor() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<WithoutDtor>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).shouldBeWithDtor) as usize -
+                    ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(WithoutDtor),
+                "::",
+                stringify!(shouldBeWithDtor)
+            )
+        );
+    }
+    test_field_shouldBeWithDtor();
 }
 impl Default for WithoutDtor {
     fn default() -> Self {

--- a/tests/expectations/tests/class_with_inner_struct.rs
+++ b/tests/expectations/tests/class_with_inner_struct.rs
@@ -30,34 +30,40 @@ fn bindgen_test_layout_A_Segment() {
         4usize,
         concat!("Alignment of ", stringify!(A_Segment))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<A_Segment>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).begin) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(A_Segment),
-            "::",
-            stringify!(begin)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<A_Segment>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).end) as usize - ptr as usize
-        },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(A_Segment),
-            "::",
-            stringify!(end)
-        )
-    );
+    fn test_field_begin() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<A_Segment>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).begin) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(A_Segment),
+                "::",
+                stringify!(begin)
+            )
+        );
+    }
+    test_field_begin();
+    fn test_field_end() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<A_Segment>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).end) as usize - ptr as usize
+            },
+            4usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(A_Segment),
+                "::",
+                stringify!(end)
+            )
+        );
+    }
+    test_field_end();
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -76,20 +82,24 @@ fn bindgen_test_layout_A__bindgen_ty_1() {
         4usize,
         concat!("Alignment of ", stringify!(A__bindgen_ty_1))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<A__bindgen_ty_1>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).f) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(A__bindgen_ty_1),
-            "::",
-            stringify!(f)
-        )
-    );
+    fn test_field_f() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<A__bindgen_ty_1>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).f) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(A__bindgen_ty_1),
+                "::",
+                stringify!(f)
+            )
+        );
+    }
+    test_field_f();
 }
 impl Default for A__bindgen_ty_1 {
     fn default() -> Self {
@@ -117,20 +127,24 @@ fn bindgen_test_layout_A__bindgen_ty_2() {
         4usize,
         concat!("Alignment of ", stringify!(A__bindgen_ty_2))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<A__bindgen_ty_2>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(A__bindgen_ty_2),
-            "::",
-            stringify!(d)
-        )
-    );
+    fn test_field_d() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<A__bindgen_ty_2>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(A__bindgen_ty_2),
+                "::",
+                stringify!(d)
+            )
+        );
+    }
+    test_field_d();
 }
 impl Default for A__bindgen_ty_2 {
     fn default() -> Self {
@@ -153,29 +167,35 @@ fn bindgen_test_layout_A() {
         4usize,
         concat!("Alignment of ", stringify!(A))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<A>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).c) as usize - ptr as usize
-        },
-        0usize,
-        concat!("Offset of field: ", stringify!(A), "::", stringify!(c))
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<A>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).named_union) as usize - ptr as usize
-        },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(A),
-            "::",
-            stringify!(named_union)
-        )
-    );
+    fn test_field_c() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<A>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).c) as usize - ptr as usize
+            },
+            0usize,
+            concat!("Offset of field: ", stringify!(A), "::", stringify!(c))
+        );
+    }
+    test_field_c();
+    fn test_field_named_union() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<A>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).named_union) as usize - ptr as usize
+            },
+            4usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(A),
+                "::",
+                stringify!(named_union)
+            )
+        );
+    }
+    test_field_named_union();
 }
 impl Default for A {
     fn default() -> Self {
@@ -209,34 +229,40 @@ fn bindgen_test_layout_B_Segment() {
         4usize,
         concat!("Alignment of ", stringify!(B_Segment))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<B_Segment>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).begin) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(B_Segment),
-            "::",
-            stringify!(begin)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<B_Segment>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).end) as usize - ptr as usize
-        },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(B_Segment),
-            "::",
-            stringify!(end)
-        )
-    );
+    fn test_field_begin() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<B_Segment>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).begin) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(B_Segment),
+                "::",
+                stringify!(begin)
+            )
+        );
+    }
+    test_field_begin();
+    fn test_field_end() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<B_Segment>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).end) as usize - ptr as usize
+            },
+            4usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(B_Segment),
+                "::",
+                stringify!(end)
+            )
+        );
+    }
+    test_field_end();
 }
 #[test]
 fn bindgen_test_layout_B() {
@@ -250,15 +276,18 @@ fn bindgen_test_layout_B() {
         4usize,
         concat!("Alignment of ", stringify!(B))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<B>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize
-        },
-        0usize,
-        concat!("Offset of field: ", stringify!(B), "::", stringify!(d))
-    );
+    fn test_field_d() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<B>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize
+            },
+            0usize,
+            concat!("Offset of field: ", stringify!(B), "::", stringify!(d))
+        );
+    }
+    test_field_d();
 }
 #[repr(i32)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -300,62 +329,82 @@ fn bindgen_test_layout_C__bindgen_ty_1__bindgen_ty_1() {
         4usize,
         concat!("Alignment of ", stringify!(C__bindgen_ty_1__bindgen_ty_1))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = :: std :: mem :: MaybeUninit :: < C__bindgen_ty_1__bindgen_ty_1 > :: uninit () ;
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mX1) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C__bindgen_ty_1__bindgen_ty_1),
-            "::",
-            stringify!(mX1)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = :: std :: mem :: MaybeUninit :: < C__bindgen_ty_1__bindgen_ty_1 > :: uninit () ;
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mY1) as usize - ptr as usize
-        },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C__bindgen_ty_1__bindgen_ty_1),
-            "::",
-            stringify!(mY1)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = :: std :: mem :: MaybeUninit :: < C__bindgen_ty_1__bindgen_ty_1 > :: uninit () ;
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mX2) as usize - ptr as usize
-        },
-        8usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C__bindgen_ty_1__bindgen_ty_1),
-            "::",
-            stringify!(mX2)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = :: std :: mem :: MaybeUninit :: < C__bindgen_ty_1__bindgen_ty_1 > :: uninit () ;
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mY2) as usize - ptr as usize
-        },
-        12usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C__bindgen_ty_1__bindgen_ty_1),
-            "::",
-            stringify!(mY2)
-        )
-    );
+    fn test_field_mX1() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<
+                    C__bindgen_ty_1__bindgen_ty_1,
+                >::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).mX1) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(C__bindgen_ty_1__bindgen_ty_1),
+                "::",
+                stringify!(mX1)
+            )
+        );
+    }
+    test_field_mX1();
+    fn test_field_mY1() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<
+                    C__bindgen_ty_1__bindgen_ty_1,
+                >::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).mY1) as usize - ptr as usize
+            },
+            4usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(C__bindgen_ty_1__bindgen_ty_1),
+                "::",
+                stringify!(mY1)
+            )
+        );
+    }
+    test_field_mY1();
+    fn test_field_mX2() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<
+                    C__bindgen_ty_1__bindgen_ty_1,
+                >::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).mX2) as usize - ptr as usize
+            },
+            8usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(C__bindgen_ty_1__bindgen_ty_1),
+                "::",
+                stringify!(mX2)
+            )
+        );
+    }
+    test_field_mX2();
+    fn test_field_mY2() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<
+                    C__bindgen_ty_1__bindgen_ty_1,
+                >::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).mY2) as usize - ptr as usize
+            },
+            12usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(C__bindgen_ty_1__bindgen_ty_1),
+                "::",
+                stringify!(mY2)
+            )
+        );
+    }
+    test_field_mY2();
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -375,34 +424,44 @@ fn bindgen_test_layout_C__bindgen_ty_1__bindgen_ty_2() {
         4usize,
         concat!("Alignment of ", stringify!(C__bindgen_ty_1__bindgen_ty_2))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = :: std :: mem :: MaybeUninit :: < C__bindgen_ty_1__bindgen_ty_2 > :: uninit () ;
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mStepSyntax) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C__bindgen_ty_1__bindgen_ty_2),
-            "::",
-            stringify!(mStepSyntax)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = :: std :: mem :: MaybeUninit :: < C__bindgen_ty_1__bindgen_ty_2 > :: uninit () ;
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mSteps) as usize - ptr as usize
-        },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C__bindgen_ty_1__bindgen_ty_2),
-            "::",
-            stringify!(mSteps)
-        )
-    );
+    fn test_field_mStepSyntax() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<
+                    C__bindgen_ty_1__bindgen_ty_2,
+                >::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).mStepSyntax) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(C__bindgen_ty_1__bindgen_ty_2),
+                "::",
+                stringify!(mStepSyntax)
+            )
+        );
+    }
+    test_field_mStepSyntax();
+    fn test_field_mSteps() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<
+                    C__bindgen_ty_1__bindgen_ty_2,
+                >::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).mSteps) as usize - ptr as usize
+            },
+            4usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(C__bindgen_ty_1__bindgen_ty_2),
+                "::",
+                stringify!(mSteps)
+            )
+        );
+    }
+    test_field_mSteps();
 }
 impl Default for C__bindgen_ty_1__bindgen_ty_2 {
     fn default() -> Self {
@@ -425,20 +484,24 @@ fn bindgen_test_layout_C__bindgen_ty_1() {
         4usize,
         concat!("Alignment of ", stringify!(C__bindgen_ty_1))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<C__bindgen_ty_1>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mFunc) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C__bindgen_ty_1),
-            "::",
-            stringify!(mFunc)
-        )
-    );
+    fn test_field_mFunc() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<C__bindgen_ty_1>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).mFunc) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(C__bindgen_ty_1),
+                "::",
+                stringify!(mFunc)
+            )
+        );
+    }
+    test_field_mFunc();
 }
 impl Default for C__bindgen_ty_1 {
     fn default() -> Self {
@@ -467,34 +530,40 @@ fn bindgen_test_layout_C_Segment() {
         4usize,
         concat!("Alignment of ", stringify!(C_Segment))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<C_Segment>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).begin) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C_Segment),
-            "::",
-            stringify!(begin)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<C_Segment>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).end) as usize - ptr as usize
-        },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C_Segment),
-            "::",
-            stringify!(end)
-        )
-    );
+    fn test_field_begin() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<C_Segment>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).begin) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(C_Segment),
+                "::",
+                stringify!(begin)
+            )
+        );
+    }
+    test_field_begin();
+    fn test_field_end() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<C_Segment>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).end) as usize - ptr as usize
+            },
+            4usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(C_Segment),
+                "::",
+                stringify!(end)
+            )
+        );
+    }
+    test_field_end();
 }
 #[test]
 fn bindgen_test_layout_C() {
@@ -508,15 +577,18 @@ fn bindgen_test_layout_C() {
         4usize,
         concat!("Alignment of ", stringify!(C))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<C>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize
-        },
-        0usize,
-        concat!("Offset of field: ", stringify!(C), "::", stringify!(d))
-    );
+    fn test_field_d() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<C>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize
+            },
+            0usize,
+            concat!("Offset of field: ", stringify!(C), "::", stringify!(d))
+        );
+    }
+    test_field_d();
 }
 impl Default for C {
     fn default() -> Self {

--- a/tests/expectations/tests/class_with_inner_struct_1_0.rs
+++ b/tests/expectations/tests/class_with_inner_struct_1_0.rs
@@ -73,34 +73,40 @@ fn bindgen_test_layout_A_Segment() {
         4usize,
         concat!("Alignment of ", stringify!(A_Segment))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<A_Segment>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).begin) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(A_Segment),
-            "::",
-            stringify!(begin)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<A_Segment>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).end) as usize - ptr as usize
-        },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(A_Segment),
-            "::",
-            stringify!(end)
-        )
-    );
+    fn test_field_begin() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<A_Segment>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).begin) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(A_Segment),
+                "::",
+                stringify!(begin)
+            )
+        );
+    }
+    test_field_begin();
+    fn test_field_end() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<A_Segment>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).end) as usize - ptr as usize
+            },
+            4usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(A_Segment),
+                "::",
+                stringify!(end)
+            )
+        );
+    }
+    test_field_end();
 }
 impl Clone for A_Segment {
     fn clone(&self) -> Self {
@@ -125,20 +131,24 @@ fn bindgen_test_layout_A__bindgen_ty_1() {
         4usize,
         concat!("Alignment of ", stringify!(A__bindgen_ty_1))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<A__bindgen_ty_1>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).f) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(A__bindgen_ty_1),
-            "::",
-            stringify!(f)
-        )
-    );
+    fn test_field_f() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<A__bindgen_ty_1>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).f) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(A__bindgen_ty_1),
+                "::",
+                stringify!(f)
+            )
+        );
+    }
+    test_field_f();
 }
 impl Clone for A__bindgen_ty_1 {
     fn clone(&self) -> Self {
@@ -163,20 +173,24 @@ fn bindgen_test_layout_A__bindgen_ty_2() {
         4usize,
         concat!("Alignment of ", stringify!(A__bindgen_ty_2))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<A__bindgen_ty_2>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(A__bindgen_ty_2),
-            "::",
-            stringify!(d)
-        )
-    );
+    fn test_field_d() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<A__bindgen_ty_2>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(A__bindgen_ty_2),
+                "::",
+                stringify!(d)
+            )
+        );
+    }
+    test_field_d();
 }
 impl Clone for A__bindgen_ty_2 {
     fn clone(&self) -> Self {
@@ -195,29 +209,35 @@ fn bindgen_test_layout_A() {
         4usize,
         concat!("Alignment of ", stringify!(A))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<A>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).c) as usize - ptr as usize
-        },
-        0usize,
-        concat!("Offset of field: ", stringify!(A), "::", stringify!(c))
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<A>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).named_union) as usize - ptr as usize
-        },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(A),
-            "::",
-            stringify!(named_union)
-        )
-    );
+    fn test_field_c() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<A>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).c) as usize - ptr as usize
+            },
+            0usize,
+            concat!("Offset of field: ", stringify!(A), "::", stringify!(c))
+        );
+    }
+    test_field_c();
+    fn test_field_named_union() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<A>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).named_union) as usize - ptr as usize
+            },
+            4usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(A),
+                "::",
+                stringify!(named_union)
+            )
+        );
+    }
+    test_field_named_union();
 }
 impl Clone for A {
     fn clone(&self) -> Self {
@@ -247,34 +267,40 @@ fn bindgen_test_layout_B_Segment() {
         4usize,
         concat!("Alignment of ", stringify!(B_Segment))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<B_Segment>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).begin) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(B_Segment),
-            "::",
-            stringify!(begin)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<B_Segment>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).end) as usize - ptr as usize
-        },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(B_Segment),
-            "::",
-            stringify!(end)
-        )
-    );
+    fn test_field_begin() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<B_Segment>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).begin) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(B_Segment),
+                "::",
+                stringify!(begin)
+            )
+        );
+    }
+    test_field_begin();
+    fn test_field_end() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<B_Segment>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).end) as usize - ptr as usize
+            },
+            4usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(B_Segment),
+                "::",
+                stringify!(end)
+            )
+        );
+    }
+    test_field_end();
 }
 impl Clone for B_Segment {
     fn clone(&self) -> Self {
@@ -293,15 +319,18 @@ fn bindgen_test_layout_B() {
         4usize,
         concat!("Alignment of ", stringify!(B))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<B>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize
-        },
-        0usize,
-        concat!("Offset of field: ", stringify!(B), "::", stringify!(d))
-    );
+    fn test_field_d() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<B>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize
+            },
+            0usize,
+            concat!("Offset of field: ", stringify!(B), "::", stringify!(d))
+        );
+    }
+    test_field_d();
 }
 impl Clone for B {
     fn clone(&self) -> Self {
@@ -349,62 +378,82 @@ fn bindgen_test_layout_C__bindgen_ty_1__bindgen_ty_1() {
         4usize,
         concat!("Alignment of ", stringify!(C__bindgen_ty_1__bindgen_ty_1))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = :: std :: mem :: MaybeUninit :: < C__bindgen_ty_1__bindgen_ty_1 > :: uninit () ;
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mX1) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C__bindgen_ty_1__bindgen_ty_1),
-            "::",
-            stringify!(mX1)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = :: std :: mem :: MaybeUninit :: < C__bindgen_ty_1__bindgen_ty_1 > :: uninit () ;
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mY1) as usize - ptr as usize
-        },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C__bindgen_ty_1__bindgen_ty_1),
-            "::",
-            stringify!(mY1)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = :: std :: mem :: MaybeUninit :: < C__bindgen_ty_1__bindgen_ty_1 > :: uninit () ;
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mX2) as usize - ptr as usize
-        },
-        8usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C__bindgen_ty_1__bindgen_ty_1),
-            "::",
-            stringify!(mX2)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = :: std :: mem :: MaybeUninit :: < C__bindgen_ty_1__bindgen_ty_1 > :: uninit () ;
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mY2) as usize - ptr as usize
-        },
-        12usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C__bindgen_ty_1__bindgen_ty_1),
-            "::",
-            stringify!(mY2)
-        )
-    );
+    fn test_field_mX1() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<
+                    C__bindgen_ty_1__bindgen_ty_1,
+                >::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).mX1) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(C__bindgen_ty_1__bindgen_ty_1),
+                "::",
+                stringify!(mX1)
+            )
+        );
+    }
+    test_field_mX1();
+    fn test_field_mY1() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<
+                    C__bindgen_ty_1__bindgen_ty_1,
+                >::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).mY1) as usize - ptr as usize
+            },
+            4usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(C__bindgen_ty_1__bindgen_ty_1),
+                "::",
+                stringify!(mY1)
+            )
+        );
+    }
+    test_field_mY1();
+    fn test_field_mX2() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<
+                    C__bindgen_ty_1__bindgen_ty_1,
+                >::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).mX2) as usize - ptr as usize
+            },
+            8usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(C__bindgen_ty_1__bindgen_ty_1),
+                "::",
+                stringify!(mX2)
+            )
+        );
+    }
+    test_field_mX2();
+    fn test_field_mY2() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<
+                    C__bindgen_ty_1__bindgen_ty_1,
+                >::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).mY2) as usize - ptr as usize
+            },
+            12usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(C__bindgen_ty_1__bindgen_ty_1),
+                "::",
+                stringify!(mY2)
+            )
+        );
+    }
+    test_field_mY2();
 }
 impl Clone for C__bindgen_ty_1__bindgen_ty_1 {
     fn clone(&self) -> Self {
@@ -429,34 +478,44 @@ fn bindgen_test_layout_C__bindgen_ty_1__bindgen_ty_2() {
         4usize,
         concat!("Alignment of ", stringify!(C__bindgen_ty_1__bindgen_ty_2))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = :: std :: mem :: MaybeUninit :: < C__bindgen_ty_1__bindgen_ty_2 > :: uninit () ;
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mStepSyntax) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C__bindgen_ty_1__bindgen_ty_2),
-            "::",
-            stringify!(mStepSyntax)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = :: std :: mem :: MaybeUninit :: < C__bindgen_ty_1__bindgen_ty_2 > :: uninit () ;
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mSteps) as usize - ptr as usize
-        },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C__bindgen_ty_1__bindgen_ty_2),
-            "::",
-            stringify!(mSteps)
-        )
-    );
+    fn test_field_mStepSyntax() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<
+                    C__bindgen_ty_1__bindgen_ty_2,
+                >::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).mStepSyntax) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(C__bindgen_ty_1__bindgen_ty_2),
+                "::",
+                stringify!(mStepSyntax)
+            )
+        );
+    }
+    test_field_mStepSyntax();
+    fn test_field_mSteps() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<
+                    C__bindgen_ty_1__bindgen_ty_2,
+                >::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).mSteps) as usize - ptr as usize
+            },
+            4usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(C__bindgen_ty_1__bindgen_ty_2),
+                "::",
+                stringify!(mSteps)
+            )
+        );
+    }
+    test_field_mSteps();
 }
 impl Clone for C__bindgen_ty_1__bindgen_ty_2 {
     fn clone(&self) -> Self {
@@ -484,20 +543,24 @@ fn bindgen_test_layout_C__bindgen_ty_1() {
         4usize,
         concat!("Alignment of ", stringify!(C__bindgen_ty_1))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<C__bindgen_ty_1>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mFunc) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C__bindgen_ty_1),
-            "::",
-            stringify!(mFunc)
-        )
-    );
+    fn test_field_mFunc() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<C__bindgen_ty_1>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).mFunc) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(C__bindgen_ty_1),
+                "::",
+                stringify!(mFunc)
+            )
+        );
+    }
+    test_field_mFunc();
 }
 impl Clone for C__bindgen_ty_1 {
     fn clone(&self) -> Self {
@@ -522,34 +585,40 @@ fn bindgen_test_layout_C_Segment() {
         4usize,
         concat!("Alignment of ", stringify!(C_Segment))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<C_Segment>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).begin) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C_Segment),
-            "::",
-            stringify!(begin)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<C_Segment>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).end) as usize - ptr as usize
-        },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C_Segment),
-            "::",
-            stringify!(end)
-        )
-    );
+    fn test_field_begin() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<C_Segment>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).begin) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(C_Segment),
+                "::",
+                stringify!(begin)
+            )
+        );
+    }
+    test_field_begin();
+    fn test_field_end() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<C_Segment>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).end) as usize - ptr as usize
+            },
+            4usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(C_Segment),
+                "::",
+                stringify!(end)
+            )
+        );
+    }
+    test_field_end();
 }
 impl Clone for C_Segment {
     fn clone(&self) -> Self {
@@ -568,15 +637,18 @@ fn bindgen_test_layout_C() {
         4usize,
         concat!("Alignment of ", stringify!(C))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<C>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize
-        },
-        0usize,
-        concat!("Offset of field: ", stringify!(C), "::", stringify!(d))
-    );
+    fn test_field_d() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<C>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize
+            },
+            0usize,
+            concat!("Offset of field: ", stringify!(C), "::", stringify!(d))
+        );
+    }
+    test_field_d();
 }
 impl Clone for C {
     fn clone(&self) -> Self {

--- a/tests/expectations/tests/class_with_typedef.rs
+++ b/tests/expectations/tests/class_with_typedef.rs
@@ -29,56 +29,71 @@ fn bindgen_test_layout_C() {
         8usize,
         concat!("Alignment of ", stringify!(C))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<C>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).c) as usize - ptr as usize
-        },
-        0usize,
-        concat!("Offset of field: ", stringify!(C), "::", stringify!(c))
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<C>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).ptr) as usize - ptr as usize
-        },
-        8usize,
-        concat!("Offset of field: ", stringify!(C), "::", stringify!(ptr))
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<C>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).arr) as usize - ptr as usize
-        },
-        16usize,
-        concat!("Offset of field: ", stringify!(C), "::", stringify!(arr))
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<C>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize
-        },
-        56usize,
-        concat!("Offset of field: ", stringify!(C), "::", stringify!(d))
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<C>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).other_ptr) as usize - ptr as usize
-        },
-        64usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C),
-            "::",
-            stringify!(other_ptr)
-        )
-    );
+    fn test_field_c() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<C>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).c) as usize - ptr as usize
+            },
+            0usize,
+            concat!("Offset of field: ", stringify!(C), "::", stringify!(c))
+        );
+    }
+    test_field_c();
+    fn test_field_ptr() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<C>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).ptr) as usize - ptr as usize
+            },
+            8usize,
+            concat!("Offset of field: ", stringify!(C), "::", stringify!(ptr))
+        );
+    }
+    test_field_ptr();
+    fn test_field_arr() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<C>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).arr) as usize - ptr as usize
+            },
+            16usize,
+            concat!("Offset of field: ", stringify!(C), "::", stringify!(arr))
+        );
+    }
+    test_field_arr();
+    fn test_field_d() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<C>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize
+            },
+            56usize,
+            concat!("Offset of field: ", stringify!(C), "::", stringify!(d))
+        );
+    }
+    test_field_d();
+    fn test_field_other_ptr() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<C>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).other_ptr) as usize - ptr as usize
+            },
+            64usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(C),
+                "::",
+                stringify!(other_ptr)
+            )
+        );
+    }
+    test_field_other_ptr();
 }
 extern "C" {
     #[link_name = "\u{1}_ZN1C6methodEi"]
@@ -141,15 +156,18 @@ fn bindgen_test_layout_D() {
         8usize,
         concat!("Alignment of ", stringify!(D))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<D>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).ptr) as usize - ptr as usize
-        },
-        72usize,
-        concat!("Offset of field: ", stringify!(D), "::", stringify!(ptr))
-    );
+    fn test_field_ptr() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<D>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).ptr) as usize - ptr as usize
+            },
+            72usize,
+            concat!("Offset of field: ", stringify!(D), "::", stringify!(ptr))
+        );
+    }
+    test_field_ptr();
 }
 impl Default for D {
     fn default() -> Self {

--- a/tests/expectations/tests/comment-indent.rs
+++ b/tests/expectations/tests/comment-indent.rs
@@ -80,20 +80,24 @@ pub mod root {
                 4usize,
                 concat!("Alignment of ", stringify!(Baz))
             );
-            assert_eq!(
-                unsafe {
-                    let uninit = ::std::mem::MaybeUninit::<Baz>::uninit();
-                    let ptr = uninit.as_ptr();
-                    ::std::ptr::addr_of!((*ptr).member) as usize - ptr as usize
-                },
-                0usize,
-                concat!(
-                    "Offset of field: ",
-                    stringify!(Baz),
-                    "::",
-                    stringify!(member)
-                )
-            );
+            fn test_field_member() {
+                assert_eq!(
+                    unsafe {
+                        let uninit = ::std::mem::MaybeUninit::<Baz>::uninit();
+                        let ptr = uninit.as_ptr();
+                        ::std::ptr::addr_of!((*ptr).member) as usize -
+                            ptr as usize
+                    },
+                    0usize,
+                    concat!(
+                        "Offset of field: ",
+                        stringify!(Baz),
+                        "::",
+                        stringify!(member)
+                    )
+                );
+            }
+            test_field_member();
         }
         /// I'm in an inline namespace, and as such I shouldn't get generated inside
         /// a rust module, except when the relevant option is specified. Also, this

--- a/tests/expectations/tests/complex.rs
+++ b/tests/expectations/tests/complex.rs
@@ -28,20 +28,23 @@ fn bindgen_test_layout_TestDouble() {
         8usize,
         concat!("Alignment of ", stringify!(TestDouble))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<TestDouble>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mMember) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(TestDouble),
-            "::",
-            stringify!(mMember)
-        )
-    );
+    fn test_field_mMember() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<TestDouble>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).mMember) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(TestDouble),
+                "::",
+                stringify!(mMember)
+            )
+        );
+    }
+    test_field_mMember();
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -60,20 +63,23 @@ fn bindgen_test_layout_TestDoublePtr() {
         8usize,
         concat!("Alignment of ", stringify!(TestDoublePtr))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<TestDoublePtr>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mMember) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(TestDoublePtr),
-            "::",
-            stringify!(mMember)
-        )
-    );
+    fn test_field_mMember() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<TestDoublePtr>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).mMember) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(TestDoublePtr),
+                "::",
+                stringify!(mMember)
+            )
+        );
+    }
+    test_field_mMember();
 }
 impl Default for TestDoublePtr {
     fn default() -> Self {
@@ -101,20 +107,23 @@ fn bindgen_test_layout_TestFloat() {
         4usize,
         concat!("Alignment of ", stringify!(TestFloat))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<TestFloat>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mMember) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(TestFloat),
-            "::",
-            stringify!(mMember)
-        )
-    );
+    fn test_field_mMember() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<TestFloat>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).mMember) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(TestFloat),
+                "::",
+                stringify!(mMember)
+            )
+        );
+    }
+    test_field_mMember();
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -133,20 +142,23 @@ fn bindgen_test_layout_TestFloatPtr() {
         8usize,
         concat!("Alignment of ", stringify!(TestFloatPtr))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<TestFloatPtr>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mMember) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(TestFloatPtr),
-            "::",
-            stringify!(mMember)
-        )
-    );
+    fn test_field_mMember() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<TestFloatPtr>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).mMember) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(TestFloatPtr),
+                "::",
+                stringify!(mMember)
+            )
+        );
+    }
+    test_field_mMember();
 }
 impl Default for TestFloatPtr {
     fn default() -> Self {

--- a/tests/expectations/tests/const-const-mut-ptr.rs
+++ b/tests/expectations/tests/const-const-mut-ptr.rs
@@ -22,15 +22,23 @@ fn bindgen_test_layout_foo() {
         8usize,
         concat!("Alignment of ", stringify!(foo))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<foo>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
-        },
-        0usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar))
-    );
+    fn test_field_bar() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<foo>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(foo),
+                "::",
+                stringify!(bar)
+            )
+        );
+    }
+    test_field_bar();
 }
 impl Default for foo {
     fn default() -> Self {

--- a/tests/expectations/tests/constified-enum-module-overflow.rs
+++ b/tests/expectations/tests/constified-enum-module-overflow.rs
@@ -33,15 +33,18 @@ fn bindgen_test_layout_A() {
         1usize,
         concat!("Alignment of ", stringify!(A))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<A>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).u) as usize - ptr as usize
-        },
-        0usize,
-        concat!("Offset of field: ", stringify!(A), "::", stringify!(u))
-    );
+    fn test_field_u() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<A>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).u) as usize - ptr as usize
+            },
+            0usize,
+            concat!("Offset of field: ", stringify!(A), "::", stringify!(u))
+        );
+    }
+    test_field_u();
 }
 #[test]
 fn __bindgen_test_layout_C_open0_A_close0_instantiation() {

--- a/tests/expectations/tests/constify-all-enums.rs
+++ b/tests/expectations/tests/constify-all-enums.rs
@@ -26,21 +26,24 @@ fn bindgen_test_layout_bar() {
         4usize,
         concat!("Alignment of ", stringify!(bar))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<bar>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).this_should_work) as usize -
-                ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(bar),
-            "::",
-            stringify!(this_should_work)
-        )
-    );
+    fn test_field_this_should_work() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<bar>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).this_should_work) as usize -
+                    ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(bar),
+                "::",
+                stringify!(this_should_work)
+            )
+        );
+    }
+    test_field_this_should_work();
 }
 impl Default for bar {
     fn default() -> Self {

--- a/tests/expectations/tests/constify-module-enums-basic.rs
+++ b/tests/expectations/tests/constify-module-enums-basic.rs
@@ -30,21 +30,24 @@ fn bindgen_test_layout_bar() {
         4usize,
         concat!("Alignment of ", stringify!(bar))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<bar>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).this_should_work) as usize -
-                ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(bar),
-            "::",
-            stringify!(this_should_work)
-        )
-    );
+    fn test_field_this_should_work() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<bar>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).this_should_work) as usize -
+                    ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(bar),
+                "::",
+                stringify!(this_should_work)
+            )
+        );
+    }
+    test_field_this_should_work();
 }
 impl Default for bar {
     fn default() -> Self {

--- a/tests/expectations/tests/constify-module-enums-namespace.rs
+++ b/tests/expectations/tests/constify-module-enums-namespace.rs
@@ -42,21 +42,26 @@ pub mod root {
                     4usize,
                     concat!("Alignment of ", stringify!(bar))
                 );
-                assert_eq!(
-                    unsafe {
-                        let uninit = ::std::mem::MaybeUninit::<bar>::uninit();
-                        let ptr = uninit.as_ptr();
-                        ::std::ptr::addr_of!((*ptr).this_should_work) as usize -
-                            ptr as usize
-                    },
-                    0usize,
-                    concat!(
-                        "Offset of field: ",
-                        stringify!(bar),
-                        "::",
-                        stringify!(this_should_work)
-                    )
-                );
+                fn test_field_this_should_work() {
+                    assert_eq!(
+                        unsafe {
+                            let uninit =
+                                ::std::mem::MaybeUninit::<bar>::uninit();
+                            let ptr = uninit.as_ptr();
+                            ::std::ptr::addr_of!((*ptr).this_should_work)
+                                as usize -
+                                ptr as usize
+                        },
+                        0usize,
+                        concat!(
+                            "Offset of field: ",
+                            stringify!(bar),
+                            "::",
+                            stringify!(this_should_work)
+                        )
+                    );
+                }
+                test_field_this_should_work();
             }
             impl Default for bar {
                 fn default() -> Self {

--- a/tests/expectations/tests/constify-module-enums-shadow-name.rs
+++ b/tests/expectations/tests/constify-module-enums-shadow-name.rs
@@ -29,20 +29,23 @@ fn bindgen_test_layout_bar() {
         4usize,
         concat!("Alignment of ", stringify!(bar))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<bar>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).member) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(bar),
-            "::",
-            stringify!(member)
-        )
-    );
+    fn test_field_member() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<bar>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).member) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(bar),
+                "::",
+                stringify!(member)
+            )
+        );
+    }
+    test_field_member();
 }
 impl Default for bar {
     fn default() -> Self {

--- a/tests/expectations/tests/constify-module-enums-simple-alias.rs
+++ b/tests/expectations/tests/constify-module-enums-simple-alias.rs
@@ -38,98 +38,142 @@ fn bindgen_test_layout_Bar() {
         8usize,
         concat!("Alignment of ", stringify!(Bar))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Bar>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).baz1) as usize - ptr as usize
-        },
-        0usize,
-        concat!("Offset of field: ", stringify!(Bar), "::", stringify!(baz1))
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Bar>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).baz2) as usize - ptr as usize
-        },
-        4usize,
-        concat!("Offset of field: ", stringify!(Bar), "::", stringify!(baz2))
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Bar>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).baz3) as usize - ptr as usize
-        },
-        8usize,
-        concat!("Offset of field: ", stringify!(Bar), "::", stringify!(baz3))
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Bar>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).baz4) as usize - ptr as usize
-        },
-        12usize,
-        concat!("Offset of field: ", stringify!(Bar), "::", stringify!(baz4))
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Bar>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).baz_ptr1) as usize - ptr as usize
-        },
-        16usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(Bar),
-            "::",
-            stringify!(baz_ptr1)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Bar>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).baz_ptr2) as usize - ptr as usize
-        },
-        24usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(Bar),
-            "::",
-            stringify!(baz_ptr2)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Bar>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).baz_ptr3) as usize - ptr as usize
-        },
-        32usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(Bar),
-            "::",
-            stringify!(baz_ptr3)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Bar>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).baz_ptr4) as usize - ptr as usize
-        },
-        40usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(Bar),
-            "::",
-            stringify!(baz_ptr4)
-        )
-    );
+    fn test_field_baz1() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Bar>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).baz1) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(Bar),
+                "::",
+                stringify!(baz1)
+            )
+        );
+    }
+    test_field_baz1();
+    fn test_field_baz2() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Bar>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).baz2) as usize - ptr as usize
+            },
+            4usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(Bar),
+                "::",
+                stringify!(baz2)
+            )
+        );
+    }
+    test_field_baz2();
+    fn test_field_baz3() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Bar>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).baz3) as usize - ptr as usize
+            },
+            8usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(Bar),
+                "::",
+                stringify!(baz3)
+            )
+        );
+    }
+    test_field_baz3();
+    fn test_field_baz4() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Bar>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).baz4) as usize - ptr as usize
+            },
+            12usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(Bar),
+                "::",
+                stringify!(baz4)
+            )
+        );
+    }
+    test_field_baz4();
+    fn test_field_baz_ptr1() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Bar>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).baz_ptr1) as usize - ptr as usize
+            },
+            16usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(Bar),
+                "::",
+                stringify!(baz_ptr1)
+            )
+        );
+    }
+    test_field_baz_ptr1();
+    fn test_field_baz_ptr2() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Bar>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).baz_ptr2) as usize - ptr as usize
+            },
+            24usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(Bar),
+                "::",
+                stringify!(baz_ptr2)
+            )
+        );
+    }
+    test_field_baz_ptr2();
+    fn test_field_baz_ptr3() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Bar>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).baz_ptr3) as usize - ptr as usize
+            },
+            32usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(Bar),
+                "::",
+                stringify!(baz_ptr3)
+            )
+        );
+    }
+    test_field_baz_ptr3();
+    fn test_field_baz_ptr4() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Bar>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).baz_ptr4) as usize - ptr as usize
+            },
+            40usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(Bar),
+                "::",
+                stringify!(baz_ptr4)
+            )
+        );
+    }
+    test_field_baz_ptr4();
 }
 impl Default for Bar {
     fn default() -> Self {

--- a/tests/expectations/tests/constify-module-enums-simple-nonamespace.rs
+++ b/tests/expectations/tests/constify-module-enums-simple-nonamespace.rs
@@ -28,24 +28,40 @@ fn bindgen_test_layout_Bar() {
         8usize,
         concat!("Alignment of ", stringify!(Bar))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Bar>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).baz1) as usize - ptr as usize
-        },
-        0usize,
-        concat!("Offset of field: ", stringify!(Bar), "::", stringify!(baz1))
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Bar>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).baz2) as usize - ptr as usize
-        },
-        8usize,
-        concat!("Offset of field: ", stringify!(Bar), "::", stringify!(baz2))
-    );
+    fn test_field_baz1() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Bar>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).baz1) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(Bar),
+                "::",
+                stringify!(baz1)
+            )
+        );
+    }
+    test_field_baz1();
+    fn test_field_baz2() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Bar>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).baz2) as usize - ptr as usize
+            },
+            8usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(Bar),
+                "::",
+                stringify!(baz2)
+            )
+        );
+    }
+    test_field_baz2();
 }
 impl Default for Bar {
     fn default() -> Self {

--- a/tests/expectations/tests/constify-module-enums-types.rs
+++ b/tests/expectations/tests/constify-module-enums-types.rs
@@ -63,146 +63,176 @@ fn bindgen_test_layout_bar() {
         8usize,
         concat!("Alignment of ", stringify!(bar))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<bar>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).member1) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(bar),
-            "::",
-            stringify!(member1)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<bar>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).member2) as usize - ptr as usize
-        },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(bar),
-            "::",
-            stringify!(member2)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<bar>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).member3) as usize - ptr as usize
-        },
-        8usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(bar),
-            "::",
-            stringify!(member3)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<bar>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).member4) as usize - ptr as usize
-        },
-        12usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(bar),
-            "::",
-            stringify!(member4)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<bar>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).member5) as usize - ptr as usize
-        },
-        16usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(bar),
-            "::",
-            stringify!(member5)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<bar>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).member6) as usize - ptr as usize
-        },
-        24usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(bar),
-            "::",
-            stringify!(member6)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<bar>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).member7) as usize - ptr as usize
-        },
-        32usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(bar),
-            "::",
-            stringify!(member7)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<bar>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).member8) as usize - ptr as usize
-        },
-        36usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(bar),
-            "::",
-            stringify!(member8)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<bar>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).member9) as usize - ptr as usize
-        },
-        40usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(bar),
-            "::",
-            stringify!(member9)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<bar>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).member10) as usize - ptr as usize
-        },
-        44usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(bar),
-            "::",
-            stringify!(member10)
-        )
-    );
+    fn test_field_member1() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<bar>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).member1) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(bar),
+                "::",
+                stringify!(member1)
+            )
+        );
+    }
+    test_field_member1();
+    fn test_field_member2() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<bar>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).member2) as usize - ptr as usize
+            },
+            4usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(bar),
+                "::",
+                stringify!(member2)
+            )
+        );
+    }
+    test_field_member2();
+    fn test_field_member3() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<bar>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).member3) as usize - ptr as usize
+            },
+            8usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(bar),
+                "::",
+                stringify!(member3)
+            )
+        );
+    }
+    test_field_member3();
+    fn test_field_member4() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<bar>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).member4) as usize - ptr as usize
+            },
+            12usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(bar),
+                "::",
+                stringify!(member4)
+            )
+        );
+    }
+    test_field_member4();
+    fn test_field_member5() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<bar>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).member5) as usize - ptr as usize
+            },
+            16usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(bar),
+                "::",
+                stringify!(member5)
+            )
+        );
+    }
+    test_field_member5();
+    fn test_field_member6() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<bar>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).member6) as usize - ptr as usize
+            },
+            24usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(bar),
+                "::",
+                stringify!(member6)
+            )
+        );
+    }
+    test_field_member6();
+    fn test_field_member7() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<bar>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).member7) as usize - ptr as usize
+            },
+            32usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(bar),
+                "::",
+                stringify!(member7)
+            )
+        );
+    }
+    test_field_member7();
+    fn test_field_member8() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<bar>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).member8) as usize - ptr as usize
+            },
+            36usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(bar),
+                "::",
+                stringify!(member8)
+            )
+        );
+    }
+    test_field_member8();
+    fn test_field_member9() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<bar>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).member9) as usize - ptr as usize
+            },
+            40usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(bar),
+                "::",
+                stringify!(member9)
+            )
+        );
+    }
+    test_field_member9();
+    fn test_field_member10() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<bar>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).member10) as usize - ptr as usize
+            },
+            44usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(bar),
+                "::",
+                stringify!(member10)
+            )
+        );
+    }
+    test_field_member10();
 }
 impl Default for bar {
     fn default() -> Self {
@@ -230,20 +260,23 @@ fn bindgen_test_layout_Baz() {
         4usize,
         concat!("Alignment of ", stringify!(Baz))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Baz>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).member1) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(Baz),
-            "::",
-            stringify!(member1)
-        )
-    );
+    fn test_field_member1() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Baz>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).member1) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(Baz),
+                "::",
+                stringify!(member1)
+            )
+        );
+    }
+    test_field_member1();
 }
 impl Default for Baz {
     fn default() -> Self {
@@ -276,15 +309,23 @@ fn bindgen_test_layout_Bar() {
         8usize,
         concat!("Alignment of ", stringify!(Bar))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Bar>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize
-        },
-        0usize,
-        concat!("Offset of field: ", stringify!(Bar), "::", stringify!(baz))
-    );
+    fn test_field_baz() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Bar>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(Bar),
+                "::",
+                stringify!(baz)
+            )
+        );
+    }
+    test_field_baz();
 }
 impl Default for Bar {
     fn default() -> Self {

--- a/tests/expectations/tests/contains-vs-inherits-zero-sized.rs
+++ b/tests/expectations/tests/contains-vs-inherits-zero-sized.rs
@@ -43,20 +43,23 @@ fn bindgen_test_layout_Inherits() {
         1usize,
         concat!("Alignment of ", stringify!(Inherits))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Inherits>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(Inherits),
-            "::",
-            stringify!(b)
-        )
-    );
+    fn test_field_b() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Inherits>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(Inherits),
+                "::",
+                stringify!(b)
+            )
+        );
+    }
+    test_field_b();
 }
 /// This should not get an `_address` byte, but contains `Empty` which *does* get
 /// one, so `sizeof(Contains)` should be `1 + 1`.
@@ -78,32 +81,38 @@ fn bindgen_test_layout_Contains() {
         1usize,
         concat!("Alignment of ", stringify!(Contains))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Contains>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).empty) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(Contains),
-            "::",
-            stringify!(empty)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Contains>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-        },
-        1usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(Contains),
-            "::",
-            stringify!(b)
-        )
-    );
+    fn test_field_empty() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Contains>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).empty) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(Contains),
+                "::",
+                stringify!(empty)
+            )
+        );
+    }
+    test_field_empty();
+    fn test_field_b() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Contains>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
+            },
+            1usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(Contains),
+                "::",
+                stringify!(b)
+            )
+        );
+    }
+    test_field_b();
 }

--- a/tests/expectations/tests/convert-floats.rs
+++ b/tests/expectations/tests/convert-floats.rs
@@ -33,75 +33,110 @@ fn bindgen_test_layout_foo() {
         8usize,
         concat!("Alignment of ", stringify!(foo))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<foo>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
-        },
-        0usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar))
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<foo>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize
-        },
-        4usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(baz))
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<foo>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).bazz) as usize - ptr as usize
-        },
-        8usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(bazz))
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<foo>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).bazzz) as usize - ptr as usize
-        },
-        16usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(foo),
-            "::",
-            stringify!(bazzz)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<foo>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).complexFloat) as usize - ptr as usize
-        },
-        24usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(foo),
-            "::",
-            stringify!(complexFloat)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<foo>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).complexDouble) as usize - ptr as usize
-        },
-        32usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(foo),
-            "::",
-            stringify!(complexDouble)
-        )
-    );
+    fn test_field_bar() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<foo>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(foo),
+                "::",
+                stringify!(bar)
+            )
+        );
+    }
+    test_field_bar();
+    fn test_field_baz() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<foo>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize
+            },
+            4usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(foo),
+                "::",
+                stringify!(baz)
+            )
+        );
+    }
+    test_field_baz();
+    fn test_field_bazz() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<foo>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).bazz) as usize - ptr as usize
+            },
+            8usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(foo),
+                "::",
+                stringify!(bazz)
+            )
+        );
+    }
+    test_field_bazz();
+    fn test_field_bazzz() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<foo>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).bazzz) as usize - ptr as usize
+            },
+            16usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(foo),
+                "::",
+                stringify!(bazzz)
+            )
+        );
+    }
+    test_field_bazzz();
+    fn test_field_complexFloat() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<foo>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).complexFloat) as usize -
+                    ptr as usize
+            },
+            24usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(foo),
+                "::",
+                stringify!(complexFloat)
+            )
+        );
+    }
+    test_field_complexFloat();
+    fn test_field_complexDouble() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<foo>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).complexDouble) as usize -
+                    ptr as usize
+            },
+            32usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(foo),
+                "::",
+                stringify!(complexDouble)
+            )
+        );
+    }
+    test_field_complexDouble();
 }
 impl Default for foo {
     fn default() -> Self {

--- a/tests/expectations/tests/ctypes-prefix-path.rs
+++ b/tests/expectations/tests/ctypes-prefix-path.rs
@@ -31,33 +31,47 @@ fn bindgen_test_layout_foo() {
         8usize,
         concat!("Alignment of ", stringify!(foo))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::core::mem::MaybeUninit::<foo>::uninit();
-            let ptr = uninit.as_ptr();
-            ::core::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
-        0usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(a))
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::core::mem::MaybeUninit::<foo>::uninit();
-            let ptr = uninit.as_ptr();
-            ::core::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-        },
-        4usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(b))
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::core::mem::MaybeUninit::<foo>::uninit();
-            let ptr = uninit.as_ptr();
-            ::core::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
-        },
-        8usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar))
-    );
+    fn test_field_a() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::core::mem::MaybeUninit::<foo>::uninit();
+                let ptr = uninit.as_ptr();
+                ::core::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+            },
+            0usize,
+            concat!("Offset of field: ", stringify!(foo), "::", stringify!(a))
+        );
+    }
+    test_field_a();
+    fn test_field_b() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::core::mem::MaybeUninit::<foo>::uninit();
+                let ptr = uninit.as_ptr();
+                ::core::ptr::addr_of!((*ptr).b) as usize - ptr as usize
+            },
+            4usize,
+            concat!("Offset of field: ", stringify!(foo), "::", stringify!(b))
+        );
+    }
+    test_field_b();
+    fn test_field_bar() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::core::mem::MaybeUninit::<foo>::uninit();
+                let ptr = uninit.as_ptr();
+                ::core::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
+            },
+            8usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(foo),
+                "::",
+                stringify!(bar)
+            )
+        );
+    }
+    test_field_bar();
 }
 impl Default for foo {
     fn default() -> Self {

--- a/tests/expectations/tests/derive-bitfield-method-same-name.rs
+++ b/tests/expectations/tests/derive-bitfield-method-same-name.rs
@@ -114,20 +114,23 @@ fn bindgen_test_layout_Foo() {
         4usize,
         concat!("Alignment of ", stringify!(Foo))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Foo>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).large) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(Foo),
-            "::",
-            stringify!(large)
-        )
-    );
+    fn test_field_large() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Foo>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).large) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(Foo),
+                "::",
+                stringify!(large)
+            )
+        );
+    }
+    test_field_large();
 }
 extern "C" {
     #[link_name = "\u{1}_ZN3Foo4typeEv"]

--- a/tests/expectations/tests/derive-clone.rs
+++ b/tests/expectations/tests/derive-clone.rs
@@ -23,20 +23,24 @@ fn bindgen_test_layout_ShouldDeriveClone() {
         4usize,
         concat!("Alignment of ", stringify!(ShouldDeriveClone))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<ShouldDeriveClone>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).large) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(ShouldDeriveClone),
-            "::",
-            stringify!(large)
-        )
-    );
+    fn test_field_large() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<ShouldDeriveClone>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).large) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(ShouldDeriveClone),
+                "::",
+                stringify!(large)
+            )
+        );
+    }
+    test_field_large();
 }
 impl Default for ShouldDeriveClone {
     fn default() -> Self {

--- a/tests/expectations/tests/derive-clone_1_0.rs
+++ b/tests/expectations/tests/derive-clone_1_0.rs
@@ -24,20 +24,24 @@ fn bindgen_test_layout_ShouldImplClone() {
         4usize,
         concat!("Alignment of ", stringify!(ShouldImplClone))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<ShouldImplClone>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).large) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(ShouldImplClone),
-            "::",
-            stringify!(large)
-        )
-    );
+    fn test_field_large() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<ShouldImplClone>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).large) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(ShouldImplClone),
+                "::",
+                stringify!(large)
+            )
+        );
+    }
+    test_field_large();
 }
 impl Clone for ShouldImplClone {
     fn clone(&self) -> Self {

--- a/tests/expectations/tests/derive-debug-bitfield-core.rs
+++ b/tests/expectations/tests/derive-debug-bitfield-core.rs
@@ -112,20 +112,24 @@ fn bindgen_test_layout_C() {
         4usize,
         concat!("Alignment of ", stringify!(C))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::core::mem::MaybeUninit::<C>::uninit();
-            let ptr = uninit.as_ptr();
-            ::core::ptr::addr_of!((*ptr).large_array) as usize - ptr as usize
-        },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C),
-            "::",
-            stringify!(large_array)
-        )
-    );
+    fn test_field_large_array() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::core::mem::MaybeUninit::<C>::uninit();
+                let ptr = uninit.as_ptr();
+                ::core::ptr::addr_of!((*ptr).large_array) as usize -
+                    ptr as usize
+            },
+            4usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(C),
+                "::",
+                stringify!(large_array)
+            )
+        );
+    }
+    test_field_large_array();
 }
 impl Default for C {
     fn default() -> Self {

--- a/tests/expectations/tests/derive-debug-bitfield.rs
+++ b/tests/expectations/tests/derive-debug-bitfield.rs
@@ -110,20 +110,23 @@ fn bindgen_test_layout_C() {
         4usize,
         concat!("Alignment of ", stringify!(C))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<C>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).large_array) as usize - ptr as usize
-        },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C),
-            "::",
-            stringify!(large_array)
-        )
-    );
+    fn test_field_large_array() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<C>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).large_array) as usize - ptr as usize
+            },
+            4usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(C),
+                "::",
+                stringify!(large_array)
+            )
+        );
+    }
+    test_field_large_array();
 }
 impl Default for C {
     fn default() -> Self {

--- a/tests/expectations/tests/derive-debug-function-pointer.rs
+++ b/tests/expectations/tests/derive-debug-function-pointer.rs
@@ -25,34 +25,40 @@ fn bindgen_test_layout_Nice() {
         8usize,
         concat!("Alignment of ", stringify!(Nice))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Nice>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).pointer) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(Nice),
-            "::",
-            stringify!(pointer)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Nice>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).large_array) as usize - ptr as usize
-        },
-        8usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(Nice),
-            "::",
-            stringify!(large_array)
-        )
-    );
+    fn test_field_pointer() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Nice>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).pointer) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(Nice),
+                "::",
+                stringify!(pointer)
+            )
+        );
+    }
+    test_field_pointer();
+    fn test_field_large_array() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Nice>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).large_array) as usize - ptr as usize
+            },
+            8usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(Nice),
+                "::",
+                stringify!(large_array)
+            )
+        );
+    }
+    test_field_large_array();
 }
 impl Default for Nice {
     fn default() -> Self {

--- a/tests/expectations/tests/derive-debug-mangle-name.rs
+++ b/tests/expectations/tests/derive-debug-mangle-name.rs
@@ -30,34 +30,44 @@ fn bindgen_test_layout_perf_event_attr__bindgen_ty_1() {
         4usize,
         concat!("Alignment of ", stringify!(perf_event_attr__bindgen_ty_1))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = :: std :: mem :: MaybeUninit :: < perf_event_attr__bindgen_ty_1 > :: uninit () ;
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(perf_event_attr__bindgen_ty_1),
-            "::",
-            stringify!(b)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = :: std :: mem :: MaybeUninit :: < perf_event_attr__bindgen_ty_1 > :: uninit () ;
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).c) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(perf_event_attr__bindgen_ty_1),
-            "::",
-            stringify!(c)
-        )
-    );
+    fn test_field_b() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<
+                    perf_event_attr__bindgen_ty_1,
+                >::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(perf_event_attr__bindgen_ty_1),
+                "::",
+                stringify!(b)
+            )
+        );
+    }
+    test_field_b();
+    fn test_field_c() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<
+                    perf_event_attr__bindgen_ty_1,
+                >::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).c) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(perf_event_attr__bindgen_ty_1),
+                "::",
+                stringify!(c)
+            )
+        );
+    }
+    test_field_c();
 }
 impl Default for perf_event_attr__bindgen_ty_1 {
     fn default() -> Self {
@@ -85,34 +95,42 @@ fn bindgen_test_layout_perf_event_attr() {
         4usize,
         concat!("Alignment of ", stringify!(perf_event_attr))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<perf_event_attr>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).type_) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(perf_event_attr),
-            "::",
-            stringify!(type_)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<perf_event_attr>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(perf_event_attr),
-            "::",
-            stringify!(a)
-        )
-    );
+    fn test_field_type() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<perf_event_attr>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).type_) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(perf_event_attr),
+                "::",
+                stringify!(type_)
+            )
+        );
+    }
+    test_field_type();
+    fn test_field_a() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<perf_event_attr>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+            },
+            4usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(perf_event_attr),
+                "::",
+                stringify!(a)
+            )
+        );
+    }
+    test_field_a();
 }
 impl Default for perf_event_attr {
     fn default() -> Self {

--- a/tests/expectations/tests/derive-debug-opaque-template-instantiation.rs
+++ b/tests/expectations/tests/derive-debug-opaque-template-instantiation.rs
@@ -21,20 +21,23 @@ fn bindgen_test_layout_Instance() {
         4usize,
         concat!("Alignment of ", stringify!(Instance))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Instance>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).val) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(Instance),
-            "::",
-            stringify!(val)
-        )
-    );
+    fn test_field_val() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Instance>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).val) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(Instance),
+                "::",
+                stringify!(val)
+            )
+        );
+    }
+    test_field_val();
 }
 impl Default for Instance {
     fn default() -> Self {

--- a/tests/expectations/tests/derive-debug-opaque.rs
+++ b/tests/expectations/tests/derive-debug-opaque.rs
@@ -53,20 +53,23 @@ fn bindgen_test_layout_OpaqueUser() {
         4usize,
         concat!("Alignment of ", stringify!(OpaqueUser))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<OpaqueUser>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).opaque) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(OpaqueUser),
-            "::",
-            stringify!(opaque)
-        )
-    );
+    fn test_field_opaque() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<OpaqueUser>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).opaque) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(OpaqueUser),
+                "::",
+                stringify!(opaque)
+            )
+        );
+    }
+    test_field_opaque();
 }
 impl Default for OpaqueUser {
     fn default() -> Self {

--- a/tests/expectations/tests/derive-default-and-blocklist.rs
+++ b/tests/expectations/tests/derive-default-and-blocklist.rs
@@ -25,21 +25,24 @@ fn bindgen_test_layout_ShouldNotDeriveDefault() {
         1usize,
         concat!("Alignment of ", stringify!(ShouldNotDeriveDefault))
     );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<ShouldNotDeriveDefault>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(ShouldNotDeriveDefault),
-            "::",
-            stringify!(a)
-        )
-    );
+    fn test_field_a() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<ShouldNotDeriveDefault>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(ShouldNotDeriveDefault),
+                "::",
+                stringify!(a)
+            )
+        );
+    }
+    test_field_a();
 }
 impl Default for ShouldNotDeriveDefault {
     fn default() -> Self {

--- a/tests/expectations/tests/derive-fn-ptr.rs
+++ b/tests/expectations/tests/derive-fn-ptr.rs
@@ -42,20 +42,23 @@ fn bindgen_test_layout_Foo() {
         8usize,
         concat!("Alignment of ", stringify!(Foo))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Foo>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).callback) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(Foo),
-            "::",
-            stringify!(callback)
-        )
-    );
+    fn test_field_callback() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Foo>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).callback) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(Foo),
+                "::",
+                stringify!(callback)
+            )
+        );
+    }
+    test_field_callback();
 }
 pub type my_fun2_t = ::std::option::Option<
     unsafe extern "C" fn(
@@ -90,18 +93,21 @@ fn bindgen_test_layout_Bar() {
         8usize,
         concat!("Alignment of ", stringify!(Bar))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Bar>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).callback) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(Bar),
-            "::",
-            stringify!(callback)
-        )
-    );
+    fn test_field_callback() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Bar>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).callback) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(Bar),
+                "::",
+                stringify!(callback)
+            )
+        );
+    }
+    test_field_callback();
 }

--- a/tests/expectations/tests/derive-hash-and-blocklist.rs
+++ b/tests/expectations/tests/derive-hash-and-blocklist.rs
@@ -24,21 +24,24 @@ fn bindgen_test_layout_ShouldNotDeriveHash() {
         1usize,
         concat!("Alignment of ", stringify!(ShouldNotDeriveHash))
     );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<ShouldNotDeriveHash>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(ShouldNotDeriveHash),
-            "::",
-            stringify!(a)
-        )
-    );
+    fn test_field_a() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<ShouldNotDeriveHash>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(ShouldNotDeriveHash),
+                "::",
+                stringify!(a)
+            )
+        );
+    }
+    test_field_a();
 }
 impl Default for ShouldNotDeriveHash {
     fn default() -> Self {

--- a/tests/expectations/tests/derive-hash-blocklisting.rs
+++ b/tests/expectations/tests/derive-hash-blocklisting.rs
@@ -30,20 +30,24 @@ fn bindgen_test_layout_AllowlistedOne() {
         4usize,
         concat!("Alignment of ", stringify!(AllowlistedOne))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<AllowlistedOne>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(AllowlistedOne),
-            "::",
-            stringify!(a)
-        )
-    );
+    fn test_field_a() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<AllowlistedOne>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(AllowlistedOne),
+                "::",
+                stringify!(a)
+            )
+        );
+    }
+    test_field_a();
 }
 impl Default for AllowlistedOne {
     fn default() -> Self {
@@ -71,20 +75,24 @@ fn bindgen_test_layout_AllowlistedTwo() {
         4usize,
         concat!("Alignment of ", stringify!(AllowlistedTwo))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<AllowlistedTwo>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(AllowlistedTwo),
-            "::",
-            stringify!(b)
-        )
-    );
+    fn test_field_b() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<AllowlistedTwo>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(AllowlistedTwo),
+                "::",
+                stringify!(b)
+            )
+        );
+    }
+    test_field_b();
 }
 impl Default for AllowlistedTwo {
     fn default() -> Self {

--- a/tests/expectations/tests/derive-hash-struct-with-anon-struct-float.rs
+++ b/tests/expectations/tests/derive-hash-struct-with-anon-struct-float.rs
@@ -29,34 +29,42 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
         4usize,
         concat!("Alignment of ", stringify!(foo__bindgen_ty_1))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<foo__bindgen_ty_1>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(foo__bindgen_ty_1),
-            "::",
-            stringify!(a)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<foo__bindgen_ty_1>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-        },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(foo__bindgen_ty_1),
-            "::",
-            stringify!(b)
-        )
-    );
+    fn test_field_a() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<foo__bindgen_ty_1>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(foo__bindgen_ty_1),
+                "::",
+                stringify!(a)
+            )
+        );
+    }
+    test_field_a();
+    fn test_field_b() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<foo__bindgen_ty_1>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
+            },
+            4usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(foo__bindgen_ty_1),
+                "::",
+                stringify!(b)
+            )
+        );
+    }
+    test_field_b();
 }
 #[test]
 fn bindgen_test_layout_foo() {
@@ -70,13 +78,21 @@ fn bindgen_test_layout_foo() {
         4usize,
         concat!("Alignment of ", stringify!(foo))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<foo>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
-        },
-        0usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar))
-    );
+    fn test_field_bar() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<foo>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(foo),
+                "::",
+                stringify!(bar)
+            )
+        );
+    }
+    test_field_bar();
 }

--- a/tests/expectations/tests/derive-hash-struct-with-float-array.rs
+++ b/tests/expectations/tests/derive-hash-struct-with-float-array.rs
@@ -23,13 +23,21 @@ fn bindgen_test_layout_foo() {
         4usize,
         concat!("Alignment of ", stringify!(foo))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<foo>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
-        },
-        0usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar))
-    );
+    fn test_field_bar() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<foo>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(foo),
+                "::",
+                stringify!(bar)
+            )
+        );
+    }
+    test_field_bar();
 }

--- a/tests/expectations/tests/derive-hash-struct-with-incomplete-array.rs
+++ b/tests/expectations/tests/derive-hash-struct-with-incomplete-array.rs
@@ -53,30 +53,36 @@ fn bindgen_test_layout_test() {
         4usize,
         concat!("Alignment of ", stringify!(test))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<test>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
-        0usize,
-        concat!("Offset of field: ", stringify!(test), "::", stringify!(a))
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<test>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).zero_length_array) as usize -
-                ptr as usize
-        },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(test),
-            "::",
-            stringify!(zero_length_array)
-        )
-    );
+    fn test_field_a() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<test>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+            },
+            0usize,
+            concat!("Offset of field: ", stringify!(test), "::", stringify!(a))
+        );
+    }
+    test_field_a();
+    fn test_field_zero_length_array() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<test>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).zero_length_array) as usize -
+                    ptr as usize
+            },
+            4usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(test),
+                "::",
+                stringify!(zero_length_array)
+            )
+        );
+    }
+    test_field_zero_length_array();
 }
 #[repr(C)]
 #[derive(Debug, Default)]

--- a/tests/expectations/tests/derive-hash-struct-with-pointer.rs
+++ b/tests/expectations/tests/derive-hash-struct-with-pointer.rs
@@ -23,20 +23,24 @@ fn bindgen_test_layout_ConstPtrMutObj() {
         8usize,
         concat!("Alignment of ", stringify!(ConstPtrMutObj))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<ConstPtrMutObj>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(ConstPtrMutObj),
-            "::",
-            stringify!(bar)
-        )
-    );
+    fn test_field_bar() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<ConstPtrMutObj>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(ConstPtrMutObj),
+                "::",
+                stringify!(bar)
+            )
+        );
+    }
+    test_field_bar();
 }
 impl Default for ConstPtrMutObj {
     fn default() -> Self {
@@ -64,20 +68,23 @@ fn bindgen_test_layout_MutPtrMutObj() {
         8usize,
         concat!("Alignment of ", stringify!(MutPtrMutObj))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<MutPtrMutObj>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(MutPtrMutObj),
-            "::",
-            stringify!(bar)
-        )
-    );
+    fn test_field_bar() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<MutPtrMutObj>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(MutPtrMutObj),
+                "::",
+                stringify!(bar)
+            )
+        );
+    }
+    test_field_bar();
 }
 impl Default for MutPtrMutObj {
     fn default() -> Self {
@@ -105,20 +112,24 @@ fn bindgen_test_layout_MutPtrConstObj() {
         8usize,
         concat!("Alignment of ", stringify!(MutPtrConstObj))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<MutPtrConstObj>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(MutPtrConstObj),
-            "::",
-            stringify!(bar)
-        )
-    );
+    fn test_field_bar() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<MutPtrConstObj>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(MutPtrConstObj),
+                "::",
+                stringify!(bar)
+            )
+        );
+    }
+    test_field_bar();
 }
 impl Default for MutPtrConstObj {
     fn default() -> Self {
@@ -146,20 +157,24 @@ fn bindgen_test_layout_ConstPtrConstObj() {
         8usize,
         concat!("Alignment of ", stringify!(ConstPtrConstObj))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<ConstPtrConstObj>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(ConstPtrConstObj),
-            "::",
-            stringify!(bar)
-        )
-    );
+    fn test_field_bar() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<ConstPtrConstObj>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(ConstPtrConstObj),
+                "::",
+                stringify!(bar)
+            )
+        );
+    }
+    test_field_bar();
 }
 impl Default for ConstPtrConstObj {
     fn default() -> Self {

--- a/tests/expectations/tests/derive-hash-template-inst-float.rs
+++ b/tests/expectations/tests/derive-hash-template-inst-float.rs
@@ -39,15 +39,23 @@ fn bindgen_test_layout_IntStr() {
         4usize,
         concat!("Alignment of ", stringify!(IntStr))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<IntStr>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
-        0usize,
-        concat!("Offset of field: ", stringify!(IntStr), "::", stringify!(a))
-    );
+    fn test_field_a() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<IntStr>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(IntStr),
+                "::",
+                stringify!(a)
+            )
+        );
+    }
+    test_field_a();
 }
 impl Default for IntStr {
     fn default() -> Self {
@@ -76,20 +84,23 @@ fn bindgen_test_layout_FloatStr() {
         4usize,
         concat!("Alignment of ", stringify!(FloatStr))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<FloatStr>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(FloatStr),
-            "::",
-            stringify!(a)
-        )
-    );
+    fn test_field_a() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<FloatStr>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(FloatStr),
+                "::",
+                stringify!(a)
+            )
+        );
+    }
+    test_field_a();
 }
 impl Default for FloatStr {
     fn default() -> Self {

--- a/tests/expectations/tests/derive-partialeq-and-blocklist.rs
+++ b/tests/expectations/tests/derive-partialeq-and-blocklist.rs
@@ -25,21 +25,25 @@ fn bindgen_test_layout_ShouldNotDerivePartialEq() {
         1usize,
         concat!("Alignment of ", stringify!(ShouldNotDerivePartialEq))
     );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<ShouldNotDerivePartialEq>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(ShouldNotDerivePartialEq),
-            "::",
-            stringify!(a)
-        )
-    );
+    fn test_field_a() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<ShouldNotDerivePartialEq>::uninit(
+                    );
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(ShouldNotDerivePartialEq),
+                "::",
+                stringify!(a)
+            )
+        );
+    }
+    test_field_a();
 }
 impl Default for ShouldNotDerivePartialEq {
     fn default() -> Self {

--- a/tests/expectations/tests/derive-partialeq-base.rs
+++ b/tests/expectations/tests/derive-partialeq-base.rs
@@ -22,20 +22,23 @@ fn bindgen_test_layout_Base() {
         4usize,
         concat!("Alignment of ", stringify!(Base))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Base>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).large) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(Base),
-            "::",
-            stringify!(large)
-        )
-    );
+    fn test_field_large() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Base>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).large) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(Base),
+                "::",
+                stringify!(large)
+            )
+        );
+    }
+    test_field_large();
 }
 impl Default for Base {
     fn default() -> Self {

--- a/tests/expectations/tests/derive-partialeq-bitfield.rs
+++ b/tests/expectations/tests/derive-partialeq-bitfield.rs
@@ -110,20 +110,23 @@ fn bindgen_test_layout_C() {
         4usize,
         concat!("Alignment of ", stringify!(C))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<C>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).large_array) as usize - ptr as usize
-        },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C),
-            "::",
-            stringify!(large_array)
-        )
-    );
+    fn test_field_large_array() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<C>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).large_array) as usize - ptr as usize
+            },
+            4usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(C),
+                "::",
+                stringify!(large_array)
+            )
+        );
+    }
+    test_field_large_array();
 }
 impl Default for C {
     fn default() -> Self {

--- a/tests/expectations/tests/derive-partialeq-core.rs
+++ b/tests/expectations/tests/derive-partialeq-core.rs
@@ -24,20 +24,24 @@ fn bindgen_test_layout_C() {
         4usize,
         concat!("Alignment of ", stringify!(C))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::core::mem::MaybeUninit::<C>::uninit();
-            let ptr = uninit.as_ptr();
-            ::core::ptr::addr_of!((*ptr).large_array) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C),
-            "::",
-            stringify!(large_array)
-        )
-    );
+    fn test_field_large_array() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::core::mem::MaybeUninit::<C>::uninit();
+                let ptr = uninit.as_ptr();
+                ::core::ptr::addr_of!((*ptr).large_array) as usize -
+                    ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(C),
+                "::",
+                stringify!(large_array)
+            )
+        );
+    }
+    test_field_large_array();
 }
 impl Default for C {
     fn default() -> Self {

--- a/tests/expectations/tests/derive-partialeq-pointer.rs
+++ b/tests/expectations/tests/derive-partialeq-pointer.rs
@@ -22,15 +22,18 @@ fn bindgen_test_layout_Bar() {
         8usize,
         concat!("Alignment of ", stringify!(Bar))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Bar>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-        },
-        0usize,
-        concat!("Offset of field: ", stringify!(Bar), "::", stringify!(b))
-    );
+    fn test_field_b() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Bar>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
+            },
+            0usize,
+            concat!("Offset of field: ", stringify!(Bar), "::", stringify!(b))
+        );
+    }
+    test_field_b();
 }
 impl Default for Bar {
     fn default() -> Self {
@@ -112,15 +115,18 @@ fn bindgen_test_layout_a() {
         1usize,
         concat!("Alignment of ", stringify!(a))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<a>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize
-        },
-        0usize,
-        concat!("Offset of field: ", stringify!(a), "::", stringify!(d))
-    );
+    fn test_field_d() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<a>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize
+            },
+            0usize,
+            concat!("Offset of field: ", stringify!(a), "::", stringify!(d))
+        );
+    }
+    test_field_d();
 }
 impl Default for a {
     fn default() -> Self {

--- a/tests/expectations/tests/derive-partialeq-union.rs
+++ b/tests/expectations/tests/derive-partialeq-union.rs
@@ -24,36 +24,44 @@ fn bindgen_test_layout_ShouldNotDerivePartialEq() {
         4usize,
         concat!("Alignment of ", stringify!(ShouldNotDerivePartialEq))
     );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<ShouldNotDerivePartialEq>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(ShouldNotDerivePartialEq),
-            "::",
-            stringify!(a)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<ShouldNotDerivePartialEq>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(ShouldNotDerivePartialEq),
-            "::",
-            stringify!(b)
-        )
-    );
+    fn test_field_a() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<ShouldNotDerivePartialEq>::uninit(
+                    );
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(ShouldNotDerivePartialEq),
+                "::",
+                stringify!(a)
+            )
+        );
+    }
+    test_field_a();
+    fn test_field_b() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<ShouldNotDerivePartialEq>::uninit(
+                    );
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(ShouldNotDerivePartialEq),
+                "::",
+                stringify!(b)
+            )
+        );
+    }
+    test_field_b();
 }
 impl Default for ShouldNotDerivePartialEq {
     fn default() -> Self {

--- a/tests/expectations/tests/derive-partialeq-union_1_0.rs
+++ b/tests/expectations/tests/derive-partialeq-union_1_0.rs
@@ -68,36 +68,42 @@ fn bindgen_test_layout_ShouldDerivePartialEq() {
         4usize,
         concat!("Alignment of ", stringify!(ShouldDerivePartialEq))
     );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<ShouldDerivePartialEq>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(ShouldDerivePartialEq),
-            "::",
-            stringify!(a)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<ShouldDerivePartialEq>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(ShouldDerivePartialEq),
-            "::",
-            stringify!(b)
-        )
-    );
+    fn test_field_a() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<ShouldDerivePartialEq>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(ShouldDerivePartialEq),
+                "::",
+                stringify!(a)
+            )
+        );
+    }
+    test_field_a();
+    fn test_field_b() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<ShouldDerivePartialEq>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(ShouldDerivePartialEq),
+                "::",
+                stringify!(b)
+            )
+        );
+    }
+    test_field_b();
 }
 impl Clone for ShouldDerivePartialEq {
     fn clone(&self) -> Self {

--- a/tests/expectations/tests/disable-nested-struct-naming.rs
+++ b/tests/expectations/tests/disable-nested-struct-naming.rs
@@ -45,15 +45,23 @@ fn bindgen_test_layout_bar4() {
         4usize,
         concat!("Alignment of ", stringify!(bar4))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<bar4>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).x4) as usize - ptr as usize
-        },
-        0usize,
-        concat!("Offset of field: ", stringify!(bar4), "::", stringify!(x4))
-    );
+    fn test_field_x4() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<bar4>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).x4) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(bar4),
+                "::",
+                stringify!(x4)
+            )
+        );
+    }
+    test_field_x4();
 }
 #[test]
 fn bindgen_test_layout_bar1__bindgen_ty_1__bindgen_ty_1() {
@@ -70,38 +78,44 @@ fn bindgen_test_layout_bar1__bindgen_ty_1__bindgen_ty_1() {
             stringify!(bar1__bindgen_ty_1__bindgen_ty_1)
         )
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<
-                bar1__bindgen_ty_1__bindgen_ty_1,
-            >::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).x3) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(bar1__bindgen_ty_1__bindgen_ty_1),
-            "::",
-            stringify!(x3)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<
-                bar1__bindgen_ty_1__bindgen_ty_1,
-            >::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).b4) as usize - ptr as usize
-        },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(bar1__bindgen_ty_1__bindgen_ty_1),
-            "::",
-            stringify!(b4)
-        )
-    );
+    fn test_field_x3() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<
+                    bar1__bindgen_ty_1__bindgen_ty_1,
+                >::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).x3) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(bar1__bindgen_ty_1__bindgen_ty_1),
+                "::",
+                stringify!(x3)
+            )
+        );
+    }
+    test_field_x3();
+    fn test_field_b4() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<
+                    bar1__bindgen_ty_1__bindgen_ty_1,
+                >::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).b4) as usize - ptr as usize
+            },
+            4usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(bar1__bindgen_ty_1__bindgen_ty_1),
+                "::",
+                stringify!(b4)
+            )
+        );
+    }
+    test_field_b4();
 }
 #[test]
 fn bindgen_test_layout_bar1__bindgen_ty_1() {
@@ -115,36 +129,42 @@ fn bindgen_test_layout_bar1__bindgen_ty_1() {
         4usize,
         concat!("Alignment of ", stringify!(bar1__bindgen_ty_1))
     );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<bar1__bindgen_ty_1>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).x2) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(bar1__bindgen_ty_1),
-            "::",
-            stringify!(x2)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<bar1__bindgen_ty_1>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).b3) as usize - ptr as usize
-        },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(bar1__bindgen_ty_1),
-            "::",
-            stringify!(b3)
-        )
-    );
+    fn test_field_x2() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<bar1__bindgen_ty_1>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).x2) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(bar1__bindgen_ty_1),
+                "::",
+                stringify!(x2)
+            )
+        );
+    }
+    test_field_x2();
+    fn test_field_b3() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<bar1__bindgen_ty_1>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).b3) as usize - ptr as usize
+            },
+            4usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(bar1__bindgen_ty_1),
+                "::",
+                stringify!(b3)
+            )
+        );
+    }
+    test_field_b3();
 }
 #[test]
 fn bindgen_test_layout_bar1() {
@@ -158,24 +178,40 @@ fn bindgen_test_layout_bar1() {
         4usize,
         concat!("Alignment of ", stringify!(bar1))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<bar1>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).x1) as usize - ptr as usize
-        },
-        0usize,
-        concat!("Offset of field: ", stringify!(bar1), "::", stringify!(x1))
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<bar1>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).b2) as usize - ptr as usize
-        },
-        4usize,
-        concat!("Offset of field: ", stringify!(bar1), "::", stringify!(b2))
-    );
+    fn test_field_x1() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<bar1>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).x1) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(bar1),
+                "::",
+                stringify!(x1)
+            )
+        );
+    }
+    test_field_x1();
+    fn test_field_b2() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<bar1>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).b2) as usize - ptr as usize
+            },
+            4usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(bar1),
+                "::",
+                stringify!(b2)
+            )
+        );
+    }
+    test_field_b2();
 }
 #[test]
 fn bindgen_test_layout_foo() {
@@ -189,15 +225,18 @@ fn bindgen_test_layout_foo() {
         4usize,
         concat!("Alignment of ", stringify!(foo))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<foo>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).b1) as usize - ptr as usize
-        },
-        0usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(b1))
-    );
+    fn test_field_b1() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<foo>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).b1) as usize - ptr as usize
+            },
+            0usize,
+            concat!("Offset of field: ", stringify!(foo), "::", stringify!(b1))
+        );
+    }
+    test_field_b1();
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
@@ -226,15 +265,18 @@ fn bindgen_test_layout_baz() {
         4usize,
         concat!("Alignment of ", stringify!(baz))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<baz>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize
-        },
-        0usize,
-        concat!("Offset of field: ", stringify!(baz), "::", stringify!(x))
-    );
+    fn test_field_x() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<baz>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize
+            },
+            0usize,
+            concat!("Offset of field: ", stringify!(baz), "::", stringify!(x))
+        );
+    }
+    test_field_x();
 }
 #[test]
 fn bindgen_test_layout__bindgen_ty_1__bindgen_ty_1() {
@@ -248,22 +290,25 @@ fn bindgen_test_layout__bindgen_ty_1__bindgen_ty_1() {
         4usize,
         concat!("Alignment of ", stringify!(_bindgen_ty_1__bindgen_ty_1))
     );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<_bindgen_ty_1__bindgen_ty_1>::uninit(
-                );
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(_bindgen_ty_1__bindgen_ty_1),
-            "::",
-            stringify!(b)
-        )
-    );
+    fn test_field_b() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<
+                    _bindgen_ty_1__bindgen_ty_1,
+                >::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(_bindgen_ty_1__bindgen_ty_1),
+                "::",
+                stringify!(b)
+            )
+        );
+    }
+    test_field_b();
 }
 #[test]
 fn bindgen_test_layout__bindgen_ty_1() {
@@ -277,20 +322,23 @@ fn bindgen_test_layout__bindgen_ty_1() {
         4usize,
         concat!("Alignment of ", stringify!(_bindgen_ty_1))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<_bindgen_ty_1>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).anon2) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(_bindgen_ty_1),
-            "::",
-            stringify!(anon2)
-        )
-    );
+    fn test_field_anon2() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<_bindgen_ty_1>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).anon2) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(_bindgen_ty_1),
+                "::",
+                stringify!(anon2)
+            )
+        );
+    }
+    test_field_anon2();
 }
 extern "C" {
     pub static mut anon1: _bindgen_ty_1;

--- a/tests/expectations/tests/disable-untagged-union.rs
+++ b/tests/expectations/tests/disable-untagged-union.rs
@@ -67,22 +67,38 @@ fn bindgen_test_layout_Foo() {
         4usize,
         concat!("Alignment of ", stringify!(Foo))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Foo>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
-        },
-        0usize,
-        concat!("Offset of field: ", stringify!(Foo), "::", stringify!(bar))
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Foo>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize
-        },
-        0usize,
-        concat!("Offset of field: ", stringify!(Foo), "::", stringify!(baz))
-    );
+    fn test_field_bar() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Foo>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(Foo),
+                "::",
+                stringify!(bar)
+            )
+        );
+    }
+    test_field_bar();
+    fn test_field_baz() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Foo>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(Foo),
+                "::",
+                stringify!(baz)
+            )
+        );
+    }
+    test_field_baz();
 }

--- a/tests/expectations/tests/do-not-derive-copy.rs
+++ b/tests/expectations/tests/do-not-derive-copy.rs
@@ -25,20 +25,23 @@ fn bindgen_test_layout_WouldBeCopyButWeAreNotDerivingCopy() {
             stringify!(WouldBeCopyButWeAreNotDerivingCopy)
         )
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<
-                WouldBeCopyButWeAreNotDerivingCopy,
-            >::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(WouldBeCopyButWeAreNotDerivingCopy),
-            "::",
-            stringify!(x)
-        )
-    );
+    fn test_field_x() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<
+                    WouldBeCopyButWeAreNotDerivingCopy,
+                >::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(WouldBeCopyButWeAreNotDerivingCopy),
+                "::",
+                stringify!(x)
+            )
+        );
+    }
+    test_field_x();
 }

--- a/tests/expectations/tests/doggo-or-null.rs
+++ b/tests/expectations/tests/doggo-or-null.rs
@@ -22,15 +22,23 @@ fn bindgen_test_layout_Doggo() {
         4usize,
         concat!("Alignment of ", stringify!(Doggo))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Doggo>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize
-        },
-        0usize,
-        concat!("Offset of field: ", stringify!(Doggo), "::", stringify!(x))
-    );
+    fn test_field_x() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Doggo>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(Doggo),
+                "::",
+                stringify!(x)
+            )
+        );
+    }
+    test_field_x();
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, Hash, PartialEq)]

--- a/tests/expectations/tests/duplicated-namespaces-definitions.rs
+++ b/tests/expectations/tests/duplicated-namespaces-definitions.rs
@@ -30,34 +30,40 @@ pub mod root {
                 4usize,
                 concat!("Alignment of ", stringify!(Bar))
             );
-            assert_eq!(
-                unsafe {
-                    let uninit = ::std::mem::MaybeUninit::<Bar>::uninit();
-                    let ptr = uninit.as_ptr();
-                    ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize
-                },
-                0usize,
-                concat!(
-                    "Offset of field: ",
-                    stringify!(Bar),
-                    "::",
-                    stringify!(foo)
-                )
-            );
-            assert_eq!(
-                unsafe {
-                    let uninit = ::std::mem::MaybeUninit::<Bar>::uninit();
-                    let ptr = uninit.as_ptr();
-                    ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize
-                },
-                4usize,
-                concat!(
-                    "Offset of field: ",
-                    stringify!(Bar),
-                    "::",
-                    stringify!(baz)
-                )
-            );
+            fn test_field_foo() {
+                assert_eq!(
+                    unsafe {
+                        let uninit = ::std::mem::MaybeUninit::<Bar>::uninit();
+                        let ptr = uninit.as_ptr();
+                        ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize
+                    },
+                    0usize,
+                    concat!(
+                        "Offset of field: ",
+                        stringify!(Bar),
+                        "::",
+                        stringify!(foo)
+                    )
+                );
+            }
+            test_field_foo();
+            fn test_field_baz() {
+                assert_eq!(
+                    unsafe {
+                        let uninit = ::std::mem::MaybeUninit::<Bar>::uninit();
+                        let ptr = uninit.as_ptr();
+                        ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize
+                    },
+                    4usize,
+                    concat!(
+                        "Offset of field: ",
+                        stringify!(Bar),
+                        "::",
+                        stringify!(baz)
+                    )
+                );
+            }
+            test_field_baz();
         }
     }
     pub mod bar {
@@ -80,20 +86,23 @@ pub mod root {
                 8usize,
                 concat!("Alignment of ", stringify!(Foo))
             );
-            assert_eq!(
-                unsafe {
-                    let uninit = ::std::mem::MaybeUninit::<Foo>::uninit();
-                    let ptr = uninit.as_ptr();
-                    ::std::ptr::addr_of!((*ptr).ptr) as usize - ptr as usize
-                },
-                0usize,
-                concat!(
-                    "Offset of field: ",
-                    stringify!(Foo),
-                    "::",
-                    stringify!(ptr)
-                )
-            );
+            fn test_field_ptr() {
+                assert_eq!(
+                    unsafe {
+                        let uninit = ::std::mem::MaybeUninit::<Foo>::uninit();
+                        let ptr = uninit.as_ptr();
+                        ::std::ptr::addr_of!((*ptr).ptr) as usize - ptr as usize
+                    },
+                    0usize,
+                    concat!(
+                        "Offset of field: ",
+                        stringify!(Foo),
+                        "::",
+                        stringify!(ptr)
+                    )
+                );
+            }
+            test_field_ptr();
         }
         impl Default for Foo {
             fn default() -> Self {

--- a/tests/expectations/tests/dynamic_loading_with_blocklist.rs
+++ b/tests/expectations/tests/dynamic_loading_with_blocklist.rs
@@ -22,15 +22,18 @@ fn bindgen_test_layout_X() {
         4usize,
         concat!("Alignment of ", stringify!(X))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<X>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr)._x) as usize - ptr as usize
-        },
-        0usize,
-        concat!("Offset of field: ", stringify!(X), "::", stringify!(_x))
-    );
+    fn test_field__x() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<X>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr)._x) as usize - ptr as usize
+            },
+            0usize,
+            concat!("Offset of field: ", stringify!(X), "::", stringify!(_x))
+        );
+    }
+    test_field__x();
 }
 extern "C" {
     #[link_name = "\u{1}_ZN1X13some_functionEv"]

--- a/tests/expectations/tests/dynamic_loading_with_class.rs
+++ b/tests/expectations/tests/dynamic_loading_with_class.rs
@@ -22,15 +22,18 @@ fn bindgen_test_layout_A() {
         4usize,
         concat!("Alignment of ", stringify!(A))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<A>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr)._x) as usize - ptr as usize
-        },
-        0usize,
-        concat!("Offset of field: ", stringify!(A), "::", stringify!(_x))
-    );
+    fn test_field__x() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<A>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr)._x) as usize - ptr as usize
+            },
+            0usize,
+            concat!("Offset of field: ", stringify!(A), "::", stringify!(_x))
+        );
+    }
+    test_field__x();
 }
 extern "C" {
     #[link_name = "\u{1}_ZN1A13some_functionEv"]

--- a/tests/expectations/tests/enum-default-bitfield.rs
+++ b/tests/expectations/tests/enum-default-bitfield.rs
@@ -53,20 +53,23 @@ fn bindgen_test_layout_foo() {
         4usize,
         concat!("Alignment of ", stringify!(foo))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<foo>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).member) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(foo),
-            "::",
-            stringify!(member)
-        )
-    );
+    fn test_field_member() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<foo>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).member) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(foo),
+                "::",
+                stringify!(member)
+            )
+        );
+    }
+    test_field_member();
 }
 impl Default for foo {
     fn default() -> Self {

--- a/tests/expectations/tests/enum-default-consts.rs
+++ b/tests/expectations/tests/enum-default-consts.rs
@@ -25,20 +25,23 @@ fn bindgen_test_layout_foo() {
         4usize,
         concat!("Alignment of ", stringify!(foo))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<foo>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).member) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(foo),
-            "::",
-            stringify!(member)
-        )
-    );
+    fn test_field_member() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<foo>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).member) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(foo),
+                "::",
+                stringify!(member)
+            )
+        );
+    }
+    test_field_member();
 }
 impl Default for foo {
     fn default() -> Self {

--- a/tests/expectations/tests/enum-default-module.rs
+++ b/tests/expectations/tests/enum-default-module.rs
@@ -27,20 +27,23 @@ fn bindgen_test_layout_foo() {
         4usize,
         concat!("Alignment of ", stringify!(foo))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<foo>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).member) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(foo),
-            "::",
-            stringify!(member)
-        )
-    );
+    fn test_field_member() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<foo>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).member) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(foo),
+                "::",
+                stringify!(member)
+            )
+        );
+    }
+    test_field_member();
 }
 impl Default for foo {
     fn default() -> Self {

--- a/tests/expectations/tests/enum-default-rust.rs
+++ b/tests/expectations/tests/enum-default-rust.rs
@@ -30,20 +30,23 @@ fn bindgen_test_layout_foo() {
         4usize,
         concat!("Alignment of ", stringify!(foo))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<foo>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).member) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(foo),
-            "::",
-            stringify!(member)
-        )
-    );
+    fn test_field_member() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<foo>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).member) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(foo),
+                "::",
+                stringify!(member)
+            )
+        );
+    }
+    test_field_member();
 }
 impl Default for foo {
     fn default() -> Self {

--- a/tests/expectations/tests/enum-no-debug-rust.rs
+++ b/tests/expectations/tests/enum-no-debug-rust.rs
@@ -30,20 +30,23 @@ fn bindgen_test_layout_foo() {
         4usize,
         concat!("Alignment of ", stringify!(foo))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<foo>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).member) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(foo),
-            "::",
-            stringify!(member)
-        )
-    );
+    fn test_field_member() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<foo>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).member) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(foo),
+                "::",
+                stringify!(member)
+            )
+        );
+    }
+    test_field_member();
 }
 impl Default for foo {
     fn default() -> Self {

--- a/tests/expectations/tests/enum.rs
+++ b/tests/expectations/tests/enum.rs
@@ -25,20 +25,23 @@ fn bindgen_test_layout_foo() {
         4usize,
         concat!("Alignment of ", stringify!(foo))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<foo>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).member) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(foo),
-            "::",
-            stringify!(member)
-        )
-    );
+    fn test_field_member() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<foo>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).member) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(foo),
+                "::",
+                stringify!(member)
+            )
+        );
+    }
+    test_field_member();
 }
 impl Default for foo {
     fn default() -> Self {

--- a/tests/expectations/tests/enum_and_vtable_mangling.rs
+++ b/tests/expectations/tests/enum_and_vtable_mangling.rs
@@ -35,15 +35,18 @@ fn bindgen_test_layout_C() {
         8usize,
         concat!("Alignment of ", stringify!(C))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<C>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).i) as usize - ptr as usize
-        },
-        8usize,
-        concat!("Offset of field: ", stringify!(C), "::", stringify!(i))
-    );
+    fn test_field_i() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<C>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).i) as usize - ptr as usize
+            },
+            8usize,
+            concat!("Offset of field: ", stringify!(C), "::", stringify!(i))
+        );
+    }
+    test_field_i();
 }
 impl Default for C {
     fn default() -> Self {

--- a/tests/expectations/tests/explicit-padding.rs
+++ b/tests/expectations/tests/explicit-padding.rs
@@ -26,48 +26,57 @@ fn bindgen_test_layout_pad_me() {
         4usize,
         concat!("Alignment of ", stringify!(pad_me))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<pad_me>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).first) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(pad_me),
-            "::",
-            stringify!(first)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<pad_me>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).second) as usize - ptr as usize
-        },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(pad_me),
-            "::",
-            stringify!(second)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<pad_me>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).third) as usize - ptr as usize
-        },
-        8usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(pad_me),
-            "::",
-            stringify!(third)
-        )
-    );
+    fn test_field_first() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<pad_me>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).first) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(pad_me),
+                "::",
+                stringify!(first)
+            )
+        );
+    }
+    test_field_first();
+    fn test_field_second() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<pad_me>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).second) as usize - ptr as usize
+            },
+            4usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(pad_me),
+                "::",
+                stringify!(second)
+            )
+        );
+    }
+    test_field_second();
+    fn test_field_third() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<pad_me>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).third) as usize - ptr as usize
+            },
+            8usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(pad_me),
+                "::",
+                stringify!(third)
+            )
+        );
+    }
+    test_field_third();
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -88,48 +97,57 @@ fn bindgen_test_layout_dont_pad_me() {
         4usize,
         concat!("Alignment of ", stringify!(dont_pad_me))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<dont_pad_me>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).first) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(dont_pad_me),
-            "::",
-            stringify!(first)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<dont_pad_me>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).second) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(dont_pad_me),
-            "::",
-            stringify!(second)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<dont_pad_me>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).third) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(dont_pad_me),
-            "::",
-            stringify!(third)
-        )
-    );
+    fn test_field_first() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<dont_pad_me>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).first) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(dont_pad_me),
+                "::",
+                stringify!(first)
+            )
+        );
+    }
+    test_field_first();
+    fn test_field_second() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<dont_pad_me>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).second) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(dont_pad_me),
+                "::",
+                stringify!(second)
+            )
+        );
+    }
+    test_field_second();
+    fn test_field_third() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<dont_pad_me>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).third) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(dont_pad_me),
+                "::",
+                stringify!(third)
+            )
+        );
+    }
+    test_field_third();
 }
 impl Default for dont_pad_me {
     fn default() -> Self {

--- a/tests/expectations/tests/extern-const-struct.rs
+++ b/tests/expectations/tests/extern-const-struct.rs
@@ -22,20 +22,23 @@ fn bindgen_test_layout_nsFoo() {
         4usize,
         concat!("Alignment of ", stringify!(nsFoo))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<nsFoo>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).details) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(nsFoo),
-            "::",
-            stringify!(details)
-        )
-    );
+    fn test_field_details() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<nsFoo>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).details) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(nsFoo),
+                "::",
+                stringify!(details)
+            )
+        );
+    }
+    test_field_details();
 }
 impl Default for nsFoo {
     fn default() -> Self {

--- a/tests/expectations/tests/forward-declaration-autoptr.rs
+++ b/tests/expectations/tests/forward-declaration-autoptr.rs
@@ -42,20 +42,23 @@ fn bindgen_test_layout_Bar() {
         8usize,
         concat!("Alignment of ", stringify!(Bar))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Bar>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).m_member) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(Bar),
-            "::",
-            stringify!(m_member)
-        )
-    );
+    fn test_field_m_member() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Bar>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).m_member) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(Bar),
+                "::",
+                stringify!(m_member)
+            )
+        );
+    }
+    test_field_m_member();
 }
 impl Default for Bar {
     fn default() -> Self {

--- a/tests/expectations/tests/forward_declared_complex_types.rs
+++ b/tests/expectations/tests/forward_declared_complex_types.rs
@@ -45,15 +45,18 @@ fn bindgen_test_layout_Bar() {
         8usize,
         concat!("Alignment of ", stringify!(Bar))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Bar>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).f) as usize - ptr as usize
-        },
-        0usize,
-        concat!("Offset of field: ", stringify!(Bar), "::", stringify!(f))
-    );
+    fn test_field_f() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Bar>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).f) as usize - ptr as usize
+            },
+            0usize,
+            concat!("Offset of field: ", stringify!(Bar), "::", stringify!(f))
+        );
+    }
+    test_field_f();
 }
 impl Default for Bar {
     fn default() -> Self {

--- a/tests/expectations/tests/forward_declared_complex_types_1_0.rs
+++ b/tests/expectations/tests/forward_declared_complex_types_1_0.rs
@@ -55,15 +55,18 @@ fn bindgen_test_layout_Bar() {
         8usize,
         concat!("Alignment of ", stringify!(Bar))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Bar>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).f) as usize - ptr as usize
-        },
-        0usize,
-        concat!("Offset of field: ", stringify!(Bar), "::", stringify!(f))
-    );
+    fn test_field_f() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Bar>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).f) as usize - ptr as usize
+            },
+            0usize,
+            concat!("Offset of field: ", stringify!(Bar), "::", stringify!(f))
+        );
+    }
+    test_field_f();
 }
 impl Clone for Bar {
     fn clone(&self) -> Self {

--- a/tests/expectations/tests/forward_declared_struct.rs
+++ b/tests/expectations/tests/forward_declared_struct.rs
@@ -22,15 +22,18 @@ fn bindgen_test_layout_a() {
         4usize,
         concat!("Alignment of ", stringify!(a))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<a>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-        },
-        0usize,
-        concat!("Offset of field: ", stringify!(a), "::", stringify!(b))
-    );
+    fn test_field_b() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<a>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
+            },
+            0usize,
+            concat!("Offset of field: ", stringify!(a), "::", stringify!(b))
+        );
+    }
+    test_field_b();
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
@@ -49,13 +52,16 @@ fn bindgen_test_layout_c() {
         4usize,
         concat!("Alignment of ", stringify!(c))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<c>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize
-        },
-        0usize,
-        concat!("Offset of field: ", stringify!(c), "::", stringify!(d))
-    );
+    fn test_field_d() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<c>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize
+            },
+            0usize,
+            concat!("Offset of field: ", stringify!(c), "::", stringify!(d))
+        );
+    }
+    test_field_d();
 }

--- a/tests/expectations/tests/func_ptr_in_struct.rs
+++ b/tests/expectations/tests/func_ptr_in_struct.rs
@@ -32,13 +32,21 @@ fn bindgen_test_layout_Foo() {
         8usize,
         concat!("Alignment of ", stringify!(Foo))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Foo>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
-        },
-        0usize,
-        concat!("Offset of field: ", stringify!(Foo), "::", stringify!(bar))
-    );
+    fn test_field_bar() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Foo>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(Foo),
+                "::",
+                stringify!(bar)
+            )
+        );
+    }
+    test_field_bar();
 }

--- a/tests/expectations/tests/gen-destructors-neg.rs
+++ b/tests/expectations/tests/gen-destructors-neg.rs
@@ -22,13 +22,21 @@ fn bindgen_test_layout_Foo() {
         4usize,
         concat!("Alignment of ", stringify!(Foo))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Foo>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
-        },
-        0usize,
-        concat!("Offset of field: ", stringify!(Foo), "::", stringify!(bar))
-    );
+    fn test_field_bar() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Foo>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(Foo),
+                "::",
+                stringify!(bar)
+            )
+        );
+    }
+    test_field_bar();
 }

--- a/tests/expectations/tests/gen-destructors.rs
+++ b/tests/expectations/tests/gen-destructors.rs
@@ -22,15 +22,23 @@ fn bindgen_test_layout_Foo() {
         4usize,
         concat!("Alignment of ", stringify!(Foo))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Foo>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
-        },
-        0usize,
-        concat!("Offset of field: ", stringify!(Foo), "::", stringify!(bar))
-    );
+    fn test_field_bar() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Foo>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(Foo),
+                "::",
+                stringify!(bar)
+            )
+        );
+    }
+    test_field_bar();
 }
 extern "C" {
     #[link_name = "\u{1}_ZN3FooD1Ev"]

--- a/tests/expectations/tests/i128.rs
+++ b/tests/expectations/tests/i128.rs
@@ -24,32 +24,38 @@ fn bindgen_test_layout_foo() {
         16usize,
         concat!("Alignment of ", stringify!(foo))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<foo>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).my_signed) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(foo),
-            "::",
-            stringify!(my_signed)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<foo>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).my_unsigned) as usize - ptr as usize
-        },
-        16usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(foo),
-            "::",
-            stringify!(my_unsigned)
-        )
-    );
+    fn test_field_my_signed() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<foo>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).my_signed) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(foo),
+                "::",
+                stringify!(my_signed)
+            )
+        );
+    }
+    test_field_my_signed();
+    fn test_field_my_unsigned() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<foo>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).my_unsigned) as usize - ptr as usize
+            },
+            16usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(foo),
+                "::",
+                stringify!(my_unsigned)
+            )
+        );
+    }
+    test_field_my_unsigned();
 }

--- a/tests/expectations/tests/inline_namespace.rs
+++ b/tests/expectations/tests/inline_namespace.rs
@@ -31,19 +31,22 @@ pub mod root {
             4usize,
             concat!("Alignment of ", stringify!(Bar))
         );
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Bar>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(Bar),
-                "::",
-                stringify!(baz)
-            )
-        );
+        fn test_field_baz() {
+            assert_eq!(
+                unsafe {
+                    let uninit = ::std::mem::MaybeUninit::<Bar>::uninit();
+                    let ptr = uninit.as_ptr();
+                    ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize
+                },
+                0usize,
+                concat!(
+                    "Offset of field: ",
+                    stringify!(Bar),
+                    "::",
+                    stringify!(baz)
+                )
+            );
+        }
+        test_field_baz();
     }
 }

--- a/tests/expectations/tests/inline_namespace_conservative.rs
+++ b/tests/expectations/tests/inline_namespace_conservative.rs
@@ -36,19 +36,22 @@ pub mod root {
             4usize,
             concat!("Alignment of ", stringify!(Bar))
         );
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Bar>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(Bar),
-                "::",
-                stringify!(baz)
-            )
-        );
+        fn test_field_baz() {
+            assert_eq!(
+                unsafe {
+                    let uninit = ::std::mem::MaybeUninit::<Bar>::uninit();
+                    let ptr = uninit.as_ptr();
+                    ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize
+                },
+                0usize,
+                concat!(
+                    "Offset of field: ",
+                    stringify!(Bar),
+                    "::",
+                    stringify!(baz)
+                )
+            );
+        }
+        test_field_baz();
     }
 }

--- a/tests/expectations/tests/inner_const.rs
+++ b/tests/expectations/tests/inner_const.rs
@@ -30,13 +30,21 @@ fn bindgen_test_layout_Foo() {
         4usize,
         concat!("Alignment of ", stringify!(Foo))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Foo>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
-        },
-        0usize,
-        concat!("Offset of field: ", stringify!(Foo), "::", stringify!(bar))
-    );
+    fn test_field_bar() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Foo>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(Foo),
+                "::",
+                stringify!(bar)
+            )
+        );
+    }
+    test_field_bar();
 }

--- a/tests/expectations/tests/inner_template_self.rs
+++ b/tests/expectations/tests/inner_template_self.rs
@@ -37,20 +37,23 @@ fn bindgen_test_layout_InstantiateIt() {
         8usize,
         concat!("Alignment of ", stringify!(InstantiateIt))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<InstantiateIt>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).m_list) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(InstantiateIt),
-            "::",
-            stringify!(m_list)
-        )
-    );
+    fn test_field_m_list() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<InstantiateIt>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).m_list) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(InstantiateIt),
+                "::",
+                stringify!(m_list)
+            )
+        );
+    }
+    test_field_m_list();
 }
 impl Default for InstantiateIt {
     fn default() -> Self {

--- a/tests/expectations/tests/issue-1118-using-forward-decl.rs
+++ b/tests/expectations/tests/issue-1118-using-forward-decl.rs
@@ -23,20 +23,23 @@ fn bindgen_test_layout_nsTArray_base() {
         8usize,
         concat!("Alignment of ", stringify!(nsTArray_base))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<nsTArray_base>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(nsTArray_base),
-            "::",
-            stringify!(d)
-        )
-    );
+    fn test_field_d() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<nsTArray_base>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(nsTArray_base),
+                "::",
+                stringify!(d)
+            )
+        );
+    }
+    test_field_d();
 }
 impl Default for nsTArray_base {
     fn default() -> Self {
@@ -78,20 +81,23 @@ fn bindgen_test_layout_nsIContent() {
         8usize,
         concat!("Alignment of ", stringify!(nsIContent))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<nsIContent>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(nsIContent),
-            "::",
-            stringify!(foo)
-        )
-    );
+    fn test_field_foo() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<nsIContent>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(nsIContent),
+                "::",
+                stringify!(foo)
+            )
+        );
+    }
+    test_field_foo();
 }
 impl Default for nsIContent {
     fn default() -> Self {

--- a/tests/expectations/tests/issue-1216-variadic-member.rs
+++ b/tests/expectations/tests/issue-1216-variadic-member.rs
@@ -32,13 +32,16 @@ fn bindgen_test_layout_Foo() {
         8usize,
         concat!("Alignment of ", stringify!(Foo))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Foo>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).f) as usize - ptr as usize
-        },
-        0usize,
-        concat!("Offset of field: ", stringify!(Foo), "::", stringify!(f))
-    );
+    fn test_field_f() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Foo>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).f) as usize - ptr as usize
+            },
+            0usize,
+            concat!("Offset of field: ", stringify!(Foo), "::", stringify!(f))
+        );
+    }
+    test_field_f();
 }

--- a/tests/expectations/tests/issue-1281.rs
+++ b/tests/expectations/tests/issue-1281.rs
@@ -27,15 +27,23 @@ fn bindgen_test_layout_foo() {
         4usize,
         concat!("Alignment of ", stringify!(foo))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<foo>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize
-        },
-        0usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(foo))
-    );
+    fn test_field_foo() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<foo>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(foo),
+                "::",
+                stringify!(foo)
+            )
+        );
+    }
+    test_field_foo();
 }
 #[test]
 fn bindgen_test_layout_bar() {
@@ -49,15 +57,18 @@ fn bindgen_test_layout_bar() {
         4usize,
         concat!("Alignment of ", stringify!(bar))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<bar>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).u) as usize - ptr as usize
-        },
-        0usize,
-        concat!("Offset of field: ", stringify!(bar), "::", stringify!(u))
-    );
+    fn test_field_u() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<bar>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).u) as usize - ptr as usize
+            },
+            0usize,
+            concat!("Offset of field: ", stringify!(bar), "::", stringify!(u))
+        );
+    }
+    test_field_u();
 }
 pub type bar_t = bar;
 #[repr(C)]
@@ -77,13 +88,16 @@ fn bindgen_test_layout_baz() {
         4usize,
         concat!("Alignment of ", stringify!(baz))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<baz>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).f) as usize - ptr as usize
-        },
-        0usize,
-        concat!("Offset of field: ", stringify!(baz), "::", stringify!(f))
-    );
+    fn test_field_f() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<baz>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).f) as usize - ptr as usize
+            },
+            0usize,
+            concat!("Offset of field: ", stringify!(baz), "::", stringify!(f))
+        );
+    }
+    test_field_f();
 }

--- a/tests/expectations/tests/issue-1285.rs
+++ b/tests/expectations/tests/issue-1285.rs
@@ -28,34 +28,42 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
         4usize,
         concat!("Alignment of ", stringify!(foo__bindgen_ty_1))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<foo__bindgen_ty_1>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(foo__bindgen_ty_1),
-            "::",
-            stringify!(a)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<foo__bindgen_ty_1>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(foo__bindgen_ty_1),
-            "::",
-            stringify!(b)
-        )
-    );
+    fn test_field_a() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<foo__bindgen_ty_1>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(foo__bindgen_ty_1),
+                "::",
+                stringify!(a)
+            )
+        );
+    }
+    test_field_a();
+    fn test_field_b() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<foo__bindgen_ty_1>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(foo__bindgen_ty_1),
+                "::",
+                stringify!(b)
+            )
+        );
+    }
+    test_field_b();
 }
 impl Default for foo__bindgen_ty_1 {
     fn default() -> Self {
@@ -78,15 +86,23 @@ fn bindgen_test_layout_foo() {
         4usize,
         concat!("Alignment of ", stringify!(foo))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<foo>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
-        },
-        0usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar))
-    );
+    fn test_field_bar() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<foo>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(foo),
+                "::",
+                stringify!(bar)
+            )
+        );
+    }
+    test_field_bar();
 }
 impl Default for foo {
     fn default() -> Self {

--- a/tests/expectations/tests/issue-1291.rs
+++ b/tests/expectations/tests/issue-1291.rs
@@ -37,204 +37,259 @@ fn bindgen_test_layout_RTCRay() {
         16usize,
         concat!("Alignment of ", stringify!(RTCRay))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<RTCRay>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).org) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(RTCRay),
-            "::",
-            stringify!(org)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<RTCRay>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).align0) as usize - ptr as usize
-        },
-        12usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(RTCRay),
-            "::",
-            stringify!(align0)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<RTCRay>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).dir) as usize - ptr as usize
-        },
-        16usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(RTCRay),
-            "::",
-            stringify!(dir)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<RTCRay>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).align1) as usize - ptr as usize
-        },
-        28usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(RTCRay),
-            "::",
-            stringify!(align1)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<RTCRay>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).tnear) as usize - ptr as usize
-        },
-        32usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(RTCRay),
-            "::",
-            stringify!(tnear)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<RTCRay>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).tfar) as usize - ptr as usize
-        },
-        36usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(RTCRay),
-            "::",
-            stringify!(tfar)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<RTCRay>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).time) as usize - ptr as usize
-        },
-        40usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(RTCRay),
-            "::",
-            stringify!(time)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<RTCRay>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mask) as usize - ptr as usize
-        },
-        44usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(RTCRay),
-            "::",
-            stringify!(mask)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<RTCRay>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).Ng) as usize - ptr as usize
-        },
-        48usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(RTCRay),
-            "::",
-            stringify!(Ng)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<RTCRay>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).align2) as usize - ptr as usize
-        },
-        60usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(RTCRay),
-            "::",
-            stringify!(align2)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<RTCRay>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).u) as usize - ptr as usize
-        },
-        64usize,
-        concat!("Offset of field: ", stringify!(RTCRay), "::", stringify!(u))
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<RTCRay>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).v) as usize - ptr as usize
-        },
-        68usize,
-        concat!("Offset of field: ", stringify!(RTCRay), "::", stringify!(v))
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<RTCRay>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).geomID) as usize - ptr as usize
-        },
-        72usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(RTCRay),
-            "::",
-            stringify!(geomID)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<RTCRay>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).primID) as usize - ptr as usize
-        },
-        76usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(RTCRay),
-            "::",
-            stringify!(primID)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<RTCRay>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).instID) as usize - ptr as usize
-        },
-        80usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(RTCRay),
-            "::",
-            stringify!(instID)
-        )
-    );
+    fn test_field_org() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<RTCRay>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).org) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(RTCRay),
+                "::",
+                stringify!(org)
+            )
+        );
+    }
+    test_field_org();
+    fn test_field_align0() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<RTCRay>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).align0) as usize - ptr as usize
+            },
+            12usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(RTCRay),
+                "::",
+                stringify!(align0)
+            )
+        );
+    }
+    test_field_align0();
+    fn test_field_dir() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<RTCRay>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).dir) as usize - ptr as usize
+            },
+            16usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(RTCRay),
+                "::",
+                stringify!(dir)
+            )
+        );
+    }
+    test_field_dir();
+    fn test_field_align1() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<RTCRay>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).align1) as usize - ptr as usize
+            },
+            28usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(RTCRay),
+                "::",
+                stringify!(align1)
+            )
+        );
+    }
+    test_field_align1();
+    fn test_field_tnear() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<RTCRay>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).tnear) as usize - ptr as usize
+            },
+            32usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(RTCRay),
+                "::",
+                stringify!(tnear)
+            )
+        );
+    }
+    test_field_tnear();
+    fn test_field_tfar() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<RTCRay>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).tfar) as usize - ptr as usize
+            },
+            36usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(RTCRay),
+                "::",
+                stringify!(tfar)
+            )
+        );
+    }
+    test_field_tfar();
+    fn test_field_time() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<RTCRay>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).time) as usize - ptr as usize
+            },
+            40usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(RTCRay),
+                "::",
+                stringify!(time)
+            )
+        );
+    }
+    test_field_time();
+    fn test_field_mask() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<RTCRay>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).mask) as usize - ptr as usize
+            },
+            44usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(RTCRay),
+                "::",
+                stringify!(mask)
+            )
+        );
+    }
+    test_field_mask();
+    fn test_field_Ng() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<RTCRay>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).Ng) as usize - ptr as usize
+            },
+            48usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(RTCRay),
+                "::",
+                stringify!(Ng)
+            )
+        );
+    }
+    test_field_Ng();
+    fn test_field_align2() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<RTCRay>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).align2) as usize - ptr as usize
+            },
+            60usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(RTCRay),
+                "::",
+                stringify!(align2)
+            )
+        );
+    }
+    test_field_align2();
+    fn test_field_u() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<RTCRay>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).u) as usize - ptr as usize
+            },
+            64usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(RTCRay),
+                "::",
+                stringify!(u)
+            )
+        );
+    }
+    test_field_u();
+    fn test_field_v() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<RTCRay>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).v) as usize - ptr as usize
+            },
+            68usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(RTCRay),
+                "::",
+                stringify!(v)
+            )
+        );
+    }
+    test_field_v();
+    fn test_field_geomID() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<RTCRay>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).geomID) as usize - ptr as usize
+            },
+            72usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(RTCRay),
+                "::",
+                stringify!(geomID)
+            )
+        );
+    }
+    test_field_geomID();
+    fn test_field_primID() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<RTCRay>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).primID) as usize - ptr as usize
+            },
+            76usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(RTCRay),
+                "::",
+                stringify!(primID)
+            )
+        );
+    }
+    test_field_primID();
+    fn test_field_instID() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<RTCRay>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).instID) as usize - ptr as usize
+            },
+            80usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(RTCRay),
+                "::",
+                stringify!(instID)
+            )
+        );
+    }
+    test_field_instID();
 }

--- a/tests/expectations/tests/issue-1382-rust-primitive-types.rs
+++ b/tests/expectations/tests/issue-1382-rust-primitive-types.rs
@@ -43,150 +43,242 @@ fn bindgen_test_layout_Foo() {
         4usize,
         concat!("Alignment of ", stringify!(Foo))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Foo>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).i8_) as usize - ptr as usize
-        },
-        0usize,
-        concat!("Offset of field: ", stringify!(Foo), "::", stringify!(i8_))
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Foo>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).u8_) as usize - ptr as usize
-        },
-        4usize,
-        concat!("Offset of field: ", stringify!(Foo), "::", stringify!(u8_))
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Foo>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).i16_) as usize - ptr as usize
-        },
-        8usize,
-        concat!("Offset of field: ", stringify!(Foo), "::", stringify!(i16_))
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Foo>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).u16_) as usize - ptr as usize
-        },
-        12usize,
-        concat!("Offset of field: ", stringify!(Foo), "::", stringify!(u16_))
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Foo>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).i32_) as usize - ptr as usize
-        },
-        16usize,
-        concat!("Offset of field: ", stringify!(Foo), "::", stringify!(i32_))
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Foo>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).u32_) as usize - ptr as usize
-        },
-        20usize,
-        concat!("Offset of field: ", stringify!(Foo), "::", stringify!(u32_))
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Foo>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).i64_) as usize - ptr as usize
-        },
-        24usize,
-        concat!("Offset of field: ", stringify!(Foo), "::", stringify!(i64_))
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Foo>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).u64_) as usize - ptr as usize
-        },
-        28usize,
-        concat!("Offset of field: ", stringify!(Foo), "::", stringify!(u64_))
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Foo>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).i128_) as usize - ptr as usize
-        },
-        32usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(Foo),
-            "::",
-            stringify!(i128_)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Foo>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).u128_) as usize - ptr as usize
-        },
-        36usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(Foo),
-            "::",
-            stringify!(u128_)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Foo>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).isize_) as usize - ptr as usize
-        },
-        40usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(Foo),
-            "::",
-            stringify!(isize_)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Foo>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).usize_) as usize - ptr as usize
-        },
-        44usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(Foo),
-            "::",
-            stringify!(usize_)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Foo>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).f32_) as usize - ptr as usize
-        },
-        48usize,
-        concat!("Offset of field: ", stringify!(Foo), "::", stringify!(f32_))
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Foo>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).f64_) as usize - ptr as usize
-        },
-        52usize,
-        concat!("Offset of field: ", stringify!(Foo), "::", stringify!(f64_))
-    );
+    fn test_field_i8() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Foo>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).i8_) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(Foo),
+                "::",
+                stringify!(i8_)
+            )
+        );
+    }
+    test_field_i8();
+    fn test_field_u8() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Foo>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).u8_) as usize - ptr as usize
+            },
+            4usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(Foo),
+                "::",
+                stringify!(u8_)
+            )
+        );
+    }
+    test_field_u8();
+    fn test_field_i16() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Foo>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).i16_) as usize - ptr as usize
+            },
+            8usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(Foo),
+                "::",
+                stringify!(i16_)
+            )
+        );
+    }
+    test_field_i16();
+    fn test_field_u16() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Foo>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).u16_) as usize - ptr as usize
+            },
+            12usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(Foo),
+                "::",
+                stringify!(u16_)
+            )
+        );
+    }
+    test_field_u16();
+    fn test_field_i32() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Foo>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).i32_) as usize - ptr as usize
+            },
+            16usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(Foo),
+                "::",
+                stringify!(i32_)
+            )
+        );
+    }
+    test_field_i32();
+    fn test_field_u32() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Foo>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).u32_) as usize - ptr as usize
+            },
+            20usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(Foo),
+                "::",
+                stringify!(u32_)
+            )
+        );
+    }
+    test_field_u32();
+    fn test_field_i64() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Foo>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).i64_) as usize - ptr as usize
+            },
+            24usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(Foo),
+                "::",
+                stringify!(i64_)
+            )
+        );
+    }
+    test_field_i64();
+    fn test_field_u64() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Foo>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).u64_) as usize - ptr as usize
+            },
+            28usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(Foo),
+                "::",
+                stringify!(u64_)
+            )
+        );
+    }
+    test_field_u64();
+    fn test_field_i128() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Foo>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).i128_) as usize - ptr as usize
+            },
+            32usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(Foo),
+                "::",
+                stringify!(i128_)
+            )
+        );
+    }
+    test_field_i128();
+    fn test_field_u128() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Foo>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).u128_) as usize - ptr as usize
+            },
+            36usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(Foo),
+                "::",
+                stringify!(u128_)
+            )
+        );
+    }
+    test_field_u128();
+    fn test_field_isize() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Foo>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).isize_) as usize - ptr as usize
+            },
+            40usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(Foo),
+                "::",
+                stringify!(isize_)
+            )
+        );
+    }
+    test_field_isize();
+    fn test_field_usize() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Foo>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).usize_) as usize - ptr as usize
+            },
+            44usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(Foo),
+                "::",
+                stringify!(usize_)
+            )
+        );
+    }
+    test_field_usize();
+    fn test_field_f32() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Foo>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).f32_) as usize - ptr as usize
+            },
+            48usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(Foo),
+                "::",
+                stringify!(f32_)
+            )
+        );
+    }
+    test_field_f32();
+    fn test_field_f64() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Foo>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).f64_) as usize - ptr as usize
+            },
+            52usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(Foo),
+                "::",
+                stringify!(f64_)
+            )
+        );
+    }
+    test_field_f64();
 }

--- a/tests/expectations/tests/issue-1443.rs
+++ b/tests/expectations/tests/issue-1443.rs
@@ -28,24 +28,30 @@ fn bindgen_test_layout_Bar() {
         8usize,
         concat!("Alignment of ", stringify!(Bar))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Bar>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).f) as usize - ptr as usize
-        },
-        0usize,
-        concat!("Offset of field: ", stringify!(Bar), "::", stringify!(f))
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Bar>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).m) as usize - ptr as usize
-        },
-        8usize,
-        concat!("Offset of field: ", stringify!(Bar), "::", stringify!(m))
-    );
+    fn test_field_f() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Bar>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).f) as usize - ptr as usize
+            },
+            0usize,
+            concat!("Offset of field: ", stringify!(Bar), "::", stringify!(f))
+        );
+    }
+    test_field_f();
+    fn test_field_m() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Bar>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).m) as usize - ptr as usize
+            },
+            8usize,
+            concat!("Offset of field: ", stringify!(Bar), "::", stringify!(m))
+        );
+    }
+    test_field_m();
 }
 impl Default for Bar {
     fn default() -> Self {
@@ -74,24 +80,30 @@ fn bindgen_test_layout_Baz() {
         8usize,
         concat!("Alignment of ", stringify!(Baz))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Baz>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).f) as usize - ptr as usize
-        },
-        0usize,
-        concat!("Offset of field: ", stringify!(Baz), "::", stringify!(f))
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Baz>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).m) as usize - ptr as usize
-        },
-        8usize,
-        concat!("Offset of field: ", stringify!(Baz), "::", stringify!(m))
-    );
+    fn test_field_f() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Baz>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).f) as usize - ptr as usize
+            },
+            0usize,
+            concat!("Offset of field: ", stringify!(Baz), "::", stringify!(f))
+        );
+    }
+    test_field_f();
+    fn test_field_m() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Baz>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).m) as usize - ptr as usize
+            },
+            8usize,
+            concat!("Offset of field: ", stringify!(Baz), "::", stringify!(m))
+        );
+    }
+    test_field_m();
 }
 impl Default for Baz {
     fn default() -> Self {
@@ -120,24 +132,30 @@ fn bindgen_test_layout_Tar() {
         8usize,
         concat!("Alignment of ", stringify!(Tar))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Tar>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).f) as usize - ptr as usize
-        },
-        0usize,
-        concat!("Offset of field: ", stringify!(Tar), "::", stringify!(f))
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Tar>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).m) as usize - ptr as usize
-        },
-        8usize,
-        concat!("Offset of field: ", stringify!(Tar), "::", stringify!(m))
-    );
+    fn test_field_f() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Tar>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).f) as usize - ptr as usize
+            },
+            0usize,
+            concat!("Offset of field: ", stringify!(Tar), "::", stringify!(f))
+        );
+    }
+    test_field_f();
+    fn test_field_m() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Tar>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).m) as usize - ptr as usize
+            },
+            8usize,
+            concat!("Offset of field: ", stringify!(Tar), "::", stringify!(m))
+        );
+    }
+    test_field_m();
 }
 impl Default for Tar {
     fn default() -> Self {
@@ -166,24 +184,30 @@ fn bindgen_test_layout_Taz() {
         8usize,
         concat!("Alignment of ", stringify!(Taz))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Taz>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).f) as usize - ptr as usize
-        },
-        0usize,
-        concat!("Offset of field: ", stringify!(Taz), "::", stringify!(f))
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Taz>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).m) as usize - ptr as usize
-        },
-        8usize,
-        concat!("Offset of field: ", stringify!(Taz), "::", stringify!(m))
-    );
+    fn test_field_f() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Taz>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).f) as usize - ptr as usize
+            },
+            0usize,
+            concat!("Offset of field: ", stringify!(Taz), "::", stringify!(f))
+        );
+    }
+    test_field_f();
+    fn test_field_m() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Taz>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).m) as usize - ptr as usize
+            },
+            8usize,
+            concat!("Offset of field: ", stringify!(Taz), "::", stringify!(m))
+        );
+    }
+    test_field_m();
 }
 impl Default for Taz {
     fn default() -> Self {

--- a/tests/expectations/tests/issue-1454.rs
+++ b/tests/expectations/tests/issue-1454.rs
@@ -26,18 +26,21 @@ fn bindgen_test_layout_local_type() {
         1usize,
         concat!("Alignment of ", stringify!(local_type))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<local_type>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).inner) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(local_type),
-            "::",
-            stringify!(inner)
-        )
-    );
+    fn test_field_inner() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<local_type>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).inner) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(local_type),
+                "::",
+                stringify!(inner)
+            )
+        );
+    }
+    test_field_inner();
 }

--- a/tests/expectations/tests/issue-1498.rs
+++ b/tests/expectations/tests/issue-1498.rs
@@ -43,36 +43,44 @@ fn bindgen_test_layout_rte_memseg__bindgen_ty_1() {
         8usize,
         concat!("Alignment of ", stringify!(rte_memseg__bindgen_ty_1))
     );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<rte_memseg__bindgen_ty_1>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).addr) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_memseg__bindgen_ty_1),
-            "::",
-            stringify!(addr)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<rte_memseg__bindgen_ty_1>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).addr_64) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_memseg__bindgen_ty_1),
-            "::",
-            stringify!(addr_64)
-        )
-    );
+    fn test_field_addr() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_memseg__bindgen_ty_1>::uninit(
+                    );
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).addr) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_memseg__bindgen_ty_1),
+                "::",
+                stringify!(addr)
+            )
+        );
+    }
+    test_field_addr();
+    fn test_field_addr_64() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_memseg__bindgen_ty_1>::uninit(
+                    );
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).addr_64) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_memseg__bindgen_ty_1),
+                "::",
+                stringify!(addr_64)
+            )
+        );
+    }
+    test_field_addr_64();
 }
 impl Default for rte_memseg__bindgen_ty_1 {
     fn default() -> Self {
@@ -95,90 +103,108 @@ fn bindgen_test_layout_rte_memseg() {
         1usize,
         concat!("Alignment of ", stringify!(rte_memseg))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_memseg>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).phys_addr) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_memseg),
-            "::",
-            stringify!(phys_addr)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_memseg>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).len) as usize - ptr as usize
-        },
-        16usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_memseg),
-            "::",
-            stringify!(len)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_memseg>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).hugepage_sz) as usize - ptr as usize
-        },
-        24usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_memseg),
-            "::",
-            stringify!(hugepage_sz)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_memseg>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).socket_id) as usize - ptr as usize
-        },
-        32usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_memseg),
-            "::",
-            stringify!(socket_id)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_memseg>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).nchannel) as usize - ptr as usize
-        },
-        36usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_memseg),
-            "::",
-            stringify!(nchannel)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_memseg>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).nrank) as usize - ptr as usize
-        },
-        40usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_memseg),
-            "::",
-            stringify!(nrank)
-        )
-    );
+    fn test_field_phys_addr() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<rte_memseg>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).phys_addr) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_memseg),
+                "::",
+                stringify!(phys_addr)
+            )
+        );
+    }
+    test_field_phys_addr();
+    fn test_field_len() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<rte_memseg>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).len) as usize - ptr as usize
+            },
+            16usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_memseg),
+                "::",
+                stringify!(len)
+            )
+        );
+    }
+    test_field_len();
+    fn test_field_hugepage_sz() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<rte_memseg>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).hugepage_sz) as usize - ptr as usize
+            },
+            24usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_memseg),
+                "::",
+                stringify!(hugepage_sz)
+            )
+        );
+    }
+    test_field_hugepage_sz();
+    fn test_field_socket_id() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<rte_memseg>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).socket_id) as usize - ptr as usize
+            },
+            32usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_memseg),
+                "::",
+                stringify!(socket_id)
+            )
+        );
+    }
+    test_field_socket_id();
+    fn test_field_nchannel() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<rte_memseg>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).nchannel) as usize - ptr as usize
+            },
+            36usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_memseg),
+                "::",
+                stringify!(nchannel)
+            )
+        );
+    }
+    test_field_nchannel();
+    fn test_field_nrank() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<rte_memseg>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).nrank) as usize - ptr as usize
+            },
+            40usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_memseg),
+                "::",
+                stringify!(nrank)
+            )
+        );
+    }
+    test_field_nrank();
 }
 impl Default for rte_memseg {
     fn default() -> Self {

--- a/tests/expectations/tests/issue-1947.rs
+++ b/tests/expectations/tests/issue-1947.rs
@@ -117,48 +117,57 @@ fn bindgen_test_layout_V56AMDY() {
         2usize,
         concat!("Alignment of ", stringify!(V56AMDY))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<V56AMDY>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).MADK) as usize - ptr as usize
-        },
-        2usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(V56AMDY),
-            "::",
-            stringify!(MADK)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<V56AMDY>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).MABR) as usize - ptr as usize
-        },
-        3usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(V56AMDY),
-            "::",
-            stringify!(MABR)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<V56AMDY>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr)._rB_) as usize - ptr as usize
-        },
-        7usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(V56AMDY),
-            "::",
-            stringify!(_rB_)
-        )
-    );
+    fn test_field_MADK() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<V56AMDY>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).MADK) as usize - ptr as usize
+            },
+            2usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(V56AMDY),
+                "::",
+                stringify!(MADK)
+            )
+        );
+    }
+    test_field_MADK();
+    fn test_field_MABR() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<V56AMDY>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).MABR) as usize - ptr as usize
+            },
+            3usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(V56AMDY),
+                "::",
+                stringify!(MABR)
+            )
+        );
+    }
+    test_field_MABR();
+    fn test_field__rB_() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<V56AMDY>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr)._rB_) as usize - ptr as usize
+            },
+            7usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(V56AMDY),
+                "::",
+                stringify!(_rB_)
+            )
+        );
+    }
+    test_field__rB_();
 }
 impl V56AMDY {
     #[inline]

--- a/tests/expectations/tests/issue-1977-larger-arrays.rs
+++ b/tests/expectations/tests/issue-1977-larger-arrays.rs
@@ -22,20 +22,23 @@ fn bindgen_test_layout_S() {
         1usize,
         concat!("Alignment of ", stringify!(S))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<S>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).large_array) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(S),
-            "::",
-            stringify!(large_array)
-        )
-    );
+    fn test_field_large_array() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<S>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).large_array) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(S),
+                "::",
+                stringify!(large_array)
+            )
+        );
+    }
+    test_field_large_array();
 }
 impl Default for S {
     fn default() -> Self {

--- a/tests/expectations/tests/issue-1995.rs
+++ b/tests/expectations/tests/issue-1995.rs
@@ -29,13 +29,21 @@ fn bindgen_test_layout_Bar() {
         4usize,
         concat!("Alignment of ", stringify!(Bar))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Bar>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize
-        },
-        0usize,
-        concat!("Offset of field: ", stringify!(Bar), "::", stringify!(baz))
-    );
+    fn test_field_baz() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Bar>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(Bar),
+                "::",
+                stringify!(baz)
+            )
+        );
+    }
+    test_field_baz();
 }

--- a/tests/expectations/tests/issue-2019.rs
+++ b/tests/expectations/tests/issue-2019.rs
@@ -22,15 +22,18 @@ fn bindgen_test_layout_A() {
         4usize,
         concat!("Alignment of ", stringify!(A))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<A>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
-        0usize,
-        concat!("Offset of field: ", stringify!(A), "::", stringify!(a))
-    );
+    fn test_field_a() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<A>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+            },
+            0usize,
+            concat!("Offset of field: ", stringify!(A), "::", stringify!(a))
+        );
+    }
+    test_field_a();
 }
 extern "C" {
     #[link_name = "\u{1}_ZN1A4makeEv"]
@@ -59,15 +62,18 @@ fn bindgen_test_layout_B() {
         4usize,
         concat!("Alignment of ", stringify!(B))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<B>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-        },
-        0usize,
-        concat!("Offset of field: ", stringify!(B), "::", stringify!(b))
-    );
+    fn test_field_b() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<B>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
+            },
+            0usize,
+            concat!("Offset of field: ", stringify!(B), "::", stringify!(b))
+        );
+    }
+    test_field_b();
 }
 extern "C" {
     #[link_name = "\u{1}_ZN1B4makeEv"]

--- a/tests/expectations/tests/issue-372.rs
+++ b/tests/expectations/tests/issue-372.rs
@@ -28,33 +28,57 @@ pub mod root {
             8usize,
             concat!("Alignment of ", stringify!(i))
         );
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<i>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).j) as usize - ptr as usize
-            },
-            0usize,
-            concat!("Offset of field: ", stringify!(i), "::", stringify!(j))
-        );
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<i>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).k) as usize - ptr as usize
-            },
-            8usize,
-            concat!("Offset of field: ", stringify!(i), "::", stringify!(k))
-        );
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<i>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).l) as usize - ptr as usize
-            },
-            16usize,
-            concat!("Offset of field: ", stringify!(i), "::", stringify!(l))
-        );
+        fn test_field_j() {
+            assert_eq!(
+                unsafe {
+                    let uninit = ::std::mem::MaybeUninit::<i>::uninit();
+                    let ptr = uninit.as_ptr();
+                    ::std::ptr::addr_of!((*ptr).j) as usize - ptr as usize
+                },
+                0usize,
+                concat!(
+                    "Offset of field: ",
+                    stringify!(i),
+                    "::",
+                    stringify!(j)
+                )
+            );
+        }
+        test_field_j();
+        fn test_field_k() {
+            assert_eq!(
+                unsafe {
+                    let uninit = ::std::mem::MaybeUninit::<i>::uninit();
+                    let ptr = uninit.as_ptr();
+                    ::std::ptr::addr_of!((*ptr).k) as usize - ptr as usize
+                },
+                8usize,
+                concat!(
+                    "Offset of field: ",
+                    stringify!(i),
+                    "::",
+                    stringify!(k)
+                )
+            );
+        }
+        test_field_k();
+        fn test_field_l() {
+            assert_eq!(
+                unsafe {
+                    let uninit = ::std::mem::MaybeUninit::<i>::uninit();
+                    let ptr = uninit.as_ptr();
+                    ::std::ptr::addr_of!((*ptr).l) as usize - ptr as usize
+                },
+                16usize,
+                concat!(
+                    "Offset of field: ",
+                    stringify!(i),
+                    "::",
+                    stringify!(l)
+                )
+            );
+        }
+        test_field_l();
     }
     impl Default for i {
         fn default() -> Self {
@@ -82,15 +106,23 @@ pub mod root {
             8usize,
             concat!("Alignment of ", stringify!(d))
         );
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<d>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).m) as usize - ptr as usize
-            },
-            0usize,
-            concat!("Offset of field: ", stringify!(d), "::", stringify!(m))
-        );
+        fn test_field_m() {
+            assert_eq!(
+                unsafe {
+                    let uninit = ::std::mem::MaybeUninit::<d>::uninit();
+                    let ptr = uninit.as_ptr();
+                    ::std::ptr::addr_of!((*ptr).m) as usize - ptr as usize
+                },
+                0usize,
+                concat!(
+                    "Offset of field: ",
+                    stringify!(d),
+                    "::",
+                    stringify!(m)
+                )
+            );
+        }
+        test_field_m();
     }
     impl Default for d {
         fn default() -> Self {
@@ -133,15 +165,23 @@ pub mod root {
             8usize,
             concat!("Alignment of ", stringify!(F))
         );
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<F>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).w) as usize - ptr as usize
-            },
-            0usize,
-            concat!("Offset of field: ", stringify!(F), "::", stringify!(w))
-        );
+        fn test_field_w() {
+            assert_eq!(
+                unsafe {
+                    let uninit = ::std::mem::MaybeUninit::<F>::uninit();
+                    let ptr = uninit.as_ptr();
+                    ::std::ptr::addr_of!((*ptr).w) as usize - ptr as usize
+                },
+                0usize,
+                concat!(
+                    "Offset of field: ",
+                    stringify!(F),
+                    "::",
+                    stringify!(w)
+                )
+            );
+        }
+        test_field_w();
     }
     impl Default for F {
         fn default() -> Self {

--- a/tests/expectations/tests/issue-537-repr-packed-n.rs
+++ b/tests/expectations/tests/issue-537-repr-packed-n.rs
@@ -25,20 +25,23 @@ fn bindgen_test_layout_AlignedToOne() {
         1usize,
         concat!("Alignment of ", stringify!(AlignedToOne))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<AlignedToOne>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).i) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(AlignedToOne),
-            "::",
-            stringify!(i)
-        )
-    );
+    fn test_field_i() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<AlignedToOne>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).i) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(AlignedToOne),
+                "::",
+                stringify!(i)
+            )
+        );
+    }
+    test_field_i();
 }
 /// This should be be packed because Rust 1.33 has `#[repr(packed(N))]`.
 #[repr(C, packed(2))]
@@ -58,20 +61,23 @@ fn bindgen_test_layout_AlignedToTwo() {
         2usize,
         concat!("Alignment of ", stringify!(AlignedToTwo))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<AlignedToTwo>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).i) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(AlignedToTwo),
-            "::",
-            stringify!(i)
-        )
-    );
+    fn test_field_i() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<AlignedToTwo>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).i) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(AlignedToTwo),
+                "::",
+                stringify!(i)
+            )
+        );
+    }
+    test_field_i();
 }
 /// This should not be opaque because although `libclang` doesn't give us the
 /// `#pragma pack(1)`, we can detect that alignment is 1 and add
@@ -94,34 +100,40 @@ fn bindgen_test_layout_PackedToOne() {
         1usize,
         concat!("Alignment of ", stringify!(PackedToOne))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<PackedToOne>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(PackedToOne),
-            "::",
-            stringify!(x)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<PackedToOne>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).y) as usize - ptr as usize
-        },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(PackedToOne),
-            "::",
-            stringify!(y)
-        )
-    );
+    fn test_field_x() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<PackedToOne>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(PackedToOne),
+                "::",
+                stringify!(x)
+            )
+        );
+    }
+    test_field_x();
+    fn test_field_y() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<PackedToOne>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).y) as usize - ptr as usize
+            },
+            4usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(PackedToOne),
+                "::",
+                stringify!(y)
+            )
+        );
+    }
+    test_field_y();
 }
 /// This should be be packed because Rust 1.33 has `#[repr(packed(N))]`.
 #[repr(C, packed(2))]
@@ -142,32 +154,38 @@ fn bindgen_test_layout_PackedToTwo() {
         2usize,
         concat!("Alignment of ", stringify!(PackedToTwo))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<PackedToTwo>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(PackedToTwo),
-            "::",
-            stringify!(x)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<PackedToTwo>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).y) as usize - ptr as usize
-        },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(PackedToTwo),
-            "::",
-            stringify!(y)
-        )
-    );
+    fn test_field_x() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<PackedToTwo>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(PackedToTwo),
+                "::",
+                stringify!(x)
+            )
+        );
+    }
+    test_field_x();
+    fn test_field_y() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<PackedToTwo>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).y) as usize - ptr as usize
+            },
+            4usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(PackedToTwo),
+                "::",
+                stringify!(y)
+            )
+        );
+    }
+    test_field_y();
 }

--- a/tests/expectations/tests/issue-537.rs
+++ b/tests/expectations/tests/issue-537.rs
@@ -24,20 +24,23 @@ fn bindgen_test_layout_AlignedToOne() {
         1usize,
         concat!("Alignment of ", stringify!(AlignedToOne))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<AlignedToOne>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).i) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(AlignedToOne),
-            "::",
-            stringify!(i)
-        )
-    );
+    fn test_field_i() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<AlignedToOne>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).i) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(AlignedToOne),
+                "::",
+                stringify!(i)
+            )
+        );
+    }
+    test_field_i();
 }
 /// This should be opaque because although we can see the attributes, Rust before
 /// 1.33 doesn't have `#[repr(packed(N))]`.
@@ -58,20 +61,23 @@ fn bindgen_test_layout_AlignedToTwo() {
         2usize,
         concat!("Alignment of ", stringify!(AlignedToTwo))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<AlignedToTwo>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).i) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(AlignedToTwo),
-            "::",
-            stringify!(i)
-        )
-    );
+    fn test_field_i() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<AlignedToTwo>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).i) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(AlignedToTwo),
+                "::",
+                stringify!(i)
+            )
+        );
+    }
+    test_field_i();
 }
 /// This should not be opaque because although `libclang` doesn't give us the
 /// `#pragma pack(1)`, we can detect that alignment is 1 and add
@@ -94,34 +100,40 @@ fn bindgen_test_layout_PackedToOne() {
         1usize,
         concat!("Alignment of ", stringify!(PackedToOne))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<PackedToOne>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(PackedToOne),
-            "::",
-            stringify!(x)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<PackedToOne>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).y) as usize - ptr as usize
-        },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(PackedToOne),
-            "::",
-            stringify!(y)
-        )
-    );
+    fn test_field_x() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<PackedToOne>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(PackedToOne),
+                "::",
+                stringify!(x)
+            )
+        );
+    }
+    test_field_x();
+    fn test_field_y() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<PackedToOne>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).y) as usize - ptr as usize
+            },
+            4usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(PackedToOne),
+                "::",
+                stringify!(y)
+            )
+        );
+    }
+    test_field_y();
 }
 /// In this case, even if we can detect the weird alignment triggered by
 /// `#pragma pack(2)`, we can't do anything about it because Rust before 1.33
@@ -144,32 +156,38 @@ fn bindgen_test_layout_PackedToTwo() {
         2usize,
         concat!("Alignment of ", stringify!(PackedToTwo))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<PackedToTwo>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(PackedToTwo),
-            "::",
-            stringify!(x)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<PackedToTwo>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).y) as usize - ptr as usize
-        },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(PackedToTwo),
-            "::",
-            stringify!(y)
-        )
-    );
+    fn test_field_x() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<PackedToTwo>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(PackedToTwo),
+                "::",
+                stringify!(x)
+            )
+        );
+    }
+    test_field_x();
+    fn test_field_y() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<PackedToTwo>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).y) as usize - ptr as usize
+            },
+            4usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(PackedToTwo),
+                "::",
+                stringify!(y)
+            )
+        );
+    }
+    test_field_y();
 }

--- a/tests/expectations/tests/issue-573-layout-test-failures.rs
+++ b/tests/expectations/tests/issue-573-layout-test-failures.rs
@@ -27,20 +27,23 @@ fn bindgen_test_layout_AutoIdVector() {
         1usize,
         concat!("Alignment of ", stringify!(AutoIdVector))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<AutoIdVector>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).ar) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(AutoIdVector),
-            "::",
-            stringify!(ar)
-        )
-    );
+    fn test_field_ar() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<AutoIdVector>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).ar) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(AutoIdVector),
+                "::",
+                stringify!(ar)
+            )
+        );
+    }
+    test_field_ar();
 }
 #[test]
 fn __bindgen_test_layout_Outer_open0_int_close0_instantiation() {

--- a/tests/expectations/tests/issue-574-assertion-failure-in-codegen.rs
+++ b/tests/expectations/tests/issue-574-assertion-failure-in-codegen.rs
@@ -27,20 +27,23 @@ fn bindgen_test_layout__bindgen_ty_1() {
         1usize,
         concat!("Alignment of ", stringify!(_bindgen_ty_1))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<_bindgen_ty_1>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).ar) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(_bindgen_ty_1),
-            "::",
-            stringify!(ar)
-        )
-    );
+    fn test_field_ar() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<_bindgen_ty_1>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).ar) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(_bindgen_ty_1),
+                "::",
+                stringify!(ar)
+            )
+        );
+    }
+    test_field_ar();
 }
 extern "C" {
     pub static mut AutoIdVector: _bindgen_ty_1;

--- a/tests/expectations/tests/issue-584-stylo-template-analysis-panic.rs
+++ b/tests/expectations/tests/issue-584-stylo-template-analysis-panic.rs
@@ -61,15 +61,18 @@ fn bindgen_test_layout_g() {
         1usize,
         concat!("Alignment of ", stringify!(g))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<g>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).h) as usize - ptr as usize
-        },
-        0usize,
-        concat!("Offset of field: ", stringify!(g), "::", stringify!(h))
-    );
+    fn test_field_h() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<g>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).h) as usize - ptr as usize
+            },
+            0usize,
+            concat!("Offset of field: ", stringify!(g), "::", stringify!(h))
+        );
+    }
+    test_field_h();
 }
 impl Default for g {
     fn default() -> Self {

--- a/tests/expectations/tests/issue-639-typedef-anon-field.rs
+++ b/tests/expectations/tests/issue-639-typedef-anon-field.rs
@@ -27,20 +27,23 @@ fn bindgen_test_layout_Foo_Bar() {
         4usize,
         concat!("Alignment of ", stringify!(Foo_Bar))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Foo_Bar>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).abc) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(Foo_Bar),
-            "::",
-            stringify!(abc)
-        )
-    );
+    fn test_field_abc() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Foo_Bar>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).abc) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(Foo_Bar),
+                "::",
+                stringify!(abc)
+            )
+        );
+    }
+    test_field_abc();
 }
 #[test]
 fn bindgen_test_layout_Foo() {
@@ -54,15 +57,23 @@ fn bindgen_test_layout_Foo() {
         4usize,
         concat!("Alignment of ", stringify!(Foo))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Foo>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
-        },
-        0usize,
-        concat!("Offset of field: ", stringify!(Foo), "::", stringify!(bar))
-    );
+    fn test_field_bar() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Foo>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(Foo),
+                "::",
+                stringify!(bar)
+            )
+        );
+    }
+    test_field_bar();
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
@@ -86,20 +97,23 @@ fn bindgen_test_layout_Baz_Bar() {
         4usize,
         concat!("Alignment of ", stringify!(Baz_Bar))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Baz_Bar>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).abc) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(Baz_Bar),
-            "::",
-            stringify!(abc)
-        )
-    );
+    fn test_field_abc() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Baz_Bar>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).abc) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(Baz_Bar),
+                "::",
+                stringify!(abc)
+            )
+        );
+    }
+    test_field_abc();
 }
 #[test]
 fn bindgen_test_layout_Baz() {

--- a/tests/expectations/tests/issue-643-inner-struct.rs
+++ b/tests/expectations/tests/issue-643-inner-struct.rs
@@ -60,20 +60,23 @@ fn bindgen_test_layout_rte_ring_prod() {
         4usize,
         concat!("Alignment of ", stringify!(rte_ring_prod))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_ring_prod>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).watermark) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_ring_prod),
-            "::",
-            stringify!(watermark)
-        )
-    );
+    fn test_field_watermark() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<rte_ring_prod>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).watermark) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_ring_prod),
+                "::",
+                stringify!(watermark)
+            )
+        );
+    }
+    test_field_watermark();
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
@@ -92,20 +95,23 @@ fn bindgen_test_layout_rte_ring_cons() {
         4usize,
         concat!("Alignment of ", stringify!(rte_ring_cons))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_ring_cons>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).sc_dequeue) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_ring_cons),
-            "::",
-            stringify!(sc_dequeue)
-        )
-    );
+    fn test_field_sc_dequeue() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<rte_ring_cons>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).sc_dequeue) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_ring_cons),
+                "::",
+                stringify!(sc_dequeue)
+            )
+        );
+    }
+    test_field_sc_dequeue();
 }
 #[test]
 fn bindgen_test_layout_rte_ring() {

--- a/tests/expectations/tests/issue-648-derive-debug-with-padding.rs
+++ b/tests/expectations/tests/issue-648-derive-debug-with-padding.rs
@@ -25,20 +25,23 @@ fn bindgen_test_layout_NoDebug() {
         64usize,
         concat!("Alignment of ", stringify!(NoDebug))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<NoDebug>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).c) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(NoDebug),
-            "::",
-            stringify!(c)
-        )
-    );
+    fn test_field_c() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<NoDebug>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).c) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(NoDebug),
+                "::",
+                stringify!(c)
+            )
+        );
+    }
+    test_field_c();
 }
 impl Default for NoDebug {
     fn default() -> Self {
@@ -77,38 +80,44 @@ fn bindgen_test_layout_ShouldDeriveDebugButDoesNot() {
         64usize,
         concat!("Alignment of ", stringify!(ShouldDeriveDebugButDoesNot))
     );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<ShouldDeriveDebugButDoesNot>::uninit(
-                );
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).c) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(ShouldDeriveDebugButDoesNot),
-            "::",
-            stringify!(c)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<ShouldDeriveDebugButDoesNot>::uninit(
-                );
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize
-        },
-        32usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(ShouldDeriveDebugButDoesNot),
-            "::",
-            stringify!(d)
-        )
-    );
+    fn test_field_c() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<
+                    ShouldDeriveDebugButDoesNot,
+                >::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).c) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(ShouldDeriveDebugButDoesNot),
+                "::",
+                stringify!(c)
+            )
+        );
+    }
+    test_field_c();
+    fn test_field_d() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<
+                    ShouldDeriveDebugButDoesNot,
+                >::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize
+            },
+            32usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(ShouldDeriveDebugButDoesNot),
+                "::",
+                stringify!(d)
+            )
+        );
+    }
+    test_field_d();
 }
 impl Default for ShouldDeriveDebugButDoesNot {
     fn default() -> Self {

--- a/tests/expectations/tests/issue-674-1.rs
+++ b/tests/expectations/tests/issue-674-1.rs
@@ -36,20 +36,24 @@ pub mod root {
             1usize,
             concat!("Alignment of ", stringify!(CapturingContentInfo))
         );
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<CapturingContentInfo>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(CapturingContentInfo),
-                "::",
-                stringify!(a)
-            )
-        );
+        fn test_field_a() {
+            assert_eq!(
+                unsafe {
+                    let uninit =
+                        ::std::mem::MaybeUninit::<CapturingContentInfo>::uninit(
+                        );
+                    let ptr = uninit.as_ptr();
+                    ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+                },
+                0usize,
+                concat!(
+                    "Offset of field: ",
+                    stringify!(CapturingContentInfo),
+                    "::",
+                    stringify!(a)
+                )
+            );
+        }
+        test_field_a();
     }
 }

--- a/tests/expectations/tests/issue-674-2.rs
+++ b/tests/expectations/tests/issue-674-2.rs
@@ -36,15 +36,23 @@ pub mod root {
             1usize,
             concat!("Alignment of ", stringify!(c))
         );
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<c>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-            },
-            0usize,
-            concat!("Offset of field: ", stringify!(c), "::", stringify!(b))
-        );
+        fn test_field_b() {
+            assert_eq!(
+                unsafe {
+                    let uninit = ::std::mem::MaybeUninit::<c>::uninit();
+                    let ptr = uninit.as_ptr();
+                    ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
+                },
+                0usize,
+                concat!(
+                    "Offset of field: ",
+                    stringify!(c),
+                    "::",
+                    stringify!(b)
+                )
+            );
+        }
+        test_field_b();
     }
     #[repr(C)]
     #[derive(Debug, Default, Copy, Clone)]
@@ -63,15 +71,23 @@ pub mod root {
             1usize,
             concat!("Alignment of ", stringify!(B))
         );
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<B>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-            },
-            0usize,
-            concat!("Offset of field: ", stringify!(B), "::", stringify!(a))
-        );
+        fn test_field_a() {
+            assert_eq!(
+                unsafe {
+                    let uninit = ::std::mem::MaybeUninit::<B>::uninit();
+                    let ptr = uninit.as_ptr();
+                    ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+                },
+                0usize,
+                concat!(
+                    "Offset of field: ",
+                    stringify!(B),
+                    "::",
+                    stringify!(a)
+                )
+            );
+        }
+        test_field_a();
     }
     #[repr(C)]
     #[derive(Debug, Default, Copy, Clone)]

--- a/tests/expectations/tests/issue-674-3.rs
+++ b/tests/expectations/tests/issue-674-3.rs
@@ -32,15 +32,23 @@ pub mod root {
             1usize,
             concat!("Alignment of ", stringify!(a))
         );
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<a>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-            },
-            0usize,
-            concat!("Offset of field: ", stringify!(a), "::", stringify!(b))
-        );
+        fn test_field_b() {
+            assert_eq!(
+                unsafe {
+                    let uninit = ::std::mem::MaybeUninit::<a>::uninit();
+                    let ptr = uninit.as_ptr();
+                    ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
+                },
+                0usize,
+                concat!(
+                    "Offset of field: ",
+                    stringify!(a),
+                    "::",
+                    stringify!(b)
+                )
+            );
+        }
+        test_field_b();
     }
     #[repr(C)]
     #[derive(Debug, Default, Copy, Clone)]
@@ -59,19 +67,23 @@ pub mod root {
             1usize,
             concat!("Alignment of ", stringify!(nsCSSValue))
         );
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<nsCSSValue>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).c) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(nsCSSValue),
-                "::",
-                stringify!(c)
-            )
-        );
+        fn test_field_c() {
+            assert_eq!(
+                unsafe {
+                    let uninit =
+                        ::std::mem::MaybeUninit::<nsCSSValue>::uninit();
+                    let ptr = uninit.as_ptr();
+                    ::std::ptr::addr_of!((*ptr).c) as usize - ptr as usize
+                },
+                0usize,
+                concat!(
+                    "Offset of field: ",
+                    stringify!(nsCSSValue),
+                    "::",
+                    stringify!(c)
+                )
+            );
+        }
+        test_field_c();
     }
 }

--- a/tests/expectations/tests/issue-801-opaque-sloppiness.rs
+++ b/tests/expectations/tests/issue-801-opaque-sloppiness.rs
@@ -50,13 +50,16 @@ fn bindgen_test_layout_C() {
         1usize,
         concat!("Alignment of ", stringify!(C))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<C>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-        },
-        0usize,
-        concat!("Offset of field: ", stringify!(C), "::", stringify!(b))
-    );
+    fn test_field_b() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<C>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
+            },
+            0usize,
+            concat!("Offset of field: ", stringify!(C), "::", stringify!(b))
+        );
+    }
+    test_field_b();
 }

--- a/tests/expectations/tests/issue-807-opaque-types-methods-being-generated.rs
+++ b/tests/expectations/tests/issue-807-opaque-types-methods-being-generated.rs
@@ -119,18 +119,21 @@ fn bindgen_test_layout_Allowlisted() {
         1usize,
         concat!("Alignment of ", stringify!(Allowlisted))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Allowlisted>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).some_member) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(Allowlisted),
-            "::",
-            stringify!(some_member)
-        )
-    );
+    fn test_field_some_member() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Allowlisted>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).some_member) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(Allowlisted),
+                "::",
+                stringify!(some_member)
+            )
+        );
+    }
+    test_field_some_member();
 }

--- a/tests/expectations/tests/issue-944-derive-copy-and-blocklisting.rs
+++ b/tests/expectations/tests/issue-944-derive-copy-and-blocklisting.rs
@@ -24,20 +24,24 @@ fn bindgen_test_layout_ShouldNotBeCopy() {
         1usize,
         concat!("Alignment of ", stringify!(ShouldNotBeCopy))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<ShouldNotBeCopy>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(ShouldNotBeCopy),
-            "::",
-            stringify!(a)
-        )
-    );
+    fn test_field_a() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<ShouldNotBeCopy>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(ShouldNotBeCopy),
+                "::",
+                stringify!(a)
+            )
+        );
+    }
+    test_field_a();
 }
 impl Default for ShouldNotBeCopy {
     fn default() -> Self {

--- a/tests/expectations/tests/jsval_layout_opaque.rs
+++ b/tests/expectations/tests/jsval_layout_opaque.rs
@@ -293,54 +293,63 @@ fn bindgen_test_layout_jsval_layout__bindgen_ty_2__bindgen_ty_1() {
             stringify!(jsval_layout__bindgen_ty_2__bindgen_ty_1)
         )
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<
-                jsval_layout__bindgen_ty_2__bindgen_ty_1,
-            >::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).i32_) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(jsval_layout__bindgen_ty_2__bindgen_ty_1),
-            "::",
-            stringify!(i32_)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<
-                jsval_layout__bindgen_ty_2__bindgen_ty_1,
-            >::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).u32_) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(jsval_layout__bindgen_ty_2__bindgen_ty_1),
-            "::",
-            stringify!(u32_)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<
-                jsval_layout__bindgen_ty_2__bindgen_ty_1,
-            >::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).why) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(jsval_layout__bindgen_ty_2__bindgen_ty_1),
-            "::",
-            stringify!(why)
-        )
-    );
+    fn test_field_i32() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<
+                    jsval_layout__bindgen_ty_2__bindgen_ty_1,
+                >::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).i32_) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(jsval_layout__bindgen_ty_2__bindgen_ty_1),
+                "::",
+                stringify!(i32_)
+            )
+        );
+    }
+    test_field_i32();
+    fn test_field_u32() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<
+                    jsval_layout__bindgen_ty_2__bindgen_ty_1,
+                >::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).u32_) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(jsval_layout__bindgen_ty_2__bindgen_ty_1),
+                "::",
+                stringify!(u32_)
+            )
+        );
+    }
+    test_field_u32();
+    fn test_field_why() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<
+                    jsval_layout__bindgen_ty_2__bindgen_ty_1,
+                >::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).why) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(jsval_layout__bindgen_ty_2__bindgen_ty_1),
+                "::",
+                stringify!(why)
+            )
+        );
+    }
+    test_field_why();
 }
 impl Default for jsval_layout__bindgen_ty_2__bindgen_ty_1 {
     fn default() -> Self {
@@ -363,21 +372,25 @@ fn bindgen_test_layout_jsval_layout__bindgen_ty_2() {
         4usize,
         concat!("Alignment of ", stringify!(jsval_layout__bindgen_ty_2))
     );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<jsval_layout__bindgen_ty_2>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).payload) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(jsval_layout__bindgen_ty_2),
-            "::",
-            stringify!(payload)
-        )
-    );
+    fn test_field_payload() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<
+                    jsval_layout__bindgen_ty_2,
+                >::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).payload) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(jsval_layout__bindgen_ty_2),
+                "::",
+                stringify!(payload)
+            )
+        );
+    }
+    test_field_payload();
 }
 impl Default for jsval_layout__bindgen_ty_2 {
     fn default() -> Self {
@@ -400,104 +413,125 @@ fn bindgen_test_layout_jsval_layout() {
         8usize,
         concat!("Alignment of ", stringify!(jsval_layout))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<jsval_layout>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).asBits) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(jsval_layout),
-            "::",
-            stringify!(asBits)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<jsval_layout>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).debugView) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(jsval_layout),
-            "::",
-            stringify!(debugView)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<jsval_layout>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).s) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(jsval_layout),
-            "::",
-            stringify!(s)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<jsval_layout>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).asDouble) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(jsval_layout),
-            "::",
-            stringify!(asDouble)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<jsval_layout>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).asPtr) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(jsval_layout),
-            "::",
-            stringify!(asPtr)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<jsval_layout>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).asWord) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(jsval_layout),
-            "::",
-            stringify!(asWord)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<jsval_layout>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).asUIntPtr) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(jsval_layout),
-            "::",
-            stringify!(asUIntPtr)
-        )
-    );
+    fn test_field_asBits() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<jsval_layout>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).asBits) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(jsval_layout),
+                "::",
+                stringify!(asBits)
+            )
+        );
+    }
+    test_field_asBits();
+    fn test_field_debugView() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<jsval_layout>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).debugView) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(jsval_layout),
+                "::",
+                stringify!(debugView)
+            )
+        );
+    }
+    test_field_debugView();
+    fn test_field_s() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<jsval_layout>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).s) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(jsval_layout),
+                "::",
+                stringify!(s)
+            )
+        );
+    }
+    test_field_s();
+    fn test_field_asDouble() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<jsval_layout>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).asDouble) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(jsval_layout),
+                "::",
+                stringify!(asDouble)
+            )
+        );
+    }
+    test_field_asDouble();
+    fn test_field_asPtr() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<jsval_layout>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).asPtr) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(jsval_layout),
+                "::",
+                stringify!(asPtr)
+            )
+        );
+    }
+    test_field_asPtr();
+    fn test_field_asWord() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<jsval_layout>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).asWord) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(jsval_layout),
+                "::",
+                stringify!(asWord)
+            )
+        );
+    }
+    test_field_asWord();
+    fn test_field_asUIntPtr() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<jsval_layout>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).asUIntPtr) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(jsval_layout),
+                "::",
+                stringify!(asUIntPtr)
+            )
+        );
+    }
+    test_field_asUIntPtr();
 }
 impl Default for jsval_layout {
     fn default() -> Self {
@@ -525,20 +559,23 @@ fn bindgen_test_layout_Value() {
         8usize,
         concat!("Alignment of ", stringify!(Value))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Value>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).data) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(Value),
-            "::",
-            stringify!(data)
-        )
-    );
+    fn test_field_data() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Value>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).data) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(Value),
+                "::",
+                stringify!(data)
+            )
+        );
+    }
+    test_field_data();
 }
 impl Default for Value {
     fn default() -> Self {

--- a/tests/expectations/tests/jsval_layout_opaque_1_0.rs
+++ b/tests/expectations/tests/jsval_layout_opaque_1_0.rs
@@ -343,54 +343,63 @@ fn bindgen_test_layout_jsval_layout__bindgen_ty_2__bindgen_ty_1() {
             stringify!(jsval_layout__bindgen_ty_2__bindgen_ty_1)
         )
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<
-                jsval_layout__bindgen_ty_2__bindgen_ty_1,
-            >::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).i32_) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(jsval_layout__bindgen_ty_2__bindgen_ty_1),
-            "::",
-            stringify!(i32_)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<
-                jsval_layout__bindgen_ty_2__bindgen_ty_1,
-            >::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).u32_) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(jsval_layout__bindgen_ty_2__bindgen_ty_1),
-            "::",
-            stringify!(u32_)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<
-                jsval_layout__bindgen_ty_2__bindgen_ty_1,
-            >::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).why) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(jsval_layout__bindgen_ty_2__bindgen_ty_1),
-            "::",
-            stringify!(why)
-        )
-    );
+    fn test_field_i32() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<
+                    jsval_layout__bindgen_ty_2__bindgen_ty_1,
+                >::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).i32_) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(jsval_layout__bindgen_ty_2__bindgen_ty_1),
+                "::",
+                stringify!(i32_)
+            )
+        );
+    }
+    test_field_i32();
+    fn test_field_u32() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<
+                    jsval_layout__bindgen_ty_2__bindgen_ty_1,
+                >::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).u32_) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(jsval_layout__bindgen_ty_2__bindgen_ty_1),
+                "::",
+                stringify!(u32_)
+            )
+        );
+    }
+    test_field_u32();
+    fn test_field_why() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<
+                    jsval_layout__bindgen_ty_2__bindgen_ty_1,
+                >::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).why) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(jsval_layout__bindgen_ty_2__bindgen_ty_1),
+                "::",
+                stringify!(why)
+            )
+        );
+    }
+    test_field_why();
 }
 impl Clone for jsval_layout__bindgen_ty_2__bindgen_ty_1 {
     fn clone(&self) -> Self {
@@ -409,21 +418,25 @@ fn bindgen_test_layout_jsval_layout__bindgen_ty_2() {
         4usize,
         concat!("Alignment of ", stringify!(jsval_layout__bindgen_ty_2))
     );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<jsval_layout__bindgen_ty_2>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).payload) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(jsval_layout__bindgen_ty_2),
-            "::",
-            stringify!(payload)
-        )
-    );
+    fn test_field_payload() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<
+                    jsval_layout__bindgen_ty_2,
+                >::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).payload) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(jsval_layout__bindgen_ty_2),
+                "::",
+                stringify!(payload)
+            )
+        );
+    }
+    test_field_payload();
 }
 impl Clone for jsval_layout__bindgen_ty_2 {
     fn clone(&self) -> Self {
@@ -442,104 +455,125 @@ fn bindgen_test_layout_jsval_layout() {
         8usize,
         concat!("Alignment of ", stringify!(jsval_layout))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<jsval_layout>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).asBits) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(jsval_layout),
-            "::",
-            stringify!(asBits)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<jsval_layout>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).debugView) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(jsval_layout),
-            "::",
-            stringify!(debugView)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<jsval_layout>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).s) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(jsval_layout),
-            "::",
-            stringify!(s)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<jsval_layout>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).asDouble) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(jsval_layout),
-            "::",
-            stringify!(asDouble)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<jsval_layout>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).asPtr) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(jsval_layout),
-            "::",
-            stringify!(asPtr)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<jsval_layout>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).asWord) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(jsval_layout),
-            "::",
-            stringify!(asWord)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<jsval_layout>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).asUIntPtr) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(jsval_layout),
-            "::",
-            stringify!(asUIntPtr)
-        )
-    );
+    fn test_field_asBits() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<jsval_layout>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).asBits) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(jsval_layout),
+                "::",
+                stringify!(asBits)
+            )
+        );
+    }
+    test_field_asBits();
+    fn test_field_debugView() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<jsval_layout>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).debugView) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(jsval_layout),
+                "::",
+                stringify!(debugView)
+            )
+        );
+    }
+    test_field_debugView();
+    fn test_field_s() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<jsval_layout>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).s) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(jsval_layout),
+                "::",
+                stringify!(s)
+            )
+        );
+    }
+    test_field_s();
+    fn test_field_asDouble() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<jsval_layout>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).asDouble) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(jsval_layout),
+                "::",
+                stringify!(asDouble)
+            )
+        );
+    }
+    test_field_asDouble();
+    fn test_field_asPtr() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<jsval_layout>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).asPtr) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(jsval_layout),
+                "::",
+                stringify!(asPtr)
+            )
+        );
+    }
+    test_field_asPtr();
+    fn test_field_asWord() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<jsval_layout>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).asWord) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(jsval_layout),
+                "::",
+                stringify!(asWord)
+            )
+        );
+    }
+    test_field_asWord();
+    fn test_field_asUIntPtr() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<jsval_layout>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).asUIntPtr) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(jsval_layout),
+                "::",
+                stringify!(asUIntPtr)
+            )
+        );
+    }
+    test_field_asUIntPtr();
 }
 impl Clone for jsval_layout {
     fn clone(&self) -> Self {
@@ -563,20 +597,23 @@ fn bindgen_test_layout_Value() {
         8usize,
         concat!("Alignment of ", stringify!(Value))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Value>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).data) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(Value),
-            "::",
-            stringify!(data)
-        )
-    );
+    fn test_field_data() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Value>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).data) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(Value),
+                "::",
+                stringify!(data)
+            )
+        );
+    }
+    test_field_data();
 }
 impl Clone for Value {
     fn clone(&self) -> Self {

--- a/tests/expectations/tests/layout_align.rs
+++ b/tests/expectations/tests/layout_align.rs
@@ -179,20 +179,23 @@ fn bindgen_test_layout_rte_eth_link() {
         8usize,
         concat!("Alignment of ", stringify!(rte_eth_link))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_eth_link>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).link_speed) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_link),
-            "::",
-            stringify!(link_speed)
-        )
-    );
+    fn test_field_link_speed() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<rte_eth_link>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).link_speed) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_link),
+                "::",
+                stringify!(link_speed)
+            )
+        );
+    }
+    test_field_link_speed();
 }
 impl rte_eth_link {
     #[inline]

--- a/tests/expectations/tests/layout_arp.rs
+++ b/tests/expectations/tests/layout_arp.rs
@@ -40,20 +40,23 @@ fn bindgen_test_layout_ether_addr() {
         1usize,
         concat!("Alignment of ", stringify!(ether_addr))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<ether_addr>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).addr_bytes) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(ether_addr),
-            "::",
-            stringify!(addr_bytes)
-        )
-    );
+    fn test_field_addr_bytes() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<ether_addr>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).addr_bytes) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(ether_addr),
+                "::",
+                stringify!(addr_bytes)
+            )
+        );
+    }
+    test_field_addr_bytes();
 }
 /// ARP header IPv4 payload.
 #[repr(C, packed)]
@@ -80,62 +83,74 @@ fn bindgen_test_layout_arp_ipv4() {
         1usize,
         concat!("Alignment of ", stringify!(arp_ipv4))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<arp_ipv4>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).arp_sha) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(arp_ipv4),
-            "::",
-            stringify!(arp_sha)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<arp_ipv4>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).arp_sip) as usize - ptr as usize
-        },
-        6usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(arp_ipv4),
-            "::",
-            stringify!(arp_sip)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<arp_ipv4>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).arp_tha) as usize - ptr as usize
-        },
-        10usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(arp_ipv4),
-            "::",
-            stringify!(arp_tha)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<arp_ipv4>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).arp_tip) as usize - ptr as usize
-        },
-        16usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(arp_ipv4),
-            "::",
-            stringify!(arp_tip)
-        )
-    );
+    fn test_field_arp_sha() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<arp_ipv4>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).arp_sha) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(arp_ipv4),
+                "::",
+                stringify!(arp_sha)
+            )
+        );
+    }
+    test_field_arp_sha();
+    fn test_field_arp_sip() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<arp_ipv4>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).arp_sip) as usize - ptr as usize
+            },
+            6usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(arp_ipv4),
+                "::",
+                stringify!(arp_sip)
+            )
+        );
+    }
+    test_field_arp_sip();
+    fn test_field_arp_tha() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<arp_ipv4>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).arp_tha) as usize - ptr as usize
+            },
+            10usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(arp_ipv4),
+                "::",
+                stringify!(arp_tha)
+            )
+        );
+    }
+    test_field_arp_tha();
+    fn test_field_arp_tip() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<arp_ipv4>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).arp_tip) as usize - ptr as usize
+            },
+            16usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(arp_ipv4),
+                "::",
+                stringify!(arp_tip)
+            )
+        );
+    }
+    test_field_arp_tip();
 }
 /// ARP header.
 #[repr(C, packed)]
@@ -160,88 +175,106 @@ fn bindgen_test_layout_arp_hdr() {
         1usize,
         concat!("Alignment of ", stringify!(arp_hdr))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<arp_hdr>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).arp_hrd) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(arp_hdr),
-            "::",
-            stringify!(arp_hrd)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<arp_hdr>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).arp_pro) as usize - ptr as usize
-        },
-        2usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(arp_hdr),
-            "::",
-            stringify!(arp_pro)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<arp_hdr>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).arp_hln) as usize - ptr as usize
-        },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(arp_hdr),
-            "::",
-            stringify!(arp_hln)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<arp_hdr>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).arp_pln) as usize - ptr as usize
-        },
-        5usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(arp_hdr),
-            "::",
-            stringify!(arp_pln)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<arp_hdr>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).arp_op) as usize - ptr as usize
-        },
-        6usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(arp_hdr),
-            "::",
-            stringify!(arp_op)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<arp_hdr>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).arp_data) as usize - ptr as usize
-        },
-        8usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(arp_hdr),
-            "::",
-            stringify!(arp_data)
-        )
-    );
+    fn test_field_arp_hrd() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<arp_hdr>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).arp_hrd) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(arp_hdr),
+                "::",
+                stringify!(arp_hrd)
+            )
+        );
+    }
+    test_field_arp_hrd();
+    fn test_field_arp_pro() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<arp_hdr>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).arp_pro) as usize - ptr as usize
+            },
+            2usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(arp_hdr),
+                "::",
+                stringify!(arp_pro)
+            )
+        );
+    }
+    test_field_arp_pro();
+    fn test_field_arp_hln() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<arp_hdr>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).arp_hln) as usize - ptr as usize
+            },
+            4usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(arp_hdr),
+                "::",
+                stringify!(arp_hln)
+            )
+        );
+    }
+    test_field_arp_hln();
+    fn test_field_arp_pln() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<arp_hdr>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).arp_pln) as usize - ptr as usize
+            },
+            5usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(arp_hdr),
+                "::",
+                stringify!(arp_pln)
+            )
+        );
+    }
+    test_field_arp_pln();
+    fn test_field_arp_op() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<arp_hdr>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).arp_op) as usize - ptr as usize
+            },
+            6usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(arp_hdr),
+                "::",
+                stringify!(arp_op)
+            )
+        );
+    }
+    test_field_arp_op();
+    fn test_field_arp_data() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<arp_hdr>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).arp_data) as usize - ptr as usize
+            },
+            8usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(arp_hdr),
+                "::",
+                stringify!(arp_data)
+            )
+        );
+    }
+    test_field_arp_data();
 }

--- a/tests/expectations/tests/layout_array.rs
+++ b/tests/expectations/tests/layout_array.rs
@@ -79,90 +79,114 @@ fn bindgen_test_layout_rte_mempool_ops() {
         64usize,
         concat!("Alignment of ", stringify!(rte_mempool_ops))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_mempool_ops>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).name) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mempool_ops),
-            "::",
-            stringify!(name)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_mempool_ops>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).alloc) as usize - ptr as usize
-        },
-        32usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mempool_ops),
-            "::",
-            stringify!(alloc)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_mempool_ops>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).free) as usize - ptr as usize
-        },
-        40usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mempool_ops),
-            "::",
-            stringify!(free)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_mempool_ops>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).enqueue) as usize - ptr as usize
-        },
-        48usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mempool_ops),
-            "::",
-            stringify!(enqueue)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_mempool_ops>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).dequeue) as usize - ptr as usize
-        },
-        56usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mempool_ops),
-            "::",
-            stringify!(dequeue)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_mempool_ops>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).get_count) as usize - ptr as usize
-        },
-        64usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mempool_ops),
-            "::",
-            stringify!(get_count)
-        )
-    );
+    fn test_field_name() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_mempool_ops>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).name) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_mempool_ops),
+                "::",
+                stringify!(name)
+            )
+        );
+    }
+    test_field_name();
+    fn test_field_alloc() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_mempool_ops>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).alloc) as usize - ptr as usize
+            },
+            32usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_mempool_ops),
+                "::",
+                stringify!(alloc)
+            )
+        );
+    }
+    test_field_alloc();
+    fn test_field_free() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_mempool_ops>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).free) as usize - ptr as usize
+            },
+            40usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_mempool_ops),
+                "::",
+                stringify!(free)
+            )
+        );
+    }
+    test_field_free();
+    fn test_field_enqueue() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_mempool_ops>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).enqueue) as usize - ptr as usize
+            },
+            48usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_mempool_ops),
+                "::",
+                stringify!(enqueue)
+            )
+        );
+    }
+    test_field_enqueue();
+    fn test_field_dequeue() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_mempool_ops>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).dequeue) as usize - ptr as usize
+            },
+            56usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_mempool_ops),
+                "::",
+                stringify!(dequeue)
+            )
+        );
+    }
+    test_field_dequeue();
+    fn test_field_get_count() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_mempool_ops>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).get_count) as usize - ptr as usize
+            },
+            64usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_mempool_ops),
+                "::",
+                stringify!(get_count)
+            )
+        );
+    }
+    test_field_get_count();
 }
 impl Default for rte_mempool_ops {
     fn default() -> Self {
@@ -202,20 +226,24 @@ fn bindgen_test_layout_rte_spinlock_t() {
         4usize,
         concat!("Alignment of ", stringify!(rte_spinlock_t))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_spinlock_t>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).locked) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_spinlock_t),
-            "::",
-            stringify!(locked)
-        )
-    );
+    fn test_field_locked() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_spinlock_t>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).locked) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_spinlock_t),
+                "::",
+                stringify!(locked)
+            )
+        );
+    }
+    test_field_locked();
 }
 /// Structure storing the table of registered ops structs, each of which contain
 /// the function pointers for the mempool ops functions.
@@ -248,51 +276,60 @@ fn bindgen_test_layout_rte_mempool_ops_table() {
         64usize,
         concat!("Alignment of ", stringify!(rte_mempool_ops_table))
     );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<rte_mempool_ops_table>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).sl) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mempool_ops_table),
-            "::",
-            stringify!(sl)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<rte_mempool_ops_table>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).num_ops) as usize - ptr as usize
-        },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mempool_ops_table),
-            "::",
-            stringify!(num_ops)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<rte_mempool_ops_table>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).ops) as usize - ptr as usize
-        },
-        64usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mempool_ops_table),
-            "::",
-            stringify!(ops)
-        )
-    );
+    fn test_field_sl() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_mempool_ops_table>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).sl) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_mempool_ops_table),
+                "::",
+                stringify!(sl)
+            )
+        );
+    }
+    test_field_sl();
+    fn test_field_num_ops() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_mempool_ops_table>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).num_ops) as usize - ptr as usize
+            },
+            4usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_mempool_ops_table),
+                "::",
+                stringify!(num_ops)
+            )
+        );
+    }
+    test_field_num_ops();
+    fn test_field_ops() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_mempool_ops_table>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).ops) as usize - ptr as usize
+            },
+            64usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_mempool_ops_table),
+                "::",
+                stringify!(ops)
+            )
+        );
+    }
+    test_field_ops();
 }
 impl Default for rte_mempool_ops_table {
     fn default() -> Self {
@@ -330,21 +367,23 @@ fn bindgen_test_layout_malloc_heap__bindgen_ty_1() {
         8usize,
         concat!("Alignment of ", stringify!(malloc_heap__bindgen_ty_1))
     );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<malloc_heap__bindgen_ty_1>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).lh_first) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(malloc_heap__bindgen_ty_1),
-            "::",
-            stringify!(lh_first)
-        )
-    );
+    fn test_field_lh_first() {
+        assert_eq!(
+            unsafe {
+                let uninit = :: std :: mem :: MaybeUninit :: < malloc_heap__bindgen_ty_1 > :: uninit () ;
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).lh_first) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(malloc_heap__bindgen_ty_1),
+                "::",
+                stringify!(lh_first)
+            )
+        );
+    }
+    test_field_lh_first();
 }
 impl Default for malloc_heap__bindgen_ty_1 {
     fn default() -> Self {
@@ -367,62 +406,74 @@ fn bindgen_test_layout_malloc_heap() {
         64usize,
         concat!("Alignment of ", stringify!(malloc_heap))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<malloc_heap>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).lock) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(malloc_heap),
-            "::",
-            stringify!(lock)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<malloc_heap>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).free_head) as usize - ptr as usize
-        },
-        8usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(malloc_heap),
-            "::",
-            stringify!(free_head)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<malloc_heap>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).alloc_count) as usize - ptr as usize
-        },
-        112usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(malloc_heap),
-            "::",
-            stringify!(alloc_count)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<malloc_heap>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).total_size) as usize - ptr as usize
-        },
-        120usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(malloc_heap),
-            "::",
-            stringify!(total_size)
-        )
-    );
+    fn test_field_lock() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<malloc_heap>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).lock) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(malloc_heap),
+                "::",
+                stringify!(lock)
+            )
+        );
+    }
+    test_field_lock();
+    fn test_field_free_head() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<malloc_heap>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).free_head) as usize - ptr as usize
+            },
+            8usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(malloc_heap),
+                "::",
+                stringify!(free_head)
+            )
+        );
+    }
+    test_field_free_head();
+    fn test_field_alloc_count() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<malloc_heap>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).alloc_count) as usize - ptr as usize
+            },
+            112usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(malloc_heap),
+                "::",
+                stringify!(alloc_count)
+            )
+        );
+    }
+    test_field_alloc_count();
+    fn test_field_total_size() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<malloc_heap>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).total_size) as usize - ptr as usize
+            },
+            120usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(malloc_heap),
+                "::",
+                stringify!(total_size)
+            )
+        );
+    }
+    test_field_total_size();
 }
 impl Default for malloc_heap {
     fn default() -> Self {

--- a/tests/expectations/tests/layout_array_too_long.rs
+++ b/tests/expectations/tests/layout_array_too_long.rs
@@ -45,48 +45,57 @@ fn bindgen_test_layout_ip_frag() {
         8usize,
         concat!("Alignment of ", stringify!(ip_frag))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<ip_frag>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).ofs) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(ip_frag),
-            "::",
-            stringify!(ofs)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<ip_frag>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).len) as usize - ptr as usize
-        },
-        2usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(ip_frag),
-            "::",
-            stringify!(len)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<ip_frag>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mb) as usize - ptr as usize
-        },
-        8usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(ip_frag),
-            "::",
-            stringify!(mb)
-        )
-    );
+    fn test_field_ofs() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<ip_frag>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).ofs) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(ip_frag),
+                "::",
+                stringify!(ofs)
+            )
+        );
+    }
+    test_field_ofs();
+    fn test_field_len() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<ip_frag>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).len) as usize - ptr as usize
+            },
+            2usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(ip_frag),
+                "::",
+                stringify!(len)
+            )
+        );
+    }
+    test_field_len();
+    fn test_field_mb() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<ip_frag>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).mb) as usize - ptr as usize
+            },
+            8usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(ip_frag),
+                "::",
+                stringify!(mb)
+            )
+        );
+    }
+    test_field_mb();
 }
 impl Default for ip_frag {
     fn default() -> Self {
@@ -120,48 +129,57 @@ fn bindgen_test_layout_ip_frag_key() {
         8usize,
         concat!("Alignment of ", stringify!(ip_frag_key))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<ip_frag_key>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).src_dst) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(ip_frag_key),
-            "::",
-            stringify!(src_dst)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<ip_frag_key>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).id) as usize - ptr as usize
-        },
-        32usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(ip_frag_key),
-            "::",
-            stringify!(id)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<ip_frag_key>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).key_len) as usize - ptr as usize
-        },
-        36usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(ip_frag_key),
-            "::",
-            stringify!(key_len)
-        )
-    );
+    fn test_field_src_dst() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<ip_frag_key>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).src_dst) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(ip_frag_key),
+                "::",
+                stringify!(src_dst)
+            )
+        );
+    }
+    test_field_src_dst();
+    fn test_field_id() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<ip_frag_key>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).id) as usize - ptr as usize
+            },
+            32usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(ip_frag_key),
+                "::",
+                stringify!(id)
+            )
+        );
+    }
+    test_field_id();
+    fn test_field_key_len() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<ip_frag_key>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).key_len) as usize - ptr as usize
+            },
+            36usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(ip_frag_key),
+                "::",
+                stringify!(key_len)
+            )
+        );
+    }
+    test_field_key_len();
 }
 /// @internal Fragmented packet to reassemble.
 /// First two entries in the frags[] array are for the last and first fragments.
@@ -202,36 +220,40 @@ fn bindgen_test_layout_ip_frag_pkt__bindgen_ty_1() {
         8usize,
         concat!("Alignment of ", stringify!(ip_frag_pkt__bindgen_ty_1))
     );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<ip_frag_pkt__bindgen_ty_1>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).tqe_next) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(ip_frag_pkt__bindgen_ty_1),
-            "::",
-            stringify!(tqe_next)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<ip_frag_pkt__bindgen_ty_1>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).tqe_prev) as usize - ptr as usize
-        },
-        8usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(ip_frag_pkt__bindgen_ty_1),
-            "::",
-            stringify!(tqe_prev)
-        )
-    );
+    fn test_field_tqe_next() {
+        assert_eq!(
+            unsafe {
+                let uninit = :: std :: mem :: MaybeUninit :: < ip_frag_pkt__bindgen_ty_1 > :: uninit () ;
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).tqe_next) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(ip_frag_pkt__bindgen_ty_1),
+                "::",
+                stringify!(tqe_next)
+            )
+        );
+    }
+    test_field_tqe_next();
+    fn test_field_tqe_prev() {
+        assert_eq!(
+            unsafe {
+                let uninit = :: std :: mem :: MaybeUninit :: < ip_frag_pkt__bindgen_ty_1 > :: uninit () ;
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).tqe_prev) as usize - ptr as usize
+            },
+            8usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(ip_frag_pkt__bindgen_ty_1),
+                "::",
+                stringify!(tqe_prev)
+            )
+        );
+    }
+    test_field_tqe_prev();
 }
 impl Default for ip_frag_pkt__bindgen_ty_1 {
     fn default() -> Self {
@@ -254,104 +276,125 @@ fn bindgen_test_layout_ip_frag_pkt() {
         64usize,
         concat!("Alignment of ", stringify!(ip_frag_pkt))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<ip_frag_pkt>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).lru) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(ip_frag_pkt),
-            "::",
-            stringify!(lru)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<ip_frag_pkt>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).key) as usize - ptr as usize
-        },
-        16usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(ip_frag_pkt),
-            "::",
-            stringify!(key)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<ip_frag_pkt>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).start) as usize - ptr as usize
-        },
-        56usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(ip_frag_pkt),
-            "::",
-            stringify!(start)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<ip_frag_pkt>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).total_size) as usize - ptr as usize
-        },
-        64usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(ip_frag_pkt),
-            "::",
-            stringify!(total_size)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<ip_frag_pkt>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).frag_size) as usize - ptr as usize
-        },
-        68usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(ip_frag_pkt),
-            "::",
-            stringify!(frag_size)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<ip_frag_pkt>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).last_idx) as usize - ptr as usize
-        },
-        72usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(ip_frag_pkt),
-            "::",
-            stringify!(last_idx)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<ip_frag_pkt>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).frags) as usize - ptr as usize
-        },
-        80usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(ip_frag_pkt),
-            "::",
-            stringify!(frags)
-        )
-    );
+    fn test_field_lru() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<ip_frag_pkt>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).lru) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(ip_frag_pkt),
+                "::",
+                stringify!(lru)
+            )
+        );
+    }
+    test_field_lru();
+    fn test_field_key() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<ip_frag_pkt>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).key) as usize - ptr as usize
+            },
+            16usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(ip_frag_pkt),
+                "::",
+                stringify!(key)
+            )
+        );
+    }
+    test_field_key();
+    fn test_field_start() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<ip_frag_pkt>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).start) as usize - ptr as usize
+            },
+            56usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(ip_frag_pkt),
+                "::",
+                stringify!(start)
+            )
+        );
+    }
+    test_field_start();
+    fn test_field_total_size() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<ip_frag_pkt>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).total_size) as usize - ptr as usize
+            },
+            64usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(ip_frag_pkt),
+                "::",
+                stringify!(total_size)
+            )
+        );
+    }
+    test_field_total_size();
+    fn test_field_frag_size() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<ip_frag_pkt>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).frag_size) as usize - ptr as usize
+            },
+            68usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(ip_frag_pkt),
+                "::",
+                stringify!(frag_size)
+            )
+        );
+    }
+    test_field_frag_size();
+    fn test_field_last_idx() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<ip_frag_pkt>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).last_idx) as usize - ptr as usize
+            },
+            72usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(ip_frag_pkt),
+                "::",
+                stringify!(last_idx)
+            )
+        );
+    }
+    test_field_last_idx();
+    fn test_field_frags() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<ip_frag_pkt>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).frags) as usize - ptr as usize
+            },
+            80usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(ip_frag_pkt),
+                "::",
+                stringify!(frags)
+            )
+        );
+    }
+    test_field_frags();
 }
 impl Default for ip_frag_pkt {
     fn default() -> Self {

--- a/tests/expectations/tests/layout_cmdline_token.rs
+++ b/tests/expectations/tests/layout_cmdline_token.rs
@@ -25,34 +25,42 @@ fn bindgen_test_layout_cmdline_token_hdr() {
         8usize,
         concat!("Alignment of ", stringify!(cmdline_token_hdr))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<cmdline_token_hdr>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).ops) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(cmdline_token_hdr),
-            "::",
-            stringify!(ops)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<cmdline_token_hdr>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).offset) as usize - ptr as usize
-        },
-        8usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(cmdline_token_hdr),
-            "::",
-            stringify!(offset)
-        )
-    );
+    fn test_field_ops() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<cmdline_token_hdr>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).ops) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(cmdline_token_hdr),
+                "::",
+                stringify!(ops)
+            )
+        );
+    }
+    test_field_ops();
+    fn test_field_offset() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<cmdline_token_hdr>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).offset) as usize - ptr as usize
+            },
+            8usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(cmdline_token_hdr),
+                "::",
+                stringify!(offset)
+            )
+        );
+    }
+    test_field_offset();
 }
 impl Default for cmdline_token_hdr {
     fn default() -> Self {
@@ -131,63 +139,80 @@ fn bindgen_test_layout_cmdline_token_ops() {
         8usize,
         concat!("Alignment of ", stringify!(cmdline_token_ops))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<cmdline_token_ops>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).parse) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(cmdline_token_ops),
-            "::",
-            stringify!(parse)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<cmdline_token_ops>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).complete_get_nb) as usize - ptr as usize
-        },
-        8usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(cmdline_token_ops),
-            "::",
-            stringify!(complete_get_nb)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<cmdline_token_ops>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).complete_get_elt) as usize -
-                ptr as usize
-        },
-        16usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(cmdline_token_ops),
-            "::",
-            stringify!(complete_get_elt)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<cmdline_token_ops>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).get_help) as usize - ptr as usize
-        },
-        24usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(cmdline_token_ops),
-            "::",
-            stringify!(get_help)
-        )
-    );
+    fn test_field_parse() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<cmdline_token_ops>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).parse) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(cmdline_token_ops),
+                "::",
+                stringify!(parse)
+            )
+        );
+    }
+    test_field_parse();
+    fn test_field_complete_get_nb() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<cmdline_token_ops>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).complete_get_nb) as usize -
+                    ptr as usize
+            },
+            8usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(cmdline_token_ops),
+                "::",
+                stringify!(complete_get_nb)
+            )
+        );
+    }
+    test_field_complete_get_nb();
+    fn test_field_complete_get_elt() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<cmdline_token_ops>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).complete_get_elt) as usize -
+                    ptr as usize
+            },
+            16usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(cmdline_token_ops),
+                "::",
+                stringify!(complete_get_elt)
+            )
+        );
+    }
+    test_field_complete_get_elt();
+    fn test_field_get_help() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<cmdline_token_ops>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).get_help) as usize - ptr as usize
+            },
+            24usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(cmdline_token_ops),
+                "::",
+                stringify!(get_help)
+            )
+        );
+    }
+    test_field_get_help();
 }
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -218,21 +243,24 @@ fn bindgen_test_layout_cmdline_token_num_data() {
         4usize,
         concat!("Alignment of ", stringify!(cmdline_token_num_data))
     );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<cmdline_token_num_data>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).type_) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(cmdline_token_num_data),
-            "::",
-            stringify!(type_)
-        )
-    );
+    fn test_field_type() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<cmdline_token_num_data>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).type_) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(cmdline_token_num_data),
+                "::",
+                stringify!(type_)
+            )
+        );
+    }
+    test_field_type();
 }
 impl Default for cmdline_token_num_data {
     fn default() -> Self {
@@ -261,34 +289,42 @@ fn bindgen_test_layout_cmdline_token_num() {
         8usize,
         concat!("Alignment of ", stringify!(cmdline_token_num))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<cmdline_token_num>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).hdr) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(cmdline_token_num),
-            "::",
-            stringify!(hdr)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<cmdline_token_num>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).num_data) as usize - ptr as usize
-        },
-        16usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(cmdline_token_num),
-            "::",
-            stringify!(num_data)
-        )
-    );
+    fn test_field_hdr() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<cmdline_token_num>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).hdr) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(cmdline_token_num),
+                "::",
+                stringify!(hdr)
+            )
+        );
+    }
+    test_field_hdr();
+    fn test_field_num_data() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<cmdline_token_num>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).num_data) as usize - ptr as usize
+            },
+            16usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(cmdline_token_num),
+                "::",
+                stringify!(num_data)
+            )
+        );
+    }
+    test_field_num_data();
 }
 impl Default for cmdline_token_num {
     fn default() -> Self {

--- a/tests/expectations/tests/layout_eth_conf.rs
+++ b/tests/expectations/tests/layout_eth_conf.rs
@@ -170,48 +170,62 @@ fn bindgen_test_layout_rte_eth_rxmode() {
         4usize,
         concat!("Alignment of ", stringify!(rte_eth_rxmode))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_eth_rxmode>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mq_mode) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_rxmode),
-            "::",
-            stringify!(mq_mode)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_eth_rxmode>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).max_rx_pkt_len) as usize - ptr as usize
-        },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_rxmode),
-            "::",
-            stringify!(max_rx_pkt_len)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_eth_rxmode>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).split_hdr_size) as usize - ptr as usize
-        },
-        8usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_rxmode),
-            "::",
-            stringify!(split_hdr_size)
-        )
-    );
+    fn test_field_mq_mode() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_eth_rxmode>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).mq_mode) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_rxmode),
+                "::",
+                stringify!(mq_mode)
+            )
+        );
+    }
+    test_field_mq_mode();
+    fn test_field_max_rx_pkt_len() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_eth_rxmode>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).max_rx_pkt_len) as usize -
+                    ptr as usize
+            },
+            4usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_rxmode),
+                "::",
+                stringify!(max_rx_pkt_len)
+            )
+        );
+    }
+    test_field_max_rx_pkt_len();
+    fn test_field_split_hdr_size() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_eth_rxmode>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).split_hdr_size) as usize -
+                    ptr as usize
+            },
+            8usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_rxmode),
+                "::",
+                stringify!(split_hdr_size)
+            )
+        );
+    }
+    test_field_split_hdr_size();
 }
 impl Default for rte_eth_rxmode {
     fn default() -> Self {
@@ -438,34 +452,42 @@ fn bindgen_test_layout_rte_eth_txmode() {
         4usize,
         concat!("Alignment of ", stringify!(rte_eth_txmode))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_eth_txmode>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mq_mode) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_txmode),
-            "::",
-            stringify!(mq_mode)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_eth_txmode>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).pvid) as usize - ptr as usize
-        },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_txmode),
-            "::",
-            stringify!(pvid)
-        )
-    );
+    fn test_field_mq_mode() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_eth_txmode>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).mq_mode) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_txmode),
+                "::",
+                stringify!(mq_mode)
+            )
+        );
+    }
+    test_field_mq_mode();
+    fn test_field_pvid() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_eth_txmode>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).pvid) as usize - ptr as usize
+            },
+            4usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_txmode),
+                "::",
+                stringify!(pvid)
+            )
+        );
+    }
+    test_field_pvid();
 }
 impl Default for rte_eth_txmode {
     fn default() -> Self {
@@ -579,48 +601,60 @@ fn bindgen_test_layout_rte_eth_rss_conf() {
         8usize,
         concat!("Alignment of ", stringify!(rte_eth_rss_conf))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_eth_rss_conf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).rss_key) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_rss_conf),
-            "::",
-            stringify!(rss_key)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_eth_rss_conf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).rss_key_len) as usize - ptr as usize
-        },
-        8usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_rss_conf),
-            "::",
-            stringify!(rss_key_len)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_eth_rss_conf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).rss_hf) as usize - ptr as usize
-        },
-        16usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_rss_conf),
-            "::",
-            stringify!(rss_hf)
-        )
-    );
+    fn test_field_rss_key() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_eth_rss_conf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).rss_key) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_rss_conf),
+                "::",
+                stringify!(rss_key)
+            )
+        );
+    }
+    test_field_rss_key();
+    fn test_field_rss_key_len() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_eth_rss_conf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).rss_key_len) as usize - ptr as usize
+            },
+            8usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_rss_conf),
+                "::",
+                stringify!(rss_key_len)
+            )
+        );
+    }
+    test_field_rss_key_len();
+    fn test_field_rss_hf() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_eth_rss_conf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).rss_hf) as usize - ptr as usize
+            },
+            16usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_rss_conf),
+                "::",
+                stringify!(rss_hf)
+            )
+        );
+    }
+    test_field_rss_hf();
 }
 impl Default for rte_eth_rss_conf {
     fn default() -> Self {
@@ -702,38 +736,44 @@ fn bindgen_test_layout_rte_eth_vmdq_dcb_conf__bindgen_ty_1() {
             stringify!(rte_eth_vmdq_dcb_conf__bindgen_ty_1)
         )
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<
-                rte_eth_vmdq_dcb_conf__bindgen_ty_1,
-            >::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).vlan_id) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_vmdq_dcb_conf__bindgen_ty_1),
-            "::",
-            stringify!(vlan_id)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<
-                rte_eth_vmdq_dcb_conf__bindgen_ty_1,
-            >::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).pools) as usize - ptr as usize
-        },
-        8usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_vmdq_dcb_conf__bindgen_ty_1),
-            "::",
-            stringify!(pools)
-        )
-    );
+    fn test_field_vlan_id() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<
+                    rte_eth_vmdq_dcb_conf__bindgen_ty_1,
+                >::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).vlan_id) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_vmdq_dcb_conf__bindgen_ty_1),
+                "::",
+                stringify!(vlan_id)
+            )
+        );
+    }
+    test_field_vlan_id();
+    fn test_field_pools() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<
+                    rte_eth_vmdq_dcb_conf__bindgen_ty_1,
+                >::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).pools) as usize - ptr as usize
+            },
+            8usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_vmdq_dcb_conf__bindgen_ty_1),
+                "::",
+                stringify!(pools)
+            )
+        );
+    }
+    test_field_pools();
 }
 #[test]
 fn bindgen_test_layout_rte_eth_vmdq_dcb_conf() {
@@ -747,97 +787,118 @@ fn bindgen_test_layout_rte_eth_vmdq_dcb_conf() {
         8usize,
         concat!("Alignment of ", stringify!(rte_eth_vmdq_dcb_conf))
     );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<rte_eth_vmdq_dcb_conf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).nb_queue_pools) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_vmdq_dcb_conf),
-            "::",
-            stringify!(nb_queue_pools)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<rte_eth_vmdq_dcb_conf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).enable_default_pool) as usize -
-                ptr as usize
-        },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_vmdq_dcb_conf),
-            "::",
-            stringify!(enable_default_pool)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<rte_eth_vmdq_dcb_conf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).default_pool) as usize - ptr as usize
-        },
-        5usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_vmdq_dcb_conf),
-            "::",
-            stringify!(default_pool)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<rte_eth_vmdq_dcb_conf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).nb_pool_maps) as usize - ptr as usize
-        },
-        6usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_vmdq_dcb_conf),
-            "::",
-            stringify!(nb_pool_maps)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<rte_eth_vmdq_dcb_conf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).pool_map) as usize - ptr as usize
-        },
-        8usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_vmdq_dcb_conf),
-            "::",
-            stringify!(pool_map)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<rte_eth_vmdq_dcb_conf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).dcb_tc) as usize - ptr as usize
-        },
-        1032usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_vmdq_dcb_conf),
-            "::",
-            stringify!(dcb_tc)
-        )
-    );
+    fn test_field_nb_queue_pools() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_eth_vmdq_dcb_conf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).nb_queue_pools) as usize -
+                    ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_vmdq_dcb_conf),
+                "::",
+                stringify!(nb_queue_pools)
+            )
+        );
+    }
+    test_field_nb_queue_pools();
+    fn test_field_enable_default_pool() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_eth_vmdq_dcb_conf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).enable_default_pool) as usize -
+                    ptr as usize
+            },
+            4usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_vmdq_dcb_conf),
+                "::",
+                stringify!(enable_default_pool)
+            )
+        );
+    }
+    test_field_enable_default_pool();
+    fn test_field_default_pool() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_eth_vmdq_dcb_conf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).default_pool) as usize -
+                    ptr as usize
+            },
+            5usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_vmdq_dcb_conf),
+                "::",
+                stringify!(default_pool)
+            )
+        );
+    }
+    test_field_default_pool();
+    fn test_field_nb_pool_maps() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_eth_vmdq_dcb_conf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).nb_pool_maps) as usize -
+                    ptr as usize
+            },
+            6usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_vmdq_dcb_conf),
+                "::",
+                stringify!(nb_pool_maps)
+            )
+        );
+    }
+    test_field_nb_pool_maps();
+    fn test_field_pool_map() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_eth_vmdq_dcb_conf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).pool_map) as usize - ptr as usize
+            },
+            8usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_vmdq_dcb_conf),
+                "::",
+                stringify!(pool_map)
+            )
+        );
+    }
+    test_field_pool_map();
+    fn test_field_dcb_tc() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_eth_vmdq_dcb_conf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).dcb_tc) as usize - ptr as usize
+            },
+            1032usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_vmdq_dcb_conf),
+                "::",
+                stringify!(dcb_tc)
+            )
+        );
+    }
+    test_field_dcb_tc();
 }
 impl Default for rte_eth_vmdq_dcb_conf {
     fn default() -> Self {
@@ -868,36 +929,42 @@ fn bindgen_test_layout_rte_eth_dcb_rx_conf() {
         4usize,
         concat!("Alignment of ", stringify!(rte_eth_dcb_rx_conf))
     );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<rte_eth_dcb_rx_conf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).nb_tcs) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_dcb_rx_conf),
-            "::",
-            stringify!(nb_tcs)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<rte_eth_dcb_rx_conf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).dcb_tc) as usize - ptr as usize
-        },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_dcb_rx_conf),
-            "::",
-            stringify!(dcb_tc)
-        )
-    );
+    fn test_field_nb_tcs() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_eth_dcb_rx_conf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).nb_tcs) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_dcb_rx_conf),
+                "::",
+                stringify!(nb_tcs)
+            )
+        );
+    }
+    test_field_nb_tcs();
+    fn test_field_dcb_tc() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_eth_dcb_rx_conf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).dcb_tc) as usize - ptr as usize
+            },
+            4usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_dcb_rx_conf),
+                "::",
+                stringify!(dcb_tc)
+            )
+        );
+    }
+    test_field_dcb_tc();
 }
 impl Default for rte_eth_dcb_rx_conf {
     fn default() -> Self {
@@ -928,36 +995,45 @@ fn bindgen_test_layout_rte_eth_vmdq_dcb_tx_conf() {
         4usize,
         concat!("Alignment of ", stringify!(rte_eth_vmdq_dcb_tx_conf))
     );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<rte_eth_vmdq_dcb_tx_conf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).nb_queue_pools) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_vmdq_dcb_tx_conf),
-            "::",
-            stringify!(nb_queue_pools)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<rte_eth_vmdq_dcb_tx_conf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).dcb_tc) as usize - ptr as usize
-        },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_vmdq_dcb_tx_conf),
-            "::",
-            stringify!(dcb_tc)
-        )
-    );
+    fn test_field_nb_queue_pools() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_eth_vmdq_dcb_tx_conf>::uninit(
+                    );
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).nb_queue_pools) as usize -
+                    ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_vmdq_dcb_tx_conf),
+                "::",
+                stringify!(nb_queue_pools)
+            )
+        );
+    }
+    test_field_nb_queue_pools();
+    fn test_field_dcb_tc() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_eth_vmdq_dcb_tx_conf>::uninit(
+                    );
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).dcb_tc) as usize - ptr as usize
+            },
+            4usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_vmdq_dcb_tx_conf),
+                "::",
+                stringify!(dcb_tc)
+            )
+        );
+    }
+    test_field_dcb_tc();
 }
 impl Default for rte_eth_vmdq_dcb_tx_conf {
     fn default() -> Self {
@@ -988,36 +1064,42 @@ fn bindgen_test_layout_rte_eth_dcb_tx_conf() {
         4usize,
         concat!("Alignment of ", stringify!(rte_eth_dcb_tx_conf))
     );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<rte_eth_dcb_tx_conf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).nb_tcs) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_dcb_tx_conf),
-            "::",
-            stringify!(nb_tcs)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<rte_eth_dcb_tx_conf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).dcb_tc) as usize - ptr as usize
-        },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_dcb_tx_conf),
-            "::",
-            stringify!(dcb_tc)
-        )
-    );
+    fn test_field_nb_tcs() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_eth_dcb_tx_conf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).nb_tcs) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_dcb_tx_conf),
+                "::",
+                stringify!(nb_tcs)
+            )
+        );
+    }
+    test_field_nb_tcs();
+    fn test_field_dcb_tc() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_eth_dcb_tx_conf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).dcb_tc) as usize - ptr as usize
+            },
+            4usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_dcb_tx_conf),
+                "::",
+                stringify!(dcb_tc)
+            )
+        );
+    }
+    test_field_dcb_tc();
 }
 impl Default for rte_eth_dcb_tx_conf {
     fn default() -> Self {
@@ -1046,21 +1128,25 @@ fn bindgen_test_layout_rte_eth_vmdq_tx_conf() {
         4usize,
         concat!("Alignment of ", stringify!(rte_eth_vmdq_tx_conf))
     );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<rte_eth_vmdq_tx_conf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).nb_queue_pools) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_vmdq_tx_conf),
-            "::",
-            stringify!(nb_queue_pools)
-        )
-    );
+    fn test_field_nb_queue_pools() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_eth_vmdq_tx_conf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).nb_queue_pools) as usize -
+                    ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_vmdq_tx_conf),
+                "::",
+                stringify!(nb_queue_pools)
+            )
+        );
+    }
+    test_field_nb_queue_pools();
 }
 impl Default for rte_eth_vmdq_tx_conf {
     fn default() -> Self {
@@ -1112,38 +1198,44 @@ fn bindgen_test_layout_rte_eth_vmdq_rx_conf__bindgen_ty_1() {
             stringify!(rte_eth_vmdq_rx_conf__bindgen_ty_1)
         )
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<
-                rte_eth_vmdq_rx_conf__bindgen_ty_1,
-            >::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).vlan_id) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_vmdq_rx_conf__bindgen_ty_1),
-            "::",
-            stringify!(vlan_id)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<
-                rte_eth_vmdq_rx_conf__bindgen_ty_1,
-            >::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).pools) as usize - ptr as usize
-        },
-        8usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_vmdq_rx_conf__bindgen_ty_1),
-            "::",
-            stringify!(pools)
-        )
-    );
+    fn test_field_vlan_id() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<
+                    rte_eth_vmdq_rx_conf__bindgen_ty_1,
+                >::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).vlan_id) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_vmdq_rx_conf__bindgen_ty_1),
+                "::",
+                stringify!(vlan_id)
+            )
+        );
+    }
+    test_field_vlan_id();
+    fn test_field_pools() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<
+                    rte_eth_vmdq_rx_conf__bindgen_ty_1,
+                >::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).pools) as usize - ptr as usize
+            },
+            8usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_vmdq_rx_conf__bindgen_ty_1),
+                "::",
+                stringify!(pools)
+            )
+        );
+    }
+    test_field_pools();
 }
 #[test]
 fn bindgen_test_layout_rte_eth_vmdq_rx_conf() {
@@ -1157,113 +1249,137 @@ fn bindgen_test_layout_rte_eth_vmdq_rx_conf() {
         8usize,
         concat!("Alignment of ", stringify!(rte_eth_vmdq_rx_conf))
     );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<rte_eth_vmdq_rx_conf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).nb_queue_pools) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_vmdq_rx_conf),
-            "::",
-            stringify!(nb_queue_pools)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<rte_eth_vmdq_rx_conf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).enable_default_pool) as usize -
-                ptr as usize
-        },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_vmdq_rx_conf),
-            "::",
-            stringify!(enable_default_pool)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<rte_eth_vmdq_rx_conf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).default_pool) as usize - ptr as usize
-        },
-        5usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_vmdq_rx_conf),
-            "::",
-            stringify!(default_pool)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<rte_eth_vmdq_rx_conf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).enable_loop_back) as usize -
-                ptr as usize
-        },
-        6usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_vmdq_rx_conf),
-            "::",
-            stringify!(enable_loop_back)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<rte_eth_vmdq_rx_conf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).nb_pool_maps) as usize - ptr as usize
-        },
-        7usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_vmdq_rx_conf),
-            "::",
-            stringify!(nb_pool_maps)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<rte_eth_vmdq_rx_conf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).rx_mode) as usize - ptr as usize
-        },
-        8usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_vmdq_rx_conf),
-            "::",
-            stringify!(rx_mode)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<rte_eth_vmdq_rx_conf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).pool_map) as usize - ptr as usize
-        },
-        16usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_vmdq_rx_conf),
-            "::",
-            stringify!(pool_map)
-        )
-    );
+    fn test_field_nb_queue_pools() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_eth_vmdq_rx_conf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).nb_queue_pools) as usize -
+                    ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_vmdq_rx_conf),
+                "::",
+                stringify!(nb_queue_pools)
+            )
+        );
+    }
+    test_field_nb_queue_pools();
+    fn test_field_enable_default_pool() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_eth_vmdq_rx_conf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).enable_default_pool) as usize -
+                    ptr as usize
+            },
+            4usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_vmdq_rx_conf),
+                "::",
+                stringify!(enable_default_pool)
+            )
+        );
+    }
+    test_field_enable_default_pool();
+    fn test_field_default_pool() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_eth_vmdq_rx_conf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).default_pool) as usize -
+                    ptr as usize
+            },
+            5usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_vmdq_rx_conf),
+                "::",
+                stringify!(default_pool)
+            )
+        );
+    }
+    test_field_default_pool();
+    fn test_field_enable_loop_back() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_eth_vmdq_rx_conf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).enable_loop_back) as usize -
+                    ptr as usize
+            },
+            6usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_vmdq_rx_conf),
+                "::",
+                stringify!(enable_loop_back)
+            )
+        );
+    }
+    test_field_enable_loop_back();
+    fn test_field_nb_pool_maps() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_eth_vmdq_rx_conf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).nb_pool_maps) as usize -
+                    ptr as usize
+            },
+            7usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_vmdq_rx_conf),
+                "::",
+                stringify!(nb_pool_maps)
+            )
+        );
+    }
+    test_field_nb_pool_maps();
+    fn test_field_rx_mode() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_eth_vmdq_rx_conf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).rx_mode) as usize - ptr as usize
+            },
+            8usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_vmdq_rx_conf),
+                "::",
+                stringify!(rx_mode)
+            )
+        );
+    }
+    test_field_rx_mode();
+    fn test_field_pool_map() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_eth_vmdq_rx_conf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).pool_map) as usize - ptr as usize
+            },
+            16usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_vmdq_rx_conf),
+                "::",
+                stringify!(pool_map)
+            )
+        );
+    }
+    test_field_pool_map();
 }
 impl Default for rte_eth_vmdq_rx_conf {
     fn default() -> Self {
@@ -1339,76 +1455,96 @@ fn bindgen_test_layout_rte_eth_ipv4_flow() {
         4usize,
         concat!("Alignment of ", stringify!(rte_eth_ipv4_flow))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_eth_ipv4_flow>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).src_ip) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_ipv4_flow),
-            "::",
-            stringify!(src_ip)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_eth_ipv4_flow>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).dst_ip) as usize - ptr as usize
-        },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_ipv4_flow),
-            "::",
-            stringify!(dst_ip)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_eth_ipv4_flow>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).tos) as usize - ptr as usize
-        },
-        8usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_ipv4_flow),
-            "::",
-            stringify!(tos)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_eth_ipv4_flow>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).ttl) as usize - ptr as usize
-        },
-        9usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_ipv4_flow),
-            "::",
-            stringify!(ttl)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_eth_ipv4_flow>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).proto) as usize - ptr as usize
-        },
-        10usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_ipv4_flow),
-            "::",
-            stringify!(proto)
-        )
-    );
+    fn test_field_src_ip() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_eth_ipv4_flow>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).src_ip) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_ipv4_flow),
+                "::",
+                stringify!(src_ip)
+            )
+        );
+    }
+    test_field_src_ip();
+    fn test_field_dst_ip() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_eth_ipv4_flow>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).dst_ip) as usize - ptr as usize
+            },
+            4usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_ipv4_flow),
+                "::",
+                stringify!(dst_ip)
+            )
+        );
+    }
+    test_field_dst_ip();
+    fn test_field_tos() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_eth_ipv4_flow>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).tos) as usize - ptr as usize
+            },
+            8usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_ipv4_flow),
+                "::",
+                stringify!(tos)
+            )
+        );
+    }
+    test_field_tos();
+    fn test_field_ttl() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_eth_ipv4_flow>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).ttl) as usize - ptr as usize
+            },
+            9usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_ipv4_flow),
+                "::",
+                stringify!(ttl)
+            )
+        );
+    }
+    test_field_ttl();
+    fn test_field_proto() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_eth_ipv4_flow>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).proto) as usize - ptr as usize
+            },
+            10usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_ipv4_flow),
+                "::",
+                stringify!(proto)
+            )
+        );
+    }
+    test_field_proto();
 }
 /// A structure used to define the input for IPV6 flow
 #[repr(C)]
@@ -1437,76 +1573,96 @@ fn bindgen_test_layout_rte_eth_ipv6_flow() {
         4usize,
         concat!("Alignment of ", stringify!(rte_eth_ipv6_flow))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_eth_ipv6_flow>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).src_ip) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_ipv6_flow),
-            "::",
-            stringify!(src_ip)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_eth_ipv6_flow>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).dst_ip) as usize - ptr as usize
-        },
-        16usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_ipv6_flow),
-            "::",
-            stringify!(dst_ip)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_eth_ipv6_flow>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).tc) as usize - ptr as usize
-        },
-        32usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_ipv6_flow),
-            "::",
-            stringify!(tc)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_eth_ipv6_flow>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).proto) as usize - ptr as usize
-        },
-        33usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_ipv6_flow),
-            "::",
-            stringify!(proto)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_eth_ipv6_flow>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).hop_limits) as usize - ptr as usize
-        },
-        34usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_ipv6_flow),
-            "::",
-            stringify!(hop_limits)
-        )
-    );
+    fn test_field_src_ip() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_eth_ipv6_flow>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).src_ip) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_ipv6_flow),
+                "::",
+                stringify!(src_ip)
+            )
+        );
+    }
+    test_field_src_ip();
+    fn test_field_dst_ip() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_eth_ipv6_flow>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).dst_ip) as usize - ptr as usize
+            },
+            16usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_ipv6_flow),
+                "::",
+                stringify!(dst_ip)
+            )
+        );
+    }
+    test_field_dst_ip();
+    fn test_field_tc() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_eth_ipv6_flow>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).tc) as usize - ptr as usize
+            },
+            32usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_ipv6_flow),
+                "::",
+                stringify!(tc)
+            )
+        );
+    }
+    test_field_tc();
+    fn test_field_proto() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_eth_ipv6_flow>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).proto) as usize - ptr as usize
+            },
+            33usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_ipv6_flow),
+                "::",
+                stringify!(proto)
+            )
+        );
+    }
+    test_field_proto();
+    fn test_field_hop_limits() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_eth_ipv6_flow>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).hop_limits) as usize - ptr as usize
+            },
+            34usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_ipv6_flow),
+                "::",
+                stringify!(hop_limits)
+            )
+        );
+    }
+    test_field_hop_limits();
 }
 ///  A structure used to configure FDIR masks that are used by the device
 ///  to match the various fields of RX packet headers.
@@ -1544,128 +1700,156 @@ fn bindgen_test_layout_rte_eth_fdir_masks() {
         4usize,
         concat!("Alignment of ", stringify!(rte_eth_fdir_masks))
     );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<rte_eth_fdir_masks>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).vlan_tci_mask) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_fdir_masks),
-            "::",
-            stringify!(vlan_tci_mask)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<rte_eth_fdir_masks>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).ipv4_mask) as usize - ptr as usize
-        },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_fdir_masks),
-            "::",
-            stringify!(ipv4_mask)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<rte_eth_fdir_masks>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).ipv6_mask) as usize - ptr as usize
-        },
-        16usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_fdir_masks),
-            "::",
-            stringify!(ipv6_mask)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<rte_eth_fdir_masks>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).src_port_mask) as usize - ptr as usize
-        },
-        52usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_fdir_masks),
-            "::",
-            stringify!(src_port_mask)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<rte_eth_fdir_masks>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).dst_port_mask) as usize - ptr as usize
-        },
-        54usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_fdir_masks),
-            "::",
-            stringify!(dst_port_mask)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<rte_eth_fdir_masks>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mac_addr_byte_mask) as usize -
-                ptr as usize
-        },
-        56usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_fdir_masks),
-            "::",
-            stringify!(mac_addr_byte_mask)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<rte_eth_fdir_masks>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).tunnel_id_mask) as usize - ptr as usize
-        },
-        60usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_fdir_masks),
-            "::",
-            stringify!(tunnel_id_mask)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<rte_eth_fdir_masks>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).tunnel_type_mask) as usize -
-                ptr as usize
-        },
-        64usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_fdir_masks),
-            "::",
-            stringify!(tunnel_type_mask)
-        )
-    );
+    fn test_field_vlan_tci_mask() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_eth_fdir_masks>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).vlan_tci_mask) as usize -
+                    ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_fdir_masks),
+                "::",
+                stringify!(vlan_tci_mask)
+            )
+        );
+    }
+    test_field_vlan_tci_mask();
+    fn test_field_ipv4_mask() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_eth_fdir_masks>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).ipv4_mask) as usize - ptr as usize
+            },
+            4usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_fdir_masks),
+                "::",
+                stringify!(ipv4_mask)
+            )
+        );
+    }
+    test_field_ipv4_mask();
+    fn test_field_ipv6_mask() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_eth_fdir_masks>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).ipv6_mask) as usize - ptr as usize
+            },
+            16usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_fdir_masks),
+                "::",
+                stringify!(ipv6_mask)
+            )
+        );
+    }
+    test_field_ipv6_mask();
+    fn test_field_src_port_mask() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_eth_fdir_masks>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).src_port_mask) as usize -
+                    ptr as usize
+            },
+            52usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_fdir_masks),
+                "::",
+                stringify!(src_port_mask)
+            )
+        );
+    }
+    test_field_src_port_mask();
+    fn test_field_dst_port_mask() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_eth_fdir_masks>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).dst_port_mask) as usize -
+                    ptr as usize
+            },
+            54usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_fdir_masks),
+                "::",
+                stringify!(dst_port_mask)
+            )
+        );
+    }
+    test_field_dst_port_mask();
+    fn test_field_mac_addr_byte_mask() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_eth_fdir_masks>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).mac_addr_byte_mask) as usize -
+                    ptr as usize
+            },
+            56usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_fdir_masks),
+                "::",
+                stringify!(mac_addr_byte_mask)
+            )
+        );
+    }
+    test_field_mac_addr_byte_mask();
+    fn test_field_tunnel_id_mask() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_eth_fdir_masks>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).tunnel_id_mask) as usize -
+                    ptr as usize
+            },
+            60usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_fdir_masks),
+                "::",
+                stringify!(tunnel_id_mask)
+            )
+        );
+    }
+    test_field_tunnel_id_mask();
+    fn test_field_tunnel_type_mask() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_eth_fdir_masks>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).tunnel_type_mask) as usize -
+                    ptr as usize
+            },
+            64usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_fdir_masks),
+                "::",
+                stringify!(tunnel_type_mask)
+            )
+        );
+    }
+    test_field_tunnel_type_mask();
 }
 #[repr(u32)]
 /// Payload type
@@ -1699,36 +1883,44 @@ fn bindgen_test_layout_rte_eth_flex_payload_cfg() {
         4usize,
         concat!("Alignment of ", stringify!(rte_eth_flex_payload_cfg))
     );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<rte_eth_flex_payload_cfg>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).type_) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_flex_payload_cfg),
-            "::",
-            stringify!(type_)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<rte_eth_flex_payload_cfg>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).src_offset) as usize - ptr as usize
-        },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_flex_payload_cfg),
-            "::",
-            stringify!(src_offset)
-        )
-    );
+    fn test_field_type() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_eth_flex_payload_cfg>::uninit(
+                    );
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).type_) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_flex_payload_cfg),
+                "::",
+                stringify!(type_)
+            )
+        );
+    }
+    test_field_type();
+    fn test_field_src_offset() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_eth_flex_payload_cfg>::uninit(
+                    );
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).src_offset) as usize - ptr as usize
+            },
+            4usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_flex_payload_cfg),
+                "::",
+                stringify!(src_offset)
+            )
+        );
+    }
+    test_field_src_offset();
 }
 impl Default for rte_eth_flex_payload_cfg {
     fn default() -> Self {
@@ -1759,36 +1951,42 @@ fn bindgen_test_layout_rte_eth_fdir_flex_mask() {
         2usize,
         concat!("Alignment of ", stringify!(rte_eth_fdir_flex_mask))
     );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<rte_eth_fdir_flex_mask>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).flow_type) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_fdir_flex_mask),
-            "::",
-            stringify!(flow_type)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<rte_eth_fdir_flex_mask>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mask) as usize - ptr as usize
-        },
-        2usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_fdir_flex_mask),
-            "::",
-            stringify!(mask)
-        )
-    );
+    fn test_field_flow_type() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_eth_fdir_flex_mask>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).flow_type) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_fdir_flex_mask),
+                "::",
+                stringify!(flow_type)
+            )
+        );
+    }
+    test_field_flow_type();
+    fn test_field_mask() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_eth_fdir_flex_mask>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).mask) as usize - ptr as usize
+            },
+            2usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_fdir_flex_mask),
+                "::",
+                stringify!(mask)
+            )
+        );
+    }
+    test_field_mask();
 }
 /// A structure used to define all flexible payload related setting
 /// include flex payload and flex mask
@@ -1814,66 +2012,79 @@ fn bindgen_test_layout_rte_eth_fdir_flex_conf() {
         4usize,
         concat!("Alignment of ", stringify!(rte_eth_fdir_flex_conf))
     );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<rte_eth_fdir_flex_conf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).nb_payloads) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_fdir_flex_conf),
-            "::",
-            stringify!(nb_payloads)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<rte_eth_fdir_flex_conf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).nb_flexmasks) as usize - ptr as usize
-        },
-        2usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_fdir_flex_conf),
-            "::",
-            stringify!(nb_flexmasks)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<rte_eth_fdir_flex_conf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).flex_set) as usize - ptr as usize
-        },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_fdir_flex_conf),
-            "::",
-            stringify!(flex_set)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<rte_eth_fdir_flex_conf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).flex_mask) as usize - ptr as usize
-        },
-        292usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_fdir_flex_conf),
-            "::",
-            stringify!(flex_mask)
-        )
-    );
+    fn test_field_nb_payloads() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_eth_fdir_flex_conf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).nb_payloads) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_fdir_flex_conf),
+                "::",
+                stringify!(nb_payloads)
+            )
+        );
+    }
+    test_field_nb_payloads();
+    fn test_field_nb_flexmasks() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_eth_fdir_flex_conf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).nb_flexmasks) as usize -
+                    ptr as usize
+            },
+            2usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_fdir_flex_conf),
+                "::",
+                stringify!(nb_flexmasks)
+            )
+        );
+    }
+    test_field_nb_flexmasks();
+    fn test_field_flex_set() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_eth_fdir_flex_conf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).flex_set) as usize - ptr as usize
+            },
+            4usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_fdir_flex_conf),
+                "::",
+                stringify!(flex_set)
+            )
+        );
+    }
+    test_field_flex_set();
+    fn test_field_flex_mask() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_eth_fdir_flex_conf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).flex_mask) as usize - ptr as usize
+            },
+            292usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_fdir_flex_conf),
+                "::",
+                stringify!(flex_mask)
+            )
+        );
+    }
+    test_field_flex_mask();
 }
 impl Default for rte_eth_fdir_flex_conf {
     fn default() -> Self {
@@ -1914,90 +2125,108 @@ fn bindgen_test_layout_rte_fdir_conf() {
         4usize,
         concat!("Alignment of ", stringify!(rte_fdir_conf))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_fdir_conf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mode) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_fdir_conf),
-            "::",
-            stringify!(mode)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_fdir_conf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).pballoc) as usize - ptr as usize
-        },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_fdir_conf),
-            "::",
-            stringify!(pballoc)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_fdir_conf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).status) as usize - ptr as usize
-        },
-        8usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_fdir_conf),
-            "::",
-            stringify!(status)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_fdir_conf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).drop_queue) as usize - ptr as usize
-        },
-        12usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_fdir_conf),
-            "::",
-            stringify!(drop_queue)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_fdir_conf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mask) as usize - ptr as usize
-        },
-        16usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_fdir_conf),
-            "::",
-            stringify!(mask)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_fdir_conf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).flex_conf) as usize - ptr as usize
-        },
-        84usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_fdir_conf),
-            "::",
-            stringify!(flex_conf)
-        )
-    );
+    fn test_field_mode() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<rte_fdir_conf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).mode) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_fdir_conf),
+                "::",
+                stringify!(mode)
+            )
+        );
+    }
+    test_field_mode();
+    fn test_field_pballoc() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<rte_fdir_conf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).pballoc) as usize - ptr as usize
+            },
+            4usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_fdir_conf),
+                "::",
+                stringify!(pballoc)
+            )
+        );
+    }
+    test_field_pballoc();
+    fn test_field_status() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<rte_fdir_conf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).status) as usize - ptr as usize
+            },
+            8usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_fdir_conf),
+                "::",
+                stringify!(status)
+            )
+        );
+    }
+    test_field_status();
+    fn test_field_drop_queue() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<rte_fdir_conf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).drop_queue) as usize - ptr as usize
+            },
+            12usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_fdir_conf),
+                "::",
+                stringify!(drop_queue)
+            )
+        );
+    }
+    test_field_drop_queue();
+    fn test_field_mask() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<rte_fdir_conf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).mask) as usize - ptr as usize
+            },
+            16usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_fdir_conf),
+                "::",
+                stringify!(mask)
+            )
+        );
+    }
+    test_field_mask();
+    fn test_field_flex_conf() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<rte_fdir_conf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).flex_conf) as usize - ptr as usize
+            },
+            84usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_fdir_conf),
+                "::",
+                stringify!(flex_conf)
+            )
+        );
+    }
+    test_field_flex_conf();
 }
 impl Default for rte_fdir_conf {
     fn default() -> Self {
@@ -2029,34 +2258,40 @@ fn bindgen_test_layout_rte_intr_conf() {
         2usize,
         concat!("Alignment of ", stringify!(rte_intr_conf))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_intr_conf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).lsc) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_intr_conf),
-            "::",
-            stringify!(lsc)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_intr_conf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).rxq) as usize - ptr as usize
-        },
-        2usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_intr_conf),
-            "::",
-            stringify!(rxq)
-        )
-    );
+    fn test_field_lsc() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<rte_intr_conf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).lsc) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_intr_conf),
+                "::",
+                stringify!(lsc)
+            )
+        );
+    }
+    test_field_lsc();
+    fn test_field_rxq() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<rte_intr_conf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).rxq) as usize - ptr as usize
+            },
+            2usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_intr_conf),
+                "::",
+                stringify!(rxq)
+            )
+        );
+    }
+    test_field_rxq();
 }
 /// A structure used to configure an Ethernet port.
 /// Depending upon the RX multi-queue mode, extra advanced
@@ -2115,66 +2350,84 @@ fn bindgen_test_layout_rte_eth_conf__bindgen_ty_1() {
         8usize,
         concat!("Alignment of ", stringify!(rte_eth_conf__bindgen_ty_1))
     );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<rte_eth_conf__bindgen_ty_1>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).rss_conf) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_conf__bindgen_ty_1),
-            "::",
-            stringify!(rss_conf)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<rte_eth_conf__bindgen_ty_1>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).vmdq_dcb_conf) as usize - ptr as usize
-        },
-        24usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_conf__bindgen_ty_1),
-            "::",
-            stringify!(vmdq_dcb_conf)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<rte_eth_conf__bindgen_ty_1>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).dcb_rx_conf) as usize - ptr as usize
-        },
-        1064usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_conf__bindgen_ty_1),
-            "::",
-            stringify!(dcb_rx_conf)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<rte_eth_conf__bindgen_ty_1>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).vmdq_rx_conf) as usize - ptr as usize
-        },
-        1080usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_conf__bindgen_ty_1),
-            "::",
-            stringify!(vmdq_rx_conf)
-        )
-    );
+    fn test_field_rss_conf() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<
+                    rte_eth_conf__bindgen_ty_1,
+                >::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).rss_conf) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_conf__bindgen_ty_1),
+                "::",
+                stringify!(rss_conf)
+            )
+        );
+    }
+    test_field_rss_conf();
+    fn test_field_vmdq_dcb_conf() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<
+                    rte_eth_conf__bindgen_ty_1,
+                >::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).vmdq_dcb_conf) as usize -
+                    ptr as usize
+            },
+            24usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_conf__bindgen_ty_1),
+                "::",
+                stringify!(vmdq_dcb_conf)
+            )
+        );
+    }
+    test_field_vmdq_dcb_conf();
+    fn test_field_dcb_rx_conf() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<
+                    rte_eth_conf__bindgen_ty_1,
+                >::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).dcb_rx_conf) as usize - ptr as usize
+            },
+            1064usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_conf__bindgen_ty_1),
+                "::",
+                stringify!(dcb_rx_conf)
+            )
+        );
+    }
+    test_field_dcb_rx_conf();
+    fn test_field_vmdq_rx_conf() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<
+                    rte_eth_conf__bindgen_ty_1,
+                >::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).vmdq_rx_conf) as usize -
+                    ptr as usize
+            },
+            1080usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_conf__bindgen_ty_1),
+                "::",
+                stringify!(vmdq_rx_conf)
+            )
+        );
+    }
+    test_field_vmdq_rx_conf();
 }
 impl Default for rte_eth_conf__bindgen_ty_1 {
     fn default() -> Self {
@@ -2204,52 +2457,65 @@ fn bindgen_test_layout_rte_eth_conf__bindgen_ty_2() {
         4usize,
         concat!("Alignment of ", stringify!(rte_eth_conf__bindgen_ty_2))
     );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<rte_eth_conf__bindgen_ty_2>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).vmdq_dcb_tx_conf) as usize -
-                ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_conf__bindgen_ty_2),
-            "::",
-            stringify!(vmdq_dcb_tx_conf)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<rte_eth_conf__bindgen_ty_2>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).dcb_tx_conf) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_conf__bindgen_ty_2),
-            "::",
-            stringify!(dcb_tx_conf)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<rte_eth_conf__bindgen_ty_2>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).vmdq_tx_conf) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_conf__bindgen_ty_2),
-            "::",
-            stringify!(vmdq_tx_conf)
-        )
-    );
+    fn test_field_vmdq_dcb_tx_conf() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<
+                    rte_eth_conf__bindgen_ty_2,
+                >::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).vmdq_dcb_tx_conf) as usize -
+                    ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_conf__bindgen_ty_2),
+                "::",
+                stringify!(vmdq_dcb_tx_conf)
+            )
+        );
+    }
+    test_field_vmdq_dcb_tx_conf();
+    fn test_field_dcb_tx_conf() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<
+                    rte_eth_conf__bindgen_ty_2,
+                >::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).dcb_tx_conf) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_conf__bindgen_ty_2),
+                "::",
+                stringify!(dcb_tx_conf)
+            )
+        );
+    }
+    test_field_dcb_tx_conf();
+    fn test_field_vmdq_tx_conf() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<
+                    rte_eth_conf__bindgen_ty_2,
+                >::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).vmdq_tx_conf) as usize -
+                    ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_conf__bindgen_ty_2),
+                "::",
+                stringify!(vmdq_tx_conf)
+            )
+        );
+    }
+    test_field_vmdq_tx_conf();
 }
 impl Default for rte_eth_conf__bindgen_ty_2 {
     fn default() -> Self {
@@ -2272,133 +2538,160 @@ fn bindgen_test_layout_rte_eth_conf() {
         8usize,
         concat!("Alignment of ", stringify!(rte_eth_conf))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_eth_conf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).link_speeds) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_conf),
-            "::",
-            stringify!(link_speeds)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_eth_conf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).rxmode) as usize - ptr as usize
-        },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_conf),
-            "::",
-            stringify!(rxmode)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_eth_conf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).txmode) as usize - ptr as usize
-        },
-        16usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_conf),
-            "::",
-            stringify!(txmode)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_eth_conf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).lpbk_mode) as usize - ptr as usize
-        },
-        24usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_conf),
-            "::",
-            stringify!(lpbk_mode)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_eth_conf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).rx_adv_conf) as usize - ptr as usize
-        },
-        32usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_conf),
-            "::",
-            stringify!(rx_adv_conf)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_eth_conf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).tx_adv_conf) as usize - ptr as usize
-        },
-        2152usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_conf),
-            "::",
-            stringify!(tx_adv_conf)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_eth_conf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).dcb_capability_en) as usize -
-                ptr as usize
-        },
-        2164usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_conf),
-            "::",
-            stringify!(dcb_capability_en)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_eth_conf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).fdir_conf) as usize - ptr as usize
-        },
-        2168usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_conf),
-            "::",
-            stringify!(fdir_conf)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_eth_conf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).intr_conf) as usize - ptr as usize
-        },
-        2940usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_conf),
-            "::",
-            stringify!(intr_conf)
-        )
-    );
+    fn test_field_link_speeds() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<rte_eth_conf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).link_speeds) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_conf),
+                "::",
+                stringify!(link_speeds)
+            )
+        );
+    }
+    test_field_link_speeds();
+    fn test_field_rxmode() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<rte_eth_conf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).rxmode) as usize - ptr as usize
+            },
+            4usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_conf),
+                "::",
+                stringify!(rxmode)
+            )
+        );
+    }
+    test_field_rxmode();
+    fn test_field_txmode() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<rte_eth_conf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).txmode) as usize - ptr as usize
+            },
+            16usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_conf),
+                "::",
+                stringify!(txmode)
+            )
+        );
+    }
+    test_field_txmode();
+    fn test_field_lpbk_mode() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<rte_eth_conf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).lpbk_mode) as usize - ptr as usize
+            },
+            24usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_conf),
+                "::",
+                stringify!(lpbk_mode)
+            )
+        );
+    }
+    test_field_lpbk_mode();
+    fn test_field_rx_adv_conf() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<rte_eth_conf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).rx_adv_conf) as usize - ptr as usize
+            },
+            32usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_conf),
+                "::",
+                stringify!(rx_adv_conf)
+            )
+        );
+    }
+    test_field_rx_adv_conf();
+    fn test_field_tx_adv_conf() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<rte_eth_conf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).tx_adv_conf) as usize - ptr as usize
+            },
+            2152usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_conf),
+                "::",
+                stringify!(tx_adv_conf)
+            )
+        );
+    }
+    test_field_tx_adv_conf();
+    fn test_field_dcb_capability_en() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<rte_eth_conf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).dcb_capability_en) as usize -
+                    ptr as usize
+            },
+            2164usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_conf),
+                "::",
+                stringify!(dcb_capability_en)
+            )
+        );
+    }
+    test_field_dcb_capability_en();
+    fn test_field_fdir_conf() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<rte_eth_conf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).fdir_conf) as usize - ptr as usize
+            },
+            2168usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_conf),
+                "::",
+                stringify!(fdir_conf)
+            )
+        );
+    }
+    test_field_fdir_conf();
+    fn test_field_intr_conf() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<rte_eth_conf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).intr_conf) as usize - ptr as usize
+            },
+            2940usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_conf),
+                "::",
+                stringify!(intr_conf)
+            )
+        );
+    }
+    test_field_intr_conf();
 }
 impl Default for rte_eth_conf {
     fn default() -> Self {

--- a/tests/expectations/tests/layout_eth_conf_1_0.rs
+++ b/tests/expectations/tests/layout_eth_conf_1_0.rs
@@ -213,48 +213,62 @@ fn bindgen_test_layout_rte_eth_rxmode() {
         4usize,
         concat!("Alignment of ", stringify!(rte_eth_rxmode))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_eth_rxmode>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mq_mode) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_rxmode),
-            "::",
-            stringify!(mq_mode)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_eth_rxmode>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).max_rx_pkt_len) as usize - ptr as usize
-        },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_rxmode),
-            "::",
-            stringify!(max_rx_pkt_len)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_eth_rxmode>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).split_hdr_size) as usize - ptr as usize
-        },
-        8usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_rxmode),
-            "::",
-            stringify!(split_hdr_size)
-        )
-    );
+    fn test_field_mq_mode() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_eth_rxmode>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).mq_mode) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_rxmode),
+                "::",
+                stringify!(mq_mode)
+            )
+        );
+    }
+    test_field_mq_mode();
+    fn test_field_max_rx_pkt_len() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_eth_rxmode>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).max_rx_pkt_len) as usize -
+                    ptr as usize
+            },
+            4usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_rxmode),
+                "::",
+                stringify!(max_rx_pkt_len)
+            )
+        );
+    }
+    test_field_max_rx_pkt_len();
+    fn test_field_split_hdr_size() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_eth_rxmode>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).split_hdr_size) as usize -
+                    ptr as usize
+            },
+            8usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_rxmode),
+                "::",
+                stringify!(split_hdr_size)
+            )
+        );
+    }
+    test_field_split_hdr_size();
 }
 impl Clone for rte_eth_rxmode {
     fn clone(&self) -> Self {
@@ -486,34 +500,42 @@ fn bindgen_test_layout_rte_eth_txmode() {
         4usize,
         concat!("Alignment of ", stringify!(rte_eth_txmode))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_eth_txmode>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mq_mode) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_txmode),
-            "::",
-            stringify!(mq_mode)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_eth_txmode>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).pvid) as usize - ptr as usize
-        },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_txmode),
-            "::",
-            stringify!(pvid)
-        )
-    );
+    fn test_field_mq_mode() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_eth_txmode>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).mq_mode) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_txmode),
+                "::",
+                stringify!(mq_mode)
+            )
+        );
+    }
+    test_field_mq_mode();
+    fn test_field_pvid() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_eth_txmode>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).pvid) as usize - ptr as usize
+            },
+            4usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_txmode),
+                "::",
+                stringify!(pvid)
+            )
+        );
+    }
+    test_field_pvid();
 }
 impl Clone for rte_eth_txmode {
     fn clone(&self) -> Self {
@@ -632,48 +654,60 @@ fn bindgen_test_layout_rte_eth_rss_conf() {
         8usize,
         concat!("Alignment of ", stringify!(rte_eth_rss_conf))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_eth_rss_conf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).rss_key) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_rss_conf),
-            "::",
-            stringify!(rss_key)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_eth_rss_conf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).rss_key_len) as usize - ptr as usize
-        },
-        8usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_rss_conf),
-            "::",
-            stringify!(rss_key_len)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_eth_rss_conf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).rss_hf) as usize - ptr as usize
-        },
-        16usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_rss_conf),
-            "::",
-            stringify!(rss_hf)
-        )
-    );
+    fn test_field_rss_key() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_eth_rss_conf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).rss_key) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_rss_conf),
+                "::",
+                stringify!(rss_key)
+            )
+        );
+    }
+    test_field_rss_key();
+    fn test_field_rss_key_len() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_eth_rss_conf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).rss_key_len) as usize - ptr as usize
+            },
+            8usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_rss_conf),
+                "::",
+                stringify!(rss_key_len)
+            )
+        );
+    }
+    test_field_rss_key_len();
+    fn test_field_rss_hf() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_eth_rss_conf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).rss_hf) as usize - ptr as usize
+            },
+            16usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_rss_conf),
+                "::",
+                stringify!(rss_hf)
+            )
+        );
+    }
+    test_field_rss_hf();
 }
 impl Clone for rte_eth_rss_conf {
     fn clone(&self) -> Self {
@@ -760,38 +794,44 @@ fn bindgen_test_layout_rte_eth_vmdq_dcb_conf__bindgen_ty_1() {
             stringify!(rte_eth_vmdq_dcb_conf__bindgen_ty_1)
         )
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<
-                rte_eth_vmdq_dcb_conf__bindgen_ty_1,
-            >::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).vlan_id) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_vmdq_dcb_conf__bindgen_ty_1),
-            "::",
-            stringify!(vlan_id)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<
-                rte_eth_vmdq_dcb_conf__bindgen_ty_1,
-            >::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).pools) as usize - ptr as usize
-        },
-        8usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_vmdq_dcb_conf__bindgen_ty_1),
-            "::",
-            stringify!(pools)
-        )
-    );
+    fn test_field_vlan_id() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<
+                    rte_eth_vmdq_dcb_conf__bindgen_ty_1,
+                >::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).vlan_id) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_vmdq_dcb_conf__bindgen_ty_1),
+                "::",
+                stringify!(vlan_id)
+            )
+        );
+    }
+    test_field_vlan_id();
+    fn test_field_pools() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<
+                    rte_eth_vmdq_dcb_conf__bindgen_ty_1,
+                >::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).pools) as usize - ptr as usize
+            },
+            8usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_vmdq_dcb_conf__bindgen_ty_1),
+                "::",
+                stringify!(pools)
+            )
+        );
+    }
+    test_field_pools();
 }
 impl Clone for rte_eth_vmdq_dcb_conf__bindgen_ty_1 {
     fn clone(&self) -> Self {
@@ -810,97 +850,118 @@ fn bindgen_test_layout_rte_eth_vmdq_dcb_conf() {
         8usize,
         concat!("Alignment of ", stringify!(rte_eth_vmdq_dcb_conf))
     );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<rte_eth_vmdq_dcb_conf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).nb_queue_pools) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_vmdq_dcb_conf),
-            "::",
-            stringify!(nb_queue_pools)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<rte_eth_vmdq_dcb_conf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).enable_default_pool) as usize -
-                ptr as usize
-        },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_vmdq_dcb_conf),
-            "::",
-            stringify!(enable_default_pool)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<rte_eth_vmdq_dcb_conf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).default_pool) as usize - ptr as usize
-        },
-        5usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_vmdq_dcb_conf),
-            "::",
-            stringify!(default_pool)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<rte_eth_vmdq_dcb_conf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).nb_pool_maps) as usize - ptr as usize
-        },
-        6usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_vmdq_dcb_conf),
-            "::",
-            stringify!(nb_pool_maps)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<rte_eth_vmdq_dcb_conf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).pool_map) as usize - ptr as usize
-        },
-        8usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_vmdq_dcb_conf),
-            "::",
-            stringify!(pool_map)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<rte_eth_vmdq_dcb_conf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).dcb_tc) as usize - ptr as usize
-        },
-        1032usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_vmdq_dcb_conf),
-            "::",
-            stringify!(dcb_tc)
-        )
-    );
+    fn test_field_nb_queue_pools() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_eth_vmdq_dcb_conf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).nb_queue_pools) as usize -
+                    ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_vmdq_dcb_conf),
+                "::",
+                stringify!(nb_queue_pools)
+            )
+        );
+    }
+    test_field_nb_queue_pools();
+    fn test_field_enable_default_pool() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_eth_vmdq_dcb_conf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).enable_default_pool) as usize -
+                    ptr as usize
+            },
+            4usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_vmdq_dcb_conf),
+                "::",
+                stringify!(enable_default_pool)
+            )
+        );
+    }
+    test_field_enable_default_pool();
+    fn test_field_default_pool() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_eth_vmdq_dcb_conf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).default_pool) as usize -
+                    ptr as usize
+            },
+            5usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_vmdq_dcb_conf),
+                "::",
+                stringify!(default_pool)
+            )
+        );
+    }
+    test_field_default_pool();
+    fn test_field_nb_pool_maps() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_eth_vmdq_dcb_conf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).nb_pool_maps) as usize -
+                    ptr as usize
+            },
+            6usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_vmdq_dcb_conf),
+                "::",
+                stringify!(nb_pool_maps)
+            )
+        );
+    }
+    test_field_nb_pool_maps();
+    fn test_field_pool_map() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_eth_vmdq_dcb_conf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).pool_map) as usize - ptr as usize
+            },
+            8usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_vmdq_dcb_conf),
+                "::",
+                stringify!(pool_map)
+            )
+        );
+    }
+    test_field_pool_map();
+    fn test_field_dcb_tc() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_eth_vmdq_dcb_conf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).dcb_tc) as usize - ptr as usize
+            },
+            1032usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_vmdq_dcb_conf),
+                "::",
+                stringify!(dcb_tc)
+            )
+        );
+    }
+    test_field_dcb_tc();
 }
 impl Clone for rte_eth_vmdq_dcb_conf {
     fn clone(&self) -> Self {
@@ -936,36 +997,42 @@ fn bindgen_test_layout_rte_eth_dcb_rx_conf() {
         4usize,
         concat!("Alignment of ", stringify!(rte_eth_dcb_rx_conf))
     );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<rte_eth_dcb_rx_conf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).nb_tcs) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_dcb_rx_conf),
-            "::",
-            stringify!(nb_tcs)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<rte_eth_dcb_rx_conf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).dcb_tc) as usize - ptr as usize
-        },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_dcb_rx_conf),
-            "::",
-            stringify!(dcb_tc)
-        )
-    );
+    fn test_field_nb_tcs() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_eth_dcb_rx_conf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).nb_tcs) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_dcb_rx_conf),
+                "::",
+                stringify!(nb_tcs)
+            )
+        );
+    }
+    test_field_nb_tcs();
+    fn test_field_dcb_tc() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_eth_dcb_rx_conf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).dcb_tc) as usize - ptr as usize
+            },
+            4usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_dcb_rx_conf),
+                "::",
+                stringify!(dcb_tc)
+            )
+        );
+    }
+    test_field_dcb_tc();
 }
 impl Clone for rte_eth_dcb_rx_conf {
     fn clone(&self) -> Self {
@@ -1001,36 +1068,45 @@ fn bindgen_test_layout_rte_eth_vmdq_dcb_tx_conf() {
         4usize,
         concat!("Alignment of ", stringify!(rte_eth_vmdq_dcb_tx_conf))
     );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<rte_eth_vmdq_dcb_tx_conf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).nb_queue_pools) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_vmdq_dcb_tx_conf),
-            "::",
-            stringify!(nb_queue_pools)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<rte_eth_vmdq_dcb_tx_conf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).dcb_tc) as usize - ptr as usize
-        },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_vmdq_dcb_tx_conf),
-            "::",
-            stringify!(dcb_tc)
-        )
-    );
+    fn test_field_nb_queue_pools() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_eth_vmdq_dcb_tx_conf>::uninit(
+                    );
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).nb_queue_pools) as usize -
+                    ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_vmdq_dcb_tx_conf),
+                "::",
+                stringify!(nb_queue_pools)
+            )
+        );
+    }
+    test_field_nb_queue_pools();
+    fn test_field_dcb_tc() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_eth_vmdq_dcb_tx_conf>::uninit(
+                    );
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).dcb_tc) as usize - ptr as usize
+            },
+            4usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_vmdq_dcb_tx_conf),
+                "::",
+                stringify!(dcb_tc)
+            )
+        );
+    }
+    test_field_dcb_tc();
 }
 impl Clone for rte_eth_vmdq_dcb_tx_conf {
     fn clone(&self) -> Self {
@@ -1066,36 +1142,42 @@ fn bindgen_test_layout_rte_eth_dcb_tx_conf() {
         4usize,
         concat!("Alignment of ", stringify!(rte_eth_dcb_tx_conf))
     );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<rte_eth_dcb_tx_conf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).nb_tcs) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_dcb_tx_conf),
-            "::",
-            stringify!(nb_tcs)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<rte_eth_dcb_tx_conf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).dcb_tc) as usize - ptr as usize
-        },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_dcb_tx_conf),
-            "::",
-            stringify!(dcb_tc)
-        )
-    );
+    fn test_field_nb_tcs() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_eth_dcb_tx_conf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).nb_tcs) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_dcb_tx_conf),
+                "::",
+                stringify!(nb_tcs)
+            )
+        );
+    }
+    test_field_nb_tcs();
+    fn test_field_dcb_tc() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_eth_dcb_tx_conf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).dcb_tc) as usize - ptr as usize
+            },
+            4usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_dcb_tx_conf),
+                "::",
+                stringify!(dcb_tc)
+            )
+        );
+    }
+    test_field_dcb_tc();
 }
 impl Clone for rte_eth_dcb_tx_conf {
     fn clone(&self) -> Self {
@@ -1129,21 +1211,25 @@ fn bindgen_test_layout_rte_eth_vmdq_tx_conf() {
         4usize,
         concat!("Alignment of ", stringify!(rte_eth_vmdq_tx_conf))
     );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<rte_eth_vmdq_tx_conf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).nb_queue_pools) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_vmdq_tx_conf),
-            "::",
-            stringify!(nb_queue_pools)
-        )
-    );
+    fn test_field_nb_queue_pools() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_eth_vmdq_tx_conf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).nb_queue_pools) as usize -
+                    ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_vmdq_tx_conf),
+                "::",
+                stringify!(nb_queue_pools)
+            )
+        );
+    }
+    test_field_nb_queue_pools();
 }
 impl Clone for rte_eth_vmdq_tx_conf {
     fn clone(&self) -> Self {
@@ -1200,38 +1286,44 @@ fn bindgen_test_layout_rte_eth_vmdq_rx_conf__bindgen_ty_1() {
             stringify!(rte_eth_vmdq_rx_conf__bindgen_ty_1)
         )
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<
-                rte_eth_vmdq_rx_conf__bindgen_ty_1,
-            >::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).vlan_id) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_vmdq_rx_conf__bindgen_ty_1),
-            "::",
-            stringify!(vlan_id)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<
-                rte_eth_vmdq_rx_conf__bindgen_ty_1,
-            >::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).pools) as usize - ptr as usize
-        },
-        8usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_vmdq_rx_conf__bindgen_ty_1),
-            "::",
-            stringify!(pools)
-        )
-    );
+    fn test_field_vlan_id() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<
+                    rte_eth_vmdq_rx_conf__bindgen_ty_1,
+                >::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).vlan_id) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_vmdq_rx_conf__bindgen_ty_1),
+                "::",
+                stringify!(vlan_id)
+            )
+        );
+    }
+    test_field_vlan_id();
+    fn test_field_pools() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<
+                    rte_eth_vmdq_rx_conf__bindgen_ty_1,
+                >::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).pools) as usize - ptr as usize
+            },
+            8usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_vmdq_rx_conf__bindgen_ty_1),
+                "::",
+                stringify!(pools)
+            )
+        );
+    }
+    test_field_pools();
 }
 impl Clone for rte_eth_vmdq_rx_conf__bindgen_ty_1 {
     fn clone(&self) -> Self {
@@ -1250,113 +1342,137 @@ fn bindgen_test_layout_rte_eth_vmdq_rx_conf() {
         8usize,
         concat!("Alignment of ", stringify!(rte_eth_vmdq_rx_conf))
     );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<rte_eth_vmdq_rx_conf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).nb_queue_pools) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_vmdq_rx_conf),
-            "::",
-            stringify!(nb_queue_pools)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<rte_eth_vmdq_rx_conf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).enable_default_pool) as usize -
-                ptr as usize
-        },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_vmdq_rx_conf),
-            "::",
-            stringify!(enable_default_pool)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<rte_eth_vmdq_rx_conf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).default_pool) as usize - ptr as usize
-        },
-        5usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_vmdq_rx_conf),
-            "::",
-            stringify!(default_pool)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<rte_eth_vmdq_rx_conf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).enable_loop_back) as usize -
-                ptr as usize
-        },
-        6usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_vmdq_rx_conf),
-            "::",
-            stringify!(enable_loop_back)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<rte_eth_vmdq_rx_conf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).nb_pool_maps) as usize - ptr as usize
-        },
-        7usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_vmdq_rx_conf),
-            "::",
-            stringify!(nb_pool_maps)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<rte_eth_vmdq_rx_conf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).rx_mode) as usize - ptr as usize
-        },
-        8usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_vmdq_rx_conf),
-            "::",
-            stringify!(rx_mode)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<rte_eth_vmdq_rx_conf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).pool_map) as usize - ptr as usize
-        },
-        16usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_vmdq_rx_conf),
-            "::",
-            stringify!(pool_map)
-        )
-    );
+    fn test_field_nb_queue_pools() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_eth_vmdq_rx_conf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).nb_queue_pools) as usize -
+                    ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_vmdq_rx_conf),
+                "::",
+                stringify!(nb_queue_pools)
+            )
+        );
+    }
+    test_field_nb_queue_pools();
+    fn test_field_enable_default_pool() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_eth_vmdq_rx_conf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).enable_default_pool) as usize -
+                    ptr as usize
+            },
+            4usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_vmdq_rx_conf),
+                "::",
+                stringify!(enable_default_pool)
+            )
+        );
+    }
+    test_field_enable_default_pool();
+    fn test_field_default_pool() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_eth_vmdq_rx_conf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).default_pool) as usize -
+                    ptr as usize
+            },
+            5usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_vmdq_rx_conf),
+                "::",
+                stringify!(default_pool)
+            )
+        );
+    }
+    test_field_default_pool();
+    fn test_field_enable_loop_back() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_eth_vmdq_rx_conf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).enable_loop_back) as usize -
+                    ptr as usize
+            },
+            6usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_vmdq_rx_conf),
+                "::",
+                stringify!(enable_loop_back)
+            )
+        );
+    }
+    test_field_enable_loop_back();
+    fn test_field_nb_pool_maps() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_eth_vmdq_rx_conf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).nb_pool_maps) as usize -
+                    ptr as usize
+            },
+            7usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_vmdq_rx_conf),
+                "::",
+                stringify!(nb_pool_maps)
+            )
+        );
+    }
+    test_field_nb_pool_maps();
+    fn test_field_rx_mode() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_eth_vmdq_rx_conf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).rx_mode) as usize - ptr as usize
+            },
+            8usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_vmdq_rx_conf),
+                "::",
+                stringify!(rx_mode)
+            )
+        );
+    }
+    test_field_rx_mode();
+    fn test_field_pool_map() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_eth_vmdq_rx_conf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).pool_map) as usize - ptr as usize
+            },
+            16usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_vmdq_rx_conf),
+                "::",
+                stringify!(pool_map)
+            )
+        );
+    }
+    test_field_pool_map();
 }
 impl Clone for rte_eth_vmdq_rx_conf {
     fn clone(&self) -> Self {
@@ -1437,76 +1553,96 @@ fn bindgen_test_layout_rte_eth_ipv4_flow() {
         4usize,
         concat!("Alignment of ", stringify!(rte_eth_ipv4_flow))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_eth_ipv4_flow>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).src_ip) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_ipv4_flow),
-            "::",
-            stringify!(src_ip)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_eth_ipv4_flow>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).dst_ip) as usize - ptr as usize
-        },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_ipv4_flow),
-            "::",
-            stringify!(dst_ip)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_eth_ipv4_flow>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).tos) as usize - ptr as usize
-        },
-        8usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_ipv4_flow),
-            "::",
-            stringify!(tos)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_eth_ipv4_flow>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).ttl) as usize - ptr as usize
-        },
-        9usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_ipv4_flow),
-            "::",
-            stringify!(ttl)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_eth_ipv4_flow>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).proto) as usize - ptr as usize
-        },
-        10usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_ipv4_flow),
-            "::",
-            stringify!(proto)
-        )
-    );
+    fn test_field_src_ip() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_eth_ipv4_flow>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).src_ip) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_ipv4_flow),
+                "::",
+                stringify!(src_ip)
+            )
+        );
+    }
+    test_field_src_ip();
+    fn test_field_dst_ip() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_eth_ipv4_flow>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).dst_ip) as usize - ptr as usize
+            },
+            4usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_ipv4_flow),
+                "::",
+                stringify!(dst_ip)
+            )
+        );
+    }
+    test_field_dst_ip();
+    fn test_field_tos() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_eth_ipv4_flow>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).tos) as usize - ptr as usize
+            },
+            8usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_ipv4_flow),
+                "::",
+                stringify!(tos)
+            )
+        );
+    }
+    test_field_tos();
+    fn test_field_ttl() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_eth_ipv4_flow>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).ttl) as usize - ptr as usize
+            },
+            9usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_ipv4_flow),
+                "::",
+                stringify!(ttl)
+            )
+        );
+    }
+    test_field_ttl();
+    fn test_field_proto() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_eth_ipv4_flow>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).proto) as usize - ptr as usize
+            },
+            10usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_ipv4_flow),
+                "::",
+                stringify!(proto)
+            )
+        );
+    }
+    test_field_proto();
 }
 impl Clone for rte_eth_ipv4_flow {
     fn clone(&self) -> Self {
@@ -1540,76 +1676,96 @@ fn bindgen_test_layout_rte_eth_ipv6_flow() {
         4usize,
         concat!("Alignment of ", stringify!(rte_eth_ipv6_flow))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_eth_ipv6_flow>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).src_ip) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_ipv6_flow),
-            "::",
-            stringify!(src_ip)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_eth_ipv6_flow>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).dst_ip) as usize - ptr as usize
-        },
-        16usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_ipv6_flow),
-            "::",
-            stringify!(dst_ip)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_eth_ipv6_flow>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).tc) as usize - ptr as usize
-        },
-        32usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_ipv6_flow),
-            "::",
-            stringify!(tc)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_eth_ipv6_flow>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).proto) as usize - ptr as usize
-        },
-        33usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_ipv6_flow),
-            "::",
-            stringify!(proto)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_eth_ipv6_flow>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).hop_limits) as usize - ptr as usize
-        },
-        34usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_ipv6_flow),
-            "::",
-            stringify!(hop_limits)
-        )
-    );
+    fn test_field_src_ip() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_eth_ipv6_flow>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).src_ip) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_ipv6_flow),
+                "::",
+                stringify!(src_ip)
+            )
+        );
+    }
+    test_field_src_ip();
+    fn test_field_dst_ip() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_eth_ipv6_flow>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).dst_ip) as usize - ptr as usize
+            },
+            16usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_ipv6_flow),
+                "::",
+                stringify!(dst_ip)
+            )
+        );
+    }
+    test_field_dst_ip();
+    fn test_field_tc() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_eth_ipv6_flow>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).tc) as usize - ptr as usize
+            },
+            32usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_ipv6_flow),
+                "::",
+                stringify!(tc)
+            )
+        );
+    }
+    test_field_tc();
+    fn test_field_proto() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_eth_ipv6_flow>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).proto) as usize - ptr as usize
+            },
+            33usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_ipv6_flow),
+                "::",
+                stringify!(proto)
+            )
+        );
+    }
+    test_field_proto();
+    fn test_field_hop_limits() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_eth_ipv6_flow>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).hop_limits) as usize - ptr as usize
+            },
+            34usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_ipv6_flow),
+                "::",
+                stringify!(hop_limits)
+            )
+        );
+    }
+    test_field_hop_limits();
 }
 impl Clone for rte_eth_ipv6_flow {
     fn clone(&self) -> Self {
@@ -1652,128 +1808,156 @@ fn bindgen_test_layout_rte_eth_fdir_masks() {
         4usize,
         concat!("Alignment of ", stringify!(rte_eth_fdir_masks))
     );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<rte_eth_fdir_masks>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).vlan_tci_mask) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_fdir_masks),
-            "::",
-            stringify!(vlan_tci_mask)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<rte_eth_fdir_masks>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).ipv4_mask) as usize - ptr as usize
-        },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_fdir_masks),
-            "::",
-            stringify!(ipv4_mask)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<rte_eth_fdir_masks>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).ipv6_mask) as usize - ptr as usize
-        },
-        16usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_fdir_masks),
-            "::",
-            stringify!(ipv6_mask)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<rte_eth_fdir_masks>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).src_port_mask) as usize - ptr as usize
-        },
-        52usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_fdir_masks),
-            "::",
-            stringify!(src_port_mask)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<rte_eth_fdir_masks>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).dst_port_mask) as usize - ptr as usize
-        },
-        54usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_fdir_masks),
-            "::",
-            stringify!(dst_port_mask)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<rte_eth_fdir_masks>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mac_addr_byte_mask) as usize -
-                ptr as usize
-        },
-        56usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_fdir_masks),
-            "::",
-            stringify!(mac_addr_byte_mask)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<rte_eth_fdir_masks>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).tunnel_id_mask) as usize - ptr as usize
-        },
-        60usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_fdir_masks),
-            "::",
-            stringify!(tunnel_id_mask)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<rte_eth_fdir_masks>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).tunnel_type_mask) as usize -
-                ptr as usize
-        },
-        64usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_fdir_masks),
-            "::",
-            stringify!(tunnel_type_mask)
-        )
-    );
+    fn test_field_vlan_tci_mask() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_eth_fdir_masks>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).vlan_tci_mask) as usize -
+                    ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_fdir_masks),
+                "::",
+                stringify!(vlan_tci_mask)
+            )
+        );
+    }
+    test_field_vlan_tci_mask();
+    fn test_field_ipv4_mask() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_eth_fdir_masks>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).ipv4_mask) as usize - ptr as usize
+            },
+            4usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_fdir_masks),
+                "::",
+                stringify!(ipv4_mask)
+            )
+        );
+    }
+    test_field_ipv4_mask();
+    fn test_field_ipv6_mask() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_eth_fdir_masks>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).ipv6_mask) as usize - ptr as usize
+            },
+            16usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_fdir_masks),
+                "::",
+                stringify!(ipv6_mask)
+            )
+        );
+    }
+    test_field_ipv6_mask();
+    fn test_field_src_port_mask() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_eth_fdir_masks>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).src_port_mask) as usize -
+                    ptr as usize
+            },
+            52usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_fdir_masks),
+                "::",
+                stringify!(src_port_mask)
+            )
+        );
+    }
+    test_field_src_port_mask();
+    fn test_field_dst_port_mask() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_eth_fdir_masks>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).dst_port_mask) as usize -
+                    ptr as usize
+            },
+            54usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_fdir_masks),
+                "::",
+                stringify!(dst_port_mask)
+            )
+        );
+    }
+    test_field_dst_port_mask();
+    fn test_field_mac_addr_byte_mask() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_eth_fdir_masks>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).mac_addr_byte_mask) as usize -
+                    ptr as usize
+            },
+            56usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_fdir_masks),
+                "::",
+                stringify!(mac_addr_byte_mask)
+            )
+        );
+    }
+    test_field_mac_addr_byte_mask();
+    fn test_field_tunnel_id_mask() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_eth_fdir_masks>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).tunnel_id_mask) as usize -
+                    ptr as usize
+            },
+            60usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_fdir_masks),
+                "::",
+                stringify!(tunnel_id_mask)
+            )
+        );
+    }
+    test_field_tunnel_id_mask();
+    fn test_field_tunnel_type_mask() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_eth_fdir_masks>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).tunnel_type_mask) as usize -
+                    ptr as usize
+            },
+            64usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_fdir_masks),
+                "::",
+                stringify!(tunnel_type_mask)
+            )
+        );
+    }
+    test_field_tunnel_type_mask();
 }
 impl Clone for rte_eth_fdir_masks {
     fn clone(&self) -> Self {
@@ -1812,36 +1996,44 @@ fn bindgen_test_layout_rte_eth_flex_payload_cfg() {
         4usize,
         concat!("Alignment of ", stringify!(rte_eth_flex_payload_cfg))
     );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<rte_eth_flex_payload_cfg>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).type_) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_flex_payload_cfg),
-            "::",
-            stringify!(type_)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<rte_eth_flex_payload_cfg>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).src_offset) as usize - ptr as usize
-        },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_flex_payload_cfg),
-            "::",
-            stringify!(src_offset)
-        )
-    );
+    fn test_field_type() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_eth_flex_payload_cfg>::uninit(
+                    );
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).type_) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_flex_payload_cfg),
+                "::",
+                stringify!(type_)
+            )
+        );
+    }
+    test_field_type();
+    fn test_field_src_offset() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_eth_flex_payload_cfg>::uninit(
+                    );
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).src_offset) as usize - ptr as usize
+            },
+            4usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_flex_payload_cfg),
+                "::",
+                stringify!(src_offset)
+            )
+        );
+    }
+    test_field_src_offset();
 }
 impl Clone for rte_eth_flex_payload_cfg {
     fn clone(&self) -> Self {
@@ -1877,36 +2069,42 @@ fn bindgen_test_layout_rte_eth_fdir_flex_mask() {
         2usize,
         concat!("Alignment of ", stringify!(rte_eth_fdir_flex_mask))
     );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<rte_eth_fdir_flex_mask>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).flow_type) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_fdir_flex_mask),
-            "::",
-            stringify!(flow_type)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<rte_eth_fdir_flex_mask>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mask) as usize - ptr as usize
-        },
-        2usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_fdir_flex_mask),
-            "::",
-            stringify!(mask)
-        )
-    );
+    fn test_field_flow_type() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_eth_fdir_flex_mask>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).flow_type) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_fdir_flex_mask),
+                "::",
+                stringify!(flow_type)
+            )
+        );
+    }
+    test_field_flow_type();
+    fn test_field_mask() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_eth_fdir_flex_mask>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).mask) as usize - ptr as usize
+            },
+            2usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_fdir_flex_mask),
+                "::",
+                stringify!(mask)
+            )
+        );
+    }
+    test_field_mask();
 }
 impl Clone for rte_eth_fdir_flex_mask {
     fn clone(&self) -> Self {
@@ -1937,66 +2135,79 @@ fn bindgen_test_layout_rte_eth_fdir_flex_conf() {
         4usize,
         concat!("Alignment of ", stringify!(rte_eth_fdir_flex_conf))
     );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<rte_eth_fdir_flex_conf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).nb_payloads) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_fdir_flex_conf),
-            "::",
-            stringify!(nb_payloads)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<rte_eth_fdir_flex_conf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).nb_flexmasks) as usize - ptr as usize
-        },
-        2usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_fdir_flex_conf),
-            "::",
-            stringify!(nb_flexmasks)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<rte_eth_fdir_flex_conf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).flex_set) as usize - ptr as usize
-        },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_fdir_flex_conf),
-            "::",
-            stringify!(flex_set)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<rte_eth_fdir_flex_conf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).flex_mask) as usize - ptr as usize
-        },
-        292usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_fdir_flex_conf),
-            "::",
-            stringify!(flex_mask)
-        )
-    );
+    fn test_field_nb_payloads() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_eth_fdir_flex_conf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).nb_payloads) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_fdir_flex_conf),
+                "::",
+                stringify!(nb_payloads)
+            )
+        );
+    }
+    test_field_nb_payloads();
+    fn test_field_nb_flexmasks() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_eth_fdir_flex_conf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).nb_flexmasks) as usize -
+                    ptr as usize
+            },
+            2usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_fdir_flex_conf),
+                "::",
+                stringify!(nb_flexmasks)
+            )
+        );
+    }
+    test_field_nb_flexmasks();
+    fn test_field_flex_set() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_eth_fdir_flex_conf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).flex_set) as usize - ptr as usize
+            },
+            4usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_fdir_flex_conf),
+                "::",
+                stringify!(flex_set)
+            )
+        );
+    }
+    test_field_flex_set();
+    fn test_field_flex_mask() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_eth_fdir_flex_conf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).flex_mask) as usize - ptr as usize
+            },
+            292usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_fdir_flex_conf),
+                "::",
+                stringify!(flex_mask)
+            )
+        );
+    }
+    test_field_flex_mask();
 }
 impl Clone for rte_eth_fdir_flex_conf {
     fn clone(&self) -> Self {
@@ -2042,90 +2253,108 @@ fn bindgen_test_layout_rte_fdir_conf() {
         4usize,
         concat!("Alignment of ", stringify!(rte_fdir_conf))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_fdir_conf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mode) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_fdir_conf),
-            "::",
-            stringify!(mode)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_fdir_conf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).pballoc) as usize - ptr as usize
-        },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_fdir_conf),
-            "::",
-            stringify!(pballoc)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_fdir_conf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).status) as usize - ptr as usize
-        },
-        8usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_fdir_conf),
-            "::",
-            stringify!(status)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_fdir_conf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).drop_queue) as usize - ptr as usize
-        },
-        12usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_fdir_conf),
-            "::",
-            stringify!(drop_queue)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_fdir_conf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mask) as usize - ptr as usize
-        },
-        16usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_fdir_conf),
-            "::",
-            stringify!(mask)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_fdir_conf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).flex_conf) as usize - ptr as usize
-        },
-        84usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_fdir_conf),
-            "::",
-            stringify!(flex_conf)
-        )
-    );
+    fn test_field_mode() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<rte_fdir_conf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).mode) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_fdir_conf),
+                "::",
+                stringify!(mode)
+            )
+        );
+    }
+    test_field_mode();
+    fn test_field_pballoc() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<rte_fdir_conf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).pballoc) as usize - ptr as usize
+            },
+            4usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_fdir_conf),
+                "::",
+                stringify!(pballoc)
+            )
+        );
+    }
+    test_field_pballoc();
+    fn test_field_status() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<rte_fdir_conf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).status) as usize - ptr as usize
+            },
+            8usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_fdir_conf),
+                "::",
+                stringify!(status)
+            )
+        );
+    }
+    test_field_status();
+    fn test_field_drop_queue() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<rte_fdir_conf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).drop_queue) as usize - ptr as usize
+            },
+            12usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_fdir_conf),
+                "::",
+                stringify!(drop_queue)
+            )
+        );
+    }
+    test_field_drop_queue();
+    fn test_field_mask() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<rte_fdir_conf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).mask) as usize - ptr as usize
+            },
+            16usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_fdir_conf),
+                "::",
+                stringify!(mask)
+            )
+        );
+    }
+    test_field_mask();
+    fn test_field_flex_conf() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<rte_fdir_conf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).flex_conf) as usize - ptr as usize
+            },
+            84usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_fdir_conf),
+                "::",
+                stringify!(flex_conf)
+            )
+        );
+    }
+    test_field_flex_conf();
 }
 impl Clone for rte_fdir_conf {
     fn clone(&self) -> Self {
@@ -2162,34 +2391,40 @@ fn bindgen_test_layout_rte_intr_conf() {
         2usize,
         concat!("Alignment of ", stringify!(rte_intr_conf))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_intr_conf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).lsc) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_intr_conf),
-            "::",
-            stringify!(lsc)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_intr_conf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).rxq) as usize - ptr as usize
-        },
-        2usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_intr_conf),
-            "::",
-            stringify!(rxq)
-        )
-    );
+    fn test_field_lsc() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<rte_intr_conf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).lsc) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_intr_conf),
+                "::",
+                stringify!(lsc)
+            )
+        );
+    }
+    test_field_lsc();
+    fn test_field_rxq() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<rte_intr_conf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).rxq) as usize - ptr as usize
+            },
+            2usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_intr_conf),
+                "::",
+                stringify!(rxq)
+            )
+        );
+    }
+    test_field_rxq();
 }
 impl Clone for rte_intr_conf {
     fn clone(&self) -> Self {
@@ -2253,66 +2488,84 @@ fn bindgen_test_layout_rte_eth_conf__bindgen_ty_1() {
         8usize,
         concat!("Alignment of ", stringify!(rte_eth_conf__bindgen_ty_1))
     );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<rte_eth_conf__bindgen_ty_1>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).rss_conf) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_conf__bindgen_ty_1),
-            "::",
-            stringify!(rss_conf)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<rte_eth_conf__bindgen_ty_1>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).vmdq_dcb_conf) as usize - ptr as usize
-        },
-        24usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_conf__bindgen_ty_1),
-            "::",
-            stringify!(vmdq_dcb_conf)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<rte_eth_conf__bindgen_ty_1>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).dcb_rx_conf) as usize - ptr as usize
-        },
-        1064usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_conf__bindgen_ty_1),
-            "::",
-            stringify!(dcb_rx_conf)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<rte_eth_conf__bindgen_ty_1>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).vmdq_rx_conf) as usize - ptr as usize
-        },
-        1080usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_conf__bindgen_ty_1),
-            "::",
-            stringify!(vmdq_rx_conf)
-        )
-    );
+    fn test_field_rss_conf() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<
+                    rte_eth_conf__bindgen_ty_1,
+                >::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).rss_conf) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_conf__bindgen_ty_1),
+                "::",
+                stringify!(rss_conf)
+            )
+        );
+    }
+    test_field_rss_conf();
+    fn test_field_vmdq_dcb_conf() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<
+                    rte_eth_conf__bindgen_ty_1,
+                >::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).vmdq_dcb_conf) as usize -
+                    ptr as usize
+            },
+            24usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_conf__bindgen_ty_1),
+                "::",
+                stringify!(vmdq_dcb_conf)
+            )
+        );
+    }
+    test_field_vmdq_dcb_conf();
+    fn test_field_dcb_rx_conf() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<
+                    rte_eth_conf__bindgen_ty_1,
+                >::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).dcb_rx_conf) as usize - ptr as usize
+            },
+            1064usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_conf__bindgen_ty_1),
+                "::",
+                stringify!(dcb_rx_conf)
+            )
+        );
+    }
+    test_field_dcb_rx_conf();
+    fn test_field_vmdq_rx_conf() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<
+                    rte_eth_conf__bindgen_ty_1,
+                >::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).vmdq_rx_conf) as usize -
+                    ptr as usize
+            },
+            1080usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_conf__bindgen_ty_1),
+                "::",
+                stringify!(vmdq_rx_conf)
+            )
+        );
+    }
+    test_field_vmdq_rx_conf();
 }
 impl Clone for rte_eth_conf__bindgen_ty_1 {
     fn clone(&self) -> Self {
@@ -2348,52 +2601,65 @@ fn bindgen_test_layout_rte_eth_conf__bindgen_ty_2() {
         4usize,
         concat!("Alignment of ", stringify!(rte_eth_conf__bindgen_ty_2))
     );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<rte_eth_conf__bindgen_ty_2>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).vmdq_dcb_tx_conf) as usize -
-                ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_conf__bindgen_ty_2),
-            "::",
-            stringify!(vmdq_dcb_tx_conf)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<rte_eth_conf__bindgen_ty_2>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).dcb_tx_conf) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_conf__bindgen_ty_2),
-            "::",
-            stringify!(dcb_tx_conf)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<rte_eth_conf__bindgen_ty_2>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).vmdq_tx_conf) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_conf__bindgen_ty_2),
-            "::",
-            stringify!(vmdq_tx_conf)
-        )
-    );
+    fn test_field_vmdq_dcb_tx_conf() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<
+                    rte_eth_conf__bindgen_ty_2,
+                >::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).vmdq_dcb_tx_conf) as usize -
+                    ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_conf__bindgen_ty_2),
+                "::",
+                stringify!(vmdq_dcb_tx_conf)
+            )
+        );
+    }
+    test_field_vmdq_dcb_tx_conf();
+    fn test_field_dcb_tx_conf() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<
+                    rte_eth_conf__bindgen_ty_2,
+                >::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).dcb_tx_conf) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_conf__bindgen_ty_2),
+                "::",
+                stringify!(dcb_tx_conf)
+            )
+        );
+    }
+    test_field_dcb_tx_conf();
+    fn test_field_vmdq_tx_conf() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<
+                    rte_eth_conf__bindgen_ty_2,
+                >::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).vmdq_tx_conf) as usize -
+                    ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_conf__bindgen_ty_2),
+                "::",
+                stringify!(vmdq_tx_conf)
+            )
+        );
+    }
+    test_field_vmdq_tx_conf();
 }
 impl Clone for rte_eth_conf__bindgen_ty_2 {
     fn clone(&self) -> Self {
@@ -2412,133 +2678,160 @@ fn bindgen_test_layout_rte_eth_conf() {
         8usize,
         concat!("Alignment of ", stringify!(rte_eth_conf))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_eth_conf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).link_speeds) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_conf),
-            "::",
-            stringify!(link_speeds)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_eth_conf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).rxmode) as usize - ptr as usize
-        },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_conf),
-            "::",
-            stringify!(rxmode)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_eth_conf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).txmode) as usize - ptr as usize
-        },
-        16usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_conf),
-            "::",
-            stringify!(txmode)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_eth_conf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).lpbk_mode) as usize - ptr as usize
-        },
-        24usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_conf),
-            "::",
-            stringify!(lpbk_mode)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_eth_conf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).rx_adv_conf) as usize - ptr as usize
-        },
-        32usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_conf),
-            "::",
-            stringify!(rx_adv_conf)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_eth_conf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).tx_adv_conf) as usize - ptr as usize
-        },
-        2152usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_conf),
-            "::",
-            stringify!(tx_adv_conf)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_eth_conf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).dcb_capability_en) as usize -
-                ptr as usize
-        },
-        2164usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_conf),
-            "::",
-            stringify!(dcb_capability_en)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_eth_conf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).fdir_conf) as usize - ptr as usize
-        },
-        2168usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_conf),
-            "::",
-            stringify!(fdir_conf)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_eth_conf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).intr_conf) as usize - ptr as usize
-        },
-        2940usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_conf),
-            "::",
-            stringify!(intr_conf)
-        )
-    );
+    fn test_field_link_speeds() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<rte_eth_conf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).link_speeds) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_conf),
+                "::",
+                stringify!(link_speeds)
+            )
+        );
+    }
+    test_field_link_speeds();
+    fn test_field_rxmode() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<rte_eth_conf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).rxmode) as usize - ptr as usize
+            },
+            4usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_conf),
+                "::",
+                stringify!(rxmode)
+            )
+        );
+    }
+    test_field_rxmode();
+    fn test_field_txmode() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<rte_eth_conf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).txmode) as usize - ptr as usize
+            },
+            16usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_conf),
+                "::",
+                stringify!(txmode)
+            )
+        );
+    }
+    test_field_txmode();
+    fn test_field_lpbk_mode() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<rte_eth_conf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).lpbk_mode) as usize - ptr as usize
+            },
+            24usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_conf),
+                "::",
+                stringify!(lpbk_mode)
+            )
+        );
+    }
+    test_field_lpbk_mode();
+    fn test_field_rx_adv_conf() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<rte_eth_conf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).rx_adv_conf) as usize - ptr as usize
+            },
+            32usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_conf),
+                "::",
+                stringify!(rx_adv_conf)
+            )
+        );
+    }
+    test_field_rx_adv_conf();
+    fn test_field_tx_adv_conf() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<rte_eth_conf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).tx_adv_conf) as usize - ptr as usize
+            },
+            2152usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_conf),
+                "::",
+                stringify!(tx_adv_conf)
+            )
+        );
+    }
+    test_field_tx_adv_conf();
+    fn test_field_dcb_capability_en() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<rte_eth_conf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).dcb_capability_en) as usize -
+                    ptr as usize
+            },
+            2164usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_conf),
+                "::",
+                stringify!(dcb_capability_en)
+            )
+        );
+    }
+    test_field_dcb_capability_en();
+    fn test_field_fdir_conf() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<rte_eth_conf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).fdir_conf) as usize - ptr as usize
+            },
+            2168usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_conf),
+                "::",
+                stringify!(fdir_conf)
+            )
+        );
+    }
+    test_field_fdir_conf();
+    fn test_field_intr_conf() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<rte_eth_conf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).intr_conf) as usize - ptr as usize
+            },
+            2940usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_conf),
+                "::",
+                stringify!(intr_conf)
+            )
+        );
+    }
+    test_field_intr_conf();
 }
 impl Clone for rte_eth_conf {
     fn clone(&self) -> Self {

--- a/tests/expectations/tests/layout_kni_mbuf.rs
+++ b/tests/expectations/tests/layout_kni_mbuf.rs
@@ -44,202 +44,245 @@ fn bindgen_test_layout_rte_kni_mbuf() {
         64usize,
         concat!("Alignment of ", stringify!(rte_kni_mbuf))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_kni_mbuf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).buf_addr) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_kni_mbuf),
-            "::",
-            stringify!(buf_addr)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_kni_mbuf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).buf_physaddr) as usize - ptr as usize
-        },
-        8usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_kni_mbuf),
-            "::",
-            stringify!(buf_physaddr)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_kni_mbuf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).pad0) as usize - ptr as usize
-        },
-        16usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_kni_mbuf),
-            "::",
-            stringify!(pad0)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_kni_mbuf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).data_off) as usize - ptr as usize
-        },
-        18usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_kni_mbuf),
-            "::",
-            stringify!(data_off)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_kni_mbuf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).pad1) as usize - ptr as usize
-        },
-        20usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_kni_mbuf),
-            "::",
-            stringify!(pad1)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_kni_mbuf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).nb_segs) as usize - ptr as usize
-        },
-        22usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_kni_mbuf),
-            "::",
-            stringify!(nb_segs)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_kni_mbuf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).pad4) as usize - ptr as usize
-        },
-        23usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_kni_mbuf),
-            "::",
-            stringify!(pad4)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_kni_mbuf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).ol_flags) as usize - ptr as usize
-        },
-        24usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_kni_mbuf),
-            "::",
-            stringify!(ol_flags)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_kni_mbuf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).pad2) as usize - ptr as usize
-        },
-        32usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_kni_mbuf),
-            "::",
-            stringify!(pad2)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_kni_mbuf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).pkt_len) as usize - ptr as usize
-        },
-        36usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_kni_mbuf),
-            "::",
-            stringify!(pkt_len)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_kni_mbuf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).data_len) as usize - ptr as usize
-        },
-        40usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_kni_mbuf),
-            "::",
-            stringify!(data_len)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_kni_mbuf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).pad3) as usize - ptr as usize
-        },
-        64usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_kni_mbuf),
-            "::",
-            stringify!(pad3)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_kni_mbuf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).pool) as usize - ptr as usize
-        },
-        72usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_kni_mbuf),
-            "::",
-            stringify!(pool)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_kni_mbuf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).next) as usize - ptr as usize
-        },
-        80usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_kni_mbuf),
-            "::",
-            stringify!(next)
-        )
-    );
+    fn test_field_buf_addr() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<rte_kni_mbuf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).buf_addr) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_kni_mbuf),
+                "::",
+                stringify!(buf_addr)
+            )
+        );
+    }
+    test_field_buf_addr();
+    fn test_field_buf_physaddr() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<rte_kni_mbuf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).buf_physaddr) as usize -
+                    ptr as usize
+            },
+            8usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_kni_mbuf),
+                "::",
+                stringify!(buf_physaddr)
+            )
+        );
+    }
+    test_field_buf_physaddr();
+    fn test_field_pad0() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<rte_kni_mbuf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).pad0) as usize - ptr as usize
+            },
+            16usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_kni_mbuf),
+                "::",
+                stringify!(pad0)
+            )
+        );
+    }
+    test_field_pad0();
+    fn test_field_data_off() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<rte_kni_mbuf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).data_off) as usize - ptr as usize
+            },
+            18usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_kni_mbuf),
+                "::",
+                stringify!(data_off)
+            )
+        );
+    }
+    test_field_data_off();
+    fn test_field_pad1() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<rte_kni_mbuf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).pad1) as usize - ptr as usize
+            },
+            20usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_kni_mbuf),
+                "::",
+                stringify!(pad1)
+            )
+        );
+    }
+    test_field_pad1();
+    fn test_field_nb_segs() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<rte_kni_mbuf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).nb_segs) as usize - ptr as usize
+            },
+            22usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_kni_mbuf),
+                "::",
+                stringify!(nb_segs)
+            )
+        );
+    }
+    test_field_nb_segs();
+    fn test_field_pad4() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<rte_kni_mbuf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).pad4) as usize - ptr as usize
+            },
+            23usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_kni_mbuf),
+                "::",
+                stringify!(pad4)
+            )
+        );
+    }
+    test_field_pad4();
+    fn test_field_ol_flags() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<rte_kni_mbuf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).ol_flags) as usize - ptr as usize
+            },
+            24usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_kni_mbuf),
+                "::",
+                stringify!(ol_flags)
+            )
+        );
+    }
+    test_field_ol_flags();
+    fn test_field_pad2() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<rte_kni_mbuf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).pad2) as usize - ptr as usize
+            },
+            32usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_kni_mbuf),
+                "::",
+                stringify!(pad2)
+            )
+        );
+    }
+    test_field_pad2();
+    fn test_field_pkt_len() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<rte_kni_mbuf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).pkt_len) as usize - ptr as usize
+            },
+            36usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_kni_mbuf),
+                "::",
+                stringify!(pkt_len)
+            )
+        );
+    }
+    test_field_pkt_len();
+    fn test_field_data_len() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<rte_kni_mbuf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).data_len) as usize - ptr as usize
+            },
+            40usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_kni_mbuf),
+                "::",
+                stringify!(data_len)
+            )
+        );
+    }
+    test_field_data_len();
+    fn test_field_pad3() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<rte_kni_mbuf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).pad3) as usize - ptr as usize
+            },
+            64usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_kni_mbuf),
+                "::",
+                stringify!(pad3)
+            )
+        );
+    }
+    test_field_pad3();
+    fn test_field_pool() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<rte_kni_mbuf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).pool) as usize - ptr as usize
+            },
+            72usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_kni_mbuf),
+                "::",
+                stringify!(pool)
+            )
+        );
+    }
+    test_field_pool();
+    fn test_field_next() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<rte_kni_mbuf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).next) as usize - ptr as usize
+            },
+            80usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_kni_mbuf),
+                "::",
+                stringify!(next)
+            )
+        );
+    }
+    test_field_next();
 }
 impl Default for rte_kni_mbuf {
     fn default() -> Self {

--- a/tests/expectations/tests/layout_large_align_field.rs
+++ b/tests/expectations/tests/layout_large_align_field.rs
@@ -75,48 +75,57 @@ fn bindgen_test_layout_ip_frag() {
         8usize,
         concat!("Alignment of ", stringify!(ip_frag))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<ip_frag>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).ofs) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(ip_frag),
-            "::",
-            stringify!(ofs)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<ip_frag>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).len) as usize - ptr as usize
-        },
-        2usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(ip_frag),
-            "::",
-            stringify!(len)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<ip_frag>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mb) as usize - ptr as usize
-        },
-        8usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(ip_frag),
-            "::",
-            stringify!(mb)
-        )
-    );
+    fn test_field_ofs() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<ip_frag>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).ofs) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(ip_frag),
+                "::",
+                stringify!(ofs)
+            )
+        );
+    }
+    test_field_ofs();
+    fn test_field_len() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<ip_frag>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).len) as usize - ptr as usize
+            },
+            2usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(ip_frag),
+                "::",
+                stringify!(len)
+            )
+        );
+    }
+    test_field_len();
+    fn test_field_mb() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<ip_frag>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).mb) as usize - ptr as usize
+            },
+            8usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(ip_frag),
+                "::",
+                stringify!(mb)
+            )
+        );
+    }
+    test_field_mb();
 }
 impl Default for ip_frag {
     fn default() -> Self {
@@ -150,48 +159,57 @@ fn bindgen_test_layout_ip_frag_key() {
         8usize,
         concat!("Alignment of ", stringify!(ip_frag_key))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<ip_frag_key>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).src_dst) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(ip_frag_key),
-            "::",
-            stringify!(src_dst)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<ip_frag_key>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).id) as usize - ptr as usize
-        },
-        32usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(ip_frag_key),
-            "::",
-            stringify!(id)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<ip_frag_key>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).key_len) as usize - ptr as usize
-        },
-        36usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(ip_frag_key),
-            "::",
-            stringify!(key_len)
-        )
-    );
+    fn test_field_src_dst() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<ip_frag_key>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).src_dst) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(ip_frag_key),
+                "::",
+                stringify!(src_dst)
+            )
+        );
+    }
+    test_field_src_dst();
+    fn test_field_id() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<ip_frag_key>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).id) as usize - ptr as usize
+            },
+            32usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(ip_frag_key),
+                "::",
+                stringify!(id)
+            )
+        );
+    }
+    test_field_id();
+    fn test_field_key_len() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<ip_frag_key>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).key_len) as usize - ptr as usize
+            },
+            36usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(ip_frag_key),
+                "::",
+                stringify!(key_len)
+            )
+        );
+    }
+    test_field_key_len();
 }
 /// @internal Fragmented packet to reassemble.
 /// First two entries in the frags[] array are for the last and first fragments.
@@ -232,36 +250,40 @@ fn bindgen_test_layout_ip_frag_pkt__bindgen_ty_1() {
         8usize,
         concat!("Alignment of ", stringify!(ip_frag_pkt__bindgen_ty_1))
     );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<ip_frag_pkt__bindgen_ty_1>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).tqe_next) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(ip_frag_pkt__bindgen_ty_1),
-            "::",
-            stringify!(tqe_next)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<ip_frag_pkt__bindgen_ty_1>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).tqe_prev) as usize - ptr as usize
-        },
-        8usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(ip_frag_pkt__bindgen_ty_1),
-            "::",
-            stringify!(tqe_prev)
-        )
-    );
+    fn test_field_tqe_next() {
+        assert_eq!(
+            unsafe {
+                let uninit = :: std :: mem :: MaybeUninit :: < ip_frag_pkt__bindgen_ty_1 > :: uninit () ;
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).tqe_next) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(ip_frag_pkt__bindgen_ty_1),
+                "::",
+                stringify!(tqe_next)
+            )
+        );
+    }
+    test_field_tqe_next();
+    fn test_field_tqe_prev() {
+        assert_eq!(
+            unsafe {
+                let uninit = :: std :: mem :: MaybeUninit :: < ip_frag_pkt__bindgen_ty_1 > :: uninit () ;
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).tqe_prev) as usize - ptr as usize
+            },
+            8usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(ip_frag_pkt__bindgen_ty_1),
+                "::",
+                stringify!(tqe_prev)
+            )
+        );
+    }
+    test_field_tqe_prev();
 }
 impl Default for ip_frag_pkt__bindgen_ty_1 {
     fn default() -> Self {
@@ -284,104 +306,125 @@ fn bindgen_test_layout_ip_frag_pkt() {
         64usize,
         concat!("Alignment of ", stringify!(ip_frag_pkt))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<ip_frag_pkt>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).lru) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(ip_frag_pkt),
-            "::",
-            stringify!(lru)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<ip_frag_pkt>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).key) as usize - ptr as usize
-        },
-        16usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(ip_frag_pkt),
-            "::",
-            stringify!(key)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<ip_frag_pkt>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).start) as usize - ptr as usize
-        },
-        56usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(ip_frag_pkt),
-            "::",
-            stringify!(start)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<ip_frag_pkt>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).total_size) as usize - ptr as usize
-        },
-        64usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(ip_frag_pkt),
-            "::",
-            stringify!(total_size)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<ip_frag_pkt>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).frag_size) as usize - ptr as usize
-        },
-        68usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(ip_frag_pkt),
-            "::",
-            stringify!(frag_size)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<ip_frag_pkt>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).last_idx) as usize - ptr as usize
-        },
-        72usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(ip_frag_pkt),
-            "::",
-            stringify!(last_idx)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<ip_frag_pkt>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).frags) as usize - ptr as usize
-        },
-        80usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(ip_frag_pkt),
-            "::",
-            stringify!(frags)
-        )
-    );
+    fn test_field_lru() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<ip_frag_pkt>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).lru) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(ip_frag_pkt),
+                "::",
+                stringify!(lru)
+            )
+        );
+    }
+    test_field_lru();
+    fn test_field_key() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<ip_frag_pkt>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).key) as usize - ptr as usize
+            },
+            16usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(ip_frag_pkt),
+                "::",
+                stringify!(key)
+            )
+        );
+    }
+    test_field_key();
+    fn test_field_start() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<ip_frag_pkt>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).start) as usize - ptr as usize
+            },
+            56usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(ip_frag_pkt),
+                "::",
+                stringify!(start)
+            )
+        );
+    }
+    test_field_start();
+    fn test_field_total_size() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<ip_frag_pkt>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).total_size) as usize - ptr as usize
+            },
+            64usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(ip_frag_pkt),
+                "::",
+                stringify!(total_size)
+            )
+        );
+    }
+    test_field_total_size();
+    fn test_field_frag_size() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<ip_frag_pkt>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).frag_size) as usize - ptr as usize
+            },
+            68usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(ip_frag_pkt),
+                "::",
+                stringify!(frag_size)
+            )
+        );
+    }
+    test_field_frag_size();
+    fn test_field_last_idx() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<ip_frag_pkt>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).last_idx) as usize - ptr as usize
+            },
+            72usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(ip_frag_pkt),
+                "::",
+                stringify!(last_idx)
+            )
+        );
+    }
+    test_field_last_idx();
+    fn test_field_frags() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<ip_frag_pkt>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).frags) as usize - ptr as usize
+            },
+            80usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(ip_frag_pkt),
+                "::",
+                stringify!(frags)
+            )
+        );
+    }
+    test_field_frags();
 }
 impl Default for ip_frag_pkt {
     fn default() -> Self {
@@ -410,34 +453,40 @@ fn bindgen_test_layout_ip_pkt_list() {
         8usize,
         concat!("Alignment of ", stringify!(ip_pkt_list))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<ip_pkt_list>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).tqh_first) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(ip_pkt_list),
-            "::",
-            stringify!(tqh_first)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<ip_pkt_list>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).tqh_last) as usize - ptr as usize
-        },
-        8usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(ip_pkt_list),
-            "::",
-            stringify!(tqh_last)
-        )
-    );
+    fn test_field_tqh_first() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<ip_pkt_list>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).tqh_first) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(ip_pkt_list),
+                "::",
+                stringify!(tqh_first)
+            )
+        );
+    }
+    test_field_tqh_first();
+    fn test_field_tqh_last() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<ip_pkt_list>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).tqh_last) as usize - ptr as usize
+            },
+            8usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(ip_pkt_list),
+                "::",
+                stringify!(tqh_last)
+            )
+        );
+    }
+    test_field_tqh_last();
 }
 impl Default for ip_pkt_list {
     fn default() -> Self {
@@ -478,90 +527,115 @@ fn bindgen_test_layout_ip_frag_tbl_stat() {
         64usize,
         concat!("Alignment of ", stringify!(ip_frag_tbl_stat))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<ip_frag_tbl_stat>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).find_num) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(ip_frag_tbl_stat),
-            "::",
-            stringify!(find_num)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<ip_frag_tbl_stat>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).add_num) as usize - ptr as usize
-        },
-        8usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(ip_frag_tbl_stat),
-            "::",
-            stringify!(add_num)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<ip_frag_tbl_stat>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).del_num) as usize - ptr as usize
-        },
-        16usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(ip_frag_tbl_stat),
-            "::",
-            stringify!(del_num)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<ip_frag_tbl_stat>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).reuse_num) as usize - ptr as usize
-        },
-        24usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(ip_frag_tbl_stat),
-            "::",
-            stringify!(reuse_num)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<ip_frag_tbl_stat>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).fail_total) as usize - ptr as usize
-        },
-        32usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(ip_frag_tbl_stat),
-            "::",
-            stringify!(fail_total)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<ip_frag_tbl_stat>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).fail_nospace) as usize - ptr as usize
-        },
-        40usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(ip_frag_tbl_stat),
-            "::",
-            stringify!(fail_nospace)
-        )
-    );
+    fn test_field_find_num() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<ip_frag_tbl_stat>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).find_num) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(ip_frag_tbl_stat),
+                "::",
+                stringify!(find_num)
+            )
+        );
+    }
+    test_field_find_num();
+    fn test_field_add_num() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<ip_frag_tbl_stat>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).add_num) as usize - ptr as usize
+            },
+            8usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(ip_frag_tbl_stat),
+                "::",
+                stringify!(add_num)
+            )
+        );
+    }
+    test_field_add_num();
+    fn test_field_del_num() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<ip_frag_tbl_stat>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).del_num) as usize - ptr as usize
+            },
+            16usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(ip_frag_tbl_stat),
+                "::",
+                stringify!(del_num)
+            )
+        );
+    }
+    test_field_del_num();
+    fn test_field_reuse_num() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<ip_frag_tbl_stat>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).reuse_num) as usize - ptr as usize
+            },
+            24usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(ip_frag_tbl_stat),
+                "::",
+                stringify!(reuse_num)
+            )
+        );
+    }
+    test_field_reuse_num();
+    fn test_field_fail_total() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<ip_frag_tbl_stat>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).fail_total) as usize - ptr as usize
+            },
+            32usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(ip_frag_tbl_stat),
+                "::",
+                stringify!(fail_total)
+            )
+        );
+    }
+    test_field_fail_total();
+    fn test_field_fail_nospace() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<ip_frag_tbl_stat>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).fail_nospace) as usize -
+                    ptr as usize
+            },
+            40usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(ip_frag_tbl_stat),
+                "::",
+                stringify!(fail_nospace)
+            )
+        );
+    }
+    test_field_fail_nospace();
 }
 impl Default for ip_frag_tbl_stat {
     fn default() -> Self {
@@ -612,160 +686,205 @@ fn bindgen_test_layout_rte_ip_frag_tbl() {
         64usize,
         concat!("Alignment of ", stringify!(rte_ip_frag_tbl))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_ip_frag_tbl>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).max_cycles) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_ip_frag_tbl),
-            "::",
-            stringify!(max_cycles)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_ip_frag_tbl>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).entry_mask) as usize - ptr as usize
-        },
-        8usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_ip_frag_tbl),
-            "::",
-            stringify!(entry_mask)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_ip_frag_tbl>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).max_entries) as usize - ptr as usize
-        },
-        12usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_ip_frag_tbl),
-            "::",
-            stringify!(max_entries)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_ip_frag_tbl>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).use_entries) as usize - ptr as usize
-        },
-        16usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_ip_frag_tbl),
-            "::",
-            stringify!(use_entries)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_ip_frag_tbl>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).bucket_entries) as usize - ptr as usize
-        },
-        20usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_ip_frag_tbl),
-            "::",
-            stringify!(bucket_entries)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_ip_frag_tbl>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).nb_entries) as usize - ptr as usize
-        },
-        24usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_ip_frag_tbl),
-            "::",
-            stringify!(nb_entries)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_ip_frag_tbl>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).nb_buckets) as usize - ptr as usize
-        },
-        28usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_ip_frag_tbl),
-            "::",
-            stringify!(nb_buckets)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_ip_frag_tbl>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).last) as usize - ptr as usize
-        },
-        32usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_ip_frag_tbl),
-            "::",
-            stringify!(last)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_ip_frag_tbl>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).lru) as usize - ptr as usize
-        },
-        40usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_ip_frag_tbl),
-            "::",
-            stringify!(lru)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_ip_frag_tbl>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).stat) as usize - ptr as usize
-        },
-        64usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_ip_frag_tbl),
-            "::",
-            stringify!(stat)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_ip_frag_tbl>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).pkt) as usize - ptr as usize
-        },
-        128usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_ip_frag_tbl),
-            "::",
-            stringify!(pkt)
-        )
-    );
+    fn test_field_max_cycles() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_ip_frag_tbl>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).max_cycles) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_ip_frag_tbl),
+                "::",
+                stringify!(max_cycles)
+            )
+        );
+    }
+    test_field_max_cycles();
+    fn test_field_entry_mask() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_ip_frag_tbl>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).entry_mask) as usize - ptr as usize
+            },
+            8usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_ip_frag_tbl),
+                "::",
+                stringify!(entry_mask)
+            )
+        );
+    }
+    test_field_entry_mask();
+    fn test_field_max_entries() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_ip_frag_tbl>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).max_entries) as usize - ptr as usize
+            },
+            12usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_ip_frag_tbl),
+                "::",
+                stringify!(max_entries)
+            )
+        );
+    }
+    test_field_max_entries();
+    fn test_field_use_entries() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_ip_frag_tbl>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).use_entries) as usize - ptr as usize
+            },
+            16usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_ip_frag_tbl),
+                "::",
+                stringify!(use_entries)
+            )
+        );
+    }
+    test_field_use_entries();
+    fn test_field_bucket_entries() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_ip_frag_tbl>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).bucket_entries) as usize -
+                    ptr as usize
+            },
+            20usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_ip_frag_tbl),
+                "::",
+                stringify!(bucket_entries)
+            )
+        );
+    }
+    test_field_bucket_entries();
+    fn test_field_nb_entries() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_ip_frag_tbl>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).nb_entries) as usize - ptr as usize
+            },
+            24usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_ip_frag_tbl),
+                "::",
+                stringify!(nb_entries)
+            )
+        );
+    }
+    test_field_nb_entries();
+    fn test_field_nb_buckets() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_ip_frag_tbl>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).nb_buckets) as usize - ptr as usize
+            },
+            28usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_ip_frag_tbl),
+                "::",
+                stringify!(nb_buckets)
+            )
+        );
+    }
+    test_field_nb_buckets();
+    fn test_field_last() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_ip_frag_tbl>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).last) as usize - ptr as usize
+            },
+            32usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_ip_frag_tbl),
+                "::",
+                stringify!(last)
+            )
+        );
+    }
+    test_field_last();
+    fn test_field_lru() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_ip_frag_tbl>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).lru) as usize - ptr as usize
+            },
+            40usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_ip_frag_tbl),
+                "::",
+                stringify!(lru)
+            )
+        );
+    }
+    test_field_lru();
+    fn test_field_stat() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_ip_frag_tbl>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).stat) as usize - ptr as usize
+            },
+            64usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_ip_frag_tbl),
+                "::",
+                stringify!(stat)
+            )
+        );
+    }
+    test_field_stat();
+    fn test_field_pkt() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_ip_frag_tbl>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).pkt) as usize - ptr as usize
+            },
+            128usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_ip_frag_tbl),
+                "::",
+                stringify!(pkt)
+            )
+        );
+    }
+    test_field_pkt();
 }
 impl Default for rte_ip_frag_tbl {
     fn default() -> Self {

--- a/tests/expectations/tests/layout_mbuf.rs
+++ b/tests/expectations/tests/layout_mbuf.rs
@@ -116,20 +116,24 @@ fn bindgen_test_layout_rte_atomic16_t() {
         2usize,
         concat!("Alignment of ", stringify!(rte_atomic16_t))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_atomic16_t>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).cnt) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_atomic16_t),
-            "::",
-            stringify!(cnt)
-        )
-    );
+    fn test_field_cnt() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_atomic16_t>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).cnt) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_atomic16_t),
+                "::",
+                stringify!(cnt)
+            )
+        );
+    }
+    test_field_cnt();
 }
 /// The generic rte_mbuf, containing a packet mbuf.
 #[repr(C)]
@@ -204,36 +208,43 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_1() {
         2usize,
         concat!("Alignment of ", stringify!(rte_mbuf__bindgen_ty_1))
     );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<rte_mbuf__bindgen_ty_1>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).refcnt_atomic) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mbuf__bindgen_ty_1),
-            "::",
-            stringify!(refcnt_atomic)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<rte_mbuf__bindgen_ty_1>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).refcnt) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mbuf__bindgen_ty_1),
-            "::",
-            stringify!(refcnt)
-        )
-    );
+    fn test_field_refcnt_atomic() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_mbuf__bindgen_ty_1>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).refcnt_atomic) as usize -
+                    ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_mbuf__bindgen_ty_1),
+                "::",
+                stringify!(refcnt_atomic)
+            )
+        );
+    }
+    test_field_refcnt_atomic();
+    fn test_field_refcnt() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_mbuf__bindgen_ty_1>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).refcnt) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_mbuf__bindgen_ty_1),
+                "::",
+                stringify!(refcnt)
+            )
+        );
+    }
+    test_field_refcnt();
 }
 impl Default for rte_mbuf__bindgen_ty_1 {
     fn default() -> Self {
@@ -427,21 +438,24 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_2() {
         4usize,
         concat!("Alignment of ", stringify!(rte_mbuf__bindgen_ty_2))
     );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<rte_mbuf__bindgen_ty_2>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).packet_type) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mbuf__bindgen_ty_2),
-            "::",
-            stringify!(packet_type)
-        )
-    );
+    fn test_field_packet_type() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_mbuf__bindgen_ty_2>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).packet_type) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_mbuf__bindgen_ty_2),
+                "::",
+                stringify!(packet_type)
+            )
+        );
+    }
+    test_field_packet_type();
 }
 impl Default for rte_mbuf__bindgen_ty_2 {
     fn default() -> Self {
@@ -488,8 +502,14 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindg
 ) {
     assert_eq ! (:: std :: mem :: size_of :: < rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1 > () , 4usize , concat ! ("Size of: " , stringify ! (rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1)));
     assert_eq ! (:: std :: mem :: align_of :: < rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1 > () , 2usize , concat ! ("Alignment of " , stringify ! (rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1)));
-    assert_eq ! (unsafe { let uninit = :: std :: mem :: MaybeUninit :: < rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1 > :: uninit () ; let ptr = uninit . as_ptr () ; :: std :: ptr :: addr_of ! ((* ptr) . hash) as usize - ptr as usize } , 0usize , concat ! ("Offset of field: " , stringify ! (rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1) , "::" , stringify ! (hash)));
-    assert_eq ! (unsafe { let uninit = :: std :: mem :: MaybeUninit :: < rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1 > :: uninit () ; let ptr = uninit . as_ptr () ; :: std :: ptr :: addr_of ! ((* ptr) . id) as usize - ptr as usize } , 2usize , concat ! ("Offset of field: " , stringify ! (rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1) , "::" , stringify ! (id)));
+    fn test_field_hash() {
+        assert_eq ! (unsafe { let uninit = :: std :: mem :: MaybeUninit :: < rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1 > :: uninit () ; let ptr = uninit . as_ptr () ; :: std :: ptr :: addr_of ! ((* ptr) . hash) as usize - ptr as usize } , 0usize , concat ! ("Offset of field: " , stringify ! (rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1) , "::" , stringify ! (hash)));
+    }
+    test_field_hash();
+    fn test_field_id() {
+        assert_eq ! (unsafe { let uninit = :: std :: mem :: MaybeUninit :: < rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1 > :: uninit () ; let ptr = uninit . as_ptr () ; :: std :: ptr :: addr_of ! ((* ptr) . id) as usize - ptr as usize } , 2usize , concat ! ("Offset of field: " , stringify ! (rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1) , "::" , stringify ! (id)));
+    }
+    test_field_id();
 }
 #[test]
 fn bindgen_test_layout_rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1() {
@@ -512,22 +532,25 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1() {
             stringify!(rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1)
         )
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<
-                rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1,
-            >::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).lo) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1),
-            "::",
-            stringify!(lo)
-        )
-    );
+    fn test_field_lo() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<
+                    rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1,
+                >::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).lo) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1),
+                "::",
+                stringify!(lo)
+            )
+        );
+    }
+    test_field_lo();
 }
 impl Default for rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1 {
     fn default() -> Self {
@@ -556,22 +579,25 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_3__bindgen_ty_1() {
             stringify!(rte_mbuf__bindgen_ty_3__bindgen_ty_1)
         )
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<
-                rte_mbuf__bindgen_ty_3__bindgen_ty_1,
-            >::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).hi) as usize - ptr as usize
-        },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mbuf__bindgen_ty_3__bindgen_ty_1),
-            "::",
-            stringify!(hi)
-        )
-    );
+    fn test_field_hi() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<
+                    rte_mbuf__bindgen_ty_3__bindgen_ty_1,
+                >::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).hi) as usize - ptr as usize
+            },
+            4usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_mbuf__bindgen_ty_3__bindgen_ty_1),
+                "::",
+                stringify!(hi)
+            )
+        );
+    }
+    test_field_hi();
 }
 impl Default for rte_mbuf__bindgen_ty_3__bindgen_ty_1 {
     fn default() -> Self {
@@ -606,38 +632,44 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_3__bindgen_ty_2() {
             stringify!(rte_mbuf__bindgen_ty_3__bindgen_ty_2)
         )
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<
-                rte_mbuf__bindgen_ty_3__bindgen_ty_2,
-            >::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).lo) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mbuf__bindgen_ty_3__bindgen_ty_2),
-            "::",
-            stringify!(lo)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<
-                rte_mbuf__bindgen_ty_3__bindgen_ty_2,
-            >::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).hi) as usize - ptr as usize
-        },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mbuf__bindgen_ty_3__bindgen_ty_2),
-            "::",
-            stringify!(hi)
-        )
-    );
+    fn test_field_lo() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<
+                    rte_mbuf__bindgen_ty_3__bindgen_ty_2,
+                >::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).lo) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_mbuf__bindgen_ty_3__bindgen_ty_2),
+                "::",
+                stringify!(lo)
+            )
+        );
+    }
+    test_field_lo();
+    fn test_field_hi() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<
+                    rte_mbuf__bindgen_ty_3__bindgen_ty_2,
+                >::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).hi) as usize - ptr as usize
+            },
+            4usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_mbuf__bindgen_ty_3__bindgen_ty_2),
+                "::",
+                stringify!(hi)
+            )
+        );
+    }
+    test_field_hi();
 }
 #[test]
 fn bindgen_test_layout_rte_mbuf__bindgen_ty_3() {
@@ -651,66 +683,78 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_3() {
         4usize,
         concat!("Alignment of ", stringify!(rte_mbuf__bindgen_ty_3))
     );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<rte_mbuf__bindgen_ty_3>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).rss) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mbuf__bindgen_ty_3),
-            "::",
-            stringify!(rss)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<rte_mbuf__bindgen_ty_3>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).fdir) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mbuf__bindgen_ty_3),
-            "::",
-            stringify!(fdir)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<rte_mbuf__bindgen_ty_3>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).sched) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mbuf__bindgen_ty_3),
-            "::",
-            stringify!(sched)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<rte_mbuf__bindgen_ty_3>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).usr) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mbuf__bindgen_ty_3),
-            "::",
-            stringify!(usr)
-        )
-    );
+    fn test_field_rss() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_mbuf__bindgen_ty_3>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).rss) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_mbuf__bindgen_ty_3),
+                "::",
+                stringify!(rss)
+            )
+        );
+    }
+    test_field_rss();
+    fn test_field_fdir() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_mbuf__bindgen_ty_3>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).fdir) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_mbuf__bindgen_ty_3),
+                "::",
+                stringify!(fdir)
+            )
+        );
+    }
+    test_field_fdir();
+    fn test_field_sched() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_mbuf__bindgen_ty_3>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).sched) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_mbuf__bindgen_ty_3),
+                "::",
+                stringify!(sched)
+            )
+        );
+    }
+    test_field_sched();
+    fn test_field_usr() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_mbuf__bindgen_ty_3>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).usr) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_mbuf__bindgen_ty_3),
+                "::",
+                stringify!(usr)
+            )
+        );
+    }
+    test_field_usr();
 }
 impl Default for rte_mbuf__bindgen_ty_3 {
     fn default() -> Self {
@@ -741,36 +785,42 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_4() {
         8usize,
         concat!("Alignment of ", stringify!(rte_mbuf__bindgen_ty_4))
     );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<rte_mbuf__bindgen_ty_4>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).userdata) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mbuf__bindgen_ty_4),
-            "::",
-            stringify!(userdata)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<rte_mbuf__bindgen_ty_4>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).udata64) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mbuf__bindgen_ty_4),
-            "::",
-            stringify!(udata64)
-        )
-    );
+    fn test_field_userdata() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_mbuf__bindgen_ty_4>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).userdata) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_mbuf__bindgen_ty_4),
+                "::",
+                stringify!(userdata)
+            )
+        );
+    }
+    test_field_userdata();
+    fn test_field_udata64() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_mbuf__bindgen_ty_4>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).udata64) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_mbuf__bindgen_ty_4),
+                "::",
+                stringify!(udata64)
+            )
+        );
+    }
+    test_field_udata64();
 }
 impl Default for rte_mbuf__bindgen_ty_4 {
     fn default() -> Self {
@@ -945,21 +995,24 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_5() {
         8usize,
         concat!("Alignment of ", stringify!(rte_mbuf__bindgen_ty_5))
     );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<rte_mbuf__bindgen_ty_5>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).tx_offload) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mbuf__bindgen_ty_5),
-            "::",
-            stringify!(tx_offload)
-        )
-    );
+    fn test_field_tx_offload() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_mbuf__bindgen_ty_5>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).tx_offload) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_mbuf__bindgen_ty_5),
+                "::",
+                stringify!(tx_offload)
+            )
+        );
+    }
+    test_field_tx_offload();
 }
 impl Default for rte_mbuf__bindgen_ty_5 {
     fn default() -> Self {
@@ -982,301 +1035,366 @@ fn bindgen_test_layout_rte_mbuf() {
         64usize,
         concat!("Alignment of ", stringify!(rte_mbuf))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_mbuf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).cacheline0) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mbuf),
-            "::",
-            stringify!(cacheline0)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_mbuf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).buf_addr) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mbuf),
-            "::",
-            stringify!(buf_addr)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_mbuf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).buf_physaddr) as usize - ptr as usize
-        },
-        8usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mbuf),
-            "::",
-            stringify!(buf_physaddr)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_mbuf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).buf_len) as usize - ptr as usize
-        },
-        16usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mbuf),
-            "::",
-            stringify!(buf_len)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_mbuf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).rearm_data) as usize - ptr as usize
-        },
-        18usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mbuf),
-            "::",
-            stringify!(rearm_data)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_mbuf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).data_off) as usize - ptr as usize
-        },
-        18usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mbuf),
-            "::",
-            stringify!(data_off)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_mbuf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).nb_segs) as usize - ptr as usize
-        },
-        22usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mbuf),
-            "::",
-            stringify!(nb_segs)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_mbuf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).port) as usize - ptr as usize
-        },
-        23usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mbuf),
-            "::",
-            stringify!(port)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_mbuf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).ol_flags) as usize - ptr as usize
-        },
-        24usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mbuf),
-            "::",
-            stringify!(ol_flags)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_mbuf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).rx_descriptor_fields1) as usize -
-                ptr as usize
-        },
-        32usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mbuf),
-            "::",
-            stringify!(rx_descriptor_fields1)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_mbuf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).pkt_len) as usize - ptr as usize
-        },
-        36usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mbuf),
-            "::",
-            stringify!(pkt_len)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_mbuf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).data_len) as usize - ptr as usize
-        },
-        40usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mbuf),
-            "::",
-            stringify!(data_len)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_mbuf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).vlan_tci) as usize - ptr as usize
-        },
-        42usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mbuf),
-            "::",
-            stringify!(vlan_tci)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_mbuf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).hash) as usize - ptr as usize
-        },
-        44usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mbuf),
-            "::",
-            stringify!(hash)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_mbuf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).seqn) as usize - ptr as usize
-        },
-        52usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mbuf),
-            "::",
-            stringify!(seqn)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_mbuf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).vlan_tci_outer) as usize - ptr as usize
-        },
-        56usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mbuf),
-            "::",
-            stringify!(vlan_tci_outer)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_mbuf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).cacheline1) as usize - ptr as usize
-        },
-        64usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mbuf),
-            "::",
-            stringify!(cacheline1)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_mbuf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).pool) as usize - ptr as usize
-        },
-        72usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mbuf),
-            "::",
-            stringify!(pool)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_mbuf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).next) as usize - ptr as usize
-        },
-        80usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mbuf),
-            "::",
-            stringify!(next)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_mbuf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).priv_size) as usize - ptr as usize
-        },
-        96usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mbuf),
-            "::",
-            stringify!(priv_size)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_mbuf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).timesync) as usize - ptr as usize
-        },
-        98usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mbuf),
-            "::",
-            stringify!(timesync)
-        )
-    );
+    fn test_field_cacheline0() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<rte_mbuf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).cacheline0) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_mbuf),
+                "::",
+                stringify!(cacheline0)
+            )
+        );
+    }
+    test_field_cacheline0();
+    fn test_field_buf_addr() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<rte_mbuf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).buf_addr) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_mbuf),
+                "::",
+                stringify!(buf_addr)
+            )
+        );
+    }
+    test_field_buf_addr();
+    fn test_field_buf_physaddr() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<rte_mbuf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).buf_physaddr) as usize -
+                    ptr as usize
+            },
+            8usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_mbuf),
+                "::",
+                stringify!(buf_physaddr)
+            )
+        );
+    }
+    test_field_buf_physaddr();
+    fn test_field_buf_len() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<rte_mbuf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).buf_len) as usize - ptr as usize
+            },
+            16usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_mbuf),
+                "::",
+                stringify!(buf_len)
+            )
+        );
+    }
+    test_field_buf_len();
+    fn test_field_rearm_data() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<rte_mbuf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).rearm_data) as usize - ptr as usize
+            },
+            18usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_mbuf),
+                "::",
+                stringify!(rearm_data)
+            )
+        );
+    }
+    test_field_rearm_data();
+    fn test_field_data_off() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<rte_mbuf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).data_off) as usize - ptr as usize
+            },
+            18usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_mbuf),
+                "::",
+                stringify!(data_off)
+            )
+        );
+    }
+    test_field_data_off();
+    fn test_field_nb_segs() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<rte_mbuf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).nb_segs) as usize - ptr as usize
+            },
+            22usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_mbuf),
+                "::",
+                stringify!(nb_segs)
+            )
+        );
+    }
+    test_field_nb_segs();
+    fn test_field_port() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<rte_mbuf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).port) as usize - ptr as usize
+            },
+            23usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_mbuf),
+                "::",
+                stringify!(port)
+            )
+        );
+    }
+    test_field_port();
+    fn test_field_ol_flags() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<rte_mbuf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).ol_flags) as usize - ptr as usize
+            },
+            24usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_mbuf),
+                "::",
+                stringify!(ol_flags)
+            )
+        );
+    }
+    test_field_ol_flags();
+    fn test_field_rx_descriptor_fields1() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<rte_mbuf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).rx_descriptor_fields1) as usize -
+                    ptr as usize
+            },
+            32usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_mbuf),
+                "::",
+                stringify!(rx_descriptor_fields1)
+            )
+        );
+    }
+    test_field_rx_descriptor_fields1();
+    fn test_field_pkt_len() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<rte_mbuf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).pkt_len) as usize - ptr as usize
+            },
+            36usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_mbuf),
+                "::",
+                stringify!(pkt_len)
+            )
+        );
+    }
+    test_field_pkt_len();
+    fn test_field_data_len() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<rte_mbuf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).data_len) as usize - ptr as usize
+            },
+            40usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_mbuf),
+                "::",
+                stringify!(data_len)
+            )
+        );
+    }
+    test_field_data_len();
+    fn test_field_vlan_tci() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<rte_mbuf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).vlan_tci) as usize - ptr as usize
+            },
+            42usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_mbuf),
+                "::",
+                stringify!(vlan_tci)
+            )
+        );
+    }
+    test_field_vlan_tci();
+    fn test_field_hash() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<rte_mbuf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).hash) as usize - ptr as usize
+            },
+            44usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_mbuf),
+                "::",
+                stringify!(hash)
+            )
+        );
+    }
+    test_field_hash();
+    fn test_field_seqn() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<rte_mbuf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).seqn) as usize - ptr as usize
+            },
+            52usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_mbuf),
+                "::",
+                stringify!(seqn)
+            )
+        );
+    }
+    test_field_seqn();
+    fn test_field_vlan_tci_outer() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<rte_mbuf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).vlan_tci_outer) as usize -
+                    ptr as usize
+            },
+            56usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_mbuf),
+                "::",
+                stringify!(vlan_tci_outer)
+            )
+        );
+    }
+    test_field_vlan_tci_outer();
+    fn test_field_cacheline1() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<rte_mbuf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).cacheline1) as usize - ptr as usize
+            },
+            64usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_mbuf),
+                "::",
+                stringify!(cacheline1)
+            )
+        );
+    }
+    test_field_cacheline1();
+    fn test_field_pool() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<rte_mbuf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).pool) as usize - ptr as usize
+            },
+            72usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_mbuf),
+                "::",
+                stringify!(pool)
+            )
+        );
+    }
+    test_field_pool();
+    fn test_field_next() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<rte_mbuf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).next) as usize - ptr as usize
+            },
+            80usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_mbuf),
+                "::",
+                stringify!(next)
+            )
+        );
+    }
+    test_field_next();
+    fn test_field_priv_size() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<rte_mbuf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).priv_size) as usize - ptr as usize
+            },
+            96usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_mbuf),
+                "::",
+                stringify!(priv_size)
+            )
+        );
+    }
+    test_field_priv_size();
+    fn test_field_timesync() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<rte_mbuf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).timesync) as usize - ptr as usize
+            },
+            98usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_mbuf),
+                "::",
+                stringify!(timesync)
+            )
+        );
+    }
+    test_field_timesync();
 }
 impl Default for rte_mbuf {
     fn default() -> Self {

--- a/tests/expectations/tests/layout_mbuf_1_0.rs
+++ b/tests/expectations/tests/layout_mbuf_1_0.rs
@@ -159,20 +159,24 @@ fn bindgen_test_layout_rte_atomic16_t() {
         2usize,
         concat!("Alignment of ", stringify!(rte_atomic16_t))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_atomic16_t>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).cnt) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_atomic16_t),
-            "::",
-            stringify!(cnt)
-        )
-    );
+    fn test_field_cnt() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_atomic16_t>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).cnt) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_atomic16_t),
+                "::",
+                stringify!(cnt)
+            )
+        );
+    }
+    test_field_cnt();
 }
 impl Clone for rte_atomic16_t {
     fn clone(&self) -> Self {
@@ -253,36 +257,43 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_1() {
         2usize,
         concat!("Alignment of ", stringify!(rte_mbuf__bindgen_ty_1))
     );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<rte_mbuf__bindgen_ty_1>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).refcnt_atomic) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mbuf__bindgen_ty_1),
-            "::",
-            stringify!(refcnt_atomic)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<rte_mbuf__bindgen_ty_1>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).refcnt) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mbuf__bindgen_ty_1),
-            "::",
-            stringify!(refcnt)
-        )
-    );
+    fn test_field_refcnt_atomic() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_mbuf__bindgen_ty_1>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).refcnt_atomic) as usize -
+                    ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_mbuf__bindgen_ty_1),
+                "::",
+                stringify!(refcnt_atomic)
+            )
+        );
+    }
+    test_field_refcnt_atomic();
+    fn test_field_refcnt() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_mbuf__bindgen_ty_1>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).refcnt) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_mbuf__bindgen_ty_1),
+                "::",
+                stringify!(refcnt)
+            )
+        );
+    }
+    test_field_refcnt();
 }
 impl Clone for rte_mbuf__bindgen_ty_1 {
     fn clone(&self) -> Self {
@@ -479,21 +490,24 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_2() {
         4usize,
         concat!("Alignment of ", stringify!(rte_mbuf__bindgen_ty_2))
     );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<rte_mbuf__bindgen_ty_2>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).packet_type) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mbuf__bindgen_ty_2),
-            "::",
-            stringify!(packet_type)
-        )
-    );
+    fn test_field_packet_type() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_mbuf__bindgen_ty_2>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).packet_type) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_mbuf__bindgen_ty_2),
+                "::",
+                stringify!(packet_type)
+            )
+        );
+    }
+    test_field_packet_type();
 }
 impl Clone for rte_mbuf__bindgen_ty_2 {
     fn clone(&self) -> Self {
@@ -539,8 +553,14 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindg
 ) {
     assert_eq ! (:: std :: mem :: size_of :: < rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1 > () , 4usize , concat ! ("Size of: " , stringify ! (rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1)));
     assert_eq ! (:: std :: mem :: align_of :: < rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1 > () , 2usize , concat ! ("Alignment of " , stringify ! (rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1)));
-    assert_eq ! (unsafe { let uninit = :: std :: mem :: MaybeUninit :: < rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1 > :: uninit () ; let ptr = uninit . as_ptr () ; :: std :: ptr :: addr_of ! ((* ptr) . hash) as usize - ptr as usize } , 0usize , concat ! ("Offset of field: " , stringify ! (rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1) , "::" , stringify ! (hash)));
-    assert_eq ! (unsafe { let uninit = :: std :: mem :: MaybeUninit :: < rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1 > :: uninit () ; let ptr = uninit . as_ptr () ; :: std :: ptr :: addr_of ! ((* ptr) . id) as usize - ptr as usize } , 2usize , concat ! ("Offset of field: " , stringify ! (rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1) , "::" , stringify ! (id)));
+    fn test_field_hash() {
+        assert_eq ! (unsafe { let uninit = :: std :: mem :: MaybeUninit :: < rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1 > :: uninit () ; let ptr = uninit . as_ptr () ; :: std :: ptr :: addr_of ! ((* ptr) . hash) as usize - ptr as usize } , 0usize , concat ! ("Offset of field: " , stringify ! (rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1) , "::" , stringify ! (hash)));
+    }
+    test_field_hash();
+    fn test_field_id() {
+        assert_eq ! (unsafe { let uninit = :: std :: mem :: MaybeUninit :: < rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1 > :: uninit () ; let ptr = uninit . as_ptr () ; :: std :: ptr :: addr_of ! ((* ptr) . id) as usize - ptr as usize } , 2usize , concat ! ("Offset of field: " , stringify ! (rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1) , "::" , stringify ! (id)));
+    }
+    test_field_id();
 }
 impl Clone
     for rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1
@@ -570,22 +590,25 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1() {
             stringify!(rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1)
         )
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<
-                rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1,
-            >::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).lo) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1),
-            "::",
-            stringify!(lo)
-        )
-    );
+    fn test_field_lo() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<
+                    rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1,
+                >::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).lo) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1),
+                "::",
+                stringify!(lo)
+            )
+        );
+    }
+    test_field_lo();
 }
 impl Clone for rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1 {
     fn clone(&self) -> Self {
@@ -610,22 +633,25 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_3__bindgen_ty_1() {
             stringify!(rte_mbuf__bindgen_ty_3__bindgen_ty_1)
         )
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<
-                rte_mbuf__bindgen_ty_3__bindgen_ty_1,
-            >::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).hi) as usize - ptr as usize
-        },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mbuf__bindgen_ty_3__bindgen_ty_1),
-            "::",
-            stringify!(hi)
-        )
-    );
+    fn test_field_hi() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<
+                    rte_mbuf__bindgen_ty_3__bindgen_ty_1,
+                >::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).hi) as usize - ptr as usize
+            },
+            4usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_mbuf__bindgen_ty_3__bindgen_ty_1),
+                "::",
+                stringify!(hi)
+            )
+        );
+    }
+    test_field_hi();
 }
 impl Clone for rte_mbuf__bindgen_ty_3__bindgen_ty_1 {
     fn clone(&self) -> Self {
@@ -656,38 +682,44 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_3__bindgen_ty_2() {
             stringify!(rte_mbuf__bindgen_ty_3__bindgen_ty_2)
         )
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<
-                rte_mbuf__bindgen_ty_3__bindgen_ty_2,
-            >::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).lo) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mbuf__bindgen_ty_3__bindgen_ty_2),
-            "::",
-            stringify!(lo)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<
-                rte_mbuf__bindgen_ty_3__bindgen_ty_2,
-            >::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).hi) as usize - ptr as usize
-        },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mbuf__bindgen_ty_3__bindgen_ty_2),
-            "::",
-            stringify!(hi)
-        )
-    );
+    fn test_field_lo() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<
+                    rte_mbuf__bindgen_ty_3__bindgen_ty_2,
+                >::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).lo) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_mbuf__bindgen_ty_3__bindgen_ty_2),
+                "::",
+                stringify!(lo)
+            )
+        );
+    }
+    test_field_lo();
+    fn test_field_hi() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<
+                    rte_mbuf__bindgen_ty_3__bindgen_ty_2,
+                >::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).hi) as usize - ptr as usize
+            },
+            4usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_mbuf__bindgen_ty_3__bindgen_ty_2),
+                "::",
+                stringify!(hi)
+            )
+        );
+    }
+    test_field_hi();
 }
 impl Clone for rte_mbuf__bindgen_ty_3__bindgen_ty_2 {
     fn clone(&self) -> Self {
@@ -706,66 +738,78 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_3() {
         4usize,
         concat!("Alignment of ", stringify!(rte_mbuf__bindgen_ty_3))
     );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<rte_mbuf__bindgen_ty_3>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).rss) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mbuf__bindgen_ty_3),
-            "::",
-            stringify!(rss)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<rte_mbuf__bindgen_ty_3>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).fdir) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mbuf__bindgen_ty_3),
-            "::",
-            stringify!(fdir)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<rte_mbuf__bindgen_ty_3>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).sched) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mbuf__bindgen_ty_3),
-            "::",
-            stringify!(sched)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<rte_mbuf__bindgen_ty_3>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).usr) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mbuf__bindgen_ty_3),
-            "::",
-            stringify!(usr)
-        )
-    );
+    fn test_field_rss() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_mbuf__bindgen_ty_3>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).rss) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_mbuf__bindgen_ty_3),
+                "::",
+                stringify!(rss)
+            )
+        );
+    }
+    test_field_rss();
+    fn test_field_fdir() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_mbuf__bindgen_ty_3>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).fdir) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_mbuf__bindgen_ty_3),
+                "::",
+                stringify!(fdir)
+            )
+        );
+    }
+    test_field_fdir();
+    fn test_field_sched() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_mbuf__bindgen_ty_3>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).sched) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_mbuf__bindgen_ty_3),
+                "::",
+                stringify!(sched)
+            )
+        );
+    }
+    test_field_sched();
+    fn test_field_usr() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_mbuf__bindgen_ty_3>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).usr) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_mbuf__bindgen_ty_3),
+                "::",
+                stringify!(usr)
+            )
+        );
+    }
+    test_field_usr();
 }
 impl Clone for rte_mbuf__bindgen_ty_3 {
     fn clone(&self) -> Self {
@@ -793,36 +837,42 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_4() {
         8usize,
         concat!("Alignment of ", stringify!(rte_mbuf__bindgen_ty_4))
     );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<rte_mbuf__bindgen_ty_4>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).userdata) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mbuf__bindgen_ty_4),
-            "::",
-            stringify!(userdata)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<rte_mbuf__bindgen_ty_4>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).udata64) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mbuf__bindgen_ty_4),
-            "::",
-            stringify!(udata64)
-        )
-    );
+    fn test_field_userdata() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_mbuf__bindgen_ty_4>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).userdata) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_mbuf__bindgen_ty_4),
+                "::",
+                stringify!(userdata)
+            )
+        );
+    }
+    test_field_userdata();
+    fn test_field_udata64() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_mbuf__bindgen_ty_4>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).udata64) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_mbuf__bindgen_ty_4),
+                "::",
+                stringify!(udata64)
+            )
+        );
+    }
+    test_field_udata64();
 }
 impl Clone for rte_mbuf__bindgen_ty_4 {
     fn clone(&self) -> Self {
@@ -1000,21 +1050,24 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_5() {
         8usize,
         concat!("Alignment of ", stringify!(rte_mbuf__bindgen_ty_5))
     );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<rte_mbuf__bindgen_ty_5>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).tx_offload) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mbuf__bindgen_ty_5),
-            "::",
-            stringify!(tx_offload)
-        )
-    );
+    fn test_field_tx_offload() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<rte_mbuf__bindgen_ty_5>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).tx_offload) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_mbuf__bindgen_ty_5),
+                "::",
+                stringify!(tx_offload)
+            )
+        );
+    }
+    test_field_tx_offload();
 }
 impl Clone for rte_mbuf__bindgen_ty_5 {
     fn clone(&self) -> Self {
@@ -1028,301 +1081,366 @@ fn bindgen_test_layout_rte_mbuf() {
         128usize,
         concat!("Size of: ", stringify!(rte_mbuf))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_mbuf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).cacheline0) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mbuf),
-            "::",
-            stringify!(cacheline0)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_mbuf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).buf_addr) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mbuf),
-            "::",
-            stringify!(buf_addr)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_mbuf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).buf_physaddr) as usize - ptr as usize
-        },
-        8usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mbuf),
-            "::",
-            stringify!(buf_physaddr)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_mbuf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).buf_len) as usize - ptr as usize
-        },
-        16usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mbuf),
-            "::",
-            stringify!(buf_len)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_mbuf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).rearm_data) as usize - ptr as usize
-        },
-        18usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mbuf),
-            "::",
-            stringify!(rearm_data)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_mbuf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).data_off) as usize - ptr as usize
-        },
-        18usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mbuf),
-            "::",
-            stringify!(data_off)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_mbuf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).nb_segs) as usize - ptr as usize
-        },
-        22usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mbuf),
-            "::",
-            stringify!(nb_segs)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_mbuf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).port) as usize - ptr as usize
-        },
-        23usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mbuf),
-            "::",
-            stringify!(port)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_mbuf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).ol_flags) as usize - ptr as usize
-        },
-        24usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mbuf),
-            "::",
-            stringify!(ol_flags)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_mbuf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).rx_descriptor_fields1) as usize -
-                ptr as usize
-        },
-        32usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mbuf),
-            "::",
-            stringify!(rx_descriptor_fields1)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_mbuf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).pkt_len) as usize - ptr as usize
-        },
-        36usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mbuf),
-            "::",
-            stringify!(pkt_len)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_mbuf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).data_len) as usize - ptr as usize
-        },
-        40usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mbuf),
-            "::",
-            stringify!(data_len)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_mbuf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).vlan_tci) as usize - ptr as usize
-        },
-        42usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mbuf),
-            "::",
-            stringify!(vlan_tci)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_mbuf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).hash) as usize - ptr as usize
-        },
-        44usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mbuf),
-            "::",
-            stringify!(hash)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_mbuf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).seqn) as usize - ptr as usize
-        },
-        52usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mbuf),
-            "::",
-            stringify!(seqn)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_mbuf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).vlan_tci_outer) as usize - ptr as usize
-        },
-        56usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mbuf),
-            "::",
-            stringify!(vlan_tci_outer)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_mbuf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).cacheline1) as usize - ptr as usize
-        },
-        64usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mbuf),
-            "::",
-            stringify!(cacheline1)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_mbuf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).pool) as usize - ptr as usize
-        },
-        72usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mbuf),
-            "::",
-            stringify!(pool)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_mbuf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).next) as usize - ptr as usize
-        },
-        80usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mbuf),
-            "::",
-            stringify!(next)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_mbuf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).priv_size) as usize - ptr as usize
-        },
-        96usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mbuf),
-            "::",
-            stringify!(priv_size)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_mbuf>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).timesync) as usize - ptr as usize
-        },
-        98usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mbuf),
-            "::",
-            stringify!(timesync)
-        )
-    );
+    fn test_field_cacheline0() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<rte_mbuf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).cacheline0) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_mbuf),
+                "::",
+                stringify!(cacheline0)
+            )
+        );
+    }
+    test_field_cacheline0();
+    fn test_field_buf_addr() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<rte_mbuf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).buf_addr) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_mbuf),
+                "::",
+                stringify!(buf_addr)
+            )
+        );
+    }
+    test_field_buf_addr();
+    fn test_field_buf_physaddr() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<rte_mbuf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).buf_physaddr) as usize -
+                    ptr as usize
+            },
+            8usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_mbuf),
+                "::",
+                stringify!(buf_physaddr)
+            )
+        );
+    }
+    test_field_buf_physaddr();
+    fn test_field_buf_len() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<rte_mbuf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).buf_len) as usize - ptr as usize
+            },
+            16usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_mbuf),
+                "::",
+                stringify!(buf_len)
+            )
+        );
+    }
+    test_field_buf_len();
+    fn test_field_rearm_data() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<rte_mbuf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).rearm_data) as usize - ptr as usize
+            },
+            18usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_mbuf),
+                "::",
+                stringify!(rearm_data)
+            )
+        );
+    }
+    test_field_rearm_data();
+    fn test_field_data_off() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<rte_mbuf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).data_off) as usize - ptr as usize
+            },
+            18usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_mbuf),
+                "::",
+                stringify!(data_off)
+            )
+        );
+    }
+    test_field_data_off();
+    fn test_field_nb_segs() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<rte_mbuf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).nb_segs) as usize - ptr as usize
+            },
+            22usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_mbuf),
+                "::",
+                stringify!(nb_segs)
+            )
+        );
+    }
+    test_field_nb_segs();
+    fn test_field_port() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<rte_mbuf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).port) as usize - ptr as usize
+            },
+            23usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_mbuf),
+                "::",
+                stringify!(port)
+            )
+        );
+    }
+    test_field_port();
+    fn test_field_ol_flags() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<rte_mbuf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).ol_flags) as usize - ptr as usize
+            },
+            24usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_mbuf),
+                "::",
+                stringify!(ol_flags)
+            )
+        );
+    }
+    test_field_ol_flags();
+    fn test_field_rx_descriptor_fields1() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<rte_mbuf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).rx_descriptor_fields1) as usize -
+                    ptr as usize
+            },
+            32usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_mbuf),
+                "::",
+                stringify!(rx_descriptor_fields1)
+            )
+        );
+    }
+    test_field_rx_descriptor_fields1();
+    fn test_field_pkt_len() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<rte_mbuf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).pkt_len) as usize - ptr as usize
+            },
+            36usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_mbuf),
+                "::",
+                stringify!(pkt_len)
+            )
+        );
+    }
+    test_field_pkt_len();
+    fn test_field_data_len() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<rte_mbuf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).data_len) as usize - ptr as usize
+            },
+            40usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_mbuf),
+                "::",
+                stringify!(data_len)
+            )
+        );
+    }
+    test_field_data_len();
+    fn test_field_vlan_tci() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<rte_mbuf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).vlan_tci) as usize - ptr as usize
+            },
+            42usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_mbuf),
+                "::",
+                stringify!(vlan_tci)
+            )
+        );
+    }
+    test_field_vlan_tci();
+    fn test_field_hash() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<rte_mbuf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).hash) as usize - ptr as usize
+            },
+            44usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_mbuf),
+                "::",
+                stringify!(hash)
+            )
+        );
+    }
+    test_field_hash();
+    fn test_field_seqn() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<rte_mbuf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).seqn) as usize - ptr as usize
+            },
+            52usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_mbuf),
+                "::",
+                stringify!(seqn)
+            )
+        );
+    }
+    test_field_seqn();
+    fn test_field_vlan_tci_outer() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<rte_mbuf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).vlan_tci_outer) as usize -
+                    ptr as usize
+            },
+            56usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_mbuf),
+                "::",
+                stringify!(vlan_tci_outer)
+            )
+        );
+    }
+    test_field_vlan_tci_outer();
+    fn test_field_cacheline1() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<rte_mbuf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).cacheline1) as usize - ptr as usize
+            },
+            64usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_mbuf),
+                "::",
+                stringify!(cacheline1)
+            )
+        );
+    }
+    test_field_cacheline1();
+    fn test_field_pool() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<rte_mbuf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).pool) as usize - ptr as usize
+            },
+            72usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_mbuf),
+                "::",
+                stringify!(pool)
+            )
+        );
+    }
+    test_field_pool();
+    fn test_field_next() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<rte_mbuf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).next) as usize - ptr as usize
+            },
+            80usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_mbuf),
+                "::",
+                stringify!(next)
+            )
+        );
+    }
+    test_field_next();
+    fn test_field_priv_size() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<rte_mbuf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).priv_size) as usize - ptr as usize
+            },
+            96usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_mbuf),
+                "::",
+                stringify!(priv_size)
+            )
+        );
+    }
+    test_field_priv_size();
+    fn test_field_timesync() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<rte_mbuf>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).timesync) as usize - ptr as usize
+            },
+            98usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_mbuf),
+                "::",
+                stringify!(timesync)
+            )
+        );
+    }
+    test_field_timesync();
 }
 impl Default for rte_mbuf {
     fn default() -> Self {

--- a/tests/expectations/tests/libclang-5/call-conv-field.rs
+++ b/tests/expectations/tests/libclang-5/call-conv-field.rs
@@ -28,36 +28,42 @@ fn bindgen_test_layout_JNINativeInterface_() {
         8usize,
         concat!("Alignment of ", stringify!(JNINativeInterface_))
     );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<JNINativeInterface_>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).GetVersion) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(JNINativeInterface_),
-            "::",
-            stringify!(GetVersion)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<JNINativeInterface_>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).__hack) as usize - ptr as usize
-        },
-        8usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(JNINativeInterface_),
-            "::",
-            stringify!(__hack)
-        )
-    );
+    fn test_field_GetVersion() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<JNINativeInterface_>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).GetVersion) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(JNINativeInterface_),
+                "::",
+                stringify!(GetVersion)
+            )
+        );
+    }
+    test_field_GetVersion();
+    fn test_field___hack() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<JNINativeInterface_>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).__hack) as usize - ptr as usize
+            },
+            8usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(JNINativeInterface_),
+                "::",
+                stringify!(__hack)
+            )
+        );
+    }
+    test_field___hack();
 }
 extern "stdcall" {
     pub fn bar();

--- a/tests/expectations/tests/libclang-5/type_alias_template_specialized.rs
+++ b/tests/expectations/tests/libclang-5/type_alias_template_specialized.rs
@@ -22,20 +22,23 @@ fn bindgen_test_layout_Rooted() {
         4usize,
         concat!("Alignment of ", stringify!(Rooted))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Rooted>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).ptr) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(Rooted),
-            "::",
-            stringify!(ptr)
-        )
-    );
+    fn test_field_ptr() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Rooted>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).ptr) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(Rooted),
+                "::",
+                stringify!(ptr)
+            )
+        );
+    }
+    test_field_ptr();
 }
 impl Default for Rooted {
     fn default() -> Self {

--- a/tests/expectations/tests/libclang-9/call-conv-field.rs
+++ b/tests/expectations/tests/libclang-9/call-conv-field.rs
@@ -28,36 +28,42 @@ fn bindgen_test_layout_JNINativeInterface_() {
         8usize,
         concat!("Alignment of ", stringify!(JNINativeInterface_))
     );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<JNINativeInterface_>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).GetVersion) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(JNINativeInterface_),
-            "::",
-            stringify!(GetVersion)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<JNINativeInterface_>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).__hack) as usize - ptr as usize
-        },
-        8usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(JNINativeInterface_),
-            "::",
-            stringify!(__hack)
-        )
-    );
+    fn test_field_GetVersion() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<JNINativeInterface_>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).GetVersion) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(JNINativeInterface_),
+                "::",
+                stringify!(GetVersion)
+            )
+        );
+    }
+    test_field_GetVersion();
+    fn test_field___hack() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<JNINativeInterface_>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).__hack) as usize - ptr as usize
+            },
+            8usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(JNINativeInterface_),
+                "::",
+                stringify!(__hack)
+            )
+        );
+    }
+    test_field___hack();
 }
 extern "stdcall" {
     pub fn bar();

--- a/tests/expectations/tests/libclang-9/class.rs
+++ b/tests/expectations/tests/libclang-9/class.rs
@@ -53,29 +53,35 @@ fn bindgen_test_layout_C() {
         4usize,
         concat!("Alignment of ", stringify!(C))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<C>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
-        0usize,
-        concat!("Offset of field: ", stringify!(C), "::", stringify!(a))
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<C>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).big_array) as usize - ptr as usize
-        },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C),
-            "::",
-            stringify!(big_array)
-        )
-    );
+    fn test_field_a() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<C>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+            },
+            0usize,
+            concat!("Offset of field: ", stringify!(C), "::", stringify!(a))
+        );
+    }
+    test_field_a();
+    fn test_field_big_array() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<C>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).big_array) as usize - ptr as usize
+            },
+            4usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(C),
+                "::",
+                stringify!(big_array)
+            )
+        );
+    }
+    test_field_big_array();
 }
 impl Default for C {
     fn default() -> Self {
@@ -104,52 +110,64 @@ fn bindgen_test_layout_C_with_zero_length_array() {
         4usize,
         concat!("Alignment of ", stringify!(C_with_zero_length_array))
     );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<C_with_zero_length_array>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C_with_zero_length_array),
-            "::",
-            stringify!(a)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<C_with_zero_length_array>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).big_array) as usize - ptr as usize
-        },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C_with_zero_length_array),
-            "::",
-            stringify!(big_array)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<C_with_zero_length_array>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).zero_length_array) as usize -
-                ptr as usize
-        },
-        37usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C_with_zero_length_array),
-            "::",
-            stringify!(zero_length_array)
-        )
-    );
+    fn test_field_a() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<C_with_zero_length_array>::uninit(
+                    );
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(C_with_zero_length_array),
+                "::",
+                stringify!(a)
+            )
+        );
+    }
+    test_field_a();
+    fn test_field_big_array() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<C_with_zero_length_array>::uninit(
+                    );
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).big_array) as usize - ptr as usize
+            },
+            4usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(C_with_zero_length_array),
+                "::",
+                stringify!(big_array)
+            )
+        );
+    }
+    test_field_big_array();
+    fn test_field_zero_length_array() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<C_with_zero_length_array>::uninit(
+                    );
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).zero_length_array) as usize -
+                    ptr as usize
+            },
+            37usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(C_with_zero_length_array),
+                "::",
+                stringify!(zero_length_array)
+            )
+        );
+    }
+    test_field_zero_length_array();
 }
 impl Default for C_with_zero_length_array {
     fn default() -> Self {
@@ -178,37 +196,45 @@ fn bindgen_test_layout_C_with_zero_length_array_2() {
         4usize,
         concat!("Alignment of ", stringify!(C_with_zero_length_array_2))
     );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<C_with_zero_length_array_2>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C_with_zero_length_array_2),
-            "::",
-            stringify!(a)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<C_with_zero_length_array_2>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).zero_length_array) as usize -
-                ptr as usize
-        },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C_with_zero_length_array_2),
-            "::",
-            stringify!(zero_length_array)
-        )
-    );
+    fn test_field_a() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<
+                    C_with_zero_length_array_2,
+                >::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(C_with_zero_length_array_2),
+                "::",
+                stringify!(a)
+            )
+        );
+    }
+    test_field_a();
+    fn test_field_zero_length_array() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<
+                    C_with_zero_length_array_2,
+                >::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).zero_length_array) as usize -
+                    ptr as usize
+            },
+            4usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(C_with_zero_length_array_2),
+                "::",
+                stringify!(zero_length_array)
+            )
+        );
+    }
+    test_field_zero_length_array();
 }
 #[repr(C)]
 pub struct C_with_incomplete_array {
@@ -228,52 +254,64 @@ fn bindgen_test_layout_C_with_incomplete_array() {
         4usize,
         concat!("Alignment of ", stringify!(C_with_incomplete_array))
     );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<C_with_incomplete_array>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C_with_incomplete_array),
-            "::",
-            stringify!(a)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<C_with_incomplete_array>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).big_array) as usize - ptr as usize
-        },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C_with_incomplete_array),
-            "::",
-            stringify!(big_array)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<C_with_incomplete_array>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).incomplete_array) as usize -
-                ptr as usize
-        },
-        37usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C_with_incomplete_array),
-            "::",
-            stringify!(incomplete_array)
-        )
-    );
+    fn test_field_a() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<C_with_incomplete_array>::uninit(
+                    );
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(C_with_incomplete_array),
+                "::",
+                stringify!(a)
+            )
+        );
+    }
+    test_field_a();
+    fn test_field_big_array() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<C_with_incomplete_array>::uninit(
+                    );
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).big_array) as usize - ptr as usize
+            },
+            4usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(C_with_incomplete_array),
+                "::",
+                stringify!(big_array)
+            )
+        );
+    }
+    test_field_big_array();
+    fn test_field_incomplete_array() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<C_with_incomplete_array>::uninit(
+                    );
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).incomplete_array) as usize -
+                    ptr as usize
+            },
+            37usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(C_with_incomplete_array),
+                "::",
+                stringify!(incomplete_array)
+            )
+        );
+    }
+    test_field_incomplete_array();
 }
 impl Default for C_with_incomplete_array {
     fn default() -> Self {
@@ -302,37 +340,41 @@ fn bindgen_test_layout_C_with_incomplete_array_2() {
         4usize,
         concat!("Alignment of ", stringify!(C_with_incomplete_array_2))
     );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<C_with_incomplete_array_2>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C_with_incomplete_array_2),
-            "::",
-            stringify!(a)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<C_with_incomplete_array_2>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).incomplete_array) as usize -
-                ptr as usize
-        },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C_with_incomplete_array_2),
-            "::",
-            stringify!(incomplete_array)
-        )
-    );
+    fn test_field_a() {
+        assert_eq!(
+            unsafe {
+                let uninit = :: std :: mem :: MaybeUninit :: < C_with_incomplete_array_2 > :: uninit () ;
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(C_with_incomplete_array_2),
+                "::",
+                stringify!(a)
+            )
+        );
+    }
+    test_field_a();
+    fn test_field_incomplete_array() {
+        assert_eq!(
+            unsafe {
+                let uninit = :: std :: mem :: MaybeUninit :: < C_with_incomplete_array_2 > :: uninit () ;
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).incomplete_array) as usize -
+                    ptr as usize
+            },
+            4usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(C_with_incomplete_array_2),
+                "::",
+                stringify!(incomplete_array)
+            )
+        );
+    }
+    test_field_incomplete_array();
 }
 #[repr(C)]
 pub struct C_with_zero_length_array_and_incomplete_array {
@@ -359,72 +401,84 @@ fn bindgen_test_layout_C_with_zero_length_array_and_incomplete_array() {
             stringify!(C_with_zero_length_array_and_incomplete_array)
         )
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<
-                C_with_zero_length_array_and_incomplete_array,
-            >::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C_with_zero_length_array_and_incomplete_array),
-            "::",
-            stringify!(a)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<
-                C_with_zero_length_array_and_incomplete_array,
-            >::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).big_array) as usize - ptr as usize
-        },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C_with_zero_length_array_and_incomplete_array),
-            "::",
-            stringify!(big_array)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<
-                C_with_zero_length_array_and_incomplete_array,
-            >::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).zero_length_array) as usize -
-                ptr as usize
-        },
-        37usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C_with_zero_length_array_and_incomplete_array),
-            "::",
-            stringify!(zero_length_array)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<
-                C_with_zero_length_array_and_incomplete_array,
-            >::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).incomplete_array) as usize -
-                ptr as usize
-        },
-        37usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C_with_zero_length_array_and_incomplete_array),
-            "::",
-            stringify!(incomplete_array)
-        )
-    );
+    fn test_field_a() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<
+                    C_with_zero_length_array_and_incomplete_array,
+                >::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(C_with_zero_length_array_and_incomplete_array),
+                "::",
+                stringify!(a)
+            )
+        );
+    }
+    test_field_a();
+    fn test_field_big_array() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<
+                    C_with_zero_length_array_and_incomplete_array,
+                >::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).big_array) as usize - ptr as usize
+            },
+            4usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(C_with_zero_length_array_and_incomplete_array),
+                "::",
+                stringify!(big_array)
+            )
+        );
+    }
+    test_field_big_array();
+    fn test_field_zero_length_array() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<
+                    C_with_zero_length_array_and_incomplete_array,
+                >::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).zero_length_array) as usize -
+                    ptr as usize
+            },
+            37usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(C_with_zero_length_array_and_incomplete_array),
+                "::",
+                stringify!(zero_length_array)
+            )
+        );
+    }
+    test_field_zero_length_array();
+    fn test_field_incomplete_array() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<
+                    C_with_zero_length_array_and_incomplete_array,
+                >::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).incomplete_array) as usize -
+                    ptr as usize
+            },
+            37usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(C_with_zero_length_array_and_incomplete_array),
+                "::",
+                stringify!(incomplete_array)
+            )
+        );
+    }
+    test_field_incomplete_array();
 }
 impl Default for C_with_zero_length_array_and_incomplete_array {
     fn default() -> Self {
@@ -462,56 +516,65 @@ fn bindgen_test_layout_C_with_zero_length_array_and_incomplete_array_2() {
             stringify!(C_with_zero_length_array_and_incomplete_array_2)
         )
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<
-                C_with_zero_length_array_and_incomplete_array_2,
-            >::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C_with_zero_length_array_and_incomplete_array_2),
-            "::",
-            stringify!(a)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<
-                C_with_zero_length_array_and_incomplete_array_2,
-            >::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).zero_length_array) as usize -
-                ptr as usize
-        },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C_with_zero_length_array_and_incomplete_array_2),
-            "::",
-            stringify!(zero_length_array)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<
-                C_with_zero_length_array_and_incomplete_array_2,
-            >::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).incomplete_array) as usize -
-                ptr as usize
-        },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C_with_zero_length_array_and_incomplete_array_2),
-            "::",
-            stringify!(incomplete_array)
-        )
-    );
+    fn test_field_a() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<
+                    C_with_zero_length_array_and_incomplete_array_2,
+                >::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(C_with_zero_length_array_and_incomplete_array_2),
+                "::",
+                stringify!(a)
+            )
+        );
+    }
+    test_field_a();
+    fn test_field_zero_length_array() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<
+                    C_with_zero_length_array_and_incomplete_array_2,
+                >::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).zero_length_array) as usize -
+                    ptr as usize
+            },
+            4usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(C_with_zero_length_array_and_incomplete_array_2),
+                "::",
+                stringify!(zero_length_array)
+            )
+        );
+    }
+    test_field_zero_length_array();
+    fn test_field_incomplete_array() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<
+                    C_with_zero_length_array_and_incomplete_array_2,
+                >::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).incomplete_array) as usize -
+                    ptr as usize
+            },
+            4usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(C_with_zero_length_array_and_incomplete_array_2),
+                "::",
+                stringify!(incomplete_array)
+            )
+        );
+    }
+    test_field_incomplete_array();
 }
 #[repr(C)]
 #[derive(Debug, Default, Hash, PartialOrd, Ord, PartialEq, Eq)]
@@ -530,20 +593,23 @@ fn bindgen_test_layout_WithDtor() {
         4usize,
         concat!("Alignment of ", stringify!(WithDtor))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<WithDtor>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(WithDtor),
-            "::",
-            stringify!(b)
-        )
-    );
+    fn test_field_b() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<WithDtor>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(WithDtor),
+                "::",
+                stringify!(b)
+            )
+        );
+    }
+    test_field_b();
 }
 #[repr(C)]
 pub struct IncompleteArrayNonCopiable {
@@ -562,37 +628,45 @@ fn bindgen_test_layout_IncompleteArrayNonCopiable() {
         8usize,
         concat!("Alignment of ", stringify!(IncompleteArrayNonCopiable))
     );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<IncompleteArrayNonCopiable>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).whatever) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(IncompleteArrayNonCopiable),
-            "::",
-            stringify!(whatever)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<IncompleteArrayNonCopiable>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).incomplete_array) as usize -
-                ptr as usize
-        },
-        8usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(IncompleteArrayNonCopiable),
-            "::",
-            stringify!(incomplete_array)
-        )
-    );
+    fn test_field_whatever() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<
+                    IncompleteArrayNonCopiable,
+                >::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).whatever) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(IncompleteArrayNonCopiable),
+                "::",
+                stringify!(whatever)
+            )
+        );
+    }
+    test_field_whatever();
+    fn test_field_incomplete_array() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<
+                    IncompleteArrayNonCopiable,
+                >::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).incomplete_array) as usize -
+                    ptr as usize
+            },
+            8usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(IncompleteArrayNonCopiable),
+                "::",
+                stringify!(incomplete_array)
+            )
+        );
+    }
+    test_field_incomplete_array();
 }
 impl Default for IncompleteArrayNonCopiable {
     fn default() -> Self {
@@ -621,24 +695,40 @@ fn bindgen_test_layout_Union() {
         4usize,
         concat!("Alignment of ", stringify!(Union))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Union>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize
-        },
-        0usize,
-        concat!("Offset of field: ", stringify!(Union), "::", stringify!(d))
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Union>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).i) as usize - ptr as usize
-        },
-        0usize,
-        concat!("Offset of field: ", stringify!(Union), "::", stringify!(i))
-    );
+    fn test_field_d() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Union>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(Union),
+                "::",
+                stringify!(d)
+            )
+        );
+    }
+    test_field_d();
+    fn test_field_i() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Union>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).i) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(Union),
+                "::",
+                stringify!(i)
+            )
+        );
+    }
+    test_field_i();
 }
 impl Default for Union {
     fn default() -> Self {
@@ -666,20 +756,23 @@ fn bindgen_test_layout_WithUnion() {
         4usize,
         concat!("Alignment of ", stringify!(WithUnion))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<WithUnion>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).data) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(WithUnion),
-            "::",
-            stringify!(data)
-        )
-    );
+    fn test_field_data() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<WithUnion>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).data) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(WithUnion),
+                "::",
+                stringify!(data)
+            )
+        );
+    }
+    test_field_data();
 }
 impl Default for WithUnion {
     fn default() -> Self {

--- a/tests/expectations/tests/libclang-9/class_1_0.rs
+++ b/tests/expectations/tests/libclang-9/class_1_0.rs
@@ -96,29 +96,35 @@ fn bindgen_test_layout_C() {
         4usize,
         concat!("Alignment of ", stringify!(C))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<C>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
-        0usize,
-        concat!("Offset of field: ", stringify!(C), "::", stringify!(a))
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<C>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).big_array) as usize - ptr as usize
-        },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C),
-            "::",
-            stringify!(big_array)
-        )
-    );
+    fn test_field_a() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<C>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+            },
+            0usize,
+            concat!("Offset of field: ", stringify!(C), "::", stringify!(a))
+        );
+    }
+    test_field_a();
+    fn test_field_big_array() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<C>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).big_array) as usize - ptr as usize
+            },
+            4usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(C),
+                "::",
+                stringify!(big_array)
+            )
+        );
+    }
+    test_field_big_array();
 }
 impl Clone for C {
     fn clone(&self) -> Self {
@@ -157,52 +163,64 @@ fn bindgen_test_layout_C_with_zero_length_array() {
         4usize,
         concat!("Alignment of ", stringify!(C_with_zero_length_array))
     );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<C_with_zero_length_array>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C_with_zero_length_array),
-            "::",
-            stringify!(a)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<C_with_zero_length_array>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).big_array) as usize - ptr as usize
-        },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C_with_zero_length_array),
-            "::",
-            stringify!(big_array)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<C_with_zero_length_array>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).zero_length_array) as usize -
-                ptr as usize
-        },
-        37usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C_with_zero_length_array),
-            "::",
-            stringify!(zero_length_array)
-        )
-    );
+    fn test_field_a() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<C_with_zero_length_array>::uninit(
+                    );
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(C_with_zero_length_array),
+                "::",
+                stringify!(a)
+            )
+        );
+    }
+    test_field_a();
+    fn test_field_big_array() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<C_with_zero_length_array>::uninit(
+                    );
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).big_array) as usize - ptr as usize
+            },
+            4usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(C_with_zero_length_array),
+                "::",
+                stringify!(big_array)
+            )
+        );
+    }
+    test_field_big_array();
+    fn test_field_zero_length_array() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<C_with_zero_length_array>::uninit(
+                    );
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).zero_length_array) as usize -
+                    ptr as usize
+            },
+            37usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(C_with_zero_length_array),
+                "::",
+                stringify!(zero_length_array)
+            )
+        );
+    }
+    test_field_zero_length_array();
 }
 impl Default for C_with_zero_length_array {
     fn default() -> Self {
@@ -231,37 +249,45 @@ fn bindgen_test_layout_C_with_zero_length_array_2() {
         4usize,
         concat!("Alignment of ", stringify!(C_with_zero_length_array_2))
     );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<C_with_zero_length_array_2>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C_with_zero_length_array_2),
-            "::",
-            stringify!(a)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<C_with_zero_length_array_2>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).zero_length_array) as usize -
-                ptr as usize
-        },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C_with_zero_length_array_2),
-            "::",
-            stringify!(zero_length_array)
-        )
-    );
+    fn test_field_a() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<
+                    C_with_zero_length_array_2,
+                >::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(C_with_zero_length_array_2),
+                "::",
+                stringify!(a)
+            )
+        );
+    }
+    test_field_a();
+    fn test_field_zero_length_array() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<
+                    C_with_zero_length_array_2,
+                >::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).zero_length_array) as usize -
+                    ptr as usize
+            },
+            4usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(C_with_zero_length_array_2),
+                "::",
+                stringify!(zero_length_array)
+            )
+        );
+    }
+    test_field_zero_length_array();
 }
 #[repr(C)]
 pub struct C_with_incomplete_array {
@@ -281,52 +307,64 @@ fn bindgen_test_layout_C_with_incomplete_array() {
         4usize,
         concat!("Alignment of ", stringify!(C_with_incomplete_array))
     );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<C_with_incomplete_array>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C_with_incomplete_array),
-            "::",
-            stringify!(a)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<C_with_incomplete_array>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).big_array) as usize - ptr as usize
-        },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C_with_incomplete_array),
-            "::",
-            stringify!(big_array)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<C_with_incomplete_array>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).incomplete_array) as usize -
-                ptr as usize
-        },
-        37usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C_with_incomplete_array),
-            "::",
-            stringify!(incomplete_array)
-        )
-    );
+    fn test_field_a() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<C_with_incomplete_array>::uninit(
+                    );
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(C_with_incomplete_array),
+                "::",
+                stringify!(a)
+            )
+        );
+    }
+    test_field_a();
+    fn test_field_big_array() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<C_with_incomplete_array>::uninit(
+                    );
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).big_array) as usize - ptr as usize
+            },
+            4usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(C_with_incomplete_array),
+                "::",
+                stringify!(big_array)
+            )
+        );
+    }
+    test_field_big_array();
+    fn test_field_incomplete_array() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<C_with_incomplete_array>::uninit(
+                    );
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).incomplete_array) as usize -
+                    ptr as usize
+            },
+            37usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(C_with_incomplete_array),
+                "::",
+                stringify!(incomplete_array)
+            )
+        );
+    }
+    test_field_incomplete_array();
 }
 impl Default for C_with_incomplete_array {
     fn default() -> Self {
@@ -355,37 +393,41 @@ fn bindgen_test_layout_C_with_incomplete_array_2() {
         4usize,
         concat!("Alignment of ", stringify!(C_with_incomplete_array_2))
     );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<C_with_incomplete_array_2>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C_with_incomplete_array_2),
-            "::",
-            stringify!(a)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<C_with_incomplete_array_2>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).incomplete_array) as usize -
-                ptr as usize
-        },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C_with_incomplete_array_2),
-            "::",
-            stringify!(incomplete_array)
-        )
-    );
+    fn test_field_a() {
+        assert_eq!(
+            unsafe {
+                let uninit = :: std :: mem :: MaybeUninit :: < C_with_incomplete_array_2 > :: uninit () ;
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(C_with_incomplete_array_2),
+                "::",
+                stringify!(a)
+            )
+        );
+    }
+    test_field_a();
+    fn test_field_incomplete_array() {
+        assert_eq!(
+            unsafe {
+                let uninit = :: std :: mem :: MaybeUninit :: < C_with_incomplete_array_2 > :: uninit () ;
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).incomplete_array) as usize -
+                    ptr as usize
+            },
+            4usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(C_with_incomplete_array_2),
+                "::",
+                stringify!(incomplete_array)
+            )
+        );
+    }
+    test_field_incomplete_array();
 }
 #[repr(C)]
 pub struct C_with_zero_length_array_and_incomplete_array {
@@ -412,72 +454,84 @@ fn bindgen_test_layout_C_with_zero_length_array_and_incomplete_array() {
             stringify!(C_with_zero_length_array_and_incomplete_array)
         )
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<
-                C_with_zero_length_array_and_incomplete_array,
-            >::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C_with_zero_length_array_and_incomplete_array),
-            "::",
-            stringify!(a)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<
-                C_with_zero_length_array_and_incomplete_array,
-            >::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).big_array) as usize - ptr as usize
-        },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C_with_zero_length_array_and_incomplete_array),
-            "::",
-            stringify!(big_array)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<
-                C_with_zero_length_array_and_incomplete_array,
-            >::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).zero_length_array) as usize -
-                ptr as usize
-        },
-        37usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C_with_zero_length_array_and_incomplete_array),
-            "::",
-            stringify!(zero_length_array)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<
-                C_with_zero_length_array_and_incomplete_array,
-            >::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).incomplete_array) as usize -
-                ptr as usize
-        },
-        37usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C_with_zero_length_array_and_incomplete_array),
-            "::",
-            stringify!(incomplete_array)
-        )
-    );
+    fn test_field_a() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<
+                    C_with_zero_length_array_and_incomplete_array,
+                >::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(C_with_zero_length_array_and_incomplete_array),
+                "::",
+                stringify!(a)
+            )
+        );
+    }
+    test_field_a();
+    fn test_field_big_array() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<
+                    C_with_zero_length_array_and_incomplete_array,
+                >::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).big_array) as usize - ptr as usize
+            },
+            4usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(C_with_zero_length_array_and_incomplete_array),
+                "::",
+                stringify!(big_array)
+            )
+        );
+    }
+    test_field_big_array();
+    fn test_field_zero_length_array() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<
+                    C_with_zero_length_array_and_incomplete_array,
+                >::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).zero_length_array) as usize -
+                    ptr as usize
+            },
+            37usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(C_with_zero_length_array_and_incomplete_array),
+                "::",
+                stringify!(zero_length_array)
+            )
+        );
+    }
+    test_field_zero_length_array();
+    fn test_field_incomplete_array() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<
+                    C_with_zero_length_array_and_incomplete_array,
+                >::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).incomplete_array) as usize -
+                    ptr as usize
+            },
+            37usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(C_with_zero_length_array_and_incomplete_array),
+                "::",
+                stringify!(incomplete_array)
+            )
+        );
+    }
+    test_field_incomplete_array();
 }
 impl Default for C_with_zero_length_array_and_incomplete_array {
     fn default() -> Self {
@@ -515,56 +569,65 @@ fn bindgen_test_layout_C_with_zero_length_array_and_incomplete_array_2() {
             stringify!(C_with_zero_length_array_and_incomplete_array_2)
         )
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<
-                C_with_zero_length_array_and_incomplete_array_2,
-            >::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C_with_zero_length_array_and_incomplete_array_2),
-            "::",
-            stringify!(a)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<
-                C_with_zero_length_array_and_incomplete_array_2,
-            >::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).zero_length_array) as usize -
-                ptr as usize
-        },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C_with_zero_length_array_and_incomplete_array_2),
-            "::",
-            stringify!(zero_length_array)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<
-                C_with_zero_length_array_and_incomplete_array_2,
-            >::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).incomplete_array) as usize -
-                ptr as usize
-        },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C_with_zero_length_array_and_incomplete_array_2),
-            "::",
-            stringify!(incomplete_array)
-        )
-    );
+    fn test_field_a() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<
+                    C_with_zero_length_array_and_incomplete_array_2,
+                >::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(C_with_zero_length_array_and_incomplete_array_2),
+                "::",
+                stringify!(a)
+            )
+        );
+    }
+    test_field_a();
+    fn test_field_zero_length_array() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<
+                    C_with_zero_length_array_and_incomplete_array_2,
+                >::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).zero_length_array) as usize -
+                    ptr as usize
+            },
+            4usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(C_with_zero_length_array_and_incomplete_array_2),
+                "::",
+                stringify!(zero_length_array)
+            )
+        );
+    }
+    test_field_zero_length_array();
+    fn test_field_incomplete_array() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<
+                    C_with_zero_length_array_and_incomplete_array_2,
+                >::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).incomplete_array) as usize -
+                    ptr as usize
+            },
+            4usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(C_with_zero_length_array_and_incomplete_array_2),
+                "::",
+                stringify!(incomplete_array)
+            )
+        );
+    }
+    test_field_incomplete_array();
 }
 #[repr(C)]
 #[derive(Debug, Default, Hash, PartialEq, Eq)]
@@ -583,20 +646,23 @@ fn bindgen_test_layout_WithDtor() {
         4usize,
         concat!("Alignment of ", stringify!(WithDtor))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<WithDtor>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(WithDtor),
-            "::",
-            stringify!(b)
-        )
-    );
+    fn test_field_b() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<WithDtor>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(WithDtor),
+                "::",
+                stringify!(b)
+            )
+        );
+    }
+    test_field_b();
 }
 #[repr(C)]
 pub struct IncompleteArrayNonCopiable {
@@ -615,37 +681,45 @@ fn bindgen_test_layout_IncompleteArrayNonCopiable() {
         8usize,
         concat!("Alignment of ", stringify!(IncompleteArrayNonCopiable))
     );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<IncompleteArrayNonCopiable>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).whatever) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(IncompleteArrayNonCopiable),
-            "::",
-            stringify!(whatever)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<IncompleteArrayNonCopiable>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).incomplete_array) as usize -
-                ptr as usize
-        },
-        8usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(IncompleteArrayNonCopiable),
-            "::",
-            stringify!(incomplete_array)
-        )
-    );
+    fn test_field_whatever() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<
+                    IncompleteArrayNonCopiable,
+                >::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).whatever) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(IncompleteArrayNonCopiable),
+                "::",
+                stringify!(whatever)
+            )
+        );
+    }
+    test_field_whatever();
+    fn test_field_incomplete_array() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<
+                    IncompleteArrayNonCopiable,
+                >::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).incomplete_array) as usize -
+                    ptr as usize
+            },
+            8usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(IncompleteArrayNonCopiable),
+                "::",
+                stringify!(incomplete_array)
+            )
+        );
+    }
+    test_field_incomplete_array();
 }
 impl Default for IncompleteArrayNonCopiable {
     fn default() -> Self {
@@ -675,24 +749,40 @@ fn bindgen_test_layout_Union() {
         4usize,
         concat!("Alignment of ", stringify!(Union))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Union>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize
-        },
-        0usize,
-        concat!("Offset of field: ", stringify!(Union), "::", stringify!(d))
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Union>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).i) as usize - ptr as usize
-        },
-        0usize,
-        concat!("Offset of field: ", stringify!(Union), "::", stringify!(i))
-    );
+    fn test_field_d() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Union>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(Union),
+                "::",
+                stringify!(d)
+            )
+        );
+    }
+    test_field_d();
+    fn test_field_i() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Union>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).i) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(Union),
+                "::",
+                stringify!(i)
+            )
+        );
+    }
+    test_field_i();
 }
 impl Clone for Union {
     fn clone(&self) -> Self {
@@ -716,20 +806,23 @@ fn bindgen_test_layout_WithUnion() {
         4usize,
         concat!("Alignment of ", stringify!(WithUnion))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<WithUnion>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).data) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(WithUnion),
-            "::",
-            stringify!(data)
-        )
-    );
+    fn test_field_data() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<WithUnion>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).data) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(WithUnion),
+                "::",
+                stringify!(data)
+            )
+        );
+    }
+    test_field_data();
 }
 impl Clone for WithUnion {
     fn clone(&self) -> Self {

--- a/tests/expectations/tests/libclang-9/derive-hash-struct-with-incomplete-array.rs
+++ b/tests/expectations/tests/libclang-9/derive-hash-struct-with-incomplete-array.rs
@@ -53,30 +53,36 @@ fn bindgen_test_layout_test() {
         4usize,
         concat!("Alignment of ", stringify!(test))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<test>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
-        0usize,
-        concat!("Offset of field: ", stringify!(test), "::", stringify!(a))
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<test>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).zero_length_array) as usize -
-                ptr as usize
-        },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(test),
-            "::",
-            stringify!(zero_length_array)
-        )
-    );
+    fn test_field_a() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<test>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+            },
+            0usize,
+            concat!("Offset of field: ", stringify!(test), "::", stringify!(a))
+        );
+    }
+    test_field_a();
+    fn test_field_zero_length_array() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<test>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).zero_length_array) as usize -
+                    ptr as usize
+            },
+            4usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(test),
+                "::",
+                stringify!(zero_length_array)
+            )
+        );
+    }
+    test_field_zero_length_array();
 }
 #[repr(C)]
 #[derive(Debug, Default)]
@@ -96,30 +102,41 @@ fn bindgen_test_layout_test2() {
         4usize,
         concat!("Alignment of ", stringify!(test2))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<test2>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
-        0usize,
-        concat!("Offset of field: ", stringify!(test2), "::", stringify!(a))
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<test2>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).incomplete_array) as usize -
-                ptr as usize
-        },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(test2),
-            "::",
-            stringify!(incomplete_array)
-        )
-    );
+    fn test_field_a() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<test2>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(test2),
+                "::",
+                stringify!(a)
+            )
+        );
+    }
+    test_field_a();
+    fn test_field_incomplete_array() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<test2>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).incomplete_array) as usize -
+                    ptr as usize
+            },
+            4usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(test2),
+                "::",
+                stringify!(incomplete_array)
+            )
+        );
+    }
+    test_field_incomplete_array();
 }
 #[repr(C)]
 #[derive(Debug, Default)]
@@ -140,43 +157,57 @@ fn bindgen_test_layout_test3() {
         4usize,
         concat!("Alignment of ", stringify!(test3))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<test3>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
-        0usize,
-        concat!("Offset of field: ", stringify!(test3), "::", stringify!(a))
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<test3>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).zero_length_array) as usize -
-                ptr as usize
-        },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(test3),
-            "::",
-            stringify!(zero_length_array)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<test3>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).incomplete_array) as usize -
-                ptr as usize
-        },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(test3),
-            "::",
-            stringify!(incomplete_array)
-        )
-    );
+    fn test_field_a() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<test3>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(test3),
+                "::",
+                stringify!(a)
+            )
+        );
+    }
+    test_field_a();
+    fn test_field_zero_length_array() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<test3>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).zero_length_array) as usize -
+                    ptr as usize
+            },
+            4usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(test3),
+                "::",
+                stringify!(zero_length_array)
+            )
+        );
+    }
+    test_field_zero_length_array();
+    fn test_field_incomplete_array() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<test3>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).incomplete_array) as usize -
+                    ptr as usize
+            },
+            4usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(test3),
+                "::",
+                stringify!(incomplete_array)
+            )
+        );
+    }
+    test_field_incomplete_array();
 }

--- a/tests/expectations/tests/libclang-9/incomplete-array-padding.rs
+++ b/tests/expectations/tests/libclang-9/incomplete-array-padding.rs
@@ -140,15 +140,18 @@ fn bindgen_test_layout_foo() {
         8usize,
         concat!("Alignment of ", stringify!(foo))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<foo>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-        },
-        8usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(b))
-    );
+    fn test_field_b() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<foo>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
+            },
+            8usize,
+            concat!("Offset of field: ", stringify!(foo), "::", stringify!(b))
+        );
+    }
+    test_field_b();
 }
 impl Default for foo {
     fn default() -> Self {

--- a/tests/expectations/tests/libclang-9/issue-643-inner-struct.rs
+++ b/tests/expectations/tests/libclang-9/issue-643-inner-struct.rs
@@ -60,20 +60,23 @@ fn bindgen_test_layout_rte_ring_prod() {
         4usize,
         concat!("Alignment of ", stringify!(rte_ring_prod))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_ring_prod>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).watermark) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_ring_prod),
-            "::",
-            stringify!(watermark)
-        )
-    );
+    fn test_field_watermark() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<rte_ring_prod>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).watermark) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_ring_prod),
+                "::",
+                stringify!(watermark)
+            )
+        );
+    }
+    test_field_watermark();
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
@@ -92,20 +95,23 @@ fn bindgen_test_layout_rte_ring_cons() {
         4usize,
         concat!("Alignment of ", stringify!(rte_ring_cons))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_ring_cons>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).sc_dequeue) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_ring_cons),
-            "::",
-            stringify!(sc_dequeue)
-        )
-    );
+    fn test_field_sc_dequeue() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<rte_ring_cons>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).sc_dequeue) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_ring_cons),
+                "::",
+                stringify!(sc_dequeue)
+            )
+        );
+    }
+    test_field_sc_dequeue();
 }
 #[test]
 fn bindgen_test_layout_rte_ring() {
@@ -119,62 +125,74 @@ fn bindgen_test_layout_rte_ring() {
         8usize,
         concat!("Alignment of ", stringify!(rte_ring))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_ring>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).memzone) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_ring),
-            "::",
-            stringify!(memzone)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_ring>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).prod) as usize - ptr as usize
-        },
-        8usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_ring),
-            "::",
-            stringify!(prod)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_ring>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).cons) as usize - ptr as usize
-        },
-        12usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_ring),
-            "::",
-            stringify!(cons)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_ring>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).ring) as usize - ptr as usize
-        },
-        16usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_ring),
-            "::",
-            stringify!(ring)
-        )
-    );
+    fn test_field_memzone() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<rte_ring>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).memzone) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_ring),
+                "::",
+                stringify!(memzone)
+            )
+        );
+    }
+    test_field_memzone();
+    fn test_field_prod() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<rte_ring>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).prod) as usize - ptr as usize
+            },
+            8usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_ring),
+                "::",
+                stringify!(prod)
+            )
+        );
+    }
+    test_field_prod();
+    fn test_field_cons() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<rte_ring>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).cons) as usize - ptr as usize
+            },
+            12usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_ring),
+                "::",
+                stringify!(cons)
+            )
+        );
+    }
+    test_field_cons();
+    fn test_field_ring() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<rte_ring>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).ring) as usize - ptr as usize
+            },
+            16usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_ring),
+                "::",
+                stringify!(ring)
+            )
+        );
+    }
+    test_field_ring();
 }
 impl Default for rte_ring {
     fn default() -> Self {

--- a/tests/expectations/tests/libclang-9/layout_align.rs
+++ b/tests/expectations/tests/libclang-9/layout_align.rs
@@ -147,76 +147,91 @@ fn bindgen_test_layout_rte_kni_fifo() {
         8usize,
         concat!("Alignment of ", stringify!(rte_kni_fifo))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_kni_fifo>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).write) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_kni_fifo),
-            "::",
-            stringify!(write)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_kni_fifo>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).read) as usize - ptr as usize
-        },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_kni_fifo),
-            "::",
-            stringify!(read)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_kni_fifo>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).len) as usize - ptr as usize
-        },
-        8usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_kni_fifo),
-            "::",
-            stringify!(len)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_kni_fifo>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).elem_size) as usize - ptr as usize
-        },
-        12usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_kni_fifo),
-            "::",
-            stringify!(elem_size)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_kni_fifo>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).buffer) as usize - ptr as usize
-        },
-        16usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_kni_fifo),
-            "::",
-            stringify!(buffer)
-        )
-    );
+    fn test_field_write() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<rte_kni_fifo>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).write) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_kni_fifo),
+                "::",
+                stringify!(write)
+            )
+        );
+    }
+    test_field_write();
+    fn test_field_read() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<rte_kni_fifo>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).read) as usize - ptr as usize
+            },
+            4usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_kni_fifo),
+                "::",
+                stringify!(read)
+            )
+        );
+    }
+    test_field_read();
+    fn test_field_len() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<rte_kni_fifo>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).len) as usize - ptr as usize
+            },
+            8usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_kni_fifo),
+                "::",
+                stringify!(len)
+            )
+        );
+    }
+    test_field_len();
+    fn test_field_elem_size() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<rte_kni_fifo>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).elem_size) as usize - ptr as usize
+            },
+            12usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_kni_fifo),
+                "::",
+                stringify!(elem_size)
+            )
+        );
+    }
+    test_field_elem_size();
+    fn test_field_buffer() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<rte_kni_fifo>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).buffer) as usize - ptr as usize
+            },
+            16usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_kni_fifo),
+                "::",
+                stringify!(buffer)
+            )
+        );
+    }
+    test_field_buffer();
 }
 impl Default for rte_kni_fifo {
     fn default() -> Self {
@@ -249,20 +264,23 @@ fn bindgen_test_layout_rte_eth_link() {
         8usize,
         concat!("Alignment of ", stringify!(rte_eth_link))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<rte_eth_link>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).link_speed) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_link),
-            "::",
-            stringify!(link_speed)
-        )
-    );
+    fn test_field_link_speed() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<rte_eth_link>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).link_speed) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(rte_eth_link),
+                "::",
+                stringify!(link_speed)
+            )
+        );
+    }
+    test_field_link_speed();
 }
 impl rte_eth_link {
     #[inline]

--- a/tests/expectations/tests/libclang-9/type_alias_template_specialized.rs
+++ b/tests/expectations/tests/libclang-9/type_alias_template_specialized.rs
@@ -22,20 +22,23 @@ fn bindgen_test_layout_Rooted() {
         4usize,
         concat!("Alignment of ", stringify!(Rooted))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Rooted>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).ptr) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(Rooted),
-            "::",
-            stringify!(ptr)
-        )
-    );
+    fn test_field_ptr() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Rooted>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).ptr) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(Rooted),
+                "::",
+                stringify!(ptr)
+            )
+        );
+    }
+    test_field_ptr();
 }
 impl Default for Rooted {
     fn default() -> Self {

--- a/tests/expectations/tests/libclang-9/zero-sized-array.rs
+++ b/tests/expectations/tests/libclang-9/zero-sized-array.rs
@@ -53,20 +53,24 @@ fn bindgen_test_layout_ZeroSizedArray() {
         1usize,
         concat!("Alignment of ", stringify!(ZeroSizedArray))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<ZeroSizedArray>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).arr) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(ZeroSizedArray),
-            "::",
-            stringify!(arr)
-        )
-    );
+    fn test_field_arr() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<ZeroSizedArray>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).arr) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(ZeroSizedArray),
+                "::",
+                stringify!(arr)
+            )
+        );
+    }
+    test_field_arr();
 }
 /// And nor should this get an `_address` field.
 #[repr(C)]
@@ -86,21 +90,24 @@ fn bindgen_test_layout_ContainsZeroSizedArray() {
         1usize,
         concat!("Alignment of ", stringify!(ContainsZeroSizedArray))
     );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<ContainsZeroSizedArray>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).zsa) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(ContainsZeroSizedArray),
-            "::",
-            stringify!(zsa)
-        )
-    );
+    fn test_field_zsa() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<ContainsZeroSizedArray>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).zsa) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(ContainsZeroSizedArray),
+                "::",
+                stringify!(zsa)
+            )
+        );
+    }
+    test_field_zsa();
 }
 /// Inheriting from ZeroSizedArray shouldn't cause an `_address` to be inserted
 /// either.
@@ -140,21 +147,24 @@ fn bindgen_test_layout_DynamicallySizedArray() {
         1usize,
         concat!("Alignment of ", stringify!(DynamicallySizedArray))
     );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<DynamicallySizedArray>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).arr) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(DynamicallySizedArray),
-            "::",
-            stringify!(arr)
-        )
-    );
+    fn test_field_arr() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<DynamicallySizedArray>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).arr) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(DynamicallySizedArray),
+                "::",
+                stringify!(arr)
+            )
+        );
+    }
+    test_field_arr();
 }
 /// No `_address` field here either.
 #[repr(C)]
@@ -174,18 +184,23 @@ fn bindgen_test_layout_ContainsDynamicallySizedArray() {
         1usize,
         concat!("Alignment of ", stringify!(ContainsDynamicallySizedArray))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = :: std :: mem :: MaybeUninit :: < ContainsDynamicallySizedArray > :: uninit () ;
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).dsa) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(ContainsDynamicallySizedArray),
-            "::",
-            stringify!(dsa)
-        )
-    );
+    fn test_field_dsa() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<
+                    ContainsDynamicallySizedArray,
+                >::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).dsa) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(ContainsDynamicallySizedArray),
+                "::",
+                stringify!(dsa)
+            )
+        );
+    }
+    test_field_dsa();
 }

--- a/tests/expectations/tests/long_double.rs
+++ b/tests/expectations/tests/long_double.rs
@@ -23,13 +23,21 @@ fn bindgen_test_layout_foo() {
         16usize,
         concat!("Alignment of ", stringify!(foo))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<foo>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
-        },
-        0usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar))
-    );
+    fn test_field_bar() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<foo>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(foo),
+                "::",
+                stringify!(bar)
+            )
+        );
+    }
+    test_field_bar();
 }

--- a/tests/expectations/tests/msvc-no-usr.rs
+++ b/tests/expectations/tests/msvc-no-usr.rs
@@ -23,13 +23,16 @@ fn bindgen_test_layout_A() {
         8usize,
         concat!("Alignment of ", stringify!(A))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<A>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize
-        },
-        0usize,
-        concat!("Offset of field: ", stringify!(A), "::", stringify!(foo))
-    );
+    fn test_field_foo() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<A>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize
+            },
+            0usize,
+            concat!("Offset of field: ", stringify!(A), "::", stringify!(foo))
+        );
+    }
+    test_field_foo();
 }

--- a/tests/expectations/tests/mutable.rs
+++ b/tests/expectations/tests/mutable.rs
@@ -23,34 +23,40 @@ fn bindgen_test_layout_C() {
         4usize,
         concat!("Alignment of ", stringify!(C))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<C>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).m_member) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C),
-            "::",
-            stringify!(m_member)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<C>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).m_other) as usize - ptr as usize
-        },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C),
-            "::",
-            stringify!(m_other)
-        )
-    );
+    fn test_field_m_member() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<C>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).m_member) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(C),
+                "::",
+                stringify!(m_member)
+            )
+        );
+    }
+    test_field_m_member();
+    fn test_field_m_other() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<C>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).m_other) as usize - ptr as usize
+            },
+            4usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(C),
+                "::",
+                stringify!(m_other)
+            )
+        );
+    }
+    test_field_m_other();
 }
 #[repr(C)]
 #[derive(Debug, Default)]
@@ -69,20 +75,23 @@ fn bindgen_test_layout_NonCopiable() {
         4usize,
         concat!("Alignment of ", stringify!(NonCopiable))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<NonCopiable>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).m_member) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(NonCopiable),
-            "::",
-            stringify!(m_member)
-        )
-    );
+    fn test_field_m_member() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<NonCopiable>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).m_member) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(NonCopiable),
+                "::",
+                stringify!(m_member)
+            )
+        );
+    }
+    test_field_m_member();
 }
 #[repr(C)]
 #[derive(Debug, Default)]
@@ -107,20 +116,23 @@ fn bindgen_test_layout_NonCopiableWithNonCopiableMutableMember() {
             stringify!(NonCopiableWithNonCopiableMutableMember)
         )
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<
-                NonCopiableWithNonCopiableMutableMember,
-            >::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).m_member) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(NonCopiableWithNonCopiableMutableMember),
-            "::",
-            stringify!(m_member)
-        )
-    );
+    fn test_field_m_member() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<
+                    NonCopiableWithNonCopiableMutableMember,
+                >::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).m_member) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(NonCopiableWithNonCopiableMutableMember),
+                "::",
+                stringify!(m_member)
+            )
+        );
+    }
+    test_field_m_member();
 }

--- a/tests/expectations/tests/namespace.rs
+++ b/tests/expectations/tests/namespace.rs
@@ -43,20 +43,23 @@ pub mod root {
                 4usize,
                 concat!("Alignment of ", stringify!(A))
             );
-            assert_eq!(
-                unsafe {
-                    let uninit = ::std::mem::MaybeUninit::<A>::uninit();
-                    let ptr = uninit.as_ptr();
-                    ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-                },
-                0usize,
-                concat!(
-                    "Offset of field: ",
-                    stringify!(A),
-                    "::",
-                    stringify!(b)
-                )
-            );
+            fn test_field_b() {
+                assert_eq!(
+                    unsafe {
+                        let uninit = ::std::mem::MaybeUninit::<A>::uninit();
+                        let ptr = uninit.as_ptr();
+                        ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
+                    },
+                    0usize,
+                    concat!(
+                        "Offset of field: ",
+                        stringify!(A),
+                        "::",
+                        stringify!(b)
+                    )
+                );
+            }
+            test_field_b();
         }
     }
     #[repr(C)]

--- a/tests/expectations/tests/nested.rs
+++ b/tests/expectations/tests/nested.rs
@@ -22,15 +22,18 @@ fn bindgen_test_layout_Calc() {
         4usize,
         concat!("Alignment of ", stringify!(Calc))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Calc>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).w) as usize - ptr as usize
-        },
-        0usize,
-        concat!("Offset of field: ", stringify!(Calc), "::", stringify!(w))
-    );
+    fn test_field_w() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Calc>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).w) as usize - ptr as usize
+            },
+            0usize,
+            concat!("Offset of field: ", stringify!(Calc), "::", stringify!(w))
+        );
+    }
+    test_field_w();
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
@@ -73,34 +76,40 @@ fn bindgen_test_layout_Test_Size() {
         4usize,
         concat!("Alignment of ", stringify!(Test_Size))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Test_Size>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mWidth) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(Test_Size),
-            "::",
-            stringify!(mWidth)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Test_Size>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mHeight) as usize - ptr as usize
-        },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(Test_Size),
-            "::",
-            stringify!(mHeight)
-        )
-    );
+    fn test_field_mWidth() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Test_Size>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).mWidth) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(Test_Size),
+                "::",
+                stringify!(mWidth)
+            )
+        );
+    }
+    test_field_mWidth();
+    fn test_field_mHeight() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Test_Size>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).mHeight) as usize - ptr as usize
+            },
+            4usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(Test_Size),
+                "::",
+                stringify!(mHeight)
+            )
+        );
+    }
+    test_field_mHeight();
 }
 #[test]
 fn bindgen_test_layout_Test() {

--- a/tests/expectations/tests/nested_within_namespace.rs
+++ b/tests/expectations/tests/nested_within_namespace.rs
@@ -34,20 +34,24 @@ pub mod root {
                 4usize,
                 concat!("Alignment of ", stringify!(Bar_Baz))
             );
-            assert_eq!(
-                unsafe {
-                    let uninit = ::std::mem::MaybeUninit::<Bar_Baz>::uninit();
-                    let ptr = uninit.as_ptr();
-                    ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize
-                },
-                0usize,
-                concat!(
-                    "Offset of field: ",
-                    stringify!(Bar_Baz),
-                    "::",
-                    stringify!(foo)
-                )
-            );
+            fn test_field_foo() {
+                assert_eq!(
+                    unsafe {
+                        let uninit =
+                            ::std::mem::MaybeUninit::<Bar_Baz>::uninit();
+                        let ptr = uninit.as_ptr();
+                        ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize
+                    },
+                    0usize,
+                    concat!(
+                        "Offset of field: ",
+                        stringify!(Bar_Baz),
+                        "::",
+                        stringify!(foo)
+                    )
+                );
+            }
+            test_field_foo();
         }
         #[test]
         fn bindgen_test_layout_Bar() {
@@ -61,20 +65,23 @@ pub mod root {
                 4usize,
                 concat!("Alignment of ", stringify!(Bar))
             );
-            assert_eq!(
-                unsafe {
-                    let uninit = ::std::mem::MaybeUninit::<Bar>::uninit();
-                    let ptr = uninit.as_ptr();
-                    ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize
-                },
-                0usize,
-                concat!(
-                    "Offset of field: ",
-                    stringify!(Bar),
-                    "::",
-                    stringify!(foo)
-                )
-            );
+            fn test_field_foo() {
+                assert_eq!(
+                    unsafe {
+                        let uninit = ::std::mem::MaybeUninit::<Bar>::uninit();
+                        let ptr = uninit.as_ptr();
+                        ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize
+                    },
+                    0usize,
+                    concat!(
+                        "Offset of field: ",
+                        stringify!(Bar),
+                        "::",
+                        stringify!(foo)
+                    )
+                );
+            }
+            test_field_foo();
         }
         #[repr(C)]
         #[derive(Debug, Default, Copy, Clone)]
@@ -93,20 +100,23 @@ pub mod root {
                 4usize,
                 concat!("Alignment of ", stringify!(Baz))
             );
-            assert_eq!(
-                unsafe {
-                    let uninit = ::std::mem::MaybeUninit::<Baz>::uninit();
-                    let ptr = uninit.as_ptr();
-                    ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize
-                },
-                0usize,
-                concat!(
-                    "Offset of field: ",
-                    stringify!(Baz),
-                    "::",
-                    stringify!(baz)
-                )
-            );
+            fn test_field_baz() {
+                assert_eq!(
+                    unsafe {
+                        let uninit = ::std::mem::MaybeUninit::<Baz>::uninit();
+                        let ptr = uninit.as_ptr();
+                        ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize
+                    },
+                    0usize,
+                    concat!(
+                        "Offset of field: ",
+                        stringify!(Baz),
+                        "::",
+                        stringify!(baz)
+                    )
+                );
+            }
+            test_field_baz();
         }
     }
 }

--- a/tests/expectations/tests/no-comments.rs
+++ b/tests/expectations/tests/no-comments.rs
@@ -22,13 +22,16 @@ fn bindgen_test_layout_Foo() {
         4usize,
         concat!("Alignment of ", stringify!(Foo))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Foo>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).s) as usize - ptr as usize
-        },
-        0usize,
-        concat!("Offset of field: ", stringify!(Foo), "::", stringify!(s))
-    );
+    fn test_field_s() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Foo>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).s) as usize - ptr as usize
+            },
+            0usize,
+            concat!("Offset of field: ", stringify!(Foo), "::", stringify!(s))
+        );
+    }
+    test_field_s();
 }

--- a/tests/expectations/tests/no-derive-debug.rs
+++ b/tests/expectations/tests/no-derive-debug.rs
@@ -31,24 +31,40 @@ fn bindgen_test_layout_bar() {
         4usize,
         concat!("Alignment of ", stringify!(bar))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<bar>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize
-        },
-        0usize,
-        concat!("Offset of field: ", stringify!(bar), "::", stringify!(foo))
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<bar>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize
-        },
-        4usize,
-        concat!("Offset of field: ", stringify!(bar), "::", stringify!(baz))
-    );
+    fn test_field_foo() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<bar>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(bar),
+                "::",
+                stringify!(foo)
+            )
+        );
+    }
+    test_field_foo();
+    fn test_field_baz() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<bar>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize
+            },
+            4usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(bar),
+                "::",
+                stringify!(baz)
+            )
+        );
+    }
+    test_field_baz();
 }
 impl Default for bar {
     fn default() -> Self {

--- a/tests/expectations/tests/no-derive-default.rs
+++ b/tests/expectations/tests/no-derive-default.rs
@@ -31,22 +31,38 @@ fn bindgen_test_layout_bar() {
         4usize,
         concat!("Alignment of ", stringify!(bar))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<bar>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize
-        },
-        0usize,
-        concat!("Offset of field: ", stringify!(bar), "::", stringify!(foo))
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<bar>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize
-        },
-        4usize,
-        concat!("Offset of field: ", stringify!(bar), "::", stringify!(baz))
-    );
+    fn test_field_foo() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<bar>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(bar),
+                "::",
+                stringify!(foo)
+            )
+        );
+    }
+    test_field_foo();
+    fn test_field_baz() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<bar>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize
+            },
+            4usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(bar),
+                "::",
+                stringify!(baz)
+            )
+        );
+    }
+    test_field_baz();
 }

--- a/tests/expectations/tests/no-hash-allowlisted.rs
+++ b/tests/expectations/tests/no-hash-allowlisted.rs
@@ -22,13 +22,21 @@ fn bindgen_test_layout_NoHash() {
         4usize,
         concat!("Alignment of ", stringify!(NoHash))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<NoHash>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).i) as usize - ptr as usize
-        },
-        0usize,
-        concat!("Offset of field: ", stringify!(NoHash), "::", stringify!(i))
-    );
+    fn test_field_i() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<NoHash>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).i) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(NoHash),
+                "::",
+                stringify!(i)
+            )
+        );
+    }
+    test_field_i();
 }

--- a/tests/expectations/tests/no-partialeq-allowlisted.rs
+++ b/tests/expectations/tests/no-partialeq-allowlisted.rs
@@ -22,18 +22,21 @@ fn bindgen_test_layout_NoPartialEq() {
         4usize,
         concat!("Alignment of ", stringify!(NoPartialEq))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<NoPartialEq>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).i) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(NoPartialEq),
-            "::",
-            stringify!(i)
-        )
-    );
+    fn test_field_i() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<NoPartialEq>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).i) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(NoPartialEq),
+                "::",
+                stringify!(i)
+            )
+        );
+    }
+    test_field_i();
 }

--- a/tests/expectations/tests/no-recursive-allowlisting.rs
+++ b/tests/expectations/tests/no-recursive-allowlisting.rs
@@ -24,15 +24,23 @@ fn bindgen_test_layout_Foo() {
         8usize,
         concat!("Alignment of ", stringify!(Foo))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Foo>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize
-        },
-        0usize,
-        concat!("Offset of field: ", stringify!(Foo), "::", stringify!(baz))
-    );
+    fn test_field_baz() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Foo>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(Foo),
+                "::",
+                stringify!(baz)
+            )
+        );
+    }
+    test_field_baz();
 }
 impl Default for Foo {
     fn default() -> Self {

--- a/tests/expectations/tests/no-std.rs
+++ b/tests/expectations/tests/no-std.rs
@@ -29,33 +29,47 @@ fn bindgen_test_layout_foo() {
         8usize,
         concat!("Alignment of ", stringify!(foo))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::core::mem::MaybeUninit::<foo>::uninit();
-            let ptr = uninit.as_ptr();
-            ::core::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
-        0usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(a))
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::core::mem::MaybeUninit::<foo>::uninit();
-            let ptr = uninit.as_ptr();
-            ::core::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-        },
-        4usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(b))
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::core::mem::MaybeUninit::<foo>::uninit();
-            let ptr = uninit.as_ptr();
-            ::core::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
-        },
-        8usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar))
-    );
+    fn test_field_a() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::core::mem::MaybeUninit::<foo>::uninit();
+                let ptr = uninit.as_ptr();
+                ::core::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+            },
+            0usize,
+            concat!("Offset of field: ", stringify!(foo), "::", stringify!(a))
+        );
+    }
+    test_field_a();
+    fn test_field_b() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::core::mem::MaybeUninit::<foo>::uninit();
+                let ptr = uninit.as_ptr();
+                ::core::ptr::addr_of!((*ptr).b) as usize - ptr as usize
+            },
+            4usize,
+            concat!("Offset of field: ", stringify!(foo), "::", stringify!(b))
+        );
+    }
+    test_field_b();
+    fn test_field_bar() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::core::mem::MaybeUninit::<foo>::uninit();
+                let ptr = uninit.as_ptr();
+                ::core::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
+            },
+            8usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(foo),
+                "::",
+                stringify!(bar)
+            )
+        );
+    }
+    test_field_bar();
 }
 impl Default for foo {
     fn default() -> Self {

--- a/tests/expectations/tests/no_copy_allowlisted.rs
+++ b/tests/expectations/tests/no_copy_allowlisted.rs
@@ -22,13 +22,21 @@ fn bindgen_test_layout_NoCopy() {
         4usize,
         concat!("Alignment of ", stringify!(NoCopy))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<NoCopy>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).i) as usize - ptr as usize
-        },
-        0usize,
-        concat!("Offset of field: ", stringify!(NoCopy), "::", stringify!(i))
-    );
+    fn test_field_i() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<NoCopy>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).i) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(NoCopy),
+                "::",
+                stringify!(i)
+            )
+        );
+    }
+    test_field_i();
 }

--- a/tests/expectations/tests/no_debug_allowlisted.rs
+++ b/tests/expectations/tests/no_debug_allowlisted.rs
@@ -22,18 +22,21 @@ fn bindgen_test_layout_NoDebug() {
         4usize,
         concat!("Alignment of ", stringify!(NoDebug))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<NoDebug>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).i) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(NoDebug),
-            "::",
-            stringify!(i)
-        )
-    );
+    fn test_field_i() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<NoDebug>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).i) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(NoDebug),
+                "::",
+                stringify!(i)
+            )
+        );
+    }
+    test_field_i();
 }

--- a/tests/expectations/tests/no_default_allowlisted.rs
+++ b/tests/expectations/tests/no_default_allowlisted.rs
@@ -22,18 +22,21 @@ fn bindgen_test_layout_NoDefault() {
         4usize,
         concat!("Alignment of ", stringify!(NoDefault))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<NoDefault>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).i) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(NoDefault),
-            "::",
-            stringify!(i)
-        )
-    );
+    fn test_field_i() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<NoDefault>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).i) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(NoDefault),
+                "::",
+                stringify!(i)
+            )
+        );
+    }
+    test_field_i();
 }

--- a/tests/expectations/tests/non-type-params.rs
+++ b/tests/expectations/tests/non-type-params.rs
@@ -26,46 +26,57 @@ fn bindgen_test_layout_UsesArray() {
         4usize,
         concat!("Alignment of ", stringify!(UsesArray))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<UsesArray>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).array_char_16) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(UsesArray),
-            "::",
-            stringify!(array_char_16)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<UsesArray>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).array_bool_8) as usize - ptr as usize
-        },
-        16usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(UsesArray),
-            "::",
-            stringify!(array_bool_8)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<UsesArray>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).array_int_4) as usize - ptr as usize
-        },
-        24usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(UsesArray),
-            "::",
-            stringify!(array_int_4)
-        )
-    );
+    fn test_field_array_char_16() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<UsesArray>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).array_char_16) as usize -
+                    ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(UsesArray),
+                "::",
+                stringify!(array_char_16)
+            )
+        );
+    }
+    test_field_array_char_16();
+    fn test_field_array_bool_8() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<UsesArray>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).array_bool_8) as usize -
+                    ptr as usize
+            },
+            16usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(UsesArray),
+                "::",
+                stringify!(array_bool_8)
+            )
+        );
+    }
+    test_field_array_bool_8();
+    fn test_field_array_int_4() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<UsesArray>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).array_int_4) as usize - ptr as usize
+            },
+            24usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(UsesArray),
+                "::",
+                stringify!(array_int_4)
+            )
+        );
+    }
+    test_field_array_int_4();
 }

--- a/tests/expectations/tests/objc_interface_type.rs
+++ b/tests/expectations/tests/objc_interface_type.rs
@@ -43,20 +43,23 @@ fn bindgen_test_layout_FooStruct() {
         8usize,
         concat!("Alignment of ", stringify!(FooStruct))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<FooStruct>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(FooStruct),
-            "::",
-            stringify!(foo)
-        )
-    );
+    fn test_field_foo() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<FooStruct>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(FooStruct),
+                "::",
+                stringify!(foo)
+            )
+        );
+    }
+    test_field_foo();
 }
 impl Default for FooStruct {
     fn default() -> Self {

--- a/tests/expectations/tests/opaque-template-inst-member-2.rs
+++ b/tests/expectations/tests/opaque-template-inst-member-2.rs
@@ -31,36 +31,42 @@ fn bindgen_test_layout_ContainsOpaqueTemplate() {
         4usize,
         concat!("Alignment of ", stringify!(ContainsOpaqueTemplate))
     );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<ContainsOpaqueTemplate>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mBlah) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(ContainsOpaqueTemplate),
-            "::",
-            stringify!(mBlah)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<ContainsOpaqueTemplate>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mBaz) as usize - ptr as usize
-        },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(ContainsOpaqueTemplate),
-            "::",
-            stringify!(mBaz)
-        )
-    );
+    fn test_field_mBlah() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<ContainsOpaqueTemplate>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).mBlah) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(ContainsOpaqueTemplate),
+                "::",
+                stringify!(mBlah)
+            )
+        );
+    }
+    test_field_mBlah();
+    fn test_field_mBaz() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<ContainsOpaqueTemplate>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).mBaz) as usize - ptr as usize
+            },
+            4usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(ContainsOpaqueTemplate),
+                "::",
+                stringify!(mBaz)
+            )
+        );
+    }
+    test_field_mBaz();
 }
 /// Should also derive Debug/Hash/PartialEq.
 #[repr(C)]
@@ -81,21 +87,24 @@ fn bindgen_test_layout_InheritsOpaqueTemplate() {
         8usize,
         concat!("Alignment of ", stringify!(InheritsOpaqueTemplate))
     );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<InheritsOpaqueTemplate>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).wow) as usize - ptr as usize
-        },
-        8usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(InheritsOpaqueTemplate),
-            "::",
-            stringify!(wow)
-        )
-    );
+    fn test_field_wow() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<InheritsOpaqueTemplate>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).wow) as usize - ptr as usize
+            },
+            8usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(InheritsOpaqueTemplate),
+                "::",
+                stringify!(wow)
+            )
+        );
+    }
+    test_field_wow();
 }
 impl Default for InheritsOpaqueTemplate {
     fn default() -> Self {

--- a/tests/expectations/tests/opaque-template-inst-member.rs
+++ b/tests/expectations/tests/opaque-template-inst-member.rs
@@ -29,36 +29,42 @@ fn bindgen_test_layout_ContainsOpaqueTemplate() {
         4usize,
         concat!("Alignment of ", stringify!(ContainsOpaqueTemplate))
     );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<ContainsOpaqueTemplate>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mBlah) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(ContainsOpaqueTemplate),
-            "::",
-            stringify!(mBlah)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<ContainsOpaqueTemplate>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mBaz) as usize - ptr as usize
-        },
-        404usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(ContainsOpaqueTemplate),
-            "::",
-            stringify!(mBaz)
-        )
-    );
+    fn test_field_mBlah() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<ContainsOpaqueTemplate>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).mBlah) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(ContainsOpaqueTemplate),
+                "::",
+                stringify!(mBlah)
+            )
+        );
+    }
+    test_field_mBlah();
+    fn test_field_mBaz() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<ContainsOpaqueTemplate>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).mBaz) as usize - ptr as usize
+            },
+            404usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(ContainsOpaqueTemplate),
+                "::",
+                stringify!(mBaz)
+            )
+        );
+    }
+    test_field_mBaz();
 }
 impl Default for ContainsOpaqueTemplate {
     fn default() -> Self {
@@ -93,21 +99,24 @@ fn bindgen_test_layout_InheritsOpaqueTemplate() {
         8usize,
         concat!("Alignment of ", stringify!(InheritsOpaqueTemplate))
     );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<InheritsOpaqueTemplate>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).wow) as usize - ptr as usize
-        },
-        408usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(InheritsOpaqueTemplate),
-            "::",
-            stringify!(wow)
-        )
-    );
+    fn test_field_wow() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<InheritsOpaqueTemplate>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).wow) as usize - ptr as usize
+            },
+            408usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(InheritsOpaqueTemplate),
+                "::",
+                stringify!(wow)
+            )
+        );
+    }
+    test_field_wow();
 }
 impl Default for InheritsOpaqueTemplate {
     fn default() -> Self {

--- a/tests/expectations/tests/opaque-template-instantiation-namespaced.rs
+++ b/tests/expectations/tests/opaque-template-instantiation-namespaced.rs
@@ -45,20 +45,23 @@ pub mod root {
                 1usize,
                 concat!("Alignment of ", stringify!(Foo))
             );
-            assert_eq!(
-                unsafe {
-                    let uninit = ::std::mem::MaybeUninit::<Foo>::uninit();
-                    let ptr = uninit.as_ptr();
-                    ::std::ptr::addr_of!((*ptr).c) as usize - ptr as usize
-                },
-                0usize,
-                concat!(
-                    "Offset of field: ",
-                    stringify!(Foo),
-                    "::",
-                    stringify!(c)
-                )
-            );
+            fn test_field_c() {
+                assert_eq!(
+                    unsafe {
+                        let uninit = ::std::mem::MaybeUninit::<Foo>::uninit();
+                        let ptr = uninit.as_ptr();
+                        ::std::ptr::addr_of!((*ptr).c) as usize - ptr as usize
+                    },
+                    0usize,
+                    concat!(
+                        "Offset of field: ",
+                        stringify!(Foo),
+                        "::",
+                        stringify!(c)
+                    )
+                );
+            }
+            test_field_c();
         }
         #[repr(C)]
         #[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
@@ -77,20 +80,23 @@ pub mod root {
                 4usize,
                 concat!("Alignment of ", stringify!(Bar))
             );
-            assert_eq!(
-                unsafe {
-                    let uninit = ::std::mem::MaybeUninit::<Bar>::uninit();
-                    let ptr = uninit.as_ptr();
-                    ::std::ptr::addr_of!((*ptr).i) as usize - ptr as usize
-                },
-                0usize,
-                concat!(
-                    "Offset of field: ",
-                    stringify!(Bar),
-                    "::",
-                    stringify!(i)
-                )
-            );
+            fn test_field_i() {
+                assert_eq!(
+                    unsafe {
+                        let uninit = ::std::mem::MaybeUninit::<Bar>::uninit();
+                        let ptr = uninit.as_ptr();
+                        ::std::ptr::addr_of!((*ptr).i) as usize - ptr as usize
+                    },
+                    0usize,
+                    concat!(
+                        "Offset of field: ",
+                        stringify!(Bar),
+                        "::",
+                        stringify!(i)
+                    )
+                );
+            }
+            test_field_i();
         }
         #[repr(C)]
         #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -109,21 +115,26 @@ pub mod root {
                 1usize,
                 concat!("Alignment of ", stringify!(ContainsInstantiation))
             );
-            assert_eq!(
-                unsafe {
-                    let uninit = :: std :: mem :: MaybeUninit :: < ContainsInstantiation > :: uninit () ;
-                    let ptr = uninit.as_ptr();
-                    ::std::ptr::addr_of!((*ptr).not_opaque) as usize -
-                        ptr as usize
-                },
-                0usize,
-                concat!(
-                    "Offset of field: ",
-                    stringify!(ContainsInstantiation),
-                    "::",
-                    stringify!(not_opaque)
-                )
-            );
+            fn test_field_not_opaque() {
+                assert_eq!(
+                    unsafe {
+                        let uninit = ::std::mem::MaybeUninit::<
+                            ContainsInstantiation,
+                        >::uninit();
+                        let ptr = uninit.as_ptr();
+                        ::std::ptr::addr_of!((*ptr).not_opaque) as usize -
+                            ptr as usize
+                    },
+                    0usize,
+                    concat!(
+                        "Offset of field: ",
+                        stringify!(ContainsInstantiation),
+                        "::",
+                        stringify!(not_opaque)
+                    )
+                );
+            }
+            test_field_not_opaque();
         }
         impl Default for ContainsInstantiation {
             fn default() -> Self {
@@ -154,22 +165,26 @@ pub mod root {
                     stringify!(ContainsOpaqueInstantiation)
                 )
             );
-            assert_eq!(
-                unsafe {
-                    let uninit = ::std::mem::MaybeUninit::<
-                        ContainsOpaqueInstantiation,
-                    >::uninit();
-                    let ptr = uninit.as_ptr();
-                    ::std::ptr::addr_of!((*ptr).opaque) as usize - ptr as usize
-                },
-                0usize,
-                concat!(
-                    "Offset of field: ",
-                    stringify!(ContainsOpaqueInstantiation),
-                    "::",
-                    stringify!(opaque)
-                )
-            );
+            fn test_field_opaque() {
+                assert_eq!(
+                    unsafe {
+                        let uninit = ::std::mem::MaybeUninit::<
+                            ContainsOpaqueInstantiation,
+                        >::uninit();
+                        let ptr = uninit.as_ptr();
+                        ::std::ptr::addr_of!((*ptr).opaque) as usize -
+                            ptr as usize
+                    },
+                    0usize,
+                    concat!(
+                        "Offset of field: ",
+                        stringify!(ContainsOpaqueInstantiation),
+                        "::",
+                        stringify!(opaque)
+                    )
+                );
+            }
+            test_field_opaque();
         }
     }
     #[test]

--- a/tests/expectations/tests/opaque-template-instantiation.rs
+++ b/tests/expectations/tests/opaque-template-instantiation.rs
@@ -37,21 +37,24 @@ fn bindgen_test_layout_ContainsInstantiation() {
         1usize,
         concat!("Alignment of ", stringify!(ContainsInstantiation))
     );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<ContainsInstantiation>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).not_opaque) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(ContainsInstantiation),
-            "::",
-            stringify!(not_opaque)
-        )
-    );
+    fn test_field_not_opaque() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<ContainsInstantiation>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).not_opaque) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(ContainsInstantiation),
+                "::",
+                stringify!(not_opaque)
+            )
+        );
+    }
+    test_field_not_opaque();
 }
 impl Default for ContainsInstantiation {
     fn default() -> Self {
@@ -79,22 +82,25 @@ fn bindgen_test_layout_ContainsOpaqueInstantiation() {
         4usize,
         concat!("Alignment of ", stringify!(ContainsOpaqueInstantiation))
     );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<ContainsOpaqueInstantiation>::uninit(
-                );
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).opaque) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(ContainsOpaqueInstantiation),
-            "::",
-            stringify!(opaque)
-        )
-    );
+    fn test_field_opaque() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<
+                    ContainsOpaqueInstantiation,
+                >::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).opaque) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(ContainsOpaqueInstantiation),
+                "::",
+                stringify!(opaque)
+            )
+        );
+    }
+    test_field_opaque();
 }
 #[test]
 fn __bindgen_test_layout_Template_open0_char_close0_instantiation() {

--- a/tests/expectations/tests/opaque_in_struct.rs
+++ b/tests/expectations/tests/opaque_in_struct.rs
@@ -42,18 +42,21 @@ fn bindgen_test_layout_container() {
         4usize,
         concat!("Alignment of ", stringify!(container))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<container>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).contained) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(container),
-            "::",
-            stringify!(contained)
-        )
-    );
+    fn test_field_contained() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<container>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).contained) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(container),
+                "::",
+                stringify!(contained)
+            )
+        );
+    }
+    test_field_contained();
 }

--- a/tests/expectations/tests/opaque_pointer.rs
+++ b/tests/expectations/tests/opaque_pointer.rs
@@ -50,48 +50,57 @@ fn bindgen_test_layout_WithOpaquePtr() {
         8usize,
         concat!("Alignment of ", stringify!(WithOpaquePtr))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<WithOpaquePtr>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).whatever) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(WithOpaquePtr),
-            "::",
-            stringify!(whatever)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<WithOpaquePtr>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).other) as usize - ptr as usize
-        },
-        8usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(WithOpaquePtr),
-            "::",
-            stringify!(other)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<WithOpaquePtr>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).t) as usize - ptr as usize
-        },
-        12usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(WithOpaquePtr),
-            "::",
-            stringify!(t)
-        )
-    );
+    fn test_field_whatever() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<WithOpaquePtr>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).whatever) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(WithOpaquePtr),
+                "::",
+                stringify!(whatever)
+            )
+        );
+    }
+    test_field_whatever();
+    fn test_field_other() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<WithOpaquePtr>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).other) as usize - ptr as usize
+            },
+            8usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(WithOpaquePtr),
+                "::",
+                stringify!(other)
+            )
+        );
+    }
+    test_field_other();
+    fn test_field_t() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<WithOpaquePtr>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).t) as usize - ptr as usize
+            },
+            12usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(WithOpaquePtr),
+                "::",
+                stringify!(t)
+            )
+        );
+    }
+    test_field_t();
 }
 impl Default for WithOpaquePtr {
     fn default() -> Self {

--- a/tests/expectations/tests/packed-n-with-padding.rs
+++ b/tests/expectations/tests/packed-n-with-padding.rs
@@ -25,40 +25,72 @@ fn bindgen_test_layout_Packed() {
         2usize,
         concat!("Alignment of ", stringify!(Packed))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Packed>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
-        0usize,
-        concat!("Offset of field: ", stringify!(Packed), "::", stringify!(a))
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Packed>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-        },
-        2usize,
-        concat!("Offset of field: ", stringify!(Packed), "::", stringify!(b))
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Packed>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).c) as usize - ptr as usize
-        },
-        4usize,
-        concat!("Offset of field: ", stringify!(Packed), "::", stringify!(c))
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Packed>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize
-        },
-        6usize,
-        concat!("Offset of field: ", stringify!(Packed), "::", stringify!(d))
-    );
+    fn test_field_a() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Packed>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(Packed),
+                "::",
+                stringify!(a)
+            )
+        );
+    }
+    test_field_a();
+    fn test_field_b() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Packed>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
+            },
+            2usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(Packed),
+                "::",
+                stringify!(b)
+            )
+        );
+    }
+    test_field_b();
+    fn test_field_c() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Packed>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).c) as usize - ptr as usize
+            },
+            4usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(Packed),
+                "::",
+                stringify!(c)
+            )
+        );
+    }
+    test_field_c();
+    fn test_field_d() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Packed>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize
+            },
+            6usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(Packed),
+                "::",
+                stringify!(d)
+            )
+        );
+    }
+    test_field_d();
 }

--- a/tests/expectations/tests/private.rs
+++ b/tests/expectations/tests/private.rs
@@ -24,34 +24,40 @@ fn bindgen_test_layout_HasPrivate() {
         4usize,
         concat!("Alignment of ", stringify!(HasPrivate))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<HasPrivate>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mNotPrivate) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(HasPrivate),
-            "::",
-            stringify!(mNotPrivate)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<HasPrivate>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mIsPrivate) as usize - ptr as usize
-        },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(HasPrivate),
-            "::",
-            stringify!(mIsPrivate)
-        )
-    );
+    fn test_field_mNotPrivate() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<HasPrivate>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).mNotPrivate) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(HasPrivate),
+                "::",
+                stringify!(mNotPrivate)
+            )
+        );
+    }
+    test_field_mNotPrivate();
+    fn test_field_mIsPrivate() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<HasPrivate>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).mIsPrivate) as usize - ptr as usize
+            },
+            4usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(HasPrivate),
+                "::",
+                stringify!(mIsPrivate)
+            )
+        );
+    }
+    test_field_mIsPrivate();
 }
 /// <div rustbindgen private></div>
 #[repr(C)]
@@ -72,34 +78,41 @@ fn bindgen_test_layout_VeryPrivate() {
         4usize,
         concat!("Alignment of ", stringify!(VeryPrivate))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<VeryPrivate>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mIsPrivate) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(VeryPrivate),
-            "::",
-            stringify!(mIsPrivate)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<VeryPrivate>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mIsAlsoPrivate) as usize - ptr as usize
-        },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(VeryPrivate),
-            "::",
-            stringify!(mIsAlsoPrivate)
-        )
-    );
+    fn test_field_mIsPrivate() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<VeryPrivate>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).mIsPrivate) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(VeryPrivate),
+                "::",
+                stringify!(mIsPrivate)
+            )
+        );
+    }
+    test_field_mIsPrivate();
+    fn test_field_mIsAlsoPrivate() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<VeryPrivate>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).mIsAlsoPrivate) as usize -
+                    ptr as usize
+            },
+            4usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(VeryPrivate),
+                "::",
+                stringify!(mIsAlsoPrivate)
+            )
+        );
+    }
+    test_field_mIsAlsoPrivate();
 }
 /// <div rustbindgen private></div>
 #[repr(C)]
@@ -121,32 +134,40 @@ fn bindgen_test_layout_ContradictPrivate() {
         4usize,
         concat!("Alignment of ", stringify!(ContradictPrivate))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<ContradictPrivate>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mNotPrivate) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(ContradictPrivate),
-            "::",
-            stringify!(mNotPrivate)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<ContradictPrivate>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mIsPrivate) as usize - ptr as usize
-        },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(ContradictPrivate),
-            "::",
-            stringify!(mIsPrivate)
-        )
-    );
+    fn test_field_mNotPrivate() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<ContradictPrivate>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).mNotPrivate) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(ContradictPrivate),
+                "::",
+                stringify!(mNotPrivate)
+            )
+        );
+    }
+    test_field_mNotPrivate();
+    fn test_field_mIsPrivate() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<ContradictPrivate>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).mIsPrivate) as usize - ptr as usize
+            },
+            4usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(ContradictPrivate),
+                "::",
+                stringify!(mIsPrivate)
+            )
+        );
+    }
+    test_field_mIsPrivate();
 }

--- a/tests/expectations/tests/private_fields.rs
+++ b/tests/expectations/tests/private_fields.rs
@@ -109,34 +109,40 @@ fn bindgen_test_layout_PubPriv() {
         4usize,
         concat!("Alignment of ", stringify!(PubPriv))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<PubPriv>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(PubPriv),
-            "::",
-            stringify!(x)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<PubPriv>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).y) as usize - ptr as usize
-        },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(PubPriv),
-            "::",
-            stringify!(y)
-        )
-    );
+    fn test_field_x() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<PubPriv>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(PubPriv),
+                "::",
+                stringify!(x)
+            )
+        );
+    }
+    test_field_x();
+    fn test_field_y() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<PubPriv>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).y) as usize - ptr as usize
+            },
+            4usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(PubPriv),
+                "::",
+                stringify!(y)
+            )
+        );
+    }
+    test_field_y();
 }
 #[repr(C)]
 #[repr(align(4))]
@@ -353,20 +359,23 @@ fn bindgen_test_layout_Base() {
         4usize,
         concat!("Alignment of ", stringify!(Base))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Base>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).member) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(Base),
-            "::",
-            stringify!(member)
-        )
-    );
+    fn test_field_member() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Base>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).member) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(Base),
+                "::",
+                stringify!(member)
+            )
+        );
+    }
+    test_field_member();
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
@@ -427,22 +436,25 @@ fn bindgen_test_layout_WithAnonStruct__bindgen_ty_1() {
         4usize,
         concat!("Alignment of ", stringify!(WithAnonStruct__bindgen_ty_1))
     );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<WithAnonStruct__bindgen_ty_1>::uninit(
-                );
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(WithAnonStruct__bindgen_ty_1),
-            "::",
-            stringify!(a)
-        )
-    );
+    fn test_field_a() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<
+                    WithAnonStruct__bindgen_ty_1,
+                >::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(WithAnonStruct__bindgen_ty_1),
+                "::",
+                stringify!(a)
+            )
+        );
+    }
+    test_field_a();
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
@@ -461,22 +473,25 @@ fn bindgen_test_layout_WithAnonStruct__bindgen_ty_2() {
         4usize,
         concat!("Alignment of ", stringify!(WithAnonStruct__bindgen_ty_2))
     );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<WithAnonStruct__bindgen_ty_2>::uninit(
-                );
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(WithAnonStruct__bindgen_ty_2),
-            "::",
-            stringify!(b)
-        )
-    );
+    fn test_field_b() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<
+                    WithAnonStruct__bindgen_ty_2,
+                >::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(WithAnonStruct__bindgen_ty_2),
+                "::",
+                stringify!(b)
+            )
+        );
+    }
+    test_field_b();
 }
 #[test]
 fn bindgen_test_layout_WithAnonStruct() {

--- a/tests/expectations/tests/reparented_replacement.rs
+++ b/tests/expectations/tests/reparented_replacement.rs
@@ -30,20 +30,24 @@ pub mod root {
                 4usize,
                 concat!("Alignment of ", stringify!(Bar))
             );
-            assert_eq!(
-                unsafe {
-                    let uninit = ::std::mem::MaybeUninit::<Bar>::uninit();
-                    let ptr = uninit.as_ptr();
-                    ::std::ptr::addr_of!((*ptr).bazz) as usize - ptr as usize
-                },
-                0usize,
-                concat!(
-                    "Offset of field: ",
-                    stringify!(Bar),
-                    "::",
-                    stringify!(bazz)
-                )
-            );
+            fn test_field_bazz() {
+                assert_eq!(
+                    unsafe {
+                        let uninit = ::std::mem::MaybeUninit::<Bar>::uninit();
+                        let ptr = uninit.as_ptr();
+                        ::std::ptr::addr_of!((*ptr).bazz) as usize -
+                            ptr as usize
+                    },
+                    0usize,
+                    concat!(
+                        "Offset of field: ",
+                        stringify!(Bar),
+                        "::",
+                        stringify!(bazz)
+                    )
+                );
+            }
+            test_field_bazz();
         }
     }
     pub type ReferencesBar = root::foo::Bar;

--- a/tests/expectations/tests/replace_use.rs
+++ b/tests/expectations/tests/replace_use.rs
@@ -28,15 +28,18 @@ fn bindgen_test_layout_Test() {
         4usize,
         concat!("Alignment of ", stringify!(Test))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Test>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
-        0usize,
-        concat!("Offset of field: ", stringify!(Test), "::", stringify!(a))
-    );
+    fn test_field_a() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Test>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+            },
+            0usize,
+            concat!("Offset of field: ", stringify!(Test), "::", stringify!(a))
+        );
+    }
+    test_field_a();
 }
 #[test]
 fn __bindgen_test_layout_nsTArray_open0_long_close0_instantiation() {

--- a/tests/expectations/tests/repr-align.rs
+++ b/tests/expectations/tests/repr-align.rs
@@ -25,24 +25,30 @@ fn bindgen_test_layout_a() {
         8usize,
         concat!("Alignment of ", stringify!(a))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<a>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-        },
-        0usize,
-        concat!("Offset of field: ", stringify!(a), "::", stringify!(b))
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<a>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).c) as usize - ptr as usize
-        },
-        4usize,
-        concat!("Offset of field: ", stringify!(a), "::", stringify!(c))
-    );
+    fn test_field_b() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<a>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
+            },
+            0usize,
+            concat!("Offset of field: ", stringify!(a), "::", stringify!(b))
+        );
+    }
+    test_field_b();
+    fn test_field_c() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<a>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).c) as usize - ptr as usize
+            },
+            4usize,
+            concat!("Offset of field: ", stringify!(a), "::", stringify!(c))
+        );
+    }
+    test_field_c();
 }
 #[repr(C)]
 #[repr(align(8))]
@@ -63,22 +69,28 @@ fn bindgen_test_layout_b() {
         8usize,
         concat!("Alignment of ", stringify!(b))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<b>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-        },
-        0usize,
-        concat!("Offset of field: ", stringify!(b), "::", stringify!(b))
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<b>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).c) as usize - ptr as usize
-        },
-        4usize,
-        concat!("Offset of field: ", stringify!(b), "::", stringify!(c))
-    );
+    fn test_field_b() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<b>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
+            },
+            0usize,
+            concat!("Offset of field: ", stringify!(b), "::", stringify!(b))
+        );
+    }
+    test_field_b();
+    fn test_field_c() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<b>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).c) as usize - ptr as usize
+            },
+            4usize,
+            concat!("Offset of field: ", stringify!(b), "::", stringify!(c))
+        );
+    }
+    test_field_c();
 }

--- a/tests/expectations/tests/same_struct_name_in_different_namespaces.rs
+++ b/tests/expectations/tests/same_struct_name_in_different_namespaces.rs
@@ -28,32 +28,40 @@ fn bindgen_test_layout_JS_shadow_Zone() {
         4usize,
         concat!("Alignment of ", stringify!(JS_shadow_Zone))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<JS_shadow_Zone>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(JS_shadow_Zone),
-            "::",
-            stringify!(x)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<JS_shadow_Zone>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).y) as usize - ptr as usize
-        },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(JS_shadow_Zone),
-            "::",
-            stringify!(y)
-        )
-    );
+    fn test_field_x() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<JS_shadow_Zone>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(JS_shadow_Zone),
+                "::",
+                stringify!(x)
+            )
+        );
+    }
+    test_field_x();
+    fn test_field_y() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<JS_shadow_Zone>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).y) as usize - ptr as usize
+            },
+            4usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(JS_shadow_Zone),
+                "::",
+                stringify!(y)
+            )
+        );
+    }
+    test_field_y();
 }

--- a/tests/expectations/tests/sentry-defined-multiple-times.rs
+++ b/tests/expectations/tests/sentry-defined-multiple-times.rs
@@ -39,21 +39,25 @@ pub mod root {
                 1usize,
                 concat!("Alignment of ", stringify!(sentry))
             );
-            assert_eq!(
-                unsafe {
-                    let uninit = ::std::mem::MaybeUninit::<sentry>::uninit();
-                    let ptr = uninit.as_ptr();
-                    ::std::ptr::addr_of!((*ptr).i_am_plain_sentry) as usize -
-                        ptr as usize
-                },
-                0usize,
-                concat!(
-                    "Offset of field: ",
-                    stringify!(sentry),
-                    "::",
-                    stringify!(i_am_plain_sentry)
-                )
-            );
+            fn test_field_i_am_plain_sentry() {
+                assert_eq!(
+                    unsafe {
+                        let uninit =
+                            ::std::mem::MaybeUninit::<sentry>::uninit();
+                        let ptr = uninit.as_ptr();
+                        ::std::ptr::addr_of!((*ptr).i_am_plain_sentry) as usize -
+                            ptr as usize
+                    },
+                    0usize,
+                    concat!(
+                        "Offset of field: ",
+                        stringify!(sentry),
+                        "::",
+                        stringify!(i_am_plain_sentry)
+                    )
+                );
+            }
+            test_field_i_am_plain_sentry();
         }
         #[repr(C)]
         #[derive(Debug, Default, Copy, Clone)]
@@ -90,25 +94,28 @@ pub mod root {
                 1usize,
                 concat!("Alignment of ", stringify!(NotTemplateWrapper_sentry))
             );
-            assert_eq!(
-                unsafe {
-                    let uninit = ::std::mem::MaybeUninit::<
-                        NotTemplateWrapper_sentry,
-                    >::uninit();
-                    let ptr = uninit.as_ptr();
-                    ::std::ptr::addr_of!(
-                        (*ptr).i_am_not_template_wrapper_sentry
-                    ) as usize -
-                        ptr as usize
-                },
-                0usize,
-                concat!(
-                    "Offset of field: ",
-                    stringify!(NotTemplateWrapper_sentry),
-                    "::",
-                    stringify!(i_am_not_template_wrapper_sentry)
-                )
-            );
+            fn test_field_i_am_not_template_wrapper_sentry() {
+                assert_eq!(
+                    unsafe {
+                        let uninit = ::std::mem::MaybeUninit::<
+                            NotTemplateWrapper_sentry,
+                        >::uninit();
+                        let ptr = uninit.as_ptr();
+                        ::std::ptr::addr_of!(
+                            (*ptr).i_am_not_template_wrapper_sentry
+                        ) as usize -
+                            ptr as usize
+                    },
+                    0usize,
+                    concat!(
+                        "Offset of field: ",
+                        stringify!(NotTemplateWrapper_sentry),
+                        "::",
+                        stringify!(i_am_not_template_wrapper_sentry)
+                    )
+                );
+            }
+            test_field_i_am_not_template_wrapper_sentry();
         }
         #[repr(C)]
         #[derive(Debug, Default, Copy, Clone)]
@@ -138,25 +145,28 @@ pub mod root {
                     stringify!(InlineNotTemplateWrapper_sentry)
                 )
             );
-            assert_eq!(
-                unsafe {
-                    let uninit = ::std::mem::MaybeUninit::<
-                        InlineNotTemplateWrapper_sentry,
-                    >::uninit();
-                    let ptr = uninit.as_ptr();
-                    ::std::ptr::addr_of!(
-                        (*ptr).i_am_inline_not_template_wrapper_sentry
-                    ) as usize -
-                        ptr as usize
-                },
-                0usize,
-                concat!(
-                    "Offset of field: ",
-                    stringify!(InlineNotTemplateWrapper_sentry),
-                    "::",
-                    stringify!(i_am_inline_not_template_wrapper_sentry)
-                )
-            );
+            fn test_field_i_am_inline_not_template_wrapper_sentry() {
+                assert_eq!(
+                    unsafe {
+                        let uninit = ::std::mem::MaybeUninit::<
+                            InlineNotTemplateWrapper_sentry,
+                        >::uninit();
+                        let ptr = uninit.as_ptr();
+                        ::std::ptr::addr_of!(
+                            (*ptr).i_am_inline_not_template_wrapper_sentry
+                        ) as usize -
+                            ptr as usize
+                    },
+                    0usize,
+                    concat!(
+                        "Offset of field: ",
+                        stringify!(InlineNotTemplateWrapper_sentry),
+                        "::",
+                        stringify!(i_am_inline_not_template_wrapper_sentry)
+                    )
+                );
+            }
+            test_field_i_am_inline_not_template_wrapper_sentry();
         }
         #[test]
         fn bindgen_test_layout_InlineNotTemplateWrapper() {
@@ -250,24 +260,29 @@ pub mod root {
                     stringify!(OuterDoubleWrapper_InnerDoubleWrapper_sentry)
                 )
             );
-            assert_eq!(
-                unsafe {
-                    let uninit = ::std::mem::MaybeUninit::<
-                        OuterDoubleWrapper_InnerDoubleWrapper_sentry,
-                    >::uninit();
-                    let ptr = uninit.as_ptr();
-                    ::std::ptr::addr_of!((*ptr).i_am_double_wrapper_sentry)
-                        as usize -
-                        ptr as usize
-                },
-                0usize,
-                concat!(
-                    "Offset of field: ",
-                    stringify!(OuterDoubleWrapper_InnerDoubleWrapper_sentry),
-                    "::",
-                    stringify!(i_am_double_wrapper_sentry)
-                )
-            );
+            fn test_field_i_am_double_wrapper_sentry() {
+                assert_eq!(
+                    unsafe {
+                        let uninit = ::std::mem::MaybeUninit::<
+                            OuterDoubleWrapper_InnerDoubleWrapper_sentry,
+                        >::uninit();
+                        let ptr = uninit.as_ptr();
+                        ::std::ptr::addr_of!((*ptr).i_am_double_wrapper_sentry)
+                            as usize -
+                            ptr as usize
+                    },
+                    0usize,
+                    concat!(
+                        "Offset of field: ",
+                        stringify!(
+                            OuterDoubleWrapper_InnerDoubleWrapper_sentry
+                        ),
+                        "::",
+                        stringify!(i_am_double_wrapper_sentry)
+                    )
+                );
+            }
+            test_field_i_am_double_wrapper_sentry();
         }
         #[repr(C)]
         #[derive(Debug, Default, Copy, Clone)]
@@ -289,7 +304,10 @@ pub mod root {
         ) {
             assert_eq ! (:: std :: mem :: size_of :: < OuterDoubleInlineWrapper_InnerDoubleInlineWrapper_sentry > () , 4usize , concat ! ("Size of: " , stringify ! (OuterDoubleInlineWrapper_InnerDoubleInlineWrapper_sentry)));
             assert_eq ! (:: std :: mem :: align_of :: < OuterDoubleInlineWrapper_InnerDoubleInlineWrapper_sentry > () , 4usize , concat ! ("Alignment of " , stringify ! (OuterDoubleInlineWrapper_InnerDoubleInlineWrapper_sentry)));
-            assert_eq ! (unsafe { let uninit = :: std :: mem :: MaybeUninit :: < OuterDoubleInlineWrapper_InnerDoubleInlineWrapper_sentry > :: uninit () ; let ptr = uninit . as_ptr () ; :: std :: ptr :: addr_of ! ((* ptr) . i_am_double_wrapper_inline_sentry) as usize - ptr as usize } , 0usize , concat ! ("Offset of field: " , stringify ! (OuterDoubleInlineWrapper_InnerDoubleInlineWrapper_sentry) , "::" , stringify ! (i_am_double_wrapper_inline_sentry)));
+            fn test_field_i_am_double_wrapper_inline_sentry() {
+                assert_eq ! (unsafe { let uninit = :: std :: mem :: MaybeUninit :: < OuterDoubleInlineWrapper_InnerDoubleInlineWrapper_sentry > :: uninit () ; let ptr = uninit . as_ptr () ; :: std :: ptr :: addr_of ! ((* ptr) . i_am_double_wrapper_inline_sentry) as usize - ptr as usize } , 0usize , concat ! ("Offset of field: " , stringify ! (OuterDoubleInlineWrapper_InnerDoubleInlineWrapper_sentry) , "::" , stringify ! (i_am_double_wrapper_inline_sentry)));
+            }
+            test_field_i_am_double_wrapper_inline_sentry();
         }
         #[test]
         fn bindgen_test_layout_OuterDoubleInlineWrapper_InnerDoubleInlineWrapper(
@@ -360,21 +378,24 @@ pub mod root {
             4usize,
             concat!("Alignment of ", stringify!(sentry))
         );
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<sentry>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).i_am_outside_namespace_sentry)
-                    as usize -
-                    ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(sentry),
-                "::",
-                stringify!(i_am_outside_namespace_sentry)
-            )
-        );
+        fn test_field_i_am_outside_namespace_sentry() {
+            assert_eq!(
+                unsafe {
+                    let uninit = ::std::mem::MaybeUninit::<sentry>::uninit();
+                    let ptr = uninit.as_ptr();
+                    ::std::ptr::addr_of!((*ptr).i_am_outside_namespace_sentry)
+                        as usize -
+                        ptr as usize
+                },
+                0usize,
+                concat!(
+                    "Offset of field: ",
+                    stringify!(sentry),
+                    "::",
+                    stringify!(i_am_outside_namespace_sentry)
+                )
+            );
+        }
+        test_field_i_am_outside_namespace_sentry();
     }
 }

--- a/tests/expectations/tests/size_t_is_usize.rs
+++ b/tests/expectations/tests/size_t_is_usize.rs
@@ -24,33 +24,47 @@ fn bindgen_test_layout_A() {
         8usize,
         concat!("Alignment of ", stringify!(A))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<A>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).len) as usize - ptr as usize
-        },
-        0usize,
-        concat!("Offset of field: ", stringify!(A), "::", stringify!(len))
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<A>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).offset) as usize - ptr as usize
-        },
-        8usize,
-        concat!("Offset of field: ", stringify!(A), "::", stringify!(offset))
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<A>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).next) as usize - ptr as usize
-        },
-        16usize,
-        concat!("Offset of field: ", stringify!(A), "::", stringify!(next))
-    );
+    fn test_field_len() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<A>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).len) as usize - ptr as usize
+            },
+            0usize,
+            concat!("Offset of field: ", stringify!(A), "::", stringify!(len))
+        );
+    }
+    test_field_len();
+    fn test_field_offset() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<A>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).offset) as usize - ptr as usize
+            },
+            8usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(A),
+                "::",
+                stringify!(offset)
+            )
+        );
+    }
+    test_field_offset();
+    fn test_field_next() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<A>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).next) as usize - ptr as usize
+            },
+            16usize,
+            concat!("Offset of field: ", stringify!(A), "::", stringify!(next))
+        );
+    }
+    test_field_next();
 }
 impl Default for A {
     fn default() -> Self {

--- a/tests/expectations/tests/size_t_template.rs
+++ b/tests/expectations/tests/size_t_template.rs
@@ -22,13 +22,16 @@ fn bindgen_test_layout_C() {
         4usize,
         concat!("Alignment of ", stringify!(C))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<C>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).arr) as usize - ptr as usize
-        },
-        0usize,
-        concat!("Offset of field: ", stringify!(C), "::", stringify!(arr))
-    );
+    fn test_field_arr() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<C>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).arr) as usize - ptr as usize
+            },
+            0usize,
+            concat!("Offset of field: ", stringify!(C), "::", stringify!(arr))
+        );
+    }
+    test_field_arr();
 }

--- a/tests/expectations/tests/struct_containing_forward_declared_struct.rs
+++ b/tests/expectations/tests/struct_containing_forward_declared_struct.rs
@@ -22,15 +22,23 @@ fn bindgen_test_layout_a() {
         8usize,
         concat!("Alignment of ", stringify!(a))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<a>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).val_a) as usize - ptr as usize
-        },
-        0usize,
-        concat!("Offset of field: ", stringify!(a), "::", stringify!(val_a))
-    );
+    fn test_field_val_a() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<a>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).val_a) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(a),
+                "::",
+                stringify!(val_a)
+            )
+        );
+    }
+    test_field_val_a();
 }
 impl Default for a {
     fn default() -> Self {
@@ -58,13 +66,21 @@ fn bindgen_test_layout_b() {
         4usize,
         concat!("Alignment of ", stringify!(b))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<b>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).val_b) as usize - ptr as usize
-        },
-        0usize,
-        concat!("Offset of field: ", stringify!(b), "::", stringify!(val_b))
-    );
+    fn test_field_val_b() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<b>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).val_b) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(b),
+                "::",
+                stringify!(val_b)
+            )
+        );
+    }
+    test_field_val_b();
 }

--- a/tests/expectations/tests/struct_typedef.rs
+++ b/tests/expectations/tests/struct_typedef.rs
@@ -22,21 +22,24 @@ fn bindgen_test_layout_typedef_named_struct() {
         1usize,
         concat!("Alignment of ", stringify!(typedef_named_struct))
     );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<typedef_named_struct>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).has_name) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(typedef_named_struct),
-            "::",
-            stringify!(has_name)
-        )
-    );
+    fn test_field_has_name() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<typedef_named_struct>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).has_name) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(typedef_named_struct),
+                "::",
+                stringify!(has_name)
+            )
+        );
+    }
+    test_field_has_name();
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -55,20 +58,23 @@ fn bindgen_test_layout__bindgen_ty_1() {
         8usize,
         concat!("Alignment of ", stringify!(_bindgen_ty_1))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<_bindgen_ty_1>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).no_name) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(_bindgen_ty_1),
-            "::",
-            stringify!(no_name)
-        )
-    );
+    fn test_field_no_name() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<_bindgen_ty_1>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).no_name) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(_bindgen_ty_1),
+                "::",
+                stringify!(no_name)
+            )
+        );
+    }
+    test_field_no_name();
 }
 impl Default for _bindgen_ty_1 {
     fn default() -> Self {

--- a/tests/expectations/tests/struct_typedef_ns.rs
+++ b/tests/expectations/tests/struct_typedef_ns.rs
@@ -29,21 +29,24 @@ pub mod root {
                 4usize,
                 concat!("Alignment of ", stringify!(typedef_struct))
             );
-            assert_eq!(
-                unsafe {
-                    let uninit =
-                        ::std::mem::MaybeUninit::<typedef_struct>::uninit();
-                    let ptr = uninit.as_ptr();
-                    ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize
-                },
-                0usize,
-                concat!(
-                    "Offset of field: ",
-                    stringify!(typedef_struct),
-                    "::",
-                    stringify!(foo)
-                )
-            );
+            fn test_field_foo() {
+                assert_eq!(
+                    unsafe {
+                        let uninit =
+                            ::std::mem::MaybeUninit::<typedef_struct>::uninit();
+                        let ptr = uninit.as_ptr();
+                        ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize
+                    },
+                    0usize,
+                    concat!(
+                        "Offset of field: ",
+                        stringify!(typedef_struct),
+                        "::",
+                        stringify!(foo)
+                    )
+                );
+            }
+            test_field_foo();
         }
         #[repr(u32)]
         #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -71,21 +74,24 @@ pub mod root {
                 4usize,
                 concat!("Alignment of ", stringify!(_bindgen_ty_1))
             );
-            assert_eq!(
-                unsafe {
-                    let uninit =
-                        ::std::mem::MaybeUninit::<_bindgen_ty_1>::uninit();
-                    let ptr = uninit.as_ptr();
-                    ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize
-                },
-                0usize,
-                concat!(
-                    "Offset of field: ",
-                    stringify!(_bindgen_ty_1),
-                    "::",
-                    stringify!(foo)
-                )
-            );
+            fn test_field_foo() {
+                assert_eq!(
+                    unsafe {
+                        let uninit =
+                            ::std::mem::MaybeUninit::<_bindgen_ty_1>::uninit();
+                        let ptr = uninit.as_ptr();
+                        ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize
+                    },
+                    0usize,
+                    concat!(
+                        "Offset of field: ",
+                        stringify!(_bindgen_ty_1),
+                        "::",
+                        stringify!(foo)
+                    )
+                );
+            }
+            test_field_foo();
         }
         pub type typedef_struct = root::_bindgen_mod_id_12::_bindgen_ty_1;
         pub const _bindgen_mod_id_12_BAR:

--- a/tests/expectations/tests/struct_with_anon_struct.rs
+++ b/tests/expectations/tests/struct_with_anon_struct.rs
@@ -28,34 +28,42 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
         4usize,
         concat!("Alignment of ", stringify!(foo__bindgen_ty_1))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<foo__bindgen_ty_1>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(foo__bindgen_ty_1),
-            "::",
-            stringify!(a)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<foo__bindgen_ty_1>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-        },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(foo__bindgen_ty_1),
-            "::",
-            stringify!(b)
-        )
-    );
+    fn test_field_a() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<foo__bindgen_ty_1>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(foo__bindgen_ty_1),
+                "::",
+                stringify!(a)
+            )
+        );
+    }
+    test_field_a();
+    fn test_field_b() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<foo__bindgen_ty_1>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
+            },
+            4usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(foo__bindgen_ty_1),
+                "::",
+                stringify!(b)
+            )
+        );
+    }
+    test_field_b();
 }
 #[test]
 fn bindgen_test_layout_foo() {
@@ -69,13 +77,21 @@ fn bindgen_test_layout_foo() {
         4usize,
         concat!("Alignment of ", stringify!(foo))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<foo>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
-        },
-        0usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar))
-    );
+    fn test_field_bar() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<foo>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(foo),
+                "::",
+                stringify!(bar)
+            )
+        );
+    }
+    test_field_bar();
 }

--- a/tests/expectations/tests/struct_with_anon_struct_array.rs
+++ b/tests/expectations/tests/struct_with_anon_struct_array.rs
@@ -29,34 +29,42 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
         4usize,
         concat!("Alignment of ", stringify!(foo__bindgen_ty_1))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<foo__bindgen_ty_1>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(foo__bindgen_ty_1),
-            "::",
-            stringify!(a)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<foo__bindgen_ty_1>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-        },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(foo__bindgen_ty_1),
-            "::",
-            stringify!(b)
-        )
-    );
+    fn test_field_a() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<foo__bindgen_ty_1>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(foo__bindgen_ty_1),
+                "::",
+                stringify!(a)
+            )
+        );
+    }
+    test_field_a();
+    fn test_field_b() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<foo__bindgen_ty_1>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
+            },
+            4usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(foo__bindgen_ty_1),
+                "::",
+                stringify!(b)
+            )
+        );
+    }
+    test_field_b();
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
@@ -76,34 +84,42 @@ fn bindgen_test_layout_foo__bindgen_ty_2() {
         4usize,
         concat!("Alignment of ", stringify!(foo__bindgen_ty_2))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<foo__bindgen_ty_2>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(foo__bindgen_ty_2),
-            "::",
-            stringify!(a)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<foo__bindgen_ty_2>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-        },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(foo__bindgen_ty_2),
-            "::",
-            stringify!(b)
-        )
-    );
+    fn test_field_a() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<foo__bindgen_ty_2>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(foo__bindgen_ty_2),
+                "::",
+                stringify!(a)
+            )
+        );
+    }
+    test_field_a();
+    fn test_field_b() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<foo__bindgen_ty_2>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
+            },
+            4usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(foo__bindgen_ty_2),
+                "::",
+                stringify!(b)
+            )
+        );
+    }
+    test_field_b();
 }
 #[test]
 fn bindgen_test_layout_foo() {
@@ -117,22 +133,38 @@ fn bindgen_test_layout_foo() {
         4usize,
         concat!("Alignment of ", stringify!(foo))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<foo>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
-        },
-        0usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar))
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<foo>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize
-        },
-        16usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(baz))
-    );
+    fn test_field_bar() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<foo>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(foo),
+                "::",
+                stringify!(bar)
+            )
+        );
+    }
+    test_field_bar();
+    fn test_field_baz() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<foo>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize
+            },
+            16usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(foo),
+                "::",
+                stringify!(baz)
+            )
+        );
+    }
+    test_field_baz();
 }

--- a/tests/expectations/tests/struct_with_anon_struct_pointer.rs
+++ b/tests/expectations/tests/struct_with_anon_struct_pointer.rs
@@ -28,34 +28,42 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
         4usize,
         concat!("Alignment of ", stringify!(foo__bindgen_ty_1))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<foo__bindgen_ty_1>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(foo__bindgen_ty_1),
-            "::",
-            stringify!(a)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<foo__bindgen_ty_1>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-        },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(foo__bindgen_ty_1),
-            "::",
-            stringify!(b)
-        )
-    );
+    fn test_field_a() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<foo__bindgen_ty_1>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(foo__bindgen_ty_1),
+                "::",
+                stringify!(a)
+            )
+        );
+    }
+    test_field_a();
+    fn test_field_b() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<foo__bindgen_ty_1>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
+            },
+            4usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(foo__bindgen_ty_1),
+                "::",
+                stringify!(b)
+            )
+        );
+    }
+    test_field_b();
 }
 #[test]
 fn bindgen_test_layout_foo() {
@@ -69,15 +77,23 @@ fn bindgen_test_layout_foo() {
         8usize,
         concat!("Alignment of ", stringify!(foo))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<foo>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
-        },
-        0usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar))
-    );
+    fn test_field_bar() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<foo>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(foo),
+                "::",
+                stringify!(bar)
+            )
+        );
+    }
+    test_field_bar();
 }
 impl Default for foo {
     fn default() -> Self {

--- a/tests/expectations/tests/struct_with_anon_union.rs
+++ b/tests/expectations/tests/struct_with_anon_union.rs
@@ -28,34 +28,42 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
         4usize,
         concat!("Alignment of ", stringify!(foo__bindgen_ty_1))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<foo__bindgen_ty_1>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(foo__bindgen_ty_1),
-            "::",
-            stringify!(a)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<foo__bindgen_ty_1>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(foo__bindgen_ty_1),
-            "::",
-            stringify!(b)
-        )
-    );
+    fn test_field_a() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<foo__bindgen_ty_1>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(foo__bindgen_ty_1),
+                "::",
+                stringify!(a)
+            )
+        );
+    }
+    test_field_a();
+    fn test_field_b() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<foo__bindgen_ty_1>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(foo__bindgen_ty_1),
+                "::",
+                stringify!(b)
+            )
+        );
+    }
+    test_field_b();
 }
 impl Default for foo__bindgen_ty_1 {
     fn default() -> Self {
@@ -78,15 +86,23 @@ fn bindgen_test_layout_foo() {
         4usize,
         concat!("Alignment of ", stringify!(foo))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<foo>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
-        },
-        0usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar))
-    );
+    fn test_field_bar() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<foo>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(foo),
+                "::",
+                stringify!(bar)
+            )
+        );
+    }
+    test_field_bar();
 }
 impl Default for foo {
     fn default() -> Self {

--- a/tests/expectations/tests/struct_with_anon_union_1_0.rs
+++ b/tests/expectations/tests/struct_with_anon_union_1_0.rs
@@ -72,34 +72,42 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
         4usize,
         concat!("Alignment of ", stringify!(foo__bindgen_ty_1))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<foo__bindgen_ty_1>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(foo__bindgen_ty_1),
-            "::",
-            stringify!(a)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<foo__bindgen_ty_1>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(foo__bindgen_ty_1),
-            "::",
-            stringify!(b)
-        )
-    );
+    fn test_field_a() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<foo__bindgen_ty_1>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(foo__bindgen_ty_1),
+                "::",
+                stringify!(a)
+            )
+        );
+    }
+    test_field_a();
+    fn test_field_b() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<foo__bindgen_ty_1>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(foo__bindgen_ty_1),
+                "::",
+                stringify!(b)
+            )
+        );
+    }
+    test_field_b();
 }
 impl Clone for foo__bindgen_ty_1 {
     fn clone(&self) -> Self {
@@ -118,15 +126,23 @@ fn bindgen_test_layout_foo() {
         4usize,
         concat!("Alignment of ", stringify!(foo))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<foo>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
-        },
-        0usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar))
-    );
+    fn test_field_bar() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<foo>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(foo),
+                "::",
+                stringify!(bar)
+            )
+        );
+    }
+    test_field_bar();
 }
 impl Clone for foo {
     fn clone(&self) -> Self {

--- a/tests/expectations/tests/struct_with_anon_unnamed_struct.rs
+++ b/tests/expectations/tests/struct_with_anon_unnamed_struct.rs
@@ -28,34 +28,42 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
         4usize,
         concat!("Alignment of ", stringify!(foo__bindgen_ty_1))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<foo__bindgen_ty_1>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(foo__bindgen_ty_1),
-            "::",
-            stringify!(a)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<foo__bindgen_ty_1>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-        },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(foo__bindgen_ty_1),
-            "::",
-            stringify!(b)
-        )
-    );
+    fn test_field_a() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<foo__bindgen_ty_1>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(foo__bindgen_ty_1),
+                "::",
+                stringify!(a)
+            )
+        );
+    }
+    test_field_a();
+    fn test_field_b() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<foo__bindgen_ty_1>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
+            },
+            4usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(foo__bindgen_ty_1),
+                "::",
+                stringify!(b)
+            )
+        );
+    }
+    test_field_b();
 }
 #[test]
 fn bindgen_test_layout_foo() {

--- a/tests/expectations/tests/struct_with_anon_unnamed_union.rs
+++ b/tests/expectations/tests/struct_with_anon_unnamed_union.rs
@@ -28,34 +28,42 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
         4usize,
         concat!("Alignment of ", stringify!(foo__bindgen_ty_1))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<foo__bindgen_ty_1>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(foo__bindgen_ty_1),
-            "::",
-            stringify!(a)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<foo__bindgen_ty_1>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(foo__bindgen_ty_1),
-            "::",
-            stringify!(b)
-        )
-    );
+    fn test_field_a() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<foo__bindgen_ty_1>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(foo__bindgen_ty_1),
+                "::",
+                stringify!(a)
+            )
+        );
+    }
+    test_field_a();
+    fn test_field_b() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<foo__bindgen_ty_1>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(foo__bindgen_ty_1),
+                "::",
+                stringify!(b)
+            )
+        );
+    }
+    test_field_b();
 }
 impl Default for foo__bindgen_ty_1 {
     fn default() -> Self {

--- a/tests/expectations/tests/struct_with_anon_unnamed_union_1_0.rs
+++ b/tests/expectations/tests/struct_with_anon_unnamed_union_1_0.rs
@@ -72,34 +72,42 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
         4usize,
         concat!("Alignment of ", stringify!(foo__bindgen_ty_1))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<foo__bindgen_ty_1>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(foo__bindgen_ty_1),
-            "::",
-            stringify!(a)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<foo__bindgen_ty_1>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(foo__bindgen_ty_1),
-            "::",
-            stringify!(b)
-        )
-    );
+    fn test_field_a() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<foo__bindgen_ty_1>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(foo__bindgen_ty_1),
+                "::",
+                stringify!(a)
+            )
+        );
+    }
+    test_field_a();
+    fn test_field_b() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<foo__bindgen_ty_1>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(foo__bindgen_ty_1),
+                "::",
+                stringify!(b)
+            )
+        );
+    }
+    test_field_b();
 }
 impl Clone for foo__bindgen_ty_1 {
     fn clone(&self) -> Self {

--- a/tests/expectations/tests/struct_with_bitfields.rs
+++ b/tests/expectations/tests/struct_with_bitfields.rs
@@ -112,20 +112,23 @@ fn bindgen_test_layout_bitfield() {
         4usize,
         concat!("Alignment of ", stringify!(bitfield))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<bitfield>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).e) as usize - ptr as usize
-        },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(bitfield),
-            "::",
-            stringify!(e)
-        )
-    );
+    fn test_field_e() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<bitfield>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).e) as usize - ptr as usize
+            },
+            4usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(bitfield),
+                "::",
+                stringify!(e)
+            )
+        );
+    }
+    test_field_e();
 }
 impl bitfield {
     #[inline]

--- a/tests/expectations/tests/struct_with_derive_debug.rs
+++ b/tests/expectations/tests/struct_with_derive_debug.rs
@@ -22,20 +22,23 @@ fn bindgen_test_layout_LittleArray() {
         4usize,
         concat!("Alignment of ", stringify!(LittleArray))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<LittleArray>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(LittleArray),
-            "::",
-            stringify!(a)
-        )
-    );
+    fn test_field_a() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<LittleArray>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(LittleArray),
+                "::",
+                stringify!(a)
+            )
+        );
+    }
+    test_field_a();
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -54,20 +57,23 @@ fn bindgen_test_layout_BigArray() {
         4usize,
         concat!("Alignment of ", stringify!(BigArray))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<BigArray>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(BigArray),
-            "::",
-            stringify!(a)
-        )
-    );
+    fn test_field_a() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<BigArray>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(BigArray),
+                "::",
+                stringify!(a)
+            )
+        );
+    }
+    test_field_a();
 }
 impl Default for BigArray {
     fn default() -> Self {
@@ -95,20 +101,24 @@ fn bindgen_test_layout_WithLittleArray() {
         4usize,
         concat!("Alignment of ", stringify!(WithLittleArray))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<WithLittleArray>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(WithLittleArray),
-            "::",
-            stringify!(a)
-        )
-    );
+    fn test_field_a() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<WithLittleArray>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(WithLittleArray),
+                "::",
+                stringify!(a)
+            )
+        );
+    }
+    test_field_a();
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -127,20 +137,23 @@ fn bindgen_test_layout_WithBigArray() {
         4usize,
         concat!("Alignment of ", stringify!(WithBigArray))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<WithBigArray>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(WithBigArray),
-            "::",
-            stringify!(a)
-        )
-    );
+    fn test_field_a() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<WithBigArray>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(WithBigArray),
+                "::",
+                stringify!(a)
+            )
+        );
+    }
+    test_field_a();
 }
 impl Default for WithBigArray {
     fn default() -> Self {

--- a/tests/expectations/tests/struct_with_large_array.rs
+++ b/tests/expectations/tests/struct_with_large_array.rs
@@ -22,20 +22,23 @@ fn bindgen_test_layout_S() {
         1usize,
         concat!("Alignment of ", stringify!(S))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<S>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).large_array) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(S),
-            "::",
-            stringify!(large_array)
-        )
-    );
+    fn test_field_large_array() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<S>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).large_array) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(S),
+                "::",
+                stringify!(large_array)
+            )
+        );
+    }
+    test_field_large_array();
 }
 impl Default for S {
     fn default() -> Self {

--- a/tests/expectations/tests/struct_with_nesting.rs
+++ b/tests/expectations/tests/struct_with_nesting.rs
@@ -36,38 +36,44 @@ fn bindgen_test_layout_foo__bindgen_ty_1__bindgen_ty_1() {
         2usize,
         concat!("Alignment of ", stringify!(foo__bindgen_ty_1__bindgen_ty_1))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<
-                foo__bindgen_ty_1__bindgen_ty_1,
-            >::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).c1) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(foo__bindgen_ty_1__bindgen_ty_1),
-            "::",
-            stringify!(c1)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<
-                foo__bindgen_ty_1__bindgen_ty_1,
-            >::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).c2) as usize - ptr as usize
-        },
-        2usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(foo__bindgen_ty_1__bindgen_ty_1),
-            "::",
-            stringify!(c2)
-        )
-    );
+    fn test_field_c1() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<
+                    foo__bindgen_ty_1__bindgen_ty_1,
+                >::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).c1) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(foo__bindgen_ty_1__bindgen_ty_1),
+                "::",
+                stringify!(c1)
+            )
+        );
+    }
+    test_field_c1();
+    fn test_field_c2() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<
+                    foo__bindgen_ty_1__bindgen_ty_1,
+                >::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).c2) as usize - ptr as usize
+            },
+            2usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(foo__bindgen_ty_1__bindgen_ty_1),
+                "::",
+                stringify!(c2)
+            )
+        );
+    }
+    test_field_c2();
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
@@ -89,70 +95,82 @@ fn bindgen_test_layout_foo__bindgen_ty_1__bindgen_ty_2() {
         1usize,
         concat!("Alignment of ", stringify!(foo__bindgen_ty_1__bindgen_ty_2))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<
-                foo__bindgen_ty_1__bindgen_ty_2,
-            >::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).d1) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(foo__bindgen_ty_1__bindgen_ty_2),
-            "::",
-            stringify!(d1)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<
-                foo__bindgen_ty_1__bindgen_ty_2,
-            >::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).d2) as usize - ptr as usize
-        },
-        1usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(foo__bindgen_ty_1__bindgen_ty_2),
-            "::",
-            stringify!(d2)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<
-                foo__bindgen_ty_1__bindgen_ty_2,
-            >::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).d3) as usize - ptr as usize
-        },
-        2usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(foo__bindgen_ty_1__bindgen_ty_2),
-            "::",
-            stringify!(d3)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<
-                foo__bindgen_ty_1__bindgen_ty_2,
-            >::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).d4) as usize - ptr as usize
-        },
-        3usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(foo__bindgen_ty_1__bindgen_ty_2),
-            "::",
-            stringify!(d4)
-        )
-    );
+    fn test_field_d1() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<
+                    foo__bindgen_ty_1__bindgen_ty_2,
+                >::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).d1) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(foo__bindgen_ty_1__bindgen_ty_2),
+                "::",
+                stringify!(d1)
+            )
+        );
+    }
+    test_field_d1();
+    fn test_field_d2() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<
+                    foo__bindgen_ty_1__bindgen_ty_2,
+                >::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).d2) as usize - ptr as usize
+            },
+            1usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(foo__bindgen_ty_1__bindgen_ty_2),
+                "::",
+                stringify!(d2)
+            )
+        );
+    }
+    test_field_d2();
+    fn test_field_d3() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<
+                    foo__bindgen_ty_1__bindgen_ty_2,
+                >::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).d3) as usize - ptr as usize
+            },
+            2usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(foo__bindgen_ty_1__bindgen_ty_2),
+                "::",
+                stringify!(d3)
+            )
+        );
+    }
+    test_field_d3();
+    fn test_field_d4() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<
+                    foo__bindgen_ty_1__bindgen_ty_2,
+                >::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).d4) as usize - ptr as usize
+            },
+            3usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(foo__bindgen_ty_1__bindgen_ty_2),
+                "::",
+                stringify!(d4)
+            )
+        );
+    }
+    test_field_d4();
 }
 #[test]
 fn bindgen_test_layout_foo__bindgen_ty_1() {
@@ -166,20 +184,24 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
         4usize,
         concat!("Alignment of ", stringify!(foo__bindgen_ty_1))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<foo__bindgen_ty_1>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(foo__bindgen_ty_1),
-            "::",
-            stringify!(b)
-        )
-    );
+    fn test_field_b() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<foo__bindgen_ty_1>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(foo__bindgen_ty_1),
+                "::",
+                stringify!(b)
+            )
+        );
+    }
+    test_field_b();
 }
 impl Default for foo__bindgen_ty_1 {
     fn default() -> Self {
@@ -202,15 +224,18 @@ fn bindgen_test_layout_foo() {
         4usize,
         concat!("Alignment of ", stringify!(foo))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<foo>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
-        0usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(a))
-    );
+    fn test_field_a() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<foo>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+            },
+            0usize,
+            concat!("Offset of field: ", stringify!(foo), "::", stringify!(a))
+        );
+    }
+    test_field_a();
 }
 impl Default for foo {
     fn default() -> Self {

--- a/tests/expectations/tests/struct_with_nesting_1_0.rs
+++ b/tests/expectations/tests/struct_with_nesting_1_0.rs
@@ -80,38 +80,44 @@ fn bindgen_test_layout_foo__bindgen_ty_1__bindgen_ty_1() {
         2usize,
         concat!("Alignment of ", stringify!(foo__bindgen_ty_1__bindgen_ty_1))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<
-                foo__bindgen_ty_1__bindgen_ty_1,
-            >::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).c1) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(foo__bindgen_ty_1__bindgen_ty_1),
-            "::",
-            stringify!(c1)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<
-                foo__bindgen_ty_1__bindgen_ty_1,
-            >::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).c2) as usize - ptr as usize
-        },
-        2usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(foo__bindgen_ty_1__bindgen_ty_1),
-            "::",
-            stringify!(c2)
-        )
-    );
+    fn test_field_c1() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<
+                    foo__bindgen_ty_1__bindgen_ty_1,
+                >::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).c1) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(foo__bindgen_ty_1__bindgen_ty_1),
+                "::",
+                stringify!(c1)
+            )
+        );
+    }
+    test_field_c1();
+    fn test_field_c2() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<
+                    foo__bindgen_ty_1__bindgen_ty_1,
+                >::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).c2) as usize - ptr as usize
+            },
+            2usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(foo__bindgen_ty_1__bindgen_ty_1),
+                "::",
+                stringify!(c2)
+            )
+        );
+    }
+    test_field_c2();
 }
 impl Clone for foo__bindgen_ty_1__bindgen_ty_1 {
     fn clone(&self) -> Self {
@@ -138,70 +144,82 @@ fn bindgen_test_layout_foo__bindgen_ty_1__bindgen_ty_2() {
         1usize,
         concat!("Alignment of ", stringify!(foo__bindgen_ty_1__bindgen_ty_2))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<
-                foo__bindgen_ty_1__bindgen_ty_2,
-            >::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).d1) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(foo__bindgen_ty_1__bindgen_ty_2),
-            "::",
-            stringify!(d1)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<
-                foo__bindgen_ty_1__bindgen_ty_2,
-            >::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).d2) as usize - ptr as usize
-        },
-        1usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(foo__bindgen_ty_1__bindgen_ty_2),
-            "::",
-            stringify!(d2)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<
-                foo__bindgen_ty_1__bindgen_ty_2,
-            >::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).d3) as usize - ptr as usize
-        },
-        2usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(foo__bindgen_ty_1__bindgen_ty_2),
-            "::",
-            stringify!(d3)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<
-                foo__bindgen_ty_1__bindgen_ty_2,
-            >::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).d4) as usize - ptr as usize
-        },
-        3usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(foo__bindgen_ty_1__bindgen_ty_2),
-            "::",
-            stringify!(d4)
-        )
-    );
+    fn test_field_d1() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<
+                    foo__bindgen_ty_1__bindgen_ty_2,
+                >::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).d1) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(foo__bindgen_ty_1__bindgen_ty_2),
+                "::",
+                stringify!(d1)
+            )
+        );
+    }
+    test_field_d1();
+    fn test_field_d2() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<
+                    foo__bindgen_ty_1__bindgen_ty_2,
+                >::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).d2) as usize - ptr as usize
+            },
+            1usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(foo__bindgen_ty_1__bindgen_ty_2),
+                "::",
+                stringify!(d2)
+            )
+        );
+    }
+    test_field_d2();
+    fn test_field_d3() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<
+                    foo__bindgen_ty_1__bindgen_ty_2,
+                >::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).d3) as usize - ptr as usize
+            },
+            2usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(foo__bindgen_ty_1__bindgen_ty_2),
+                "::",
+                stringify!(d3)
+            )
+        );
+    }
+    test_field_d3();
+    fn test_field_d4() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<
+                    foo__bindgen_ty_1__bindgen_ty_2,
+                >::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).d4) as usize - ptr as usize
+            },
+            3usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(foo__bindgen_ty_1__bindgen_ty_2),
+                "::",
+                stringify!(d4)
+            )
+        );
+    }
+    test_field_d4();
 }
 impl Clone for foo__bindgen_ty_1__bindgen_ty_2 {
     fn clone(&self) -> Self {
@@ -220,20 +238,24 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
         4usize,
         concat!("Alignment of ", stringify!(foo__bindgen_ty_1))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<foo__bindgen_ty_1>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(foo__bindgen_ty_1),
-            "::",
-            stringify!(b)
-        )
-    );
+    fn test_field_b() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<foo__bindgen_ty_1>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(foo__bindgen_ty_1),
+                "::",
+                stringify!(b)
+            )
+        );
+    }
+    test_field_b();
 }
 impl Clone for foo__bindgen_ty_1 {
     fn clone(&self) -> Self {
@@ -252,15 +274,18 @@ fn bindgen_test_layout_foo() {
         4usize,
         concat!("Alignment of ", stringify!(foo))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<foo>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
-        0usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(a))
-    );
+    fn test_field_a() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<foo>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+            },
+            0usize,
+            concat!("Offset of field: ", stringify!(foo), "::", stringify!(a))
+        );
+    }
+    test_field_a();
 }
 impl Clone for foo {
     fn clone(&self) -> Self {

--- a/tests/expectations/tests/struct_with_packing.rs
+++ b/tests/expectations/tests/struct_with_packing.rs
@@ -23,22 +23,28 @@ fn bindgen_test_layout_a() {
         1usize,
         concat!("Alignment of ", stringify!(a))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<a>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-        },
-        0usize,
-        concat!("Offset of field: ", stringify!(a), "::", stringify!(b))
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<a>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).c) as usize - ptr as usize
-        },
-        1usize,
-        concat!("Offset of field: ", stringify!(a), "::", stringify!(c))
-    );
+    fn test_field_b() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<a>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
+            },
+            0usize,
+            concat!("Offset of field: ", stringify!(a), "::", stringify!(b))
+        );
+    }
+    test_field_b();
+    fn test_field_c() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<a>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).c) as usize - ptr as usize
+            },
+            1usize,
+            concat!("Offset of field: ", stringify!(a), "::", stringify!(c))
+        );
+    }
+    test_field_c();
 }

--- a/tests/expectations/tests/struct_with_struct.rs
+++ b/tests/expectations/tests/struct_with_struct.rs
@@ -28,34 +28,42 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
         4usize,
         concat!("Alignment of ", stringify!(foo__bindgen_ty_1))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<foo__bindgen_ty_1>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(foo__bindgen_ty_1),
-            "::",
-            stringify!(x)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<foo__bindgen_ty_1>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).y) as usize - ptr as usize
-        },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(foo__bindgen_ty_1),
-            "::",
-            stringify!(y)
-        )
-    );
+    fn test_field_x() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<foo__bindgen_ty_1>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(foo__bindgen_ty_1),
+                "::",
+                stringify!(x)
+            )
+        );
+    }
+    test_field_x();
+    fn test_field_y() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<foo__bindgen_ty_1>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).y) as usize - ptr as usize
+            },
+            4usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(foo__bindgen_ty_1),
+                "::",
+                stringify!(y)
+            )
+        );
+    }
+    test_field_y();
 }
 #[test]
 fn bindgen_test_layout_foo() {
@@ -69,13 +77,21 @@ fn bindgen_test_layout_foo() {
         4usize,
         concat!("Alignment of ", stringify!(foo))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<foo>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
-        },
-        0usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar))
-    );
+    fn test_field_bar() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<foo>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(foo),
+                "::",
+                stringify!(bar)
+            )
+        );
+    }
+    test_field_bar();
 }

--- a/tests/expectations/tests/template.rs
+++ b/tests/expectations/tests/template.rs
@@ -78,222 +78,276 @@ fn bindgen_test_layout_C() {
         8usize,
         concat!("Alignment of ", stringify!(C))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<C>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mB) as usize - ptr as usize
-        },
-        0usize,
-        concat!("Offset of field: ", stringify!(C), "::", stringify!(mB))
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<C>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mBConstPtr) as usize - ptr as usize
-        },
-        8usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C),
-            "::",
-            stringify!(mBConstPtr)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<C>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mBConstStructPtr) as usize -
-                ptr as usize
-        },
-        16usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C),
-            "::",
-            stringify!(mBConstStructPtr)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<C>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mBConstStructPtrArray) as usize -
-                ptr as usize
-        },
-        24usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C),
-            "::",
-            stringify!(mBConstStructPtrArray)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<C>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mBConst) as usize - ptr as usize
-        },
-        32usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C),
-            "::",
-            stringify!(mBConst)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<C>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mBVolatile) as usize - ptr as usize
-        },
-        36usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C),
-            "::",
-            stringify!(mBVolatile)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<C>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mBConstBool) as usize - ptr as usize
-        },
-        40usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C),
-            "::",
-            stringify!(mBConstBool)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<C>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mBConstChar) as usize - ptr as usize
-        },
-        42usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C),
-            "::",
-            stringify!(mBConstChar)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<C>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mBArray) as usize - ptr as usize
-        },
-        44usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C),
-            "::",
-            stringify!(mBArray)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<C>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mBPtrArray) as usize - ptr as usize
-        },
-        48usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C),
-            "::",
-            stringify!(mBPtrArray)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<C>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mBArrayPtr) as usize - ptr as usize
-        },
-        56usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C),
-            "::",
-            stringify!(mBArrayPtr)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<C>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mBRef) as usize - ptr as usize
-        },
-        64usize,
-        concat!("Offset of field: ", stringify!(C), "::", stringify!(mBRef))
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<C>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mBConstRef) as usize - ptr as usize
-        },
-        72usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C),
-            "::",
-            stringify!(mBConstRef)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<C>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mPtrRef) as usize - ptr as usize
-        },
-        80usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C),
-            "::",
-            stringify!(mPtrRef)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<C>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mArrayRef) as usize - ptr as usize
-        },
-        88usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C),
-            "::",
-            stringify!(mArrayRef)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<C>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mBConstArray) as usize - ptr as usize
-        },
-        96usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C),
-            "::",
-            stringify!(mBConstArray)
-        )
-    );
+    fn test_field_mB() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<C>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).mB) as usize - ptr as usize
+            },
+            0usize,
+            concat!("Offset of field: ", stringify!(C), "::", stringify!(mB))
+        );
+    }
+    test_field_mB();
+    fn test_field_mBConstPtr() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<C>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).mBConstPtr) as usize - ptr as usize
+            },
+            8usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(C),
+                "::",
+                stringify!(mBConstPtr)
+            )
+        );
+    }
+    test_field_mBConstPtr();
+    fn test_field_mBConstStructPtr() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<C>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).mBConstStructPtr) as usize -
+                    ptr as usize
+            },
+            16usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(C),
+                "::",
+                stringify!(mBConstStructPtr)
+            )
+        );
+    }
+    test_field_mBConstStructPtr();
+    fn test_field_mBConstStructPtrArray() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<C>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).mBConstStructPtrArray) as usize -
+                    ptr as usize
+            },
+            24usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(C),
+                "::",
+                stringify!(mBConstStructPtrArray)
+            )
+        );
+    }
+    test_field_mBConstStructPtrArray();
+    fn test_field_mBConst() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<C>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).mBConst) as usize - ptr as usize
+            },
+            32usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(C),
+                "::",
+                stringify!(mBConst)
+            )
+        );
+    }
+    test_field_mBConst();
+    fn test_field_mBVolatile() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<C>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).mBVolatile) as usize - ptr as usize
+            },
+            36usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(C),
+                "::",
+                stringify!(mBVolatile)
+            )
+        );
+    }
+    test_field_mBVolatile();
+    fn test_field_mBConstBool() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<C>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).mBConstBool) as usize - ptr as usize
+            },
+            40usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(C),
+                "::",
+                stringify!(mBConstBool)
+            )
+        );
+    }
+    test_field_mBConstBool();
+    fn test_field_mBConstChar() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<C>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).mBConstChar) as usize - ptr as usize
+            },
+            42usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(C),
+                "::",
+                stringify!(mBConstChar)
+            )
+        );
+    }
+    test_field_mBConstChar();
+    fn test_field_mBArray() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<C>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).mBArray) as usize - ptr as usize
+            },
+            44usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(C),
+                "::",
+                stringify!(mBArray)
+            )
+        );
+    }
+    test_field_mBArray();
+    fn test_field_mBPtrArray() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<C>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).mBPtrArray) as usize - ptr as usize
+            },
+            48usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(C),
+                "::",
+                stringify!(mBPtrArray)
+            )
+        );
+    }
+    test_field_mBPtrArray();
+    fn test_field_mBArrayPtr() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<C>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).mBArrayPtr) as usize - ptr as usize
+            },
+            56usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(C),
+                "::",
+                stringify!(mBArrayPtr)
+            )
+        );
+    }
+    test_field_mBArrayPtr();
+    fn test_field_mBRef() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<C>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).mBRef) as usize - ptr as usize
+            },
+            64usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(C),
+                "::",
+                stringify!(mBRef)
+            )
+        );
+    }
+    test_field_mBRef();
+    fn test_field_mBConstRef() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<C>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).mBConstRef) as usize - ptr as usize
+            },
+            72usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(C),
+                "::",
+                stringify!(mBConstRef)
+            )
+        );
+    }
+    test_field_mBConstRef();
+    fn test_field_mPtrRef() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<C>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).mPtrRef) as usize - ptr as usize
+            },
+            80usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(C),
+                "::",
+                stringify!(mPtrRef)
+            )
+        );
+    }
+    test_field_mPtrRef();
+    fn test_field_mArrayRef() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<C>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).mArrayRef) as usize - ptr as usize
+            },
+            88usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(C),
+                "::",
+                stringify!(mArrayRef)
+            )
+        );
+    }
+    test_field_mArrayRef();
+    fn test_field_mBConstArray() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<C>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).mBConstArray) as usize -
+                    ptr as usize
+            },
+            96usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(C),
+                "::",
+                stringify!(mBConstArray)
+            )
+        );
+    }
+    test_field_mBConstArray();
 }
 impl Default for C {
     fn default() -> Self {
@@ -369,20 +423,24 @@ fn bindgen_test_layout_RootedContainer() {
         8usize,
         concat!("Alignment of ", stringify!(RootedContainer))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<RootedContainer>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).root) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(RootedContainer),
-            "::",
-            stringify!(root)
-        )
-    );
+    fn test_field_root() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<RootedContainer>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).root) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(RootedContainer),
+                "::",
+                stringify!(root)
+            )
+        );
+    }
+    test_field_root();
 }
 impl Default for RootedContainer {
     fn default() -> Self {
@@ -426,21 +484,24 @@ fn bindgen_test_layout_PODButContainsDtor() {
         4usize,
         concat!("Alignment of ", stringify!(PODButContainsDtor))
     );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<PODButContainsDtor>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).member) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(PODButContainsDtor),
-            "::",
-            stringify!(member)
-        )
-    );
+    fn test_field_member() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<PODButContainsDtor>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).member) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(PODButContainsDtor),
+                "::",
+                stringify!(member)
+            )
+        );
+    }
+    test_field_member();
 }
 impl Default for PODButContainsDtor {
     fn default() -> Self {
@@ -474,20 +535,24 @@ fn bindgen_test_layout_POD() {
         4usize,
         concat!("Alignment of ", stringify!(POD))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<POD>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).opaque_member) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(POD),
-            "::",
-            stringify!(opaque_member)
-        )
-    );
+    fn test_field_opaque_member() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<POD>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).opaque_member) as usize -
+                    ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(POD),
+                "::",
+                stringify!(opaque_member)
+            )
+        );
+    }
+    test_field_opaque_member();
 }
 /// <div rustbindgen replaces="NestedReplaced"></div>
 #[repr(C)]

--- a/tests/expectations/tests/test_mixed_header_and_header_contents.rs
+++ b/tests/expectations/tests/test_mixed_header_and_header_contents.rs
@@ -43,117 +43,198 @@ fn bindgen_test_layout_Test() {
         1usize,
         concat!("Alignment of ", stringify!(Test))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Test>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).ch) as usize - ptr as usize
-        },
-        0usize,
-        concat!("Offset of field: ", stringify!(Test), "::", stringify!(ch))
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Test>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).u) as usize - ptr as usize
-        },
-        1usize,
-        concat!("Offset of field: ", stringify!(Test), "::", stringify!(u))
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Test>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize
-        },
-        2usize,
-        concat!("Offset of field: ", stringify!(Test), "::", stringify!(d))
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Test>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).cch) as usize - ptr as usize
-        },
-        3usize,
-        concat!("Offset of field: ", stringify!(Test), "::", stringify!(cch))
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Test>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).cu) as usize - ptr as usize
-        },
-        4usize,
-        concat!("Offset of field: ", stringify!(Test), "::", stringify!(cu))
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Test>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).cd) as usize - ptr as usize
-        },
-        5usize,
-        concat!("Offset of field: ", stringify!(Test), "::", stringify!(cd))
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Test>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).Cch) as usize - ptr as usize
-        },
-        6usize,
-        concat!("Offset of field: ", stringify!(Test), "::", stringify!(Cch))
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Test>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).Cu) as usize - ptr as usize
-        },
-        7usize,
-        concat!("Offset of field: ", stringify!(Test), "::", stringify!(Cu))
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Test>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).Cd) as usize - ptr as usize
-        },
-        8usize,
-        concat!("Offset of field: ", stringify!(Test), "::", stringify!(Cd))
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Test>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).Ccch) as usize - ptr as usize
-        },
-        9usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(Test),
-            "::",
-            stringify!(Ccch)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Test>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).Ccu) as usize - ptr as usize
-        },
-        10usize,
-        concat!("Offset of field: ", stringify!(Test), "::", stringify!(Ccu))
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Test>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).Ccd) as usize - ptr as usize
-        },
-        11usize,
-        concat!("Offset of field: ", stringify!(Test), "::", stringify!(Ccd))
-    );
+    fn test_field_ch() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Test>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).ch) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(Test),
+                "::",
+                stringify!(ch)
+            )
+        );
+    }
+    test_field_ch();
+    fn test_field_u() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Test>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).u) as usize - ptr as usize
+            },
+            1usize,
+            concat!("Offset of field: ", stringify!(Test), "::", stringify!(u))
+        );
+    }
+    test_field_u();
+    fn test_field_d() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Test>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize
+            },
+            2usize,
+            concat!("Offset of field: ", stringify!(Test), "::", stringify!(d))
+        );
+    }
+    test_field_d();
+    fn test_field_cch() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Test>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).cch) as usize - ptr as usize
+            },
+            3usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(Test),
+                "::",
+                stringify!(cch)
+            )
+        );
+    }
+    test_field_cch();
+    fn test_field_cu() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Test>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).cu) as usize - ptr as usize
+            },
+            4usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(Test),
+                "::",
+                stringify!(cu)
+            )
+        );
+    }
+    test_field_cu();
+    fn test_field_cd() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Test>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).cd) as usize - ptr as usize
+            },
+            5usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(Test),
+                "::",
+                stringify!(cd)
+            )
+        );
+    }
+    test_field_cd();
+    fn test_field_Cch() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Test>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).Cch) as usize - ptr as usize
+            },
+            6usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(Test),
+                "::",
+                stringify!(Cch)
+            )
+        );
+    }
+    test_field_Cch();
+    fn test_field_Cu() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Test>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).Cu) as usize - ptr as usize
+            },
+            7usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(Test),
+                "::",
+                stringify!(Cu)
+            )
+        );
+    }
+    test_field_Cu();
+    fn test_field_Cd() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Test>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).Cd) as usize - ptr as usize
+            },
+            8usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(Test),
+                "::",
+                stringify!(Cd)
+            )
+        );
+    }
+    test_field_Cd();
+    fn test_field_Ccch() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Test>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).Ccch) as usize - ptr as usize
+            },
+            9usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(Test),
+                "::",
+                stringify!(Ccch)
+            )
+        );
+    }
+    test_field_Ccch();
+    fn test_field_Ccu() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Test>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).Ccu) as usize - ptr as usize
+            },
+            10usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(Test),
+                "::",
+                stringify!(Ccu)
+            )
+        );
+    }
+    test_field_Ccu();
+    fn test_field_Ccd() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Test>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).Ccd) as usize - ptr as usize
+            },
+            11usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(Test),
+                "::",
+                stringify!(Ccd)
+            )
+        );
+    }
+    test_field_Ccd();
 }

--- a/tests/expectations/tests/test_multiple_header_calls_in_builder.rs
+++ b/tests/expectations/tests/test_multiple_header_calls_in_builder.rs
@@ -37,117 +37,198 @@ fn bindgen_test_layout_Test() {
         1usize,
         concat!("Alignment of ", stringify!(Test))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Test>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).ch) as usize - ptr as usize
-        },
-        0usize,
-        concat!("Offset of field: ", stringify!(Test), "::", stringify!(ch))
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Test>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).u) as usize - ptr as usize
-        },
-        1usize,
-        concat!("Offset of field: ", stringify!(Test), "::", stringify!(u))
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Test>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize
-        },
-        2usize,
-        concat!("Offset of field: ", stringify!(Test), "::", stringify!(d))
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Test>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).cch) as usize - ptr as usize
-        },
-        3usize,
-        concat!("Offset of field: ", stringify!(Test), "::", stringify!(cch))
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Test>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).cu) as usize - ptr as usize
-        },
-        4usize,
-        concat!("Offset of field: ", stringify!(Test), "::", stringify!(cu))
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Test>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).cd) as usize - ptr as usize
-        },
-        5usize,
-        concat!("Offset of field: ", stringify!(Test), "::", stringify!(cd))
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Test>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).Cch) as usize - ptr as usize
-        },
-        6usize,
-        concat!("Offset of field: ", stringify!(Test), "::", stringify!(Cch))
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Test>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).Cu) as usize - ptr as usize
-        },
-        7usize,
-        concat!("Offset of field: ", stringify!(Test), "::", stringify!(Cu))
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Test>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).Cd) as usize - ptr as usize
-        },
-        8usize,
-        concat!("Offset of field: ", stringify!(Test), "::", stringify!(Cd))
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Test>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).Ccch) as usize - ptr as usize
-        },
-        9usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(Test),
-            "::",
-            stringify!(Ccch)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Test>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).Ccu) as usize - ptr as usize
-        },
-        10usize,
-        concat!("Offset of field: ", stringify!(Test), "::", stringify!(Ccu))
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Test>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).Ccd) as usize - ptr as usize
-        },
-        11usize,
-        concat!("Offset of field: ", stringify!(Test), "::", stringify!(Ccd))
-    );
+    fn test_field_ch() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Test>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).ch) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(Test),
+                "::",
+                stringify!(ch)
+            )
+        );
+    }
+    test_field_ch();
+    fn test_field_u() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Test>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).u) as usize - ptr as usize
+            },
+            1usize,
+            concat!("Offset of field: ", stringify!(Test), "::", stringify!(u))
+        );
+    }
+    test_field_u();
+    fn test_field_d() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Test>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize
+            },
+            2usize,
+            concat!("Offset of field: ", stringify!(Test), "::", stringify!(d))
+        );
+    }
+    test_field_d();
+    fn test_field_cch() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Test>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).cch) as usize - ptr as usize
+            },
+            3usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(Test),
+                "::",
+                stringify!(cch)
+            )
+        );
+    }
+    test_field_cch();
+    fn test_field_cu() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Test>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).cu) as usize - ptr as usize
+            },
+            4usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(Test),
+                "::",
+                stringify!(cu)
+            )
+        );
+    }
+    test_field_cu();
+    fn test_field_cd() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Test>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).cd) as usize - ptr as usize
+            },
+            5usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(Test),
+                "::",
+                stringify!(cd)
+            )
+        );
+    }
+    test_field_cd();
+    fn test_field_Cch() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Test>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).Cch) as usize - ptr as usize
+            },
+            6usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(Test),
+                "::",
+                stringify!(Cch)
+            )
+        );
+    }
+    test_field_Cch();
+    fn test_field_Cu() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Test>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).Cu) as usize - ptr as usize
+            },
+            7usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(Test),
+                "::",
+                stringify!(Cu)
+            )
+        );
+    }
+    test_field_Cu();
+    fn test_field_Cd() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Test>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).Cd) as usize - ptr as usize
+            },
+            8usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(Test),
+                "::",
+                stringify!(Cd)
+            )
+        );
+    }
+    test_field_Cd();
+    fn test_field_Ccch() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Test>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).Ccch) as usize - ptr as usize
+            },
+            9usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(Test),
+                "::",
+                stringify!(Ccch)
+            )
+        );
+    }
+    test_field_Ccch();
+    fn test_field_Ccu() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Test>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).Ccu) as usize - ptr as usize
+            },
+            10usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(Test),
+                "::",
+                stringify!(Ccu)
+            )
+        );
+    }
+    test_field_Ccu();
+    fn test_field_Ccd() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Test>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).Ccd) as usize - ptr as usize
+            },
+            11usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(Test),
+                "::",
+                stringify!(Ccd)
+            )
+        );
+    }
+    test_field_Ccd();
 }

--- a/tests/expectations/tests/timex.rs
+++ b/tests/expectations/tests/timex.rs
@@ -110,20 +110,23 @@ fn bindgen_test_layout_timex() {
         4usize,
         concat!("Alignment of ", stringify!(timex))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<timex>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).tai) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(timex),
-            "::",
-            stringify!(tai)
-        )
-    );
+    fn test_field_tai() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<timex>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).tai) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(timex),
+                "::",
+                stringify!(tai)
+            )
+        );
+    }
+    test_field_tai();
 }
 impl Default for timex {
     fn default() -> Self {
@@ -153,20 +156,23 @@ fn bindgen_test_layout_timex_named() {
         4usize,
         concat!("Alignment of ", stringify!(timex_named))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<timex_named>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).tai) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(timex_named),
-            "::",
-            stringify!(tai)
-        )
-    );
+    fn test_field_tai() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<timex_named>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).tai) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(timex_named),
+                "::",
+                stringify!(tai)
+            )
+        );
+    }
+    test_field_tai();
 }
 impl Default for timex_named {
     fn default() -> Self {

--- a/tests/expectations/tests/type-referenced-by-allowlisted-function.rs
+++ b/tests/expectations/tests/type-referenced-by-allowlisted-function.rs
@@ -22,20 +22,23 @@ fn bindgen_test_layout_dl_phdr_info() {
         4usize,
         concat!("Alignment of ", stringify!(dl_phdr_info))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<dl_phdr_info>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(dl_phdr_info),
-            "::",
-            stringify!(x)
-        )
-    );
+    fn test_field_x() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<dl_phdr_info>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(dl_phdr_info),
+                "::",
+                stringify!(x)
+            )
+        );
+    }
+    test_field_x();
 }
 extern "C" {
     pub fn dl_iterate_phdr(arg1: *mut dl_phdr_info) -> ::std::os::raw::c_int;

--- a/tests/expectations/tests/typeref.rs
+++ b/tests/expectations/tests/typeref.rs
@@ -22,21 +22,24 @@ fn bindgen_test_layout_mozilla_FragmentOrURL() {
         1usize,
         concat!("Alignment of ", stringify!(mozilla_FragmentOrURL))
     );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<mozilla_FragmentOrURL>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mIsLocalRef) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(mozilla_FragmentOrURL),
-            "::",
-            stringify!(mIsLocalRef)
-        )
-    );
+    fn test_field_mIsLocalRef() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<mozilla_FragmentOrURL>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).mIsLocalRef) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(mozilla_FragmentOrURL),
+                "::",
+                stringify!(mIsLocalRef)
+            )
+        );
+    }
+    test_field_mIsLocalRef();
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
@@ -100,15 +103,23 @@ fn bindgen_test_layout_Bar() {
         8usize,
         concat!("Alignment of ", stringify!(Bar))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Bar>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mFoo) as usize - ptr as usize
-        },
-        0usize,
-        concat!("Offset of field: ", stringify!(Bar), "::", stringify!(mFoo))
-    );
+    fn test_field_mFoo() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Bar>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).mFoo) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(Bar),
+                "::",
+                stringify!(mFoo)
+            )
+        );
+    }
+    test_field_mFoo();
 }
 impl Default for Bar {
     fn default() -> Self {
@@ -135,20 +146,23 @@ fn bindgen_test_layout_nsFoo() {
         8usize,
         concat!("Alignment of ", stringify!(nsFoo))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<nsFoo>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mBar) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(nsFoo),
-            "::",
-            stringify!(mBar)
-        )
-    );
+    fn test_field_mBar() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<nsFoo>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).mBar) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(nsFoo),
+                "::",
+                stringify!(mBar)
+            )
+        );
+    }
+    test_field_mBar();
 }
 impl Default for nsFoo {
     fn default() -> Self {

--- a/tests/expectations/tests/typeref_1_0.rs
+++ b/tests/expectations/tests/typeref_1_0.rs
@@ -65,21 +65,24 @@ fn bindgen_test_layout_mozilla_FragmentOrURL() {
         1usize,
         concat!("Alignment of ", stringify!(mozilla_FragmentOrURL))
     );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<mozilla_FragmentOrURL>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mIsLocalRef) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(mozilla_FragmentOrURL),
-            "::",
-            stringify!(mIsLocalRef)
-        )
-    );
+    fn test_field_mIsLocalRef() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<mozilla_FragmentOrURL>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).mIsLocalRef) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(mozilla_FragmentOrURL),
+                "::",
+                stringify!(mIsLocalRef)
+            )
+        );
+    }
+    test_field_mIsLocalRef();
 }
 impl Clone for mozilla_FragmentOrURL {
     fn clone(&self) -> Self {
@@ -138,15 +141,23 @@ fn bindgen_test_layout_Bar() {
         8usize,
         concat!("Alignment of ", stringify!(Bar))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Bar>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mFoo) as usize - ptr as usize
-        },
-        0usize,
-        concat!("Offset of field: ", stringify!(Bar), "::", stringify!(mFoo))
-    );
+    fn test_field_mFoo() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Bar>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).mFoo) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(Bar),
+                "::",
+                stringify!(mFoo)
+            )
+        );
+    }
+    test_field_mFoo();
 }
 impl Clone for Bar {
     fn clone(&self) -> Self {
@@ -179,20 +190,23 @@ fn bindgen_test_layout_nsFoo() {
         8usize,
         concat!("Alignment of ", stringify!(nsFoo))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<nsFoo>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mBar) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(nsFoo),
-            "::",
-            stringify!(mBar)
-        )
-    );
+    fn test_field_mBar() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<nsFoo>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).mBar) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(nsFoo),
+                "::",
+                stringify!(mBar)
+            )
+        );
+    }
+    test_field_mBar();
 }
 impl Clone for nsFoo {
     fn clone(&self) -> Self {

--- a/tests/expectations/tests/underscore.rs
+++ b/tests/expectations/tests/underscore.rs
@@ -23,13 +23,21 @@ fn bindgen_test_layout_ptr_t() {
         1usize,
         concat!("Alignment of ", stringify!(ptr_t))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<ptr_t>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).__) as usize - ptr as usize
-        },
-        0usize,
-        concat!("Offset of field: ", stringify!(ptr_t), "::", stringify!(__))
-    );
+    fn test_field__() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<ptr_t>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).__) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(ptr_t),
+                "::",
+                stringify!(__)
+            )
+        );
+    }
+    test_field__();
 }

--- a/tests/expectations/tests/union-align.rs
+++ b/tests/expectations/tests/union-align.rs
@@ -23,15 +23,23 @@ fn bindgen_test_layout_Bar() {
         16usize,
         concat!("Alignment of ", stringify!(Bar))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Bar>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize
-        },
-        0usize,
-        concat!("Offset of field: ", stringify!(Bar), "::", stringify!(foo))
-    );
+    fn test_field_foo() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Bar>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(Bar),
+                "::",
+                stringify!(foo)
+            )
+        );
+    }
+    test_field_foo();
 }
 impl Default for Bar {
     fn default() -> Self {
@@ -60,15 +68,23 @@ fn bindgen_test_layout_Baz() {
         16usize,
         concat!("Alignment of ", stringify!(Baz))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Baz>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
-        },
-        0usize,
-        concat!("Offset of field: ", stringify!(Baz), "::", stringify!(bar))
-    );
+    fn test_field_bar() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Baz>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(Baz),
+                "::",
+                stringify!(bar)
+            )
+        );
+    }
+    test_field_bar();
 }
 impl Default for Baz {
     fn default() -> Self {

--- a/tests/expectations/tests/union-in-ns.rs
+++ b/tests/expectations/tests/union-in-ns.rs
@@ -26,20 +26,23 @@ pub mod root {
             4usize,
             concat!("Alignment of ", stringify!(bar))
         );
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<bar>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(bar),
-                "::",
-                stringify!(baz)
-            )
-        );
+        fn test_field_baz() {
+            assert_eq!(
+                unsafe {
+                    let uninit = ::std::mem::MaybeUninit::<bar>::uninit();
+                    let ptr = uninit.as_ptr();
+                    ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize
+                },
+                0usize,
+                concat!(
+                    "Offset of field: ",
+                    stringify!(bar),
+                    "::",
+                    stringify!(baz)
+                )
+            );
+        }
+        test_field_baz();
     }
     impl Default for bar {
         fn default() -> Self {

--- a/tests/expectations/tests/union-in-ns_1_0.rs
+++ b/tests/expectations/tests/union-in-ns_1_0.rs
@@ -73,20 +73,23 @@ pub mod root {
             4usize,
             concat!("Alignment of ", stringify!(bar))
         );
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<bar>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(bar),
-                "::",
-                stringify!(baz)
-            )
-        );
+        fn test_field_baz() {
+            assert_eq!(
+                unsafe {
+                    let uninit = ::std::mem::MaybeUninit::<bar>::uninit();
+                    let ptr = uninit.as_ptr();
+                    ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize
+                },
+                0usize,
+                concat!(
+                    "Offset of field: ",
+                    stringify!(bar),
+                    "::",
+                    stringify!(baz)
+                )
+            );
+        }
+        test_field_baz();
     }
     impl Clone for bar {
         fn clone(&self) -> Self {

--- a/tests/expectations/tests/union_dtor.rs
+++ b/tests/expectations/tests/union_dtor.rs
@@ -22,34 +22,40 @@ fn bindgen_test_layout_UnionWithDtor() {
         8usize,
         concat!("Alignment of ", stringify!(UnionWithDtor))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<UnionWithDtor>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mFoo) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(UnionWithDtor),
-            "::",
-            stringify!(mFoo)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<UnionWithDtor>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mBar) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(UnionWithDtor),
-            "::",
-            stringify!(mBar)
-        )
-    );
+    fn test_field_mFoo() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<UnionWithDtor>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).mFoo) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(UnionWithDtor),
+                "::",
+                stringify!(mFoo)
+            )
+        );
+    }
+    test_field_mFoo();
+    fn test_field_mBar() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<UnionWithDtor>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).mBar) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(UnionWithDtor),
+                "::",
+                stringify!(mBar)
+            )
+        );
+    }
+    test_field_mBar();
 }
 extern "C" {
     #[link_name = "\u{1}_ZN13UnionWithDtorD1Ev"]

--- a/tests/expectations/tests/union_dtor_1_0.rs
+++ b/tests/expectations/tests/union_dtor_1_0.rs
@@ -67,34 +67,40 @@ fn bindgen_test_layout_UnionWithDtor() {
         8usize,
         concat!("Alignment of ", stringify!(UnionWithDtor))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<UnionWithDtor>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mFoo) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(UnionWithDtor),
-            "::",
-            stringify!(mFoo)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<UnionWithDtor>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mBar) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(UnionWithDtor),
-            "::",
-            stringify!(mBar)
-        )
-    );
+    fn test_field_mFoo() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<UnionWithDtor>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).mFoo) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(UnionWithDtor),
+                "::",
+                stringify!(mFoo)
+            )
+        );
+    }
+    test_field_mFoo();
+    fn test_field_mBar() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<UnionWithDtor>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).mBar) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(UnionWithDtor),
+                "::",
+                stringify!(mBar)
+            )
+        );
+    }
+    test_field_mBar();
 }
 extern "C" {
     #[link_name = "\u{1}_ZN13UnionWithDtorD1Ev"]

--- a/tests/expectations/tests/union_fields.rs
+++ b/tests/expectations/tests/union_fields.rs
@@ -24,48 +24,57 @@ fn bindgen_test_layout_nsStyleUnion() {
         8usize,
         concat!("Alignment of ", stringify!(nsStyleUnion))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<nsStyleUnion>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mInt) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(nsStyleUnion),
-            "::",
-            stringify!(mInt)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<nsStyleUnion>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mFloat) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(nsStyleUnion),
-            "::",
-            stringify!(mFloat)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<nsStyleUnion>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mPointer) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(nsStyleUnion),
-            "::",
-            stringify!(mPointer)
-        )
-    );
+    fn test_field_mInt() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<nsStyleUnion>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).mInt) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(nsStyleUnion),
+                "::",
+                stringify!(mInt)
+            )
+        );
+    }
+    test_field_mInt();
+    fn test_field_mFloat() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<nsStyleUnion>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).mFloat) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(nsStyleUnion),
+                "::",
+                stringify!(mFloat)
+            )
+        );
+    }
+    test_field_mFloat();
+    fn test_field_mPointer() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<nsStyleUnion>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).mPointer) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(nsStyleUnion),
+                "::",
+                stringify!(mPointer)
+            )
+        );
+    }
+    test_field_mPointer();
 }
 impl Default for nsStyleUnion {
     fn default() -> Self {

--- a/tests/expectations/tests/union_fields_1_0.rs
+++ b/tests/expectations/tests/union_fields_1_0.rs
@@ -68,48 +68,57 @@ fn bindgen_test_layout_nsStyleUnion() {
         8usize,
         concat!("Alignment of ", stringify!(nsStyleUnion))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<nsStyleUnion>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mInt) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(nsStyleUnion),
-            "::",
-            stringify!(mInt)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<nsStyleUnion>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mFloat) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(nsStyleUnion),
-            "::",
-            stringify!(mFloat)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<nsStyleUnion>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mPointer) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(nsStyleUnion),
-            "::",
-            stringify!(mPointer)
-        )
-    );
+    fn test_field_mInt() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<nsStyleUnion>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).mInt) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(nsStyleUnion),
+                "::",
+                stringify!(mInt)
+            )
+        );
+    }
+    test_field_mInt();
+    fn test_field_mFloat() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<nsStyleUnion>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).mFloat) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(nsStyleUnion),
+                "::",
+                stringify!(mFloat)
+            )
+        );
+    }
+    test_field_mFloat();
+    fn test_field_mPointer() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<nsStyleUnion>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).mPointer) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(nsStyleUnion),
+                "::",
+                stringify!(mPointer)
+            )
+        );
+    }
+    test_field_mPointer();
 }
 impl Clone for nsStyleUnion {
     fn clone(&self) -> Self {

--- a/tests/expectations/tests/union_with_anon_struct.rs
+++ b/tests/expectations/tests/union_with_anon_struct.rs
@@ -28,34 +28,42 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
         4usize,
         concat!("Alignment of ", stringify!(foo__bindgen_ty_1))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<foo__bindgen_ty_1>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(foo__bindgen_ty_1),
-            "::",
-            stringify!(a)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<foo__bindgen_ty_1>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-        },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(foo__bindgen_ty_1),
-            "::",
-            stringify!(b)
-        )
-    );
+    fn test_field_a() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<foo__bindgen_ty_1>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(foo__bindgen_ty_1),
+                "::",
+                stringify!(a)
+            )
+        );
+    }
+    test_field_a();
+    fn test_field_b() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<foo__bindgen_ty_1>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
+            },
+            4usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(foo__bindgen_ty_1),
+                "::",
+                stringify!(b)
+            )
+        );
+    }
+    test_field_b();
 }
 #[test]
 fn bindgen_test_layout_foo() {
@@ -69,15 +77,23 @@ fn bindgen_test_layout_foo() {
         4usize,
         concat!("Alignment of ", stringify!(foo))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<foo>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
-        },
-        0usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar))
-    );
+    fn test_field_bar() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<foo>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(foo),
+                "::",
+                stringify!(bar)
+            )
+        );
+    }
+    test_field_bar();
 }
 impl Default for foo {
     fn default() -> Self {

--- a/tests/expectations/tests/union_with_anon_struct_1_0.rs
+++ b/tests/expectations/tests/union_with_anon_struct_1_0.rs
@@ -72,34 +72,42 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
         4usize,
         concat!("Alignment of ", stringify!(foo__bindgen_ty_1))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<foo__bindgen_ty_1>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(foo__bindgen_ty_1),
-            "::",
-            stringify!(a)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<foo__bindgen_ty_1>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-        },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(foo__bindgen_ty_1),
-            "::",
-            stringify!(b)
-        )
-    );
+    fn test_field_a() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<foo__bindgen_ty_1>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(foo__bindgen_ty_1),
+                "::",
+                stringify!(a)
+            )
+        );
+    }
+    test_field_a();
+    fn test_field_b() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<foo__bindgen_ty_1>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
+            },
+            4usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(foo__bindgen_ty_1),
+                "::",
+                stringify!(b)
+            )
+        );
+    }
+    test_field_b();
 }
 impl Clone for foo__bindgen_ty_1 {
     fn clone(&self) -> Self {
@@ -118,15 +126,23 @@ fn bindgen_test_layout_foo() {
         4usize,
         concat!("Alignment of ", stringify!(foo))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<foo>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
-        },
-        0usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar))
-    );
+    fn test_field_bar() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<foo>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(foo),
+                "::",
+                stringify!(bar)
+            )
+        );
+    }
+    test_field_bar();
 }
 impl Clone for foo {
     fn clone(&self) -> Self {

--- a/tests/expectations/tests/union_with_anon_struct_bitfield.rs
+++ b/tests/expectations/tests/union_with_anon_struct_bitfield.rs
@@ -174,15 +174,18 @@ fn bindgen_test_layout_foo() {
         4usize,
         concat!("Alignment of ", stringify!(foo))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<foo>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
-        0usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(a))
-    );
+    fn test_field_a() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<foo>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+            },
+            0usize,
+            concat!("Offset of field: ", stringify!(foo), "::", stringify!(a))
+        );
+    }
+    test_field_a();
 }
 impl Default for foo {
     fn default() -> Self {

--- a/tests/expectations/tests/union_with_anon_struct_bitfield_1_0.rs
+++ b/tests/expectations/tests/union_with_anon_struct_bitfield_1_0.rs
@@ -223,15 +223,18 @@ fn bindgen_test_layout_foo() {
         4usize,
         concat!("Alignment of ", stringify!(foo))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<foo>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
-        0usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(a))
-    );
+    fn test_field_a() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<foo>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+            },
+            0usize,
+            concat!("Offset of field: ", stringify!(foo), "::", stringify!(a))
+        );
+    }
+    test_field_a();
 }
 impl Clone for foo {
     fn clone(&self) -> Self {

--- a/tests/expectations/tests/union_with_anon_union.rs
+++ b/tests/expectations/tests/union_with_anon_union.rs
@@ -28,34 +28,42 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
         4usize,
         concat!("Alignment of ", stringify!(foo__bindgen_ty_1))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<foo__bindgen_ty_1>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(foo__bindgen_ty_1),
-            "::",
-            stringify!(a)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<foo__bindgen_ty_1>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(foo__bindgen_ty_1),
-            "::",
-            stringify!(b)
-        )
-    );
+    fn test_field_a() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<foo__bindgen_ty_1>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(foo__bindgen_ty_1),
+                "::",
+                stringify!(a)
+            )
+        );
+    }
+    test_field_a();
+    fn test_field_b() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<foo__bindgen_ty_1>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(foo__bindgen_ty_1),
+                "::",
+                stringify!(b)
+            )
+        );
+    }
+    test_field_b();
 }
 impl Default for foo__bindgen_ty_1 {
     fn default() -> Self {
@@ -78,15 +86,23 @@ fn bindgen_test_layout_foo() {
         4usize,
         concat!("Alignment of ", stringify!(foo))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<foo>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
-        },
-        0usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar))
-    );
+    fn test_field_bar() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<foo>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(foo),
+                "::",
+                stringify!(bar)
+            )
+        );
+    }
+    test_field_bar();
 }
 impl Default for foo {
     fn default() -> Self {

--- a/tests/expectations/tests/union_with_anon_union_1_0.rs
+++ b/tests/expectations/tests/union_with_anon_union_1_0.rs
@@ -73,34 +73,42 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
         4usize,
         concat!("Alignment of ", stringify!(foo__bindgen_ty_1))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<foo__bindgen_ty_1>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(foo__bindgen_ty_1),
-            "::",
-            stringify!(a)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<foo__bindgen_ty_1>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(foo__bindgen_ty_1),
-            "::",
-            stringify!(b)
-        )
-    );
+    fn test_field_a() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<foo__bindgen_ty_1>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(foo__bindgen_ty_1),
+                "::",
+                stringify!(a)
+            )
+        );
+    }
+    test_field_a();
+    fn test_field_b() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<foo__bindgen_ty_1>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(foo__bindgen_ty_1),
+                "::",
+                stringify!(b)
+            )
+        );
+    }
+    test_field_b();
 }
 impl Clone for foo__bindgen_ty_1 {
     fn clone(&self) -> Self {
@@ -119,15 +127,23 @@ fn bindgen_test_layout_foo() {
         4usize,
         concat!("Alignment of ", stringify!(foo))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<foo>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
-        },
-        0usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar))
-    );
+    fn test_field_bar() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<foo>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(foo),
+                "::",
+                stringify!(bar)
+            )
+        );
+    }
+    test_field_bar();
 }
 impl Clone for foo {
     fn clone(&self) -> Self {

--- a/tests/expectations/tests/union_with_anon_unnamed_struct.rs
+++ b/tests/expectations/tests/union_with_anon_unnamed_struct.rs
@@ -31,66 +31,78 @@ fn bindgen_test_layout_pixel__bindgen_ty_1() {
         1usize,
         concat!("Alignment of ", stringify!(pixel__bindgen_ty_1))
     );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<pixel__bindgen_ty_1>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).r) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(pixel__bindgen_ty_1),
-            "::",
-            stringify!(r)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<pixel__bindgen_ty_1>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).g) as usize - ptr as usize
-        },
-        1usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(pixel__bindgen_ty_1),
-            "::",
-            stringify!(g)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<pixel__bindgen_ty_1>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-        },
-        2usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(pixel__bindgen_ty_1),
-            "::",
-            stringify!(b)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<pixel__bindgen_ty_1>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
-        3usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(pixel__bindgen_ty_1),
-            "::",
-            stringify!(a)
-        )
-    );
+    fn test_field_r() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<pixel__bindgen_ty_1>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).r) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(pixel__bindgen_ty_1),
+                "::",
+                stringify!(r)
+            )
+        );
+    }
+    test_field_r();
+    fn test_field_g() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<pixel__bindgen_ty_1>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).g) as usize - ptr as usize
+            },
+            1usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(pixel__bindgen_ty_1),
+                "::",
+                stringify!(g)
+            )
+        );
+    }
+    test_field_g();
+    fn test_field_b() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<pixel__bindgen_ty_1>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
+            },
+            2usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(pixel__bindgen_ty_1),
+                "::",
+                stringify!(b)
+            )
+        );
+    }
+    test_field_b();
+    fn test_field_a() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<pixel__bindgen_ty_1>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+            },
+            3usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(pixel__bindgen_ty_1),
+                "::",
+                stringify!(a)
+            )
+        );
+    }
+    test_field_a();
 }
 #[test]
 fn bindgen_test_layout_pixel() {
@@ -104,20 +116,23 @@ fn bindgen_test_layout_pixel() {
         4usize,
         concat!("Alignment of ", stringify!(pixel))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<pixel>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).rgba) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(pixel),
-            "::",
-            stringify!(rgba)
-        )
-    );
+    fn test_field_rgba() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<pixel>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).rgba) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(pixel),
+                "::",
+                stringify!(rgba)
+            )
+        );
+    }
+    test_field_rgba();
 }
 impl Default for pixel {
     fn default() -> Self {

--- a/tests/expectations/tests/union_with_anon_unnamed_struct_1_0.rs
+++ b/tests/expectations/tests/union_with_anon_unnamed_struct_1_0.rs
@@ -75,66 +75,78 @@ fn bindgen_test_layout_pixel__bindgen_ty_1() {
         1usize,
         concat!("Alignment of ", stringify!(pixel__bindgen_ty_1))
     );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<pixel__bindgen_ty_1>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).r) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(pixel__bindgen_ty_1),
-            "::",
-            stringify!(r)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<pixel__bindgen_ty_1>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).g) as usize - ptr as usize
-        },
-        1usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(pixel__bindgen_ty_1),
-            "::",
-            stringify!(g)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<pixel__bindgen_ty_1>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-        },
-        2usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(pixel__bindgen_ty_1),
-            "::",
-            stringify!(b)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<pixel__bindgen_ty_1>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
-        3usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(pixel__bindgen_ty_1),
-            "::",
-            stringify!(a)
-        )
-    );
+    fn test_field_r() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<pixel__bindgen_ty_1>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).r) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(pixel__bindgen_ty_1),
+                "::",
+                stringify!(r)
+            )
+        );
+    }
+    test_field_r();
+    fn test_field_g() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<pixel__bindgen_ty_1>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).g) as usize - ptr as usize
+            },
+            1usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(pixel__bindgen_ty_1),
+                "::",
+                stringify!(g)
+            )
+        );
+    }
+    test_field_g();
+    fn test_field_b() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<pixel__bindgen_ty_1>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
+            },
+            2usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(pixel__bindgen_ty_1),
+                "::",
+                stringify!(b)
+            )
+        );
+    }
+    test_field_b();
+    fn test_field_a() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<pixel__bindgen_ty_1>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+            },
+            3usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(pixel__bindgen_ty_1),
+                "::",
+                stringify!(a)
+            )
+        );
+    }
+    test_field_a();
 }
 impl Clone for pixel__bindgen_ty_1 {
     fn clone(&self) -> Self {
@@ -153,20 +165,23 @@ fn bindgen_test_layout_pixel() {
         4usize,
         concat!("Alignment of ", stringify!(pixel))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<pixel>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).rgba) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(pixel),
-            "::",
-            stringify!(rgba)
-        )
-    );
+    fn test_field_rgba() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<pixel>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).rgba) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(pixel),
+                "::",
+                stringify!(rgba)
+            )
+        );
+    }
+    test_field_rgba();
 }
 impl Clone for pixel {
     fn clone(&self) -> Self {

--- a/tests/expectations/tests/union_with_anon_unnamed_union.rs
+++ b/tests/expectations/tests/union_with_anon_unnamed_union.rs
@@ -29,34 +29,42 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
         2usize,
         concat!("Alignment of ", stringify!(foo__bindgen_ty_1))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<foo__bindgen_ty_1>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(foo__bindgen_ty_1),
-            "::",
-            stringify!(b)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<foo__bindgen_ty_1>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).c) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(foo__bindgen_ty_1),
-            "::",
-            stringify!(c)
-        )
-    );
+    fn test_field_b() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<foo__bindgen_ty_1>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(foo__bindgen_ty_1),
+                "::",
+                stringify!(b)
+            )
+        );
+    }
+    test_field_b();
+    fn test_field_c() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<foo__bindgen_ty_1>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).c) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(foo__bindgen_ty_1),
+                "::",
+                stringify!(c)
+            )
+        );
+    }
+    test_field_c();
 }
 impl Default for foo__bindgen_ty_1 {
     fn default() -> Self {
@@ -79,15 +87,18 @@ fn bindgen_test_layout_foo() {
         4usize,
         concat!("Alignment of ", stringify!(foo))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<foo>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
-        0usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(a))
-    );
+    fn test_field_a() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<foo>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+            },
+            0usize,
+            concat!("Offset of field: ", stringify!(foo), "::", stringify!(a))
+        );
+    }
+    test_field_a();
 }
 impl Default for foo {
     fn default() -> Self {

--- a/tests/expectations/tests/union_with_anon_unnamed_union_1_0.rs
+++ b/tests/expectations/tests/union_with_anon_unnamed_union_1_0.rs
@@ -74,34 +74,42 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
         2usize,
         concat!("Alignment of ", stringify!(foo__bindgen_ty_1))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<foo__bindgen_ty_1>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(foo__bindgen_ty_1),
-            "::",
-            stringify!(b)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<foo__bindgen_ty_1>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).c) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(foo__bindgen_ty_1),
-            "::",
-            stringify!(c)
-        )
-    );
+    fn test_field_b() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<foo__bindgen_ty_1>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(foo__bindgen_ty_1),
+                "::",
+                stringify!(b)
+            )
+        );
+    }
+    test_field_b();
+    fn test_field_c() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<foo__bindgen_ty_1>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).c) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(foo__bindgen_ty_1),
+                "::",
+                stringify!(c)
+            )
+        );
+    }
+    test_field_c();
 }
 impl Clone for foo__bindgen_ty_1 {
     fn clone(&self) -> Self {
@@ -120,15 +128,18 @@ fn bindgen_test_layout_foo() {
         4usize,
         concat!("Alignment of ", stringify!(foo))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<foo>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
-        0usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(a))
-    );
+    fn test_field_a() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<foo>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+            },
+            0usize,
+            concat!("Offset of field: ", stringify!(foo), "::", stringify!(a))
+        );
+    }
+    test_field_a();
 }
 impl Clone for foo {
     fn clone(&self) -> Self {

--- a/tests/expectations/tests/union_with_big_member.rs
+++ b/tests/expectations/tests/union_with_big_member.rs
@@ -23,34 +23,40 @@ fn bindgen_test_layout_WithBigArray() {
         4usize,
         concat!("Alignment of ", stringify!(WithBigArray))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<WithBigArray>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(WithBigArray),
-            "::",
-            stringify!(a)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<WithBigArray>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(WithBigArray),
-            "::",
-            stringify!(b)
-        )
-    );
+    fn test_field_a() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<WithBigArray>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(WithBigArray),
+                "::",
+                stringify!(a)
+            )
+        );
+    }
+    test_field_a();
+    fn test_field_b() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<WithBigArray>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(WithBigArray),
+                "::",
+                stringify!(b)
+            )
+        );
+    }
+    test_field_b();
 }
 impl Default for WithBigArray {
     fn default() -> Self {
@@ -79,34 +85,40 @@ fn bindgen_test_layout_WithBigArray2() {
         4usize,
         concat!("Alignment of ", stringify!(WithBigArray2))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<WithBigArray2>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(WithBigArray2),
-            "::",
-            stringify!(a)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<WithBigArray2>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(WithBigArray2),
-            "::",
-            stringify!(b)
-        )
-    );
+    fn test_field_a() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<WithBigArray2>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(WithBigArray2),
+                "::",
+                stringify!(a)
+            )
+        );
+    }
+    test_field_a();
+    fn test_field_b() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<WithBigArray2>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(WithBigArray2),
+                "::",
+                stringify!(b)
+            )
+        );
+    }
+    test_field_b();
 }
 impl Default for WithBigArray2 {
     fn default() -> Self {
@@ -135,34 +147,40 @@ fn bindgen_test_layout_WithBigMember() {
         4usize,
         concat!("Alignment of ", stringify!(WithBigMember))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<WithBigMember>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(WithBigMember),
-            "::",
-            stringify!(a)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<WithBigMember>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(WithBigMember),
-            "::",
-            stringify!(b)
-        )
-    );
+    fn test_field_a() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<WithBigMember>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(WithBigMember),
+                "::",
+                stringify!(a)
+            )
+        );
+    }
+    test_field_a();
+    fn test_field_b() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<WithBigMember>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(WithBigMember),
+                "::",
+                stringify!(b)
+            )
+        );
+    }
+    test_field_b();
 }
 impl Default for WithBigMember {
     fn default() -> Self {

--- a/tests/expectations/tests/union_with_big_member_1_0.rs
+++ b/tests/expectations/tests/union_with_big_member_1_0.rs
@@ -67,34 +67,40 @@ fn bindgen_test_layout_WithBigArray() {
         4usize,
         concat!("Alignment of ", stringify!(WithBigArray))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<WithBigArray>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(WithBigArray),
-            "::",
-            stringify!(a)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<WithBigArray>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(WithBigArray),
-            "::",
-            stringify!(b)
-        )
-    );
+    fn test_field_a() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<WithBigArray>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(WithBigArray),
+                "::",
+                stringify!(a)
+            )
+        );
+    }
+    test_field_a();
+    fn test_field_b() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<WithBigArray>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(WithBigArray),
+                "::",
+                stringify!(b)
+            )
+        );
+    }
+    test_field_b();
 }
 impl Clone for WithBigArray {
     fn clone(&self) -> Self {
@@ -129,34 +135,40 @@ fn bindgen_test_layout_WithBigArray2() {
         4usize,
         concat!("Alignment of ", stringify!(WithBigArray2))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<WithBigArray2>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(WithBigArray2),
-            "::",
-            stringify!(a)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<WithBigArray2>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(WithBigArray2),
-            "::",
-            stringify!(b)
-        )
-    );
+    fn test_field_a() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<WithBigArray2>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(WithBigArray2),
+                "::",
+                stringify!(a)
+            )
+        );
+    }
+    test_field_a();
+    fn test_field_b() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<WithBigArray2>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(WithBigArray2),
+                "::",
+                stringify!(b)
+            )
+        );
+    }
+    test_field_b();
 }
 impl Clone for WithBigArray2 {
     fn clone(&self) -> Self {
@@ -182,34 +194,40 @@ fn bindgen_test_layout_WithBigMember() {
         4usize,
         concat!("Alignment of ", stringify!(WithBigMember))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<WithBigMember>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(WithBigMember),
-            "::",
-            stringify!(a)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<WithBigMember>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(WithBigMember),
-            "::",
-            stringify!(b)
-        )
-    );
+    fn test_field_a() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<WithBigMember>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(WithBigMember),
+                "::",
+                stringify!(a)
+            )
+        );
+    }
+    test_field_a();
+    fn test_field_b() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<WithBigMember>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(WithBigMember),
+                "::",
+                stringify!(b)
+            )
+        );
+    }
+    test_field_b();
 }
 impl Clone for WithBigMember {
     fn clone(&self) -> Self {

--- a/tests/expectations/tests/union_with_nesting.rs
+++ b/tests/expectations/tests/union_with_nesting.rs
@@ -35,38 +35,44 @@ fn bindgen_test_layout_foo__bindgen_ty_1__bindgen_ty_1() {
         2usize,
         concat!("Alignment of ", stringify!(foo__bindgen_ty_1__bindgen_ty_1))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<
-                foo__bindgen_ty_1__bindgen_ty_1,
-            >::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).b1) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(foo__bindgen_ty_1__bindgen_ty_1),
-            "::",
-            stringify!(b1)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<
-                foo__bindgen_ty_1__bindgen_ty_1,
-            >::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).b2) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(foo__bindgen_ty_1__bindgen_ty_1),
-            "::",
-            stringify!(b2)
-        )
-    );
+    fn test_field_b1() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<
+                    foo__bindgen_ty_1__bindgen_ty_1,
+                >::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).b1) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(foo__bindgen_ty_1__bindgen_ty_1),
+                "::",
+                stringify!(b1)
+            )
+        );
+    }
+    test_field_b1();
+    fn test_field_b2() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<
+                    foo__bindgen_ty_1__bindgen_ty_1,
+                >::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).b2) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(foo__bindgen_ty_1__bindgen_ty_1),
+                "::",
+                stringify!(b2)
+            )
+        );
+    }
+    test_field_b2();
 }
 impl Default for foo__bindgen_ty_1__bindgen_ty_1 {
     fn default() -> Self {
@@ -95,38 +101,44 @@ fn bindgen_test_layout_foo__bindgen_ty_1__bindgen_ty_2() {
         2usize,
         concat!("Alignment of ", stringify!(foo__bindgen_ty_1__bindgen_ty_2))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<
-                foo__bindgen_ty_1__bindgen_ty_2,
-            >::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).c1) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(foo__bindgen_ty_1__bindgen_ty_2),
-            "::",
-            stringify!(c1)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<
-                foo__bindgen_ty_1__bindgen_ty_2,
-            >::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).c2) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(foo__bindgen_ty_1__bindgen_ty_2),
-            "::",
-            stringify!(c2)
-        )
-    );
+    fn test_field_c1() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<
+                    foo__bindgen_ty_1__bindgen_ty_2,
+                >::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).c1) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(foo__bindgen_ty_1__bindgen_ty_2),
+                "::",
+                stringify!(c1)
+            )
+        );
+    }
+    test_field_c1();
+    fn test_field_c2() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<
+                    foo__bindgen_ty_1__bindgen_ty_2,
+                >::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).c2) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(foo__bindgen_ty_1__bindgen_ty_2),
+                "::",
+                stringify!(c2)
+            )
+        );
+    }
+    test_field_c2();
 }
 impl Default for foo__bindgen_ty_1__bindgen_ty_2 {
     fn default() -> Self {
@@ -171,15 +183,18 @@ fn bindgen_test_layout_foo() {
         4usize,
         concat!("Alignment of ", stringify!(foo))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<foo>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
-        0usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(a))
-    );
+    fn test_field_a() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<foo>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+            },
+            0usize,
+            concat!("Offset of field: ", stringify!(foo), "::", stringify!(a))
+        );
+    }
+    test_field_a();
 }
 impl Default for foo {
     fn default() -> Self {

--- a/tests/expectations/tests/union_with_nesting_1_0.rs
+++ b/tests/expectations/tests/union_with_nesting_1_0.rs
@@ -80,38 +80,44 @@ fn bindgen_test_layout_foo__bindgen_ty_1__bindgen_ty_1() {
         2usize,
         concat!("Alignment of ", stringify!(foo__bindgen_ty_1__bindgen_ty_1))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<
-                foo__bindgen_ty_1__bindgen_ty_1,
-            >::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).b1) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(foo__bindgen_ty_1__bindgen_ty_1),
-            "::",
-            stringify!(b1)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<
-                foo__bindgen_ty_1__bindgen_ty_1,
-            >::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).b2) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(foo__bindgen_ty_1__bindgen_ty_1),
-            "::",
-            stringify!(b2)
-        )
-    );
+    fn test_field_b1() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<
+                    foo__bindgen_ty_1__bindgen_ty_1,
+                >::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).b1) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(foo__bindgen_ty_1__bindgen_ty_1),
+                "::",
+                stringify!(b1)
+            )
+        );
+    }
+    test_field_b1();
+    fn test_field_b2() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<
+                    foo__bindgen_ty_1__bindgen_ty_1,
+                >::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).b2) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(foo__bindgen_ty_1__bindgen_ty_1),
+                "::",
+                stringify!(b2)
+            )
+        );
+    }
+    test_field_b2();
 }
 impl Clone for foo__bindgen_ty_1__bindgen_ty_1 {
     fn clone(&self) -> Self {
@@ -137,38 +143,44 @@ fn bindgen_test_layout_foo__bindgen_ty_1__bindgen_ty_2() {
         2usize,
         concat!("Alignment of ", stringify!(foo__bindgen_ty_1__bindgen_ty_2))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<
-                foo__bindgen_ty_1__bindgen_ty_2,
-            >::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).c1) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(foo__bindgen_ty_1__bindgen_ty_2),
-            "::",
-            stringify!(c1)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<
-                foo__bindgen_ty_1__bindgen_ty_2,
-            >::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).c2) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(foo__bindgen_ty_1__bindgen_ty_2),
-            "::",
-            stringify!(c2)
-        )
-    );
+    fn test_field_c1() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<
+                    foo__bindgen_ty_1__bindgen_ty_2,
+                >::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).c1) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(foo__bindgen_ty_1__bindgen_ty_2),
+                "::",
+                stringify!(c1)
+            )
+        );
+    }
+    test_field_c1();
+    fn test_field_c2() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<
+                    foo__bindgen_ty_1__bindgen_ty_2,
+                >::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).c2) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(foo__bindgen_ty_1__bindgen_ty_2),
+                "::",
+                stringify!(c2)
+            )
+        );
+    }
+    test_field_c2();
 }
 impl Clone for foo__bindgen_ty_1__bindgen_ty_2 {
     fn clone(&self) -> Self {
@@ -205,15 +217,18 @@ fn bindgen_test_layout_foo() {
         4usize,
         concat!("Alignment of ", stringify!(foo))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<foo>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
-        0usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(a))
-    );
+    fn test_field_a() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<foo>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+            },
+            0usize,
+            concat!("Offset of field: ", stringify!(foo), "::", stringify!(a))
+        );
+    }
+    test_field_a();
 }
 impl Clone for foo {
     fn clone(&self) -> Self {

--- a/tests/expectations/tests/unknown_attr.rs
+++ b/tests/expectations/tests/unknown_attr.rs
@@ -25,34 +25,40 @@ fn bindgen_test_layout_max_align_t() {
         16usize,
         concat!("Alignment of ", stringify!(max_align_t))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<max_align_t>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).__clang_max_align_nonce1) as usize -
-                ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(max_align_t),
-            "::",
-            stringify!(__clang_max_align_nonce1)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<max_align_t>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).__clang_max_align_nonce2) as usize -
-                ptr as usize
-        },
-        16usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(max_align_t),
-            "::",
-            stringify!(__clang_max_align_nonce2)
-        )
-    );
+    fn test_field___clang_max_align_nonce1() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<max_align_t>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).__clang_max_align_nonce1) as usize -
+                    ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(max_align_t),
+                "::",
+                stringify!(__clang_max_align_nonce1)
+            )
+        );
+    }
+    test_field___clang_max_align_nonce1();
+    fn test_field___clang_max_align_nonce2() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<max_align_t>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).__clang_max_align_nonce2) as usize -
+                    ptr as usize
+            },
+            16usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(max_align_t),
+                "::",
+                stringify!(__clang_max_align_nonce2)
+            )
+        );
+    }
+    test_field___clang_max_align_nonce2();
 }

--- a/tests/expectations/tests/use-core.rs
+++ b/tests/expectations/tests/use-core.rs
@@ -26,33 +26,47 @@ fn bindgen_test_layout_foo() {
         8usize,
         concat!("Alignment of ", stringify!(foo))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::core::mem::MaybeUninit::<foo>::uninit();
-            let ptr = uninit.as_ptr();
-            ::core::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
-        0usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(a))
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::core::mem::MaybeUninit::<foo>::uninit();
-            let ptr = uninit.as_ptr();
-            ::core::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-        },
-        4usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(b))
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::core::mem::MaybeUninit::<foo>::uninit();
-            let ptr = uninit.as_ptr();
-            ::core::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
-        },
-        8usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar))
-    );
+    fn test_field_a() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::core::mem::MaybeUninit::<foo>::uninit();
+                let ptr = uninit.as_ptr();
+                ::core::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+            },
+            0usize,
+            concat!("Offset of field: ", stringify!(foo), "::", stringify!(a))
+        );
+    }
+    test_field_a();
+    fn test_field_b() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::core::mem::MaybeUninit::<foo>::uninit();
+                let ptr = uninit.as_ptr();
+                ::core::ptr::addr_of!((*ptr).b) as usize - ptr as usize
+            },
+            4usize,
+            concat!("Offset of field: ", stringify!(foo), "::", stringify!(b))
+        );
+    }
+    test_field_b();
+    fn test_field_bar() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::core::mem::MaybeUninit::<foo>::uninit();
+                let ptr = uninit.as_ptr();
+                ::core::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
+            },
+            8usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(foo),
+                "::",
+                stringify!(bar)
+            )
+        );
+    }
+    test_field_bar();
 }
 impl Default for foo {
     fn default() -> Self {
@@ -81,34 +95,42 @@ fn bindgen_test_layout__bindgen_ty_1() {
         8usize,
         concat!("Alignment of ", stringify!(_bindgen_ty_1))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::core::mem::MaybeUninit::<_bindgen_ty_1>::uninit();
-            let ptr = uninit.as_ptr();
-            ::core::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(_bindgen_ty_1),
-            "::",
-            stringify!(bar)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::core::mem::MaybeUninit::<_bindgen_ty_1>::uninit();
-            let ptr = uninit.as_ptr();
-            ::core::ptr::addr_of!((*ptr).baz) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(_bindgen_ty_1),
-            "::",
-            stringify!(baz)
-        )
-    );
+    fn test_field_bar() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::core::mem::MaybeUninit::<_bindgen_ty_1>::uninit();
+                let ptr = uninit.as_ptr();
+                ::core::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(_bindgen_ty_1),
+                "::",
+                stringify!(bar)
+            )
+        );
+    }
+    test_field_bar();
+    fn test_field_baz() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::core::mem::MaybeUninit::<_bindgen_ty_1>::uninit();
+                let ptr = uninit.as_ptr();
+                ::core::ptr::addr_of!((*ptr).baz) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(_bindgen_ty_1),
+                "::",
+                stringify!(baz)
+            )
+        );
+    }
+    test_field_baz();
 }
 impl Default for _bindgen_ty_1 {
     fn default() -> Self {

--- a/tests/expectations/tests/use-core_1_0.rs
+++ b/tests/expectations/tests/use-core_1_0.rs
@@ -69,33 +69,47 @@ fn bindgen_test_layout_foo() {
         8usize,
         concat!("Alignment of ", stringify!(foo))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::core::mem::MaybeUninit::<foo>::uninit();
-            let ptr = uninit.as_ptr();
-            ::core::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
-        0usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(a))
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::core::mem::MaybeUninit::<foo>::uninit();
-            let ptr = uninit.as_ptr();
-            ::core::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-        },
-        4usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(b))
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::core::mem::MaybeUninit::<foo>::uninit();
-            let ptr = uninit.as_ptr();
-            ::core::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
-        },
-        8usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar))
-    );
+    fn test_field_a() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::core::mem::MaybeUninit::<foo>::uninit();
+                let ptr = uninit.as_ptr();
+                ::core::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+            },
+            0usize,
+            concat!("Offset of field: ", stringify!(foo), "::", stringify!(a))
+        );
+    }
+    test_field_a();
+    fn test_field_b() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::core::mem::MaybeUninit::<foo>::uninit();
+                let ptr = uninit.as_ptr();
+                ::core::ptr::addr_of!((*ptr).b) as usize - ptr as usize
+            },
+            4usize,
+            concat!("Offset of field: ", stringify!(foo), "::", stringify!(b))
+        );
+    }
+    test_field_b();
+    fn test_field_bar() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::core::mem::MaybeUninit::<foo>::uninit();
+                let ptr = uninit.as_ptr();
+                ::core::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
+            },
+            8usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(foo),
+                "::",
+                stringify!(bar)
+            )
+        );
+    }
+    test_field_bar();
 }
 impl Clone for foo {
     fn clone(&self) -> Self {
@@ -130,34 +144,42 @@ fn bindgen_test_layout__bindgen_ty_1() {
         8usize,
         concat!("Alignment of ", stringify!(_bindgen_ty_1))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::core::mem::MaybeUninit::<_bindgen_ty_1>::uninit();
-            let ptr = uninit.as_ptr();
-            ::core::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(_bindgen_ty_1),
-            "::",
-            stringify!(bar)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::core::mem::MaybeUninit::<_bindgen_ty_1>::uninit();
-            let ptr = uninit.as_ptr();
-            ::core::ptr::addr_of!((*ptr).baz) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(_bindgen_ty_1),
-            "::",
-            stringify!(baz)
-        )
-    );
+    fn test_field_bar() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::core::mem::MaybeUninit::<_bindgen_ty_1>::uninit();
+                let ptr = uninit.as_ptr();
+                ::core::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(_bindgen_ty_1),
+                "::",
+                stringify!(bar)
+            )
+        );
+    }
+    test_field_bar();
+    fn test_field_baz() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::core::mem::MaybeUninit::<_bindgen_ty_1>::uninit();
+                let ptr = uninit.as_ptr();
+                ::core::ptr::addr_of!((*ptr).baz) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(_bindgen_ty_1),
+                "::",
+                stringify!(baz)
+            )
+        );
+    }
+    test_field_baz();
 }
 impl Clone for _bindgen_ty_1 {
     fn clone(&self) -> Self {

--- a/tests/expectations/tests/var-tracing.rs
+++ b/tests/expectations/tests/var-tracing.rs
@@ -22,20 +22,23 @@ fn bindgen_test_layout_Bar() {
         4usize,
         concat!("Alignment of ", stringify!(Bar))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Bar>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).m_baz) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(Bar),
-            "::",
-            stringify!(m_baz)
-        )
-    );
+    fn test_field_m_baz() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Bar>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).m_baz) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(Bar),
+                "::",
+                stringify!(m_baz)
+            )
+        );
+    }
+    test_field_m_baz();
 }
 extern "C" {
     #[link_name = "\u{1}_ZN3BarC1Ei"]

--- a/tests/expectations/tests/vector.rs
+++ b/tests/expectations/tests/vector.rs
@@ -22,20 +22,23 @@ fn bindgen_test_layout_foo() {
         8usize,
         concat!("Alignment of ", stringify!(foo))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<foo>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mMember) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(foo),
-            "::",
-            stringify!(mMember)
-        )
-    );
+    fn test_field_mMember() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<foo>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).mMember) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(foo),
+                "::",
+                stringify!(mMember)
+            )
+        );
+    }
+    test_field_mMember();
 }
 pub type __m128 = [f32; 4usize];
 pub type __m128d = [f64; 2usize];

--- a/tests/expectations/tests/virtual_inheritance.rs
+++ b/tests/expectations/tests/virtual_inheritance.rs
@@ -22,15 +22,18 @@ fn bindgen_test_layout_A() {
         4usize,
         concat!("Alignment of ", stringify!(A))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<A>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize
-        },
-        0usize,
-        concat!("Offset of field: ", stringify!(A), "::", stringify!(foo))
-    );
+    fn test_field_foo() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<A>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize
+            },
+            0usize,
+            concat!("Offset of field: ", stringify!(A), "::", stringify!(foo))
+        );
+    }
+    test_field_foo();
 }
 #[repr(C)]
 pub struct B__bindgen_vtable(::std::os::raw::c_void);
@@ -52,15 +55,18 @@ fn bindgen_test_layout_B() {
         8usize,
         concat!("Alignment of ", stringify!(B))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<B>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
-        },
-        8usize,
-        concat!("Offset of field: ", stringify!(B), "::", stringify!(bar))
-    );
+    fn test_field_bar() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<B>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
+            },
+            8usize,
+            concat!("Offset of field: ", stringify!(B), "::", stringify!(bar))
+        );
+    }
+    test_field_bar();
 }
 impl Default for B {
     fn default() -> Self {
@@ -91,15 +97,18 @@ fn bindgen_test_layout_C() {
         8usize,
         concat!("Alignment of ", stringify!(C))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<C>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize
-        },
-        8usize,
-        concat!("Offset of field: ", stringify!(C), "::", stringify!(baz))
-    );
+    fn test_field_baz() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<C>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize
+            },
+            8usize,
+            concat!("Offset of field: ", stringify!(C), "::", stringify!(baz))
+        );
+    }
+    test_field_baz();
 }
 impl Default for C {
     fn default() -> Self {

--- a/tests/expectations/tests/weird_bitfields.rs
+++ b/tests/expectations/tests/weird_bitfields.rs
@@ -131,177 +131,218 @@ fn bindgen_test_layout_Weird() {
         4usize,
         concat!("Alignment of ", stringify!(Weird))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Weird>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mStrokeDasharrayLength) as usize -
-                ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(Weird),
-            "::",
-            stringify!(mStrokeDasharrayLength)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Weird>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mClipRule) as usize - ptr as usize
-        },
-        8usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(Weird),
-            "::",
-            stringify!(mClipRule)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Weird>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mColorInterpolation) as usize -
-                ptr as usize
-        },
-        9usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(Weird),
-            "::",
-            stringify!(mColorInterpolation)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Weird>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mColorInterpolationFilters) as usize -
-                ptr as usize
-        },
-        10usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(Weird),
-            "::",
-            stringify!(mColorInterpolationFilters)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Weird>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mFillRule) as usize - ptr as usize
-        },
-        11usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(Weird),
-            "::",
-            stringify!(mFillRule)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Weird>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mImageRendering) as usize - ptr as usize
-        },
-        12usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(Weird),
-            "::",
-            stringify!(mImageRendering)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Weird>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mPaintOrder) as usize - ptr as usize
-        },
-        13usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(Weird),
-            "::",
-            stringify!(mPaintOrder)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Weird>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mShapeRendering) as usize - ptr as usize
-        },
-        14usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(Weird),
-            "::",
-            stringify!(mShapeRendering)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Weird>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mStrokeLinecap) as usize - ptr as usize
-        },
-        15usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(Weird),
-            "::",
-            stringify!(mStrokeLinecap)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Weird>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mStrokeLinejoin) as usize - ptr as usize
-        },
-        16usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(Weird),
-            "::",
-            stringify!(mStrokeLinejoin)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Weird>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mTextAnchor) as usize - ptr as usize
-        },
-        17usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(Weird),
-            "::",
-            stringify!(mTextAnchor)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<Weird>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mTextRendering) as usize - ptr as usize
-        },
-        18usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(Weird),
-            "::",
-            stringify!(mTextRendering)
-        )
-    );
+    fn test_field_mStrokeDasharrayLength() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Weird>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).mStrokeDasharrayLength) as usize -
+                    ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(Weird),
+                "::",
+                stringify!(mStrokeDasharrayLength)
+            )
+        );
+    }
+    test_field_mStrokeDasharrayLength();
+    fn test_field_mClipRule() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Weird>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).mClipRule) as usize - ptr as usize
+            },
+            8usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(Weird),
+                "::",
+                stringify!(mClipRule)
+            )
+        );
+    }
+    test_field_mClipRule();
+    fn test_field_mColorInterpolation() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Weird>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).mColorInterpolation) as usize -
+                    ptr as usize
+            },
+            9usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(Weird),
+                "::",
+                stringify!(mColorInterpolation)
+            )
+        );
+    }
+    test_field_mColorInterpolation();
+    fn test_field_mColorInterpolationFilters() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Weird>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).mColorInterpolationFilters) as usize -
+                    ptr as usize
+            },
+            10usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(Weird),
+                "::",
+                stringify!(mColorInterpolationFilters)
+            )
+        );
+    }
+    test_field_mColorInterpolationFilters();
+    fn test_field_mFillRule() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Weird>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).mFillRule) as usize - ptr as usize
+            },
+            11usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(Weird),
+                "::",
+                stringify!(mFillRule)
+            )
+        );
+    }
+    test_field_mFillRule();
+    fn test_field_mImageRendering() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Weird>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).mImageRendering) as usize -
+                    ptr as usize
+            },
+            12usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(Weird),
+                "::",
+                stringify!(mImageRendering)
+            )
+        );
+    }
+    test_field_mImageRendering();
+    fn test_field_mPaintOrder() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Weird>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).mPaintOrder) as usize - ptr as usize
+            },
+            13usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(Weird),
+                "::",
+                stringify!(mPaintOrder)
+            )
+        );
+    }
+    test_field_mPaintOrder();
+    fn test_field_mShapeRendering() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Weird>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).mShapeRendering) as usize -
+                    ptr as usize
+            },
+            14usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(Weird),
+                "::",
+                stringify!(mShapeRendering)
+            )
+        );
+    }
+    test_field_mShapeRendering();
+    fn test_field_mStrokeLinecap() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Weird>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).mStrokeLinecap) as usize -
+                    ptr as usize
+            },
+            15usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(Weird),
+                "::",
+                stringify!(mStrokeLinecap)
+            )
+        );
+    }
+    test_field_mStrokeLinecap();
+    fn test_field_mStrokeLinejoin() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Weird>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).mStrokeLinejoin) as usize -
+                    ptr as usize
+            },
+            16usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(Weird),
+                "::",
+                stringify!(mStrokeLinejoin)
+            )
+        );
+    }
+    test_field_mStrokeLinejoin();
+    fn test_field_mTextAnchor() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Weird>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).mTextAnchor) as usize - ptr as usize
+            },
+            17usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(Weird),
+                "::",
+                stringify!(mTextAnchor)
+            )
+        );
+    }
+    test_field_mTextAnchor();
+    fn test_field_mTextRendering() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<Weird>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).mTextRendering) as usize -
+                    ptr as usize
+            },
+            18usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(Weird),
+                "::",
+                stringify!(mTextRendering)
+            )
+        );
+    }
+    test_field_mTextRendering();
 }
 impl Default for Weird {
     fn default() -> Self {

--- a/tests/expectations/tests/zero-size-array-align.rs
+++ b/tests/expectations/tests/zero-size-array-align.rs
@@ -54,46 +54,55 @@ fn bindgen_test_layout_dm_deps() {
         8usize,
         concat!("Alignment of ", stringify!(dm_deps))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<dm_deps>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).count) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(dm_deps),
-            "::",
-            stringify!(count)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<dm_deps>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).filler) as usize - ptr as usize
-        },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(dm_deps),
-            "::",
-            stringify!(filler)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<dm_deps>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).device) as usize - ptr as usize
-        },
-        8usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(dm_deps),
-            "::",
-            stringify!(device)
-        )
-    );
+    fn test_field_count() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<dm_deps>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).count) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(dm_deps),
+                "::",
+                stringify!(count)
+            )
+        );
+    }
+    test_field_count();
+    fn test_field_filler() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<dm_deps>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).filler) as usize - ptr as usize
+            },
+            4usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(dm_deps),
+                "::",
+                stringify!(filler)
+            )
+        );
+    }
+    test_field_filler();
+    fn test_field_device() {
+        assert_eq!(
+            unsafe {
+                let uninit = ::std::mem::MaybeUninit::<dm_deps>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).device) as usize - ptr as usize
+            },
+            8usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(dm_deps),
+                "::",
+                stringify!(device)
+            )
+        );
+    }
+    test_field_device();
 }

--- a/tests/expectations/tests/zero-sized-array.rs
+++ b/tests/expectations/tests/zero-sized-array.rs
@@ -53,20 +53,24 @@ fn bindgen_test_layout_ZeroSizedArray() {
         1usize,
         concat!("Alignment of ", stringify!(ZeroSizedArray))
     );
-    assert_eq!(
-        unsafe {
-            let uninit = ::std::mem::MaybeUninit::<ZeroSizedArray>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).arr) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(ZeroSizedArray),
-            "::",
-            stringify!(arr)
-        )
-    );
+    fn test_field_arr() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<ZeroSizedArray>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).arr) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(ZeroSizedArray),
+                "::",
+                stringify!(arr)
+            )
+        );
+    }
+    test_field_arr();
 }
 /// And nor should this get an `_address` field.
 #[repr(C)]
@@ -86,21 +90,24 @@ fn bindgen_test_layout_ContainsZeroSizedArray() {
         1usize,
         concat!("Alignment of ", stringify!(ContainsZeroSizedArray))
     );
-    assert_eq!(
-        unsafe {
-            let uninit =
-                ::std::mem::MaybeUninit::<ContainsZeroSizedArray>::uninit();
-            let ptr = uninit.as_ptr();
-            ::std::ptr::addr_of!((*ptr).zsa) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(ContainsZeroSizedArray),
-            "::",
-            stringify!(zsa)
-        )
-    );
+    fn test_field_zsa() {
+        assert_eq!(
+            unsafe {
+                let uninit =
+                    ::std::mem::MaybeUninit::<ContainsZeroSizedArray>::uninit();
+                let ptr = uninit.as_ptr();
+                ::std::ptr::addr_of!((*ptr).zsa) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(ContainsZeroSizedArray),
+                "::",
+                stringify!(zsa)
+            )
+        );
+    }
+    test_field_zsa();
 }
 /// Inheriting from ZeroSizedArray shouldn't cause an `_address` to be inserted
 /// either.


### PR DESCRIPTION
So that rustc doesn't take too much stack space without optimizations.

Fixes https://github.com/rust-lang/rust-bindgen/issues/2218