### PR TITLE
Bump msrv to 1.56.1

### DIFF
--- a/.github/workflows/bindgen.yml
+++ b/.github/workflows/bindgen.yml
@@ -46,13 +46,13 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          # MSRV below is documented in README.md, please update that if you
+          # MSRV below is documented in Cargo.toml and README.md, please update those if you
           # change this.
-          toolchain: 1.54.0
+          toolchain: 1.56.1
           override: true
 
       - name: Build with msrv
-        run: rm Cargo.lock && cargo +1.54.0 build --lib
+        run: rm Cargo.lock && cargo +1.56.1 build --lib
 
   quickchecking:
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,8 @@ homepage = "https://rust-lang.github.io/rust-bindgen/"
 version = "0.60.1"
 edition = "2018"
 build = "build.rs"
+# If you change this, also update README.md and msrv in .github/workflows/bindgen.yml
+rust-version = "1.56.1"
 
 include = [
   "LICENSE",

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ extern "C" {
 
 ## MSRV
 
-The minimum supported Rust version is **1.54**.
+The minimum supported Rust version is **1.56.1**.
 
 No MSRV bump policy has been established yet, so MSRV may increase in any release.
 


### PR DESCRIPTION
Older toolchain versions, including 1.56.0, fail msrv check:
```
[I] ➜ rm Cargo.lock && cargo +1.56.0 build --lib
    Updating crates.io index
error: package `hashbrown v0.12.1` cannot be built because it requires rustc 1.56.1 or newer, while the currently active rustc version is 1.56.0
```