### PR TITLE
Fix `clippy::items_after_statements` lint in struct field alignment tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ lazycell = "1"
 lazy_static = "1"
 peeking_take_while = "0.1.2"
 quote = { version = "1", default-features = false }
-regex = { version = "1.5", default-features = false , features = [ "std", "unicode"]}
+regex = { version = "1.5", default-features = false , features = ["std", "unicode"] }
 which = { version = "4.2.1", optional = true, default-features = false }
 shlex = "1"
 rustc-hash = "1.0.1"

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -2190,7 +2190,6 @@ impl CodeGenerator for CompInfo {
                                     quote! {
                                         assert_eq!(
                                             unsafe {
-                                                let ptr = UNINIT.as_ptr();
                                                 ::#prefix::ptr::addr_of!((*ptr).#field_name) as usize - ptr as usize
                                             },
                                             #field_offset,
@@ -2208,6 +2207,7 @@ impl CodeGenerator for CompInfo {
                             // opt-level=0 doesn't take too much stack space,
                             // see #2218.
                             const UNINIT: ::#prefix::mem::MaybeUninit<#canonical_ident> = ::#prefix::mem::MaybeUninit::uninit();
+                            let ptr = UNINIT.as_ptr();
                         })
                     } else {
                         None

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -2172,11 +2172,11 @@ impl CodeGenerator for CompInfo {
                     let should_skip_field_offset_checks =
                         is_opaque || too_many_base_vtables;
 
-                    let (uninit_decl, check_field_offset) = if should_skip_field_offset_checks
-                    {
-                        (None, vec![])
-                    } else {
-                        (
+                    let (uninit_decl, check_field_offset) =
+                        if should_skip_field_offset_checks {
+                            (None, vec![])
+                        } else {
+                            (
                             Some(quote! {
                                 // Use a shared MaybeUninit so that rustc with
                                 // opt-level=0 doesn't take too much stack
@@ -2207,8 +2207,8 @@ impl CodeGenerator for CompInfo {
                                     })
                                 })
                                 .collect()
-                        )
-                    };
+                            )
+                        };
 
                     let item = quote! {
                         #[test]

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -2172,56 +2172,54 @@ impl CodeGenerator for CompInfo {
                     let should_skip_field_offset_checks =
                         is_opaque || too_many_base_vtables;
 
-                    let (check_field_offset_decls, check_field_offset_invocs) = if should_skip_field_offset_checks
+                    let (uninit_decl, check_field_offset) = if should_skip_field_offset_checks
                     {
-                        (vec![], vec![])
+                        (None, vec![])
                     } else {
-                        self.fields()
-                            .iter()
-                            .filter_map(|field| match *field {
-                                Field::DataMember(ref f) if f.name().is_some() => Some(f),
-                                _ => None,
-                            })
-                            .flat_map(|field| {
-                                let name = field.name().unwrap();
-                                field.offset().map(|offset| {
-                                    let field_offset = offset / 8;
-                                    let field_name = ctx.rust_ident(name);
-                                    // Put each check in its own function, so
-                                    // that rustc with opt-level=0 doesn't take
-                                    // too much stack space, see #2218.
-                                    let test_fn = Ident::new(&format!("test_field_{}", name), Span::call_site());
-                                    (
-                                        quote! {
-                                            fn #test_fn() {
-                                                assert_eq!(
-                                                    unsafe {
-                                                        let uninit = ::#prefix::mem::MaybeUninit::<#canonical_ident>::uninit();
-                                                        let ptr = uninit.as_ptr();
-                                                        ::#prefix::ptr::addr_of!((*ptr).#field_name) as usize - ptr as usize
-                                                    },
-                                                    #field_offset,
-                                                    concat!("Offset of field: ", stringify!(#canonical_ident), "::", stringify!(#field_name))
-                                                );
-                                            }
-                                        },
-                                        quote! { #test_fn(); }
-                                    )
+                        (
+                            Some(quote! {
+                                // Use a shared MaybeUninit so that rustc with
+                                // opt-level=0 doesn't take too much stack
+                                // space, see #2218.
+                                const UNINIT: ::#prefix::mem::MaybeUninit<#canonical_ident> = ::#prefix::mem::MaybeUninit::uninit();
+                            }),
+                            self.fields()
+                                .iter()
+                                .filter_map(|field| match *field {
+                                    Field::DataMember(ref f) if f.name().is_some() => Some(f),
+                                    _ => None,
                                 })
-                            })
-                            .unzip()
+                                .flat_map(|field| {
+                                    let name = field.name().unwrap();
+                                    field.offset().map(|offset| {
+                                        let field_offset = offset / 8;
+                                        let field_name = ctx.rust_ident(name);
+                                        quote! {
+                                            assert_eq!(
+                                                unsafe {
+                                                    let ptr = UNINIT.as_ptr();
+                                                    ::#prefix::ptr::addr_of!((*ptr).#field_name) as usize - ptr as usize
+                                                },
+                                                #field_offset,
+                                                concat!("Offset of field: ", stringify!(#canonical_ident), "::", stringify!(#field_name))
+                                            );
+                                        }
+                                    })
+                                })
+                                .collect()
+                        )
                     };
 
                     let item = quote! {
                         #[test]
                         fn #fn_name() {
-                            #( #check_field_offset_decls )*
+                            #uninit_decl
                             assert_eq!(#size_of_expr,
                                        #size,
                                        concat!("Size of: ", stringify!(#canonical_ident)));
 
                             #check_struct_align
-                            #( #check_field_offset_invocs )*
+                            #( #check_field_offset )*
                         }
                     };
                     result.push(item);

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -2202,6 +2202,8 @@ impl CodeGenerator for CompInfo {
                     };
 
                     let uninit_decl = if !check_field_offset.is_empty() {
+                        // FIXME: When MSRV >= 1.59.0, we can use
+                        // > const PTR: *const #canonical_ident = ::#prefix::mem::MaybeUninit::uninit().as_ptr();
                         Some(quote! {
                             // Use a shared MaybeUninit so that rustc with
                             // opt-level=0 doesn't take too much stack space,

--- a/tests/expectations/tests/16-byte-alignment.rs
+++ b/tests/expectations/tests/16-byte-alignment.rs
@@ -26,6 +26,9 @@ pub struct rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1 {
 }
 #[test]
 fn bindgen_test_layout_rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1() {
+    const UNINIT: ::std::mem::MaybeUninit<
+        rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1,
+    > = ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1>(),
         4usize,
@@ -42,47 +45,37 @@ fn bindgen_test_layout_rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1() {
             stringify!(rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1)
         )
     );
-    fn test_field_dport() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<
-                    rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1,
-                >::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).dport) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1),
-                "::",
-                stringify!(dport)
-            )
-        );
-    }
-    test_field_dport();
-    fn test_field_sport() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<
-                    rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1,
-                >::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).sport) as usize - ptr as usize
-            },
-            2usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1),
-                "::",
-                stringify!(sport)
-            )
-        );
-    }
-    test_field_sport();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).dport) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1),
+            "::",
+            stringify!(dport)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).sport) as usize - ptr as usize
+        },
+        2usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1),
+            "::",
+            stringify!(sport)
+        )
+    );
 }
 #[test]
 fn bindgen_test_layout_rte_ipv4_tuple__bindgen_ty_1() {
+    const UNINIT: ::std::mem::MaybeUninit<rte_ipv4_tuple__bindgen_ty_1> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<rte_ipv4_tuple__bindgen_ty_1>(),
         4usize,
@@ -93,25 +86,19 @@ fn bindgen_test_layout_rte_ipv4_tuple__bindgen_ty_1() {
         4usize,
         concat!("Alignment of ", stringify!(rte_ipv4_tuple__bindgen_ty_1))
     );
-    fn test_field_sctp_tag() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<
-                    rte_ipv4_tuple__bindgen_ty_1,
-                >::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).sctp_tag) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_ipv4_tuple__bindgen_ty_1),
-                "::",
-                stringify!(sctp_tag)
-            )
-        );
-    }
-    test_field_sctp_tag();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).sctp_tag) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_ipv4_tuple__bindgen_ty_1),
+            "::",
+            stringify!(sctp_tag)
+        )
+    );
 }
 impl Default for rte_ipv4_tuple__bindgen_ty_1 {
     fn default() -> Self {
@@ -124,6 +111,8 @@ impl Default for rte_ipv4_tuple__bindgen_ty_1 {
 }
 #[test]
 fn bindgen_test_layout_rte_ipv4_tuple() {
+    const UNINIT: ::std::mem::MaybeUninit<rte_ipv4_tuple> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<rte_ipv4_tuple>(),
         12usize,
@@ -134,42 +123,32 @@ fn bindgen_test_layout_rte_ipv4_tuple() {
         4usize,
         concat!("Alignment of ", stringify!(rte_ipv4_tuple))
     );
-    fn test_field_src_addr() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_ipv4_tuple>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).src_addr) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_ipv4_tuple),
-                "::",
-                stringify!(src_addr)
-            )
-        );
-    }
-    test_field_src_addr();
-    fn test_field_dst_addr() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_ipv4_tuple>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).dst_addr) as usize - ptr as usize
-            },
-            4usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_ipv4_tuple),
-                "::",
-                stringify!(dst_addr)
-            )
-        );
-    }
-    test_field_dst_addr();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).src_addr) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_ipv4_tuple),
+            "::",
+            stringify!(src_addr)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).dst_addr) as usize - ptr as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_ipv4_tuple),
+            "::",
+            stringify!(dst_addr)
+        )
+    );
 }
 impl Default for rte_ipv4_tuple {
     fn default() -> Self {
@@ -201,6 +180,9 @@ pub struct rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1 {
 }
 #[test]
 fn bindgen_test_layout_rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1() {
+    const UNINIT: ::std::mem::MaybeUninit<
+        rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1,
+    > = ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1>(),
         4usize,
@@ -217,47 +199,37 @@ fn bindgen_test_layout_rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1() {
             stringify!(rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1)
         )
     );
-    fn test_field_dport() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<
-                    rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1,
-                >::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).dport) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1),
-                "::",
-                stringify!(dport)
-            )
-        );
-    }
-    test_field_dport();
-    fn test_field_sport() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<
-                    rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1,
-                >::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).sport) as usize - ptr as usize
-            },
-            2usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1),
-                "::",
-                stringify!(sport)
-            )
-        );
-    }
-    test_field_sport();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).dport) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1),
+            "::",
+            stringify!(dport)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).sport) as usize - ptr as usize
+        },
+        2usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1),
+            "::",
+            stringify!(sport)
+        )
+    );
 }
 #[test]
 fn bindgen_test_layout_rte_ipv6_tuple__bindgen_ty_1() {
+    const UNINIT: ::std::mem::MaybeUninit<rte_ipv6_tuple__bindgen_ty_1> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<rte_ipv6_tuple__bindgen_ty_1>(),
         4usize,
@@ -268,25 +240,19 @@ fn bindgen_test_layout_rte_ipv6_tuple__bindgen_ty_1() {
         4usize,
         concat!("Alignment of ", stringify!(rte_ipv6_tuple__bindgen_ty_1))
     );
-    fn test_field_sctp_tag() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<
-                    rte_ipv6_tuple__bindgen_ty_1,
-                >::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).sctp_tag) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_ipv6_tuple__bindgen_ty_1),
-                "::",
-                stringify!(sctp_tag)
-            )
-        );
-    }
-    test_field_sctp_tag();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).sctp_tag) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_ipv6_tuple__bindgen_ty_1),
+            "::",
+            stringify!(sctp_tag)
+        )
+    );
 }
 impl Default for rte_ipv6_tuple__bindgen_ty_1 {
     fn default() -> Self {
@@ -299,6 +265,8 @@ impl Default for rte_ipv6_tuple__bindgen_ty_1 {
 }
 #[test]
 fn bindgen_test_layout_rte_ipv6_tuple() {
+    const UNINIT: ::std::mem::MaybeUninit<rte_ipv6_tuple> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<rte_ipv6_tuple>(),
         36usize,
@@ -309,42 +277,32 @@ fn bindgen_test_layout_rte_ipv6_tuple() {
         4usize,
         concat!("Alignment of ", stringify!(rte_ipv6_tuple))
     );
-    fn test_field_src_addr() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_ipv6_tuple>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).src_addr) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_ipv6_tuple),
-                "::",
-                stringify!(src_addr)
-            )
-        );
-    }
-    test_field_src_addr();
-    fn test_field_dst_addr() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_ipv6_tuple>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).dst_addr) as usize - ptr as usize
-            },
-            16usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_ipv6_tuple),
-                "::",
-                stringify!(dst_addr)
-            )
-        );
-    }
-    test_field_dst_addr();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).src_addr) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_ipv6_tuple),
+            "::",
+            stringify!(src_addr)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).dst_addr) as usize - ptr as usize
+        },
+        16usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_ipv6_tuple),
+            "::",
+            stringify!(dst_addr)
+        )
+    );
 }
 impl Default for rte_ipv6_tuple {
     fn default() -> Self {
@@ -364,6 +322,8 @@ pub union rte_thash_tuple {
 }
 #[test]
 fn bindgen_test_layout_rte_thash_tuple() {
+    const UNINIT: ::std::mem::MaybeUninit<rte_thash_tuple> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<rte_thash_tuple>(),
         48usize,
@@ -374,42 +334,32 @@ fn bindgen_test_layout_rte_thash_tuple() {
         16usize,
         concat!("Alignment of ", stringify!(rte_thash_tuple))
     );
-    fn test_field_v4() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_thash_tuple>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).v4) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_thash_tuple),
-                "::",
-                stringify!(v4)
-            )
-        );
-    }
-    test_field_v4();
-    fn test_field_v6() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_thash_tuple>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).v6) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_thash_tuple),
-                "::",
-                stringify!(v6)
-            )
-        );
-    }
-    test_field_v6();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).v4) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_thash_tuple),
+            "::",
+            stringify!(v4)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).v6) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_thash_tuple),
+            "::",
+            stringify!(v6)
+        )
+    );
 }
 impl Default for rte_thash_tuple {
     fn default() -> Self {

--- a/tests/expectations/tests/16-byte-alignment.rs
+++ b/tests/expectations/tests/16-byte-alignment.rs
@@ -29,6 +29,7 @@ fn bindgen_test_layout_rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<
         rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1,
     > = ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1>(),
         4usize,
@@ -46,10 +47,7 @@ fn bindgen_test_layout_rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).dport) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).dport) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -59,10 +57,7 @@ fn bindgen_test_layout_rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).sport) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).sport) as usize - ptr as usize },
         2usize,
         concat!(
             "Offset of field: ",
@@ -76,6 +71,7 @@ fn bindgen_test_layout_rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1() {
 fn bindgen_test_layout_rte_ipv4_tuple__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<rte_ipv4_tuple__bindgen_ty_1> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<rte_ipv4_tuple__bindgen_ty_1>(),
         4usize,
@@ -88,7 +84,6 @@ fn bindgen_test_layout_rte_ipv4_tuple__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).sctp_tag) as usize - ptr as usize
         },
         0usize,
@@ -113,6 +108,7 @@ impl Default for rte_ipv4_tuple__bindgen_ty_1 {
 fn bindgen_test_layout_rte_ipv4_tuple() {
     const UNINIT: ::std::mem::MaybeUninit<rte_ipv4_tuple> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<rte_ipv4_tuple>(),
         12usize,
@@ -125,7 +121,6 @@ fn bindgen_test_layout_rte_ipv4_tuple() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).src_addr) as usize - ptr as usize
         },
         0usize,
@@ -138,7 +133,6 @@ fn bindgen_test_layout_rte_ipv4_tuple() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).dst_addr) as usize - ptr as usize
         },
         4usize,
@@ -183,6 +177,7 @@ fn bindgen_test_layout_rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<
         rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1,
     > = ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1>(),
         4usize,
@@ -200,10 +195,7 @@ fn bindgen_test_layout_rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).dport) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).dport) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -213,10 +205,7 @@ fn bindgen_test_layout_rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).sport) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).sport) as usize - ptr as usize },
         2usize,
         concat!(
             "Offset of field: ",
@@ -230,6 +219,7 @@ fn bindgen_test_layout_rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1() {
 fn bindgen_test_layout_rte_ipv6_tuple__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<rte_ipv6_tuple__bindgen_ty_1> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<rte_ipv6_tuple__bindgen_ty_1>(),
         4usize,
@@ -242,7 +232,6 @@ fn bindgen_test_layout_rte_ipv6_tuple__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).sctp_tag) as usize - ptr as usize
         },
         0usize,
@@ -267,6 +256,7 @@ impl Default for rte_ipv6_tuple__bindgen_ty_1 {
 fn bindgen_test_layout_rte_ipv6_tuple() {
     const UNINIT: ::std::mem::MaybeUninit<rte_ipv6_tuple> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<rte_ipv6_tuple>(),
         36usize,
@@ -279,7 +269,6 @@ fn bindgen_test_layout_rte_ipv6_tuple() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).src_addr) as usize - ptr as usize
         },
         0usize,
@@ -292,7 +281,6 @@ fn bindgen_test_layout_rte_ipv6_tuple() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).dst_addr) as usize - ptr as usize
         },
         16usize,
@@ -324,6 +312,7 @@ pub union rte_thash_tuple {
 fn bindgen_test_layout_rte_thash_tuple() {
     const UNINIT: ::std::mem::MaybeUninit<rte_thash_tuple> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<rte_thash_tuple>(),
         48usize,
@@ -335,10 +324,7 @@ fn bindgen_test_layout_rte_thash_tuple() {
         concat!("Alignment of ", stringify!(rte_thash_tuple))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).v4) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).v4) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -348,10 +334,7 @@ fn bindgen_test_layout_rte_thash_tuple() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).v6) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).v6) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/16-byte-alignment_1_0.rs
+++ b/tests/expectations/tests/16-byte-alignment_1_0.rs
@@ -71,6 +71,9 @@ pub struct rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1 {
 }
 #[test]
 fn bindgen_test_layout_rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1() {
+    const UNINIT: ::std::mem::MaybeUninit<
+        rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1,
+    > = ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1>(),
         4usize,
@@ -87,44 +90,32 @@ fn bindgen_test_layout_rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1() {
             stringify!(rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1)
         )
     );
-    fn test_field_dport() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<
-                    rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1,
-                >::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).dport) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1),
-                "::",
-                stringify!(dport)
-            )
-        );
-    }
-    test_field_dport();
-    fn test_field_sport() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<
-                    rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1,
-                >::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).sport) as usize - ptr as usize
-            },
-            2usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1),
-                "::",
-                stringify!(sport)
-            )
-        );
-    }
-    test_field_sport();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).dport) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1),
+            "::",
+            stringify!(dport)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).sport) as usize - ptr as usize
+        },
+        2usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1),
+            "::",
+            stringify!(sport)
+        )
+    );
 }
 impl Clone for rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1 {
     fn clone(&self) -> Self {
@@ -133,6 +124,8 @@ impl Clone for rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1 {
 }
 #[test]
 fn bindgen_test_layout_rte_ipv4_tuple__bindgen_ty_1() {
+    const UNINIT: ::std::mem::MaybeUninit<rte_ipv4_tuple__bindgen_ty_1> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<rte_ipv4_tuple__bindgen_ty_1>(),
         4usize,
@@ -143,25 +136,19 @@ fn bindgen_test_layout_rte_ipv4_tuple__bindgen_ty_1() {
         4usize,
         concat!("Alignment of ", stringify!(rte_ipv4_tuple__bindgen_ty_1))
     );
-    fn test_field_sctp_tag() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<
-                    rte_ipv4_tuple__bindgen_ty_1,
-                >::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).sctp_tag) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_ipv4_tuple__bindgen_ty_1),
-                "::",
-                stringify!(sctp_tag)
-            )
-        );
-    }
-    test_field_sctp_tag();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).sctp_tag) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_ipv4_tuple__bindgen_ty_1),
+            "::",
+            stringify!(sctp_tag)
+        )
+    );
 }
 impl Clone for rte_ipv4_tuple__bindgen_ty_1 {
     fn clone(&self) -> Self {
@@ -170,6 +157,8 @@ impl Clone for rte_ipv4_tuple__bindgen_ty_1 {
 }
 #[test]
 fn bindgen_test_layout_rte_ipv4_tuple() {
+    const UNINIT: ::std::mem::MaybeUninit<rte_ipv4_tuple> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<rte_ipv4_tuple>(),
         12usize,
@@ -180,42 +169,32 @@ fn bindgen_test_layout_rte_ipv4_tuple() {
         4usize,
         concat!("Alignment of ", stringify!(rte_ipv4_tuple))
     );
-    fn test_field_src_addr() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_ipv4_tuple>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).src_addr) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_ipv4_tuple),
-                "::",
-                stringify!(src_addr)
-            )
-        );
-    }
-    test_field_src_addr();
-    fn test_field_dst_addr() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_ipv4_tuple>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).dst_addr) as usize - ptr as usize
-            },
-            4usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_ipv4_tuple),
-                "::",
-                stringify!(dst_addr)
-            )
-        );
-    }
-    test_field_dst_addr();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).src_addr) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_ipv4_tuple),
+            "::",
+            stringify!(src_addr)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).dst_addr) as usize - ptr as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_ipv4_tuple),
+            "::",
+            stringify!(dst_addr)
+        )
+    );
 }
 impl Clone for rte_ipv4_tuple {
     fn clone(&self) -> Self {
@@ -245,6 +224,9 @@ pub struct rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1 {
 }
 #[test]
 fn bindgen_test_layout_rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1() {
+    const UNINIT: ::std::mem::MaybeUninit<
+        rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1,
+    > = ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1>(),
         4usize,
@@ -261,44 +243,32 @@ fn bindgen_test_layout_rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1() {
             stringify!(rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1)
         )
     );
-    fn test_field_dport() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<
-                    rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1,
-                >::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).dport) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1),
-                "::",
-                stringify!(dport)
-            )
-        );
-    }
-    test_field_dport();
-    fn test_field_sport() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<
-                    rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1,
-                >::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).sport) as usize - ptr as usize
-            },
-            2usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1),
-                "::",
-                stringify!(sport)
-            )
-        );
-    }
-    test_field_sport();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).dport) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1),
+            "::",
+            stringify!(dport)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).sport) as usize - ptr as usize
+        },
+        2usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1),
+            "::",
+            stringify!(sport)
+        )
+    );
 }
 impl Clone for rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1 {
     fn clone(&self) -> Self {
@@ -307,6 +277,8 @@ impl Clone for rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1 {
 }
 #[test]
 fn bindgen_test_layout_rte_ipv6_tuple__bindgen_ty_1() {
+    const UNINIT: ::std::mem::MaybeUninit<rte_ipv6_tuple__bindgen_ty_1> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<rte_ipv6_tuple__bindgen_ty_1>(),
         4usize,
@@ -317,25 +289,19 @@ fn bindgen_test_layout_rte_ipv6_tuple__bindgen_ty_1() {
         4usize,
         concat!("Alignment of ", stringify!(rte_ipv6_tuple__bindgen_ty_1))
     );
-    fn test_field_sctp_tag() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<
-                    rte_ipv6_tuple__bindgen_ty_1,
-                >::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).sctp_tag) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_ipv6_tuple__bindgen_ty_1),
-                "::",
-                stringify!(sctp_tag)
-            )
-        );
-    }
-    test_field_sctp_tag();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).sctp_tag) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_ipv6_tuple__bindgen_ty_1),
+            "::",
+            stringify!(sctp_tag)
+        )
+    );
 }
 impl Clone for rte_ipv6_tuple__bindgen_ty_1 {
     fn clone(&self) -> Self {
@@ -344,6 +310,8 @@ impl Clone for rte_ipv6_tuple__bindgen_ty_1 {
 }
 #[test]
 fn bindgen_test_layout_rte_ipv6_tuple() {
+    const UNINIT: ::std::mem::MaybeUninit<rte_ipv6_tuple> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<rte_ipv6_tuple>(),
         36usize,
@@ -354,42 +322,32 @@ fn bindgen_test_layout_rte_ipv6_tuple() {
         4usize,
         concat!("Alignment of ", stringify!(rte_ipv6_tuple))
     );
-    fn test_field_src_addr() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_ipv6_tuple>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).src_addr) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_ipv6_tuple),
-                "::",
-                stringify!(src_addr)
-            )
-        );
-    }
-    test_field_src_addr();
-    fn test_field_dst_addr() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_ipv6_tuple>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).dst_addr) as usize - ptr as usize
-            },
-            16usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_ipv6_tuple),
-                "::",
-                stringify!(dst_addr)
-            )
-        );
-    }
-    test_field_dst_addr();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).src_addr) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_ipv6_tuple),
+            "::",
+            stringify!(src_addr)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).dst_addr) as usize - ptr as usize
+        },
+        16usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_ipv6_tuple),
+            "::",
+            stringify!(dst_addr)
+        )
+    );
 }
 impl Clone for rte_ipv6_tuple {
     fn clone(&self) -> Self {
@@ -405,47 +363,39 @@ pub struct rte_thash_tuple {
 }
 #[test]
 fn bindgen_test_layout_rte_thash_tuple() {
+    const UNINIT: ::std::mem::MaybeUninit<rte_thash_tuple> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<rte_thash_tuple>(),
         48usize,
         concat!("Size of: ", stringify!(rte_thash_tuple))
     );
-    fn test_field_v4() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_thash_tuple>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).v4) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_thash_tuple),
-                "::",
-                stringify!(v4)
-            )
-        );
-    }
-    test_field_v4();
-    fn test_field_v6() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_thash_tuple>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).v6) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_thash_tuple),
-                "::",
-                stringify!(v6)
-            )
-        );
-    }
-    test_field_v6();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).v4) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_thash_tuple),
+            "::",
+            stringify!(v4)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).v6) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_thash_tuple),
+            "::",
+            stringify!(v6)
+        )
+    );
 }
 impl Clone for rte_thash_tuple {
     fn clone(&self) -> Self {

--- a/tests/expectations/tests/16-byte-alignment_1_0.rs
+++ b/tests/expectations/tests/16-byte-alignment_1_0.rs
@@ -74,6 +74,7 @@ fn bindgen_test_layout_rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<
         rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1,
     > = ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1>(),
         4usize,
@@ -91,10 +92,7 @@ fn bindgen_test_layout_rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).dport) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).dport) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -104,10 +102,7 @@ fn bindgen_test_layout_rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).sport) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).sport) as usize - ptr as usize },
         2usize,
         concat!(
             "Offset of field: ",
@@ -126,6 +121,7 @@ impl Clone for rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1 {
 fn bindgen_test_layout_rte_ipv4_tuple__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<rte_ipv4_tuple__bindgen_ty_1> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<rte_ipv4_tuple__bindgen_ty_1>(),
         4usize,
@@ -138,7 +134,6 @@ fn bindgen_test_layout_rte_ipv4_tuple__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).sctp_tag) as usize - ptr as usize
         },
         0usize,
@@ -159,6 +154,7 @@ impl Clone for rte_ipv4_tuple__bindgen_ty_1 {
 fn bindgen_test_layout_rte_ipv4_tuple() {
     const UNINIT: ::std::mem::MaybeUninit<rte_ipv4_tuple> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<rte_ipv4_tuple>(),
         12usize,
@@ -171,7 +167,6 @@ fn bindgen_test_layout_rte_ipv4_tuple() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).src_addr) as usize - ptr as usize
         },
         0usize,
@@ -184,7 +179,6 @@ fn bindgen_test_layout_rte_ipv4_tuple() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).dst_addr) as usize - ptr as usize
         },
         4usize,
@@ -227,6 +221,7 @@ fn bindgen_test_layout_rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<
         rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1,
     > = ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1>(),
         4usize,
@@ -244,10 +239,7 @@ fn bindgen_test_layout_rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).dport) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).dport) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -257,10 +249,7 @@ fn bindgen_test_layout_rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).sport) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).sport) as usize - ptr as usize },
         2usize,
         concat!(
             "Offset of field: ",
@@ -279,6 +268,7 @@ impl Clone for rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1 {
 fn bindgen_test_layout_rte_ipv6_tuple__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<rte_ipv6_tuple__bindgen_ty_1> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<rte_ipv6_tuple__bindgen_ty_1>(),
         4usize,
@@ -291,7 +281,6 @@ fn bindgen_test_layout_rte_ipv6_tuple__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).sctp_tag) as usize - ptr as usize
         },
         0usize,
@@ -312,6 +301,7 @@ impl Clone for rte_ipv6_tuple__bindgen_ty_1 {
 fn bindgen_test_layout_rte_ipv6_tuple() {
     const UNINIT: ::std::mem::MaybeUninit<rte_ipv6_tuple> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<rte_ipv6_tuple>(),
         36usize,
@@ -324,7 +314,6 @@ fn bindgen_test_layout_rte_ipv6_tuple() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).src_addr) as usize - ptr as usize
         },
         0usize,
@@ -337,7 +326,6 @@ fn bindgen_test_layout_rte_ipv6_tuple() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).dst_addr) as usize - ptr as usize
         },
         16usize,
@@ -365,16 +353,14 @@ pub struct rte_thash_tuple {
 fn bindgen_test_layout_rte_thash_tuple() {
     const UNINIT: ::std::mem::MaybeUninit<rte_thash_tuple> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<rte_thash_tuple>(),
         48usize,
         concat!("Size of: ", stringify!(rte_thash_tuple))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).v4) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).v4) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -384,10 +370,7 @@ fn bindgen_test_layout_rte_thash_tuple() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).v6) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).v6) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/accessors.rs
+++ b/tests/expectations/tests/accessors.rs
@@ -18,6 +18,8 @@ pub struct SomeAccessors {
 }
 #[test]
 fn bindgen_test_layout_SomeAccessors() {
+    const UNINIT: ::std::mem::MaybeUninit<SomeAccessors> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<SomeAccessors>(),
         16usize,
@@ -28,77 +30,60 @@ fn bindgen_test_layout_SomeAccessors() {
         4usize,
         concat!("Alignment of ", stringify!(SomeAccessors))
     );
-    fn test_field_mNoAccessor() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<SomeAccessors>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).mNoAccessor) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(SomeAccessors),
-                "::",
-                stringify!(mNoAccessor)
-            )
-        );
-    }
-    test_field_mNoAccessor();
-    fn test_field_mBothAccessors() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<SomeAccessors>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).mBothAccessors) as usize -
-                    ptr as usize
-            },
-            4usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(SomeAccessors),
-                "::",
-                stringify!(mBothAccessors)
-            )
-        );
-    }
-    test_field_mBothAccessors();
-    fn test_field_mUnsafeAccessors() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<SomeAccessors>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).mUnsafeAccessors) as usize -
-                    ptr as usize
-            },
-            8usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(SomeAccessors),
-                "::",
-                stringify!(mUnsafeAccessors)
-            )
-        );
-    }
-    test_field_mUnsafeAccessors();
-    fn test_field_mImmutableAccessor() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<SomeAccessors>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).mImmutableAccessor) as usize -
-                    ptr as usize
-            },
-            12usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(SomeAccessors),
-                "::",
-                stringify!(mImmutableAccessor)
-            )
-        );
-    }
-    test_field_mImmutableAccessor();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).mNoAccessor) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(SomeAccessors),
+            "::",
+            stringify!(mNoAccessor)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).mBothAccessors) as usize - ptr as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(SomeAccessors),
+            "::",
+            stringify!(mBothAccessors)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).mUnsafeAccessors) as usize -
+                ptr as usize
+        },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(SomeAccessors),
+            "::",
+            stringify!(mUnsafeAccessors)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).mImmutableAccessor) as usize -
+                ptr as usize
+        },
+        12usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(SomeAccessors),
+            "::",
+            stringify!(mImmutableAccessor)
+        )
+    );
 }
 impl SomeAccessors {
     #[inline]
@@ -133,6 +118,8 @@ pub struct AllAccessors {
 }
 #[test]
 fn bindgen_test_layout_AllAccessors() {
+    const UNINIT: ::std::mem::MaybeUninit<AllAccessors> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<AllAccessors>(),
         8usize,
@@ -143,42 +130,33 @@ fn bindgen_test_layout_AllAccessors() {
         4usize,
         concat!("Alignment of ", stringify!(AllAccessors))
     );
-    fn test_field_mBothAccessors() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<AllAccessors>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).mBothAccessors) as usize -
-                    ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(AllAccessors),
-                "::",
-                stringify!(mBothAccessors)
-            )
-        );
-    }
-    test_field_mBothAccessors();
-    fn test_field_mAlsoBothAccessors() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<AllAccessors>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).mAlsoBothAccessors) as usize -
-                    ptr as usize
-            },
-            4usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(AllAccessors),
-                "::",
-                stringify!(mAlsoBothAccessors)
-            )
-        );
-    }
-    test_field_mAlsoBothAccessors();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).mBothAccessors) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(AllAccessors),
+            "::",
+            stringify!(mBothAccessors)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).mAlsoBothAccessors) as usize -
+                ptr as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(AllAccessors),
+            "::",
+            stringify!(mAlsoBothAccessors)
+        )
+    );
 }
 impl AllAccessors {
     #[inline]
@@ -207,6 +185,8 @@ pub struct AllUnsafeAccessors {
 }
 #[test]
 fn bindgen_test_layout_AllUnsafeAccessors() {
+    const UNINIT: ::std::mem::MaybeUninit<AllUnsafeAccessors> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<AllUnsafeAccessors>(),
         8usize,
@@ -217,44 +197,33 @@ fn bindgen_test_layout_AllUnsafeAccessors() {
         4usize,
         concat!("Alignment of ", stringify!(AllUnsafeAccessors))
     );
-    fn test_field_mBothAccessors() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<AllUnsafeAccessors>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).mBothAccessors) as usize -
-                    ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(AllUnsafeAccessors),
-                "::",
-                stringify!(mBothAccessors)
-            )
-        );
-    }
-    test_field_mBothAccessors();
-    fn test_field_mAlsoBothAccessors() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<AllUnsafeAccessors>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).mAlsoBothAccessors) as usize -
-                    ptr as usize
-            },
-            4usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(AllUnsafeAccessors),
-                "::",
-                stringify!(mAlsoBothAccessors)
-            )
-        );
-    }
-    test_field_mAlsoBothAccessors();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).mBothAccessors) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(AllUnsafeAccessors),
+            "::",
+            stringify!(mBothAccessors)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).mAlsoBothAccessors) as usize -
+                ptr as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(AllUnsafeAccessors),
+            "::",
+            stringify!(mAlsoBothAccessors)
+        )
+    );
 }
 impl AllUnsafeAccessors {
     #[inline]
@@ -292,6 +261,8 @@ pub struct ContradictAccessors {
 }
 #[test]
 fn bindgen_test_layout_ContradictAccessors() {
+    const UNINIT: ::std::mem::MaybeUninit<ContradictAccessors> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<ContradictAccessors>(),
         16usize,
@@ -302,82 +273,60 @@ fn bindgen_test_layout_ContradictAccessors() {
         4usize,
         concat!("Alignment of ", stringify!(ContradictAccessors))
     );
-    fn test_field_mBothAccessors() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<ContradictAccessors>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).mBothAccessors) as usize -
-                    ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(ContradictAccessors),
-                "::",
-                stringify!(mBothAccessors)
-            )
-        );
-    }
-    test_field_mBothAccessors();
-    fn test_field_mNoAccessors() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<ContradictAccessors>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).mNoAccessors) as usize -
-                    ptr as usize
-            },
-            4usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(ContradictAccessors),
-                "::",
-                stringify!(mNoAccessors)
-            )
-        );
-    }
-    test_field_mNoAccessors();
-    fn test_field_mUnsafeAccessors() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<ContradictAccessors>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).mUnsafeAccessors) as usize -
-                    ptr as usize
-            },
-            8usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(ContradictAccessors),
-                "::",
-                stringify!(mUnsafeAccessors)
-            )
-        );
-    }
-    test_field_mUnsafeAccessors();
-    fn test_field_mImmutableAccessor() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<ContradictAccessors>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).mImmutableAccessor) as usize -
-                    ptr as usize
-            },
-            12usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(ContradictAccessors),
-                "::",
-                stringify!(mImmutableAccessor)
-            )
-        );
-    }
-    test_field_mImmutableAccessor();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).mBothAccessors) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ContradictAccessors),
+            "::",
+            stringify!(mBothAccessors)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).mNoAccessors) as usize - ptr as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ContradictAccessors),
+            "::",
+            stringify!(mNoAccessors)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).mUnsafeAccessors) as usize -
+                ptr as usize
+        },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ContradictAccessors),
+            "::",
+            stringify!(mUnsafeAccessors)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).mImmutableAccessor) as usize -
+                ptr as usize
+        },
+        12usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ContradictAccessors),
+            "::",
+            stringify!(mImmutableAccessor)
+        )
+    );
 }
 impl ContradictAccessors {
     #[inline]
@@ -411,6 +360,8 @@ pub struct Replaced {
 }
 #[test]
 fn bindgen_test_layout_Replaced() {
+    const UNINIT: ::std::mem::MaybeUninit<Replaced> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<Replaced>(),
         4usize,
@@ -421,23 +372,19 @@ fn bindgen_test_layout_Replaced() {
         4usize,
         concat!("Alignment of ", stringify!(Replaced))
     );
-    fn test_field_mAccessor() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Replaced>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).mAccessor) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(Replaced),
-                "::",
-                stringify!(mAccessor)
-            )
-        );
-    }
-    test_field_mAccessor();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).mAccessor) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(Replaced),
+            "::",
+            stringify!(mAccessor)
+        )
+    );
 }
 impl Replaced {
     #[inline]
@@ -457,6 +404,8 @@ pub struct Wrapper {
 }
 #[test]
 fn bindgen_test_layout_Wrapper() {
+    const UNINIT: ::std::mem::MaybeUninit<Wrapper> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<Wrapper>(),
         4usize,
@@ -467,23 +416,19 @@ fn bindgen_test_layout_Wrapper() {
         4usize,
         concat!("Alignment of ", stringify!(Wrapper))
     );
-    fn test_field_mReplaced() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Wrapper>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).mReplaced) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(Wrapper),
-                "::",
-                stringify!(mReplaced)
-            )
-        );
-    }
-    test_field_mReplaced();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).mReplaced) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(Wrapper),
+            "::",
+            stringify!(mReplaced)
+        )
+    );
 }
 impl Wrapper {
     #[inline]

--- a/tests/expectations/tests/accessors.rs
+++ b/tests/expectations/tests/accessors.rs
@@ -20,6 +20,7 @@ pub struct SomeAccessors {
 fn bindgen_test_layout_SomeAccessors() {
     const UNINIT: ::std::mem::MaybeUninit<SomeAccessors> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<SomeAccessors>(),
         16usize,
@@ -32,7 +33,6 @@ fn bindgen_test_layout_SomeAccessors() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).mNoAccessor) as usize - ptr as usize
         },
         0usize,
@@ -45,7 +45,6 @@ fn bindgen_test_layout_SomeAccessors() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).mBothAccessors) as usize - ptr as usize
         },
         4usize,
@@ -58,7 +57,6 @@ fn bindgen_test_layout_SomeAccessors() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).mUnsafeAccessors) as usize -
                 ptr as usize
         },
@@ -72,7 +70,6 @@ fn bindgen_test_layout_SomeAccessors() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).mImmutableAccessor) as usize -
                 ptr as usize
         },
@@ -120,6 +117,7 @@ pub struct AllAccessors {
 fn bindgen_test_layout_AllAccessors() {
     const UNINIT: ::std::mem::MaybeUninit<AllAccessors> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<AllAccessors>(),
         8usize,
@@ -132,7 +130,6 @@ fn bindgen_test_layout_AllAccessors() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).mBothAccessors) as usize - ptr as usize
         },
         0usize,
@@ -145,7 +142,6 @@ fn bindgen_test_layout_AllAccessors() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).mAlsoBothAccessors) as usize -
                 ptr as usize
         },
@@ -187,6 +183,7 @@ pub struct AllUnsafeAccessors {
 fn bindgen_test_layout_AllUnsafeAccessors() {
     const UNINIT: ::std::mem::MaybeUninit<AllUnsafeAccessors> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<AllUnsafeAccessors>(),
         8usize,
@@ -199,7 +196,6 @@ fn bindgen_test_layout_AllUnsafeAccessors() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).mBothAccessors) as usize - ptr as usize
         },
         0usize,
@@ -212,7 +208,6 @@ fn bindgen_test_layout_AllUnsafeAccessors() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).mAlsoBothAccessors) as usize -
                 ptr as usize
         },
@@ -263,6 +258,7 @@ pub struct ContradictAccessors {
 fn bindgen_test_layout_ContradictAccessors() {
     const UNINIT: ::std::mem::MaybeUninit<ContradictAccessors> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<ContradictAccessors>(),
         16usize,
@@ -275,7 +271,6 @@ fn bindgen_test_layout_ContradictAccessors() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).mBothAccessors) as usize - ptr as usize
         },
         0usize,
@@ -288,7 +283,6 @@ fn bindgen_test_layout_ContradictAccessors() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).mNoAccessors) as usize - ptr as usize
         },
         4usize,
@@ -301,7 +295,6 @@ fn bindgen_test_layout_ContradictAccessors() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).mUnsafeAccessors) as usize -
                 ptr as usize
         },
@@ -315,7 +308,6 @@ fn bindgen_test_layout_ContradictAccessors() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).mImmutableAccessor) as usize -
                 ptr as usize
         },
@@ -362,6 +354,7 @@ pub struct Replaced {
 fn bindgen_test_layout_Replaced() {
     const UNINIT: ::std::mem::MaybeUninit<Replaced> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<Replaced>(),
         4usize,
@@ -374,7 +367,6 @@ fn bindgen_test_layout_Replaced() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).mAccessor) as usize - ptr as usize
         },
         0usize,
@@ -406,6 +398,7 @@ pub struct Wrapper {
 fn bindgen_test_layout_Wrapper() {
     const UNINIT: ::std::mem::MaybeUninit<Wrapper> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<Wrapper>(),
         4usize,
@@ -418,7 +411,6 @@ fn bindgen_test_layout_Wrapper() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).mReplaced) as usize - ptr as usize
         },
         0usize,

--- a/tests/expectations/tests/allowlist-file.rs
+++ b/tests/expectations/tests/allowlist-file.rs
@@ -58,6 +58,8 @@ pub struct StructWithAllowlistedDefinition {
 }
 #[test]
 fn bindgen_test_layout_StructWithAllowlistedDefinition() {
+    const UNINIT: ::std::mem::MaybeUninit<StructWithAllowlistedDefinition> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<StructWithAllowlistedDefinition>(),
         8usize,
@@ -68,25 +70,19 @@ fn bindgen_test_layout_StructWithAllowlistedDefinition() {
         8usize,
         concat!("Alignment of ", stringify!(StructWithAllowlistedDefinition))
     );
-    fn test_field_other() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<
-                    StructWithAllowlistedDefinition,
-                >::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).other) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(StructWithAllowlistedDefinition),
-                "::",
-                stringify!(other)
-            )
-        );
-    }
-    test_field_other();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).other) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(StructWithAllowlistedDefinition),
+            "::",
+            stringify!(other)
+        )
+    );
 }
 impl Default for StructWithAllowlistedDefinition {
     fn default() -> Self {
@@ -104,6 +100,8 @@ pub struct StructWithAllowlistedFwdDecl {
 }
 #[test]
 fn bindgen_test_layout_StructWithAllowlistedFwdDecl() {
+    const UNINIT: ::std::mem::MaybeUninit<StructWithAllowlistedFwdDecl> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<StructWithAllowlistedFwdDecl>(),
         4usize,
@@ -114,25 +112,19 @@ fn bindgen_test_layout_StructWithAllowlistedFwdDecl() {
         4usize,
         concat!("Alignment of ", stringify!(StructWithAllowlistedFwdDecl))
     );
-    fn test_field_b() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<
-                    StructWithAllowlistedFwdDecl,
-                >::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(StructWithAllowlistedFwdDecl),
-                "::",
-                stringify!(b)
-            )
-        );
-    }
-    test_field_b();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(StructWithAllowlistedFwdDecl),
+            "::",
+            stringify!(b)
+        )
+    );
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
@@ -141,6 +133,8 @@ pub struct AllowlistMe {
 }
 #[test]
 fn bindgen_test_layout_AllowlistMe() {
+    const UNINIT: ::std::mem::MaybeUninit<AllowlistMe> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<AllowlistMe>(),
         4usize,
@@ -151,21 +145,17 @@ fn bindgen_test_layout_AllowlistMe() {
         4usize,
         concat!("Alignment of ", stringify!(AllowlistMe))
     );
-    fn test_field_foo() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<AllowlistMe>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(AllowlistMe),
-                "::",
-                stringify!(foo)
-            )
-        );
-    }
-    test_field_foo();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(AllowlistMe),
+            "::",
+            stringify!(foo)
+        )
+    );
 }

--- a/tests/expectations/tests/allowlist-file.rs
+++ b/tests/expectations/tests/allowlist-file.rs
@@ -60,6 +60,7 @@ pub struct StructWithAllowlistedDefinition {
 fn bindgen_test_layout_StructWithAllowlistedDefinition() {
     const UNINIT: ::std::mem::MaybeUninit<StructWithAllowlistedDefinition> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<StructWithAllowlistedDefinition>(),
         8usize,
@@ -71,10 +72,7 @@ fn bindgen_test_layout_StructWithAllowlistedDefinition() {
         concat!("Alignment of ", stringify!(StructWithAllowlistedDefinition))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).other) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).other) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -102,6 +100,7 @@ pub struct StructWithAllowlistedFwdDecl {
 fn bindgen_test_layout_StructWithAllowlistedFwdDecl() {
     const UNINIT: ::std::mem::MaybeUninit<StructWithAllowlistedFwdDecl> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<StructWithAllowlistedFwdDecl>(),
         4usize,
@@ -113,10 +112,7 @@ fn bindgen_test_layout_StructWithAllowlistedFwdDecl() {
         concat!("Alignment of ", stringify!(StructWithAllowlistedFwdDecl))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -135,6 +131,7 @@ pub struct AllowlistMe {
 fn bindgen_test_layout_AllowlistMe() {
     const UNINIT: ::std::mem::MaybeUninit<AllowlistMe> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<AllowlistMe>(),
         4usize,
@@ -146,10 +143,7 @@ fn bindgen_test_layout_AllowlistMe() {
         concat!("Alignment of ", stringify!(AllowlistMe))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/allowlist-namespaces.rs
+++ b/tests/expectations/tests/allowlist-namespaces.rs
@@ -43,6 +43,7 @@ pub mod root {
         fn bindgen_test_layout_Test() {
             const UNINIT: ::std::mem::MaybeUninit<Test> =
                 ::std::mem::MaybeUninit::uninit();
+            let ptr = UNINIT.as_ptr();
             assert_eq!(
                 ::std::mem::size_of::<Test>(),
                 1usize,
@@ -55,7 +56,6 @@ pub mod root {
             );
             assert_eq!(
                 unsafe {
-                    let ptr = UNINIT.as_ptr();
                     ::std::ptr::addr_of!((*ptr).helper) as usize - ptr as usize
                 },
                 0usize,

--- a/tests/expectations/tests/allowlist-namespaces.rs
+++ b/tests/expectations/tests/allowlist-namespaces.rs
@@ -41,6 +41,8 @@ pub mod root {
         }
         #[test]
         fn bindgen_test_layout_Test() {
+            const UNINIT: ::std::mem::MaybeUninit<Test> =
+                ::std::mem::MaybeUninit::uninit();
             assert_eq!(
                 ::std::mem::size_of::<Test>(),
                 1usize,
@@ -51,24 +53,19 @@ pub mod root {
                 1usize,
                 concat!("Alignment of ", stringify!(Test))
             );
-            fn test_field_helper() {
-                assert_eq!(
-                    unsafe {
-                        let uninit = ::std::mem::MaybeUninit::<Test>::uninit();
-                        let ptr = uninit.as_ptr();
-                        ::std::ptr::addr_of!((*ptr).helper) as usize -
-                            ptr as usize
-                    },
-                    0usize,
-                    concat!(
-                        "Offset of field: ",
-                        stringify!(Test),
-                        "::",
-                        stringify!(helper)
-                    )
-                );
-            }
-            test_field_helper();
+            assert_eq!(
+                unsafe {
+                    let ptr = UNINIT.as_ptr();
+                    ::std::ptr::addr_of!((*ptr).helper) as usize - ptr as usize
+                },
+                0usize,
+                concat!(
+                    "Offset of field: ",
+                    stringify!(Test),
+                    "::",
+                    stringify!(helper)
+                )
+            );
         }
     }
 }

--- a/tests/expectations/tests/allowlisted-item-references-no-hash.rs
+++ b/tests/expectations/tests/allowlisted-item-references-no-hash.rs
@@ -30,6 +30,8 @@ pub struct AllowlistMe {
 }
 #[test]
 fn bindgen_test_layout_AllowlistMe() {
+    const UNINIT: ::std::mem::MaybeUninit<AllowlistMe> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<AllowlistMe>(),
         1usize,
@@ -40,21 +42,17 @@ fn bindgen_test_layout_AllowlistMe() {
         1usize,
         concat!("Alignment of ", stringify!(AllowlistMe))
     );
-    fn test_field_a() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<AllowlistMe>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(AllowlistMe),
-                "::",
-                stringify!(a)
-            )
-        );
-    }
-    test_field_a();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(AllowlistMe),
+            "::",
+            stringify!(a)
+        )
+    );
 }

--- a/tests/expectations/tests/allowlisted-item-references-no-hash.rs
+++ b/tests/expectations/tests/allowlisted-item-references-no-hash.rs
@@ -32,6 +32,7 @@ pub struct AllowlistMe {
 fn bindgen_test_layout_AllowlistMe() {
     const UNINIT: ::std::mem::MaybeUninit<AllowlistMe> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<AllowlistMe>(),
         1usize,
@@ -43,10 +44,7 @@ fn bindgen_test_layout_AllowlistMe() {
         concat!("Alignment of ", stringify!(AllowlistMe))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/allowlisted-item-references-no-partialeq.rs
+++ b/tests/expectations/tests/allowlisted-item-references-no-partialeq.rs
@@ -30,6 +30,8 @@ pub struct AllowlistMe {
 }
 #[test]
 fn bindgen_test_layout_AllowlistMe() {
+    const UNINIT: ::std::mem::MaybeUninit<AllowlistMe> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<AllowlistMe>(),
         1usize,
@@ -40,21 +42,17 @@ fn bindgen_test_layout_AllowlistMe() {
         1usize,
         concat!("Alignment of ", stringify!(AllowlistMe))
     );
-    fn test_field_a() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<AllowlistMe>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(AllowlistMe),
-                "::",
-                stringify!(a)
-            )
-        );
-    }
-    test_field_a();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(AllowlistMe),
+            "::",
+            stringify!(a)
+        )
+    );
 }

--- a/tests/expectations/tests/allowlisted-item-references-no-partialeq.rs
+++ b/tests/expectations/tests/allowlisted-item-references-no-partialeq.rs
@@ -32,6 +32,7 @@ pub struct AllowlistMe {
 fn bindgen_test_layout_AllowlistMe() {
     const UNINIT: ::std::mem::MaybeUninit<AllowlistMe> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<AllowlistMe>(),
         1usize,
@@ -43,10 +44,7 @@ fn bindgen_test_layout_AllowlistMe() {
         concat!("Alignment of ", stringify!(AllowlistMe))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/allowlisted_item_references_no_copy.rs
+++ b/tests/expectations/tests/allowlisted_item_references_no_copy.rs
@@ -30,6 +30,8 @@ pub struct AllowlistMe {
 }
 #[test]
 fn bindgen_test_layout_AllowlistMe() {
+    const UNINIT: ::std::mem::MaybeUninit<AllowlistMe> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<AllowlistMe>(),
         1usize,
@@ -40,21 +42,17 @@ fn bindgen_test_layout_AllowlistMe() {
         1usize,
         concat!("Alignment of ", stringify!(AllowlistMe))
     );
-    fn test_field_a() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<AllowlistMe>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(AllowlistMe),
-                "::",
-                stringify!(a)
-            )
-        );
-    }
-    test_field_a();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(AllowlistMe),
+            "::",
+            stringify!(a)
+        )
+    );
 }

--- a/tests/expectations/tests/allowlisted_item_references_no_copy.rs
+++ b/tests/expectations/tests/allowlisted_item_references_no_copy.rs
@@ -32,6 +32,7 @@ pub struct AllowlistMe {
 fn bindgen_test_layout_AllowlistMe() {
     const UNINIT: ::std::mem::MaybeUninit<AllowlistMe> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<AllowlistMe>(),
         1usize,
@@ -43,10 +44,7 @@ fn bindgen_test_layout_AllowlistMe() {
         concat!("Alignment of ", stringify!(AllowlistMe))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/annotation_hide.rs
+++ b/tests/expectations/tests/annotation_hide.rs
@@ -34,6 +34,7 @@ pub struct NotAnnotated {
 fn bindgen_test_layout_NotAnnotated() {
     const UNINIT: ::std::mem::MaybeUninit<NotAnnotated> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<NotAnnotated>(),
         4usize,
@@ -45,10 +46,7 @@ fn bindgen_test_layout_NotAnnotated() {
         concat!("Alignment of ", stringify!(NotAnnotated))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).f) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).f) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/annotation_hide.rs
+++ b/tests/expectations/tests/annotation_hide.rs
@@ -32,6 +32,8 @@ pub struct NotAnnotated {
 }
 #[test]
 fn bindgen_test_layout_NotAnnotated() {
+    const UNINIT: ::std::mem::MaybeUninit<NotAnnotated> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<NotAnnotated>(),
         4usize,
@@ -42,21 +44,17 @@ fn bindgen_test_layout_NotAnnotated() {
         4usize,
         concat!("Alignment of ", stringify!(NotAnnotated))
     );
-    fn test_field_f() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<NotAnnotated>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).f) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(NotAnnotated),
-                "::",
-                stringify!(f)
-            )
-        );
-    }
-    test_field_f();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).f) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(NotAnnotated),
+            "::",
+            stringify!(f)
+        )
+    );
 }

--- a/tests/expectations/tests/anon-fields-prefix.rs
+++ b/tests/expectations/tests/anon-fields-prefix.rs
@@ -23,6 +23,7 @@ pub struct color__bindgen_ty_1 {
 fn bindgen_test_layout_color__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<color__bindgen_ty_1> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<color__bindgen_ty_1>(),
         3usize,
@@ -34,10 +35,7 @@ fn bindgen_test_layout_color__bindgen_ty_1() {
         concat!("Alignment of ", stringify!(color__bindgen_ty_1))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).r) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).r) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -47,10 +45,7 @@ fn bindgen_test_layout_color__bindgen_ty_1() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).g) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).g) as usize - ptr as usize },
         1usize,
         concat!(
             "Offset of field: ",
@@ -60,10 +55,7 @@ fn bindgen_test_layout_color__bindgen_ty_1() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
         2usize,
         concat!(
             "Offset of field: ",
@@ -84,6 +76,7 @@ pub struct color__bindgen_ty_2 {
 fn bindgen_test_layout_color__bindgen_ty_2() {
     const UNINIT: ::std::mem::MaybeUninit<color__bindgen_ty_2> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<color__bindgen_ty_2>(),
         3usize,
@@ -95,10 +88,7 @@ fn bindgen_test_layout_color__bindgen_ty_2() {
         concat!("Alignment of ", stringify!(color__bindgen_ty_2))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).y) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).y) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -108,10 +98,7 @@ fn bindgen_test_layout_color__bindgen_ty_2() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).u) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).u) as usize - ptr as usize },
         1usize,
         concat!(
             "Offset of field: ",
@@ -121,10 +108,7 @@ fn bindgen_test_layout_color__bindgen_ty_2() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).v) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).v) as usize - ptr as usize },
         2usize,
         concat!(
             "Offset of field: ",
@@ -138,6 +122,7 @@ fn bindgen_test_layout_color__bindgen_ty_2() {
 fn bindgen_test_layout_color() {
     const UNINIT: ::std::mem::MaybeUninit<color> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<color>(),
         3usize,
@@ -149,10 +134,7 @@ fn bindgen_test_layout_color() {
         concat!("Alignment of ", stringify!(color))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).v3) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).v3) as usize - ptr as usize },
         0usize,
         concat!("Offset of field: ", stringify!(color), "::", stringify!(v3))
     );

--- a/tests/expectations/tests/anon-fields-prefix.rs
+++ b/tests/expectations/tests/anon-fields-prefix.rs
@@ -21,6 +21,8 @@ pub struct color__bindgen_ty_1 {
 }
 #[test]
 fn bindgen_test_layout_color__bindgen_ty_1() {
+    const UNINIT: ::std::mem::MaybeUninit<color__bindgen_ty_1> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<color__bindgen_ty_1>(),
         3usize,
@@ -31,60 +33,45 @@ fn bindgen_test_layout_color__bindgen_ty_1() {
         1usize,
         concat!("Alignment of ", stringify!(color__bindgen_ty_1))
     );
-    fn test_field_r() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<color__bindgen_ty_1>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).r) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(color__bindgen_ty_1),
-                "::",
-                stringify!(r)
-            )
-        );
-    }
-    test_field_r();
-    fn test_field_g() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<color__bindgen_ty_1>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).g) as usize - ptr as usize
-            },
-            1usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(color__bindgen_ty_1),
-                "::",
-                stringify!(g)
-            )
-        );
-    }
-    test_field_g();
-    fn test_field_b() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<color__bindgen_ty_1>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-            },
-            2usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(color__bindgen_ty_1),
-                "::",
-                stringify!(b)
-            )
-        );
-    }
-    test_field_b();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).r) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(color__bindgen_ty_1),
+            "::",
+            stringify!(r)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).g) as usize - ptr as usize
+        },
+        1usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(color__bindgen_ty_1),
+            "::",
+            stringify!(g)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
+        },
+        2usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(color__bindgen_ty_1),
+            "::",
+            stringify!(b)
+        )
+    );
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
@@ -95,6 +82,8 @@ pub struct color__bindgen_ty_2 {
 }
 #[test]
 fn bindgen_test_layout_color__bindgen_ty_2() {
+    const UNINIT: ::std::mem::MaybeUninit<color__bindgen_ty_2> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<color__bindgen_ty_2>(),
         3usize,
@@ -105,63 +94,50 @@ fn bindgen_test_layout_color__bindgen_ty_2() {
         1usize,
         concat!("Alignment of ", stringify!(color__bindgen_ty_2))
     );
-    fn test_field_y() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<color__bindgen_ty_2>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).y) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(color__bindgen_ty_2),
-                "::",
-                stringify!(y)
-            )
-        );
-    }
-    test_field_y();
-    fn test_field_u() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<color__bindgen_ty_2>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).u) as usize - ptr as usize
-            },
-            1usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(color__bindgen_ty_2),
-                "::",
-                stringify!(u)
-            )
-        );
-    }
-    test_field_u();
-    fn test_field_v() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<color__bindgen_ty_2>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).v) as usize - ptr as usize
-            },
-            2usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(color__bindgen_ty_2),
-                "::",
-                stringify!(v)
-            )
-        );
-    }
-    test_field_v();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).y) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(color__bindgen_ty_2),
+            "::",
+            stringify!(y)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).u) as usize - ptr as usize
+        },
+        1usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(color__bindgen_ty_2),
+            "::",
+            stringify!(u)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).v) as usize - ptr as usize
+        },
+        2usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(color__bindgen_ty_2),
+            "::",
+            stringify!(v)
+        )
+    );
 }
 #[test]
 fn bindgen_test_layout_color() {
+    const UNINIT: ::std::mem::MaybeUninit<color> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<color>(),
         3usize,
@@ -172,23 +148,14 @@ fn bindgen_test_layout_color() {
         1usize,
         concat!("Alignment of ", stringify!(color))
     );
-    fn test_field_v3() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<color>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).v3) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(color),
-                "::",
-                stringify!(v3)
-            )
-        );
-    }
-    test_field_v3();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).v3) as usize - ptr as usize
+        },
+        0usize,
+        concat!("Offset of field: ", stringify!(color), "::", stringify!(v3))
+    );
 }
 impl Default for color {
     fn default() -> Self {

--- a/tests/expectations/tests/anon_enum.rs
+++ b/tests/expectations/tests/anon_enum.rs
@@ -19,6 +19,8 @@ pub enum Test__bindgen_ty_1 {
 }
 #[test]
 fn bindgen_test_layout_Test() {
+    const UNINIT: ::std::mem::MaybeUninit<Test> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<Test>(),
         8usize,
@@ -29,40 +31,22 @@ fn bindgen_test_layout_Test() {
         4usize,
         concat!("Alignment of ", stringify!(Test))
     );
-    fn test_field_foo() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Test>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(Test),
-                "::",
-                stringify!(foo)
-            )
-        );
-    }
-    test_field_foo();
-    fn test_field_bar() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Test>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
-            },
-            4usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(Test),
-                "::",
-                stringify!(bar)
-            )
-        );
-    }
-    test_field_bar();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize
+        },
+        0usize,
+        concat!("Offset of field: ", stringify!(Test), "::", stringify!(foo))
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
+        },
+        4usize,
+        concat!("Offset of field: ", stringify!(Test), "::", stringify!(bar))
+    );
 }
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]

--- a/tests/expectations/tests/anon_enum.rs
+++ b/tests/expectations/tests/anon_enum.rs
@@ -21,6 +21,7 @@ pub enum Test__bindgen_ty_1 {
 fn bindgen_test_layout_Test() {
     const UNINIT: ::std::mem::MaybeUninit<Test> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<Test>(),
         8usize,
@@ -32,18 +33,12 @@ fn bindgen_test_layout_Test() {
         concat!("Alignment of ", stringify!(Test))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize },
         0usize,
         concat!("Offset of field: ", stringify!(Test), "::", stringify!(foo))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize },
         4usize,
         concat!("Offset of field: ", stringify!(Test), "::", stringify!(bar))
     );

--- a/tests/expectations/tests/anon_struct_in_union.rs
+++ b/tests/expectations/tests/anon_struct_in_union.rs
@@ -24,6 +24,7 @@ pub struct s__bindgen_ty_1_inner {
 fn bindgen_test_layout_s__bindgen_ty_1_inner() {
     const UNINIT: ::std::mem::MaybeUninit<s__bindgen_ty_1_inner> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<s__bindgen_ty_1_inner>(),
         4usize,
@@ -35,10 +36,7 @@ fn bindgen_test_layout_s__bindgen_ty_1_inner() {
         concat!("Alignment of ", stringify!(s__bindgen_ty_1_inner))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -52,6 +50,7 @@ fn bindgen_test_layout_s__bindgen_ty_1_inner() {
 fn bindgen_test_layout_s__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<s__bindgen_ty_1> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<s__bindgen_ty_1>(),
         4usize,
@@ -63,10 +62,7 @@ fn bindgen_test_layout_s__bindgen_ty_1() {
         concat!("Alignment of ", stringify!(s__bindgen_ty_1))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).field) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).field) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -89,6 +85,7 @@ impl Default for s__bindgen_ty_1 {
 fn bindgen_test_layout_s() {
     const UNINIT: ::std::mem::MaybeUninit<s> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<s>(),
         4usize,
@@ -100,10 +97,7 @@ fn bindgen_test_layout_s() {
         concat!("Alignment of ", stringify!(s))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).u) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).u) as usize - ptr as usize },
         0usize,
         concat!("Offset of field: ", stringify!(s), "::", stringify!(u))
     );

--- a/tests/expectations/tests/anon_struct_in_union.rs
+++ b/tests/expectations/tests/anon_struct_in_union.rs
@@ -22,6 +22,8 @@ pub struct s__bindgen_ty_1_inner {
 }
 #[test]
 fn bindgen_test_layout_s__bindgen_ty_1_inner() {
+    const UNINIT: ::std::mem::MaybeUninit<s__bindgen_ty_1_inner> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<s__bindgen_ty_1_inner>(),
         4usize,
@@ -32,27 +34,24 @@ fn bindgen_test_layout_s__bindgen_ty_1_inner() {
         4usize,
         concat!("Alignment of ", stringify!(s__bindgen_ty_1_inner))
     );
-    fn test_field_b() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<s__bindgen_ty_1_inner>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(s__bindgen_ty_1_inner),
-                "::",
-                stringify!(b)
-            )
-        );
-    }
-    test_field_b();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(s__bindgen_ty_1_inner),
+            "::",
+            stringify!(b)
+        )
+    );
 }
 #[test]
 fn bindgen_test_layout_s__bindgen_ty_1() {
+    const UNINIT: ::std::mem::MaybeUninit<s__bindgen_ty_1> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<s__bindgen_ty_1>(),
         4usize,
@@ -63,24 +62,19 @@ fn bindgen_test_layout_s__bindgen_ty_1() {
         4usize,
         concat!("Alignment of ", stringify!(s__bindgen_ty_1))
     );
-    fn test_field_field() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<s__bindgen_ty_1>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).field) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(s__bindgen_ty_1),
-                "::",
-                stringify!(field)
-            )
-        );
-    }
-    test_field_field();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).field) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(s__bindgen_ty_1),
+            "::",
+            stringify!(field)
+        )
+    );
 }
 impl Default for s__bindgen_ty_1 {
     fn default() -> Self {
@@ -93,6 +87,8 @@ impl Default for s__bindgen_ty_1 {
 }
 #[test]
 fn bindgen_test_layout_s() {
+    const UNINIT: ::std::mem::MaybeUninit<s> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<s>(),
         4usize,
@@ -103,18 +99,14 @@ fn bindgen_test_layout_s() {
         4usize,
         concat!("Alignment of ", stringify!(s))
     );
-    fn test_field_u() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<s>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).u) as usize - ptr as usize
-            },
-            0usize,
-            concat!("Offset of field: ", stringify!(s), "::", stringify!(u))
-        );
-    }
-    test_field_u();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).u) as usize - ptr as usize
+        },
+        0usize,
+        concat!("Offset of field: ", stringify!(s), "::", stringify!(u))
+    );
 }
 impl Default for s {
     fn default() -> Self {

--- a/tests/expectations/tests/anon_struct_in_union_1_0.rs
+++ b/tests/expectations/tests/anon_struct_in_union_1_0.rs
@@ -66,6 +66,8 @@ pub struct s__bindgen_ty_1_inner {
 }
 #[test]
 fn bindgen_test_layout_s__bindgen_ty_1_inner() {
+    const UNINIT: ::std::mem::MaybeUninit<s__bindgen_ty_1_inner> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<s__bindgen_ty_1_inner>(),
         4usize,
@@ -76,24 +78,19 @@ fn bindgen_test_layout_s__bindgen_ty_1_inner() {
         4usize,
         concat!("Alignment of ", stringify!(s__bindgen_ty_1_inner))
     );
-    fn test_field_b() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<s__bindgen_ty_1_inner>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(s__bindgen_ty_1_inner),
-                "::",
-                stringify!(b)
-            )
-        );
-    }
-    test_field_b();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(s__bindgen_ty_1_inner),
+            "::",
+            stringify!(b)
+        )
+    );
 }
 impl Clone for s__bindgen_ty_1_inner {
     fn clone(&self) -> Self {
@@ -102,6 +99,8 @@ impl Clone for s__bindgen_ty_1_inner {
 }
 #[test]
 fn bindgen_test_layout_s__bindgen_ty_1() {
+    const UNINIT: ::std::mem::MaybeUninit<s__bindgen_ty_1> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<s__bindgen_ty_1>(),
         4usize,
@@ -112,24 +111,19 @@ fn bindgen_test_layout_s__bindgen_ty_1() {
         4usize,
         concat!("Alignment of ", stringify!(s__bindgen_ty_1))
     );
-    fn test_field_field() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<s__bindgen_ty_1>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).field) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(s__bindgen_ty_1),
-                "::",
-                stringify!(field)
-            )
-        );
-    }
-    test_field_field();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).field) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(s__bindgen_ty_1),
+            "::",
+            stringify!(field)
+        )
+    );
 }
 impl Clone for s__bindgen_ty_1 {
     fn clone(&self) -> Self {
@@ -138,6 +132,8 @@ impl Clone for s__bindgen_ty_1 {
 }
 #[test]
 fn bindgen_test_layout_s() {
+    const UNINIT: ::std::mem::MaybeUninit<s> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<s>(),
         4usize,
@@ -148,18 +144,14 @@ fn bindgen_test_layout_s() {
         4usize,
         concat!("Alignment of ", stringify!(s))
     );
-    fn test_field_u() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<s>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).u) as usize - ptr as usize
-            },
-            0usize,
-            concat!("Offset of field: ", stringify!(s), "::", stringify!(u))
-        );
-    }
-    test_field_u();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).u) as usize - ptr as usize
+        },
+        0usize,
+        concat!("Offset of field: ", stringify!(s), "::", stringify!(u))
+    );
 }
 impl Clone for s {
     fn clone(&self) -> Self {

--- a/tests/expectations/tests/anon_struct_in_union_1_0.rs
+++ b/tests/expectations/tests/anon_struct_in_union_1_0.rs
@@ -68,6 +68,7 @@ pub struct s__bindgen_ty_1_inner {
 fn bindgen_test_layout_s__bindgen_ty_1_inner() {
     const UNINIT: ::std::mem::MaybeUninit<s__bindgen_ty_1_inner> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<s__bindgen_ty_1_inner>(),
         4usize,
@@ -79,10 +80,7 @@ fn bindgen_test_layout_s__bindgen_ty_1_inner() {
         concat!("Alignment of ", stringify!(s__bindgen_ty_1_inner))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -101,6 +99,7 @@ impl Clone for s__bindgen_ty_1_inner {
 fn bindgen_test_layout_s__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<s__bindgen_ty_1> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<s__bindgen_ty_1>(),
         4usize,
@@ -112,10 +111,7 @@ fn bindgen_test_layout_s__bindgen_ty_1() {
         concat!("Alignment of ", stringify!(s__bindgen_ty_1))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).field) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).field) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -134,6 +130,7 @@ impl Clone for s__bindgen_ty_1 {
 fn bindgen_test_layout_s() {
     const UNINIT: ::std::mem::MaybeUninit<s> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<s>(),
         4usize,
@@ -145,10 +142,7 @@ fn bindgen_test_layout_s() {
         concat!("Alignment of ", stringify!(s))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).u) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).u) as usize - ptr as usize },
         0usize,
         concat!("Offset of field: ", stringify!(s), "::", stringify!(u))
     );

--- a/tests/expectations/tests/array-of-zero-sized-types.rs
+++ b/tests/expectations/tests/array-of-zero-sized-types.rs
@@ -35,6 +35,7 @@ pub struct HasArrayOfEmpty {
 fn bindgen_test_layout_HasArrayOfEmpty() {
     const UNINIT: ::std::mem::MaybeUninit<HasArrayOfEmpty> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<HasArrayOfEmpty>(),
         10usize,
@@ -46,10 +47,7 @@ fn bindgen_test_layout_HasArrayOfEmpty() {
         concat!("Alignment of ", stringify!(HasArrayOfEmpty))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).empties) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).empties) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/array-of-zero-sized-types.rs
+++ b/tests/expectations/tests/array-of-zero-sized-types.rs
@@ -33,6 +33,8 @@ pub struct HasArrayOfEmpty {
 }
 #[test]
 fn bindgen_test_layout_HasArrayOfEmpty() {
+    const UNINIT: ::std::mem::MaybeUninit<HasArrayOfEmpty> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<HasArrayOfEmpty>(),
         10usize,
@@ -43,22 +45,17 @@ fn bindgen_test_layout_HasArrayOfEmpty() {
         1usize,
         concat!("Alignment of ", stringify!(HasArrayOfEmpty))
     );
-    fn test_field_empties() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<HasArrayOfEmpty>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).empties) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(HasArrayOfEmpty),
-                "::",
-                stringify!(empties)
-            )
-        );
-    }
-    test_field_empties();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).empties) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(HasArrayOfEmpty),
+            "::",
+            stringify!(empties)
+        )
+    );
 }

--- a/tests/expectations/tests/bindgen-union-inside-namespace.rs
+++ b/tests/expectations/tests/bindgen-union-inside-namespace.rs
@@ -67,6 +67,8 @@ pub mod root {
         }
         #[test]
         fn bindgen_test_layout_Bar() {
+            const UNINIT: ::std::mem::MaybeUninit<Bar> =
+                ::std::mem::MaybeUninit::uninit();
             assert_eq!(
                 ::std::mem::size_of::<Bar>(),
                 4usize,
@@ -77,40 +79,32 @@ pub mod root {
                 4usize,
                 concat!("Alignment of ", stringify!(Bar))
             );
-            fn test_field_foo() {
-                assert_eq!(
-                    unsafe {
-                        let uninit = ::std::mem::MaybeUninit::<Bar>::uninit();
-                        let ptr = uninit.as_ptr();
-                        ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize
-                    },
-                    0usize,
-                    concat!(
-                        "Offset of field: ",
-                        stringify!(Bar),
-                        "::",
-                        stringify!(foo)
-                    )
-                );
-            }
-            test_field_foo();
-            fn test_field_bar() {
-                assert_eq!(
-                    unsafe {
-                        let uninit = ::std::mem::MaybeUninit::<Bar>::uninit();
-                        let ptr = uninit.as_ptr();
-                        ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
-                    },
-                    0usize,
-                    concat!(
-                        "Offset of field: ",
-                        stringify!(Bar),
-                        "::",
-                        stringify!(bar)
-                    )
-                );
-            }
-            test_field_bar();
+            assert_eq!(
+                unsafe {
+                    let ptr = UNINIT.as_ptr();
+                    ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize
+                },
+                0usize,
+                concat!(
+                    "Offset of field: ",
+                    stringify!(Bar),
+                    "::",
+                    stringify!(foo)
+                )
+            );
+            assert_eq!(
+                unsafe {
+                    let ptr = UNINIT.as_ptr();
+                    ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
+                },
+                0usize,
+                concat!(
+                    "Offset of field: ",
+                    stringify!(Bar),
+                    "::",
+                    stringify!(bar)
+                )
+            );
         }
         impl Clone for Bar {
             fn clone(&self) -> Self {

--- a/tests/expectations/tests/bindgen-union-inside-namespace.rs
+++ b/tests/expectations/tests/bindgen-union-inside-namespace.rs
@@ -69,6 +69,7 @@ pub mod root {
         fn bindgen_test_layout_Bar() {
             const UNINIT: ::std::mem::MaybeUninit<Bar> =
                 ::std::mem::MaybeUninit::uninit();
+            let ptr = UNINIT.as_ptr();
             assert_eq!(
                 ::std::mem::size_of::<Bar>(),
                 4usize,
@@ -81,7 +82,6 @@ pub mod root {
             );
             assert_eq!(
                 unsafe {
-                    let ptr = UNINIT.as_ptr();
                     ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize
                 },
                 0usize,
@@ -94,7 +94,6 @@ pub mod root {
             );
             assert_eq!(
                 unsafe {
-                    let ptr = UNINIT.as_ptr();
                     ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
                 },
                 0usize,

--- a/tests/expectations/tests/bitfield-linux-32.rs
+++ b/tests/expectations/tests/bitfield-linux-32.rs
@@ -102,6 +102,7 @@ pub struct Test {
 fn bindgen_test_layout_Test() {
     const UNINIT: ::std::mem::MaybeUninit<Test> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<Test>(),
         16usize,
@@ -113,10 +114,7 @@ fn bindgen_test_layout_Test() {
         concat!("Alignment of ", stringify!(Test))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize },
         0usize,
         concat!("Offset of field: ", stringify!(Test), "::", stringify!(foo))
     );

--- a/tests/expectations/tests/bitfield-linux-32.rs
+++ b/tests/expectations/tests/bitfield-linux-32.rs
@@ -100,6 +100,8 @@ pub struct Test {
 }
 #[test]
 fn bindgen_test_layout_Test() {
+    const UNINIT: ::std::mem::MaybeUninit<Test> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<Test>(),
         16usize,
@@ -110,23 +112,14 @@ fn bindgen_test_layout_Test() {
         4usize,
         concat!("Alignment of ", stringify!(Test))
     );
-    fn test_field_foo() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Test>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(Test),
-                "::",
-                stringify!(foo)
-            )
-        );
-    }
-    test_field_foo();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize
+        },
+        0usize,
+        concat!("Offset of field: ", stringify!(Test), "::", stringify!(foo))
+    );
 }
 impl Test {
     #[inline]

--- a/tests/expectations/tests/bitfield_align.rs
+++ b/tests/expectations/tests/bitfield_align.rs
@@ -104,6 +104,7 @@ pub struct A {
 fn bindgen_test_layout_A() {
     const UNINIT: ::std::mem::MaybeUninit<A> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<A>(),
         4usize,
@@ -115,18 +116,12 @@ fn bindgen_test_layout_A() {
         concat!("Alignment of ", stringify!(A))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize },
         0usize,
         concat!("Offset of field: ", stringify!(A), "::", stringify!(x))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).y) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).y) as usize - ptr as usize },
         3usize,
         concat!("Offset of field: ", stringify!(A), "::", stringify!(y))
     );
@@ -397,6 +392,7 @@ pub struct C {
 fn bindgen_test_layout_C() {
     const UNINIT: ::std::mem::MaybeUninit<C> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<C>(),
         8usize,
@@ -408,18 +404,12 @@ fn bindgen_test_layout_C() {
         concat!("Alignment of ", stringify!(C))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize },
         0usize,
         concat!("Offset of field: ", stringify!(C), "::", stringify!(x))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize },
         4usize,
         concat!("Offset of field: ", stringify!(C), "::", stringify!(baz))
     );
@@ -702,6 +692,7 @@ pub struct Date3 {
 fn bindgen_test_layout_Date3() {
     const UNINIT: ::std::mem::MaybeUninit<Date3> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<Date3>(),
         4usize,
@@ -713,10 +704,7 @@ fn bindgen_test_layout_Date3() {
         concat!("Alignment of ", stringify!(Date3))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).byte) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).byte) as usize - ptr as usize },
         3usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/bitfield_align.rs
+++ b/tests/expectations/tests/bitfield_align.rs
@@ -102,6 +102,8 @@ pub struct A {
 }
 #[test]
 fn bindgen_test_layout_A() {
+    const UNINIT: ::std::mem::MaybeUninit<A> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<A>(),
         4usize,
@@ -112,30 +114,22 @@ fn bindgen_test_layout_A() {
         4usize,
         concat!("Alignment of ", stringify!(A))
     );
-    fn test_field_x() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<A>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize
-            },
-            0usize,
-            concat!("Offset of field: ", stringify!(A), "::", stringify!(x))
-        );
-    }
-    test_field_x();
-    fn test_field_y() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<A>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).y) as usize - ptr as usize
-            },
-            3usize,
-            concat!("Offset of field: ", stringify!(A), "::", stringify!(y))
-        );
-    }
-    test_field_y();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize
+        },
+        0usize,
+        concat!("Offset of field: ", stringify!(A), "::", stringify!(x))
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).y) as usize - ptr as usize
+        },
+        3usize,
+        concat!("Offset of field: ", stringify!(A), "::", stringify!(y))
+    );
 }
 impl A {
     #[inline]
@@ -401,6 +395,8 @@ pub struct C {
 }
 #[test]
 fn bindgen_test_layout_C() {
+    const UNINIT: ::std::mem::MaybeUninit<C> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<C>(),
         8usize,
@@ -411,30 +407,22 @@ fn bindgen_test_layout_C() {
         4usize,
         concat!("Alignment of ", stringify!(C))
     );
-    fn test_field_x() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<C>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize
-            },
-            0usize,
-            concat!("Offset of field: ", stringify!(C), "::", stringify!(x))
-        );
-    }
-    test_field_x();
-    fn test_field_baz() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<C>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize
-            },
-            4usize,
-            concat!("Offset of field: ", stringify!(C), "::", stringify!(baz))
-        );
-    }
-    test_field_baz();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize
+        },
+        0usize,
+        concat!("Offset of field: ", stringify!(C), "::", stringify!(x))
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize
+        },
+        4usize,
+        concat!("Offset of field: ", stringify!(C), "::", stringify!(baz))
+    );
 }
 impl C {
     #[inline]
@@ -712,6 +700,8 @@ pub struct Date3 {
 }
 #[test]
 fn bindgen_test_layout_Date3() {
+    const UNINIT: ::std::mem::MaybeUninit<Date3> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<Date3>(),
         4usize,
@@ -722,23 +712,19 @@ fn bindgen_test_layout_Date3() {
         2usize,
         concat!("Alignment of ", stringify!(Date3))
     );
-    fn test_field_byte() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Date3>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).byte) as usize - ptr as usize
-            },
-            3usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(Date3),
-                "::",
-                stringify!(byte)
-            )
-        );
-    }
-    test_field_byte();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).byte) as usize - ptr as usize
+        },
+        3usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(Date3),
+            "::",
+            stringify!(byte)
+        )
+    );
 }
 impl Date3 {
     #[inline]

--- a/tests/expectations/tests/blocklist-and-impl-debug.rs
+++ b/tests/expectations/tests/blocklist-and-impl-debug.rs
@@ -14,6 +14,8 @@ pub struct ShouldManuallyImplDebug {
 }
 #[test]
 fn bindgen_test_layout_ShouldManuallyImplDebug() {
+    const UNINIT: ::std::mem::MaybeUninit<ShouldManuallyImplDebug> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<ShouldManuallyImplDebug>(),
         1usize,
@@ -24,25 +26,19 @@ fn bindgen_test_layout_ShouldManuallyImplDebug() {
         1usize,
         concat!("Alignment of ", stringify!(ShouldManuallyImplDebug))
     );
-    fn test_field_a() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<ShouldManuallyImplDebug>::uninit(
-                    );
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(ShouldManuallyImplDebug),
-                "::",
-                stringify!(a)
-            )
-        );
-    }
-    test_field_a();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ShouldManuallyImplDebug),
+            "::",
+            stringify!(a)
+        )
+    );
 }
 impl Default for ShouldManuallyImplDebug {
     fn default() -> Self {

--- a/tests/expectations/tests/blocklist-and-impl-debug.rs
+++ b/tests/expectations/tests/blocklist-and-impl-debug.rs
@@ -16,6 +16,7 @@ pub struct ShouldManuallyImplDebug {
 fn bindgen_test_layout_ShouldManuallyImplDebug() {
     const UNINIT: ::std::mem::MaybeUninit<ShouldManuallyImplDebug> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<ShouldManuallyImplDebug>(),
         1usize,
@@ -27,10 +28,7 @@ fn bindgen_test_layout_ShouldManuallyImplDebug() {
         concat!("Alignment of ", stringify!(ShouldManuallyImplDebug))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/blocklist-file.rs
+++ b/tests/expectations/tests/blocklist-file.rs
@@ -16,6 +16,7 @@ pub struct SizedIntegers {
 fn bindgen_test_layout_SizedIntegers() {
     const UNINIT: ::std::mem::MaybeUninit<SizedIntegers> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<SizedIntegers>(),
         8usize,
@@ -27,10 +28,7 @@ fn bindgen_test_layout_SizedIntegers() {
         concat!("Alignment of ", stringify!(SizedIntegers))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -40,10 +38,7 @@ fn bindgen_test_layout_SizedIntegers() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).y) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).y) as usize - ptr as usize },
         2usize,
         concat!(
             "Offset of field: ",
@@ -53,10 +48,7 @@ fn bindgen_test_layout_SizedIntegers() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).z) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).z) as usize - ptr as usize },
         4usize,
         concat!(
             "Offset of field: ",
@@ -75,6 +67,7 @@ pub struct StructWithBlocklistedFwdDecl {
 fn bindgen_test_layout_StructWithBlocklistedFwdDecl() {
     const UNINIT: ::std::mem::MaybeUninit<StructWithBlocklistedFwdDecl> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<StructWithBlocklistedFwdDecl>(),
         1usize,
@@ -86,10 +79,7 @@ fn bindgen_test_layout_StructWithBlocklistedFwdDecl() {
         concat!("Alignment of ", stringify!(StructWithBlocklistedFwdDecl))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/blocklist-file.rs
+++ b/tests/expectations/tests/blocklist-file.rs
@@ -14,6 +14,8 @@ pub struct SizedIntegers {
 }
 #[test]
 fn bindgen_test_layout_SizedIntegers() {
+    const UNINIT: ::std::mem::MaybeUninit<SizedIntegers> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<SizedIntegers>(),
         8usize,
@@ -24,57 +26,45 @@ fn bindgen_test_layout_SizedIntegers() {
         4usize,
         concat!("Alignment of ", stringify!(SizedIntegers))
     );
-    fn test_field_x() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<SizedIntegers>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(SizedIntegers),
-                "::",
-                stringify!(x)
-            )
-        );
-    }
-    test_field_x();
-    fn test_field_y() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<SizedIntegers>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).y) as usize - ptr as usize
-            },
-            2usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(SizedIntegers),
-                "::",
-                stringify!(y)
-            )
-        );
-    }
-    test_field_y();
-    fn test_field_z() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<SizedIntegers>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).z) as usize - ptr as usize
-            },
-            4usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(SizedIntegers),
-                "::",
-                stringify!(z)
-            )
-        );
-    }
-    test_field_z();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(SizedIntegers),
+            "::",
+            stringify!(x)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).y) as usize - ptr as usize
+        },
+        2usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(SizedIntegers),
+            "::",
+            stringify!(y)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).z) as usize - ptr as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(SizedIntegers),
+            "::",
+            stringify!(z)
+        )
+    );
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
@@ -83,6 +73,8 @@ pub struct StructWithBlocklistedFwdDecl {
 }
 #[test]
 fn bindgen_test_layout_StructWithBlocklistedFwdDecl() {
+    const UNINIT: ::std::mem::MaybeUninit<StructWithBlocklistedFwdDecl> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<StructWithBlocklistedFwdDecl>(),
         1usize,
@@ -93,23 +85,17 @@ fn bindgen_test_layout_StructWithBlocklistedFwdDecl() {
         1usize,
         concat!("Alignment of ", stringify!(StructWithBlocklistedFwdDecl))
     );
-    fn test_field_b() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<
-                    StructWithBlocklistedFwdDecl,
-                >::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(StructWithBlocklistedFwdDecl),
-                "::",
-                stringify!(b)
-            )
-        );
-    }
-    test_field_b();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(StructWithBlocklistedFwdDecl),
+            "::",
+            stringify!(b)
+        )
+    );
 }

--- a/tests/expectations/tests/blocks-signature.rs
+++ b/tests/expectations/tests/blocks-signature.rs
@@ -39,6 +39,7 @@ pub struct contains_block_pointers {
 fn bindgen_test_layout_contains_block_pointers() {
     const UNINIT: ::std::mem::MaybeUninit<contains_block_pointers> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<contains_block_pointers>(),
         16usize,
@@ -50,10 +51,7 @@ fn bindgen_test_layout_contains_block_pointers() {
         concat!("Alignment of ", stringify!(contains_block_pointers))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).val) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).val) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -63,10 +61,7 @@ fn bindgen_test_layout_contains_block_pointers() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).ptr_val) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).ptr_val) as usize - ptr as usize },
         8usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/blocks-signature.rs
+++ b/tests/expectations/tests/blocks-signature.rs
@@ -37,6 +37,8 @@ pub struct contains_block_pointers {
 }
 #[test]
 fn bindgen_test_layout_contains_block_pointers() {
+    const UNINIT: ::std::mem::MaybeUninit<contains_block_pointers> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<contains_block_pointers>(),
         16usize,
@@ -47,44 +49,32 @@ fn bindgen_test_layout_contains_block_pointers() {
         8usize,
         concat!("Alignment of ", stringify!(contains_block_pointers))
     );
-    fn test_field_val() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<contains_block_pointers>::uninit(
-                    );
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).val) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(contains_block_pointers),
-                "::",
-                stringify!(val)
-            )
-        );
-    }
-    test_field_val();
-    fn test_field_ptr_val() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<contains_block_pointers>::uninit(
-                    );
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).ptr_val) as usize - ptr as usize
-            },
-            8usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(contains_block_pointers),
-                "::",
-                stringify!(ptr_val)
-            )
-        );
-    }
-    test_field_ptr_val();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).val) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(contains_block_pointers),
+            "::",
+            stringify!(val)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).ptr_val) as usize - ptr as usize
+        },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(contains_block_pointers),
+            "::",
+            stringify!(ptr_val)
+        )
+    );
 }
 impl Default for contains_block_pointers {
     fn default() -> Self {

--- a/tests/expectations/tests/blocks.rs
+++ b/tests/expectations/tests/blocks.rs
@@ -36,6 +36,8 @@ pub struct contains_block_pointers {
 }
 #[test]
 fn bindgen_test_layout_contains_block_pointers() {
+    const UNINIT: ::std::mem::MaybeUninit<contains_block_pointers> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<contains_block_pointers>(),
         16usize,
@@ -46,44 +48,32 @@ fn bindgen_test_layout_contains_block_pointers() {
         8usize,
         concat!("Alignment of ", stringify!(contains_block_pointers))
     );
-    fn test_field_val() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<contains_block_pointers>::uninit(
-                    );
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).val) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(contains_block_pointers),
-                "::",
-                stringify!(val)
-            )
-        );
-    }
-    test_field_val();
-    fn test_field_ptr_val() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<contains_block_pointers>::uninit(
-                    );
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).ptr_val) as usize - ptr as usize
-            },
-            8usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(contains_block_pointers),
-                "::",
-                stringify!(ptr_val)
-            )
-        );
-    }
-    test_field_ptr_val();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).val) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(contains_block_pointers),
+            "::",
+            stringify!(val)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).ptr_val) as usize - ptr as usize
+        },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(contains_block_pointers),
+            "::",
+            stringify!(ptr_val)
+        )
+    );
 }
 impl Default for contains_block_pointers {
     fn default() -> Self {

--- a/tests/expectations/tests/blocks.rs
+++ b/tests/expectations/tests/blocks.rs
@@ -38,6 +38,7 @@ pub struct contains_block_pointers {
 fn bindgen_test_layout_contains_block_pointers() {
     const UNINIT: ::std::mem::MaybeUninit<contains_block_pointers> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<contains_block_pointers>(),
         16usize,
@@ -49,10 +50,7 @@ fn bindgen_test_layout_contains_block_pointers() {
         concat!("Alignment of ", stringify!(contains_block_pointers))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).val) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).val) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -62,10 +60,7 @@ fn bindgen_test_layout_contains_block_pointers() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).ptr_val) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).ptr_val) as usize - ptr as usize },
         8usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/c_naming.rs
+++ b/tests/expectations/tests/c_naming.rs
@@ -14,6 +14,7 @@ pub struct struct_a {
 fn bindgen_test_layout_struct_a() {
     const UNINIT: ::std::mem::MaybeUninit<struct_a> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<struct_a>(),
         4usize,
@@ -25,10 +26,7 @@ fn bindgen_test_layout_struct_a() {
         concat!("Alignment of ", stringify!(struct_a))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -49,6 +47,7 @@ pub union union_b {
 fn bindgen_test_layout_union_b() {
     const UNINIT: ::std::mem::MaybeUninit<union_b> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<union_b>(),
         4usize,
@@ -60,10 +59,7 @@ fn bindgen_test_layout_union_b() {
         concat!("Alignment of ", stringify!(union_b))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -73,10 +69,7 @@ fn bindgen_test_layout_union_b() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/c_naming.rs
+++ b/tests/expectations/tests/c_naming.rs
@@ -12,6 +12,8 @@ pub struct struct_a {
 }
 #[test]
 fn bindgen_test_layout_struct_a() {
+    const UNINIT: ::std::mem::MaybeUninit<struct_a> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<struct_a>(),
         4usize,
@@ -22,23 +24,19 @@ fn bindgen_test_layout_struct_a() {
         4usize,
         concat!("Alignment of ", stringify!(struct_a))
     );
-    fn test_field_a() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<struct_a>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(struct_a),
-                "::",
-                stringify!(a)
-            )
-        );
-    }
-    test_field_a();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(struct_a),
+            "::",
+            stringify!(a)
+        )
+    );
 }
 pub type a = *const struct_a;
 #[repr(C)]
@@ -49,6 +47,8 @@ pub union union_b {
 }
 #[test]
 fn bindgen_test_layout_union_b() {
+    const UNINIT: ::std::mem::MaybeUninit<union_b> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<union_b>(),
         4usize,
@@ -59,40 +59,32 @@ fn bindgen_test_layout_union_b() {
         4usize,
         concat!("Alignment of ", stringify!(union_b))
     );
-    fn test_field_a() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<union_b>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(union_b),
-                "::",
-                stringify!(a)
-            )
-        );
-    }
-    test_field_a();
-    fn test_field_b() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<union_b>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(union_b),
-                "::",
-                stringify!(b)
-            )
-        );
-    }
-    test_field_b();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(union_b),
+            "::",
+            stringify!(a)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(union_b),
+            "::",
+            stringify!(b)
+        )
+    );
 }
 impl Default for union_b {
     fn default() -> Self {

--- a/tests/expectations/tests/canonical-types.rs
+++ b/tests/expectations/tests/canonical-types.rs
@@ -168,6 +168,7 @@ pub struct ClassAInner {
 fn bindgen_test_layout_ClassAInner() {
     const UNINIT: ::std::mem::MaybeUninit<ClassAInner> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<ClassAInner>(),
         8usize,
@@ -179,10 +180,7 @@ fn bindgen_test_layout_ClassAInner() {
         concat!("Alignment of ", stringify!(ClassAInner))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -210,6 +208,7 @@ pub struct ClassCInnerA {
 fn bindgen_test_layout_ClassCInnerA() {
     const UNINIT: ::std::mem::MaybeUninit<ClassCInnerA> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<ClassCInnerA>(),
         8usize,
@@ -221,10 +220,7 @@ fn bindgen_test_layout_ClassCInnerA() {
         concat!("Alignment of ", stringify!(ClassCInnerA))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).member) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).member) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -252,6 +248,7 @@ pub struct ClassCInnerB {
 fn bindgen_test_layout_ClassCInnerB() {
     const UNINIT: ::std::mem::MaybeUninit<ClassCInnerB> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<ClassCInnerB>(),
         8usize,
@@ -263,10 +260,7 @@ fn bindgen_test_layout_ClassCInnerB() {
         concat!("Alignment of ", stringify!(ClassCInnerB))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).cache) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).cache) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/canonical-types.rs
+++ b/tests/expectations/tests/canonical-types.rs
@@ -166,6 +166,8 @@ pub struct ClassAInner {
 }
 #[test]
 fn bindgen_test_layout_ClassAInner() {
+    const UNINIT: ::std::mem::MaybeUninit<ClassAInner> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<ClassAInner>(),
         8usize,
@@ -176,23 +178,19 @@ fn bindgen_test_layout_ClassAInner() {
         8usize,
         concat!("Alignment of ", stringify!(ClassAInner))
     );
-    fn test_field_x() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<ClassAInner>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(ClassAInner),
-                "::",
-                stringify!(x)
-            )
-        );
-    }
-    test_field_x();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ClassAInner),
+            "::",
+            stringify!(x)
+        )
+    );
 }
 impl Default for ClassAInner {
     fn default() -> Self {
@@ -210,6 +208,8 @@ pub struct ClassCInnerA {
 }
 #[test]
 fn bindgen_test_layout_ClassCInnerA() {
+    const UNINIT: ::std::mem::MaybeUninit<ClassCInnerA> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<ClassCInnerA>(),
         8usize,
@@ -220,23 +220,19 @@ fn bindgen_test_layout_ClassCInnerA() {
         8usize,
         concat!("Alignment of ", stringify!(ClassCInnerA))
     );
-    fn test_field_member() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<ClassCInnerA>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).member) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(ClassCInnerA),
-                "::",
-                stringify!(member)
-            )
-        );
-    }
-    test_field_member();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).member) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ClassCInnerA),
+            "::",
+            stringify!(member)
+        )
+    );
 }
 impl Default for ClassCInnerA {
     fn default() -> Self {
@@ -254,6 +250,8 @@ pub struct ClassCInnerB {
 }
 #[test]
 fn bindgen_test_layout_ClassCInnerB() {
+    const UNINIT: ::std::mem::MaybeUninit<ClassCInnerB> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<ClassCInnerB>(),
         8usize,
@@ -264,23 +262,19 @@ fn bindgen_test_layout_ClassCInnerB() {
         8usize,
         concat!("Alignment of ", stringify!(ClassCInnerB))
     );
-    fn test_field_cache() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<ClassCInnerB>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).cache) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(ClassCInnerB),
-                "::",
-                stringify!(cache)
-            )
-        );
-    }
-    test_field_cache();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).cache) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ClassCInnerB),
+            "::",
+            stringify!(cache)
+        )
+    );
 }
 impl Default for ClassCInnerB {
     fn default() -> Self {

--- a/tests/expectations/tests/char.rs
+++ b/tests/expectations/tests/char.rs
@@ -28,6 +28,7 @@ pub struct Test {
 fn bindgen_test_layout_Test() {
     const UNINIT: ::std::mem::MaybeUninit<Test> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<Test>(),
         12usize,
@@ -39,82 +40,52 @@ fn bindgen_test_layout_Test() {
         concat!("Alignment of ", stringify!(Test))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).ch) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).ch) as usize - ptr as usize },
         0usize,
         concat!("Offset of field: ", stringify!(Test), "::", stringify!(ch))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).u) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).u) as usize - ptr as usize },
         1usize,
         concat!("Offset of field: ", stringify!(Test), "::", stringify!(u))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize },
         2usize,
         concat!("Offset of field: ", stringify!(Test), "::", stringify!(d))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).cch) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).cch) as usize - ptr as usize },
         3usize,
         concat!("Offset of field: ", stringify!(Test), "::", stringify!(cch))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).cu) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).cu) as usize - ptr as usize },
         4usize,
         concat!("Offset of field: ", stringify!(Test), "::", stringify!(cu))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).cd) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).cd) as usize - ptr as usize },
         5usize,
         concat!("Offset of field: ", stringify!(Test), "::", stringify!(cd))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).Cch) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).Cch) as usize - ptr as usize },
         6usize,
         concat!("Offset of field: ", stringify!(Test), "::", stringify!(Cch))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).Cu) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).Cu) as usize - ptr as usize },
         7usize,
         concat!("Offset of field: ", stringify!(Test), "::", stringify!(Cu))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).Cd) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).Cd) as usize - ptr as usize },
         8usize,
         concat!("Offset of field: ", stringify!(Test), "::", stringify!(Cd))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).Ccch) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).Ccch) as usize - ptr as usize },
         9usize,
         concat!(
             "Offset of field: ",
@@ -124,18 +95,12 @@ fn bindgen_test_layout_Test() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).Ccu) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).Ccu) as usize - ptr as usize },
         10usize,
         concat!("Offset of field: ", stringify!(Test), "::", stringify!(Ccu))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).Ccd) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).Ccd) as usize - ptr as usize },
         11usize,
         concat!("Offset of field: ", stringify!(Test), "::", stringify!(Ccd))
     );

--- a/tests/expectations/tests/char.rs
+++ b/tests/expectations/tests/char.rs
@@ -26,6 +26,8 @@ pub struct Test {
 }
 #[test]
 fn bindgen_test_layout_Test() {
+    const UNINIT: ::std::mem::MaybeUninit<Test> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<Test>(),
         12usize,
@@ -36,198 +38,105 @@ fn bindgen_test_layout_Test() {
         1usize,
         concat!("Alignment of ", stringify!(Test))
     );
-    fn test_field_ch() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Test>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).ch) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(Test),
-                "::",
-                stringify!(ch)
-            )
-        );
-    }
-    test_field_ch();
-    fn test_field_u() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Test>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).u) as usize - ptr as usize
-            },
-            1usize,
-            concat!("Offset of field: ", stringify!(Test), "::", stringify!(u))
-        );
-    }
-    test_field_u();
-    fn test_field_d() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Test>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize
-            },
-            2usize,
-            concat!("Offset of field: ", stringify!(Test), "::", stringify!(d))
-        );
-    }
-    test_field_d();
-    fn test_field_cch() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Test>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).cch) as usize - ptr as usize
-            },
-            3usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(Test),
-                "::",
-                stringify!(cch)
-            )
-        );
-    }
-    test_field_cch();
-    fn test_field_cu() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Test>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).cu) as usize - ptr as usize
-            },
-            4usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(Test),
-                "::",
-                stringify!(cu)
-            )
-        );
-    }
-    test_field_cu();
-    fn test_field_cd() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Test>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).cd) as usize - ptr as usize
-            },
-            5usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(Test),
-                "::",
-                stringify!(cd)
-            )
-        );
-    }
-    test_field_cd();
-    fn test_field_Cch() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Test>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).Cch) as usize - ptr as usize
-            },
-            6usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(Test),
-                "::",
-                stringify!(Cch)
-            )
-        );
-    }
-    test_field_Cch();
-    fn test_field_Cu() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Test>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).Cu) as usize - ptr as usize
-            },
-            7usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(Test),
-                "::",
-                stringify!(Cu)
-            )
-        );
-    }
-    test_field_Cu();
-    fn test_field_Cd() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Test>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).Cd) as usize - ptr as usize
-            },
-            8usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(Test),
-                "::",
-                stringify!(Cd)
-            )
-        );
-    }
-    test_field_Cd();
-    fn test_field_Ccch() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Test>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).Ccch) as usize - ptr as usize
-            },
-            9usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(Test),
-                "::",
-                stringify!(Ccch)
-            )
-        );
-    }
-    test_field_Ccch();
-    fn test_field_Ccu() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Test>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).Ccu) as usize - ptr as usize
-            },
-            10usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(Test),
-                "::",
-                stringify!(Ccu)
-            )
-        );
-    }
-    test_field_Ccu();
-    fn test_field_Ccd() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Test>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).Ccd) as usize - ptr as usize
-            },
-            11usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(Test),
-                "::",
-                stringify!(Ccd)
-            )
-        );
-    }
-    test_field_Ccd();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).ch) as usize - ptr as usize
+        },
+        0usize,
+        concat!("Offset of field: ", stringify!(Test), "::", stringify!(ch))
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).u) as usize - ptr as usize
+        },
+        1usize,
+        concat!("Offset of field: ", stringify!(Test), "::", stringify!(u))
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize
+        },
+        2usize,
+        concat!("Offset of field: ", stringify!(Test), "::", stringify!(d))
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).cch) as usize - ptr as usize
+        },
+        3usize,
+        concat!("Offset of field: ", stringify!(Test), "::", stringify!(cch))
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).cu) as usize - ptr as usize
+        },
+        4usize,
+        concat!("Offset of field: ", stringify!(Test), "::", stringify!(cu))
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).cd) as usize - ptr as usize
+        },
+        5usize,
+        concat!("Offset of field: ", stringify!(Test), "::", stringify!(cd))
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).Cch) as usize - ptr as usize
+        },
+        6usize,
+        concat!("Offset of field: ", stringify!(Test), "::", stringify!(Cch))
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).Cu) as usize - ptr as usize
+        },
+        7usize,
+        concat!("Offset of field: ", stringify!(Test), "::", stringify!(Cu))
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).Cd) as usize - ptr as usize
+        },
+        8usize,
+        concat!("Offset of field: ", stringify!(Test), "::", stringify!(Cd))
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).Ccch) as usize - ptr as usize
+        },
+        9usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(Test),
+            "::",
+            stringify!(Ccch)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).Ccu) as usize - ptr as usize
+        },
+        10usize,
+        concat!("Offset of field: ", stringify!(Test), "::", stringify!(Ccu))
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).Ccd) as usize - ptr as usize
+        },
+        11usize,
+        concat!("Offset of field: ", stringify!(Test), "::", stringify!(Ccd))
+    );
 }

--- a/tests/expectations/tests/class.rs
+++ b/tests/expectations/tests/class.rs
@@ -45,6 +45,7 @@ pub struct C {
 fn bindgen_test_layout_C() {
     const UNINIT: ::std::mem::MaybeUninit<C> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<C>(),
         40usize,
@@ -56,16 +57,12 @@ fn bindgen_test_layout_C() {
         concat!("Alignment of ", stringify!(C))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
         0usize,
         concat!("Offset of field: ", stringify!(C), "::", stringify!(a))
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).big_array) as usize - ptr as usize
         },
         4usize,
@@ -96,6 +93,7 @@ pub struct C_with_zero_length_array {
 fn bindgen_test_layout_C_with_zero_length_array() {
     const UNINIT: ::std::mem::MaybeUninit<C_with_zero_length_array> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<C_with_zero_length_array>(),
         40usize,
@@ -107,10 +105,7 @@ fn bindgen_test_layout_C_with_zero_length_array() {
         concat!("Alignment of ", stringify!(C_with_zero_length_array))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -121,7 +116,6 @@ fn bindgen_test_layout_C_with_zero_length_array() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).big_array) as usize - ptr as usize
         },
         4usize,
@@ -134,7 +128,6 @@ fn bindgen_test_layout_C_with_zero_length_array() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).zero_length_array) as usize -
                 ptr as usize
         },
@@ -166,6 +159,7 @@ pub struct C_with_zero_length_array_2 {
 fn bindgen_test_layout_C_with_zero_length_array_2() {
     const UNINIT: ::std::mem::MaybeUninit<C_with_zero_length_array_2> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<C_with_zero_length_array_2>(),
         4usize,
@@ -177,10 +171,7 @@ fn bindgen_test_layout_C_with_zero_length_array_2() {
         concat!("Alignment of ", stringify!(C_with_zero_length_array_2))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -191,7 +182,6 @@ fn bindgen_test_layout_C_with_zero_length_array_2() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).zero_length_array) as usize -
                 ptr as usize
         },
@@ -323,6 +313,7 @@ pub struct WithDtor {
 fn bindgen_test_layout_WithDtor() {
     const UNINIT: ::std::mem::MaybeUninit<WithDtor> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<WithDtor>(),
         4usize,
@@ -334,10 +325,7 @@ fn bindgen_test_layout_WithDtor() {
         concat!("Alignment of ", stringify!(WithDtor))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -384,6 +372,7 @@ pub union Union {
 fn bindgen_test_layout_Union() {
     const UNINIT: ::std::mem::MaybeUninit<Union> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<Union>(),
         4usize,
@@ -395,18 +384,12 @@ fn bindgen_test_layout_Union() {
         concat!("Alignment of ", stringify!(Union))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize },
         0usize,
         concat!("Offset of field: ", stringify!(Union), "::", stringify!(d))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).i) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).i) as usize - ptr as usize },
         0usize,
         concat!("Offset of field: ", stringify!(Union), "::", stringify!(i))
     );
@@ -429,6 +412,7 @@ pub struct WithUnion {
 fn bindgen_test_layout_WithUnion() {
     const UNINIT: ::std::mem::MaybeUninit<WithUnion> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<WithUnion>(),
         4usize,
@@ -440,10 +424,7 @@ fn bindgen_test_layout_WithUnion() {
         concat!("Alignment of ", stringify!(WithUnion))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).data) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).data) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/class.rs
+++ b/tests/expectations/tests/class.rs
@@ -43,6 +43,8 @@ pub struct C {
 }
 #[test]
 fn bindgen_test_layout_C() {
+    const UNINIT: ::std::mem::MaybeUninit<C> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<C>(),
         40usize,
@@ -53,35 +55,27 @@ fn bindgen_test_layout_C() {
         4usize,
         concat!("Alignment of ", stringify!(C))
     );
-    fn test_field_a() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<C>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-            },
-            0usize,
-            concat!("Offset of field: ", stringify!(C), "::", stringify!(a))
-        );
-    }
-    test_field_a();
-    fn test_field_big_array() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<C>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).big_array) as usize - ptr as usize
-            },
-            4usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(C),
-                "::",
-                stringify!(big_array)
-            )
-        );
-    }
-    test_field_big_array();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+        },
+        0usize,
+        concat!("Offset of field: ", stringify!(C), "::", stringify!(a))
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).big_array) as usize - ptr as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C),
+            "::",
+            stringify!(big_array)
+        )
+    );
 }
 impl Default for C {
     fn default() -> Self {
@@ -100,6 +94,8 @@ pub struct C_with_zero_length_array {
 }
 #[test]
 fn bindgen_test_layout_C_with_zero_length_array() {
+    const UNINIT: ::std::mem::MaybeUninit<C_with_zero_length_array> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<C_with_zero_length_array>(),
         40usize,
@@ -110,64 +106,46 @@ fn bindgen_test_layout_C_with_zero_length_array() {
         4usize,
         concat!("Alignment of ", stringify!(C_with_zero_length_array))
     );
-    fn test_field_a() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<C_with_zero_length_array>::uninit(
-                    );
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(C_with_zero_length_array),
-                "::",
-                stringify!(a)
-            )
-        );
-    }
-    test_field_a();
-    fn test_field_big_array() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<C_with_zero_length_array>::uninit(
-                    );
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).big_array) as usize - ptr as usize
-            },
-            4usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(C_with_zero_length_array),
-                "::",
-                stringify!(big_array)
-            )
-        );
-    }
-    test_field_big_array();
-    fn test_field_zero_length_array() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<C_with_zero_length_array>::uninit(
-                    );
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).zero_length_array) as usize -
-                    ptr as usize
-            },
-            37usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(C_with_zero_length_array),
-                "::",
-                stringify!(zero_length_array)
-            )
-        );
-    }
-    test_field_zero_length_array();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C_with_zero_length_array),
+            "::",
+            stringify!(a)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).big_array) as usize - ptr as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C_with_zero_length_array),
+            "::",
+            stringify!(big_array)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).zero_length_array) as usize -
+                ptr as usize
+        },
+        37usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C_with_zero_length_array),
+            "::",
+            stringify!(zero_length_array)
+        )
+    );
 }
 impl Default for C_with_zero_length_array {
     fn default() -> Self {
@@ -186,6 +164,8 @@ pub struct C_with_zero_length_array_2 {
 }
 #[test]
 fn bindgen_test_layout_C_with_zero_length_array_2() {
+    const UNINIT: ::std::mem::MaybeUninit<C_with_zero_length_array_2> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<C_with_zero_length_array_2>(),
         4usize,
@@ -196,45 +176,33 @@ fn bindgen_test_layout_C_with_zero_length_array_2() {
         4usize,
         concat!("Alignment of ", stringify!(C_with_zero_length_array_2))
     );
-    fn test_field_a() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<
-                    C_with_zero_length_array_2,
-                >::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(C_with_zero_length_array_2),
-                "::",
-                stringify!(a)
-            )
-        );
-    }
-    test_field_a();
-    fn test_field_zero_length_array() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<
-                    C_with_zero_length_array_2,
-                >::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).zero_length_array) as usize -
-                    ptr as usize
-            },
-            4usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(C_with_zero_length_array_2),
-                "::",
-                stringify!(zero_length_array)
-            )
-        );
-    }
-    test_field_zero_length_array();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C_with_zero_length_array_2),
+            "::",
+            stringify!(a)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).zero_length_array) as usize -
+                ptr as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C_with_zero_length_array_2),
+            "::",
+            stringify!(zero_length_array)
+        )
+    );
 }
 #[repr(C)]
 pub struct C_with_incomplete_array {
@@ -353,6 +321,8 @@ pub struct WithDtor {
 }
 #[test]
 fn bindgen_test_layout_WithDtor() {
+    const UNINIT: ::std::mem::MaybeUninit<WithDtor> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<WithDtor>(),
         4usize,
@@ -363,23 +333,19 @@ fn bindgen_test_layout_WithDtor() {
         4usize,
         concat!("Alignment of ", stringify!(WithDtor))
     );
-    fn test_field_b() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<WithDtor>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(WithDtor),
-                "::",
-                stringify!(b)
-            )
-        );
-    }
-    test_field_b();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(WithDtor),
+            "::",
+            stringify!(b)
+        )
+    );
 }
 #[repr(C)]
 pub struct IncompleteArrayNonCopiable {
@@ -416,6 +382,8 @@ pub union Union {
 }
 #[test]
 fn bindgen_test_layout_Union() {
+    const UNINIT: ::std::mem::MaybeUninit<Union> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<Union>(),
         4usize,
@@ -426,40 +394,22 @@ fn bindgen_test_layout_Union() {
         4usize,
         concat!("Alignment of ", stringify!(Union))
     );
-    fn test_field_d() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Union>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(Union),
-                "::",
-                stringify!(d)
-            )
-        );
-    }
-    test_field_d();
-    fn test_field_i() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Union>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).i) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(Union),
-                "::",
-                stringify!(i)
-            )
-        );
-    }
-    test_field_i();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize
+        },
+        0usize,
+        concat!("Offset of field: ", stringify!(Union), "::", stringify!(d))
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).i) as usize - ptr as usize
+        },
+        0usize,
+        concat!("Offset of field: ", stringify!(Union), "::", stringify!(i))
+    );
 }
 impl Default for Union {
     fn default() -> Self {
@@ -477,6 +427,8 @@ pub struct WithUnion {
 }
 #[test]
 fn bindgen_test_layout_WithUnion() {
+    const UNINIT: ::std::mem::MaybeUninit<WithUnion> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<WithUnion>(),
         4usize,
@@ -487,23 +439,19 @@ fn bindgen_test_layout_WithUnion() {
         4usize,
         concat!("Alignment of ", stringify!(WithUnion))
     );
-    fn test_field_data() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<WithUnion>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).data) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(WithUnion),
-                "::",
-                stringify!(data)
-            )
-        );
-    }
-    test_field_data();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).data) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(WithUnion),
+            "::",
+            stringify!(data)
+        )
+    );
 }
 impl Default for WithUnion {
     fn default() -> Self {

--- a/tests/expectations/tests/class_1_0.rs
+++ b/tests/expectations/tests/class_1_0.rs
@@ -86,6 +86,8 @@ pub struct C {
 }
 #[test]
 fn bindgen_test_layout_C() {
+    const UNINIT: ::std::mem::MaybeUninit<C> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<C>(),
         40usize,
@@ -96,35 +98,27 @@ fn bindgen_test_layout_C() {
         4usize,
         concat!("Alignment of ", stringify!(C))
     );
-    fn test_field_a() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<C>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-            },
-            0usize,
-            concat!("Offset of field: ", stringify!(C), "::", stringify!(a))
-        );
-    }
-    test_field_a();
-    fn test_field_big_array() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<C>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).big_array) as usize - ptr as usize
-            },
-            4usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(C),
-                "::",
-                stringify!(big_array)
-            )
-        );
-    }
-    test_field_big_array();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+        },
+        0usize,
+        concat!("Offset of field: ", stringify!(C), "::", stringify!(a))
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).big_array) as usize - ptr as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C),
+            "::",
+            stringify!(big_array)
+        )
+    );
 }
 impl Clone for C {
     fn clone(&self) -> Self {
@@ -153,6 +147,8 @@ pub struct C_with_zero_length_array {
 }
 #[test]
 fn bindgen_test_layout_C_with_zero_length_array() {
+    const UNINIT: ::std::mem::MaybeUninit<C_with_zero_length_array> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<C_with_zero_length_array>(),
         40usize,
@@ -163,64 +159,46 @@ fn bindgen_test_layout_C_with_zero_length_array() {
         4usize,
         concat!("Alignment of ", stringify!(C_with_zero_length_array))
     );
-    fn test_field_a() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<C_with_zero_length_array>::uninit(
-                    );
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(C_with_zero_length_array),
-                "::",
-                stringify!(a)
-            )
-        );
-    }
-    test_field_a();
-    fn test_field_big_array() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<C_with_zero_length_array>::uninit(
-                    );
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).big_array) as usize - ptr as usize
-            },
-            4usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(C_with_zero_length_array),
-                "::",
-                stringify!(big_array)
-            )
-        );
-    }
-    test_field_big_array();
-    fn test_field_zero_length_array() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<C_with_zero_length_array>::uninit(
-                    );
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).zero_length_array) as usize -
-                    ptr as usize
-            },
-            37usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(C_with_zero_length_array),
-                "::",
-                stringify!(zero_length_array)
-            )
-        );
-    }
-    test_field_zero_length_array();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C_with_zero_length_array),
+            "::",
+            stringify!(a)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).big_array) as usize - ptr as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C_with_zero_length_array),
+            "::",
+            stringify!(big_array)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).zero_length_array) as usize -
+                ptr as usize
+        },
+        37usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C_with_zero_length_array),
+            "::",
+            stringify!(zero_length_array)
+        )
+    );
 }
 impl Default for C_with_zero_length_array {
     fn default() -> Self {
@@ -239,6 +217,8 @@ pub struct C_with_zero_length_array_2 {
 }
 #[test]
 fn bindgen_test_layout_C_with_zero_length_array_2() {
+    const UNINIT: ::std::mem::MaybeUninit<C_with_zero_length_array_2> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<C_with_zero_length_array_2>(),
         4usize,
@@ -249,45 +229,33 @@ fn bindgen_test_layout_C_with_zero_length_array_2() {
         4usize,
         concat!("Alignment of ", stringify!(C_with_zero_length_array_2))
     );
-    fn test_field_a() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<
-                    C_with_zero_length_array_2,
-                >::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(C_with_zero_length_array_2),
-                "::",
-                stringify!(a)
-            )
-        );
-    }
-    test_field_a();
-    fn test_field_zero_length_array() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<
-                    C_with_zero_length_array_2,
-                >::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).zero_length_array) as usize -
-                    ptr as usize
-            },
-            4usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(C_with_zero_length_array_2),
-                "::",
-                stringify!(zero_length_array)
-            )
-        );
-    }
-    test_field_zero_length_array();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C_with_zero_length_array_2),
+            "::",
+            stringify!(a)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).zero_length_array) as usize -
+                ptr as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C_with_zero_length_array_2),
+            "::",
+            stringify!(zero_length_array)
+        )
+    );
 }
 #[repr(C)]
 pub struct C_with_incomplete_array {
@@ -406,6 +374,8 @@ pub struct WithDtor {
 }
 #[test]
 fn bindgen_test_layout_WithDtor() {
+    const UNINIT: ::std::mem::MaybeUninit<WithDtor> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<WithDtor>(),
         4usize,
@@ -416,23 +386,19 @@ fn bindgen_test_layout_WithDtor() {
         4usize,
         concat!("Alignment of ", stringify!(WithDtor))
     );
-    fn test_field_b() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<WithDtor>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(WithDtor),
-                "::",
-                stringify!(b)
-            )
-        );
-    }
-    test_field_b();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(WithDtor),
+            "::",
+            stringify!(b)
+        )
+    );
 }
 #[repr(C)]
 pub struct IncompleteArrayNonCopiable {
@@ -470,6 +436,8 @@ pub struct Union {
 }
 #[test]
 fn bindgen_test_layout_Union() {
+    const UNINIT: ::std::mem::MaybeUninit<Union> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<Union>(),
         4usize,
@@ -480,40 +448,22 @@ fn bindgen_test_layout_Union() {
         4usize,
         concat!("Alignment of ", stringify!(Union))
     );
-    fn test_field_d() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Union>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(Union),
-                "::",
-                stringify!(d)
-            )
-        );
-    }
-    test_field_d();
-    fn test_field_i() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Union>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).i) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(Union),
-                "::",
-                stringify!(i)
-            )
-        );
-    }
-    test_field_i();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize
+        },
+        0usize,
+        concat!("Offset of field: ", stringify!(Union), "::", stringify!(d))
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).i) as usize - ptr as usize
+        },
+        0usize,
+        concat!("Offset of field: ", stringify!(Union), "::", stringify!(i))
+    );
 }
 impl Clone for Union {
     fn clone(&self) -> Self {
@@ -527,6 +477,8 @@ pub struct WithUnion {
 }
 #[test]
 fn bindgen_test_layout_WithUnion() {
+    const UNINIT: ::std::mem::MaybeUninit<WithUnion> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<WithUnion>(),
         4usize,
@@ -537,23 +489,19 @@ fn bindgen_test_layout_WithUnion() {
         4usize,
         concat!("Alignment of ", stringify!(WithUnion))
     );
-    fn test_field_data() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<WithUnion>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).data) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(WithUnion),
-                "::",
-                stringify!(data)
-            )
-        );
-    }
-    test_field_data();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).data) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(WithUnion),
+            "::",
+            stringify!(data)
+        )
+    );
 }
 impl Clone for WithUnion {
     fn clone(&self) -> Self {

--- a/tests/expectations/tests/class_1_0.rs
+++ b/tests/expectations/tests/class_1_0.rs
@@ -88,6 +88,7 @@ pub struct C {
 fn bindgen_test_layout_C() {
     const UNINIT: ::std::mem::MaybeUninit<C> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<C>(),
         40usize,
@@ -99,16 +100,12 @@ fn bindgen_test_layout_C() {
         concat!("Alignment of ", stringify!(C))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
         0usize,
         concat!("Offset of field: ", stringify!(C), "::", stringify!(a))
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).big_array) as usize - ptr as usize
         },
         4usize,
@@ -149,6 +146,7 @@ pub struct C_with_zero_length_array {
 fn bindgen_test_layout_C_with_zero_length_array() {
     const UNINIT: ::std::mem::MaybeUninit<C_with_zero_length_array> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<C_with_zero_length_array>(),
         40usize,
@@ -160,10 +158,7 @@ fn bindgen_test_layout_C_with_zero_length_array() {
         concat!("Alignment of ", stringify!(C_with_zero_length_array))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -174,7 +169,6 @@ fn bindgen_test_layout_C_with_zero_length_array() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).big_array) as usize - ptr as usize
         },
         4usize,
@@ -187,7 +181,6 @@ fn bindgen_test_layout_C_with_zero_length_array() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).zero_length_array) as usize -
                 ptr as usize
         },
@@ -219,6 +212,7 @@ pub struct C_with_zero_length_array_2 {
 fn bindgen_test_layout_C_with_zero_length_array_2() {
     const UNINIT: ::std::mem::MaybeUninit<C_with_zero_length_array_2> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<C_with_zero_length_array_2>(),
         4usize,
@@ -230,10 +224,7 @@ fn bindgen_test_layout_C_with_zero_length_array_2() {
         concat!("Alignment of ", stringify!(C_with_zero_length_array_2))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -244,7 +235,6 @@ fn bindgen_test_layout_C_with_zero_length_array_2() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).zero_length_array) as usize -
                 ptr as usize
         },
@@ -376,6 +366,7 @@ pub struct WithDtor {
 fn bindgen_test_layout_WithDtor() {
     const UNINIT: ::std::mem::MaybeUninit<WithDtor> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<WithDtor>(),
         4usize,
@@ -387,10 +378,7 @@ fn bindgen_test_layout_WithDtor() {
         concat!("Alignment of ", stringify!(WithDtor))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -438,6 +426,7 @@ pub struct Union {
 fn bindgen_test_layout_Union() {
     const UNINIT: ::std::mem::MaybeUninit<Union> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<Union>(),
         4usize,
@@ -449,18 +438,12 @@ fn bindgen_test_layout_Union() {
         concat!("Alignment of ", stringify!(Union))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize },
         0usize,
         concat!("Offset of field: ", stringify!(Union), "::", stringify!(d))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).i) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).i) as usize - ptr as usize },
         0usize,
         concat!("Offset of field: ", stringify!(Union), "::", stringify!(i))
     );
@@ -479,6 +462,7 @@ pub struct WithUnion {
 fn bindgen_test_layout_WithUnion() {
     const UNINIT: ::std::mem::MaybeUninit<WithUnion> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<WithUnion>(),
         4usize,
@@ -490,10 +474,7 @@ fn bindgen_test_layout_WithUnion() {
         concat!("Alignment of ", stringify!(WithUnion))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).data) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).data) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/class_nested.rs
+++ b/tests/expectations/tests/class_nested.rs
@@ -19,6 +19,7 @@ pub struct A_B {
 fn bindgen_test_layout_A_B() {
     const UNINIT: ::std::mem::MaybeUninit<A_B> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<A_B>(),
         4usize,
@@ -31,7 +32,6 @@ fn bindgen_test_layout_A_B() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).member_b) as usize - ptr as usize
         },
         0usize,
@@ -62,6 +62,7 @@ impl<T> Default for A_D<T> {
 fn bindgen_test_layout_A() {
     const UNINIT: ::std::mem::MaybeUninit<A> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<A>(),
         4usize,
@@ -74,7 +75,6 @@ fn bindgen_test_layout_A() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).member_a) as usize - ptr as usize
         },
         0usize,
@@ -95,6 +95,7 @@ pub struct A_C {
 fn bindgen_test_layout_A_C() {
     const UNINIT: ::std::mem::MaybeUninit<A_C> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<A_C>(),
         4usize,
@@ -106,10 +107,7 @@ fn bindgen_test_layout_A_C() {
         concat!("Alignment of ", stringify!(A_C))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize },
         0usize,
         concat!("Offset of field: ", stringify!(A_C), "::", stringify!(baz))
     );
@@ -148,6 +146,7 @@ pub struct D {
 fn bindgen_test_layout_D() {
     const UNINIT: ::std::mem::MaybeUninit<D> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<D>(),
         4usize,
@@ -159,10 +158,7 @@ fn bindgen_test_layout_D() {
         concat!("Alignment of ", stringify!(D))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).member) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).member) as usize - ptr as usize },
         0usize,
         concat!("Offset of field: ", stringify!(D), "::", stringify!(member))
     );

--- a/tests/expectations/tests/class_nested.rs
+++ b/tests/expectations/tests/class_nested.rs
@@ -17,6 +17,8 @@ pub struct A_B {
 }
 #[test]
 fn bindgen_test_layout_A_B() {
+    const UNINIT: ::std::mem::MaybeUninit<A_B> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<A_B>(),
         4usize,
@@ -27,23 +29,19 @@ fn bindgen_test_layout_A_B() {
         4usize,
         concat!("Alignment of ", stringify!(A_B))
     );
-    fn test_field_member_b() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<A_B>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).member_b) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(A_B),
-                "::",
-                stringify!(member_b)
-            )
-        );
-    }
-    test_field_member_b();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).member_b) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(A_B),
+            "::",
+            stringify!(member_b)
+        )
+    );
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -62,6 +60,8 @@ impl<T> Default for A_D<T> {
 }
 #[test]
 fn bindgen_test_layout_A() {
+    const UNINIT: ::std::mem::MaybeUninit<A> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<A>(),
         4usize,
@@ -72,23 +72,19 @@ fn bindgen_test_layout_A() {
         4usize,
         concat!("Alignment of ", stringify!(A))
     );
-    fn test_field_member_a() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<A>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).member_a) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(A),
-                "::",
-                stringify!(member_a)
-            )
-        );
-    }
-    test_field_member_a();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).member_a) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(A),
+            "::",
+            stringify!(member_a)
+        )
+    );
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
@@ -97,6 +93,8 @@ pub struct A_C {
 }
 #[test]
 fn bindgen_test_layout_A_C() {
+    const UNINIT: ::std::mem::MaybeUninit<A_C> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<A_C>(),
         4usize,
@@ -107,23 +105,14 @@ fn bindgen_test_layout_A_C() {
         4usize,
         concat!("Alignment of ", stringify!(A_C))
     );
-    fn test_field_baz() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<A_C>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(A_C),
-                "::",
-                stringify!(baz)
-            )
-        );
-    }
-    test_field_baz();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize
+        },
+        0usize,
+        concat!("Offset of field: ", stringify!(A_C), "::", stringify!(baz))
+    );
 }
 extern "C" {
     pub static mut var: A_B;
@@ -157,6 +146,8 @@ pub struct D {
 }
 #[test]
 fn bindgen_test_layout_D() {
+    const UNINIT: ::std::mem::MaybeUninit<D> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<D>(),
         4usize,
@@ -167,23 +158,14 @@ fn bindgen_test_layout_D() {
         4usize,
         concat!("Alignment of ", stringify!(D))
     );
-    fn test_field_member() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<D>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).member) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(D),
-                "::",
-                stringify!(member)
-            )
-        );
-    }
-    test_field_member();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).member) as usize - ptr as usize
+        },
+        0usize,
+        concat!("Offset of field: ", stringify!(D), "::", stringify!(member))
+    );
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]

--- a/tests/expectations/tests/class_no_members.rs
+++ b/tests/expectations/tests/class_no_members.rs
@@ -48,6 +48,8 @@ pub struct whatever_child_with_member {
 }
 #[test]
 fn bindgen_test_layout_whatever_child_with_member() {
+    const UNINIT: ::std::mem::MaybeUninit<whatever_child_with_member> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<whatever_child_with_member>(),
         4usize,
@@ -58,23 +60,17 @@ fn bindgen_test_layout_whatever_child_with_member() {
         4usize,
         concat!("Alignment of ", stringify!(whatever_child_with_member))
     );
-    fn test_field_m_member() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<
-                    whatever_child_with_member,
-                >::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).m_member) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(whatever_child_with_member),
-                "::",
-                stringify!(m_member)
-            )
-        );
-    }
-    test_field_m_member();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).m_member) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(whatever_child_with_member),
+            "::",
+            stringify!(m_member)
+        )
+    );
 }

--- a/tests/expectations/tests/class_no_members.rs
+++ b/tests/expectations/tests/class_no_members.rs
@@ -50,6 +50,7 @@ pub struct whatever_child_with_member {
 fn bindgen_test_layout_whatever_child_with_member() {
     const UNINIT: ::std::mem::MaybeUninit<whatever_child_with_member> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<whatever_child_with_member>(),
         4usize,
@@ -62,7 +63,6 @@ fn bindgen_test_layout_whatever_child_with_member() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).m_member) as usize - ptr as usize
         },
         0usize,

--- a/tests/expectations/tests/class_use_as.rs
+++ b/tests/expectations/tests/class_use_as.rs
@@ -13,6 +13,8 @@ pub struct whatever {
 }
 #[test]
 fn bindgen_test_layout_whatever() {
+    const UNINIT: ::std::mem::MaybeUninit<whatever> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<whatever>(),
         4usize,
@@ -23,23 +25,19 @@ fn bindgen_test_layout_whatever() {
         4usize,
         concat!("Alignment of ", stringify!(whatever))
     );
-    fn test_field_replacement() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<whatever>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).replacement) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(whatever),
-                "::",
-                stringify!(replacement)
-            )
-        );
-    }
-    test_field_replacement();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).replacement) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(whatever),
+            "::",
+            stringify!(replacement)
+        )
+    );
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
@@ -48,6 +46,8 @@ pub struct container {
 }
 #[test]
 fn bindgen_test_layout_container() {
+    const UNINIT: ::std::mem::MaybeUninit<container> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<container>(),
         4usize,
@@ -58,21 +58,17 @@ fn bindgen_test_layout_container() {
         4usize,
         concat!("Alignment of ", stringify!(container))
     );
-    fn test_field_c() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<container>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).c) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(container),
-                "::",
-                stringify!(c)
-            )
-        );
-    }
-    test_field_c();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).c) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(container),
+            "::",
+            stringify!(c)
+        )
+    );
 }

--- a/tests/expectations/tests/class_use_as.rs
+++ b/tests/expectations/tests/class_use_as.rs
@@ -15,6 +15,7 @@ pub struct whatever {
 fn bindgen_test_layout_whatever() {
     const UNINIT: ::std::mem::MaybeUninit<whatever> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<whatever>(),
         4usize,
@@ -27,7 +28,6 @@ fn bindgen_test_layout_whatever() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).replacement) as usize - ptr as usize
         },
         0usize,
@@ -48,6 +48,7 @@ pub struct container {
 fn bindgen_test_layout_container() {
     const UNINIT: ::std::mem::MaybeUninit<container> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<container>(),
         4usize,
@@ -59,10 +60,7 @@ fn bindgen_test_layout_container() {
         concat!("Alignment of ", stringify!(container))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).c) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).c) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/class_with_dtor.rs
+++ b/tests/expectations/tests/class_with_dtor.rs
@@ -30,6 +30,7 @@ pub struct WithoutDtor {
 fn bindgen_test_layout_WithoutDtor() {
     const UNINIT: ::std::mem::MaybeUninit<WithoutDtor> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<WithoutDtor>(),
         8usize,
@@ -42,7 +43,6 @@ fn bindgen_test_layout_WithoutDtor() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).shouldBeWithDtor) as usize -
                 ptr as usize
         },

--- a/tests/expectations/tests/class_with_dtor.rs
+++ b/tests/expectations/tests/class_with_dtor.rs
@@ -28,6 +28,8 @@ pub struct WithoutDtor {
 }
 #[test]
 fn bindgen_test_layout_WithoutDtor() {
+    const UNINIT: ::std::mem::MaybeUninit<WithoutDtor> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<WithoutDtor>(),
         8usize,
@@ -38,24 +40,20 @@ fn bindgen_test_layout_WithoutDtor() {
         8usize,
         concat!("Alignment of ", stringify!(WithoutDtor))
     );
-    fn test_field_shouldBeWithDtor() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<WithoutDtor>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).shouldBeWithDtor) as usize -
-                    ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(WithoutDtor),
-                "::",
-                stringify!(shouldBeWithDtor)
-            )
-        );
-    }
-    test_field_shouldBeWithDtor();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).shouldBeWithDtor) as usize -
+                ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(WithoutDtor),
+            "::",
+            stringify!(shouldBeWithDtor)
+        )
+    );
 }
 impl Default for WithoutDtor {
     fn default() -> Self {

--- a/tests/expectations/tests/class_with_inner_struct.rs
+++ b/tests/expectations/tests/class_with_inner_struct.rs
@@ -22,6 +22,7 @@ pub struct A_Segment {
 fn bindgen_test_layout_A_Segment() {
     const UNINIT: ::std::mem::MaybeUninit<A_Segment> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<A_Segment>(),
         8usize,
@@ -33,10 +34,7 @@ fn bindgen_test_layout_A_Segment() {
         concat!("Alignment of ", stringify!(A_Segment))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).begin) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).begin) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -46,10 +44,7 @@ fn bindgen_test_layout_A_Segment() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).end) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).end) as usize - ptr as usize },
         4usize,
         concat!(
             "Offset of field: ",
@@ -68,6 +63,7 @@ pub union A__bindgen_ty_1 {
 fn bindgen_test_layout_A__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<A__bindgen_ty_1> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<A__bindgen_ty_1>(),
         4usize,
@@ -79,10 +75,7 @@ fn bindgen_test_layout_A__bindgen_ty_1() {
         concat!("Alignment of ", stringify!(A__bindgen_ty_1))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).f) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).f) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -110,6 +103,7 @@ pub union A__bindgen_ty_2 {
 fn bindgen_test_layout_A__bindgen_ty_2() {
     const UNINIT: ::std::mem::MaybeUninit<A__bindgen_ty_2> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<A__bindgen_ty_2>(),
         4usize,
@@ -121,10 +115,7 @@ fn bindgen_test_layout_A__bindgen_ty_2() {
         concat!("Alignment of ", stringify!(A__bindgen_ty_2))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -147,6 +138,7 @@ impl Default for A__bindgen_ty_2 {
 fn bindgen_test_layout_A() {
     const UNINIT: ::std::mem::MaybeUninit<A> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<A>(),
         12usize,
@@ -158,16 +150,12 @@ fn bindgen_test_layout_A() {
         concat!("Alignment of ", stringify!(A))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).c) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).c) as usize - ptr as usize },
         0usize,
         concat!("Offset of field: ", stringify!(A), "::", stringify!(c))
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).named_union) as usize - ptr as usize
         },
         4usize,
@@ -203,6 +191,7 @@ pub struct B_Segment {
 fn bindgen_test_layout_B_Segment() {
     const UNINIT: ::std::mem::MaybeUninit<B_Segment> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<B_Segment>(),
         8usize,
@@ -214,10 +203,7 @@ fn bindgen_test_layout_B_Segment() {
         concat!("Alignment of ", stringify!(B_Segment))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).begin) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).begin) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -227,10 +213,7 @@ fn bindgen_test_layout_B_Segment() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).end) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).end) as usize - ptr as usize },
         4usize,
         concat!(
             "Offset of field: ",
@@ -244,6 +227,7 @@ fn bindgen_test_layout_B_Segment() {
 fn bindgen_test_layout_B() {
     const UNINIT: ::std::mem::MaybeUninit<B> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<B>(),
         4usize,
@@ -255,10 +239,7 @@ fn bindgen_test_layout_B() {
         concat!("Alignment of ", stringify!(B))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize },
         0usize,
         concat!("Offset of field: ", stringify!(B), "::", stringify!(d))
     );
@@ -295,6 +276,7 @@ pub struct C__bindgen_ty_1__bindgen_ty_1 {
 fn bindgen_test_layout_C__bindgen_ty_1__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<C__bindgen_ty_1__bindgen_ty_1> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<C__bindgen_ty_1__bindgen_ty_1>(),
         16usize,
@@ -306,10 +288,7 @@ fn bindgen_test_layout_C__bindgen_ty_1__bindgen_ty_1() {
         concat!("Alignment of ", stringify!(C__bindgen_ty_1__bindgen_ty_1))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mX1) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).mX1) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -319,10 +298,7 @@ fn bindgen_test_layout_C__bindgen_ty_1__bindgen_ty_1() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mY1) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).mY1) as usize - ptr as usize },
         4usize,
         concat!(
             "Offset of field: ",
@@ -332,10 +308,7 @@ fn bindgen_test_layout_C__bindgen_ty_1__bindgen_ty_1() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mX2) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).mX2) as usize - ptr as usize },
         8usize,
         concat!(
             "Offset of field: ",
@@ -345,10 +318,7 @@ fn bindgen_test_layout_C__bindgen_ty_1__bindgen_ty_1() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mY2) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).mY2) as usize - ptr as usize },
         12usize,
         concat!(
             "Offset of field: ",
@@ -368,6 +338,7 @@ pub struct C__bindgen_ty_1__bindgen_ty_2 {
 fn bindgen_test_layout_C__bindgen_ty_1__bindgen_ty_2() {
     const UNINIT: ::std::mem::MaybeUninit<C__bindgen_ty_1__bindgen_ty_2> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<C__bindgen_ty_1__bindgen_ty_2>(),
         8usize,
@@ -380,7 +351,6 @@ fn bindgen_test_layout_C__bindgen_ty_1__bindgen_ty_2() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).mStepSyntax) as usize - ptr as usize
         },
         0usize,
@@ -392,10 +362,7 @@ fn bindgen_test_layout_C__bindgen_ty_1__bindgen_ty_2() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mSteps) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).mSteps) as usize - ptr as usize },
         4usize,
         concat!(
             "Offset of field: ",
@@ -418,6 +385,7 @@ impl Default for C__bindgen_ty_1__bindgen_ty_2 {
 fn bindgen_test_layout_C__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<C__bindgen_ty_1> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<C__bindgen_ty_1>(),
         16usize,
@@ -429,10 +397,7 @@ fn bindgen_test_layout_C__bindgen_ty_1() {
         concat!("Alignment of ", stringify!(C__bindgen_ty_1))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mFunc) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).mFunc) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -461,6 +426,7 @@ pub struct C_Segment {
 fn bindgen_test_layout_C_Segment() {
     const UNINIT: ::std::mem::MaybeUninit<C_Segment> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<C_Segment>(),
         8usize,
@@ -472,10 +438,7 @@ fn bindgen_test_layout_C_Segment() {
         concat!("Alignment of ", stringify!(C_Segment))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).begin) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).begin) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -485,10 +448,7 @@ fn bindgen_test_layout_C_Segment() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).end) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).end) as usize - ptr as usize },
         4usize,
         concat!(
             "Offset of field: ",
@@ -502,6 +462,7 @@ fn bindgen_test_layout_C_Segment() {
 fn bindgen_test_layout_C() {
     const UNINIT: ::std::mem::MaybeUninit<C> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<C>(),
         20usize,
@@ -513,10 +474,7 @@ fn bindgen_test_layout_C() {
         concat!("Alignment of ", stringify!(C))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize },
         0usize,
         concat!("Offset of field: ", stringify!(C), "::", stringify!(d))
     );

--- a/tests/expectations/tests/class_with_inner_struct.rs
+++ b/tests/expectations/tests/class_with_inner_struct.rs
@@ -20,6 +20,8 @@ pub struct A_Segment {
 }
 #[test]
 fn bindgen_test_layout_A_Segment() {
+    const UNINIT: ::std::mem::MaybeUninit<A_Segment> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<A_Segment>(),
         8usize,
@@ -30,40 +32,32 @@ fn bindgen_test_layout_A_Segment() {
         4usize,
         concat!("Alignment of ", stringify!(A_Segment))
     );
-    fn test_field_begin() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<A_Segment>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).begin) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(A_Segment),
-                "::",
-                stringify!(begin)
-            )
-        );
-    }
-    test_field_begin();
-    fn test_field_end() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<A_Segment>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).end) as usize - ptr as usize
-            },
-            4usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(A_Segment),
-                "::",
-                stringify!(end)
-            )
-        );
-    }
-    test_field_end();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).begin) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(A_Segment),
+            "::",
+            stringify!(begin)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).end) as usize - ptr as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(A_Segment),
+            "::",
+            stringify!(end)
+        )
+    );
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -72,6 +66,8 @@ pub union A__bindgen_ty_1 {
 }
 #[test]
 fn bindgen_test_layout_A__bindgen_ty_1() {
+    const UNINIT: ::std::mem::MaybeUninit<A__bindgen_ty_1> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<A__bindgen_ty_1>(),
         4usize,
@@ -82,24 +78,19 @@ fn bindgen_test_layout_A__bindgen_ty_1() {
         4usize,
         concat!("Alignment of ", stringify!(A__bindgen_ty_1))
     );
-    fn test_field_f() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<A__bindgen_ty_1>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).f) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(A__bindgen_ty_1),
-                "::",
-                stringify!(f)
-            )
-        );
-    }
-    test_field_f();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).f) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(A__bindgen_ty_1),
+            "::",
+            stringify!(f)
+        )
+    );
 }
 impl Default for A__bindgen_ty_1 {
     fn default() -> Self {
@@ -117,6 +108,8 @@ pub union A__bindgen_ty_2 {
 }
 #[test]
 fn bindgen_test_layout_A__bindgen_ty_2() {
+    const UNINIT: ::std::mem::MaybeUninit<A__bindgen_ty_2> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<A__bindgen_ty_2>(),
         4usize,
@@ -127,24 +120,19 @@ fn bindgen_test_layout_A__bindgen_ty_2() {
         4usize,
         concat!("Alignment of ", stringify!(A__bindgen_ty_2))
     );
-    fn test_field_d() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<A__bindgen_ty_2>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(A__bindgen_ty_2),
-                "::",
-                stringify!(d)
-            )
-        );
-    }
-    test_field_d();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(A__bindgen_ty_2),
+            "::",
+            stringify!(d)
+        )
+    );
 }
 impl Default for A__bindgen_ty_2 {
     fn default() -> Self {
@@ -157,6 +145,8 @@ impl Default for A__bindgen_ty_2 {
 }
 #[test]
 fn bindgen_test_layout_A() {
+    const UNINIT: ::std::mem::MaybeUninit<A> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<A>(),
         12usize,
@@ -167,35 +157,27 @@ fn bindgen_test_layout_A() {
         4usize,
         concat!("Alignment of ", stringify!(A))
     );
-    fn test_field_c() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<A>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).c) as usize - ptr as usize
-            },
-            0usize,
-            concat!("Offset of field: ", stringify!(A), "::", stringify!(c))
-        );
-    }
-    test_field_c();
-    fn test_field_named_union() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<A>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).named_union) as usize - ptr as usize
-            },
-            4usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(A),
-                "::",
-                stringify!(named_union)
-            )
-        );
-    }
-    test_field_named_union();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).c) as usize - ptr as usize
+        },
+        0usize,
+        concat!("Offset of field: ", stringify!(A), "::", stringify!(c))
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).named_union) as usize - ptr as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(A),
+            "::",
+            stringify!(named_union)
+        )
+    );
 }
 impl Default for A {
     fn default() -> Self {
@@ -219,6 +201,8 @@ pub struct B_Segment {
 }
 #[test]
 fn bindgen_test_layout_B_Segment() {
+    const UNINIT: ::std::mem::MaybeUninit<B_Segment> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<B_Segment>(),
         8usize,
@@ -229,43 +213,37 @@ fn bindgen_test_layout_B_Segment() {
         4usize,
         concat!("Alignment of ", stringify!(B_Segment))
     );
-    fn test_field_begin() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<B_Segment>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).begin) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(B_Segment),
-                "::",
-                stringify!(begin)
-            )
-        );
-    }
-    test_field_begin();
-    fn test_field_end() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<B_Segment>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).end) as usize - ptr as usize
-            },
-            4usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(B_Segment),
-                "::",
-                stringify!(end)
-            )
-        );
-    }
-    test_field_end();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).begin) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(B_Segment),
+            "::",
+            stringify!(begin)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).end) as usize - ptr as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(B_Segment),
+            "::",
+            stringify!(end)
+        )
+    );
 }
 #[test]
 fn bindgen_test_layout_B() {
+    const UNINIT: ::std::mem::MaybeUninit<B> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<B>(),
         4usize,
@@ -276,18 +254,14 @@ fn bindgen_test_layout_B() {
         4usize,
         concat!("Alignment of ", stringify!(B))
     );
-    fn test_field_d() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<B>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize
-            },
-            0usize,
-            concat!("Offset of field: ", stringify!(B), "::", stringify!(d))
-        );
-    }
-    test_field_d();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize
+        },
+        0usize,
+        concat!("Offset of field: ", stringify!(B), "::", stringify!(d))
+    );
 }
 #[repr(i32)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -319,6 +293,8 @@ pub struct C__bindgen_ty_1__bindgen_ty_1 {
 }
 #[test]
 fn bindgen_test_layout_C__bindgen_ty_1__bindgen_ty_1() {
+    const UNINIT: ::std::mem::MaybeUninit<C__bindgen_ty_1__bindgen_ty_1> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<C__bindgen_ty_1__bindgen_ty_1>(),
         16usize,
@@ -329,82 +305,58 @@ fn bindgen_test_layout_C__bindgen_ty_1__bindgen_ty_1() {
         4usize,
         concat!("Alignment of ", stringify!(C__bindgen_ty_1__bindgen_ty_1))
     );
-    fn test_field_mX1() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<
-                    C__bindgen_ty_1__bindgen_ty_1,
-                >::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).mX1) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(C__bindgen_ty_1__bindgen_ty_1),
-                "::",
-                stringify!(mX1)
-            )
-        );
-    }
-    test_field_mX1();
-    fn test_field_mY1() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<
-                    C__bindgen_ty_1__bindgen_ty_1,
-                >::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).mY1) as usize - ptr as usize
-            },
-            4usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(C__bindgen_ty_1__bindgen_ty_1),
-                "::",
-                stringify!(mY1)
-            )
-        );
-    }
-    test_field_mY1();
-    fn test_field_mX2() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<
-                    C__bindgen_ty_1__bindgen_ty_1,
-                >::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).mX2) as usize - ptr as usize
-            },
-            8usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(C__bindgen_ty_1__bindgen_ty_1),
-                "::",
-                stringify!(mX2)
-            )
-        );
-    }
-    test_field_mX2();
-    fn test_field_mY2() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<
-                    C__bindgen_ty_1__bindgen_ty_1,
-                >::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).mY2) as usize - ptr as usize
-            },
-            12usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(C__bindgen_ty_1__bindgen_ty_1),
-                "::",
-                stringify!(mY2)
-            )
-        );
-    }
-    test_field_mY2();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).mX1) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C__bindgen_ty_1__bindgen_ty_1),
+            "::",
+            stringify!(mX1)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).mY1) as usize - ptr as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C__bindgen_ty_1__bindgen_ty_1),
+            "::",
+            stringify!(mY1)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).mX2) as usize - ptr as usize
+        },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C__bindgen_ty_1__bindgen_ty_1),
+            "::",
+            stringify!(mX2)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).mY2) as usize - ptr as usize
+        },
+        12usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C__bindgen_ty_1__bindgen_ty_1),
+            "::",
+            stringify!(mY2)
+        )
+    );
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -414,6 +366,8 @@ pub struct C__bindgen_ty_1__bindgen_ty_2 {
 }
 #[test]
 fn bindgen_test_layout_C__bindgen_ty_1__bindgen_ty_2() {
+    const UNINIT: ::std::mem::MaybeUninit<C__bindgen_ty_1__bindgen_ty_2> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<C__bindgen_ty_1__bindgen_ty_2>(),
         8usize,
@@ -424,44 +378,32 @@ fn bindgen_test_layout_C__bindgen_ty_1__bindgen_ty_2() {
         4usize,
         concat!("Alignment of ", stringify!(C__bindgen_ty_1__bindgen_ty_2))
     );
-    fn test_field_mStepSyntax() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<
-                    C__bindgen_ty_1__bindgen_ty_2,
-                >::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).mStepSyntax) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(C__bindgen_ty_1__bindgen_ty_2),
-                "::",
-                stringify!(mStepSyntax)
-            )
-        );
-    }
-    test_field_mStepSyntax();
-    fn test_field_mSteps() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<
-                    C__bindgen_ty_1__bindgen_ty_2,
-                >::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).mSteps) as usize - ptr as usize
-            },
-            4usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(C__bindgen_ty_1__bindgen_ty_2),
-                "::",
-                stringify!(mSteps)
-            )
-        );
-    }
-    test_field_mSteps();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).mStepSyntax) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C__bindgen_ty_1__bindgen_ty_2),
+            "::",
+            stringify!(mStepSyntax)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).mSteps) as usize - ptr as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C__bindgen_ty_1__bindgen_ty_2),
+            "::",
+            stringify!(mSteps)
+        )
+    );
 }
 impl Default for C__bindgen_ty_1__bindgen_ty_2 {
     fn default() -> Self {
@@ -474,6 +416,8 @@ impl Default for C__bindgen_ty_1__bindgen_ty_2 {
 }
 #[test]
 fn bindgen_test_layout_C__bindgen_ty_1() {
+    const UNINIT: ::std::mem::MaybeUninit<C__bindgen_ty_1> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<C__bindgen_ty_1>(),
         16usize,
@@ -484,24 +428,19 @@ fn bindgen_test_layout_C__bindgen_ty_1() {
         4usize,
         concat!("Alignment of ", stringify!(C__bindgen_ty_1))
     );
-    fn test_field_mFunc() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<C__bindgen_ty_1>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).mFunc) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(C__bindgen_ty_1),
-                "::",
-                stringify!(mFunc)
-            )
-        );
-    }
-    test_field_mFunc();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).mFunc) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C__bindgen_ty_1),
+            "::",
+            stringify!(mFunc)
+        )
+    );
 }
 impl Default for C__bindgen_ty_1 {
     fn default() -> Self {
@@ -520,6 +459,8 @@ pub struct C_Segment {
 }
 #[test]
 fn bindgen_test_layout_C_Segment() {
+    const UNINIT: ::std::mem::MaybeUninit<C_Segment> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<C_Segment>(),
         8usize,
@@ -530,43 +471,37 @@ fn bindgen_test_layout_C_Segment() {
         4usize,
         concat!("Alignment of ", stringify!(C_Segment))
     );
-    fn test_field_begin() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<C_Segment>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).begin) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(C_Segment),
-                "::",
-                stringify!(begin)
-            )
-        );
-    }
-    test_field_begin();
-    fn test_field_end() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<C_Segment>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).end) as usize - ptr as usize
-            },
-            4usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(C_Segment),
-                "::",
-                stringify!(end)
-            )
-        );
-    }
-    test_field_end();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).begin) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C_Segment),
+            "::",
+            stringify!(begin)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).end) as usize - ptr as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C_Segment),
+            "::",
+            stringify!(end)
+        )
+    );
 }
 #[test]
 fn bindgen_test_layout_C() {
+    const UNINIT: ::std::mem::MaybeUninit<C> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<C>(),
         20usize,
@@ -577,18 +512,14 @@ fn bindgen_test_layout_C() {
         4usize,
         concat!("Alignment of ", stringify!(C))
     );
-    fn test_field_d() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<C>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize
-            },
-            0usize,
-            concat!("Offset of field: ", stringify!(C), "::", stringify!(d))
-        );
-    }
-    test_field_d();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize
+        },
+        0usize,
+        concat!("Offset of field: ", stringify!(C), "::", stringify!(d))
+    );
 }
 impl Default for C {
     fn default() -> Self {

--- a/tests/expectations/tests/class_with_inner_struct_1_0.rs
+++ b/tests/expectations/tests/class_with_inner_struct_1_0.rs
@@ -65,6 +65,7 @@ pub struct A_Segment {
 fn bindgen_test_layout_A_Segment() {
     const UNINIT: ::std::mem::MaybeUninit<A_Segment> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<A_Segment>(),
         8usize,
@@ -76,10 +77,7 @@ fn bindgen_test_layout_A_Segment() {
         concat!("Alignment of ", stringify!(A_Segment))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).begin) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).begin) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -89,10 +87,7 @@ fn bindgen_test_layout_A_Segment() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).end) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).end) as usize - ptr as usize },
         4usize,
         concat!(
             "Offset of field: ",
@@ -117,6 +112,7 @@ pub struct A__bindgen_ty_1 {
 fn bindgen_test_layout_A__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<A__bindgen_ty_1> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<A__bindgen_ty_1>(),
         4usize,
@@ -128,10 +124,7 @@ fn bindgen_test_layout_A__bindgen_ty_1() {
         concat!("Alignment of ", stringify!(A__bindgen_ty_1))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).f) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).f) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -156,6 +149,7 @@ pub struct A__bindgen_ty_2 {
 fn bindgen_test_layout_A__bindgen_ty_2() {
     const UNINIT: ::std::mem::MaybeUninit<A__bindgen_ty_2> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<A__bindgen_ty_2>(),
         4usize,
@@ -167,10 +161,7 @@ fn bindgen_test_layout_A__bindgen_ty_2() {
         concat!("Alignment of ", stringify!(A__bindgen_ty_2))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -189,6 +180,7 @@ impl Clone for A__bindgen_ty_2 {
 fn bindgen_test_layout_A() {
     const UNINIT: ::std::mem::MaybeUninit<A> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<A>(),
         12usize,
@@ -200,16 +192,12 @@ fn bindgen_test_layout_A() {
         concat!("Alignment of ", stringify!(A))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).c) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).c) as usize - ptr as usize },
         0usize,
         concat!("Offset of field: ", stringify!(A), "::", stringify!(c))
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).named_union) as usize - ptr as usize
         },
         4usize,
@@ -241,6 +229,7 @@ pub struct B_Segment {
 fn bindgen_test_layout_B_Segment() {
     const UNINIT: ::std::mem::MaybeUninit<B_Segment> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<B_Segment>(),
         8usize,
@@ -252,10 +241,7 @@ fn bindgen_test_layout_B_Segment() {
         concat!("Alignment of ", stringify!(B_Segment))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).begin) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).begin) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -265,10 +251,7 @@ fn bindgen_test_layout_B_Segment() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).end) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).end) as usize - ptr as usize },
         4usize,
         concat!(
             "Offset of field: ",
@@ -287,6 +270,7 @@ impl Clone for B_Segment {
 fn bindgen_test_layout_B() {
     const UNINIT: ::std::mem::MaybeUninit<B> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<B>(),
         4usize,
@@ -298,10 +282,7 @@ fn bindgen_test_layout_B() {
         concat!("Alignment of ", stringify!(B))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize },
         0usize,
         concat!("Offset of field: ", stringify!(B), "::", stringify!(d))
     );
@@ -344,6 +325,7 @@ pub struct C__bindgen_ty_1__bindgen_ty_1 {
 fn bindgen_test_layout_C__bindgen_ty_1__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<C__bindgen_ty_1__bindgen_ty_1> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<C__bindgen_ty_1__bindgen_ty_1>(),
         16usize,
@@ -355,10 +337,7 @@ fn bindgen_test_layout_C__bindgen_ty_1__bindgen_ty_1() {
         concat!("Alignment of ", stringify!(C__bindgen_ty_1__bindgen_ty_1))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mX1) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).mX1) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -368,10 +347,7 @@ fn bindgen_test_layout_C__bindgen_ty_1__bindgen_ty_1() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mY1) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).mY1) as usize - ptr as usize },
         4usize,
         concat!(
             "Offset of field: ",
@@ -381,10 +357,7 @@ fn bindgen_test_layout_C__bindgen_ty_1__bindgen_ty_1() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mX2) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).mX2) as usize - ptr as usize },
         8usize,
         concat!(
             "Offset of field: ",
@@ -394,10 +367,7 @@ fn bindgen_test_layout_C__bindgen_ty_1__bindgen_ty_1() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mY2) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).mY2) as usize - ptr as usize },
         12usize,
         concat!(
             "Offset of field: ",
@@ -422,6 +392,7 @@ pub struct C__bindgen_ty_1__bindgen_ty_2 {
 fn bindgen_test_layout_C__bindgen_ty_1__bindgen_ty_2() {
     const UNINIT: ::std::mem::MaybeUninit<C__bindgen_ty_1__bindgen_ty_2> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<C__bindgen_ty_1__bindgen_ty_2>(),
         8usize,
@@ -434,7 +405,6 @@ fn bindgen_test_layout_C__bindgen_ty_1__bindgen_ty_2() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).mStepSyntax) as usize - ptr as usize
         },
         0usize,
@@ -446,10 +416,7 @@ fn bindgen_test_layout_C__bindgen_ty_1__bindgen_ty_2() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mSteps) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).mSteps) as usize - ptr as usize },
         4usize,
         concat!(
             "Offset of field: ",
@@ -477,6 +444,7 @@ impl Default for C__bindgen_ty_1__bindgen_ty_2 {
 fn bindgen_test_layout_C__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<C__bindgen_ty_1> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<C__bindgen_ty_1>(),
         16usize,
@@ -488,10 +456,7 @@ fn bindgen_test_layout_C__bindgen_ty_1() {
         concat!("Alignment of ", stringify!(C__bindgen_ty_1))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mFunc) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).mFunc) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -516,6 +481,7 @@ pub struct C_Segment {
 fn bindgen_test_layout_C_Segment() {
     const UNINIT: ::std::mem::MaybeUninit<C_Segment> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<C_Segment>(),
         8usize,
@@ -527,10 +493,7 @@ fn bindgen_test_layout_C_Segment() {
         concat!("Alignment of ", stringify!(C_Segment))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).begin) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).begin) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -540,10 +503,7 @@ fn bindgen_test_layout_C_Segment() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).end) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).end) as usize - ptr as usize },
         4usize,
         concat!(
             "Offset of field: ",
@@ -562,6 +522,7 @@ impl Clone for C_Segment {
 fn bindgen_test_layout_C() {
     const UNINIT: ::std::mem::MaybeUninit<C> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<C>(),
         20usize,
@@ -573,10 +534,7 @@ fn bindgen_test_layout_C() {
         concat!("Alignment of ", stringify!(C))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize },
         0usize,
         concat!("Offset of field: ", stringify!(C), "::", stringify!(d))
     );

--- a/tests/expectations/tests/class_with_inner_struct_1_0.rs
+++ b/tests/expectations/tests/class_with_inner_struct_1_0.rs
@@ -63,6 +63,8 @@ pub struct A_Segment {
 }
 #[test]
 fn bindgen_test_layout_A_Segment() {
+    const UNINIT: ::std::mem::MaybeUninit<A_Segment> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<A_Segment>(),
         8usize,
@@ -73,40 +75,32 @@ fn bindgen_test_layout_A_Segment() {
         4usize,
         concat!("Alignment of ", stringify!(A_Segment))
     );
-    fn test_field_begin() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<A_Segment>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).begin) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(A_Segment),
-                "::",
-                stringify!(begin)
-            )
-        );
-    }
-    test_field_begin();
-    fn test_field_end() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<A_Segment>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).end) as usize - ptr as usize
-            },
-            4usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(A_Segment),
-                "::",
-                stringify!(end)
-            )
-        );
-    }
-    test_field_end();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).begin) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(A_Segment),
+            "::",
+            stringify!(begin)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).end) as usize - ptr as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(A_Segment),
+            "::",
+            stringify!(end)
+        )
+    );
 }
 impl Clone for A_Segment {
     fn clone(&self) -> Self {
@@ -121,6 +115,8 @@ pub struct A__bindgen_ty_1 {
 }
 #[test]
 fn bindgen_test_layout_A__bindgen_ty_1() {
+    const UNINIT: ::std::mem::MaybeUninit<A__bindgen_ty_1> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<A__bindgen_ty_1>(),
         4usize,
@@ -131,24 +127,19 @@ fn bindgen_test_layout_A__bindgen_ty_1() {
         4usize,
         concat!("Alignment of ", stringify!(A__bindgen_ty_1))
     );
-    fn test_field_f() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<A__bindgen_ty_1>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).f) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(A__bindgen_ty_1),
-                "::",
-                stringify!(f)
-            )
-        );
-    }
-    test_field_f();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).f) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(A__bindgen_ty_1),
+            "::",
+            stringify!(f)
+        )
+    );
 }
 impl Clone for A__bindgen_ty_1 {
     fn clone(&self) -> Self {
@@ -163,6 +154,8 @@ pub struct A__bindgen_ty_2 {
 }
 #[test]
 fn bindgen_test_layout_A__bindgen_ty_2() {
+    const UNINIT: ::std::mem::MaybeUninit<A__bindgen_ty_2> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<A__bindgen_ty_2>(),
         4usize,
@@ -173,24 +166,19 @@ fn bindgen_test_layout_A__bindgen_ty_2() {
         4usize,
         concat!("Alignment of ", stringify!(A__bindgen_ty_2))
     );
-    fn test_field_d() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<A__bindgen_ty_2>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(A__bindgen_ty_2),
-                "::",
-                stringify!(d)
-            )
-        );
-    }
-    test_field_d();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(A__bindgen_ty_2),
+            "::",
+            stringify!(d)
+        )
+    );
 }
 impl Clone for A__bindgen_ty_2 {
     fn clone(&self) -> Self {
@@ -199,6 +187,8 @@ impl Clone for A__bindgen_ty_2 {
 }
 #[test]
 fn bindgen_test_layout_A() {
+    const UNINIT: ::std::mem::MaybeUninit<A> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<A>(),
         12usize,
@@ -209,35 +199,27 @@ fn bindgen_test_layout_A() {
         4usize,
         concat!("Alignment of ", stringify!(A))
     );
-    fn test_field_c() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<A>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).c) as usize - ptr as usize
-            },
-            0usize,
-            concat!("Offset of field: ", stringify!(A), "::", stringify!(c))
-        );
-    }
-    test_field_c();
-    fn test_field_named_union() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<A>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).named_union) as usize - ptr as usize
-            },
-            4usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(A),
-                "::",
-                stringify!(named_union)
-            )
-        );
-    }
-    test_field_named_union();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).c) as usize - ptr as usize
+        },
+        0usize,
+        concat!("Offset of field: ", stringify!(A), "::", stringify!(c))
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).named_union) as usize - ptr as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(A),
+            "::",
+            stringify!(named_union)
+        )
+    );
 }
 impl Clone for A {
     fn clone(&self) -> Self {
@@ -257,6 +239,8 @@ pub struct B_Segment {
 }
 #[test]
 fn bindgen_test_layout_B_Segment() {
+    const UNINIT: ::std::mem::MaybeUninit<B_Segment> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<B_Segment>(),
         8usize,
@@ -267,40 +251,32 @@ fn bindgen_test_layout_B_Segment() {
         4usize,
         concat!("Alignment of ", stringify!(B_Segment))
     );
-    fn test_field_begin() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<B_Segment>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).begin) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(B_Segment),
-                "::",
-                stringify!(begin)
-            )
-        );
-    }
-    test_field_begin();
-    fn test_field_end() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<B_Segment>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).end) as usize - ptr as usize
-            },
-            4usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(B_Segment),
-                "::",
-                stringify!(end)
-            )
-        );
-    }
-    test_field_end();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).begin) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(B_Segment),
+            "::",
+            stringify!(begin)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).end) as usize - ptr as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(B_Segment),
+            "::",
+            stringify!(end)
+        )
+    );
 }
 impl Clone for B_Segment {
     fn clone(&self) -> Self {
@@ -309,6 +285,8 @@ impl Clone for B_Segment {
 }
 #[test]
 fn bindgen_test_layout_B() {
+    const UNINIT: ::std::mem::MaybeUninit<B> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<B>(),
         4usize,
@@ -319,18 +297,14 @@ fn bindgen_test_layout_B() {
         4usize,
         concat!("Alignment of ", stringify!(B))
     );
-    fn test_field_d() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<B>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize
-            },
-            0usize,
-            concat!("Offset of field: ", stringify!(B), "::", stringify!(d))
-        );
-    }
-    test_field_d();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize
+        },
+        0usize,
+        concat!("Offset of field: ", stringify!(B), "::", stringify!(d))
+    );
 }
 impl Clone for B {
     fn clone(&self) -> Self {
@@ -368,6 +342,8 @@ pub struct C__bindgen_ty_1__bindgen_ty_1 {
 }
 #[test]
 fn bindgen_test_layout_C__bindgen_ty_1__bindgen_ty_1() {
+    const UNINIT: ::std::mem::MaybeUninit<C__bindgen_ty_1__bindgen_ty_1> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<C__bindgen_ty_1__bindgen_ty_1>(),
         16usize,
@@ -378,82 +354,58 @@ fn bindgen_test_layout_C__bindgen_ty_1__bindgen_ty_1() {
         4usize,
         concat!("Alignment of ", stringify!(C__bindgen_ty_1__bindgen_ty_1))
     );
-    fn test_field_mX1() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<
-                    C__bindgen_ty_1__bindgen_ty_1,
-                >::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).mX1) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(C__bindgen_ty_1__bindgen_ty_1),
-                "::",
-                stringify!(mX1)
-            )
-        );
-    }
-    test_field_mX1();
-    fn test_field_mY1() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<
-                    C__bindgen_ty_1__bindgen_ty_1,
-                >::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).mY1) as usize - ptr as usize
-            },
-            4usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(C__bindgen_ty_1__bindgen_ty_1),
-                "::",
-                stringify!(mY1)
-            )
-        );
-    }
-    test_field_mY1();
-    fn test_field_mX2() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<
-                    C__bindgen_ty_1__bindgen_ty_1,
-                >::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).mX2) as usize - ptr as usize
-            },
-            8usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(C__bindgen_ty_1__bindgen_ty_1),
-                "::",
-                stringify!(mX2)
-            )
-        );
-    }
-    test_field_mX2();
-    fn test_field_mY2() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<
-                    C__bindgen_ty_1__bindgen_ty_1,
-                >::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).mY2) as usize - ptr as usize
-            },
-            12usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(C__bindgen_ty_1__bindgen_ty_1),
-                "::",
-                stringify!(mY2)
-            )
-        );
-    }
-    test_field_mY2();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).mX1) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C__bindgen_ty_1__bindgen_ty_1),
+            "::",
+            stringify!(mX1)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).mY1) as usize - ptr as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C__bindgen_ty_1__bindgen_ty_1),
+            "::",
+            stringify!(mY1)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).mX2) as usize - ptr as usize
+        },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C__bindgen_ty_1__bindgen_ty_1),
+            "::",
+            stringify!(mX2)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).mY2) as usize - ptr as usize
+        },
+        12usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C__bindgen_ty_1__bindgen_ty_1),
+            "::",
+            stringify!(mY2)
+        )
+    );
 }
 impl Clone for C__bindgen_ty_1__bindgen_ty_1 {
     fn clone(&self) -> Self {
@@ -468,6 +420,8 @@ pub struct C__bindgen_ty_1__bindgen_ty_2 {
 }
 #[test]
 fn bindgen_test_layout_C__bindgen_ty_1__bindgen_ty_2() {
+    const UNINIT: ::std::mem::MaybeUninit<C__bindgen_ty_1__bindgen_ty_2> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<C__bindgen_ty_1__bindgen_ty_2>(),
         8usize,
@@ -478,44 +432,32 @@ fn bindgen_test_layout_C__bindgen_ty_1__bindgen_ty_2() {
         4usize,
         concat!("Alignment of ", stringify!(C__bindgen_ty_1__bindgen_ty_2))
     );
-    fn test_field_mStepSyntax() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<
-                    C__bindgen_ty_1__bindgen_ty_2,
-                >::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).mStepSyntax) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(C__bindgen_ty_1__bindgen_ty_2),
-                "::",
-                stringify!(mStepSyntax)
-            )
-        );
-    }
-    test_field_mStepSyntax();
-    fn test_field_mSteps() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<
-                    C__bindgen_ty_1__bindgen_ty_2,
-                >::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).mSteps) as usize - ptr as usize
-            },
-            4usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(C__bindgen_ty_1__bindgen_ty_2),
-                "::",
-                stringify!(mSteps)
-            )
-        );
-    }
-    test_field_mSteps();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).mStepSyntax) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C__bindgen_ty_1__bindgen_ty_2),
+            "::",
+            stringify!(mStepSyntax)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).mSteps) as usize - ptr as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C__bindgen_ty_1__bindgen_ty_2),
+            "::",
+            stringify!(mSteps)
+        )
+    );
 }
 impl Clone for C__bindgen_ty_1__bindgen_ty_2 {
     fn clone(&self) -> Self {
@@ -533,6 +475,8 @@ impl Default for C__bindgen_ty_1__bindgen_ty_2 {
 }
 #[test]
 fn bindgen_test_layout_C__bindgen_ty_1() {
+    const UNINIT: ::std::mem::MaybeUninit<C__bindgen_ty_1> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<C__bindgen_ty_1>(),
         16usize,
@@ -543,24 +487,19 @@ fn bindgen_test_layout_C__bindgen_ty_1() {
         4usize,
         concat!("Alignment of ", stringify!(C__bindgen_ty_1))
     );
-    fn test_field_mFunc() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<C__bindgen_ty_1>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).mFunc) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(C__bindgen_ty_1),
-                "::",
-                stringify!(mFunc)
-            )
-        );
-    }
-    test_field_mFunc();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).mFunc) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C__bindgen_ty_1),
+            "::",
+            stringify!(mFunc)
+        )
+    );
 }
 impl Clone for C__bindgen_ty_1 {
     fn clone(&self) -> Self {
@@ -575,6 +514,8 @@ pub struct C_Segment {
 }
 #[test]
 fn bindgen_test_layout_C_Segment() {
+    const UNINIT: ::std::mem::MaybeUninit<C_Segment> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<C_Segment>(),
         8usize,
@@ -585,40 +526,32 @@ fn bindgen_test_layout_C_Segment() {
         4usize,
         concat!("Alignment of ", stringify!(C_Segment))
     );
-    fn test_field_begin() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<C_Segment>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).begin) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(C_Segment),
-                "::",
-                stringify!(begin)
-            )
-        );
-    }
-    test_field_begin();
-    fn test_field_end() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<C_Segment>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).end) as usize - ptr as usize
-            },
-            4usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(C_Segment),
-                "::",
-                stringify!(end)
-            )
-        );
-    }
-    test_field_end();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).begin) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C_Segment),
+            "::",
+            stringify!(begin)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).end) as usize - ptr as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C_Segment),
+            "::",
+            stringify!(end)
+        )
+    );
 }
 impl Clone for C_Segment {
     fn clone(&self) -> Self {
@@ -627,6 +560,8 @@ impl Clone for C_Segment {
 }
 #[test]
 fn bindgen_test_layout_C() {
+    const UNINIT: ::std::mem::MaybeUninit<C> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<C>(),
         20usize,
@@ -637,18 +572,14 @@ fn bindgen_test_layout_C() {
         4usize,
         concat!("Alignment of ", stringify!(C))
     );
-    fn test_field_d() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<C>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize
-            },
-            0usize,
-            concat!("Offset of field: ", stringify!(C), "::", stringify!(d))
-        );
-    }
-    test_field_d();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize
+        },
+        0usize,
+        concat!("Offset of field: ", stringify!(C), "::", stringify!(d))
+    );
 }
 impl Clone for C {
     fn clone(&self) -> Self {

--- a/tests/expectations/tests/class_with_typedef.rs
+++ b/tests/expectations/tests/class_with_typedef.rs
@@ -21,6 +21,7 @@ pub type C_Lookup = *const ::std::os::raw::c_char;
 fn bindgen_test_layout_C() {
     const UNINIT: ::std::mem::MaybeUninit<C> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<C>(),
         72usize,
@@ -32,40 +33,27 @@ fn bindgen_test_layout_C() {
         concat!("Alignment of ", stringify!(C))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).c) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).c) as usize - ptr as usize },
         0usize,
         concat!("Offset of field: ", stringify!(C), "::", stringify!(c))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).ptr) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).ptr) as usize - ptr as usize },
         8usize,
         concat!("Offset of field: ", stringify!(C), "::", stringify!(ptr))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).arr) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).arr) as usize - ptr as usize },
         16usize,
         concat!("Offset of field: ", stringify!(C), "::", stringify!(arr))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize },
         56usize,
         concat!("Offset of field: ", stringify!(C), "::", stringify!(d))
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).other_ptr) as usize - ptr as usize
         },
         64usize,
@@ -130,6 +118,7 @@ pub struct D {
 fn bindgen_test_layout_D() {
     const UNINIT: ::std::mem::MaybeUninit<D> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<D>(),
         80usize,
@@ -141,10 +130,7 @@ fn bindgen_test_layout_D() {
         concat!("Alignment of ", stringify!(D))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).ptr) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).ptr) as usize - ptr as usize },
         72usize,
         concat!("Offset of field: ", stringify!(D), "::", stringify!(ptr))
     );

--- a/tests/expectations/tests/class_with_typedef.rs
+++ b/tests/expectations/tests/class_with_typedef.rs
@@ -19,6 +19,8 @@ pub type C_MyInt = ::std::os::raw::c_int;
 pub type C_Lookup = *const ::std::os::raw::c_char;
 #[test]
 fn bindgen_test_layout_C() {
+    const UNINIT: ::std::mem::MaybeUninit<C> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<C>(),
         72usize,
@@ -29,71 +31,51 @@ fn bindgen_test_layout_C() {
         8usize,
         concat!("Alignment of ", stringify!(C))
     );
-    fn test_field_c() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<C>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).c) as usize - ptr as usize
-            },
-            0usize,
-            concat!("Offset of field: ", stringify!(C), "::", stringify!(c))
-        );
-    }
-    test_field_c();
-    fn test_field_ptr() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<C>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).ptr) as usize - ptr as usize
-            },
-            8usize,
-            concat!("Offset of field: ", stringify!(C), "::", stringify!(ptr))
-        );
-    }
-    test_field_ptr();
-    fn test_field_arr() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<C>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).arr) as usize - ptr as usize
-            },
-            16usize,
-            concat!("Offset of field: ", stringify!(C), "::", stringify!(arr))
-        );
-    }
-    test_field_arr();
-    fn test_field_d() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<C>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize
-            },
-            56usize,
-            concat!("Offset of field: ", stringify!(C), "::", stringify!(d))
-        );
-    }
-    test_field_d();
-    fn test_field_other_ptr() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<C>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).other_ptr) as usize - ptr as usize
-            },
-            64usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(C),
-                "::",
-                stringify!(other_ptr)
-            )
-        );
-    }
-    test_field_other_ptr();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).c) as usize - ptr as usize
+        },
+        0usize,
+        concat!("Offset of field: ", stringify!(C), "::", stringify!(c))
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).ptr) as usize - ptr as usize
+        },
+        8usize,
+        concat!("Offset of field: ", stringify!(C), "::", stringify!(ptr))
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).arr) as usize - ptr as usize
+        },
+        16usize,
+        concat!("Offset of field: ", stringify!(C), "::", stringify!(arr))
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize
+        },
+        56usize,
+        concat!("Offset of field: ", stringify!(C), "::", stringify!(d))
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).other_ptr) as usize - ptr as usize
+        },
+        64usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C),
+            "::",
+            stringify!(other_ptr)
+        )
+    );
 }
 extern "C" {
     #[link_name = "\u{1}_ZN1C6methodEi"]
@@ -146,6 +128,8 @@ pub struct D {
 }
 #[test]
 fn bindgen_test_layout_D() {
+    const UNINIT: ::std::mem::MaybeUninit<D> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<D>(),
         80usize,
@@ -156,18 +140,14 @@ fn bindgen_test_layout_D() {
         8usize,
         concat!("Alignment of ", stringify!(D))
     );
-    fn test_field_ptr() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<D>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).ptr) as usize - ptr as usize
-            },
-            72usize,
-            concat!("Offset of field: ", stringify!(D), "::", stringify!(ptr))
-        );
-    }
-    test_field_ptr();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).ptr) as usize - ptr as usize
+        },
+        72usize,
+        concat!("Offset of field: ", stringify!(D), "::", stringify!(ptr))
+    );
 }
 impl Default for D {
     fn default() -> Self {

--- a/tests/expectations/tests/comment-indent.rs
+++ b/tests/expectations/tests/comment-indent.rs
@@ -72,6 +72,7 @@ pub mod root {
         fn bindgen_test_layout_Baz() {
             const UNINIT: ::std::mem::MaybeUninit<Baz> =
                 ::std::mem::MaybeUninit::uninit();
+            let ptr = UNINIT.as_ptr();
             assert_eq!(
                 ::std::mem::size_of::<Baz>(),
                 4usize,
@@ -84,7 +85,6 @@ pub mod root {
             );
             assert_eq!(
                 unsafe {
-                    let ptr = UNINIT.as_ptr();
                     ::std::ptr::addr_of!((*ptr).member) as usize - ptr as usize
                 },
                 0usize,

--- a/tests/expectations/tests/comment-indent.rs
+++ b/tests/expectations/tests/comment-indent.rs
@@ -70,6 +70,8 @@ pub mod root {
         }
         #[test]
         fn bindgen_test_layout_Baz() {
+            const UNINIT: ::std::mem::MaybeUninit<Baz> =
+                ::std::mem::MaybeUninit::uninit();
             assert_eq!(
                 ::std::mem::size_of::<Baz>(),
                 4usize,
@@ -80,24 +82,19 @@ pub mod root {
                 4usize,
                 concat!("Alignment of ", stringify!(Baz))
             );
-            fn test_field_member() {
-                assert_eq!(
-                    unsafe {
-                        let uninit = ::std::mem::MaybeUninit::<Baz>::uninit();
-                        let ptr = uninit.as_ptr();
-                        ::std::ptr::addr_of!((*ptr).member) as usize -
-                            ptr as usize
-                    },
-                    0usize,
-                    concat!(
-                        "Offset of field: ",
-                        stringify!(Baz),
-                        "::",
-                        stringify!(member)
-                    )
-                );
-            }
-            test_field_member();
+            assert_eq!(
+                unsafe {
+                    let ptr = UNINIT.as_ptr();
+                    ::std::ptr::addr_of!((*ptr).member) as usize - ptr as usize
+                },
+                0usize,
+                concat!(
+                    "Offset of field: ",
+                    stringify!(Baz),
+                    "::",
+                    stringify!(member)
+                )
+            );
         }
         /// I'm in an inline namespace, and as such I shouldn't get generated inside
         /// a rust module, except when the relevant option is specified. Also, this

--- a/tests/expectations/tests/complex.rs
+++ b/tests/expectations/tests/complex.rs
@@ -20,6 +20,7 @@ pub struct TestDouble {
 fn bindgen_test_layout_TestDouble() {
     const UNINIT: ::std::mem::MaybeUninit<TestDouble> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<TestDouble>(),
         16usize,
@@ -31,10 +32,7 @@ fn bindgen_test_layout_TestDouble() {
         concat!("Alignment of ", stringify!(TestDouble))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mMember) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).mMember) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -53,6 +51,7 @@ pub struct TestDoublePtr {
 fn bindgen_test_layout_TestDoublePtr() {
     const UNINIT: ::std::mem::MaybeUninit<TestDoublePtr> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<TestDoublePtr>(),
         8usize,
@@ -64,10 +63,7 @@ fn bindgen_test_layout_TestDoublePtr() {
         concat!("Alignment of ", stringify!(TestDoublePtr))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mMember) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).mMember) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -95,6 +91,7 @@ pub struct TestFloat {
 fn bindgen_test_layout_TestFloat() {
     const UNINIT: ::std::mem::MaybeUninit<TestFloat> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<TestFloat>(),
         8usize,
@@ -106,10 +103,7 @@ fn bindgen_test_layout_TestFloat() {
         concat!("Alignment of ", stringify!(TestFloat))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mMember) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).mMember) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -128,6 +122,7 @@ pub struct TestFloatPtr {
 fn bindgen_test_layout_TestFloatPtr() {
     const UNINIT: ::std::mem::MaybeUninit<TestFloatPtr> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<TestFloatPtr>(),
         8usize,
@@ -139,10 +134,7 @@ fn bindgen_test_layout_TestFloatPtr() {
         concat!("Alignment of ", stringify!(TestFloatPtr))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mMember) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).mMember) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/complex.rs
+++ b/tests/expectations/tests/complex.rs
@@ -18,6 +18,8 @@ pub struct TestDouble {
 }
 #[test]
 fn bindgen_test_layout_TestDouble() {
+    const UNINIT: ::std::mem::MaybeUninit<TestDouble> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<TestDouble>(),
         16usize,
@@ -28,23 +30,19 @@ fn bindgen_test_layout_TestDouble() {
         8usize,
         concat!("Alignment of ", stringify!(TestDouble))
     );
-    fn test_field_mMember() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<TestDouble>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).mMember) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(TestDouble),
-                "::",
-                stringify!(mMember)
-            )
-        );
-    }
-    test_field_mMember();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).mMember) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(TestDouble),
+            "::",
+            stringify!(mMember)
+        )
+    );
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -53,6 +51,8 @@ pub struct TestDoublePtr {
 }
 #[test]
 fn bindgen_test_layout_TestDoublePtr() {
+    const UNINIT: ::std::mem::MaybeUninit<TestDoublePtr> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<TestDoublePtr>(),
         8usize,
@@ -63,23 +63,19 @@ fn bindgen_test_layout_TestDoublePtr() {
         8usize,
         concat!("Alignment of ", stringify!(TestDoublePtr))
     );
-    fn test_field_mMember() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<TestDoublePtr>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).mMember) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(TestDoublePtr),
-                "::",
-                stringify!(mMember)
-            )
-        );
-    }
-    test_field_mMember();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).mMember) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(TestDoublePtr),
+            "::",
+            stringify!(mMember)
+        )
+    );
 }
 impl Default for TestDoublePtr {
     fn default() -> Self {
@@ -97,6 +93,8 @@ pub struct TestFloat {
 }
 #[test]
 fn bindgen_test_layout_TestFloat() {
+    const UNINIT: ::std::mem::MaybeUninit<TestFloat> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<TestFloat>(),
         8usize,
@@ -107,23 +105,19 @@ fn bindgen_test_layout_TestFloat() {
         4usize,
         concat!("Alignment of ", stringify!(TestFloat))
     );
-    fn test_field_mMember() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<TestFloat>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).mMember) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(TestFloat),
-                "::",
-                stringify!(mMember)
-            )
-        );
-    }
-    test_field_mMember();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).mMember) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(TestFloat),
+            "::",
+            stringify!(mMember)
+        )
+    );
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -132,6 +126,8 @@ pub struct TestFloatPtr {
 }
 #[test]
 fn bindgen_test_layout_TestFloatPtr() {
+    const UNINIT: ::std::mem::MaybeUninit<TestFloatPtr> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<TestFloatPtr>(),
         8usize,
@@ -142,23 +138,19 @@ fn bindgen_test_layout_TestFloatPtr() {
         8usize,
         concat!("Alignment of ", stringify!(TestFloatPtr))
     );
-    fn test_field_mMember() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<TestFloatPtr>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).mMember) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(TestFloatPtr),
-                "::",
-                stringify!(mMember)
-            )
-        );
-    }
-    test_field_mMember();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).mMember) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(TestFloatPtr),
+            "::",
+            stringify!(mMember)
+        )
+    );
 }
 impl Default for TestFloatPtr {
     fn default() -> Self {

--- a/tests/expectations/tests/const-const-mut-ptr.rs
+++ b/tests/expectations/tests/const-const-mut-ptr.rs
@@ -12,6 +12,8 @@ pub struct foo {
 }
 #[test]
 fn bindgen_test_layout_foo() {
+    const UNINIT: ::std::mem::MaybeUninit<foo> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<foo>(),
         8usize,
@@ -22,23 +24,14 @@ fn bindgen_test_layout_foo() {
         8usize,
         concat!("Alignment of ", stringify!(foo))
     );
-    fn test_field_bar() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<foo>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(foo),
-                "::",
-                stringify!(bar)
-            )
-        );
-    }
-    test_field_bar();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
+        },
+        0usize,
+        concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar))
+    );
 }
 impl Default for foo {
     fn default() -> Self {

--- a/tests/expectations/tests/const-const-mut-ptr.rs
+++ b/tests/expectations/tests/const-const-mut-ptr.rs
@@ -14,6 +14,7 @@ pub struct foo {
 fn bindgen_test_layout_foo() {
     const UNINIT: ::std::mem::MaybeUninit<foo> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<foo>(),
         8usize,
@@ -25,10 +26,7 @@ fn bindgen_test_layout_foo() {
         concat!("Alignment of ", stringify!(foo))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize },
         0usize,
         concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar))
     );

--- a/tests/expectations/tests/constified-enum-module-overflow.rs
+++ b/tests/expectations/tests/constified-enum-module-overflow.rs
@@ -25,6 +25,7 @@ pub struct A {
 fn bindgen_test_layout_A() {
     const UNINIT: ::std::mem::MaybeUninit<A> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<A>(),
         1usize,
@@ -36,10 +37,7 @@ fn bindgen_test_layout_A() {
         concat!("Alignment of ", stringify!(A))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).u) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).u) as usize - ptr as usize },
         0usize,
         concat!("Offset of field: ", stringify!(A), "::", stringify!(u))
     );

--- a/tests/expectations/tests/constified-enum-module-overflow.rs
+++ b/tests/expectations/tests/constified-enum-module-overflow.rs
@@ -23,6 +23,8 @@ pub struct A {
 }
 #[test]
 fn bindgen_test_layout_A() {
+    const UNINIT: ::std::mem::MaybeUninit<A> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<A>(),
         1usize,
@@ -33,18 +35,14 @@ fn bindgen_test_layout_A() {
         1usize,
         concat!("Alignment of ", stringify!(A))
     );
-    fn test_field_u() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<A>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).u) as usize - ptr as usize
-            },
-            0usize,
-            concat!("Offset of field: ", stringify!(A), "::", stringify!(u))
-        );
-    }
-    test_field_u();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).u) as usize - ptr as usize
+        },
+        0usize,
+        concat!("Offset of field: ", stringify!(A), "::", stringify!(u))
+    );
 }
 #[test]
 fn __bindgen_test_layout_C_open0_A_close0_instantiation() {

--- a/tests/expectations/tests/constify-all-enums.rs
+++ b/tests/expectations/tests/constify-all-enums.rs
@@ -16,6 +16,8 @@ pub struct bar {
 }
 #[test]
 fn bindgen_test_layout_bar() {
+    const UNINIT: ::std::mem::MaybeUninit<bar> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<bar>(),
         4usize,
@@ -26,24 +28,20 @@ fn bindgen_test_layout_bar() {
         4usize,
         concat!("Alignment of ", stringify!(bar))
     );
-    fn test_field_this_should_work() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<bar>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).this_should_work) as usize -
-                    ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(bar),
-                "::",
-                stringify!(this_should_work)
-            )
-        );
-    }
-    test_field_this_should_work();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).this_should_work) as usize -
+                ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bar),
+            "::",
+            stringify!(this_should_work)
+        )
+    );
 }
 impl Default for bar {
     fn default() -> Self {

--- a/tests/expectations/tests/constify-all-enums.rs
+++ b/tests/expectations/tests/constify-all-enums.rs
@@ -18,6 +18,7 @@ pub struct bar {
 fn bindgen_test_layout_bar() {
     const UNINIT: ::std::mem::MaybeUninit<bar> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<bar>(),
         4usize,
@@ -30,7 +31,6 @@ fn bindgen_test_layout_bar() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).this_should_work) as usize -
                 ptr as usize
         },

--- a/tests/expectations/tests/constify-module-enums-basic.rs
+++ b/tests/expectations/tests/constify-module-enums-basic.rs
@@ -22,6 +22,7 @@ pub struct bar {
 fn bindgen_test_layout_bar() {
     const UNINIT: ::std::mem::MaybeUninit<bar> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<bar>(),
         4usize,
@@ -34,7 +35,6 @@ fn bindgen_test_layout_bar() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).this_should_work) as usize -
                 ptr as usize
         },

--- a/tests/expectations/tests/constify-module-enums-basic.rs
+++ b/tests/expectations/tests/constify-module-enums-basic.rs
@@ -20,6 +20,8 @@ pub struct bar {
 }
 #[test]
 fn bindgen_test_layout_bar() {
+    const UNINIT: ::std::mem::MaybeUninit<bar> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<bar>(),
         4usize,
@@ -30,24 +32,20 @@ fn bindgen_test_layout_bar() {
         4usize,
         concat!("Alignment of ", stringify!(bar))
     );
-    fn test_field_this_should_work() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<bar>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).this_should_work) as usize -
-                    ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(bar),
-                "::",
-                stringify!(this_should_work)
-            )
-        );
-    }
-    test_field_this_should_work();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).this_should_work) as usize -
+                ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bar),
+            "::",
+            stringify!(this_should_work)
+        )
+    );
 }
 impl Default for bar {
     fn default() -> Self {

--- a/tests/expectations/tests/constify-module-enums-namespace.rs
+++ b/tests/expectations/tests/constify-module-enums-namespace.rs
@@ -32,6 +32,8 @@ pub mod root {
             }
             #[test]
             fn bindgen_test_layout_bar() {
+                const UNINIT: ::std::mem::MaybeUninit<bar> =
+                    ::std::mem::MaybeUninit::uninit();
                 assert_eq!(
                     ::std::mem::size_of::<bar>(),
                     4usize,
@@ -42,26 +44,20 @@ pub mod root {
                     4usize,
                     concat!("Alignment of ", stringify!(bar))
                 );
-                fn test_field_this_should_work() {
-                    assert_eq!(
-                        unsafe {
-                            let uninit =
-                                ::std::mem::MaybeUninit::<bar>::uninit();
-                            let ptr = uninit.as_ptr();
-                            ::std::ptr::addr_of!((*ptr).this_should_work)
-                                as usize -
-                                ptr as usize
-                        },
-                        0usize,
-                        concat!(
-                            "Offset of field: ",
-                            stringify!(bar),
-                            "::",
-                            stringify!(this_should_work)
-                        )
-                    );
-                }
-                test_field_this_should_work();
+                assert_eq!(
+                    unsafe {
+                        let ptr = UNINIT.as_ptr();
+                        ::std::ptr::addr_of!((*ptr).this_should_work) as usize -
+                            ptr as usize
+                    },
+                    0usize,
+                    concat!(
+                        "Offset of field: ",
+                        stringify!(bar),
+                        "::",
+                        stringify!(this_should_work)
+                    )
+                );
             }
             impl Default for bar {
                 fn default() -> Self {

--- a/tests/expectations/tests/constify-module-enums-namespace.rs
+++ b/tests/expectations/tests/constify-module-enums-namespace.rs
@@ -34,6 +34,7 @@ pub mod root {
             fn bindgen_test_layout_bar() {
                 const UNINIT: ::std::mem::MaybeUninit<bar> =
                     ::std::mem::MaybeUninit::uninit();
+                let ptr = UNINIT.as_ptr();
                 assert_eq!(
                     ::std::mem::size_of::<bar>(),
                     4usize,
@@ -46,7 +47,6 @@ pub mod root {
                 );
                 assert_eq!(
                     unsafe {
-                        let ptr = UNINIT.as_ptr();
                         ::std::ptr::addr_of!((*ptr).this_should_work) as usize -
                             ptr as usize
                     },

--- a/tests/expectations/tests/constify-module-enums-shadow-name.rs
+++ b/tests/expectations/tests/constify-module-enums-shadow-name.rs
@@ -19,6 +19,8 @@ pub struct bar {
 }
 #[test]
 fn bindgen_test_layout_bar() {
+    const UNINIT: ::std::mem::MaybeUninit<bar> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<bar>(),
         4usize,
@@ -29,23 +31,19 @@ fn bindgen_test_layout_bar() {
         4usize,
         concat!("Alignment of ", stringify!(bar))
     );
-    fn test_field_member() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<bar>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).member) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(bar),
-                "::",
-                stringify!(member)
-            )
-        );
-    }
-    test_field_member();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).member) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bar),
+            "::",
+            stringify!(member)
+        )
+    );
 }
 impl Default for bar {
     fn default() -> Self {

--- a/tests/expectations/tests/constify-module-enums-shadow-name.rs
+++ b/tests/expectations/tests/constify-module-enums-shadow-name.rs
@@ -21,6 +21,7 @@ pub struct bar {
 fn bindgen_test_layout_bar() {
     const UNINIT: ::std::mem::MaybeUninit<bar> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<bar>(),
         4usize,
@@ -32,10 +33,7 @@ fn bindgen_test_layout_bar() {
         concat!("Alignment of ", stringify!(bar))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).member) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).member) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/constify-module-enums-simple-alias.rs
+++ b/tests/expectations/tests/constify-module-enums-simple-alias.rs
@@ -28,6 +28,8 @@ pub struct Bar {
 }
 #[test]
 fn bindgen_test_layout_Bar() {
+    const UNINIT: ::std::mem::MaybeUninit<Bar> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<Bar>(),
         48usize,
@@ -38,142 +40,90 @@ fn bindgen_test_layout_Bar() {
         8usize,
         concat!("Alignment of ", stringify!(Bar))
     );
-    fn test_field_baz1() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Bar>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).baz1) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(Bar),
-                "::",
-                stringify!(baz1)
-            )
-        );
-    }
-    test_field_baz1();
-    fn test_field_baz2() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Bar>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).baz2) as usize - ptr as usize
-            },
-            4usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(Bar),
-                "::",
-                stringify!(baz2)
-            )
-        );
-    }
-    test_field_baz2();
-    fn test_field_baz3() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Bar>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).baz3) as usize - ptr as usize
-            },
-            8usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(Bar),
-                "::",
-                stringify!(baz3)
-            )
-        );
-    }
-    test_field_baz3();
-    fn test_field_baz4() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Bar>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).baz4) as usize - ptr as usize
-            },
-            12usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(Bar),
-                "::",
-                stringify!(baz4)
-            )
-        );
-    }
-    test_field_baz4();
-    fn test_field_baz_ptr1() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Bar>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).baz_ptr1) as usize - ptr as usize
-            },
-            16usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(Bar),
-                "::",
-                stringify!(baz_ptr1)
-            )
-        );
-    }
-    test_field_baz_ptr1();
-    fn test_field_baz_ptr2() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Bar>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).baz_ptr2) as usize - ptr as usize
-            },
-            24usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(Bar),
-                "::",
-                stringify!(baz_ptr2)
-            )
-        );
-    }
-    test_field_baz_ptr2();
-    fn test_field_baz_ptr3() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Bar>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).baz_ptr3) as usize - ptr as usize
-            },
-            32usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(Bar),
-                "::",
-                stringify!(baz_ptr3)
-            )
-        );
-    }
-    test_field_baz_ptr3();
-    fn test_field_baz_ptr4() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Bar>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).baz_ptr4) as usize - ptr as usize
-            },
-            40usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(Bar),
-                "::",
-                stringify!(baz_ptr4)
-            )
-        );
-    }
-    test_field_baz_ptr4();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).baz1) as usize - ptr as usize
+        },
+        0usize,
+        concat!("Offset of field: ", stringify!(Bar), "::", stringify!(baz1))
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).baz2) as usize - ptr as usize
+        },
+        4usize,
+        concat!("Offset of field: ", stringify!(Bar), "::", stringify!(baz2))
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).baz3) as usize - ptr as usize
+        },
+        8usize,
+        concat!("Offset of field: ", stringify!(Bar), "::", stringify!(baz3))
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).baz4) as usize - ptr as usize
+        },
+        12usize,
+        concat!("Offset of field: ", stringify!(Bar), "::", stringify!(baz4))
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).baz_ptr1) as usize - ptr as usize
+        },
+        16usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(Bar),
+            "::",
+            stringify!(baz_ptr1)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).baz_ptr2) as usize - ptr as usize
+        },
+        24usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(Bar),
+            "::",
+            stringify!(baz_ptr2)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).baz_ptr3) as usize - ptr as usize
+        },
+        32usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(Bar),
+            "::",
+            stringify!(baz_ptr3)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).baz_ptr4) as usize - ptr as usize
+        },
+        40usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(Bar),
+            "::",
+            stringify!(baz_ptr4)
+        )
+    );
 }
 impl Default for Bar {
     fn default() -> Self {

--- a/tests/expectations/tests/constify-module-enums-simple-alias.rs
+++ b/tests/expectations/tests/constify-module-enums-simple-alias.rs
@@ -30,6 +30,7 @@ pub struct Bar {
 fn bindgen_test_layout_Bar() {
     const UNINIT: ::std::mem::MaybeUninit<Bar> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<Bar>(),
         48usize,
@@ -41,40 +42,27 @@ fn bindgen_test_layout_Bar() {
         concat!("Alignment of ", stringify!(Bar))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).baz1) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).baz1) as usize - ptr as usize },
         0usize,
         concat!("Offset of field: ", stringify!(Bar), "::", stringify!(baz1))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).baz2) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).baz2) as usize - ptr as usize },
         4usize,
         concat!("Offset of field: ", stringify!(Bar), "::", stringify!(baz2))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).baz3) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).baz3) as usize - ptr as usize },
         8usize,
         concat!("Offset of field: ", stringify!(Bar), "::", stringify!(baz3))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).baz4) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).baz4) as usize - ptr as usize },
         12usize,
         concat!("Offset of field: ", stringify!(Bar), "::", stringify!(baz4))
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).baz_ptr1) as usize - ptr as usize
         },
         16usize,
@@ -87,7 +75,6 @@ fn bindgen_test_layout_Bar() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).baz_ptr2) as usize - ptr as usize
         },
         24usize,
@@ -100,7 +87,6 @@ fn bindgen_test_layout_Bar() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).baz_ptr3) as usize - ptr as usize
         },
         32usize,
@@ -113,7 +99,6 @@ fn bindgen_test_layout_Bar() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).baz_ptr4) as usize - ptr as usize
         },
         40usize,

--- a/tests/expectations/tests/constify-module-enums-simple-nonamespace.rs
+++ b/tests/expectations/tests/constify-module-enums-simple-nonamespace.rs
@@ -20,6 +20,7 @@ pub struct Bar {
 fn bindgen_test_layout_Bar() {
     const UNINIT: ::std::mem::MaybeUninit<Bar> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<Bar>(),
         16usize,
@@ -31,18 +32,12 @@ fn bindgen_test_layout_Bar() {
         concat!("Alignment of ", stringify!(Bar))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).baz1) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).baz1) as usize - ptr as usize },
         0usize,
         concat!("Offset of field: ", stringify!(Bar), "::", stringify!(baz1))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).baz2) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).baz2) as usize - ptr as usize },
         8usize,
         concat!("Offset of field: ", stringify!(Bar), "::", stringify!(baz2))
     );

--- a/tests/expectations/tests/constify-module-enums-simple-nonamespace.rs
+++ b/tests/expectations/tests/constify-module-enums-simple-nonamespace.rs
@@ -18,6 +18,8 @@ pub struct Bar {
 }
 #[test]
 fn bindgen_test_layout_Bar() {
+    const UNINIT: ::std::mem::MaybeUninit<Bar> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<Bar>(),
         16usize,
@@ -28,40 +30,22 @@ fn bindgen_test_layout_Bar() {
         8usize,
         concat!("Alignment of ", stringify!(Bar))
     );
-    fn test_field_baz1() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Bar>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).baz1) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(Bar),
-                "::",
-                stringify!(baz1)
-            )
-        );
-    }
-    test_field_baz1();
-    fn test_field_baz2() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Bar>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).baz2) as usize - ptr as usize
-            },
-            8usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(Bar),
-                "::",
-                stringify!(baz2)
-            )
-        );
-    }
-    test_field_baz2();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).baz1) as usize - ptr as usize
+        },
+        0usize,
+        concat!("Offset of field: ", stringify!(Bar), "::", stringify!(baz1))
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).baz2) as usize - ptr as usize
+        },
+        8usize,
+        concat!("Offset of field: ", stringify!(Bar), "::", stringify!(baz2))
+    );
 }
 impl Default for Bar {
     fn default() -> Self {

--- a/tests/expectations/tests/constify-module-enums-types.rs
+++ b/tests/expectations/tests/constify-module-enums-types.rs
@@ -53,6 +53,8 @@ pub struct bar {
 }
 #[test]
 fn bindgen_test_layout_bar() {
+    const UNINIT: ::std::mem::MaybeUninit<bar> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<bar>(),
         48usize,
@@ -63,176 +65,136 @@ fn bindgen_test_layout_bar() {
         8usize,
         concat!("Alignment of ", stringify!(bar))
     );
-    fn test_field_member1() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<bar>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).member1) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(bar),
-                "::",
-                stringify!(member1)
-            )
-        );
-    }
-    test_field_member1();
-    fn test_field_member2() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<bar>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).member2) as usize - ptr as usize
-            },
-            4usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(bar),
-                "::",
-                stringify!(member2)
-            )
-        );
-    }
-    test_field_member2();
-    fn test_field_member3() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<bar>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).member3) as usize - ptr as usize
-            },
-            8usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(bar),
-                "::",
-                stringify!(member3)
-            )
-        );
-    }
-    test_field_member3();
-    fn test_field_member4() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<bar>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).member4) as usize - ptr as usize
-            },
-            12usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(bar),
-                "::",
-                stringify!(member4)
-            )
-        );
-    }
-    test_field_member4();
-    fn test_field_member5() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<bar>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).member5) as usize - ptr as usize
-            },
-            16usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(bar),
-                "::",
-                stringify!(member5)
-            )
-        );
-    }
-    test_field_member5();
-    fn test_field_member6() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<bar>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).member6) as usize - ptr as usize
-            },
-            24usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(bar),
-                "::",
-                stringify!(member6)
-            )
-        );
-    }
-    test_field_member6();
-    fn test_field_member7() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<bar>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).member7) as usize - ptr as usize
-            },
-            32usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(bar),
-                "::",
-                stringify!(member7)
-            )
-        );
-    }
-    test_field_member7();
-    fn test_field_member8() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<bar>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).member8) as usize - ptr as usize
-            },
-            36usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(bar),
-                "::",
-                stringify!(member8)
-            )
-        );
-    }
-    test_field_member8();
-    fn test_field_member9() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<bar>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).member9) as usize - ptr as usize
-            },
-            40usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(bar),
-                "::",
-                stringify!(member9)
-            )
-        );
-    }
-    test_field_member9();
-    fn test_field_member10() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<bar>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).member10) as usize - ptr as usize
-            },
-            44usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(bar),
-                "::",
-                stringify!(member10)
-            )
-        );
-    }
-    test_field_member10();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).member1) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bar),
+            "::",
+            stringify!(member1)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).member2) as usize - ptr as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bar),
+            "::",
+            stringify!(member2)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).member3) as usize - ptr as usize
+        },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bar),
+            "::",
+            stringify!(member3)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).member4) as usize - ptr as usize
+        },
+        12usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bar),
+            "::",
+            stringify!(member4)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).member5) as usize - ptr as usize
+        },
+        16usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bar),
+            "::",
+            stringify!(member5)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).member6) as usize - ptr as usize
+        },
+        24usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bar),
+            "::",
+            stringify!(member6)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).member7) as usize - ptr as usize
+        },
+        32usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bar),
+            "::",
+            stringify!(member7)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).member8) as usize - ptr as usize
+        },
+        36usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bar),
+            "::",
+            stringify!(member8)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).member9) as usize - ptr as usize
+        },
+        40usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bar),
+            "::",
+            stringify!(member9)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).member10) as usize - ptr as usize
+        },
+        44usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bar),
+            "::",
+            stringify!(member10)
+        )
+    );
 }
 impl Default for bar {
     fn default() -> Self {
@@ -250,6 +212,8 @@ pub struct Baz {
 }
 #[test]
 fn bindgen_test_layout_Baz() {
+    const UNINIT: ::std::mem::MaybeUninit<Baz> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<Baz>(),
         4usize,
@@ -260,23 +224,19 @@ fn bindgen_test_layout_Baz() {
         4usize,
         concat!("Alignment of ", stringify!(Baz))
     );
-    fn test_field_member1() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Baz>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).member1) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(Baz),
-                "::",
-                stringify!(member1)
-            )
-        );
-    }
-    test_field_member1();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).member1) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(Baz),
+            "::",
+            stringify!(member1)
+        )
+    );
 }
 impl Default for Baz {
     fn default() -> Self {
@@ -299,6 +259,8 @@ pub struct Bar {
 }
 #[test]
 fn bindgen_test_layout_Bar() {
+    const UNINIT: ::std::mem::MaybeUninit<Bar> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<Bar>(),
         8usize,
@@ -309,23 +271,14 @@ fn bindgen_test_layout_Bar() {
         8usize,
         concat!("Alignment of ", stringify!(Bar))
     );
-    fn test_field_baz() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Bar>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(Bar),
-                "::",
-                stringify!(baz)
-            )
-        );
-    }
-    test_field_baz();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize
+        },
+        0usize,
+        concat!("Offset of field: ", stringify!(Bar), "::", stringify!(baz))
+    );
 }
 impl Default for Bar {
     fn default() -> Self {

--- a/tests/expectations/tests/constify-module-enums-types.rs
+++ b/tests/expectations/tests/constify-module-enums-types.rs
@@ -55,6 +55,7 @@ pub struct bar {
 fn bindgen_test_layout_bar() {
     const UNINIT: ::std::mem::MaybeUninit<bar> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<bar>(),
         48usize,
@@ -66,10 +67,7 @@ fn bindgen_test_layout_bar() {
         concat!("Alignment of ", stringify!(bar))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).member1) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).member1) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -79,10 +77,7 @@ fn bindgen_test_layout_bar() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).member2) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).member2) as usize - ptr as usize },
         4usize,
         concat!(
             "Offset of field: ",
@@ -92,10 +87,7 @@ fn bindgen_test_layout_bar() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).member3) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).member3) as usize - ptr as usize },
         8usize,
         concat!(
             "Offset of field: ",
@@ -105,10 +97,7 @@ fn bindgen_test_layout_bar() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).member4) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).member4) as usize - ptr as usize },
         12usize,
         concat!(
             "Offset of field: ",
@@ -118,10 +107,7 @@ fn bindgen_test_layout_bar() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).member5) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).member5) as usize - ptr as usize },
         16usize,
         concat!(
             "Offset of field: ",
@@ -131,10 +117,7 @@ fn bindgen_test_layout_bar() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).member6) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).member6) as usize - ptr as usize },
         24usize,
         concat!(
             "Offset of field: ",
@@ -144,10 +127,7 @@ fn bindgen_test_layout_bar() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).member7) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).member7) as usize - ptr as usize },
         32usize,
         concat!(
             "Offset of field: ",
@@ -157,10 +137,7 @@ fn bindgen_test_layout_bar() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).member8) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).member8) as usize - ptr as usize },
         36usize,
         concat!(
             "Offset of field: ",
@@ -170,10 +147,7 @@ fn bindgen_test_layout_bar() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).member9) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).member9) as usize - ptr as usize },
         40usize,
         concat!(
             "Offset of field: ",
@@ -184,7 +158,6 @@ fn bindgen_test_layout_bar() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).member10) as usize - ptr as usize
         },
         44usize,
@@ -214,6 +187,7 @@ pub struct Baz {
 fn bindgen_test_layout_Baz() {
     const UNINIT: ::std::mem::MaybeUninit<Baz> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<Baz>(),
         4usize,
@@ -225,10 +199,7 @@ fn bindgen_test_layout_Baz() {
         concat!("Alignment of ", stringify!(Baz))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).member1) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).member1) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -261,6 +232,7 @@ pub struct Bar {
 fn bindgen_test_layout_Bar() {
     const UNINIT: ::std::mem::MaybeUninit<Bar> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<Bar>(),
         8usize,
@@ -272,10 +244,7 @@ fn bindgen_test_layout_Bar() {
         concat!("Alignment of ", stringify!(Bar))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize },
         0usize,
         concat!("Offset of field: ", stringify!(Bar), "::", stringify!(baz))
     );

--- a/tests/expectations/tests/contains-vs-inherits-zero-sized.rs
+++ b/tests/expectations/tests/contains-vs-inherits-zero-sized.rs
@@ -35,6 +35,7 @@ pub struct Inherits {
 fn bindgen_test_layout_Inherits() {
     const UNINIT: ::std::mem::MaybeUninit<Inherits> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<Inherits>(),
         1usize,
@@ -46,10 +47,7 @@ fn bindgen_test_layout_Inherits() {
         concat!("Alignment of ", stringify!(Inherits))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -71,6 +69,7 @@ pub struct Contains {
 fn bindgen_test_layout_Contains() {
     const UNINIT: ::std::mem::MaybeUninit<Contains> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<Contains>(),
         2usize,
@@ -82,10 +81,7 @@ fn bindgen_test_layout_Contains() {
         concat!("Alignment of ", stringify!(Contains))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).empty) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).empty) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -95,10 +91,7 @@ fn bindgen_test_layout_Contains() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
         1usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/contains-vs-inherits-zero-sized.rs
+++ b/tests/expectations/tests/contains-vs-inherits-zero-sized.rs
@@ -33,6 +33,8 @@ pub struct Inherits {
 }
 #[test]
 fn bindgen_test_layout_Inherits() {
+    const UNINIT: ::std::mem::MaybeUninit<Inherits> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<Inherits>(),
         1usize,
@@ -43,23 +45,19 @@ fn bindgen_test_layout_Inherits() {
         1usize,
         concat!("Alignment of ", stringify!(Inherits))
     );
-    fn test_field_b() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Inherits>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(Inherits),
-                "::",
-                stringify!(b)
-            )
-        );
-    }
-    test_field_b();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(Inherits),
+            "::",
+            stringify!(b)
+        )
+    );
 }
 /// This should not get an `_address` byte, but contains `Empty` which *does* get
 /// one, so `sizeof(Contains)` should be `1 + 1`.
@@ -71,6 +69,8 @@ pub struct Contains {
 }
 #[test]
 fn bindgen_test_layout_Contains() {
+    const UNINIT: ::std::mem::MaybeUninit<Contains> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<Contains>(),
         2usize,
@@ -81,38 +81,30 @@ fn bindgen_test_layout_Contains() {
         1usize,
         concat!("Alignment of ", stringify!(Contains))
     );
-    fn test_field_empty() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Contains>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).empty) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(Contains),
-                "::",
-                stringify!(empty)
-            )
-        );
-    }
-    test_field_empty();
-    fn test_field_b() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Contains>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-            },
-            1usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(Contains),
-                "::",
-                stringify!(b)
-            )
-        );
-    }
-    test_field_b();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).empty) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(Contains),
+            "::",
+            stringify!(empty)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
+        },
+        1usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(Contains),
+            "::",
+            stringify!(b)
+        )
+    );
 }

--- a/tests/expectations/tests/convert-floats.rs
+++ b/tests/expectations/tests/convert-floats.rs
@@ -25,6 +25,7 @@ pub struct foo {
 fn bindgen_test_layout_foo() {
     const UNINIT: ::std::mem::MaybeUninit<foo> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<foo>(),
         48usize,
@@ -36,34 +37,22 @@ fn bindgen_test_layout_foo() {
         concat!("Alignment of ", stringify!(foo))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize },
         0usize,
         concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize },
         4usize,
         concat!("Offset of field: ", stringify!(foo), "::", stringify!(baz))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).bazz) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).bazz) as usize - ptr as usize },
         8usize,
         concat!("Offset of field: ", stringify!(foo), "::", stringify!(bazz))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).bazzz) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).bazzz) as usize - ptr as usize },
         16usize,
         concat!(
             "Offset of field: ",
@@ -74,7 +63,6 @@ fn bindgen_test_layout_foo() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).complexFloat) as usize - ptr as usize
         },
         24usize,
@@ -87,7 +75,6 @@ fn bindgen_test_layout_foo() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).complexDouble) as usize - ptr as usize
         },
         32usize,

--- a/tests/expectations/tests/convert-floats.rs
+++ b/tests/expectations/tests/convert-floats.rs
@@ -23,6 +23,8 @@ pub struct foo {
 }
 #[test]
 fn bindgen_test_layout_foo() {
+    const UNINIT: ::std::mem::MaybeUninit<foo> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<foo>(),
         48usize,
@@ -33,110 +35,69 @@ fn bindgen_test_layout_foo() {
         8usize,
         concat!("Alignment of ", stringify!(foo))
     );
-    fn test_field_bar() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<foo>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(foo),
-                "::",
-                stringify!(bar)
-            )
-        );
-    }
-    test_field_bar();
-    fn test_field_baz() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<foo>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize
-            },
-            4usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(foo),
-                "::",
-                stringify!(baz)
-            )
-        );
-    }
-    test_field_baz();
-    fn test_field_bazz() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<foo>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).bazz) as usize - ptr as usize
-            },
-            8usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(foo),
-                "::",
-                stringify!(bazz)
-            )
-        );
-    }
-    test_field_bazz();
-    fn test_field_bazzz() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<foo>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).bazzz) as usize - ptr as usize
-            },
-            16usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(foo),
-                "::",
-                stringify!(bazzz)
-            )
-        );
-    }
-    test_field_bazzz();
-    fn test_field_complexFloat() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<foo>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).complexFloat) as usize -
-                    ptr as usize
-            },
-            24usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(foo),
-                "::",
-                stringify!(complexFloat)
-            )
-        );
-    }
-    test_field_complexFloat();
-    fn test_field_complexDouble() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<foo>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).complexDouble) as usize -
-                    ptr as usize
-            },
-            32usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(foo),
-                "::",
-                stringify!(complexDouble)
-            )
-        );
-    }
-    test_field_complexDouble();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
+        },
+        0usize,
+        concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar))
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize
+        },
+        4usize,
+        concat!("Offset of field: ", stringify!(foo), "::", stringify!(baz))
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).bazz) as usize - ptr as usize
+        },
+        8usize,
+        concat!("Offset of field: ", stringify!(foo), "::", stringify!(bazz))
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).bazzz) as usize - ptr as usize
+        },
+        16usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(foo),
+            "::",
+            stringify!(bazzz)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).complexFloat) as usize - ptr as usize
+        },
+        24usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(foo),
+            "::",
+            stringify!(complexFloat)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).complexDouble) as usize - ptr as usize
+        },
+        32usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(foo),
+            "::",
+            stringify!(complexDouble)
+        )
+    );
 }
 impl Default for foo {
     fn default() -> Self {

--- a/tests/expectations/tests/ctypes-prefix-path.rs
+++ b/tests/expectations/tests/ctypes-prefix-path.rs
@@ -23,6 +23,7 @@ pub struct foo {
 fn bindgen_test_layout_foo() {
     const UNINIT: ::core::mem::MaybeUninit<foo> =
         ::core::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::core::mem::size_of::<foo>(),
         16usize,
@@ -34,26 +35,17 @@ fn bindgen_test_layout_foo() {
         concat!("Alignment of ", stringify!(foo))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::core::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
+        unsafe { ::core::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
         0usize,
         concat!("Offset of field: ", stringify!(foo), "::", stringify!(a))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::core::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-        },
+        unsafe { ::core::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
         4usize,
         concat!("Offset of field: ", stringify!(foo), "::", stringify!(b))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::core::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
-        },
+        unsafe { ::core::ptr::addr_of!((*ptr).bar) as usize - ptr as usize },
         8usize,
         concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar))
     );

--- a/tests/expectations/tests/ctypes-prefix-path.rs
+++ b/tests/expectations/tests/ctypes-prefix-path.rs
@@ -21,6 +21,8 @@ pub struct foo {
 }
 #[test]
 fn bindgen_test_layout_foo() {
+    const UNINIT: ::core::mem::MaybeUninit<foo> =
+        ::core::mem::MaybeUninit::uninit();
     assert_eq!(
         ::core::mem::size_of::<foo>(),
         16usize,
@@ -31,47 +33,30 @@ fn bindgen_test_layout_foo() {
         8usize,
         concat!("Alignment of ", stringify!(foo))
     );
-    fn test_field_a() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::core::mem::MaybeUninit::<foo>::uninit();
-                let ptr = uninit.as_ptr();
-                ::core::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-            },
-            0usize,
-            concat!("Offset of field: ", stringify!(foo), "::", stringify!(a))
-        );
-    }
-    test_field_a();
-    fn test_field_b() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::core::mem::MaybeUninit::<foo>::uninit();
-                let ptr = uninit.as_ptr();
-                ::core::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-            },
-            4usize,
-            concat!("Offset of field: ", stringify!(foo), "::", stringify!(b))
-        );
-    }
-    test_field_b();
-    fn test_field_bar() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::core::mem::MaybeUninit::<foo>::uninit();
-                let ptr = uninit.as_ptr();
-                ::core::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
-            },
-            8usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(foo),
-                "::",
-                stringify!(bar)
-            )
-        );
-    }
-    test_field_bar();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::core::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+        },
+        0usize,
+        concat!("Offset of field: ", stringify!(foo), "::", stringify!(a))
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::core::ptr::addr_of!((*ptr).b) as usize - ptr as usize
+        },
+        4usize,
+        concat!("Offset of field: ", stringify!(foo), "::", stringify!(b))
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::core::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
+        },
+        8usize,
+        concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar))
+    );
 }
 impl Default for foo {
     fn default() -> Self {

--- a/tests/expectations/tests/derive-bitfield-method-same-name.rs
+++ b/tests/expectations/tests/derive-bitfield-method-same-name.rs
@@ -104,6 +104,8 @@ pub struct Foo {
 }
 #[test]
 fn bindgen_test_layout_Foo() {
+    const UNINIT: ::std::mem::MaybeUninit<Foo> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<Foo>(),
         136usize,
@@ -114,23 +116,19 @@ fn bindgen_test_layout_Foo() {
         4usize,
         concat!("Alignment of ", stringify!(Foo))
     );
-    fn test_field_large() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Foo>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).large) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(Foo),
-                "::",
-                stringify!(large)
-            )
-        );
-    }
-    test_field_large();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).large) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(Foo),
+            "::",
+            stringify!(large)
+        )
+    );
 }
 extern "C" {
     #[link_name = "\u{1}_ZN3Foo4typeEv"]

--- a/tests/expectations/tests/derive-bitfield-method-same-name.rs
+++ b/tests/expectations/tests/derive-bitfield-method-same-name.rs
@@ -106,6 +106,7 @@ pub struct Foo {
 fn bindgen_test_layout_Foo() {
     const UNINIT: ::std::mem::MaybeUninit<Foo> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<Foo>(),
         136usize,
@@ -117,10 +118,7 @@ fn bindgen_test_layout_Foo() {
         concat!("Alignment of ", stringify!(Foo))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).large) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).large) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/derive-clone.rs
+++ b/tests/expectations/tests/derive-clone.rs
@@ -13,6 +13,8 @@ pub struct ShouldDeriveClone {
 }
 #[test]
 fn bindgen_test_layout_ShouldDeriveClone() {
+    const UNINIT: ::std::mem::MaybeUninit<ShouldDeriveClone> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<ShouldDeriveClone>(),
         132usize,
@@ -23,24 +25,19 @@ fn bindgen_test_layout_ShouldDeriveClone() {
         4usize,
         concat!("Alignment of ", stringify!(ShouldDeriveClone))
     );
-    fn test_field_large() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<ShouldDeriveClone>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).large) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(ShouldDeriveClone),
-                "::",
-                stringify!(large)
-            )
-        );
-    }
-    test_field_large();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).large) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ShouldDeriveClone),
+            "::",
+            stringify!(large)
+        )
+    );
 }
 impl Default for ShouldDeriveClone {
     fn default() -> Self {

--- a/tests/expectations/tests/derive-clone.rs
+++ b/tests/expectations/tests/derive-clone.rs
@@ -15,6 +15,7 @@ pub struct ShouldDeriveClone {
 fn bindgen_test_layout_ShouldDeriveClone() {
     const UNINIT: ::std::mem::MaybeUninit<ShouldDeriveClone> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<ShouldDeriveClone>(),
         132usize,
@@ -26,10 +27,7 @@ fn bindgen_test_layout_ShouldDeriveClone() {
         concat!("Alignment of ", stringify!(ShouldDeriveClone))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).large) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).large) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/derive-clone_1_0.rs
+++ b/tests/expectations/tests/derive-clone_1_0.rs
@@ -16,6 +16,7 @@ pub struct ShouldImplClone {
 fn bindgen_test_layout_ShouldImplClone() {
     const UNINIT: ::std::mem::MaybeUninit<ShouldImplClone> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<ShouldImplClone>(),
         132usize,
@@ -27,10 +28,7 @@ fn bindgen_test_layout_ShouldImplClone() {
         concat!("Alignment of ", stringify!(ShouldImplClone))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).large) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).large) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/derive-clone_1_0.rs
+++ b/tests/expectations/tests/derive-clone_1_0.rs
@@ -14,6 +14,8 @@ pub struct ShouldImplClone {
 }
 #[test]
 fn bindgen_test_layout_ShouldImplClone() {
+    const UNINIT: ::std::mem::MaybeUninit<ShouldImplClone> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<ShouldImplClone>(),
         132usize,
@@ -24,24 +26,19 @@ fn bindgen_test_layout_ShouldImplClone() {
         4usize,
         concat!("Alignment of ", stringify!(ShouldImplClone))
     );
-    fn test_field_large() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<ShouldImplClone>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).large) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(ShouldImplClone),
-                "::",
-                stringify!(large)
-            )
-        );
-    }
-    test_field_large();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).large) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ShouldImplClone),
+            "::",
+            stringify!(large)
+        )
+    );
 }
 impl Clone for ShouldImplClone {
     fn clone(&self) -> Self {

--- a/tests/expectations/tests/derive-debug-bitfield-core.rs
+++ b/tests/expectations/tests/derive-debug-bitfield-core.rs
@@ -102,6 +102,8 @@ pub struct C {
 }
 #[test]
 fn bindgen_test_layout_C() {
+    const UNINIT: ::core::mem::MaybeUninit<C> =
+        ::core::mem::MaybeUninit::uninit();
     assert_eq!(
         ::core::mem::size_of::<C>(),
         204usize,
@@ -112,24 +114,19 @@ fn bindgen_test_layout_C() {
         4usize,
         concat!("Alignment of ", stringify!(C))
     );
-    fn test_field_large_array() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::core::mem::MaybeUninit::<C>::uninit();
-                let ptr = uninit.as_ptr();
-                ::core::ptr::addr_of!((*ptr).large_array) as usize -
-                    ptr as usize
-            },
-            4usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(C),
-                "::",
-                stringify!(large_array)
-            )
-        );
-    }
-    test_field_large_array();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::core::ptr::addr_of!((*ptr).large_array) as usize - ptr as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C),
+            "::",
+            stringify!(large_array)
+        )
+    );
 }
 impl Default for C {
     fn default() -> Self {

--- a/tests/expectations/tests/derive-debug-bitfield-core.rs
+++ b/tests/expectations/tests/derive-debug-bitfield-core.rs
@@ -104,6 +104,7 @@ pub struct C {
 fn bindgen_test_layout_C() {
     const UNINIT: ::core::mem::MaybeUninit<C> =
         ::core::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::core::mem::size_of::<C>(),
         204usize,
@@ -116,7 +117,6 @@ fn bindgen_test_layout_C() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::core::ptr::addr_of!((*ptr).large_array) as usize - ptr as usize
         },
         4usize,

--- a/tests/expectations/tests/derive-debug-bitfield.rs
+++ b/tests/expectations/tests/derive-debug-bitfield.rs
@@ -102,6 +102,7 @@ pub struct C {
 fn bindgen_test_layout_C() {
     const UNINIT: ::std::mem::MaybeUninit<C> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<C>(),
         204usize,
@@ -114,7 +115,6 @@ fn bindgen_test_layout_C() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).large_array) as usize - ptr as usize
         },
         4usize,

--- a/tests/expectations/tests/derive-debug-bitfield.rs
+++ b/tests/expectations/tests/derive-debug-bitfield.rs
@@ -100,6 +100,8 @@ pub struct C {
 }
 #[test]
 fn bindgen_test_layout_C() {
+    const UNINIT: ::std::mem::MaybeUninit<C> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<C>(),
         204usize,
@@ -110,23 +112,19 @@ fn bindgen_test_layout_C() {
         4usize,
         concat!("Alignment of ", stringify!(C))
     );
-    fn test_field_large_array() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<C>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).large_array) as usize - ptr as usize
-            },
-            4usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(C),
-                "::",
-                stringify!(large_array)
-            )
-        );
-    }
-    test_field_large_array();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).large_array) as usize - ptr as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C),
+            "::",
+            stringify!(large_array)
+        )
+    );
 }
 impl Default for C {
     fn default() -> Self {

--- a/tests/expectations/tests/derive-debug-function-pointer.rs
+++ b/tests/expectations/tests/derive-debug-function-pointer.rs
@@ -17,6 +17,7 @@ pub type Nice_Function =
 fn bindgen_test_layout_Nice() {
     const UNINIT: ::std::mem::MaybeUninit<Nice> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<Nice>(),
         144usize,
@@ -28,10 +29,7 @@ fn bindgen_test_layout_Nice() {
         concat!("Alignment of ", stringify!(Nice))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).pointer) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).pointer) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -42,7 +40,6 @@ fn bindgen_test_layout_Nice() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).large_array) as usize - ptr as usize
         },
         8usize,

--- a/tests/expectations/tests/derive-debug-function-pointer.rs
+++ b/tests/expectations/tests/derive-debug-function-pointer.rs
@@ -15,6 +15,8 @@ pub type Nice_Function =
     ::std::option::Option<unsafe extern "C" fn(data: ::std::os::raw::c_int)>;
 #[test]
 fn bindgen_test_layout_Nice() {
+    const UNINIT: ::std::mem::MaybeUninit<Nice> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<Nice>(),
         144usize,
@@ -25,40 +27,32 @@ fn bindgen_test_layout_Nice() {
         8usize,
         concat!("Alignment of ", stringify!(Nice))
     );
-    fn test_field_pointer() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Nice>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).pointer) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(Nice),
-                "::",
-                stringify!(pointer)
-            )
-        );
-    }
-    test_field_pointer();
-    fn test_field_large_array() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Nice>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).large_array) as usize - ptr as usize
-            },
-            8usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(Nice),
-                "::",
-                stringify!(large_array)
-            )
-        );
-    }
-    test_field_large_array();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).pointer) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(Nice),
+            "::",
+            stringify!(pointer)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).large_array) as usize - ptr as usize
+        },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(Nice),
+            "::",
+            stringify!(large_array)
+        )
+    );
 }
 impl Default for Nice {
     fn default() -> Self {

--- a/tests/expectations/tests/derive-debug-mangle-name.rs
+++ b/tests/expectations/tests/derive-debug-mangle-name.rs
@@ -22,6 +22,7 @@ pub union perf_event_attr__bindgen_ty_1 {
 fn bindgen_test_layout_perf_event_attr__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<perf_event_attr__bindgen_ty_1> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<perf_event_attr__bindgen_ty_1>(),
         4usize,
@@ -33,10 +34,7 @@ fn bindgen_test_layout_perf_event_attr__bindgen_ty_1() {
         concat!("Alignment of ", stringify!(perf_event_attr__bindgen_ty_1))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -46,10 +44,7 @@ fn bindgen_test_layout_perf_event_attr__bindgen_ty_1() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).c) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).c) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -77,6 +72,7 @@ impl ::std::fmt::Debug for perf_event_attr__bindgen_ty_1 {
 fn bindgen_test_layout_perf_event_attr() {
     const UNINIT: ::std::mem::MaybeUninit<perf_event_attr> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<perf_event_attr>(),
         12usize,
@@ -88,10 +84,7 @@ fn bindgen_test_layout_perf_event_attr() {
         concat!("Alignment of ", stringify!(perf_event_attr))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).type_) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).type_) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -101,10 +94,7 @@ fn bindgen_test_layout_perf_event_attr() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
         4usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/derive-debug-mangle-name.rs
+++ b/tests/expectations/tests/derive-debug-mangle-name.rs
@@ -20,6 +20,8 @@ pub union perf_event_attr__bindgen_ty_1 {
 }
 #[test]
 fn bindgen_test_layout_perf_event_attr__bindgen_ty_1() {
+    const UNINIT: ::std::mem::MaybeUninit<perf_event_attr__bindgen_ty_1> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<perf_event_attr__bindgen_ty_1>(),
         4usize,
@@ -30,44 +32,32 @@ fn bindgen_test_layout_perf_event_attr__bindgen_ty_1() {
         4usize,
         concat!("Alignment of ", stringify!(perf_event_attr__bindgen_ty_1))
     );
-    fn test_field_b() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<
-                    perf_event_attr__bindgen_ty_1,
-                >::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(perf_event_attr__bindgen_ty_1),
-                "::",
-                stringify!(b)
-            )
-        );
-    }
-    test_field_b();
-    fn test_field_c() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<
-                    perf_event_attr__bindgen_ty_1,
-                >::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).c) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(perf_event_attr__bindgen_ty_1),
-                "::",
-                stringify!(c)
-            )
-        );
-    }
-    test_field_c();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(perf_event_attr__bindgen_ty_1),
+            "::",
+            stringify!(b)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).c) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(perf_event_attr__bindgen_ty_1),
+            "::",
+            stringify!(c)
+        )
+    );
 }
 impl Default for perf_event_attr__bindgen_ty_1 {
     fn default() -> Self {
@@ -85,6 +75,8 @@ impl ::std::fmt::Debug for perf_event_attr__bindgen_ty_1 {
 }
 #[test]
 fn bindgen_test_layout_perf_event_attr() {
+    const UNINIT: ::std::mem::MaybeUninit<perf_event_attr> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<perf_event_attr>(),
         12usize,
@@ -95,42 +87,32 @@ fn bindgen_test_layout_perf_event_attr() {
         4usize,
         concat!("Alignment of ", stringify!(perf_event_attr))
     );
-    fn test_field_type() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<perf_event_attr>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).type_) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(perf_event_attr),
-                "::",
-                stringify!(type_)
-            )
-        );
-    }
-    test_field_type();
-    fn test_field_a() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<perf_event_attr>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-            },
-            4usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(perf_event_attr),
-                "::",
-                stringify!(a)
-            )
-        );
-    }
-    test_field_a();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).type_) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(perf_event_attr),
+            "::",
+            stringify!(type_)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(perf_event_attr),
+            "::",
+            stringify!(a)
+        )
+    );
 }
 impl Default for perf_event_attr {
     fn default() -> Self {

--- a/tests/expectations/tests/derive-debug-opaque-template-instantiation.rs
+++ b/tests/expectations/tests/derive-debug-opaque-template-instantiation.rs
@@ -11,6 +11,8 @@ pub struct Instance {
 }
 #[test]
 fn bindgen_test_layout_Instance() {
+    const UNINIT: ::std::mem::MaybeUninit<Instance> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<Instance>(),
         200usize,
@@ -21,23 +23,19 @@ fn bindgen_test_layout_Instance() {
         4usize,
         concat!("Alignment of ", stringify!(Instance))
     );
-    fn test_field_val() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Instance>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).val) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(Instance),
-                "::",
-                stringify!(val)
-            )
-        );
-    }
-    test_field_val();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).val) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(Instance),
+            "::",
+            stringify!(val)
+        )
+    );
 }
 impl Default for Instance {
     fn default() -> Self {

--- a/tests/expectations/tests/derive-debug-opaque-template-instantiation.rs
+++ b/tests/expectations/tests/derive-debug-opaque-template-instantiation.rs
@@ -13,6 +13,7 @@ pub struct Instance {
 fn bindgen_test_layout_Instance() {
     const UNINIT: ::std::mem::MaybeUninit<Instance> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<Instance>(),
         200usize,
@@ -24,10 +25,7 @@ fn bindgen_test_layout_Instance() {
         concat!("Alignment of ", stringify!(Instance))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).val) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).val) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/derive-debug-opaque.rs
+++ b/tests/expectations/tests/derive-debug-opaque.rs
@@ -43,6 +43,8 @@ pub struct OpaqueUser {
 }
 #[test]
 fn bindgen_test_layout_OpaqueUser() {
+    const UNINIT: ::std::mem::MaybeUninit<OpaqueUser> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<OpaqueUser>(),
         164usize,
@@ -53,23 +55,19 @@ fn bindgen_test_layout_OpaqueUser() {
         4usize,
         concat!("Alignment of ", stringify!(OpaqueUser))
     );
-    fn test_field_opaque() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<OpaqueUser>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).opaque) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(OpaqueUser),
-                "::",
-                stringify!(opaque)
-            )
-        );
-    }
-    test_field_opaque();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).opaque) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(OpaqueUser),
+            "::",
+            stringify!(opaque)
+        )
+    );
 }
 impl Default for OpaqueUser {
     fn default() -> Self {

--- a/tests/expectations/tests/derive-debug-opaque.rs
+++ b/tests/expectations/tests/derive-debug-opaque.rs
@@ -45,6 +45,7 @@ pub struct OpaqueUser {
 fn bindgen_test_layout_OpaqueUser() {
     const UNINIT: ::std::mem::MaybeUninit<OpaqueUser> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<OpaqueUser>(),
         164usize,
@@ -56,10 +57,7 @@ fn bindgen_test_layout_OpaqueUser() {
         concat!("Alignment of ", stringify!(OpaqueUser))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).opaque) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).opaque) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/derive-default-and-blocklist.rs
+++ b/tests/expectations/tests/derive-default-and-blocklist.rs
@@ -15,6 +15,8 @@ pub struct ShouldNotDeriveDefault {
 }
 #[test]
 fn bindgen_test_layout_ShouldNotDeriveDefault() {
+    const UNINIT: ::std::mem::MaybeUninit<ShouldNotDeriveDefault> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<ShouldNotDeriveDefault>(),
         1usize,
@@ -25,24 +27,19 @@ fn bindgen_test_layout_ShouldNotDeriveDefault() {
         1usize,
         concat!("Alignment of ", stringify!(ShouldNotDeriveDefault))
     );
-    fn test_field_a() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<ShouldNotDeriveDefault>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(ShouldNotDeriveDefault),
-                "::",
-                stringify!(a)
-            )
-        );
-    }
-    test_field_a();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ShouldNotDeriveDefault),
+            "::",
+            stringify!(a)
+        )
+    );
 }
 impl Default for ShouldNotDeriveDefault {
     fn default() -> Self {

--- a/tests/expectations/tests/derive-default-and-blocklist.rs
+++ b/tests/expectations/tests/derive-default-and-blocklist.rs
@@ -17,6 +17,7 @@ pub struct ShouldNotDeriveDefault {
 fn bindgen_test_layout_ShouldNotDeriveDefault() {
     const UNINIT: ::std::mem::MaybeUninit<ShouldNotDeriveDefault> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<ShouldNotDeriveDefault>(),
         1usize,
@@ -28,10 +29,7 @@ fn bindgen_test_layout_ShouldNotDeriveDefault() {
         concat!("Alignment of ", stringify!(ShouldNotDeriveDefault))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/derive-fn-ptr.rs
+++ b/tests/expectations/tests/derive-fn-ptr.rs
@@ -34,6 +34,7 @@ pub struct Foo {
 fn bindgen_test_layout_Foo() {
     const UNINIT: ::std::mem::MaybeUninit<Foo> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<Foo>(),
         8usize,
@@ -46,7 +47,6 @@ fn bindgen_test_layout_Foo() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).callback) as usize - ptr as usize
         },
         0usize,
@@ -83,6 +83,7 @@ pub struct Bar {
 fn bindgen_test_layout_Bar() {
     const UNINIT: ::std::mem::MaybeUninit<Bar> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<Bar>(),
         8usize,
@@ -95,7 +96,6 @@ fn bindgen_test_layout_Bar() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).callback) as usize - ptr as usize
         },
         0usize,

--- a/tests/expectations/tests/derive-fn-ptr.rs
+++ b/tests/expectations/tests/derive-fn-ptr.rs
@@ -32,6 +32,8 @@ pub struct Foo {
 }
 #[test]
 fn bindgen_test_layout_Foo() {
+    const UNINIT: ::std::mem::MaybeUninit<Foo> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<Foo>(),
         8usize,
@@ -42,23 +44,19 @@ fn bindgen_test_layout_Foo() {
         8usize,
         concat!("Alignment of ", stringify!(Foo))
     );
-    fn test_field_callback() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Foo>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).callback) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(Foo),
-                "::",
-                stringify!(callback)
-            )
-        );
-    }
-    test_field_callback();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).callback) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(Foo),
+            "::",
+            stringify!(callback)
+        )
+    );
 }
 pub type my_fun2_t = ::std::option::Option<
     unsafe extern "C" fn(
@@ -83,6 +81,8 @@ pub struct Bar {
 }
 #[test]
 fn bindgen_test_layout_Bar() {
+    const UNINIT: ::std::mem::MaybeUninit<Bar> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<Bar>(),
         8usize,
@@ -93,21 +93,17 @@ fn bindgen_test_layout_Bar() {
         8usize,
         concat!("Alignment of ", stringify!(Bar))
     );
-    fn test_field_callback() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Bar>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).callback) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(Bar),
-                "::",
-                stringify!(callback)
-            )
-        );
-    }
-    test_field_callback();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).callback) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(Bar),
+            "::",
+            stringify!(callback)
+        )
+    );
 }

--- a/tests/expectations/tests/derive-hash-and-blocklist.rs
+++ b/tests/expectations/tests/derive-hash-and-blocklist.rs
@@ -14,6 +14,8 @@ pub struct ShouldNotDeriveHash {
 }
 #[test]
 fn bindgen_test_layout_ShouldNotDeriveHash() {
+    const UNINIT: ::std::mem::MaybeUninit<ShouldNotDeriveHash> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<ShouldNotDeriveHash>(),
         1usize,
@@ -24,24 +26,19 @@ fn bindgen_test_layout_ShouldNotDeriveHash() {
         1usize,
         concat!("Alignment of ", stringify!(ShouldNotDeriveHash))
     );
-    fn test_field_a() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<ShouldNotDeriveHash>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(ShouldNotDeriveHash),
-                "::",
-                stringify!(a)
-            )
-        );
-    }
-    test_field_a();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ShouldNotDeriveHash),
+            "::",
+            stringify!(a)
+        )
+    );
 }
 impl Default for ShouldNotDeriveHash {
     fn default() -> Self {

--- a/tests/expectations/tests/derive-hash-and-blocklist.rs
+++ b/tests/expectations/tests/derive-hash-and-blocklist.rs
@@ -16,6 +16,7 @@ pub struct ShouldNotDeriveHash {
 fn bindgen_test_layout_ShouldNotDeriveHash() {
     const UNINIT: ::std::mem::MaybeUninit<ShouldNotDeriveHash> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<ShouldNotDeriveHash>(),
         1usize,
@@ -27,10 +28,7 @@ fn bindgen_test_layout_ShouldNotDeriveHash() {
         concat!("Alignment of ", stringify!(ShouldNotDeriveHash))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/derive-hash-blocklisting.rs
+++ b/tests/expectations/tests/derive-hash-blocklisting.rs
@@ -20,6 +20,8 @@ pub struct AllowlistedOne {
 }
 #[test]
 fn bindgen_test_layout_AllowlistedOne() {
+    const UNINIT: ::std::mem::MaybeUninit<AllowlistedOne> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<AllowlistedOne>(),
         4usize,
@@ -30,24 +32,19 @@ fn bindgen_test_layout_AllowlistedOne() {
         4usize,
         concat!("Alignment of ", stringify!(AllowlistedOne))
     );
-    fn test_field_a() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<AllowlistedOne>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(AllowlistedOne),
-                "::",
-                stringify!(a)
-            )
-        );
-    }
-    test_field_a();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(AllowlistedOne),
+            "::",
+            stringify!(a)
+        )
+    );
 }
 impl Default for AllowlistedOne {
     fn default() -> Self {
@@ -65,6 +62,8 @@ pub struct AllowlistedTwo {
 }
 #[test]
 fn bindgen_test_layout_AllowlistedTwo() {
+    const UNINIT: ::std::mem::MaybeUninit<AllowlistedTwo> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<AllowlistedTwo>(),
         4usize,
@@ -75,24 +74,19 @@ fn bindgen_test_layout_AllowlistedTwo() {
         4usize,
         concat!("Alignment of ", stringify!(AllowlistedTwo))
     );
-    fn test_field_b() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<AllowlistedTwo>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(AllowlistedTwo),
-                "::",
-                stringify!(b)
-            )
-        );
-    }
-    test_field_b();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(AllowlistedTwo),
+            "::",
+            stringify!(b)
+        )
+    );
 }
 impl Default for AllowlistedTwo {
     fn default() -> Self {

--- a/tests/expectations/tests/derive-hash-blocklisting.rs
+++ b/tests/expectations/tests/derive-hash-blocklisting.rs
@@ -22,6 +22,7 @@ pub struct AllowlistedOne {
 fn bindgen_test_layout_AllowlistedOne() {
     const UNINIT: ::std::mem::MaybeUninit<AllowlistedOne> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<AllowlistedOne>(),
         4usize,
@@ -33,10 +34,7 @@ fn bindgen_test_layout_AllowlistedOne() {
         concat!("Alignment of ", stringify!(AllowlistedOne))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -64,6 +62,7 @@ pub struct AllowlistedTwo {
 fn bindgen_test_layout_AllowlistedTwo() {
     const UNINIT: ::std::mem::MaybeUninit<AllowlistedTwo> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<AllowlistedTwo>(),
         4usize,
@@ -75,10 +74,7 @@ fn bindgen_test_layout_AllowlistedTwo() {
         concat!("Alignment of ", stringify!(AllowlistedTwo))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/derive-hash-struct-with-anon-struct-float.rs
+++ b/tests/expectations/tests/derive-hash-struct-with-anon-struct-float.rs
@@ -21,6 +21,7 @@ pub struct foo__bindgen_ty_1 {
 fn bindgen_test_layout_foo__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<foo__bindgen_ty_1> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<foo__bindgen_ty_1>(),
         8usize,
@@ -32,10 +33,7 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
         concat!("Alignment of ", stringify!(foo__bindgen_ty_1))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -45,10 +43,7 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
         4usize,
         concat!(
             "Offset of field: ",
@@ -62,6 +57,7 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
 fn bindgen_test_layout_foo() {
     const UNINIT: ::std::mem::MaybeUninit<foo> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<foo>(),
         8usize,
@@ -73,10 +69,7 @@ fn bindgen_test_layout_foo() {
         concat!("Alignment of ", stringify!(foo))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize },
         0usize,
         concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar))
     );

--- a/tests/expectations/tests/derive-hash-struct-with-anon-struct-float.rs
+++ b/tests/expectations/tests/derive-hash-struct-with-anon-struct-float.rs
@@ -19,6 +19,8 @@ pub struct foo__bindgen_ty_1 {
 }
 #[test]
 fn bindgen_test_layout_foo__bindgen_ty_1() {
+    const UNINIT: ::std::mem::MaybeUninit<foo__bindgen_ty_1> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<foo__bindgen_ty_1>(),
         8usize,
@@ -29,45 +31,37 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
         4usize,
         concat!("Alignment of ", stringify!(foo__bindgen_ty_1))
     );
-    fn test_field_a() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<foo__bindgen_ty_1>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(foo__bindgen_ty_1),
-                "::",
-                stringify!(a)
-            )
-        );
-    }
-    test_field_a();
-    fn test_field_b() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<foo__bindgen_ty_1>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-            },
-            4usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(foo__bindgen_ty_1),
-                "::",
-                stringify!(b)
-            )
-        );
-    }
-    test_field_b();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(foo__bindgen_ty_1),
+            "::",
+            stringify!(a)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(foo__bindgen_ty_1),
+            "::",
+            stringify!(b)
+        )
+    );
 }
 #[test]
 fn bindgen_test_layout_foo() {
+    const UNINIT: ::std::mem::MaybeUninit<foo> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<foo>(),
         8usize,
@@ -78,21 +72,12 @@ fn bindgen_test_layout_foo() {
         4usize,
         concat!("Alignment of ", stringify!(foo))
     );
-    fn test_field_bar() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<foo>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(foo),
-                "::",
-                stringify!(bar)
-            )
-        );
-    }
-    test_field_bar();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
+        },
+        0usize,
+        concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar))
+    );
 }

--- a/tests/expectations/tests/derive-hash-struct-with-float-array.rs
+++ b/tests/expectations/tests/derive-hash-struct-with-float-array.rs
@@ -15,6 +15,7 @@ pub struct foo {
 fn bindgen_test_layout_foo() {
     const UNINIT: ::std::mem::MaybeUninit<foo> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<foo>(),
         12usize,
@@ -26,10 +27,7 @@ fn bindgen_test_layout_foo() {
         concat!("Alignment of ", stringify!(foo))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize },
         0usize,
         concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar))
     );

--- a/tests/expectations/tests/derive-hash-struct-with-float-array.rs
+++ b/tests/expectations/tests/derive-hash-struct-with-float-array.rs
@@ -13,6 +13,8 @@ pub struct foo {
 }
 #[test]
 fn bindgen_test_layout_foo() {
+    const UNINIT: ::std::mem::MaybeUninit<foo> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<foo>(),
         12usize,
@@ -23,21 +25,12 @@ fn bindgen_test_layout_foo() {
         4usize,
         concat!("Alignment of ", stringify!(foo))
     );
-    fn test_field_bar() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<foo>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(foo),
-                "::",
-                stringify!(bar)
-            )
-        );
-    }
-    test_field_bar();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
+        },
+        0usize,
+        concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar))
+    );
 }

--- a/tests/expectations/tests/derive-hash-struct-with-incomplete-array.rs
+++ b/tests/expectations/tests/derive-hash-struct-with-incomplete-array.rs
@@ -43,6 +43,8 @@ pub struct test {
 }
 #[test]
 fn bindgen_test_layout_test() {
+    const UNINIT: ::std::mem::MaybeUninit<test> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<test>(),
         4usize,
@@ -53,36 +55,28 @@ fn bindgen_test_layout_test() {
         4usize,
         concat!("Alignment of ", stringify!(test))
     );
-    fn test_field_a() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<test>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-            },
-            0usize,
-            concat!("Offset of field: ", stringify!(test), "::", stringify!(a))
-        );
-    }
-    test_field_a();
-    fn test_field_zero_length_array() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<test>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).zero_length_array) as usize -
-                    ptr as usize
-            },
-            4usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(test),
-                "::",
-                stringify!(zero_length_array)
-            )
-        );
-    }
-    test_field_zero_length_array();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+        },
+        0usize,
+        concat!("Offset of field: ", stringify!(test), "::", stringify!(a))
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).zero_length_array) as usize -
+                ptr as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(test),
+            "::",
+            stringify!(zero_length_array)
+        )
+    );
 }
 #[repr(C)]
 #[derive(Debug, Default)]

--- a/tests/expectations/tests/derive-hash-struct-with-incomplete-array.rs
+++ b/tests/expectations/tests/derive-hash-struct-with-incomplete-array.rs
@@ -45,6 +45,7 @@ pub struct test {
 fn bindgen_test_layout_test() {
     const UNINIT: ::std::mem::MaybeUninit<test> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<test>(),
         4usize,
@@ -56,16 +57,12 @@ fn bindgen_test_layout_test() {
         concat!("Alignment of ", stringify!(test))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
         0usize,
         concat!("Offset of field: ", stringify!(test), "::", stringify!(a))
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).zero_length_array) as usize -
                 ptr as usize
         },

--- a/tests/expectations/tests/derive-hash-struct-with-pointer.rs
+++ b/tests/expectations/tests/derive-hash-struct-with-pointer.rs
@@ -15,6 +15,7 @@ pub struct ConstPtrMutObj {
 fn bindgen_test_layout_ConstPtrMutObj() {
     const UNINIT: ::std::mem::MaybeUninit<ConstPtrMutObj> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<ConstPtrMutObj>(),
         8usize,
@@ -26,10 +27,7 @@ fn bindgen_test_layout_ConstPtrMutObj() {
         concat!("Alignment of ", stringify!(ConstPtrMutObj))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -57,6 +55,7 @@ pub struct MutPtrMutObj {
 fn bindgen_test_layout_MutPtrMutObj() {
     const UNINIT: ::std::mem::MaybeUninit<MutPtrMutObj> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<MutPtrMutObj>(),
         8usize,
@@ -68,10 +67,7 @@ fn bindgen_test_layout_MutPtrMutObj() {
         concat!("Alignment of ", stringify!(MutPtrMutObj))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -99,6 +95,7 @@ pub struct MutPtrConstObj {
 fn bindgen_test_layout_MutPtrConstObj() {
     const UNINIT: ::std::mem::MaybeUninit<MutPtrConstObj> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<MutPtrConstObj>(),
         8usize,
@@ -110,10 +107,7 @@ fn bindgen_test_layout_MutPtrConstObj() {
         concat!("Alignment of ", stringify!(MutPtrConstObj))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -141,6 +135,7 @@ pub struct ConstPtrConstObj {
 fn bindgen_test_layout_ConstPtrConstObj() {
     const UNINIT: ::std::mem::MaybeUninit<ConstPtrConstObj> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<ConstPtrConstObj>(),
         8usize,
@@ -152,10 +147,7 @@ fn bindgen_test_layout_ConstPtrConstObj() {
         concat!("Alignment of ", stringify!(ConstPtrConstObj))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/derive-hash-struct-with-pointer.rs
+++ b/tests/expectations/tests/derive-hash-struct-with-pointer.rs
@@ -13,6 +13,8 @@ pub struct ConstPtrMutObj {
 }
 #[test]
 fn bindgen_test_layout_ConstPtrMutObj() {
+    const UNINIT: ::std::mem::MaybeUninit<ConstPtrMutObj> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<ConstPtrMutObj>(),
         8usize,
@@ -23,24 +25,19 @@ fn bindgen_test_layout_ConstPtrMutObj() {
         8usize,
         concat!("Alignment of ", stringify!(ConstPtrMutObj))
     );
-    fn test_field_bar() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<ConstPtrMutObj>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(ConstPtrMutObj),
-                "::",
-                stringify!(bar)
-            )
-        );
-    }
-    test_field_bar();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ConstPtrMutObj),
+            "::",
+            stringify!(bar)
+        )
+    );
 }
 impl Default for ConstPtrMutObj {
     fn default() -> Self {
@@ -58,6 +55,8 @@ pub struct MutPtrMutObj {
 }
 #[test]
 fn bindgen_test_layout_MutPtrMutObj() {
+    const UNINIT: ::std::mem::MaybeUninit<MutPtrMutObj> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<MutPtrMutObj>(),
         8usize,
@@ -68,23 +67,19 @@ fn bindgen_test_layout_MutPtrMutObj() {
         8usize,
         concat!("Alignment of ", stringify!(MutPtrMutObj))
     );
-    fn test_field_bar() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<MutPtrMutObj>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(MutPtrMutObj),
-                "::",
-                stringify!(bar)
-            )
-        );
-    }
-    test_field_bar();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(MutPtrMutObj),
+            "::",
+            stringify!(bar)
+        )
+    );
 }
 impl Default for MutPtrMutObj {
     fn default() -> Self {
@@ -102,6 +97,8 @@ pub struct MutPtrConstObj {
 }
 #[test]
 fn bindgen_test_layout_MutPtrConstObj() {
+    const UNINIT: ::std::mem::MaybeUninit<MutPtrConstObj> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<MutPtrConstObj>(),
         8usize,
@@ -112,24 +109,19 @@ fn bindgen_test_layout_MutPtrConstObj() {
         8usize,
         concat!("Alignment of ", stringify!(MutPtrConstObj))
     );
-    fn test_field_bar() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<MutPtrConstObj>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(MutPtrConstObj),
-                "::",
-                stringify!(bar)
-            )
-        );
-    }
-    test_field_bar();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(MutPtrConstObj),
+            "::",
+            stringify!(bar)
+        )
+    );
 }
 impl Default for MutPtrConstObj {
     fn default() -> Self {
@@ -147,6 +139,8 @@ pub struct ConstPtrConstObj {
 }
 #[test]
 fn bindgen_test_layout_ConstPtrConstObj() {
+    const UNINIT: ::std::mem::MaybeUninit<ConstPtrConstObj> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<ConstPtrConstObj>(),
         8usize,
@@ -157,24 +151,19 @@ fn bindgen_test_layout_ConstPtrConstObj() {
         8usize,
         concat!("Alignment of ", stringify!(ConstPtrConstObj))
     );
-    fn test_field_bar() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<ConstPtrConstObj>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(ConstPtrConstObj),
-                "::",
-                stringify!(bar)
-            )
-        );
-    }
-    test_field_bar();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ConstPtrConstObj),
+            "::",
+            stringify!(bar)
+        )
+    );
 }
 impl Default for ConstPtrConstObj {
     fn default() -> Self {

--- a/tests/expectations/tests/derive-hash-template-inst-float.rs
+++ b/tests/expectations/tests/derive-hash-template-inst-float.rs
@@ -31,6 +31,7 @@ pub struct IntStr {
 fn bindgen_test_layout_IntStr() {
     const UNINIT: ::std::mem::MaybeUninit<IntStr> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<IntStr>(),
         4usize,
@@ -42,10 +43,7 @@ fn bindgen_test_layout_IntStr() {
         concat!("Alignment of ", stringify!(IntStr))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
         0usize,
         concat!("Offset of field: ", stringify!(IntStr), "::", stringify!(a))
     );
@@ -69,6 +67,7 @@ pub struct FloatStr {
 fn bindgen_test_layout_FloatStr() {
     const UNINIT: ::std::mem::MaybeUninit<FloatStr> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<FloatStr>(),
         4usize,
@@ -80,10 +79,7 @@ fn bindgen_test_layout_FloatStr() {
         concat!("Alignment of ", stringify!(FloatStr))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/derive-hash-template-inst-float.rs
+++ b/tests/expectations/tests/derive-hash-template-inst-float.rs
@@ -29,6 +29,8 @@ pub struct IntStr {
 }
 #[test]
 fn bindgen_test_layout_IntStr() {
+    const UNINIT: ::std::mem::MaybeUninit<IntStr> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<IntStr>(),
         4usize,
@@ -39,23 +41,14 @@ fn bindgen_test_layout_IntStr() {
         4usize,
         concat!("Alignment of ", stringify!(IntStr))
     );
-    fn test_field_a() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<IntStr>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(IntStr),
-                "::",
-                stringify!(a)
-            )
-        );
-    }
-    test_field_a();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+        },
+        0usize,
+        concat!("Offset of field: ", stringify!(IntStr), "::", stringify!(a))
+    );
 }
 impl Default for IntStr {
     fn default() -> Self {
@@ -74,6 +67,8 @@ pub struct FloatStr {
 }
 #[test]
 fn bindgen_test_layout_FloatStr() {
+    const UNINIT: ::std::mem::MaybeUninit<FloatStr> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<FloatStr>(),
         4usize,
@@ -84,23 +79,19 @@ fn bindgen_test_layout_FloatStr() {
         4usize,
         concat!("Alignment of ", stringify!(FloatStr))
     );
-    fn test_field_a() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<FloatStr>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(FloatStr),
-                "::",
-                stringify!(a)
-            )
-        );
-    }
-    test_field_a();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(FloatStr),
+            "::",
+            stringify!(a)
+        )
+    );
 }
 impl Default for FloatStr {
     fn default() -> Self {

--- a/tests/expectations/tests/derive-partialeq-and-blocklist.rs
+++ b/tests/expectations/tests/derive-partialeq-and-blocklist.rs
@@ -17,6 +17,7 @@ pub struct ShouldNotDerivePartialEq {
 fn bindgen_test_layout_ShouldNotDerivePartialEq() {
     const UNINIT: ::std::mem::MaybeUninit<ShouldNotDerivePartialEq> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<ShouldNotDerivePartialEq>(),
         1usize,
@@ -28,10 +29,7 @@ fn bindgen_test_layout_ShouldNotDerivePartialEq() {
         concat!("Alignment of ", stringify!(ShouldNotDerivePartialEq))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/derive-partialeq-and-blocklist.rs
+++ b/tests/expectations/tests/derive-partialeq-and-blocklist.rs
@@ -15,6 +15,8 @@ pub struct ShouldNotDerivePartialEq {
 }
 #[test]
 fn bindgen_test_layout_ShouldNotDerivePartialEq() {
+    const UNINIT: ::std::mem::MaybeUninit<ShouldNotDerivePartialEq> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<ShouldNotDerivePartialEq>(),
         1usize,
@@ -25,25 +27,19 @@ fn bindgen_test_layout_ShouldNotDerivePartialEq() {
         1usize,
         concat!("Alignment of ", stringify!(ShouldNotDerivePartialEq))
     );
-    fn test_field_a() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<ShouldNotDerivePartialEq>::uninit(
-                    );
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(ShouldNotDerivePartialEq),
-                "::",
-                stringify!(a)
-            )
-        );
-    }
-    test_field_a();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ShouldNotDerivePartialEq),
+            "::",
+            stringify!(a)
+        )
+    );
 }
 impl Default for ShouldNotDerivePartialEq {
     fn default() -> Self {

--- a/tests/expectations/tests/derive-partialeq-base.rs
+++ b/tests/expectations/tests/derive-partialeq-base.rs
@@ -12,6 +12,8 @@ pub struct Base {
 }
 #[test]
 fn bindgen_test_layout_Base() {
+    const UNINIT: ::std::mem::MaybeUninit<Base> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<Base>(),
         132usize,
@@ -22,23 +24,19 @@ fn bindgen_test_layout_Base() {
         4usize,
         concat!("Alignment of ", stringify!(Base))
     );
-    fn test_field_large() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Base>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).large) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(Base),
-                "::",
-                stringify!(large)
-            )
-        );
-    }
-    test_field_large();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).large) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(Base),
+            "::",
+            stringify!(large)
+        )
+    );
 }
 impl Default for Base {
     fn default() -> Self {

--- a/tests/expectations/tests/derive-partialeq-base.rs
+++ b/tests/expectations/tests/derive-partialeq-base.rs
@@ -14,6 +14,7 @@ pub struct Base {
 fn bindgen_test_layout_Base() {
     const UNINIT: ::std::mem::MaybeUninit<Base> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<Base>(),
         132usize,
@@ -25,10 +26,7 @@ fn bindgen_test_layout_Base() {
         concat!("Alignment of ", stringify!(Base))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).large) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).large) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/derive-partialeq-bitfield.rs
+++ b/tests/expectations/tests/derive-partialeq-bitfield.rs
@@ -102,6 +102,7 @@ pub struct C {
 fn bindgen_test_layout_C() {
     const UNINIT: ::std::mem::MaybeUninit<C> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<C>(),
         204usize,
@@ -114,7 +115,6 @@ fn bindgen_test_layout_C() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).large_array) as usize - ptr as usize
         },
         4usize,

--- a/tests/expectations/tests/derive-partialeq-bitfield.rs
+++ b/tests/expectations/tests/derive-partialeq-bitfield.rs
@@ -100,6 +100,8 @@ pub struct C {
 }
 #[test]
 fn bindgen_test_layout_C() {
+    const UNINIT: ::std::mem::MaybeUninit<C> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<C>(),
         204usize,
@@ -110,23 +112,19 @@ fn bindgen_test_layout_C() {
         4usize,
         concat!("Alignment of ", stringify!(C))
     );
-    fn test_field_large_array() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<C>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).large_array) as usize - ptr as usize
-            },
-            4usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(C),
-                "::",
-                stringify!(large_array)
-            )
-        );
-    }
-    test_field_large_array();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).large_array) as usize - ptr as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C),
+            "::",
+            stringify!(large_array)
+        )
+    );
 }
 impl Default for C {
     fn default() -> Self {

--- a/tests/expectations/tests/derive-partialeq-core.rs
+++ b/tests/expectations/tests/derive-partialeq-core.rs
@@ -16,6 +16,7 @@ pub struct C {
 fn bindgen_test_layout_C() {
     const UNINIT: ::core::mem::MaybeUninit<C> =
         ::core::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::core::mem::size_of::<C>(),
         1680usize,
@@ -28,7 +29,6 @@ fn bindgen_test_layout_C() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::core::ptr::addr_of!((*ptr).large_array) as usize - ptr as usize
         },
         0usize,

--- a/tests/expectations/tests/derive-partialeq-core.rs
+++ b/tests/expectations/tests/derive-partialeq-core.rs
@@ -14,6 +14,8 @@ pub struct C {
 }
 #[test]
 fn bindgen_test_layout_C() {
+    const UNINIT: ::core::mem::MaybeUninit<C> =
+        ::core::mem::MaybeUninit::uninit();
     assert_eq!(
         ::core::mem::size_of::<C>(),
         1680usize,
@@ -24,24 +26,19 @@ fn bindgen_test_layout_C() {
         4usize,
         concat!("Alignment of ", stringify!(C))
     );
-    fn test_field_large_array() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::core::mem::MaybeUninit::<C>::uninit();
-                let ptr = uninit.as_ptr();
-                ::core::ptr::addr_of!((*ptr).large_array) as usize -
-                    ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(C),
-                "::",
-                stringify!(large_array)
-            )
-        );
-    }
-    test_field_large_array();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::core::ptr::addr_of!((*ptr).large_array) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C),
+            "::",
+            stringify!(large_array)
+        )
+    );
 }
 impl Default for C {
     fn default() -> Self {

--- a/tests/expectations/tests/derive-partialeq-pointer.rs
+++ b/tests/expectations/tests/derive-partialeq-pointer.rs
@@ -14,6 +14,7 @@ pub struct Bar {
 fn bindgen_test_layout_Bar() {
     const UNINIT: ::std::mem::MaybeUninit<Bar> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<Bar>(),
         8usize,
@@ -25,10 +26,7 @@ fn bindgen_test_layout_Bar() {
         concat!("Alignment of ", stringify!(Bar))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
         0usize,
         concat!("Offset of field: ", stringify!(Bar), "::", stringify!(b))
     );
@@ -105,6 +103,7 @@ pub struct a {
 fn bindgen_test_layout_a() {
     const UNINIT: ::std::mem::MaybeUninit<a> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<a>(),
         1usize,
@@ -116,10 +115,7 @@ fn bindgen_test_layout_a() {
         concat!("Alignment of ", stringify!(a))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize },
         0usize,
         concat!("Offset of field: ", stringify!(a), "::", stringify!(d))
     );

--- a/tests/expectations/tests/derive-partialeq-pointer.rs
+++ b/tests/expectations/tests/derive-partialeq-pointer.rs
@@ -12,6 +12,8 @@ pub struct Bar {
 }
 #[test]
 fn bindgen_test_layout_Bar() {
+    const UNINIT: ::std::mem::MaybeUninit<Bar> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<Bar>(),
         8usize,
@@ -22,18 +24,14 @@ fn bindgen_test_layout_Bar() {
         8usize,
         concat!("Alignment of ", stringify!(Bar))
     );
-    fn test_field_b() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Bar>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-            },
-            0usize,
-            concat!("Offset of field: ", stringify!(Bar), "::", stringify!(b))
-        );
-    }
-    test_field_b();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
+        },
+        0usize,
+        concat!("Offset of field: ", stringify!(Bar), "::", stringify!(b))
+    );
 }
 impl Default for Bar {
     fn default() -> Self {
@@ -105,6 +103,8 @@ pub struct a {
 }
 #[test]
 fn bindgen_test_layout_a() {
+    const UNINIT: ::std::mem::MaybeUninit<a> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<a>(),
         1usize,
@@ -115,18 +115,14 @@ fn bindgen_test_layout_a() {
         1usize,
         concat!("Alignment of ", stringify!(a))
     );
-    fn test_field_d() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<a>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize
-            },
-            0usize,
-            concat!("Offset of field: ", stringify!(a), "::", stringify!(d))
-        );
-    }
-    test_field_d();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize
+        },
+        0usize,
+        concat!("Offset of field: ", stringify!(a), "::", stringify!(d))
+    );
 }
 impl Default for a {
     fn default() -> Self {

--- a/tests/expectations/tests/derive-partialeq-union.rs
+++ b/tests/expectations/tests/derive-partialeq-union.rs
@@ -14,6 +14,8 @@ pub union ShouldNotDerivePartialEq {
 }
 #[test]
 fn bindgen_test_layout_ShouldNotDerivePartialEq() {
+    const UNINIT: ::std::mem::MaybeUninit<ShouldNotDerivePartialEq> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<ShouldNotDerivePartialEq>(),
         4usize,
@@ -24,44 +26,32 @@ fn bindgen_test_layout_ShouldNotDerivePartialEq() {
         4usize,
         concat!("Alignment of ", stringify!(ShouldNotDerivePartialEq))
     );
-    fn test_field_a() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<ShouldNotDerivePartialEq>::uninit(
-                    );
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(ShouldNotDerivePartialEq),
-                "::",
-                stringify!(a)
-            )
-        );
-    }
-    test_field_a();
-    fn test_field_b() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<ShouldNotDerivePartialEq>::uninit(
-                    );
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(ShouldNotDerivePartialEq),
-                "::",
-                stringify!(b)
-            )
-        );
-    }
-    test_field_b();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ShouldNotDerivePartialEq),
+            "::",
+            stringify!(a)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ShouldNotDerivePartialEq),
+            "::",
+            stringify!(b)
+        )
+    );
 }
 impl Default for ShouldNotDerivePartialEq {
     fn default() -> Self {

--- a/tests/expectations/tests/derive-partialeq-union.rs
+++ b/tests/expectations/tests/derive-partialeq-union.rs
@@ -16,6 +16,7 @@ pub union ShouldNotDerivePartialEq {
 fn bindgen_test_layout_ShouldNotDerivePartialEq() {
     const UNINIT: ::std::mem::MaybeUninit<ShouldNotDerivePartialEq> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<ShouldNotDerivePartialEq>(),
         4usize,
@@ -27,10 +28,7 @@ fn bindgen_test_layout_ShouldNotDerivePartialEq() {
         concat!("Alignment of ", stringify!(ShouldNotDerivePartialEq))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -40,10 +38,7 @@ fn bindgen_test_layout_ShouldNotDerivePartialEq() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/derive-partialeq-union_1_0.rs
+++ b/tests/expectations/tests/derive-partialeq-union_1_0.rs
@@ -58,6 +58,8 @@ pub struct ShouldDerivePartialEq {
 }
 #[test]
 fn bindgen_test_layout_ShouldDerivePartialEq() {
+    const UNINIT: ::std::mem::MaybeUninit<ShouldDerivePartialEq> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<ShouldDerivePartialEq>(),
         152usize,
@@ -68,42 +70,32 @@ fn bindgen_test_layout_ShouldDerivePartialEq() {
         4usize,
         concat!("Alignment of ", stringify!(ShouldDerivePartialEq))
     );
-    fn test_field_a() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<ShouldDerivePartialEq>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(ShouldDerivePartialEq),
-                "::",
-                stringify!(a)
-            )
-        );
-    }
-    test_field_a();
-    fn test_field_b() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<ShouldDerivePartialEq>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(ShouldDerivePartialEq),
-                "::",
-                stringify!(b)
-            )
-        );
-    }
-    test_field_b();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ShouldDerivePartialEq),
+            "::",
+            stringify!(a)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ShouldDerivePartialEq),
+            "::",
+            stringify!(b)
+        )
+    );
 }
 impl Clone for ShouldDerivePartialEq {
     fn clone(&self) -> Self {

--- a/tests/expectations/tests/derive-partialeq-union_1_0.rs
+++ b/tests/expectations/tests/derive-partialeq-union_1_0.rs
@@ -60,6 +60,7 @@ pub struct ShouldDerivePartialEq {
 fn bindgen_test_layout_ShouldDerivePartialEq() {
     const UNINIT: ::std::mem::MaybeUninit<ShouldDerivePartialEq> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<ShouldDerivePartialEq>(),
         152usize,
@@ -71,10 +72,7 @@ fn bindgen_test_layout_ShouldDerivePartialEq() {
         concat!("Alignment of ", stringify!(ShouldDerivePartialEq))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -84,10 +82,7 @@ fn bindgen_test_layout_ShouldDerivePartialEq() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/disable-nested-struct-naming.rs
+++ b/tests/expectations/tests/disable-nested-struct-naming.rs
@@ -35,6 +35,8 @@ pub struct bar4 {
 }
 #[test]
 fn bindgen_test_layout_bar4() {
+    const UNINIT: ::std::mem::MaybeUninit<bar4> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<bar4>(),
         4usize,
@@ -45,26 +47,19 @@ fn bindgen_test_layout_bar4() {
         4usize,
         concat!("Alignment of ", stringify!(bar4))
     );
-    fn test_field_x4() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<bar4>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).x4) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(bar4),
-                "::",
-                stringify!(x4)
-            )
-        );
-    }
-    test_field_x4();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).x4) as usize - ptr as usize
+        },
+        0usize,
+        concat!("Offset of field: ", stringify!(bar4), "::", stringify!(x4))
+    );
 }
 #[test]
 fn bindgen_test_layout_bar1__bindgen_ty_1__bindgen_ty_1() {
+    const UNINIT: ::std::mem::MaybeUninit<bar1__bindgen_ty_1__bindgen_ty_1> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<bar1__bindgen_ty_1__bindgen_ty_1>(),
         8usize,
@@ -78,47 +73,37 @@ fn bindgen_test_layout_bar1__bindgen_ty_1__bindgen_ty_1() {
             stringify!(bar1__bindgen_ty_1__bindgen_ty_1)
         )
     );
-    fn test_field_x3() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<
-                    bar1__bindgen_ty_1__bindgen_ty_1,
-                >::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).x3) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(bar1__bindgen_ty_1__bindgen_ty_1),
-                "::",
-                stringify!(x3)
-            )
-        );
-    }
-    test_field_x3();
-    fn test_field_b4() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<
-                    bar1__bindgen_ty_1__bindgen_ty_1,
-                >::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).b4) as usize - ptr as usize
-            },
-            4usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(bar1__bindgen_ty_1__bindgen_ty_1),
-                "::",
-                stringify!(b4)
-            )
-        );
-    }
-    test_field_b4();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).x3) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bar1__bindgen_ty_1__bindgen_ty_1),
+            "::",
+            stringify!(x3)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).b4) as usize - ptr as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bar1__bindgen_ty_1__bindgen_ty_1),
+            "::",
+            stringify!(b4)
+        )
+    );
 }
 #[test]
 fn bindgen_test_layout_bar1__bindgen_ty_1() {
+    const UNINIT: ::std::mem::MaybeUninit<bar1__bindgen_ty_1> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<bar1__bindgen_ty_1>(),
         12usize,
@@ -129,45 +114,37 @@ fn bindgen_test_layout_bar1__bindgen_ty_1() {
         4usize,
         concat!("Alignment of ", stringify!(bar1__bindgen_ty_1))
     );
-    fn test_field_x2() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<bar1__bindgen_ty_1>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).x2) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(bar1__bindgen_ty_1),
-                "::",
-                stringify!(x2)
-            )
-        );
-    }
-    test_field_x2();
-    fn test_field_b3() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<bar1__bindgen_ty_1>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).b3) as usize - ptr as usize
-            },
-            4usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(bar1__bindgen_ty_1),
-                "::",
-                stringify!(b3)
-            )
-        );
-    }
-    test_field_b3();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).x2) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bar1__bindgen_ty_1),
+            "::",
+            stringify!(x2)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).b3) as usize - ptr as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bar1__bindgen_ty_1),
+            "::",
+            stringify!(b3)
+        )
+    );
 }
 #[test]
 fn bindgen_test_layout_bar1() {
+    const UNINIT: ::std::mem::MaybeUninit<bar1> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<bar1>(),
         16usize,
@@ -178,43 +155,27 @@ fn bindgen_test_layout_bar1() {
         4usize,
         concat!("Alignment of ", stringify!(bar1))
     );
-    fn test_field_x1() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<bar1>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).x1) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(bar1),
-                "::",
-                stringify!(x1)
-            )
-        );
-    }
-    test_field_x1();
-    fn test_field_b2() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<bar1>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).b2) as usize - ptr as usize
-            },
-            4usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(bar1),
-                "::",
-                stringify!(b2)
-            )
-        );
-    }
-    test_field_b2();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).x1) as usize - ptr as usize
+        },
+        0usize,
+        concat!("Offset of field: ", stringify!(bar1), "::", stringify!(x1))
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).b2) as usize - ptr as usize
+        },
+        4usize,
+        concat!("Offset of field: ", stringify!(bar1), "::", stringify!(b2))
+    );
 }
 #[test]
 fn bindgen_test_layout_foo() {
+    const UNINIT: ::std::mem::MaybeUninit<foo> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<foo>(),
         16usize,
@@ -225,18 +186,14 @@ fn bindgen_test_layout_foo() {
         4usize,
         concat!("Alignment of ", stringify!(foo))
     );
-    fn test_field_b1() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<foo>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).b1) as usize - ptr as usize
-            },
-            0usize,
-            concat!("Offset of field: ", stringify!(foo), "::", stringify!(b1))
-        );
-    }
-    test_field_b1();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).b1) as usize - ptr as usize
+        },
+        0usize,
+        concat!("Offset of field: ", stringify!(foo), "::", stringify!(b1))
+    );
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
@@ -255,6 +212,8 @@ pub struct baz {
 }
 #[test]
 fn bindgen_test_layout_baz() {
+    const UNINIT: ::std::mem::MaybeUninit<baz> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<baz>(),
         4usize,
@@ -265,21 +224,19 @@ fn bindgen_test_layout_baz() {
         4usize,
         concat!("Alignment of ", stringify!(baz))
     );
-    fn test_field_x() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<baz>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize
-            },
-            0usize,
-            concat!("Offset of field: ", stringify!(baz), "::", stringify!(x))
-        );
-    }
-    test_field_x();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize
+        },
+        0usize,
+        concat!("Offset of field: ", stringify!(baz), "::", stringify!(x))
+    );
 }
 #[test]
 fn bindgen_test_layout__bindgen_ty_1__bindgen_ty_1() {
+    const UNINIT: ::std::mem::MaybeUninit<_bindgen_ty_1__bindgen_ty_1> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<_bindgen_ty_1__bindgen_ty_1>(),
         4usize,
@@ -290,28 +247,24 @@ fn bindgen_test_layout__bindgen_ty_1__bindgen_ty_1() {
         4usize,
         concat!("Alignment of ", stringify!(_bindgen_ty_1__bindgen_ty_1))
     );
-    fn test_field_b() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<
-                    _bindgen_ty_1__bindgen_ty_1,
-                >::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(_bindgen_ty_1__bindgen_ty_1),
-                "::",
-                stringify!(b)
-            )
-        );
-    }
-    test_field_b();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(_bindgen_ty_1__bindgen_ty_1),
+            "::",
+            stringify!(b)
+        )
+    );
 }
 #[test]
 fn bindgen_test_layout__bindgen_ty_1() {
+    const UNINIT: ::std::mem::MaybeUninit<_bindgen_ty_1> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<_bindgen_ty_1>(),
         4usize,
@@ -322,23 +275,19 @@ fn bindgen_test_layout__bindgen_ty_1() {
         4usize,
         concat!("Alignment of ", stringify!(_bindgen_ty_1))
     );
-    fn test_field_anon2() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<_bindgen_ty_1>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).anon2) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(_bindgen_ty_1),
-                "::",
-                stringify!(anon2)
-            )
-        );
-    }
-    test_field_anon2();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).anon2) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(_bindgen_ty_1),
+            "::",
+            stringify!(anon2)
+        )
+    );
 }
 extern "C" {
     pub static mut anon1: _bindgen_ty_1;

--- a/tests/expectations/tests/disable-nested-struct-naming.rs
+++ b/tests/expectations/tests/disable-nested-struct-naming.rs
@@ -37,6 +37,7 @@ pub struct bar4 {
 fn bindgen_test_layout_bar4() {
     const UNINIT: ::std::mem::MaybeUninit<bar4> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<bar4>(),
         4usize,
@@ -48,10 +49,7 @@ fn bindgen_test_layout_bar4() {
         concat!("Alignment of ", stringify!(bar4))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).x4) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).x4) as usize - ptr as usize },
         0usize,
         concat!("Offset of field: ", stringify!(bar4), "::", stringify!(x4))
     );
@@ -60,6 +58,7 @@ fn bindgen_test_layout_bar4() {
 fn bindgen_test_layout_bar1__bindgen_ty_1__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<bar1__bindgen_ty_1__bindgen_ty_1> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<bar1__bindgen_ty_1__bindgen_ty_1>(),
         8usize,
@@ -74,10 +73,7 @@ fn bindgen_test_layout_bar1__bindgen_ty_1__bindgen_ty_1() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).x3) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).x3) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -87,10 +83,7 @@ fn bindgen_test_layout_bar1__bindgen_ty_1__bindgen_ty_1() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).b4) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).b4) as usize - ptr as usize },
         4usize,
         concat!(
             "Offset of field: ",
@@ -104,6 +97,7 @@ fn bindgen_test_layout_bar1__bindgen_ty_1__bindgen_ty_1() {
 fn bindgen_test_layout_bar1__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<bar1__bindgen_ty_1> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<bar1__bindgen_ty_1>(),
         12usize,
@@ -115,10 +109,7 @@ fn bindgen_test_layout_bar1__bindgen_ty_1() {
         concat!("Alignment of ", stringify!(bar1__bindgen_ty_1))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).x2) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).x2) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -128,10 +119,7 @@ fn bindgen_test_layout_bar1__bindgen_ty_1() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).b3) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).b3) as usize - ptr as usize },
         4usize,
         concat!(
             "Offset of field: ",
@@ -145,6 +133,7 @@ fn bindgen_test_layout_bar1__bindgen_ty_1() {
 fn bindgen_test_layout_bar1() {
     const UNINIT: ::std::mem::MaybeUninit<bar1> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<bar1>(),
         16usize,
@@ -156,18 +145,12 @@ fn bindgen_test_layout_bar1() {
         concat!("Alignment of ", stringify!(bar1))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).x1) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).x1) as usize - ptr as usize },
         0usize,
         concat!("Offset of field: ", stringify!(bar1), "::", stringify!(x1))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).b2) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).b2) as usize - ptr as usize },
         4usize,
         concat!("Offset of field: ", stringify!(bar1), "::", stringify!(b2))
     );
@@ -176,6 +159,7 @@ fn bindgen_test_layout_bar1() {
 fn bindgen_test_layout_foo() {
     const UNINIT: ::std::mem::MaybeUninit<foo> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<foo>(),
         16usize,
@@ -187,10 +171,7 @@ fn bindgen_test_layout_foo() {
         concat!("Alignment of ", stringify!(foo))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).b1) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).b1) as usize - ptr as usize },
         0usize,
         concat!("Offset of field: ", stringify!(foo), "::", stringify!(b1))
     );
@@ -214,6 +195,7 @@ pub struct baz {
 fn bindgen_test_layout_baz() {
     const UNINIT: ::std::mem::MaybeUninit<baz> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<baz>(),
         4usize,
@@ -225,10 +207,7 @@ fn bindgen_test_layout_baz() {
         concat!("Alignment of ", stringify!(baz))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize },
         0usize,
         concat!("Offset of field: ", stringify!(baz), "::", stringify!(x))
     );
@@ -237,6 +216,7 @@ fn bindgen_test_layout_baz() {
 fn bindgen_test_layout__bindgen_ty_1__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<_bindgen_ty_1__bindgen_ty_1> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<_bindgen_ty_1__bindgen_ty_1>(),
         4usize,
@@ -248,10 +228,7 @@ fn bindgen_test_layout__bindgen_ty_1__bindgen_ty_1() {
         concat!("Alignment of ", stringify!(_bindgen_ty_1__bindgen_ty_1))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -265,6 +242,7 @@ fn bindgen_test_layout__bindgen_ty_1__bindgen_ty_1() {
 fn bindgen_test_layout__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<_bindgen_ty_1> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<_bindgen_ty_1>(),
         4usize,
@@ -276,10 +254,7 @@ fn bindgen_test_layout__bindgen_ty_1() {
         concat!("Alignment of ", stringify!(_bindgen_ty_1))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).anon2) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).anon2) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/disable-untagged-union.rs
+++ b/tests/expectations/tests/disable-untagged-union.rs
@@ -59,6 +59,7 @@ pub struct Foo {
 fn bindgen_test_layout_Foo() {
     const UNINIT: ::std::mem::MaybeUninit<Foo> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<Foo>(),
         4usize,
@@ -70,18 +71,12 @@ fn bindgen_test_layout_Foo() {
         concat!("Alignment of ", stringify!(Foo))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize },
         0usize,
         concat!("Offset of field: ", stringify!(Foo), "::", stringify!(bar))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize },
         0usize,
         concat!("Offset of field: ", stringify!(Foo), "::", stringify!(baz))
     );

--- a/tests/expectations/tests/disable-untagged-union.rs
+++ b/tests/expectations/tests/disable-untagged-union.rs
@@ -57,6 +57,8 @@ pub struct Foo {
 }
 #[test]
 fn bindgen_test_layout_Foo() {
+    const UNINIT: ::std::mem::MaybeUninit<Foo> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<Foo>(),
         4usize,
@@ -67,38 +69,20 @@ fn bindgen_test_layout_Foo() {
         4usize,
         concat!("Alignment of ", stringify!(Foo))
     );
-    fn test_field_bar() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Foo>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(Foo),
-                "::",
-                stringify!(bar)
-            )
-        );
-    }
-    test_field_bar();
-    fn test_field_baz() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Foo>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(Foo),
-                "::",
-                stringify!(baz)
-            )
-        );
-    }
-    test_field_baz();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
+        },
+        0usize,
+        concat!("Offset of field: ", stringify!(Foo), "::", stringify!(bar))
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize
+        },
+        0usize,
+        concat!("Offset of field: ", stringify!(Foo), "::", stringify!(baz))
+    );
 }

--- a/tests/expectations/tests/do-not-derive-copy.rs
+++ b/tests/expectations/tests/do-not-derive-copy.rs
@@ -14,6 +14,7 @@ pub struct WouldBeCopyButWeAreNotDerivingCopy {
 fn bindgen_test_layout_WouldBeCopyButWeAreNotDerivingCopy() {
     const UNINIT: ::std::mem::MaybeUninit<WouldBeCopyButWeAreNotDerivingCopy> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<WouldBeCopyButWeAreNotDerivingCopy>(),
         4usize,
@@ -28,10 +29,7 @@ fn bindgen_test_layout_WouldBeCopyButWeAreNotDerivingCopy() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/do-not-derive-copy.rs
+++ b/tests/expectations/tests/do-not-derive-copy.rs
@@ -12,6 +12,8 @@ pub struct WouldBeCopyButWeAreNotDerivingCopy {
 }
 #[test]
 fn bindgen_test_layout_WouldBeCopyButWeAreNotDerivingCopy() {
+    const UNINIT: ::std::mem::MaybeUninit<WouldBeCopyButWeAreNotDerivingCopy> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<WouldBeCopyButWeAreNotDerivingCopy>(),
         4usize,
@@ -25,23 +27,17 @@ fn bindgen_test_layout_WouldBeCopyButWeAreNotDerivingCopy() {
             stringify!(WouldBeCopyButWeAreNotDerivingCopy)
         )
     );
-    fn test_field_x() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<
-                    WouldBeCopyButWeAreNotDerivingCopy,
-                >::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(WouldBeCopyButWeAreNotDerivingCopy),
-                "::",
-                stringify!(x)
-            )
-        );
-    }
-    test_field_x();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(WouldBeCopyButWeAreNotDerivingCopy),
+            "::",
+            stringify!(x)
+        )
+    );
 }

--- a/tests/expectations/tests/doggo-or-null.rs
+++ b/tests/expectations/tests/doggo-or-null.rs
@@ -12,6 +12,8 @@ pub struct Doggo {
 }
 #[test]
 fn bindgen_test_layout_Doggo() {
+    const UNINIT: ::std::mem::MaybeUninit<Doggo> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<Doggo>(),
         4usize,
@@ -22,23 +24,14 @@ fn bindgen_test_layout_Doggo() {
         4usize,
         concat!("Alignment of ", stringify!(Doggo))
     );
-    fn test_field_x() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Doggo>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(Doggo),
-                "::",
-                stringify!(x)
-            )
-        );
-    }
-    test_field_x();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize
+        },
+        0usize,
+        concat!("Offset of field: ", stringify!(Doggo), "::", stringify!(x))
+    );
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, Hash, PartialEq)]

--- a/tests/expectations/tests/doggo-or-null.rs
+++ b/tests/expectations/tests/doggo-or-null.rs
@@ -14,6 +14,7 @@ pub struct Doggo {
 fn bindgen_test_layout_Doggo() {
     const UNINIT: ::std::mem::MaybeUninit<Doggo> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<Doggo>(),
         4usize,
@@ -25,10 +26,7 @@ fn bindgen_test_layout_Doggo() {
         concat!("Alignment of ", stringify!(Doggo))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize },
         0usize,
         concat!("Offset of field: ", stringify!(Doggo), "::", stringify!(x))
     );

--- a/tests/expectations/tests/duplicated-namespaces-definitions.rs
+++ b/tests/expectations/tests/duplicated-namespaces-definitions.rs
@@ -20,6 +20,8 @@ pub mod root {
         }
         #[test]
         fn bindgen_test_layout_Bar() {
+            const UNINIT: ::std::mem::MaybeUninit<Bar> =
+                ::std::mem::MaybeUninit::uninit();
             assert_eq!(
                 ::std::mem::size_of::<Bar>(),
                 8usize,
@@ -30,40 +32,32 @@ pub mod root {
                 4usize,
                 concat!("Alignment of ", stringify!(Bar))
             );
-            fn test_field_foo() {
-                assert_eq!(
-                    unsafe {
-                        let uninit = ::std::mem::MaybeUninit::<Bar>::uninit();
-                        let ptr = uninit.as_ptr();
-                        ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize
-                    },
-                    0usize,
-                    concat!(
-                        "Offset of field: ",
-                        stringify!(Bar),
-                        "::",
-                        stringify!(foo)
-                    )
-                );
-            }
-            test_field_foo();
-            fn test_field_baz() {
-                assert_eq!(
-                    unsafe {
-                        let uninit = ::std::mem::MaybeUninit::<Bar>::uninit();
-                        let ptr = uninit.as_ptr();
-                        ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize
-                    },
-                    4usize,
-                    concat!(
-                        "Offset of field: ",
-                        stringify!(Bar),
-                        "::",
-                        stringify!(baz)
-                    )
-                );
-            }
-            test_field_baz();
+            assert_eq!(
+                unsafe {
+                    let ptr = UNINIT.as_ptr();
+                    ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize
+                },
+                0usize,
+                concat!(
+                    "Offset of field: ",
+                    stringify!(Bar),
+                    "::",
+                    stringify!(foo)
+                )
+            );
+            assert_eq!(
+                unsafe {
+                    let ptr = UNINIT.as_ptr();
+                    ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize
+                },
+                4usize,
+                concat!(
+                    "Offset of field: ",
+                    stringify!(Bar),
+                    "::",
+                    stringify!(baz)
+                )
+            );
         }
     }
     pub mod bar {
@@ -76,6 +70,8 @@ pub mod root {
         }
         #[test]
         fn bindgen_test_layout_Foo() {
+            const UNINIT: ::std::mem::MaybeUninit<Foo> =
+                ::std::mem::MaybeUninit::uninit();
             assert_eq!(
                 ::std::mem::size_of::<Foo>(),
                 8usize,
@@ -86,23 +82,19 @@ pub mod root {
                 8usize,
                 concat!("Alignment of ", stringify!(Foo))
             );
-            fn test_field_ptr() {
-                assert_eq!(
-                    unsafe {
-                        let uninit = ::std::mem::MaybeUninit::<Foo>::uninit();
-                        let ptr = uninit.as_ptr();
-                        ::std::ptr::addr_of!((*ptr).ptr) as usize - ptr as usize
-                    },
-                    0usize,
-                    concat!(
-                        "Offset of field: ",
-                        stringify!(Foo),
-                        "::",
-                        stringify!(ptr)
-                    )
-                );
-            }
-            test_field_ptr();
+            assert_eq!(
+                unsafe {
+                    let ptr = UNINIT.as_ptr();
+                    ::std::ptr::addr_of!((*ptr).ptr) as usize - ptr as usize
+                },
+                0usize,
+                concat!(
+                    "Offset of field: ",
+                    stringify!(Foo),
+                    "::",
+                    stringify!(ptr)
+                )
+            );
         }
         impl Default for Foo {
             fn default() -> Self {

--- a/tests/expectations/tests/duplicated-namespaces-definitions.rs
+++ b/tests/expectations/tests/duplicated-namespaces-definitions.rs
@@ -22,6 +22,7 @@ pub mod root {
         fn bindgen_test_layout_Bar() {
             const UNINIT: ::std::mem::MaybeUninit<Bar> =
                 ::std::mem::MaybeUninit::uninit();
+            let ptr = UNINIT.as_ptr();
             assert_eq!(
                 ::std::mem::size_of::<Bar>(),
                 8usize,
@@ -34,7 +35,6 @@ pub mod root {
             );
             assert_eq!(
                 unsafe {
-                    let ptr = UNINIT.as_ptr();
                     ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize
                 },
                 0usize,
@@ -47,7 +47,6 @@ pub mod root {
             );
             assert_eq!(
                 unsafe {
-                    let ptr = UNINIT.as_ptr();
                     ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize
                 },
                 4usize,
@@ -72,6 +71,7 @@ pub mod root {
         fn bindgen_test_layout_Foo() {
             const UNINIT: ::std::mem::MaybeUninit<Foo> =
                 ::std::mem::MaybeUninit::uninit();
+            let ptr = UNINIT.as_ptr();
             assert_eq!(
                 ::std::mem::size_of::<Foo>(),
                 8usize,
@@ -84,7 +84,6 @@ pub mod root {
             );
             assert_eq!(
                 unsafe {
-                    let ptr = UNINIT.as_ptr();
                     ::std::ptr::addr_of!((*ptr).ptr) as usize - ptr as usize
                 },
                 0usize,

--- a/tests/expectations/tests/dynamic_loading_with_blocklist.rs
+++ b/tests/expectations/tests/dynamic_loading_with_blocklist.rs
@@ -12,6 +12,8 @@ pub struct X {
 }
 #[test]
 fn bindgen_test_layout_X() {
+    const UNINIT: ::std::mem::MaybeUninit<X> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<X>(),
         4usize,
@@ -22,18 +24,14 @@ fn bindgen_test_layout_X() {
         4usize,
         concat!("Alignment of ", stringify!(X))
     );
-    fn test_field__x() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<X>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr)._x) as usize - ptr as usize
-            },
-            0usize,
-            concat!("Offset of field: ", stringify!(X), "::", stringify!(_x))
-        );
-    }
-    test_field__x();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr)._x) as usize - ptr as usize
+        },
+        0usize,
+        concat!("Offset of field: ", stringify!(X), "::", stringify!(_x))
+    );
 }
 extern "C" {
     #[link_name = "\u{1}_ZN1X13some_functionEv"]

--- a/tests/expectations/tests/dynamic_loading_with_blocklist.rs
+++ b/tests/expectations/tests/dynamic_loading_with_blocklist.rs
@@ -14,6 +14,7 @@ pub struct X {
 fn bindgen_test_layout_X() {
     const UNINIT: ::std::mem::MaybeUninit<X> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<X>(),
         4usize,
@@ -25,10 +26,7 @@ fn bindgen_test_layout_X() {
         concat!("Alignment of ", stringify!(X))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr)._x) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr)._x) as usize - ptr as usize },
         0usize,
         concat!("Offset of field: ", stringify!(X), "::", stringify!(_x))
     );

--- a/tests/expectations/tests/dynamic_loading_with_class.rs
+++ b/tests/expectations/tests/dynamic_loading_with_class.rs
@@ -12,6 +12,8 @@ pub struct A {
 }
 #[test]
 fn bindgen_test_layout_A() {
+    const UNINIT: ::std::mem::MaybeUninit<A> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<A>(),
         4usize,
@@ -22,18 +24,14 @@ fn bindgen_test_layout_A() {
         4usize,
         concat!("Alignment of ", stringify!(A))
     );
-    fn test_field__x() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<A>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr)._x) as usize - ptr as usize
-            },
-            0usize,
-            concat!("Offset of field: ", stringify!(A), "::", stringify!(_x))
-        );
-    }
-    test_field__x();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr)._x) as usize - ptr as usize
+        },
+        0usize,
+        concat!("Offset of field: ", stringify!(A), "::", stringify!(_x))
+    );
 }
 extern "C" {
     #[link_name = "\u{1}_ZN1A13some_functionEv"]

--- a/tests/expectations/tests/dynamic_loading_with_class.rs
+++ b/tests/expectations/tests/dynamic_loading_with_class.rs
@@ -14,6 +14,7 @@ pub struct A {
 fn bindgen_test_layout_A() {
     const UNINIT: ::std::mem::MaybeUninit<A> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<A>(),
         4usize,
@@ -25,10 +26,7 @@ fn bindgen_test_layout_A() {
         concat!("Alignment of ", stringify!(A))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr)._x) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr)._x) as usize - ptr as usize },
         0usize,
         concat!("Offset of field: ", stringify!(A), "::", stringify!(_x))
     );

--- a/tests/expectations/tests/enum-default-bitfield.rs
+++ b/tests/expectations/tests/enum-default-bitfield.rs
@@ -45,6 +45,7 @@ pub struct foo__bindgen_ty_1(pub ::std::os::raw::c_uint);
 fn bindgen_test_layout_foo() {
     const UNINIT: ::std::mem::MaybeUninit<foo> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<foo>(),
         4usize,
@@ -56,10 +57,7 @@ fn bindgen_test_layout_foo() {
         concat!("Alignment of ", stringify!(foo))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).member) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).member) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/enum-default-bitfield.rs
+++ b/tests/expectations/tests/enum-default-bitfield.rs
@@ -43,6 +43,8 @@ impl ::std::ops::BitAndAssign for foo__bindgen_ty_1 {
 pub struct foo__bindgen_ty_1(pub ::std::os::raw::c_uint);
 #[test]
 fn bindgen_test_layout_foo() {
+    const UNINIT: ::std::mem::MaybeUninit<foo> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<foo>(),
         4usize,
@@ -53,23 +55,19 @@ fn bindgen_test_layout_foo() {
         4usize,
         concat!("Alignment of ", stringify!(foo))
     );
-    fn test_field_member() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<foo>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).member) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(foo),
-                "::",
-                stringify!(member)
-            )
-        );
-    }
-    test_field_member();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).member) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(foo),
+            "::",
+            stringify!(member)
+        )
+    );
 }
 impl Default for foo {
     fn default() -> Self {

--- a/tests/expectations/tests/enum-default-consts.rs
+++ b/tests/expectations/tests/enum-default-consts.rs
@@ -15,6 +15,8 @@ pub const foo_FOO_B: foo__bindgen_ty_1 = 1;
 pub type foo__bindgen_ty_1 = ::std::os::raw::c_uint;
 #[test]
 fn bindgen_test_layout_foo() {
+    const UNINIT: ::std::mem::MaybeUninit<foo> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<foo>(),
         4usize,
@@ -25,23 +27,19 @@ fn bindgen_test_layout_foo() {
         4usize,
         concat!("Alignment of ", stringify!(foo))
     );
-    fn test_field_member() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<foo>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).member) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(foo),
-                "::",
-                stringify!(member)
-            )
-        );
-    }
-    test_field_member();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).member) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(foo),
+            "::",
+            stringify!(member)
+        )
+    );
 }
 impl Default for foo {
     fn default() -> Self {

--- a/tests/expectations/tests/enum-default-consts.rs
+++ b/tests/expectations/tests/enum-default-consts.rs
@@ -17,6 +17,7 @@ pub type foo__bindgen_ty_1 = ::std::os::raw::c_uint;
 fn bindgen_test_layout_foo() {
     const UNINIT: ::std::mem::MaybeUninit<foo> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<foo>(),
         4usize,
@@ -28,10 +29,7 @@ fn bindgen_test_layout_foo() {
         concat!("Alignment of ", stringify!(foo))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).member) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).member) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/enum-default-module.rs
+++ b/tests/expectations/tests/enum-default-module.rs
@@ -19,6 +19,7 @@ pub mod foo__bindgen_ty_1 {
 fn bindgen_test_layout_foo() {
     const UNINIT: ::std::mem::MaybeUninit<foo> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<foo>(),
         4usize,
@@ -30,10 +31,7 @@ fn bindgen_test_layout_foo() {
         concat!("Alignment of ", stringify!(foo))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).member) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).member) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/enum-default-module.rs
+++ b/tests/expectations/tests/enum-default-module.rs
@@ -17,6 +17,8 @@ pub mod foo__bindgen_ty_1 {
 }
 #[test]
 fn bindgen_test_layout_foo() {
+    const UNINIT: ::std::mem::MaybeUninit<foo> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<foo>(),
         4usize,
@@ -27,23 +29,19 @@ fn bindgen_test_layout_foo() {
         4usize,
         concat!("Alignment of ", stringify!(foo))
     );
-    fn test_field_member() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<foo>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).member) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(foo),
-                "::",
-                stringify!(member)
-            )
-        );
-    }
-    test_field_member();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).member) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(foo),
+            "::",
+            stringify!(member)
+        )
+    );
 }
 impl Default for foo {
     fn default() -> Self {

--- a/tests/expectations/tests/enum-default-rust.rs
+++ b/tests/expectations/tests/enum-default-rust.rs
@@ -20,6 +20,8 @@ pub enum foo__bindgen_ty_1 {
 }
 #[test]
 fn bindgen_test_layout_foo() {
+    const UNINIT: ::std::mem::MaybeUninit<foo> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<foo>(),
         4usize,
@@ -30,23 +32,19 @@ fn bindgen_test_layout_foo() {
         4usize,
         concat!("Alignment of ", stringify!(foo))
     );
-    fn test_field_member() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<foo>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).member) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(foo),
-                "::",
-                stringify!(member)
-            )
-        );
-    }
-    test_field_member();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).member) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(foo),
+            "::",
+            stringify!(member)
+        )
+    );
 }
 impl Default for foo {
     fn default() -> Self {

--- a/tests/expectations/tests/enum-default-rust.rs
+++ b/tests/expectations/tests/enum-default-rust.rs
@@ -22,6 +22,7 @@ pub enum foo__bindgen_ty_1 {
 fn bindgen_test_layout_foo() {
     const UNINIT: ::std::mem::MaybeUninit<foo> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<foo>(),
         4usize,
@@ -33,10 +34,7 @@ fn bindgen_test_layout_foo() {
         concat!("Alignment of ", stringify!(foo))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).member) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).member) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/enum-no-debug-rust.rs
+++ b/tests/expectations/tests/enum-no-debug-rust.rs
@@ -20,6 +20,8 @@ pub enum foo__bindgen_ty_1 {
 }
 #[test]
 fn bindgen_test_layout_foo() {
+    const UNINIT: ::std::mem::MaybeUninit<foo> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<foo>(),
         4usize,
@@ -30,23 +32,19 @@ fn bindgen_test_layout_foo() {
         4usize,
         concat!("Alignment of ", stringify!(foo))
     );
-    fn test_field_member() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<foo>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).member) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(foo),
-                "::",
-                stringify!(member)
-            )
-        );
-    }
-    test_field_member();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).member) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(foo),
+            "::",
+            stringify!(member)
+        )
+    );
 }
 impl Default for foo {
     fn default() -> Self {

--- a/tests/expectations/tests/enum-no-debug-rust.rs
+++ b/tests/expectations/tests/enum-no-debug-rust.rs
@@ -22,6 +22,7 @@ pub enum foo__bindgen_ty_1 {
 fn bindgen_test_layout_foo() {
     const UNINIT: ::std::mem::MaybeUninit<foo> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<foo>(),
         4usize,
@@ -33,10 +34,7 @@ fn bindgen_test_layout_foo() {
         concat!("Alignment of ", stringify!(foo))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).member) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).member) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/enum.rs
+++ b/tests/expectations/tests/enum.rs
@@ -15,6 +15,8 @@ pub const foo_FOO_B: foo__bindgen_ty_1 = 1;
 pub type foo__bindgen_ty_1 = ::std::os::raw::c_uint;
 #[test]
 fn bindgen_test_layout_foo() {
+    const UNINIT: ::std::mem::MaybeUninit<foo> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<foo>(),
         4usize,
@@ -25,23 +27,19 @@ fn bindgen_test_layout_foo() {
         4usize,
         concat!("Alignment of ", stringify!(foo))
     );
-    fn test_field_member() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<foo>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).member) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(foo),
-                "::",
-                stringify!(member)
-            )
-        );
-    }
-    test_field_member();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).member) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(foo),
+            "::",
+            stringify!(member)
+        )
+    );
 }
 impl Default for foo {
     fn default() -> Self {

--- a/tests/expectations/tests/enum.rs
+++ b/tests/expectations/tests/enum.rs
@@ -17,6 +17,7 @@ pub type foo__bindgen_ty_1 = ::std::os::raw::c_uint;
 fn bindgen_test_layout_foo() {
     const UNINIT: ::std::mem::MaybeUninit<foo> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<foo>(),
         4usize,
@@ -28,10 +29,7 @@ fn bindgen_test_layout_foo() {
         concat!("Alignment of ", stringify!(foo))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).member) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).member) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/enum_and_vtable_mangling.rs
+++ b/tests/expectations/tests/enum_and_vtable_mangling.rs
@@ -25,6 +25,8 @@ pub struct C {
 }
 #[test]
 fn bindgen_test_layout_C() {
+    const UNINIT: ::std::mem::MaybeUninit<C> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<C>(),
         16usize,
@@ -35,18 +37,14 @@ fn bindgen_test_layout_C() {
         8usize,
         concat!("Alignment of ", stringify!(C))
     );
-    fn test_field_i() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<C>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).i) as usize - ptr as usize
-            },
-            8usize,
-            concat!("Offset of field: ", stringify!(C), "::", stringify!(i))
-        );
-    }
-    test_field_i();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).i) as usize - ptr as usize
+        },
+        8usize,
+        concat!("Offset of field: ", stringify!(C), "::", stringify!(i))
+    );
 }
 impl Default for C {
     fn default() -> Self {

--- a/tests/expectations/tests/enum_and_vtable_mangling.rs
+++ b/tests/expectations/tests/enum_and_vtable_mangling.rs
@@ -27,6 +27,7 @@ pub struct C {
 fn bindgen_test_layout_C() {
     const UNINIT: ::std::mem::MaybeUninit<C> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<C>(),
         16usize,
@@ -38,10 +39,7 @@ fn bindgen_test_layout_C() {
         concat!("Alignment of ", stringify!(C))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).i) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).i) as usize - ptr as usize },
         8usize,
         concat!("Offset of field: ", stringify!(C), "::", stringify!(i))
     );

--- a/tests/expectations/tests/explicit-padding.rs
+++ b/tests/expectations/tests/explicit-padding.rs
@@ -16,6 +16,8 @@ pub struct pad_me {
 }
 #[test]
 fn bindgen_test_layout_pad_me() {
+    const UNINIT: ::std::mem::MaybeUninit<pad_me> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<pad_me>(),
         12usize,
@@ -26,57 +28,45 @@ fn bindgen_test_layout_pad_me() {
         4usize,
         concat!("Alignment of ", stringify!(pad_me))
     );
-    fn test_field_first() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<pad_me>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).first) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(pad_me),
-                "::",
-                stringify!(first)
-            )
-        );
-    }
-    test_field_first();
-    fn test_field_second() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<pad_me>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).second) as usize - ptr as usize
-            },
-            4usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(pad_me),
-                "::",
-                stringify!(second)
-            )
-        );
-    }
-    test_field_second();
-    fn test_field_third() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<pad_me>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).third) as usize - ptr as usize
-            },
-            8usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(pad_me),
-                "::",
-                stringify!(third)
-            )
-        );
-    }
-    test_field_third();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).first) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(pad_me),
+            "::",
+            stringify!(first)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).second) as usize - ptr as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(pad_me),
+            "::",
+            stringify!(second)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).third) as usize - ptr as usize
+        },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(pad_me),
+            "::",
+            stringify!(third)
+        )
+    );
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -87,6 +77,8 @@ pub union dont_pad_me {
 }
 #[test]
 fn bindgen_test_layout_dont_pad_me() {
+    const UNINIT: ::std::mem::MaybeUninit<dont_pad_me> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<dont_pad_me>(),
         4usize,
@@ -97,57 +89,45 @@ fn bindgen_test_layout_dont_pad_me() {
         4usize,
         concat!("Alignment of ", stringify!(dont_pad_me))
     );
-    fn test_field_first() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<dont_pad_me>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).first) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(dont_pad_me),
-                "::",
-                stringify!(first)
-            )
-        );
-    }
-    test_field_first();
-    fn test_field_second() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<dont_pad_me>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).second) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(dont_pad_me),
-                "::",
-                stringify!(second)
-            )
-        );
-    }
-    test_field_second();
-    fn test_field_third() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<dont_pad_me>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).third) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(dont_pad_me),
-                "::",
-                stringify!(third)
-            )
-        );
-    }
-    test_field_third();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).first) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(dont_pad_me),
+            "::",
+            stringify!(first)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).second) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(dont_pad_me),
+            "::",
+            stringify!(second)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).third) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(dont_pad_me),
+            "::",
+            stringify!(third)
+        )
+    );
 }
 impl Default for dont_pad_me {
     fn default() -> Self {

--- a/tests/expectations/tests/explicit-padding.rs
+++ b/tests/expectations/tests/explicit-padding.rs
@@ -18,6 +18,7 @@ pub struct pad_me {
 fn bindgen_test_layout_pad_me() {
     const UNINIT: ::std::mem::MaybeUninit<pad_me> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<pad_me>(),
         12usize,
@@ -29,10 +30,7 @@ fn bindgen_test_layout_pad_me() {
         concat!("Alignment of ", stringify!(pad_me))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).first) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).first) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -42,10 +40,7 @@ fn bindgen_test_layout_pad_me() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).second) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).second) as usize - ptr as usize },
         4usize,
         concat!(
             "Offset of field: ",
@@ -55,10 +50,7 @@ fn bindgen_test_layout_pad_me() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).third) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).third) as usize - ptr as usize },
         8usize,
         concat!(
             "Offset of field: ",
@@ -79,6 +71,7 @@ pub union dont_pad_me {
 fn bindgen_test_layout_dont_pad_me() {
     const UNINIT: ::std::mem::MaybeUninit<dont_pad_me> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<dont_pad_me>(),
         4usize,
@@ -90,10 +83,7 @@ fn bindgen_test_layout_dont_pad_me() {
         concat!("Alignment of ", stringify!(dont_pad_me))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).first) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).first) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -103,10 +93,7 @@ fn bindgen_test_layout_dont_pad_me() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).second) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).second) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -116,10 +103,7 @@ fn bindgen_test_layout_dont_pad_me() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).third) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).third) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/extern-const-struct.rs
+++ b/tests/expectations/tests/extern-const-struct.rs
@@ -12,6 +12,8 @@ pub struct nsFoo {
 }
 #[test]
 fn bindgen_test_layout_nsFoo() {
+    const UNINIT: ::std::mem::MaybeUninit<nsFoo> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<nsFoo>(),
         1600usize,
@@ -22,23 +24,19 @@ fn bindgen_test_layout_nsFoo() {
         4usize,
         concat!("Alignment of ", stringify!(nsFoo))
     );
-    fn test_field_details() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<nsFoo>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).details) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(nsFoo),
-                "::",
-                stringify!(details)
-            )
-        );
-    }
-    test_field_details();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).details) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(nsFoo),
+            "::",
+            stringify!(details)
+        )
+    );
 }
 impl Default for nsFoo {
     fn default() -> Self {

--- a/tests/expectations/tests/extern-const-struct.rs
+++ b/tests/expectations/tests/extern-const-struct.rs
@@ -14,6 +14,7 @@ pub struct nsFoo {
 fn bindgen_test_layout_nsFoo() {
     const UNINIT: ::std::mem::MaybeUninit<nsFoo> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<nsFoo>(),
         1600usize,
@@ -25,10 +26,7 @@ fn bindgen_test_layout_nsFoo() {
         concat!("Alignment of ", stringify!(nsFoo))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).details) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).details) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/forward-declaration-autoptr.rs
+++ b/tests/expectations/tests/forward-declaration-autoptr.rs
@@ -32,6 +32,8 @@ pub struct Bar {
 }
 #[test]
 fn bindgen_test_layout_Bar() {
+    const UNINIT: ::std::mem::MaybeUninit<Bar> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<Bar>(),
         8usize,
@@ -42,23 +44,19 @@ fn bindgen_test_layout_Bar() {
         8usize,
         concat!("Alignment of ", stringify!(Bar))
     );
-    fn test_field_m_member() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Bar>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).m_member) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(Bar),
-                "::",
-                stringify!(m_member)
-            )
-        );
-    }
-    test_field_m_member();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).m_member) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(Bar),
+            "::",
+            stringify!(m_member)
+        )
+    );
 }
 impl Default for Bar {
     fn default() -> Self {

--- a/tests/expectations/tests/forward-declaration-autoptr.rs
+++ b/tests/expectations/tests/forward-declaration-autoptr.rs
@@ -34,6 +34,7 @@ pub struct Bar {
 fn bindgen_test_layout_Bar() {
     const UNINIT: ::std::mem::MaybeUninit<Bar> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<Bar>(),
         8usize,
@@ -46,7 +47,6 @@ fn bindgen_test_layout_Bar() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).m_member) as usize - ptr as usize
         },
         0usize,

--- a/tests/expectations/tests/forward_declared_complex_types.rs
+++ b/tests/expectations/tests/forward_declared_complex_types.rs
@@ -35,6 +35,8 @@ pub struct Bar {
 }
 #[test]
 fn bindgen_test_layout_Bar() {
+    const UNINIT: ::std::mem::MaybeUninit<Bar> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<Bar>(),
         8usize,
@@ -45,18 +47,14 @@ fn bindgen_test_layout_Bar() {
         8usize,
         concat!("Alignment of ", stringify!(Bar))
     );
-    fn test_field_f() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Bar>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).f) as usize - ptr as usize
-            },
-            0usize,
-            concat!("Offset of field: ", stringify!(Bar), "::", stringify!(f))
-        );
-    }
-    test_field_f();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).f) as usize - ptr as usize
+        },
+        0usize,
+        concat!("Offset of field: ", stringify!(Bar), "::", stringify!(f))
+    );
 }
 impl Default for Bar {
     fn default() -> Self {

--- a/tests/expectations/tests/forward_declared_complex_types.rs
+++ b/tests/expectations/tests/forward_declared_complex_types.rs
@@ -37,6 +37,7 @@ pub struct Bar {
 fn bindgen_test_layout_Bar() {
     const UNINIT: ::std::mem::MaybeUninit<Bar> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<Bar>(),
         8usize,
@@ -48,10 +49,7 @@ fn bindgen_test_layout_Bar() {
         concat!("Alignment of ", stringify!(Bar))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).f) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).f) as usize - ptr as usize },
         0usize,
         concat!("Offset of field: ", stringify!(Bar), "::", stringify!(f))
     );

--- a/tests/expectations/tests/forward_declared_complex_types_1_0.rs
+++ b/tests/expectations/tests/forward_declared_complex_types_1_0.rs
@@ -47,6 +47,7 @@ pub struct Bar {
 fn bindgen_test_layout_Bar() {
     const UNINIT: ::std::mem::MaybeUninit<Bar> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<Bar>(),
         8usize,
@@ -58,10 +59,7 @@ fn bindgen_test_layout_Bar() {
         concat!("Alignment of ", stringify!(Bar))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).f) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).f) as usize - ptr as usize },
         0usize,
         concat!("Offset of field: ", stringify!(Bar), "::", stringify!(f))
     );

--- a/tests/expectations/tests/forward_declared_complex_types_1_0.rs
+++ b/tests/expectations/tests/forward_declared_complex_types_1_0.rs
@@ -45,6 +45,8 @@ pub struct Bar {
 }
 #[test]
 fn bindgen_test_layout_Bar() {
+    const UNINIT: ::std::mem::MaybeUninit<Bar> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<Bar>(),
         8usize,
@@ -55,18 +57,14 @@ fn bindgen_test_layout_Bar() {
         8usize,
         concat!("Alignment of ", stringify!(Bar))
     );
-    fn test_field_f() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Bar>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).f) as usize - ptr as usize
-            },
-            0usize,
-            concat!("Offset of field: ", stringify!(Bar), "::", stringify!(f))
-        );
-    }
-    test_field_f();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).f) as usize - ptr as usize
+        },
+        0usize,
+        concat!("Offset of field: ", stringify!(Bar), "::", stringify!(f))
+    );
 }
 impl Clone for Bar {
     fn clone(&self) -> Self {

--- a/tests/expectations/tests/forward_declared_struct.rs
+++ b/tests/expectations/tests/forward_declared_struct.rs
@@ -14,6 +14,7 @@ pub struct a {
 fn bindgen_test_layout_a() {
     const UNINIT: ::std::mem::MaybeUninit<a> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<a>(),
         4usize,
@@ -25,10 +26,7 @@ fn bindgen_test_layout_a() {
         concat!("Alignment of ", stringify!(a))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
         0usize,
         concat!("Offset of field: ", stringify!(a), "::", stringify!(b))
     );
@@ -42,6 +40,7 @@ pub struct c {
 fn bindgen_test_layout_c() {
     const UNINIT: ::std::mem::MaybeUninit<c> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<c>(),
         4usize,
@@ -53,10 +52,7 @@ fn bindgen_test_layout_c() {
         concat!("Alignment of ", stringify!(c))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize },
         0usize,
         concat!("Offset of field: ", stringify!(c), "::", stringify!(d))
     );

--- a/tests/expectations/tests/forward_declared_struct.rs
+++ b/tests/expectations/tests/forward_declared_struct.rs
@@ -12,6 +12,8 @@ pub struct a {
 }
 #[test]
 fn bindgen_test_layout_a() {
+    const UNINIT: ::std::mem::MaybeUninit<a> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<a>(),
         4usize,
@@ -22,18 +24,14 @@ fn bindgen_test_layout_a() {
         4usize,
         concat!("Alignment of ", stringify!(a))
     );
-    fn test_field_b() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<a>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-            },
-            0usize,
-            concat!("Offset of field: ", stringify!(a), "::", stringify!(b))
-        );
-    }
-    test_field_b();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
+        },
+        0usize,
+        concat!("Offset of field: ", stringify!(a), "::", stringify!(b))
+    );
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
@@ -42,6 +40,8 @@ pub struct c {
 }
 #[test]
 fn bindgen_test_layout_c() {
+    const UNINIT: ::std::mem::MaybeUninit<c> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<c>(),
         4usize,
@@ -52,16 +52,12 @@ fn bindgen_test_layout_c() {
         4usize,
         concat!("Alignment of ", stringify!(c))
     );
-    fn test_field_d() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<c>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize
-            },
-            0usize,
-            concat!("Offset of field: ", stringify!(c), "::", stringify!(d))
-        );
-    }
-    test_field_d();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize
+        },
+        0usize,
+        concat!("Offset of field: ", stringify!(c), "::", stringify!(d))
+    );
 }

--- a/tests/expectations/tests/func_ptr_in_struct.rs
+++ b/tests/expectations/tests/func_ptr_in_struct.rs
@@ -22,6 +22,8 @@ pub struct Foo {
 }
 #[test]
 fn bindgen_test_layout_Foo() {
+    const UNINIT: ::std::mem::MaybeUninit<Foo> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<Foo>(),
         8usize,
@@ -32,21 +34,12 @@ fn bindgen_test_layout_Foo() {
         8usize,
         concat!("Alignment of ", stringify!(Foo))
     );
-    fn test_field_bar() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Foo>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(Foo),
-                "::",
-                stringify!(bar)
-            )
-        );
-    }
-    test_field_bar();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
+        },
+        0usize,
+        concat!("Offset of field: ", stringify!(Foo), "::", stringify!(bar))
+    );
 }

--- a/tests/expectations/tests/func_ptr_in_struct.rs
+++ b/tests/expectations/tests/func_ptr_in_struct.rs
@@ -24,6 +24,7 @@ pub struct Foo {
 fn bindgen_test_layout_Foo() {
     const UNINIT: ::std::mem::MaybeUninit<Foo> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<Foo>(),
         8usize,
@@ -35,10 +36,7 @@ fn bindgen_test_layout_Foo() {
         concat!("Alignment of ", stringify!(Foo))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize },
         0usize,
         concat!("Offset of field: ", stringify!(Foo), "::", stringify!(bar))
     );

--- a/tests/expectations/tests/gen-destructors-neg.rs
+++ b/tests/expectations/tests/gen-destructors-neg.rs
@@ -12,6 +12,8 @@ pub struct Foo {
 }
 #[test]
 fn bindgen_test_layout_Foo() {
+    const UNINIT: ::std::mem::MaybeUninit<Foo> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<Foo>(),
         4usize,
@@ -22,21 +24,12 @@ fn bindgen_test_layout_Foo() {
         4usize,
         concat!("Alignment of ", stringify!(Foo))
     );
-    fn test_field_bar() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Foo>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(Foo),
-                "::",
-                stringify!(bar)
-            )
-        );
-    }
-    test_field_bar();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
+        },
+        0usize,
+        concat!("Offset of field: ", stringify!(Foo), "::", stringify!(bar))
+    );
 }

--- a/tests/expectations/tests/gen-destructors-neg.rs
+++ b/tests/expectations/tests/gen-destructors-neg.rs
@@ -14,6 +14,7 @@ pub struct Foo {
 fn bindgen_test_layout_Foo() {
     const UNINIT: ::std::mem::MaybeUninit<Foo> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<Foo>(),
         4usize,
@@ -25,10 +26,7 @@ fn bindgen_test_layout_Foo() {
         concat!("Alignment of ", stringify!(Foo))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize },
         0usize,
         concat!("Offset of field: ", stringify!(Foo), "::", stringify!(bar))
     );

--- a/tests/expectations/tests/gen-destructors.rs
+++ b/tests/expectations/tests/gen-destructors.rs
@@ -12,6 +12,8 @@ pub struct Foo {
 }
 #[test]
 fn bindgen_test_layout_Foo() {
+    const UNINIT: ::std::mem::MaybeUninit<Foo> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<Foo>(),
         4usize,
@@ -22,23 +24,14 @@ fn bindgen_test_layout_Foo() {
         4usize,
         concat!("Alignment of ", stringify!(Foo))
     );
-    fn test_field_bar() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Foo>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(Foo),
-                "::",
-                stringify!(bar)
-            )
-        );
-    }
-    test_field_bar();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
+        },
+        0usize,
+        concat!("Offset of field: ", stringify!(Foo), "::", stringify!(bar))
+    );
 }
 extern "C" {
     #[link_name = "\u{1}_ZN3FooD1Ev"]

--- a/tests/expectations/tests/gen-destructors.rs
+++ b/tests/expectations/tests/gen-destructors.rs
@@ -14,6 +14,7 @@ pub struct Foo {
 fn bindgen_test_layout_Foo() {
     const UNINIT: ::std::mem::MaybeUninit<Foo> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<Foo>(),
         4usize,
@@ -25,10 +26,7 @@ fn bindgen_test_layout_Foo() {
         concat!("Alignment of ", stringify!(Foo))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize },
         0usize,
         concat!("Offset of field: ", stringify!(Foo), "::", stringify!(bar))
     );

--- a/tests/expectations/tests/i128.rs
+++ b/tests/expectations/tests/i128.rs
@@ -16,6 +16,7 @@ pub struct foo {
 fn bindgen_test_layout_foo() {
     const UNINIT: ::std::mem::MaybeUninit<foo> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<foo>(),
         32usize,
@@ -28,7 +29,6 @@ fn bindgen_test_layout_foo() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).my_signed) as usize - ptr as usize
         },
         0usize,
@@ -41,7 +41,6 @@ fn bindgen_test_layout_foo() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).my_unsigned) as usize - ptr as usize
         },
         16usize,

--- a/tests/expectations/tests/i128.rs
+++ b/tests/expectations/tests/i128.rs
@@ -14,6 +14,8 @@ pub struct foo {
 }
 #[test]
 fn bindgen_test_layout_foo() {
+    const UNINIT: ::std::mem::MaybeUninit<foo> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<foo>(),
         32usize,
@@ -24,38 +26,30 @@ fn bindgen_test_layout_foo() {
         16usize,
         concat!("Alignment of ", stringify!(foo))
     );
-    fn test_field_my_signed() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<foo>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).my_signed) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(foo),
-                "::",
-                stringify!(my_signed)
-            )
-        );
-    }
-    test_field_my_signed();
-    fn test_field_my_unsigned() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<foo>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).my_unsigned) as usize - ptr as usize
-            },
-            16usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(foo),
-                "::",
-                stringify!(my_unsigned)
-            )
-        );
-    }
-    test_field_my_unsigned();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).my_signed) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(foo),
+            "::",
+            stringify!(my_signed)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).my_unsigned) as usize - ptr as usize
+        },
+        16usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(foo),
+            "::",
+            stringify!(my_unsigned)
+        )
+    );
 }

--- a/tests/expectations/tests/inline_namespace.rs
+++ b/tests/expectations/tests/inline_namespace.rs
@@ -23,6 +23,7 @@ pub mod root {
     fn bindgen_test_layout_Bar() {
         const UNINIT: ::std::mem::MaybeUninit<Bar> =
             ::std::mem::MaybeUninit::uninit();
+        let ptr = UNINIT.as_ptr();
         assert_eq!(
             ::std::mem::size_of::<Bar>(),
             4usize,
@@ -34,10 +35,7 @@ pub mod root {
             concat!("Alignment of ", stringify!(Bar))
         );
         assert_eq!(
-            unsafe {
-                let ptr = UNINIT.as_ptr();
-                ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize
-            },
+            unsafe { ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize },
             0usize,
             concat!(
                 "Offset of field: ",

--- a/tests/expectations/tests/inline_namespace.rs
+++ b/tests/expectations/tests/inline_namespace.rs
@@ -21,6 +21,8 @@ pub mod root {
     }
     #[test]
     fn bindgen_test_layout_Bar() {
+        const UNINIT: ::std::mem::MaybeUninit<Bar> =
+            ::std::mem::MaybeUninit::uninit();
         assert_eq!(
             ::std::mem::size_of::<Bar>(),
             4usize,
@@ -31,22 +33,18 @@ pub mod root {
             4usize,
             concat!("Alignment of ", stringify!(Bar))
         );
-        fn test_field_baz() {
-            assert_eq!(
-                unsafe {
-                    let uninit = ::std::mem::MaybeUninit::<Bar>::uninit();
-                    let ptr = uninit.as_ptr();
-                    ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize
-                },
-                0usize,
-                concat!(
-                    "Offset of field: ",
-                    stringify!(Bar),
-                    "::",
-                    stringify!(baz)
-                )
-            );
-        }
-        test_field_baz();
+        assert_eq!(
+            unsafe {
+                let ptr = UNINIT.as_ptr();
+                ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(Bar),
+                "::",
+                stringify!(baz)
+            )
+        );
     }
 }

--- a/tests/expectations/tests/inline_namespace_conservative.rs
+++ b/tests/expectations/tests/inline_namespace_conservative.rs
@@ -26,6 +26,8 @@ pub mod root {
     }
     #[test]
     fn bindgen_test_layout_Bar() {
+        const UNINIT: ::std::mem::MaybeUninit<Bar> =
+            ::std::mem::MaybeUninit::uninit();
         assert_eq!(
             ::std::mem::size_of::<Bar>(),
             4usize,
@@ -36,22 +38,18 @@ pub mod root {
             4usize,
             concat!("Alignment of ", stringify!(Bar))
         );
-        fn test_field_baz() {
-            assert_eq!(
-                unsafe {
-                    let uninit = ::std::mem::MaybeUninit::<Bar>::uninit();
-                    let ptr = uninit.as_ptr();
-                    ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize
-                },
-                0usize,
-                concat!(
-                    "Offset of field: ",
-                    stringify!(Bar),
-                    "::",
-                    stringify!(baz)
-                )
-            );
-        }
-        test_field_baz();
+        assert_eq!(
+            unsafe {
+                let ptr = UNINIT.as_ptr();
+                ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(Bar),
+                "::",
+                stringify!(baz)
+            )
+        );
     }
 }

--- a/tests/expectations/tests/inline_namespace_conservative.rs
+++ b/tests/expectations/tests/inline_namespace_conservative.rs
@@ -28,6 +28,7 @@ pub mod root {
     fn bindgen_test_layout_Bar() {
         const UNINIT: ::std::mem::MaybeUninit<Bar> =
             ::std::mem::MaybeUninit::uninit();
+        let ptr = UNINIT.as_ptr();
         assert_eq!(
             ::std::mem::size_of::<Bar>(),
             4usize,
@@ -39,10 +40,7 @@ pub mod root {
             concat!("Alignment of ", stringify!(Bar))
         );
         assert_eq!(
-            unsafe {
-                let ptr = UNINIT.as_ptr();
-                ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize
-            },
+            unsafe { ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize },
             0usize,
             concat!(
                 "Offset of field: ",

--- a/tests/expectations/tests/inner_const.rs
+++ b/tests/expectations/tests/inner_const.rs
@@ -20,6 +20,8 @@ extern "C" {
 }
 #[test]
 fn bindgen_test_layout_Foo() {
+    const UNINIT: ::std::mem::MaybeUninit<Foo> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<Foo>(),
         4usize,
@@ -30,21 +32,12 @@ fn bindgen_test_layout_Foo() {
         4usize,
         concat!("Alignment of ", stringify!(Foo))
     );
-    fn test_field_bar() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Foo>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(Foo),
-                "::",
-                stringify!(bar)
-            )
-        );
-    }
-    test_field_bar();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
+        },
+        0usize,
+        concat!("Offset of field: ", stringify!(Foo), "::", stringify!(bar))
+    );
 }

--- a/tests/expectations/tests/inner_const.rs
+++ b/tests/expectations/tests/inner_const.rs
@@ -22,6 +22,7 @@ extern "C" {
 fn bindgen_test_layout_Foo() {
     const UNINIT: ::std::mem::MaybeUninit<Foo> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<Foo>(),
         4usize,
@@ -33,10 +34,7 @@ fn bindgen_test_layout_Foo() {
         concat!("Alignment of ", stringify!(Foo))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize },
         0usize,
         concat!("Offset of field: ", stringify!(Foo), "::", stringify!(bar))
     );

--- a/tests/expectations/tests/inner_template_self.rs
+++ b/tests/expectations/tests/inner_template_self.rs
@@ -27,6 +27,8 @@ pub struct InstantiateIt {
 }
 #[test]
 fn bindgen_test_layout_InstantiateIt() {
+    const UNINIT: ::std::mem::MaybeUninit<InstantiateIt> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<InstantiateIt>(),
         16usize,
@@ -37,23 +39,19 @@ fn bindgen_test_layout_InstantiateIt() {
         8usize,
         concat!("Alignment of ", stringify!(InstantiateIt))
     );
-    fn test_field_m_list() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<InstantiateIt>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).m_list) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(InstantiateIt),
-                "::",
-                stringify!(m_list)
-            )
-        );
-    }
-    test_field_m_list();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).m_list) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(InstantiateIt),
+            "::",
+            stringify!(m_list)
+        )
+    );
 }
 impl Default for InstantiateIt {
     fn default() -> Self {

--- a/tests/expectations/tests/inner_template_self.rs
+++ b/tests/expectations/tests/inner_template_self.rs
@@ -29,6 +29,7 @@ pub struct InstantiateIt {
 fn bindgen_test_layout_InstantiateIt() {
     const UNINIT: ::std::mem::MaybeUninit<InstantiateIt> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<InstantiateIt>(),
         16usize,
@@ -40,10 +41,7 @@ fn bindgen_test_layout_InstantiateIt() {
         concat!("Alignment of ", stringify!(InstantiateIt))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).m_list) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).m_list) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/issue-1118-using-forward-decl.rs
+++ b/tests/expectations/tests/issue-1118-using-forward-decl.rs
@@ -15,6 +15,7 @@ pub struct nsTArray_base {
 fn bindgen_test_layout_nsTArray_base() {
     const UNINIT: ::std::mem::MaybeUninit<nsTArray_base> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<nsTArray_base>(),
         8usize,
@@ -26,10 +27,7 @@ fn bindgen_test_layout_nsTArray_base() {
         concat!("Alignment of ", stringify!(nsTArray_base))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -71,6 +69,7 @@ pub struct nsIContent {
 fn bindgen_test_layout_nsIContent() {
     const UNINIT: ::std::mem::MaybeUninit<nsIContent> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<nsIContent>(),
         8usize,
@@ -82,10 +81,7 @@ fn bindgen_test_layout_nsIContent() {
         concat!("Alignment of ", stringify!(nsIContent))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/issue-1118-using-forward-decl.rs
+++ b/tests/expectations/tests/issue-1118-using-forward-decl.rs
@@ -13,6 +13,8 @@ pub struct nsTArray_base {
 }
 #[test]
 fn bindgen_test_layout_nsTArray_base() {
+    const UNINIT: ::std::mem::MaybeUninit<nsTArray_base> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<nsTArray_base>(),
         8usize,
@@ -23,23 +25,19 @@ fn bindgen_test_layout_nsTArray_base() {
         8usize,
         concat!("Alignment of ", stringify!(nsTArray_base))
     );
-    fn test_field_d() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<nsTArray_base>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(nsTArray_base),
-                "::",
-                stringify!(d)
-            )
-        );
-    }
-    test_field_d();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(nsTArray_base),
+            "::",
+            stringify!(d)
+        )
+    );
 }
 impl Default for nsTArray_base {
     fn default() -> Self {
@@ -71,6 +69,8 @@ pub struct nsIContent {
 }
 #[test]
 fn bindgen_test_layout_nsIContent() {
+    const UNINIT: ::std::mem::MaybeUninit<nsIContent> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<nsIContent>(),
         8usize,
@@ -81,23 +81,19 @@ fn bindgen_test_layout_nsIContent() {
         8usize,
         concat!("Alignment of ", stringify!(nsIContent))
     );
-    fn test_field_foo() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<nsIContent>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(nsIContent),
-                "::",
-                stringify!(foo)
-            )
-        );
-    }
-    test_field_foo();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(nsIContent),
+            "::",
+            stringify!(foo)
+        )
+    );
 }
 impl Default for nsIContent {
     fn default() -> Self {

--- a/tests/expectations/tests/issue-1216-variadic-member.rs
+++ b/tests/expectations/tests/issue-1216-variadic-member.rs
@@ -22,6 +22,8 @@ pub struct Foo {
 }
 #[test]
 fn bindgen_test_layout_Foo() {
+    const UNINIT: ::std::mem::MaybeUninit<Foo> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<Foo>(),
         8usize,
@@ -32,16 +34,12 @@ fn bindgen_test_layout_Foo() {
         8usize,
         concat!("Alignment of ", stringify!(Foo))
     );
-    fn test_field_f() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Foo>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).f) as usize - ptr as usize
-            },
-            0usize,
-            concat!("Offset of field: ", stringify!(Foo), "::", stringify!(f))
-        );
-    }
-    test_field_f();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).f) as usize - ptr as usize
+        },
+        0usize,
+        concat!("Offset of field: ", stringify!(Foo), "::", stringify!(f))
+    );
 }

--- a/tests/expectations/tests/issue-1216-variadic-member.rs
+++ b/tests/expectations/tests/issue-1216-variadic-member.rs
@@ -24,6 +24,7 @@ pub struct Foo {
 fn bindgen_test_layout_Foo() {
     const UNINIT: ::std::mem::MaybeUninit<Foo> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<Foo>(),
         8usize,
@@ -35,10 +36,7 @@ fn bindgen_test_layout_Foo() {
         concat!("Alignment of ", stringify!(Foo))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).f) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).f) as usize - ptr as usize },
         0usize,
         concat!("Offset of field: ", stringify!(Foo), "::", stringify!(f))
     );

--- a/tests/expectations/tests/issue-1281.rs
+++ b/tests/expectations/tests/issue-1281.rs
@@ -19,6 +19,7 @@ pub struct foo {
 fn bindgen_test_layout_foo() {
     const UNINIT: ::std::mem::MaybeUninit<foo> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<foo>(),
         4usize,
@@ -30,10 +31,7 @@ fn bindgen_test_layout_foo() {
         concat!("Alignment of ", stringify!(foo))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize },
         0usize,
         concat!("Offset of field: ", stringify!(foo), "::", stringify!(foo))
     );
@@ -42,6 +40,7 @@ fn bindgen_test_layout_foo() {
 fn bindgen_test_layout_bar() {
     const UNINIT: ::std::mem::MaybeUninit<bar> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<bar>(),
         4usize,
@@ -53,10 +52,7 @@ fn bindgen_test_layout_bar() {
         concat!("Alignment of ", stringify!(bar))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).u) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).u) as usize - ptr as usize },
         0usize,
         concat!("Offset of field: ", stringify!(bar), "::", stringify!(u))
     );
@@ -71,6 +67,7 @@ pub struct baz {
 fn bindgen_test_layout_baz() {
     const UNINIT: ::std::mem::MaybeUninit<baz> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<baz>(),
         4usize,
@@ -82,10 +79,7 @@ fn bindgen_test_layout_baz() {
         concat!("Alignment of ", stringify!(baz))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).f) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).f) as usize - ptr as usize },
         0usize,
         concat!("Offset of field: ", stringify!(baz), "::", stringify!(f))
     );

--- a/tests/expectations/tests/issue-1281.rs
+++ b/tests/expectations/tests/issue-1281.rs
@@ -17,6 +17,8 @@ pub struct foo {
 }
 #[test]
 fn bindgen_test_layout_foo() {
+    const UNINIT: ::std::mem::MaybeUninit<foo> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<foo>(),
         4usize,
@@ -27,26 +29,19 @@ fn bindgen_test_layout_foo() {
         4usize,
         concat!("Alignment of ", stringify!(foo))
     );
-    fn test_field_foo() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<foo>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(foo),
-                "::",
-                stringify!(foo)
-            )
-        );
-    }
-    test_field_foo();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize
+        },
+        0usize,
+        concat!("Offset of field: ", stringify!(foo), "::", stringify!(foo))
+    );
 }
 #[test]
 fn bindgen_test_layout_bar() {
+    const UNINIT: ::std::mem::MaybeUninit<bar> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<bar>(),
         4usize,
@@ -57,18 +52,14 @@ fn bindgen_test_layout_bar() {
         4usize,
         concat!("Alignment of ", stringify!(bar))
     );
-    fn test_field_u() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<bar>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).u) as usize - ptr as usize
-            },
-            0usize,
-            concat!("Offset of field: ", stringify!(bar), "::", stringify!(u))
-        );
-    }
-    test_field_u();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).u) as usize - ptr as usize
+        },
+        0usize,
+        concat!("Offset of field: ", stringify!(bar), "::", stringify!(u))
+    );
 }
 pub type bar_t = bar;
 #[repr(C)]
@@ -78,6 +69,8 @@ pub struct baz {
 }
 #[test]
 fn bindgen_test_layout_baz() {
+    const UNINIT: ::std::mem::MaybeUninit<baz> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<baz>(),
         4usize,
@@ -88,16 +81,12 @@ fn bindgen_test_layout_baz() {
         4usize,
         concat!("Alignment of ", stringify!(baz))
     );
-    fn test_field_f() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<baz>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).f) as usize - ptr as usize
-            },
-            0usize,
-            concat!("Offset of field: ", stringify!(baz), "::", stringify!(f))
-        );
-    }
-    test_field_f();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).f) as usize - ptr as usize
+        },
+        0usize,
+        concat!("Offset of field: ", stringify!(baz), "::", stringify!(f))
+    );
 }

--- a/tests/expectations/tests/issue-1285.rs
+++ b/tests/expectations/tests/issue-1285.rs
@@ -20,6 +20,7 @@ pub union foo__bindgen_ty_1 {
 fn bindgen_test_layout_foo__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<foo__bindgen_ty_1> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<foo__bindgen_ty_1>(),
         4usize,
@@ -31,10 +32,7 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
         concat!("Alignment of ", stringify!(foo__bindgen_ty_1))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -44,10 +42,7 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -70,6 +65,7 @@ impl Default for foo__bindgen_ty_1 {
 fn bindgen_test_layout_foo() {
     const UNINIT: ::std::mem::MaybeUninit<foo> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<foo>(),
         4usize,
@@ -81,10 +77,7 @@ fn bindgen_test_layout_foo() {
         concat!("Alignment of ", stringify!(foo))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize },
         0usize,
         concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar))
     );

--- a/tests/expectations/tests/issue-1285.rs
+++ b/tests/expectations/tests/issue-1285.rs
@@ -18,6 +18,8 @@ pub union foo__bindgen_ty_1 {
 }
 #[test]
 fn bindgen_test_layout_foo__bindgen_ty_1() {
+    const UNINIT: ::std::mem::MaybeUninit<foo__bindgen_ty_1> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<foo__bindgen_ty_1>(),
         4usize,
@@ -28,42 +30,32 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
         4usize,
         concat!("Alignment of ", stringify!(foo__bindgen_ty_1))
     );
-    fn test_field_a() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<foo__bindgen_ty_1>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(foo__bindgen_ty_1),
-                "::",
-                stringify!(a)
-            )
-        );
-    }
-    test_field_a();
-    fn test_field_b() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<foo__bindgen_ty_1>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(foo__bindgen_ty_1),
-                "::",
-                stringify!(b)
-            )
-        );
-    }
-    test_field_b();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(foo__bindgen_ty_1),
+            "::",
+            stringify!(a)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(foo__bindgen_ty_1),
+            "::",
+            stringify!(b)
+        )
+    );
 }
 impl Default for foo__bindgen_ty_1 {
     fn default() -> Self {
@@ -76,6 +68,8 @@ impl Default for foo__bindgen_ty_1 {
 }
 #[test]
 fn bindgen_test_layout_foo() {
+    const UNINIT: ::std::mem::MaybeUninit<foo> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<foo>(),
         4usize,
@@ -86,23 +80,14 @@ fn bindgen_test_layout_foo() {
         4usize,
         concat!("Alignment of ", stringify!(foo))
     );
-    fn test_field_bar() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<foo>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(foo),
-                "::",
-                stringify!(bar)
-            )
-        );
-    }
-    test_field_bar();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
+        },
+        0usize,
+        concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar))
+    );
 }
 impl Default for foo {
     fn default() -> Self {

--- a/tests/expectations/tests/issue-1291.rs
+++ b/tests/expectations/tests/issue-1291.rs
@@ -27,6 +27,8 @@ pub struct RTCRay {
 }
 #[test]
 fn bindgen_test_layout_RTCRay() {
+    const UNINIT: ::std::mem::MaybeUninit<RTCRay> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<RTCRay>(),
         96usize,
@@ -37,259 +39,189 @@ fn bindgen_test_layout_RTCRay() {
         16usize,
         concat!("Alignment of ", stringify!(RTCRay))
     );
-    fn test_field_org() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<RTCRay>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).org) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(RTCRay),
-                "::",
-                stringify!(org)
-            )
-        );
-    }
-    test_field_org();
-    fn test_field_align0() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<RTCRay>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).align0) as usize - ptr as usize
-            },
-            12usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(RTCRay),
-                "::",
-                stringify!(align0)
-            )
-        );
-    }
-    test_field_align0();
-    fn test_field_dir() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<RTCRay>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).dir) as usize - ptr as usize
-            },
-            16usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(RTCRay),
-                "::",
-                stringify!(dir)
-            )
-        );
-    }
-    test_field_dir();
-    fn test_field_align1() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<RTCRay>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).align1) as usize - ptr as usize
-            },
-            28usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(RTCRay),
-                "::",
-                stringify!(align1)
-            )
-        );
-    }
-    test_field_align1();
-    fn test_field_tnear() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<RTCRay>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).tnear) as usize - ptr as usize
-            },
-            32usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(RTCRay),
-                "::",
-                stringify!(tnear)
-            )
-        );
-    }
-    test_field_tnear();
-    fn test_field_tfar() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<RTCRay>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).tfar) as usize - ptr as usize
-            },
-            36usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(RTCRay),
-                "::",
-                stringify!(tfar)
-            )
-        );
-    }
-    test_field_tfar();
-    fn test_field_time() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<RTCRay>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).time) as usize - ptr as usize
-            },
-            40usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(RTCRay),
-                "::",
-                stringify!(time)
-            )
-        );
-    }
-    test_field_time();
-    fn test_field_mask() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<RTCRay>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).mask) as usize - ptr as usize
-            },
-            44usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(RTCRay),
-                "::",
-                stringify!(mask)
-            )
-        );
-    }
-    test_field_mask();
-    fn test_field_Ng() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<RTCRay>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).Ng) as usize - ptr as usize
-            },
-            48usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(RTCRay),
-                "::",
-                stringify!(Ng)
-            )
-        );
-    }
-    test_field_Ng();
-    fn test_field_align2() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<RTCRay>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).align2) as usize - ptr as usize
-            },
-            60usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(RTCRay),
-                "::",
-                stringify!(align2)
-            )
-        );
-    }
-    test_field_align2();
-    fn test_field_u() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<RTCRay>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).u) as usize - ptr as usize
-            },
-            64usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(RTCRay),
-                "::",
-                stringify!(u)
-            )
-        );
-    }
-    test_field_u();
-    fn test_field_v() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<RTCRay>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).v) as usize - ptr as usize
-            },
-            68usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(RTCRay),
-                "::",
-                stringify!(v)
-            )
-        );
-    }
-    test_field_v();
-    fn test_field_geomID() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<RTCRay>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).geomID) as usize - ptr as usize
-            },
-            72usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(RTCRay),
-                "::",
-                stringify!(geomID)
-            )
-        );
-    }
-    test_field_geomID();
-    fn test_field_primID() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<RTCRay>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).primID) as usize - ptr as usize
-            },
-            76usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(RTCRay),
-                "::",
-                stringify!(primID)
-            )
-        );
-    }
-    test_field_primID();
-    fn test_field_instID() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<RTCRay>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).instID) as usize - ptr as usize
-            },
-            80usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(RTCRay),
-                "::",
-                stringify!(instID)
-            )
-        );
-    }
-    test_field_instID();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).org) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(RTCRay),
+            "::",
+            stringify!(org)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).align0) as usize - ptr as usize
+        },
+        12usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(RTCRay),
+            "::",
+            stringify!(align0)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).dir) as usize - ptr as usize
+        },
+        16usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(RTCRay),
+            "::",
+            stringify!(dir)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).align1) as usize - ptr as usize
+        },
+        28usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(RTCRay),
+            "::",
+            stringify!(align1)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).tnear) as usize - ptr as usize
+        },
+        32usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(RTCRay),
+            "::",
+            stringify!(tnear)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).tfar) as usize - ptr as usize
+        },
+        36usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(RTCRay),
+            "::",
+            stringify!(tfar)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).time) as usize - ptr as usize
+        },
+        40usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(RTCRay),
+            "::",
+            stringify!(time)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).mask) as usize - ptr as usize
+        },
+        44usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(RTCRay),
+            "::",
+            stringify!(mask)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).Ng) as usize - ptr as usize
+        },
+        48usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(RTCRay),
+            "::",
+            stringify!(Ng)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).align2) as usize - ptr as usize
+        },
+        60usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(RTCRay),
+            "::",
+            stringify!(align2)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).u) as usize - ptr as usize
+        },
+        64usize,
+        concat!("Offset of field: ", stringify!(RTCRay), "::", stringify!(u))
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).v) as usize - ptr as usize
+        },
+        68usize,
+        concat!("Offset of field: ", stringify!(RTCRay), "::", stringify!(v))
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).geomID) as usize - ptr as usize
+        },
+        72usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(RTCRay),
+            "::",
+            stringify!(geomID)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).primID) as usize - ptr as usize
+        },
+        76usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(RTCRay),
+            "::",
+            stringify!(primID)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).instID) as usize - ptr as usize
+        },
+        80usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(RTCRay),
+            "::",
+            stringify!(instID)
+        )
+    );
 }

--- a/tests/expectations/tests/issue-1291.rs
+++ b/tests/expectations/tests/issue-1291.rs
@@ -29,6 +29,7 @@ pub struct RTCRay {
 fn bindgen_test_layout_RTCRay() {
     const UNINIT: ::std::mem::MaybeUninit<RTCRay> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<RTCRay>(),
         96usize,
@@ -40,10 +41,7 @@ fn bindgen_test_layout_RTCRay() {
         concat!("Alignment of ", stringify!(RTCRay))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).org) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).org) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -53,10 +51,7 @@ fn bindgen_test_layout_RTCRay() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).align0) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).align0) as usize - ptr as usize },
         12usize,
         concat!(
             "Offset of field: ",
@@ -66,10 +61,7 @@ fn bindgen_test_layout_RTCRay() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).dir) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).dir) as usize - ptr as usize },
         16usize,
         concat!(
             "Offset of field: ",
@@ -79,10 +71,7 @@ fn bindgen_test_layout_RTCRay() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).align1) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).align1) as usize - ptr as usize },
         28usize,
         concat!(
             "Offset of field: ",
@@ -92,10 +81,7 @@ fn bindgen_test_layout_RTCRay() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).tnear) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).tnear) as usize - ptr as usize },
         32usize,
         concat!(
             "Offset of field: ",
@@ -105,10 +91,7 @@ fn bindgen_test_layout_RTCRay() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).tfar) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).tfar) as usize - ptr as usize },
         36usize,
         concat!(
             "Offset of field: ",
@@ -118,10 +101,7 @@ fn bindgen_test_layout_RTCRay() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).time) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).time) as usize - ptr as usize },
         40usize,
         concat!(
             "Offset of field: ",
@@ -131,10 +111,7 @@ fn bindgen_test_layout_RTCRay() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mask) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).mask) as usize - ptr as usize },
         44usize,
         concat!(
             "Offset of field: ",
@@ -144,10 +121,7 @@ fn bindgen_test_layout_RTCRay() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).Ng) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).Ng) as usize - ptr as usize },
         48usize,
         concat!(
             "Offset of field: ",
@@ -157,10 +131,7 @@ fn bindgen_test_layout_RTCRay() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).align2) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).align2) as usize - ptr as usize },
         60usize,
         concat!(
             "Offset of field: ",
@@ -170,26 +141,17 @@ fn bindgen_test_layout_RTCRay() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).u) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).u) as usize - ptr as usize },
         64usize,
         concat!("Offset of field: ", stringify!(RTCRay), "::", stringify!(u))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).v) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).v) as usize - ptr as usize },
         68usize,
         concat!("Offset of field: ", stringify!(RTCRay), "::", stringify!(v))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).geomID) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).geomID) as usize - ptr as usize },
         72usize,
         concat!(
             "Offset of field: ",
@@ -199,10 +161,7 @@ fn bindgen_test_layout_RTCRay() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).primID) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).primID) as usize - ptr as usize },
         76usize,
         concat!(
             "Offset of field: ",
@@ -212,10 +171,7 @@ fn bindgen_test_layout_RTCRay() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).instID) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).instID) as usize - ptr as usize },
         80usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/issue-1382-rust-primitive-types.rs
+++ b/tests/expectations/tests/issue-1382-rust-primitive-types.rs
@@ -35,6 +35,7 @@ pub struct Foo {
 fn bindgen_test_layout_Foo() {
     const UNINIT: ::std::mem::MaybeUninit<Foo> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<Foo>(),
         56usize,
@@ -46,74 +47,47 @@ fn bindgen_test_layout_Foo() {
         concat!("Alignment of ", stringify!(Foo))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).i8_) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).i8_) as usize - ptr as usize },
         0usize,
         concat!("Offset of field: ", stringify!(Foo), "::", stringify!(i8_))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).u8_) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).u8_) as usize - ptr as usize },
         4usize,
         concat!("Offset of field: ", stringify!(Foo), "::", stringify!(u8_))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).i16_) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).i16_) as usize - ptr as usize },
         8usize,
         concat!("Offset of field: ", stringify!(Foo), "::", stringify!(i16_))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).u16_) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).u16_) as usize - ptr as usize },
         12usize,
         concat!("Offset of field: ", stringify!(Foo), "::", stringify!(u16_))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).i32_) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).i32_) as usize - ptr as usize },
         16usize,
         concat!("Offset of field: ", stringify!(Foo), "::", stringify!(i32_))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).u32_) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).u32_) as usize - ptr as usize },
         20usize,
         concat!("Offset of field: ", stringify!(Foo), "::", stringify!(u32_))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).i64_) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).i64_) as usize - ptr as usize },
         24usize,
         concat!("Offset of field: ", stringify!(Foo), "::", stringify!(i64_))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).u64_) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).u64_) as usize - ptr as usize },
         28usize,
         concat!("Offset of field: ", stringify!(Foo), "::", stringify!(u64_))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).i128_) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).i128_) as usize - ptr as usize },
         32usize,
         concat!(
             "Offset of field: ",
@@ -123,10 +97,7 @@ fn bindgen_test_layout_Foo() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).u128_) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).u128_) as usize - ptr as usize },
         36usize,
         concat!(
             "Offset of field: ",
@@ -136,10 +107,7 @@ fn bindgen_test_layout_Foo() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).isize_) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).isize_) as usize - ptr as usize },
         40usize,
         concat!(
             "Offset of field: ",
@@ -149,10 +117,7 @@ fn bindgen_test_layout_Foo() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).usize_) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).usize_) as usize - ptr as usize },
         44usize,
         concat!(
             "Offset of field: ",
@@ -162,18 +127,12 @@ fn bindgen_test_layout_Foo() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).f32_) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).f32_) as usize - ptr as usize },
         48usize,
         concat!("Offset of field: ", stringify!(Foo), "::", stringify!(f32_))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).f64_) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).f64_) as usize - ptr as usize },
         52usize,
         concat!("Offset of field: ", stringify!(Foo), "::", stringify!(f64_))
     );

--- a/tests/expectations/tests/issue-1382-rust-primitive-types.rs
+++ b/tests/expectations/tests/issue-1382-rust-primitive-types.rs
@@ -33,6 +33,8 @@ pub struct Foo {
 }
 #[test]
 fn bindgen_test_layout_Foo() {
+    const UNINIT: ::std::mem::MaybeUninit<Foo> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<Foo>(),
         56usize,
@@ -43,242 +45,136 @@ fn bindgen_test_layout_Foo() {
         4usize,
         concat!("Alignment of ", stringify!(Foo))
     );
-    fn test_field_i8() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Foo>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).i8_) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(Foo),
-                "::",
-                stringify!(i8_)
-            )
-        );
-    }
-    test_field_i8();
-    fn test_field_u8() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Foo>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).u8_) as usize - ptr as usize
-            },
-            4usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(Foo),
-                "::",
-                stringify!(u8_)
-            )
-        );
-    }
-    test_field_u8();
-    fn test_field_i16() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Foo>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).i16_) as usize - ptr as usize
-            },
-            8usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(Foo),
-                "::",
-                stringify!(i16_)
-            )
-        );
-    }
-    test_field_i16();
-    fn test_field_u16() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Foo>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).u16_) as usize - ptr as usize
-            },
-            12usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(Foo),
-                "::",
-                stringify!(u16_)
-            )
-        );
-    }
-    test_field_u16();
-    fn test_field_i32() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Foo>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).i32_) as usize - ptr as usize
-            },
-            16usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(Foo),
-                "::",
-                stringify!(i32_)
-            )
-        );
-    }
-    test_field_i32();
-    fn test_field_u32() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Foo>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).u32_) as usize - ptr as usize
-            },
-            20usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(Foo),
-                "::",
-                stringify!(u32_)
-            )
-        );
-    }
-    test_field_u32();
-    fn test_field_i64() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Foo>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).i64_) as usize - ptr as usize
-            },
-            24usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(Foo),
-                "::",
-                stringify!(i64_)
-            )
-        );
-    }
-    test_field_i64();
-    fn test_field_u64() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Foo>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).u64_) as usize - ptr as usize
-            },
-            28usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(Foo),
-                "::",
-                stringify!(u64_)
-            )
-        );
-    }
-    test_field_u64();
-    fn test_field_i128() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Foo>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).i128_) as usize - ptr as usize
-            },
-            32usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(Foo),
-                "::",
-                stringify!(i128_)
-            )
-        );
-    }
-    test_field_i128();
-    fn test_field_u128() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Foo>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).u128_) as usize - ptr as usize
-            },
-            36usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(Foo),
-                "::",
-                stringify!(u128_)
-            )
-        );
-    }
-    test_field_u128();
-    fn test_field_isize() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Foo>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).isize_) as usize - ptr as usize
-            },
-            40usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(Foo),
-                "::",
-                stringify!(isize_)
-            )
-        );
-    }
-    test_field_isize();
-    fn test_field_usize() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Foo>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).usize_) as usize - ptr as usize
-            },
-            44usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(Foo),
-                "::",
-                stringify!(usize_)
-            )
-        );
-    }
-    test_field_usize();
-    fn test_field_f32() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Foo>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).f32_) as usize - ptr as usize
-            },
-            48usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(Foo),
-                "::",
-                stringify!(f32_)
-            )
-        );
-    }
-    test_field_f32();
-    fn test_field_f64() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Foo>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).f64_) as usize - ptr as usize
-            },
-            52usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(Foo),
-                "::",
-                stringify!(f64_)
-            )
-        );
-    }
-    test_field_f64();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).i8_) as usize - ptr as usize
+        },
+        0usize,
+        concat!("Offset of field: ", stringify!(Foo), "::", stringify!(i8_))
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).u8_) as usize - ptr as usize
+        },
+        4usize,
+        concat!("Offset of field: ", stringify!(Foo), "::", stringify!(u8_))
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).i16_) as usize - ptr as usize
+        },
+        8usize,
+        concat!("Offset of field: ", stringify!(Foo), "::", stringify!(i16_))
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).u16_) as usize - ptr as usize
+        },
+        12usize,
+        concat!("Offset of field: ", stringify!(Foo), "::", stringify!(u16_))
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).i32_) as usize - ptr as usize
+        },
+        16usize,
+        concat!("Offset of field: ", stringify!(Foo), "::", stringify!(i32_))
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).u32_) as usize - ptr as usize
+        },
+        20usize,
+        concat!("Offset of field: ", stringify!(Foo), "::", stringify!(u32_))
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).i64_) as usize - ptr as usize
+        },
+        24usize,
+        concat!("Offset of field: ", stringify!(Foo), "::", stringify!(i64_))
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).u64_) as usize - ptr as usize
+        },
+        28usize,
+        concat!("Offset of field: ", stringify!(Foo), "::", stringify!(u64_))
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).i128_) as usize - ptr as usize
+        },
+        32usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(Foo),
+            "::",
+            stringify!(i128_)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).u128_) as usize - ptr as usize
+        },
+        36usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(Foo),
+            "::",
+            stringify!(u128_)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).isize_) as usize - ptr as usize
+        },
+        40usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(Foo),
+            "::",
+            stringify!(isize_)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).usize_) as usize - ptr as usize
+        },
+        44usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(Foo),
+            "::",
+            stringify!(usize_)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).f32_) as usize - ptr as usize
+        },
+        48usize,
+        concat!("Offset of field: ", stringify!(Foo), "::", stringify!(f32_))
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).f64_) as usize - ptr as usize
+        },
+        52usize,
+        concat!("Offset of field: ", stringify!(Foo), "::", stringify!(f64_))
+    );
 }

--- a/tests/expectations/tests/issue-1443.rs
+++ b/tests/expectations/tests/issue-1443.rs
@@ -20,6 +20,7 @@ pub struct Bar {
 fn bindgen_test_layout_Bar() {
     const UNINIT: ::std::mem::MaybeUninit<Bar> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<Bar>(),
         16usize,
@@ -31,18 +32,12 @@ fn bindgen_test_layout_Bar() {
         concat!("Alignment of ", stringify!(Bar))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).f) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).f) as usize - ptr as usize },
         0usize,
         concat!("Offset of field: ", stringify!(Bar), "::", stringify!(f))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).m) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).m) as usize - ptr as usize },
         8usize,
         concat!("Offset of field: ", stringify!(Bar), "::", stringify!(m))
     );
@@ -66,6 +61,7 @@ pub struct Baz {
 fn bindgen_test_layout_Baz() {
     const UNINIT: ::std::mem::MaybeUninit<Baz> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<Baz>(),
         16usize,
@@ -77,18 +73,12 @@ fn bindgen_test_layout_Baz() {
         concat!("Alignment of ", stringify!(Baz))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).f) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).f) as usize - ptr as usize },
         0usize,
         concat!("Offset of field: ", stringify!(Baz), "::", stringify!(f))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).m) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).m) as usize - ptr as usize },
         8usize,
         concat!("Offset of field: ", stringify!(Baz), "::", stringify!(m))
     );
@@ -112,6 +102,7 @@ pub struct Tar {
 fn bindgen_test_layout_Tar() {
     const UNINIT: ::std::mem::MaybeUninit<Tar> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<Tar>(),
         16usize,
@@ -123,18 +114,12 @@ fn bindgen_test_layout_Tar() {
         concat!("Alignment of ", stringify!(Tar))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).f) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).f) as usize - ptr as usize },
         0usize,
         concat!("Offset of field: ", stringify!(Tar), "::", stringify!(f))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).m) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).m) as usize - ptr as usize },
         8usize,
         concat!("Offset of field: ", stringify!(Tar), "::", stringify!(m))
     );
@@ -158,6 +143,7 @@ pub struct Taz {
 fn bindgen_test_layout_Taz() {
     const UNINIT: ::std::mem::MaybeUninit<Taz> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<Taz>(),
         16usize,
@@ -169,18 +155,12 @@ fn bindgen_test_layout_Taz() {
         concat!("Alignment of ", stringify!(Taz))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).f) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).f) as usize - ptr as usize },
         0usize,
         concat!("Offset of field: ", stringify!(Taz), "::", stringify!(f))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).m) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).m) as usize - ptr as usize },
         8usize,
         concat!("Offset of field: ", stringify!(Taz), "::", stringify!(m))
     );

--- a/tests/expectations/tests/issue-1443.rs
+++ b/tests/expectations/tests/issue-1443.rs
@@ -18,6 +18,8 @@ pub struct Bar {
 }
 #[test]
 fn bindgen_test_layout_Bar() {
+    const UNINIT: ::std::mem::MaybeUninit<Bar> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<Bar>(),
         16usize,
@@ -28,30 +30,22 @@ fn bindgen_test_layout_Bar() {
         8usize,
         concat!("Alignment of ", stringify!(Bar))
     );
-    fn test_field_f() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Bar>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).f) as usize - ptr as usize
-            },
-            0usize,
-            concat!("Offset of field: ", stringify!(Bar), "::", stringify!(f))
-        );
-    }
-    test_field_f();
-    fn test_field_m() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Bar>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).m) as usize - ptr as usize
-            },
-            8usize,
-            concat!("Offset of field: ", stringify!(Bar), "::", stringify!(m))
-        );
-    }
-    test_field_m();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).f) as usize - ptr as usize
+        },
+        0usize,
+        concat!("Offset of field: ", stringify!(Bar), "::", stringify!(f))
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).m) as usize - ptr as usize
+        },
+        8usize,
+        concat!("Offset of field: ", stringify!(Bar), "::", stringify!(m))
+    );
 }
 impl Default for Bar {
     fn default() -> Self {
@@ -70,6 +64,8 @@ pub struct Baz {
 }
 #[test]
 fn bindgen_test_layout_Baz() {
+    const UNINIT: ::std::mem::MaybeUninit<Baz> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<Baz>(),
         16usize,
@@ -80,30 +76,22 @@ fn bindgen_test_layout_Baz() {
         8usize,
         concat!("Alignment of ", stringify!(Baz))
     );
-    fn test_field_f() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Baz>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).f) as usize - ptr as usize
-            },
-            0usize,
-            concat!("Offset of field: ", stringify!(Baz), "::", stringify!(f))
-        );
-    }
-    test_field_f();
-    fn test_field_m() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Baz>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).m) as usize - ptr as usize
-            },
-            8usize,
-            concat!("Offset of field: ", stringify!(Baz), "::", stringify!(m))
-        );
-    }
-    test_field_m();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).f) as usize - ptr as usize
+        },
+        0usize,
+        concat!("Offset of field: ", stringify!(Baz), "::", stringify!(f))
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).m) as usize - ptr as usize
+        },
+        8usize,
+        concat!("Offset of field: ", stringify!(Baz), "::", stringify!(m))
+    );
 }
 impl Default for Baz {
     fn default() -> Self {
@@ -122,6 +110,8 @@ pub struct Tar {
 }
 #[test]
 fn bindgen_test_layout_Tar() {
+    const UNINIT: ::std::mem::MaybeUninit<Tar> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<Tar>(),
         16usize,
@@ -132,30 +122,22 @@ fn bindgen_test_layout_Tar() {
         8usize,
         concat!("Alignment of ", stringify!(Tar))
     );
-    fn test_field_f() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Tar>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).f) as usize - ptr as usize
-            },
-            0usize,
-            concat!("Offset of field: ", stringify!(Tar), "::", stringify!(f))
-        );
-    }
-    test_field_f();
-    fn test_field_m() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Tar>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).m) as usize - ptr as usize
-            },
-            8usize,
-            concat!("Offset of field: ", stringify!(Tar), "::", stringify!(m))
-        );
-    }
-    test_field_m();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).f) as usize - ptr as usize
+        },
+        0usize,
+        concat!("Offset of field: ", stringify!(Tar), "::", stringify!(f))
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).m) as usize - ptr as usize
+        },
+        8usize,
+        concat!("Offset of field: ", stringify!(Tar), "::", stringify!(m))
+    );
 }
 impl Default for Tar {
     fn default() -> Self {
@@ -174,6 +156,8 @@ pub struct Taz {
 }
 #[test]
 fn bindgen_test_layout_Taz() {
+    const UNINIT: ::std::mem::MaybeUninit<Taz> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<Taz>(),
         16usize,
@@ -184,30 +168,22 @@ fn bindgen_test_layout_Taz() {
         8usize,
         concat!("Alignment of ", stringify!(Taz))
     );
-    fn test_field_f() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Taz>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).f) as usize - ptr as usize
-            },
-            0usize,
-            concat!("Offset of field: ", stringify!(Taz), "::", stringify!(f))
-        );
-    }
-    test_field_f();
-    fn test_field_m() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Taz>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).m) as usize - ptr as usize
-            },
-            8usize,
-            concat!("Offset of field: ", stringify!(Taz), "::", stringify!(m))
-        );
-    }
-    test_field_m();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).f) as usize - ptr as usize
+        },
+        0usize,
+        concat!("Offset of field: ", stringify!(Taz), "::", stringify!(f))
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).m) as usize - ptr as usize
+        },
+        8usize,
+        concat!("Offset of field: ", stringify!(Taz), "::", stringify!(m))
+    );
 }
 impl Default for Taz {
     fn default() -> Self {

--- a/tests/expectations/tests/issue-1454.rs
+++ b/tests/expectations/tests/issue-1454.rs
@@ -18,6 +18,7 @@ pub struct local_type {
 fn bindgen_test_layout_local_type() {
     const UNINIT: ::std::mem::MaybeUninit<local_type> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<local_type>(),
         0usize,
@@ -29,10 +30,7 @@ fn bindgen_test_layout_local_type() {
         concat!("Alignment of ", stringify!(local_type))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).inner) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).inner) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/issue-1454.rs
+++ b/tests/expectations/tests/issue-1454.rs
@@ -16,6 +16,8 @@ pub struct local_type {
 }
 #[test]
 fn bindgen_test_layout_local_type() {
+    const UNINIT: ::std::mem::MaybeUninit<local_type> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<local_type>(),
         0usize,
@@ -26,21 +28,17 @@ fn bindgen_test_layout_local_type() {
         1usize,
         concat!("Alignment of ", stringify!(local_type))
     );
-    fn test_field_inner() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<local_type>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).inner) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(local_type),
-                "::",
-                stringify!(inner)
-            )
-        );
-    }
-    test_field_inner();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).inner) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(local_type),
+            "::",
+            stringify!(inner)
+        )
+    );
 }

--- a/tests/expectations/tests/issue-1498.rs
+++ b/tests/expectations/tests/issue-1498.rs
@@ -35,6 +35,7 @@ pub union rte_memseg__bindgen_ty_1 {
 fn bindgen_test_layout_rte_memseg__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<rte_memseg__bindgen_ty_1> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<rte_memseg__bindgen_ty_1>(),
         8usize,
@@ -46,10 +47,7 @@ fn bindgen_test_layout_rte_memseg__bindgen_ty_1() {
         concat!("Alignment of ", stringify!(rte_memseg__bindgen_ty_1))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).addr) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).addr) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -59,10 +57,7 @@ fn bindgen_test_layout_rte_memseg__bindgen_ty_1() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).addr_64) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).addr_64) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -85,6 +80,7 @@ impl Default for rte_memseg__bindgen_ty_1 {
 fn bindgen_test_layout_rte_memseg() {
     const UNINIT: ::std::mem::MaybeUninit<rte_memseg> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<rte_memseg>(),
         44usize,
@@ -97,7 +93,6 @@ fn bindgen_test_layout_rte_memseg() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).phys_addr) as usize - ptr as usize
         },
         0usize,
@@ -109,10 +104,7 @@ fn bindgen_test_layout_rte_memseg() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).len) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).len) as usize - ptr as usize },
         16usize,
         concat!(
             "Offset of field: ",
@@ -123,7 +115,6 @@ fn bindgen_test_layout_rte_memseg() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).hugepage_sz) as usize - ptr as usize
         },
         24usize,
@@ -136,7 +127,6 @@ fn bindgen_test_layout_rte_memseg() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).socket_id) as usize - ptr as usize
         },
         32usize,
@@ -149,7 +139,6 @@ fn bindgen_test_layout_rte_memseg() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).nchannel) as usize - ptr as usize
         },
         36usize,
@@ -161,10 +150,7 @@ fn bindgen_test_layout_rte_memseg() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).nrank) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).nrank) as usize - ptr as usize },
         40usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/issue-1498.rs
+++ b/tests/expectations/tests/issue-1498.rs
@@ -33,6 +33,8 @@ pub union rte_memseg__bindgen_ty_1 {
 }
 #[test]
 fn bindgen_test_layout_rte_memseg__bindgen_ty_1() {
+    const UNINIT: ::std::mem::MaybeUninit<rte_memseg__bindgen_ty_1> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<rte_memseg__bindgen_ty_1>(),
         8usize,
@@ -43,44 +45,32 @@ fn bindgen_test_layout_rte_memseg__bindgen_ty_1() {
         8usize,
         concat!("Alignment of ", stringify!(rte_memseg__bindgen_ty_1))
     );
-    fn test_field_addr() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_memseg__bindgen_ty_1>::uninit(
-                    );
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).addr) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_memseg__bindgen_ty_1),
-                "::",
-                stringify!(addr)
-            )
-        );
-    }
-    test_field_addr();
-    fn test_field_addr_64() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_memseg__bindgen_ty_1>::uninit(
-                    );
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).addr_64) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_memseg__bindgen_ty_1),
-                "::",
-                stringify!(addr_64)
-            )
-        );
-    }
-    test_field_addr_64();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).addr) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_memseg__bindgen_ty_1),
+            "::",
+            stringify!(addr)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).addr_64) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_memseg__bindgen_ty_1),
+            "::",
+            stringify!(addr_64)
+        )
+    );
 }
 impl Default for rte_memseg__bindgen_ty_1 {
     fn default() -> Self {
@@ -93,6 +83,8 @@ impl Default for rte_memseg__bindgen_ty_1 {
 }
 #[test]
 fn bindgen_test_layout_rte_memseg() {
+    const UNINIT: ::std::mem::MaybeUninit<rte_memseg> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<rte_memseg>(),
         44usize,
@@ -103,108 +95,84 @@ fn bindgen_test_layout_rte_memseg() {
         1usize,
         concat!("Alignment of ", stringify!(rte_memseg))
     );
-    fn test_field_phys_addr() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<rte_memseg>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).phys_addr) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_memseg),
-                "::",
-                stringify!(phys_addr)
-            )
-        );
-    }
-    test_field_phys_addr();
-    fn test_field_len() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<rte_memseg>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).len) as usize - ptr as usize
-            },
-            16usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_memseg),
-                "::",
-                stringify!(len)
-            )
-        );
-    }
-    test_field_len();
-    fn test_field_hugepage_sz() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<rte_memseg>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).hugepage_sz) as usize - ptr as usize
-            },
-            24usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_memseg),
-                "::",
-                stringify!(hugepage_sz)
-            )
-        );
-    }
-    test_field_hugepage_sz();
-    fn test_field_socket_id() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<rte_memseg>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).socket_id) as usize - ptr as usize
-            },
-            32usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_memseg),
-                "::",
-                stringify!(socket_id)
-            )
-        );
-    }
-    test_field_socket_id();
-    fn test_field_nchannel() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<rte_memseg>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).nchannel) as usize - ptr as usize
-            },
-            36usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_memseg),
-                "::",
-                stringify!(nchannel)
-            )
-        );
-    }
-    test_field_nchannel();
-    fn test_field_nrank() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<rte_memseg>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).nrank) as usize - ptr as usize
-            },
-            40usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_memseg),
-                "::",
-                stringify!(nrank)
-            )
-        );
-    }
-    test_field_nrank();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).phys_addr) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_memseg),
+            "::",
+            stringify!(phys_addr)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).len) as usize - ptr as usize
+        },
+        16usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_memseg),
+            "::",
+            stringify!(len)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).hugepage_sz) as usize - ptr as usize
+        },
+        24usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_memseg),
+            "::",
+            stringify!(hugepage_sz)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).socket_id) as usize - ptr as usize
+        },
+        32usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_memseg),
+            "::",
+            stringify!(socket_id)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).nchannel) as usize - ptr as usize
+        },
+        36usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_memseg),
+            "::",
+            stringify!(nchannel)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).nrank) as usize - ptr as usize
+        },
+        40usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_memseg),
+            "::",
+            stringify!(nrank)
+        )
+    );
 }
 impl Default for rte_memseg {
     fn default() -> Self {

--- a/tests/expectations/tests/issue-1947.rs
+++ b/tests/expectations/tests/issue-1947.rs
@@ -107,6 +107,8 @@ pub struct V56AMDY {
 }
 #[test]
 fn bindgen_test_layout_V56AMDY() {
+    const UNINIT: ::std::mem::MaybeUninit<V56AMDY> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<V56AMDY>(),
         8usize,
@@ -117,57 +119,45 @@ fn bindgen_test_layout_V56AMDY() {
         2usize,
         concat!("Alignment of ", stringify!(V56AMDY))
     );
-    fn test_field_MADK() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<V56AMDY>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).MADK) as usize - ptr as usize
-            },
-            2usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(V56AMDY),
-                "::",
-                stringify!(MADK)
-            )
-        );
-    }
-    test_field_MADK();
-    fn test_field_MABR() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<V56AMDY>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).MABR) as usize - ptr as usize
-            },
-            3usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(V56AMDY),
-                "::",
-                stringify!(MABR)
-            )
-        );
-    }
-    test_field_MABR();
-    fn test_field__rB_() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<V56AMDY>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr)._rB_) as usize - ptr as usize
-            },
-            7usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(V56AMDY),
-                "::",
-                stringify!(_rB_)
-            )
-        );
-    }
-    test_field__rB_();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).MADK) as usize - ptr as usize
+        },
+        2usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(V56AMDY),
+            "::",
+            stringify!(MADK)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).MABR) as usize - ptr as usize
+        },
+        3usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(V56AMDY),
+            "::",
+            stringify!(MABR)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr)._rB_) as usize - ptr as usize
+        },
+        7usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(V56AMDY),
+            "::",
+            stringify!(_rB_)
+        )
+    );
 }
 impl V56AMDY {
     #[inline]

--- a/tests/expectations/tests/issue-1947.rs
+++ b/tests/expectations/tests/issue-1947.rs
@@ -109,6 +109,7 @@ pub struct V56AMDY {
 fn bindgen_test_layout_V56AMDY() {
     const UNINIT: ::std::mem::MaybeUninit<V56AMDY> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<V56AMDY>(),
         8usize,
@@ -120,10 +121,7 @@ fn bindgen_test_layout_V56AMDY() {
         concat!("Alignment of ", stringify!(V56AMDY))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).MADK) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).MADK) as usize - ptr as usize },
         2usize,
         concat!(
             "Offset of field: ",
@@ -133,10 +131,7 @@ fn bindgen_test_layout_V56AMDY() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).MABR) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).MABR) as usize - ptr as usize },
         3usize,
         concat!(
             "Offset of field: ",
@@ -146,10 +141,7 @@ fn bindgen_test_layout_V56AMDY() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr)._rB_) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr)._rB_) as usize - ptr as usize },
         7usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/issue-1977-larger-arrays.rs
+++ b/tests/expectations/tests/issue-1977-larger-arrays.rs
@@ -14,6 +14,7 @@ pub struct S {
 fn bindgen_test_layout_S() {
     const UNINIT: ::std::mem::MaybeUninit<S> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<S>(),
         33usize,
@@ -26,7 +27,6 @@ fn bindgen_test_layout_S() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).large_array) as usize - ptr as usize
         },
         0usize,

--- a/tests/expectations/tests/issue-1977-larger-arrays.rs
+++ b/tests/expectations/tests/issue-1977-larger-arrays.rs
@@ -12,6 +12,8 @@ pub struct S {
 }
 #[test]
 fn bindgen_test_layout_S() {
+    const UNINIT: ::std::mem::MaybeUninit<S> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<S>(),
         33usize,
@@ -22,23 +24,19 @@ fn bindgen_test_layout_S() {
         1usize,
         concat!("Alignment of ", stringify!(S))
     );
-    fn test_field_large_array() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<S>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).large_array) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(S),
-                "::",
-                stringify!(large_array)
-            )
-        );
-    }
-    test_field_large_array();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).large_array) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(S),
+            "::",
+            stringify!(large_array)
+        )
+    );
 }
 impl Default for S {
     fn default() -> Self {

--- a/tests/expectations/tests/issue-1995.rs
+++ b/tests/expectations/tests/issue-1995.rs
@@ -19,6 +19,8 @@ pub struct Bar {
 }
 #[test]
 fn bindgen_test_layout_Bar() {
+    const UNINIT: ::std::mem::MaybeUninit<Bar> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<Bar>(),
         4usize,
@@ -29,21 +31,12 @@ fn bindgen_test_layout_Bar() {
         4usize,
         concat!("Alignment of ", stringify!(Bar))
     );
-    fn test_field_baz() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Bar>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(Bar),
-                "::",
-                stringify!(baz)
-            )
-        );
-    }
-    test_field_baz();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize
+        },
+        0usize,
+        concat!("Offset of field: ", stringify!(Bar), "::", stringify!(baz))
+    );
 }

--- a/tests/expectations/tests/issue-1995.rs
+++ b/tests/expectations/tests/issue-1995.rs
@@ -21,6 +21,7 @@ pub struct Bar {
 fn bindgen_test_layout_Bar() {
     const UNINIT: ::std::mem::MaybeUninit<Bar> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<Bar>(),
         4usize,
@@ -32,10 +33,7 @@ fn bindgen_test_layout_Bar() {
         concat!("Alignment of ", stringify!(Bar))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize },
         0usize,
         concat!("Offset of field: ", stringify!(Bar), "::", stringify!(baz))
     );

--- a/tests/expectations/tests/issue-2019.rs
+++ b/tests/expectations/tests/issue-2019.rs
@@ -12,6 +12,8 @@ pub struct A {
 }
 #[test]
 fn bindgen_test_layout_A() {
+    const UNINIT: ::std::mem::MaybeUninit<A> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<A>(),
         4usize,
@@ -22,18 +24,14 @@ fn bindgen_test_layout_A() {
         4usize,
         concat!("Alignment of ", stringify!(A))
     );
-    fn test_field_a() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<A>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-            },
-            0usize,
-            concat!("Offset of field: ", stringify!(A), "::", stringify!(a))
-        );
-    }
-    test_field_a();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+        },
+        0usize,
+        concat!("Offset of field: ", stringify!(A), "::", stringify!(a))
+    );
 }
 extern "C" {
     #[link_name = "\u{1}_ZN1A4makeEv"]
@@ -52,6 +50,8 @@ pub struct B {
 }
 #[test]
 fn bindgen_test_layout_B() {
+    const UNINIT: ::std::mem::MaybeUninit<B> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<B>(),
         4usize,
@@ -62,18 +62,14 @@ fn bindgen_test_layout_B() {
         4usize,
         concat!("Alignment of ", stringify!(B))
     );
-    fn test_field_b() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<B>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-            },
-            0usize,
-            concat!("Offset of field: ", stringify!(B), "::", stringify!(b))
-        );
-    }
-    test_field_b();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
+        },
+        0usize,
+        concat!("Offset of field: ", stringify!(B), "::", stringify!(b))
+    );
 }
 extern "C" {
     #[link_name = "\u{1}_ZN1B4makeEv"]

--- a/tests/expectations/tests/issue-2019.rs
+++ b/tests/expectations/tests/issue-2019.rs
@@ -14,6 +14,7 @@ pub struct A {
 fn bindgen_test_layout_A() {
     const UNINIT: ::std::mem::MaybeUninit<A> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<A>(),
         4usize,
@@ -25,10 +26,7 @@ fn bindgen_test_layout_A() {
         concat!("Alignment of ", stringify!(A))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
         0usize,
         concat!("Offset of field: ", stringify!(A), "::", stringify!(a))
     );
@@ -52,6 +50,7 @@ pub struct B {
 fn bindgen_test_layout_B() {
     const UNINIT: ::std::mem::MaybeUninit<B> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<B>(),
         4usize,
@@ -63,10 +62,7 @@ fn bindgen_test_layout_B() {
         concat!("Alignment of ", stringify!(B))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
         0usize,
         concat!("Offset of field: ", stringify!(B), "::", stringify!(b))
     );

--- a/tests/expectations/tests/issue-372.rs
+++ b/tests/expectations/tests/issue-372.rs
@@ -18,6 +18,8 @@ pub mod root {
     }
     #[test]
     fn bindgen_test_layout_i() {
+        const UNINIT: ::std::mem::MaybeUninit<i> =
+            ::std::mem::MaybeUninit::uninit();
         assert_eq!(
             ::std::mem::size_of::<i>(),
             24usize,
@@ -28,57 +30,30 @@ pub mod root {
             8usize,
             concat!("Alignment of ", stringify!(i))
         );
-        fn test_field_j() {
-            assert_eq!(
-                unsafe {
-                    let uninit = ::std::mem::MaybeUninit::<i>::uninit();
-                    let ptr = uninit.as_ptr();
-                    ::std::ptr::addr_of!((*ptr).j) as usize - ptr as usize
-                },
-                0usize,
-                concat!(
-                    "Offset of field: ",
-                    stringify!(i),
-                    "::",
-                    stringify!(j)
-                )
-            );
-        }
-        test_field_j();
-        fn test_field_k() {
-            assert_eq!(
-                unsafe {
-                    let uninit = ::std::mem::MaybeUninit::<i>::uninit();
-                    let ptr = uninit.as_ptr();
-                    ::std::ptr::addr_of!((*ptr).k) as usize - ptr as usize
-                },
-                8usize,
-                concat!(
-                    "Offset of field: ",
-                    stringify!(i),
-                    "::",
-                    stringify!(k)
-                )
-            );
-        }
-        test_field_k();
-        fn test_field_l() {
-            assert_eq!(
-                unsafe {
-                    let uninit = ::std::mem::MaybeUninit::<i>::uninit();
-                    let ptr = uninit.as_ptr();
-                    ::std::ptr::addr_of!((*ptr).l) as usize - ptr as usize
-                },
-                16usize,
-                concat!(
-                    "Offset of field: ",
-                    stringify!(i),
-                    "::",
-                    stringify!(l)
-                )
-            );
-        }
-        test_field_l();
+        assert_eq!(
+            unsafe {
+                let ptr = UNINIT.as_ptr();
+                ::std::ptr::addr_of!((*ptr).j) as usize - ptr as usize
+            },
+            0usize,
+            concat!("Offset of field: ", stringify!(i), "::", stringify!(j))
+        );
+        assert_eq!(
+            unsafe {
+                let ptr = UNINIT.as_ptr();
+                ::std::ptr::addr_of!((*ptr).k) as usize - ptr as usize
+            },
+            8usize,
+            concat!("Offset of field: ", stringify!(i), "::", stringify!(k))
+        );
+        assert_eq!(
+            unsafe {
+                let ptr = UNINIT.as_ptr();
+                ::std::ptr::addr_of!((*ptr).l) as usize - ptr as usize
+            },
+            16usize,
+            concat!("Offset of field: ", stringify!(i), "::", stringify!(l))
+        );
     }
     impl Default for i {
         fn default() -> Self {
@@ -96,6 +71,8 @@ pub mod root {
     }
     #[test]
     fn bindgen_test_layout_d() {
+        const UNINIT: ::std::mem::MaybeUninit<d> =
+            ::std::mem::MaybeUninit::uninit();
         assert_eq!(
             ::std::mem::size_of::<d>(),
             24usize,
@@ -106,23 +83,14 @@ pub mod root {
             8usize,
             concat!("Alignment of ", stringify!(d))
         );
-        fn test_field_m() {
-            assert_eq!(
-                unsafe {
-                    let uninit = ::std::mem::MaybeUninit::<d>::uninit();
-                    let ptr = uninit.as_ptr();
-                    ::std::ptr::addr_of!((*ptr).m) as usize - ptr as usize
-                },
-                0usize,
-                concat!(
-                    "Offset of field: ",
-                    stringify!(d),
-                    "::",
-                    stringify!(m)
-                )
-            );
-        }
-        test_field_m();
+        assert_eq!(
+            unsafe {
+                let ptr = UNINIT.as_ptr();
+                ::std::ptr::addr_of!((*ptr).m) as usize - ptr as usize
+            },
+            0usize,
+            concat!("Offset of field: ", stringify!(d), "::", stringify!(m))
+        );
     }
     impl Default for d {
         fn default() -> Self {
@@ -155,6 +123,8 @@ pub mod root {
     }
     #[test]
     fn bindgen_test_layout_F() {
+        const UNINIT: ::std::mem::MaybeUninit<F> =
+            ::std::mem::MaybeUninit::uninit();
         assert_eq!(
             ::std::mem::size_of::<F>(),
             264usize,
@@ -165,23 +135,14 @@ pub mod root {
             8usize,
             concat!("Alignment of ", stringify!(F))
         );
-        fn test_field_w() {
-            assert_eq!(
-                unsafe {
-                    let uninit = ::std::mem::MaybeUninit::<F>::uninit();
-                    let ptr = uninit.as_ptr();
-                    ::std::ptr::addr_of!((*ptr).w) as usize - ptr as usize
-                },
-                0usize,
-                concat!(
-                    "Offset of field: ",
-                    stringify!(F),
-                    "::",
-                    stringify!(w)
-                )
-            );
-        }
-        test_field_w();
+        assert_eq!(
+            unsafe {
+                let ptr = UNINIT.as_ptr();
+                ::std::ptr::addr_of!((*ptr).w) as usize - ptr as usize
+            },
+            0usize,
+            concat!("Offset of field: ", stringify!(F), "::", stringify!(w))
+        );
     }
     impl Default for F {
         fn default() -> Self {

--- a/tests/expectations/tests/issue-372.rs
+++ b/tests/expectations/tests/issue-372.rs
@@ -20,6 +20,7 @@ pub mod root {
     fn bindgen_test_layout_i() {
         const UNINIT: ::std::mem::MaybeUninit<i> =
             ::std::mem::MaybeUninit::uninit();
+        let ptr = UNINIT.as_ptr();
         assert_eq!(
             ::std::mem::size_of::<i>(),
             24usize,
@@ -31,26 +32,17 @@ pub mod root {
             concat!("Alignment of ", stringify!(i))
         );
         assert_eq!(
-            unsafe {
-                let ptr = UNINIT.as_ptr();
-                ::std::ptr::addr_of!((*ptr).j) as usize - ptr as usize
-            },
+            unsafe { ::std::ptr::addr_of!((*ptr).j) as usize - ptr as usize },
             0usize,
             concat!("Offset of field: ", stringify!(i), "::", stringify!(j))
         );
         assert_eq!(
-            unsafe {
-                let ptr = UNINIT.as_ptr();
-                ::std::ptr::addr_of!((*ptr).k) as usize - ptr as usize
-            },
+            unsafe { ::std::ptr::addr_of!((*ptr).k) as usize - ptr as usize },
             8usize,
             concat!("Offset of field: ", stringify!(i), "::", stringify!(k))
         );
         assert_eq!(
-            unsafe {
-                let ptr = UNINIT.as_ptr();
-                ::std::ptr::addr_of!((*ptr).l) as usize - ptr as usize
-            },
+            unsafe { ::std::ptr::addr_of!((*ptr).l) as usize - ptr as usize },
             16usize,
             concat!("Offset of field: ", stringify!(i), "::", stringify!(l))
         );
@@ -73,6 +65,7 @@ pub mod root {
     fn bindgen_test_layout_d() {
         const UNINIT: ::std::mem::MaybeUninit<d> =
             ::std::mem::MaybeUninit::uninit();
+        let ptr = UNINIT.as_ptr();
         assert_eq!(
             ::std::mem::size_of::<d>(),
             24usize,
@@ -84,10 +77,7 @@ pub mod root {
             concat!("Alignment of ", stringify!(d))
         );
         assert_eq!(
-            unsafe {
-                let ptr = UNINIT.as_ptr();
-                ::std::ptr::addr_of!((*ptr).m) as usize - ptr as usize
-            },
+            unsafe { ::std::ptr::addr_of!((*ptr).m) as usize - ptr as usize },
             0usize,
             concat!("Offset of field: ", stringify!(d), "::", stringify!(m))
         );
@@ -125,6 +115,7 @@ pub mod root {
     fn bindgen_test_layout_F() {
         const UNINIT: ::std::mem::MaybeUninit<F> =
             ::std::mem::MaybeUninit::uninit();
+        let ptr = UNINIT.as_ptr();
         assert_eq!(
             ::std::mem::size_of::<F>(),
             264usize,
@@ -136,10 +127,7 @@ pub mod root {
             concat!("Alignment of ", stringify!(F))
         );
         assert_eq!(
-            unsafe {
-                let ptr = UNINIT.as_ptr();
-                ::std::ptr::addr_of!((*ptr).w) as usize - ptr as usize
-            },
+            unsafe { ::std::ptr::addr_of!((*ptr).w) as usize - ptr as usize },
             0usize,
             concat!("Offset of field: ", stringify!(F), "::", stringify!(w))
         );

--- a/tests/expectations/tests/issue-537-repr-packed-n.rs
+++ b/tests/expectations/tests/issue-537-repr-packed-n.rs
@@ -15,6 +15,8 @@ pub struct AlignedToOne {
 }
 #[test]
 fn bindgen_test_layout_AlignedToOne() {
+    const UNINIT: ::std::mem::MaybeUninit<AlignedToOne> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<AlignedToOne>(),
         4usize,
@@ -25,23 +27,19 @@ fn bindgen_test_layout_AlignedToOne() {
         1usize,
         concat!("Alignment of ", stringify!(AlignedToOne))
     );
-    fn test_field_i() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<AlignedToOne>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).i) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(AlignedToOne),
-                "::",
-                stringify!(i)
-            )
-        );
-    }
-    test_field_i();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).i) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(AlignedToOne),
+            "::",
+            stringify!(i)
+        )
+    );
 }
 /// This should be be packed because Rust 1.33 has `#[repr(packed(N))]`.
 #[repr(C, packed(2))]
@@ -51,6 +49,8 @@ pub struct AlignedToTwo {
 }
 #[test]
 fn bindgen_test_layout_AlignedToTwo() {
+    const UNINIT: ::std::mem::MaybeUninit<AlignedToTwo> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<AlignedToTwo>(),
         4usize,
@@ -61,23 +61,19 @@ fn bindgen_test_layout_AlignedToTwo() {
         2usize,
         concat!("Alignment of ", stringify!(AlignedToTwo))
     );
-    fn test_field_i() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<AlignedToTwo>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).i) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(AlignedToTwo),
-                "::",
-                stringify!(i)
-            )
-        );
-    }
-    test_field_i();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).i) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(AlignedToTwo),
+            "::",
+            stringify!(i)
+        )
+    );
 }
 /// This should not be opaque because although `libclang` doesn't give us the
 /// `#pragma pack(1)`, we can detect that alignment is 1 and add
@@ -90,6 +86,8 @@ pub struct PackedToOne {
 }
 #[test]
 fn bindgen_test_layout_PackedToOne() {
+    const UNINIT: ::std::mem::MaybeUninit<PackedToOne> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<PackedToOne>(),
         8usize,
@@ -100,40 +98,32 @@ fn bindgen_test_layout_PackedToOne() {
         1usize,
         concat!("Alignment of ", stringify!(PackedToOne))
     );
-    fn test_field_x() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<PackedToOne>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(PackedToOne),
-                "::",
-                stringify!(x)
-            )
-        );
-    }
-    test_field_x();
-    fn test_field_y() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<PackedToOne>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).y) as usize - ptr as usize
-            },
-            4usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(PackedToOne),
-                "::",
-                stringify!(y)
-            )
-        );
-    }
-    test_field_y();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(PackedToOne),
+            "::",
+            stringify!(x)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).y) as usize - ptr as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(PackedToOne),
+            "::",
+            stringify!(y)
+        )
+    );
 }
 /// This should be be packed because Rust 1.33 has `#[repr(packed(N))]`.
 #[repr(C, packed(2))]
@@ -144,6 +134,8 @@ pub struct PackedToTwo {
 }
 #[test]
 fn bindgen_test_layout_PackedToTwo() {
+    const UNINIT: ::std::mem::MaybeUninit<PackedToTwo> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<PackedToTwo>(),
         8usize,
@@ -154,38 +146,30 @@ fn bindgen_test_layout_PackedToTwo() {
         2usize,
         concat!("Alignment of ", stringify!(PackedToTwo))
     );
-    fn test_field_x() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<PackedToTwo>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(PackedToTwo),
-                "::",
-                stringify!(x)
-            )
-        );
-    }
-    test_field_x();
-    fn test_field_y() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<PackedToTwo>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).y) as usize - ptr as usize
-            },
-            4usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(PackedToTwo),
-                "::",
-                stringify!(y)
-            )
-        );
-    }
-    test_field_y();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(PackedToTwo),
+            "::",
+            stringify!(x)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).y) as usize - ptr as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(PackedToTwo),
+            "::",
+            stringify!(y)
+        )
+    );
 }

--- a/tests/expectations/tests/issue-537-repr-packed-n.rs
+++ b/tests/expectations/tests/issue-537-repr-packed-n.rs
@@ -17,6 +17,7 @@ pub struct AlignedToOne {
 fn bindgen_test_layout_AlignedToOne() {
     const UNINIT: ::std::mem::MaybeUninit<AlignedToOne> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<AlignedToOne>(),
         4usize,
@@ -28,10 +29,7 @@ fn bindgen_test_layout_AlignedToOne() {
         concat!("Alignment of ", stringify!(AlignedToOne))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).i) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).i) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -51,6 +49,7 @@ pub struct AlignedToTwo {
 fn bindgen_test_layout_AlignedToTwo() {
     const UNINIT: ::std::mem::MaybeUninit<AlignedToTwo> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<AlignedToTwo>(),
         4usize,
@@ -62,10 +61,7 @@ fn bindgen_test_layout_AlignedToTwo() {
         concat!("Alignment of ", stringify!(AlignedToTwo))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).i) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).i) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -88,6 +84,7 @@ pub struct PackedToOne {
 fn bindgen_test_layout_PackedToOne() {
     const UNINIT: ::std::mem::MaybeUninit<PackedToOne> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<PackedToOne>(),
         8usize,
@@ -99,10 +96,7 @@ fn bindgen_test_layout_PackedToOne() {
         concat!("Alignment of ", stringify!(PackedToOne))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -112,10 +106,7 @@ fn bindgen_test_layout_PackedToOne() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).y) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).y) as usize - ptr as usize },
         4usize,
         concat!(
             "Offset of field: ",
@@ -136,6 +127,7 @@ pub struct PackedToTwo {
 fn bindgen_test_layout_PackedToTwo() {
     const UNINIT: ::std::mem::MaybeUninit<PackedToTwo> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<PackedToTwo>(),
         8usize,
@@ -147,10 +139,7 @@ fn bindgen_test_layout_PackedToTwo() {
         concat!("Alignment of ", stringify!(PackedToTwo))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -160,10 +149,7 @@ fn bindgen_test_layout_PackedToTwo() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).y) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).y) as usize - ptr as usize },
         4usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/issue-537.rs
+++ b/tests/expectations/tests/issue-537.rs
@@ -16,6 +16,7 @@ pub struct AlignedToOne {
 fn bindgen_test_layout_AlignedToOne() {
     const UNINIT: ::std::mem::MaybeUninit<AlignedToOne> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<AlignedToOne>(),
         4usize,
@@ -27,10 +28,7 @@ fn bindgen_test_layout_AlignedToOne() {
         concat!("Alignment of ", stringify!(AlignedToOne))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).i) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).i) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -51,6 +49,7 @@ pub struct AlignedToTwo {
 fn bindgen_test_layout_AlignedToTwo() {
     const UNINIT: ::std::mem::MaybeUninit<AlignedToTwo> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<AlignedToTwo>(),
         4usize,
@@ -62,10 +61,7 @@ fn bindgen_test_layout_AlignedToTwo() {
         concat!("Alignment of ", stringify!(AlignedToTwo))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).i) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).i) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -88,6 +84,7 @@ pub struct PackedToOne {
 fn bindgen_test_layout_PackedToOne() {
     const UNINIT: ::std::mem::MaybeUninit<PackedToOne> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<PackedToOne>(),
         8usize,
@@ -99,10 +96,7 @@ fn bindgen_test_layout_PackedToOne() {
         concat!("Alignment of ", stringify!(PackedToOne))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -112,10 +106,7 @@ fn bindgen_test_layout_PackedToOne() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).y) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).y) as usize - ptr as usize },
         4usize,
         concat!(
             "Offset of field: ",
@@ -138,6 +129,7 @@ pub struct PackedToTwo {
 fn bindgen_test_layout_PackedToTwo() {
     const UNINIT: ::std::mem::MaybeUninit<PackedToTwo> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<PackedToTwo>(),
         8usize,
@@ -149,10 +141,7 @@ fn bindgen_test_layout_PackedToTwo() {
         concat!("Alignment of ", stringify!(PackedToTwo))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -162,10 +151,7 @@ fn bindgen_test_layout_PackedToTwo() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).y) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).y) as usize - ptr as usize },
         4usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/issue-537.rs
+++ b/tests/expectations/tests/issue-537.rs
@@ -14,6 +14,8 @@ pub struct AlignedToOne {
 }
 #[test]
 fn bindgen_test_layout_AlignedToOne() {
+    const UNINIT: ::std::mem::MaybeUninit<AlignedToOne> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<AlignedToOne>(),
         4usize,
@@ -24,23 +26,19 @@ fn bindgen_test_layout_AlignedToOne() {
         1usize,
         concat!("Alignment of ", stringify!(AlignedToOne))
     );
-    fn test_field_i() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<AlignedToOne>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).i) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(AlignedToOne),
-                "::",
-                stringify!(i)
-            )
-        );
-    }
-    test_field_i();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).i) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(AlignedToOne),
+            "::",
+            stringify!(i)
+        )
+    );
 }
 /// This should be opaque because although we can see the attributes, Rust before
 /// 1.33 doesn't have `#[repr(packed(N))]`.
@@ -51,6 +49,8 @@ pub struct AlignedToTwo {
 }
 #[test]
 fn bindgen_test_layout_AlignedToTwo() {
+    const UNINIT: ::std::mem::MaybeUninit<AlignedToTwo> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<AlignedToTwo>(),
         4usize,
@@ -61,23 +61,19 @@ fn bindgen_test_layout_AlignedToTwo() {
         2usize,
         concat!("Alignment of ", stringify!(AlignedToTwo))
     );
-    fn test_field_i() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<AlignedToTwo>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).i) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(AlignedToTwo),
-                "::",
-                stringify!(i)
-            )
-        );
-    }
-    test_field_i();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).i) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(AlignedToTwo),
+            "::",
+            stringify!(i)
+        )
+    );
 }
 /// This should not be opaque because although `libclang` doesn't give us the
 /// `#pragma pack(1)`, we can detect that alignment is 1 and add
@@ -90,6 +86,8 @@ pub struct PackedToOne {
 }
 #[test]
 fn bindgen_test_layout_PackedToOne() {
+    const UNINIT: ::std::mem::MaybeUninit<PackedToOne> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<PackedToOne>(),
         8usize,
@@ -100,40 +98,32 @@ fn bindgen_test_layout_PackedToOne() {
         1usize,
         concat!("Alignment of ", stringify!(PackedToOne))
     );
-    fn test_field_x() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<PackedToOne>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(PackedToOne),
-                "::",
-                stringify!(x)
-            )
-        );
-    }
-    test_field_x();
-    fn test_field_y() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<PackedToOne>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).y) as usize - ptr as usize
-            },
-            4usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(PackedToOne),
-                "::",
-                stringify!(y)
-            )
-        );
-    }
-    test_field_y();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(PackedToOne),
+            "::",
+            stringify!(x)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).y) as usize - ptr as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(PackedToOne),
+            "::",
+            stringify!(y)
+        )
+    );
 }
 /// In this case, even if we can detect the weird alignment triggered by
 /// `#pragma pack(2)`, we can't do anything about it because Rust before 1.33
@@ -146,6 +136,8 @@ pub struct PackedToTwo {
 }
 #[test]
 fn bindgen_test_layout_PackedToTwo() {
+    const UNINIT: ::std::mem::MaybeUninit<PackedToTwo> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<PackedToTwo>(),
         8usize,
@@ -156,38 +148,30 @@ fn bindgen_test_layout_PackedToTwo() {
         2usize,
         concat!("Alignment of ", stringify!(PackedToTwo))
     );
-    fn test_field_x() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<PackedToTwo>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(PackedToTwo),
-                "::",
-                stringify!(x)
-            )
-        );
-    }
-    test_field_x();
-    fn test_field_y() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<PackedToTwo>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).y) as usize - ptr as usize
-            },
-            4usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(PackedToTwo),
-                "::",
-                stringify!(y)
-            )
-        );
-    }
-    test_field_y();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(PackedToTwo),
+            "::",
+            stringify!(x)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).y) as usize - ptr as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(PackedToTwo),
+            "::",
+            stringify!(y)
+        )
+    );
 }

--- a/tests/expectations/tests/issue-573-layout-test-failures.rs
+++ b/tests/expectations/tests/issue-573-layout-test-failures.rs
@@ -19,6 +19,7 @@ pub struct AutoIdVector {
 fn bindgen_test_layout_AutoIdVector() {
     const UNINIT: ::std::mem::MaybeUninit<AutoIdVector> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<AutoIdVector>(),
         1usize,
@@ -30,10 +31,7 @@ fn bindgen_test_layout_AutoIdVector() {
         concat!("Alignment of ", stringify!(AutoIdVector))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).ar) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).ar) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/issue-573-layout-test-failures.rs
+++ b/tests/expectations/tests/issue-573-layout-test-failures.rs
@@ -17,6 +17,8 @@ pub struct AutoIdVector {
 }
 #[test]
 fn bindgen_test_layout_AutoIdVector() {
+    const UNINIT: ::std::mem::MaybeUninit<AutoIdVector> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<AutoIdVector>(),
         1usize,
@@ -27,23 +29,19 @@ fn bindgen_test_layout_AutoIdVector() {
         1usize,
         concat!("Alignment of ", stringify!(AutoIdVector))
     );
-    fn test_field_ar() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<AutoIdVector>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).ar) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(AutoIdVector),
-                "::",
-                stringify!(ar)
-            )
-        );
-    }
-    test_field_ar();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).ar) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(AutoIdVector),
+            "::",
+            stringify!(ar)
+        )
+    );
 }
 #[test]
 fn __bindgen_test_layout_Outer_open0_int_close0_instantiation() {

--- a/tests/expectations/tests/issue-574-assertion-failure-in-codegen.rs
+++ b/tests/expectations/tests/issue-574-assertion-failure-in-codegen.rs
@@ -19,6 +19,7 @@ pub struct _bindgen_ty_1 {
 fn bindgen_test_layout__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<_bindgen_ty_1> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<_bindgen_ty_1>(),
         1usize,
@@ -30,10 +31,7 @@ fn bindgen_test_layout__bindgen_ty_1() {
         concat!("Alignment of ", stringify!(_bindgen_ty_1))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).ar) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).ar) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/issue-574-assertion-failure-in-codegen.rs
+++ b/tests/expectations/tests/issue-574-assertion-failure-in-codegen.rs
@@ -17,6 +17,8 @@ pub struct _bindgen_ty_1 {
 }
 #[test]
 fn bindgen_test_layout__bindgen_ty_1() {
+    const UNINIT: ::std::mem::MaybeUninit<_bindgen_ty_1> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<_bindgen_ty_1>(),
         1usize,
@@ -27,23 +29,19 @@ fn bindgen_test_layout__bindgen_ty_1() {
         1usize,
         concat!("Alignment of ", stringify!(_bindgen_ty_1))
     );
-    fn test_field_ar() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<_bindgen_ty_1>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).ar) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(_bindgen_ty_1),
-                "::",
-                stringify!(ar)
-            )
-        );
-    }
-    test_field_ar();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).ar) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(_bindgen_ty_1),
+            "::",
+            stringify!(ar)
+        )
+    );
 }
 extern "C" {
     pub static mut AutoIdVector: _bindgen_ty_1;

--- a/tests/expectations/tests/issue-584-stylo-template-analysis-panic.rs
+++ b/tests/expectations/tests/issue-584-stylo-template-analysis-panic.rs
@@ -51,6 +51,8 @@ pub struct g {
 }
 #[test]
 fn bindgen_test_layout_g() {
+    const UNINIT: ::std::mem::MaybeUninit<g> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<g>(),
         1usize,
@@ -61,18 +63,14 @@ fn bindgen_test_layout_g() {
         1usize,
         concat!("Alignment of ", stringify!(g))
     );
-    fn test_field_h() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<g>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).h) as usize - ptr as usize
-            },
-            0usize,
-            concat!("Offset of field: ", stringify!(g), "::", stringify!(h))
-        );
-    }
-    test_field_h();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).h) as usize - ptr as usize
+        },
+        0usize,
+        concat!("Offset of field: ", stringify!(g), "::", stringify!(h))
+    );
 }
 impl Default for g {
     fn default() -> Self {

--- a/tests/expectations/tests/issue-584-stylo-template-analysis-panic.rs
+++ b/tests/expectations/tests/issue-584-stylo-template-analysis-panic.rs
@@ -53,6 +53,7 @@ pub struct g {
 fn bindgen_test_layout_g() {
     const UNINIT: ::std::mem::MaybeUninit<g> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<g>(),
         1usize,
@@ -64,10 +65,7 @@ fn bindgen_test_layout_g() {
         concat!("Alignment of ", stringify!(g))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).h) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).h) as usize - ptr as usize },
         0usize,
         concat!("Offset of field: ", stringify!(g), "::", stringify!(h))
     );

--- a/tests/expectations/tests/issue-639-typedef-anon-field.rs
+++ b/tests/expectations/tests/issue-639-typedef-anon-field.rs
@@ -19,6 +19,7 @@ pub struct Foo_Bar {
 fn bindgen_test_layout_Foo_Bar() {
     const UNINIT: ::std::mem::MaybeUninit<Foo_Bar> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<Foo_Bar>(),
         4usize,
@@ -30,10 +31,7 @@ fn bindgen_test_layout_Foo_Bar() {
         concat!("Alignment of ", stringify!(Foo_Bar))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).abc) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).abc) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -47,6 +45,7 @@ fn bindgen_test_layout_Foo_Bar() {
 fn bindgen_test_layout_Foo() {
     const UNINIT: ::std::mem::MaybeUninit<Foo> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<Foo>(),
         4usize,
@@ -58,10 +57,7 @@ fn bindgen_test_layout_Foo() {
         concat!("Alignment of ", stringify!(Foo))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize },
         0usize,
         concat!("Offset of field: ", stringify!(Foo), "::", stringify!(bar))
     );
@@ -80,6 +76,7 @@ pub struct Baz_Bar {
 fn bindgen_test_layout_Baz_Bar() {
     const UNINIT: ::std::mem::MaybeUninit<Baz_Bar> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<Baz_Bar>(),
         4usize,
@@ -91,10 +88,7 @@ fn bindgen_test_layout_Baz_Bar() {
         concat!("Alignment of ", stringify!(Baz_Bar))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).abc) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).abc) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/issue-639-typedef-anon-field.rs
+++ b/tests/expectations/tests/issue-639-typedef-anon-field.rs
@@ -17,6 +17,8 @@ pub struct Foo_Bar {
 }
 #[test]
 fn bindgen_test_layout_Foo_Bar() {
+    const UNINIT: ::std::mem::MaybeUninit<Foo_Bar> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<Foo_Bar>(),
         4usize,
@@ -27,26 +29,24 @@ fn bindgen_test_layout_Foo_Bar() {
         4usize,
         concat!("Alignment of ", stringify!(Foo_Bar))
     );
-    fn test_field_abc() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Foo_Bar>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).abc) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(Foo_Bar),
-                "::",
-                stringify!(abc)
-            )
-        );
-    }
-    test_field_abc();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).abc) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(Foo_Bar),
+            "::",
+            stringify!(abc)
+        )
+    );
 }
 #[test]
 fn bindgen_test_layout_Foo() {
+    const UNINIT: ::std::mem::MaybeUninit<Foo> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<Foo>(),
         4usize,
@@ -57,23 +57,14 @@ fn bindgen_test_layout_Foo() {
         4usize,
         concat!("Alignment of ", stringify!(Foo))
     );
-    fn test_field_bar() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Foo>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(Foo),
-                "::",
-                stringify!(bar)
-            )
-        );
-    }
-    test_field_bar();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
+        },
+        0usize,
+        concat!("Offset of field: ", stringify!(Foo), "::", stringify!(bar))
+    );
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
@@ -87,6 +78,8 @@ pub struct Baz_Bar {
 }
 #[test]
 fn bindgen_test_layout_Baz_Bar() {
+    const UNINIT: ::std::mem::MaybeUninit<Baz_Bar> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<Baz_Bar>(),
         4usize,
@@ -97,23 +90,19 @@ fn bindgen_test_layout_Baz_Bar() {
         4usize,
         concat!("Alignment of ", stringify!(Baz_Bar))
     );
-    fn test_field_abc() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Baz_Bar>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).abc) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(Baz_Bar),
-                "::",
-                stringify!(abc)
-            )
-        );
-    }
-    test_field_abc();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).abc) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(Baz_Bar),
+            "::",
+            stringify!(abc)
+        )
+    );
 }
 #[test]
 fn bindgen_test_layout_Baz() {

--- a/tests/expectations/tests/issue-643-inner-struct.rs
+++ b/tests/expectations/tests/issue-643-inner-struct.rs
@@ -50,6 +50,8 @@ pub struct rte_ring_prod {
 }
 #[test]
 fn bindgen_test_layout_rte_ring_prod() {
+    const UNINIT: ::std::mem::MaybeUninit<rte_ring_prod> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<rte_ring_prod>(),
         4usize,
@@ -60,23 +62,19 @@ fn bindgen_test_layout_rte_ring_prod() {
         4usize,
         concat!("Alignment of ", stringify!(rte_ring_prod))
     );
-    fn test_field_watermark() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<rte_ring_prod>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).watermark) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_ring_prod),
-                "::",
-                stringify!(watermark)
-            )
-        );
-    }
-    test_field_watermark();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).watermark) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_ring_prod),
+            "::",
+            stringify!(watermark)
+        )
+    );
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
@@ -85,6 +83,8 @@ pub struct rte_ring_cons {
 }
 #[test]
 fn bindgen_test_layout_rte_ring_cons() {
+    const UNINIT: ::std::mem::MaybeUninit<rte_ring_cons> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<rte_ring_cons>(),
         4usize,
@@ -95,23 +95,19 @@ fn bindgen_test_layout_rte_ring_cons() {
         4usize,
         concat!("Alignment of ", stringify!(rte_ring_cons))
     );
-    fn test_field_sc_dequeue() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<rte_ring_cons>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).sc_dequeue) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_ring_cons),
-                "::",
-                stringify!(sc_dequeue)
-            )
-        );
-    }
-    test_field_sc_dequeue();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).sc_dequeue) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_ring_cons),
+            "::",
+            stringify!(sc_dequeue)
+        )
+    );
 }
 #[test]
 fn bindgen_test_layout_rte_ring() {

--- a/tests/expectations/tests/issue-643-inner-struct.rs
+++ b/tests/expectations/tests/issue-643-inner-struct.rs
@@ -52,6 +52,7 @@ pub struct rte_ring_prod {
 fn bindgen_test_layout_rte_ring_prod() {
     const UNINIT: ::std::mem::MaybeUninit<rte_ring_prod> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<rte_ring_prod>(),
         4usize,
@@ -64,7 +65,6 @@ fn bindgen_test_layout_rte_ring_prod() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).watermark) as usize - ptr as usize
         },
         0usize,
@@ -85,6 +85,7 @@ pub struct rte_ring_cons {
 fn bindgen_test_layout_rte_ring_cons() {
     const UNINIT: ::std::mem::MaybeUninit<rte_ring_cons> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<rte_ring_cons>(),
         4usize,
@@ -97,7 +98,6 @@ fn bindgen_test_layout_rte_ring_cons() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).sc_dequeue) as usize - ptr as usize
         },
         0usize,

--- a/tests/expectations/tests/issue-648-derive-debug-with-padding.rs
+++ b/tests/expectations/tests/issue-648-derive-debug-with-padding.rs
@@ -15,6 +15,8 @@ pub struct NoDebug {
 }
 #[test]
 fn bindgen_test_layout_NoDebug() {
+    const UNINIT: ::std::mem::MaybeUninit<NoDebug> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<NoDebug>(),
         64usize,
@@ -25,23 +27,19 @@ fn bindgen_test_layout_NoDebug() {
         64usize,
         concat!("Alignment of ", stringify!(NoDebug))
     );
-    fn test_field_c() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<NoDebug>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).c) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(NoDebug),
-                "::",
-                stringify!(c)
-            )
-        );
-    }
-    test_field_c();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).c) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(NoDebug),
+            "::",
+            stringify!(c)
+        )
+    );
 }
 impl Default for NoDebug {
     fn default() -> Self {
@@ -70,6 +68,8 @@ pub struct ShouldDeriveDebugButDoesNot {
 }
 #[test]
 fn bindgen_test_layout_ShouldDeriveDebugButDoesNot() {
+    const UNINIT: ::std::mem::MaybeUninit<ShouldDeriveDebugButDoesNot> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<ShouldDeriveDebugButDoesNot>(),
         64usize,
@@ -80,44 +80,32 @@ fn bindgen_test_layout_ShouldDeriveDebugButDoesNot() {
         64usize,
         concat!("Alignment of ", stringify!(ShouldDeriveDebugButDoesNot))
     );
-    fn test_field_c() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<
-                    ShouldDeriveDebugButDoesNot,
-                >::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).c) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(ShouldDeriveDebugButDoesNot),
-                "::",
-                stringify!(c)
-            )
-        );
-    }
-    test_field_c();
-    fn test_field_d() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<
-                    ShouldDeriveDebugButDoesNot,
-                >::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize
-            },
-            32usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(ShouldDeriveDebugButDoesNot),
-                "::",
-                stringify!(d)
-            )
-        );
-    }
-    test_field_d();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).c) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ShouldDeriveDebugButDoesNot),
+            "::",
+            stringify!(c)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize
+        },
+        32usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ShouldDeriveDebugButDoesNot),
+            "::",
+            stringify!(d)
+        )
+    );
 }
 impl Default for ShouldDeriveDebugButDoesNot {
     fn default() -> Self {

--- a/tests/expectations/tests/issue-648-derive-debug-with-padding.rs
+++ b/tests/expectations/tests/issue-648-derive-debug-with-padding.rs
@@ -17,6 +17,7 @@ pub struct NoDebug {
 fn bindgen_test_layout_NoDebug() {
     const UNINIT: ::std::mem::MaybeUninit<NoDebug> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<NoDebug>(),
         64usize,
@@ -28,10 +29,7 @@ fn bindgen_test_layout_NoDebug() {
         concat!("Alignment of ", stringify!(NoDebug))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).c) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).c) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -70,6 +68,7 @@ pub struct ShouldDeriveDebugButDoesNot {
 fn bindgen_test_layout_ShouldDeriveDebugButDoesNot() {
     const UNINIT: ::std::mem::MaybeUninit<ShouldDeriveDebugButDoesNot> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<ShouldDeriveDebugButDoesNot>(),
         64usize,
@@ -81,10 +80,7 @@ fn bindgen_test_layout_ShouldDeriveDebugButDoesNot() {
         concat!("Alignment of ", stringify!(ShouldDeriveDebugButDoesNot))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).c) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).c) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -94,10 +90,7 @@ fn bindgen_test_layout_ShouldDeriveDebugButDoesNot() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize },
         32usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/issue-674-1.rs
+++ b/tests/expectations/tests/issue-674-1.rs
@@ -26,6 +26,8 @@ pub mod root {
     }
     #[test]
     fn bindgen_test_layout_CapturingContentInfo() {
+        const UNINIT: ::std::mem::MaybeUninit<CapturingContentInfo> =
+            ::std::mem::MaybeUninit::uninit();
         assert_eq!(
             ::std::mem::size_of::<CapturingContentInfo>(),
             1usize,
@@ -36,24 +38,18 @@ pub mod root {
             1usize,
             concat!("Alignment of ", stringify!(CapturingContentInfo))
         );
-        fn test_field_a() {
-            assert_eq!(
-                unsafe {
-                    let uninit =
-                        ::std::mem::MaybeUninit::<CapturingContentInfo>::uninit(
-                        );
-                    let ptr = uninit.as_ptr();
-                    ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-                },
-                0usize,
-                concat!(
-                    "Offset of field: ",
-                    stringify!(CapturingContentInfo),
-                    "::",
-                    stringify!(a)
-                )
-            );
-        }
-        test_field_a();
+        assert_eq!(
+            unsafe {
+                let ptr = UNINIT.as_ptr();
+                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(CapturingContentInfo),
+                "::",
+                stringify!(a)
+            )
+        );
     }
 }

--- a/tests/expectations/tests/issue-674-1.rs
+++ b/tests/expectations/tests/issue-674-1.rs
@@ -28,6 +28,7 @@ pub mod root {
     fn bindgen_test_layout_CapturingContentInfo() {
         const UNINIT: ::std::mem::MaybeUninit<CapturingContentInfo> =
             ::std::mem::MaybeUninit::uninit();
+        let ptr = UNINIT.as_ptr();
         assert_eq!(
             ::std::mem::size_of::<CapturingContentInfo>(),
             1usize,
@@ -39,10 +40,7 @@ pub mod root {
             concat!("Alignment of ", stringify!(CapturingContentInfo))
         );
         assert_eq!(
-            unsafe {
-                let ptr = UNINIT.as_ptr();
-                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-            },
+            unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
             0usize,
             concat!(
                 "Offset of field: ",

--- a/tests/expectations/tests/issue-674-2.rs
+++ b/tests/expectations/tests/issue-674-2.rs
@@ -28,6 +28,7 @@ pub mod root {
     fn bindgen_test_layout_c() {
         const UNINIT: ::std::mem::MaybeUninit<c> =
             ::std::mem::MaybeUninit::uninit();
+        let ptr = UNINIT.as_ptr();
         assert_eq!(
             ::std::mem::size_of::<c>(),
             1usize,
@@ -39,10 +40,7 @@ pub mod root {
             concat!("Alignment of ", stringify!(c))
         );
         assert_eq!(
-            unsafe {
-                let ptr = UNINIT.as_ptr();
-                ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-            },
+            unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
             0usize,
             concat!("Offset of field: ", stringify!(c), "::", stringify!(b))
         );
@@ -56,6 +54,7 @@ pub mod root {
     fn bindgen_test_layout_B() {
         const UNINIT: ::std::mem::MaybeUninit<B> =
             ::std::mem::MaybeUninit::uninit();
+        let ptr = UNINIT.as_ptr();
         assert_eq!(
             ::std::mem::size_of::<B>(),
             1usize,
@@ -67,10 +66,7 @@ pub mod root {
             concat!("Alignment of ", stringify!(B))
         );
         assert_eq!(
-            unsafe {
-                let ptr = UNINIT.as_ptr();
-                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-            },
+            unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
             0usize,
             concat!("Offset of field: ", stringify!(B), "::", stringify!(a))
         );

--- a/tests/expectations/tests/issue-674-2.rs
+++ b/tests/expectations/tests/issue-674-2.rs
@@ -26,6 +26,8 @@ pub mod root {
     }
     #[test]
     fn bindgen_test_layout_c() {
+        const UNINIT: ::std::mem::MaybeUninit<c> =
+            ::std::mem::MaybeUninit::uninit();
         assert_eq!(
             ::std::mem::size_of::<c>(),
             1usize,
@@ -36,23 +38,14 @@ pub mod root {
             1usize,
             concat!("Alignment of ", stringify!(c))
         );
-        fn test_field_b() {
-            assert_eq!(
-                unsafe {
-                    let uninit = ::std::mem::MaybeUninit::<c>::uninit();
-                    let ptr = uninit.as_ptr();
-                    ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-                },
-                0usize,
-                concat!(
-                    "Offset of field: ",
-                    stringify!(c),
-                    "::",
-                    stringify!(b)
-                )
-            );
-        }
-        test_field_b();
+        assert_eq!(
+            unsafe {
+                let ptr = UNINIT.as_ptr();
+                ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
+            },
+            0usize,
+            concat!("Offset of field: ", stringify!(c), "::", stringify!(b))
+        );
     }
     #[repr(C)]
     #[derive(Debug, Default, Copy, Clone)]
@@ -61,6 +54,8 @@ pub mod root {
     }
     #[test]
     fn bindgen_test_layout_B() {
+        const UNINIT: ::std::mem::MaybeUninit<B> =
+            ::std::mem::MaybeUninit::uninit();
         assert_eq!(
             ::std::mem::size_of::<B>(),
             1usize,
@@ -71,23 +66,14 @@ pub mod root {
             1usize,
             concat!("Alignment of ", stringify!(B))
         );
-        fn test_field_a() {
-            assert_eq!(
-                unsafe {
-                    let uninit = ::std::mem::MaybeUninit::<B>::uninit();
-                    let ptr = uninit.as_ptr();
-                    ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-                },
-                0usize,
-                concat!(
-                    "Offset of field: ",
-                    stringify!(B),
-                    "::",
-                    stringify!(a)
-                )
-            );
-        }
-        test_field_a();
+        assert_eq!(
+            unsafe {
+                let ptr = UNINIT.as_ptr();
+                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+            },
+            0usize,
+            concat!("Offset of field: ", stringify!(B), "::", stringify!(a))
+        );
     }
     #[repr(C)]
     #[derive(Debug, Default, Copy, Clone)]

--- a/tests/expectations/tests/issue-674-3.rs
+++ b/tests/expectations/tests/issue-674-3.rs
@@ -22,6 +22,8 @@ pub mod root {
     }
     #[test]
     fn bindgen_test_layout_a() {
+        const UNINIT: ::std::mem::MaybeUninit<a> =
+            ::std::mem::MaybeUninit::uninit();
         assert_eq!(
             ::std::mem::size_of::<a>(),
             1usize,
@@ -32,23 +34,14 @@ pub mod root {
             1usize,
             concat!("Alignment of ", stringify!(a))
         );
-        fn test_field_b() {
-            assert_eq!(
-                unsafe {
-                    let uninit = ::std::mem::MaybeUninit::<a>::uninit();
-                    let ptr = uninit.as_ptr();
-                    ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-                },
-                0usize,
-                concat!(
-                    "Offset of field: ",
-                    stringify!(a),
-                    "::",
-                    stringify!(b)
-                )
-            );
-        }
-        test_field_b();
+        assert_eq!(
+            unsafe {
+                let ptr = UNINIT.as_ptr();
+                ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
+            },
+            0usize,
+            concat!("Offset of field: ", stringify!(a), "::", stringify!(b))
+        );
     }
     #[repr(C)]
     #[derive(Debug, Default, Copy, Clone)]
@@ -57,6 +50,8 @@ pub mod root {
     }
     #[test]
     fn bindgen_test_layout_nsCSSValue() {
+        const UNINIT: ::std::mem::MaybeUninit<nsCSSValue> =
+            ::std::mem::MaybeUninit::uninit();
         assert_eq!(
             ::std::mem::size_of::<nsCSSValue>(),
             1usize,
@@ -67,23 +62,18 @@ pub mod root {
             1usize,
             concat!("Alignment of ", stringify!(nsCSSValue))
         );
-        fn test_field_c() {
-            assert_eq!(
-                unsafe {
-                    let uninit =
-                        ::std::mem::MaybeUninit::<nsCSSValue>::uninit();
-                    let ptr = uninit.as_ptr();
-                    ::std::ptr::addr_of!((*ptr).c) as usize - ptr as usize
-                },
-                0usize,
-                concat!(
-                    "Offset of field: ",
-                    stringify!(nsCSSValue),
-                    "::",
-                    stringify!(c)
-                )
-            );
-        }
-        test_field_c();
+        assert_eq!(
+            unsafe {
+                let ptr = UNINIT.as_ptr();
+                ::std::ptr::addr_of!((*ptr).c) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(nsCSSValue),
+                "::",
+                stringify!(c)
+            )
+        );
     }
 }

--- a/tests/expectations/tests/issue-674-3.rs
+++ b/tests/expectations/tests/issue-674-3.rs
@@ -24,6 +24,7 @@ pub mod root {
     fn bindgen_test_layout_a() {
         const UNINIT: ::std::mem::MaybeUninit<a> =
             ::std::mem::MaybeUninit::uninit();
+        let ptr = UNINIT.as_ptr();
         assert_eq!(
             ::std::mem::size_of::<a>(),
             1usize,
@@ -35,10 +36,7 @@ pub mod root {
             concat!("Alignment of ", stringify!(a))
         );
         assert_eq!(
-            unsafe {
-                let ptr = UNINIT.as_ptr();
-                ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-            },
+            unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
             0usize,
             concat!("Offset of field: ", stringify!(a), "::", stringify!(b))
         );
@@ -52,6 +50,7 @@ pub mod root {
     fn bindgen_test_layout_nsCSSValue() {
         const UNINIT: ::std::mem::MaybeUninit<nsCSSValue> =
             ::std::mem::MaybeUninit::uninit();
+        let ptr = UNINIT.as_ptr();
         assert_eq!(
             ::std::mem::size_of::<nsCSSValue>(),
             1usize,
@@ -63,10 +62,7 @@ pub mod root {
             concat!("Alignment of ", stringify!(nsCSSValue))
         );
         assert_eq!(
-            unsafe {
-                let ptr = UNINIT.as_ptr();
-                ::std::ptr::addr_of!((*ptr).c) as usize - ptr as usize
-            },
+            unsafe { ::std::ptr::addr_of!((*ptr).c) as usize - ptr as usize },
             0usize,
             concat!(
                 "Offset of field: ",

--- a/tests/expectations/tests/issue-801-opaque-sloppiness.rs
+++ b/tests/expectations/tests/issue-801-opaque-sloppiness.rs
@@ -40,6 +40,8 @@ pub struct C {
 }
 #[test]
 fn bindgen_test_layout_C() {
+    const UNINIT: ::std::mem::MaybeUninit<C> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<C>(),
         1usize,
@@ -50,16 +52,12 @@ fn bindgen_test_layout_C() {
         1usize,
         concat!("Alignment of ", stringify!(C))
     );
-    fn test_field_b() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<C>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-            },
-            0usize,
-            concat!("Offset of field: ", stringify!(C), "::", stringify!(b))
-        );
-    }
-    test_field_b();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
+        },
+        0usize,
+        concat!("Offset of field: ", stringify!(C), "::", stringify!(b))
+    );
 }

--- a/tests/expectations/tests/issue-801-opaque-sloppiness.rs
+++ b/tests/expectations/tests/issue-801-opaque-sloppiness.rs
@@ -42,6 +42,7 @@ pub struct C {
 fn bindgen_test_layout_C() {
     const UNINIT: ::std::mem::MaybeUninit<C> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<C>(),
         1usize,
@@ -53,10 +54,7 @@ fn bindgen_test_layout_C() {
         concat!("Alignment of ", stringify!(C))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
         0usize,
         concat!("Offset of field: ", stringify!(C), "::", stringify!(b))
     );

--- a/tests/expectations/tests/issue-807-opaque-types-methods-being-generated.rs
+++ b/tests/expectations/tests/issue-807-opaque-types-methods-being-generated.rs
@@ -111,6 +111,7 @@ pub struct Allowlisted {
 fn bindgen_test_layout_Allowlisted() {
     const UNINIT: ::std::mem::MaybeUninit<Allowlisted> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<Allowlisted>(),
         1usize,
@@ -123,7 +124,6 @@ fn bindgen_test_layout_Allowlisted() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).some_member) as usize - ptr as usize
         },
         0usize,

--- a/tests/expectations/tests/issue-807-opaque-types-methods-being-generated.rs
+++ b/tests/expectations/tests/issue-807-opaque-types-methods-being-generated.rs
@@ -109,6 +109,8 @@ pub struct Allowlisted {
 }
 #[test]
 fn bindgen_test_layout_Allowlisted() {
+    const UNINIT: ::std::mem::MaybeUninit<Allowlisted> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<Allowlisted>(),
         1usize,
@@ -119,21 +121,17 @@ fn bindgen_test_layout_Allowlisted() {
         1usize,
         concat!("Alignment of ", stringify!(Allowlisted))
     );
-    fn test_field_some_member() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Allowlisted>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).some_member) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(Allowlisted),
-                "::",
-                stringify!(some_member)
-            )
-        );
-    }
-    test_field_some_member();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).some_member) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(Allowlisted),
+            "::",
+            stringify!(some_member)
+        )
+    );
 }

--- a/tests/expectations/tests/issue-944-derive-copy-and-blocklisting.rs
+++ b/tests/expectations/tests/issue-944-derive-copy-and-blocklisting.rs
@@ -16,6 +16,7 @@ pub struct ShouldNotBeCopy {
 fn bindgen_test_layout_ShouldNotBeCopy() {
     const UNINIT: ::std::mem::MaybeUninit<ShouldNotBeCopy> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<ShouldNotBeCopy>(),
         1usize,
@@ -27,10 +28,7 @@ fn bindgen_test_layout_ShouldNotBeCopy() {
         concat!("Alignment of ", stringify!(ShouldNotBeCopy))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/issue-944-derive-copy-and-blocklisting.rs
+++ b/tests/expectations/tests/issue-944-derive-copy-and-blocklisting.rs
@@ -14,6 +14,8 @@ pub struct ShouldNotBeCopy {
 }
 #[test]
 fn bindgen_test_layout_ShouldNotBeCopy() {
+    const UNINIT: ::std::mem::MaybeUninit<ShouldNotBeCopy> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<ShouldNotBeCopy>(),
         1usize,
@@ -24,24 +26,19 @@ fn bindgen_test_layout_ShouldNotBeCopy() {
         1usize,
         concat!("Alignment of ", stringify!(ShouldNotBeCopy))
     );
-    fn test_field_a() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<ShouldNotBeCopy>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(ShouldNotBeCopy),
-                "::",
-                stringify!(a)
-            )
-        );
-    }
-    test_field_a();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ShouldNotBeCopy),
+            "::",
+            stringify!(a)
+        )
+    );
 }
 impl Default for ShouldNotBeCopy {
     fn default() -> Self {

--- a/tests/expectations/tests/jsval_layout_opaque.rs
+++ b/tests/expectations/tests/jsval_layout_opaque.rs
@@ -280,6 +280,7 @@ fn bindgen_test_layout_jsval_layout__bindgen_ty_2__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<
         jsval_layout__bindgen_ty_2__bindgen_ty_1,
     > = ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<jsval_layout__bindgen_ty_2__bindgen_ty_1>(),
         4usize,
@@ -297,10 +298,7 @@ fn bindgen_test_layout_jsval_layout__bindgen_ty_2__bindgen_ty_1() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).i32_) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).i32_) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -310,10 +308,7 @@ fn bindgen_test_layout_jsval_layout__bindgen_ty_2__bindgen_ty_1() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).u32_) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).u32_) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -323,10 +318,7 @@ fn bindgen_test_layout_jsval_layout__bindgen_ty_2__bindgen_ty_1() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).why) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).why) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -349,6 +341,7 @@ impl Default for jsval_layout__bindgen_ty_2__bindgen_ty_1 {
 fn bindgen_test_layout_jsval_layout__bindgen_ty_2() {
     const UNINIT: ::std::mem::MaybeUninit<jsval_layout__bindgen_ty_2> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<jsval_layout__bindgen_ty_2>(),
         4usize,
@@ -360,10 +353,7 @@ fn bindgen_test_layout_jsval_layout__bindgen_ty_2() {
         concat!("Alignment of ", stringify!(jsval_layout__bindgen_ty_2))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).payload) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).payload) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -386,6 +376,7 @@ impl Default for jsval_layout__bindgen_ty_2 {
 fn bindgen_test_layout_jsval_layout() {
     const UNINIT: ::std::mem::MaybeUninit<jsval_layout> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<jsval_layout>(),
         8usize,
@@ -397,10 +388,7 @@ fn bindgen_test_layout_jsval_layout() {
         concat!("Alignment of ", stringify!(jsval_layout))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).asBits) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).asBits) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -411,7 +399,6 @@ fn bindgen_test_layout_jsval_layout() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).debugView) as usize - ptr as usize
         },
         0usize,
@@ -423,10 +410,7 @@ fn bindgen_test_layout_jsval_layout() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).s) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).s) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -437,7 +421,6 @@ fn bindgen_test_layout_jsval_layout() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).asDouble) as usize - ptr as usize
         },
         0usize,
@@ -449,10 +432,7 @@ fn bindgen_test_layout_jsval_layout() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).asPtr) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).asPtr) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -462,10 +442,7 @@ fn bindgen_test_layout_jsval_layout() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).asWord) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).asWord) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -476,7 +453,6 @@ fn bindgen_test_layout_jsval_layout() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).asUIntPtr) as usize - ptr as usize
         },
         0usize,
@@ -506,6 +482,7 @@ pub struct Value {
 fn bindgen_test_layout_Value() {
     const UNINIT: ::std::mem::MaybeUninit<Value> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<Value>(),
         8usize,
@@ -517,10 +494,7 @@ fn bindgen_test_layout_Value() {
         concat!("Alignment of ", stringify!(Value))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).data) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).data) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/jsval_layout_opaque.rs
+++ b/tests/expectations/tests/jsval_layout_opaque.rs
@@ -277,6 +277,9 @@ pub union jsval_layout__bindgen_ty_2__bindgen_ty_1 {
 }
 #[test]
 fn bindgen_test_layout_jsval_layout__bindgen_ty_2__bindgen_ty_1() {
+    const UNINIT: ::std::mem::MaybeUninit<
+        jsval_layout__bindgen_ty_2__bindgen_ty_1,
+    > = ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<jsval_layout__bindgen_ty_2__bindgen_ty_1>(),
         4usize,
@@ -293,63 +296,45 @@ fn bindgen_test_layout_jsval_layout__bindgen_ty_2__bindgen_ty_1() {
             stringify!(jsval_layout__bindgen_ty_2__bindgen_ty_1)
         )
     );
-    fn test_field_i32() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<
-                    jsval_layout__bindgen_ty_2__bindgen_ty_1,
-                >::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).i32_) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(jsval_layout__bindgen_ty_2__bindgen_ty_1),
-                "::",
-                stringify!(i32_)
-            )
-        );
-    }
-    test_field_i32();
-    fn test_field_u32() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<
-                    jsval_layout__bindgen_ty_2__bindgen_ty_1,
-                >::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).u32_) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(jsval_layout__bindgen_ty_2__bindgen_ty_1),
-                "::",
-                stringify!(u32_)
-            )
-        );
-    }
-    test_field_u32();
-    fn test_field_why() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<
-                    jsval_layout__bindgen_ty_2__bindgen_ty_1,
-                >::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).why) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(jsval_layout__bindgen_ty_2__bindgen_ty_1),
-                "::",
-                stringify!(why)
-            )
-        );
-    }
-    test_field_why();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).i32_) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(jsval_layout__bindgen_ty_2__bindgen_ty_1),
+            "::",
+            stringify!(i32_)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).u32_) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(jsval_layout__bindgen_ty_2__bindgen_ty_1),
+            "::",
+            stringify!(u32_)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).why) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(jsval_layout__bindgen_ty_2__bindgen_ty_1),
+            "::",
+            stringify!(why)
+        )
+    );
 }
 impl Default for jsval_layout__bindgen_ty_2__bindgen_ty_1 {
     fn default() -> Self {
@@ -362,6 +347,8 @@ impl Default for jsval_layout__bindgen_ty_2__bindgen_ty_1 {
 }
 #[test]
 fn bindgen_test_layout_jsval_layout__bindgen_ty_2() {
+    const UNINIT: ::std::mem::MaybeUninit<jsval_layout__bindgen_ty_2> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<jsval_layout__bindgen_ty_2>(),
         4usize,
@@ -372,25 +359,19 @@ fn bindgen_test_layout_jsval_layout__bindgen_ty_2() {
         4usize,
         concat!("Alignment of ", stringify!(jsval_layout__bindgen_ty_2))
     );
-    fn test_field_payload() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<
-                    jsval_layout__bindgen_ty_2,
-                >::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).payload) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(jsval_layout__bindgen_ty_2),
-                "::",
-                stringify!(payload)
-            )
-        );
-    }
-    test_field_payload();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).payload) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(jsval_layout__bindgen_ty_2),
+            "::",
+            stringify!(payload)
+        )
+    );
 }
 impl Default for jsval_layout__bindgen_ty_2 {
     fn default() -> Self {
@@ -403,6 +384,8 @@ impl Default for jsval_layout__bindgen_ty_2 {
 }
 #[test]
 fn bindgen_test_layout_jsval_layout() {
+    const UNINIT: ::std::mem::MaybeUninit<jsval_layout> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<jsval_layout>(),
         8usize,
@@ -413,125 +396,97 @@ fn bindgen_test_layout_jsval_layout() {
         8usize,
         concat!("Alignment of ", stringify!(jsval_layout))
     );
-    fn test_field_asBits() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<jsval_layout>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).asBits) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(jsval_layout),
-                "::",
-                stringify!(asBits)
-            )
-        );
-    }
-    test_field_asBits();
-    fn test_field_debugView() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<jsval_layout>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).debugView) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(jsval_layout),
-                "::",
-                stringify!(debugView)
-            )
-        );
-    }
-    test_field_debugView();
-    fn test_field_s() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<jsval_layout>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).s) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(jsval_layout),
-                "::",
-                stringify!(s)
-            )
-        );
-    }
-    test_field_s();
-    fn test_field_asDouble() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<jsval_layout>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).asDouble) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(jsval_layout),
-                "::",
-                stringify!(asDouble)
-            )
-        );
-    }
-    test_field_asDouble();
-    fn test_field_asPtr() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<jsval_layout>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).asPtr) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(jsval_layout),
-                "::",
-                stringify!(asPtr)
-            )
-        );
-    }
-    test_field_asPtr();
-    fn test_field_asWord() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<jsval_layout>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).asWord) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(jsval_layout),
-                "::",
-                stringify!(asWord)
-            )
-        );
-    }
-    test_field_asWord();
-    fn test_field_asUIntPtr() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<jsval_layout>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).asUIntPtr) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(jsval_layout),
-                "::",
-                stringify!(asUIntPtr)
-            )
-        );
-    }
-    test_field_asUIntPtr();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).asBits) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(jsval_layout),
+            "::",
+            stringify!(asBits)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).debugView) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(jsval_layout),
+            "::",
+            stringify!(debugView)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).s) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(jsval_layout),
+            "::",
+            stringify!(s)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).asDouble) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(jsval_layout),
+            "::",
+            stringify!(asDouble)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).asPtr) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(jsval_layout),
+            "::",
+            stringify!(asPtr)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).asWord) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(jsval_layout),
+            "::",
+            stringify!(asWord)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).asUIntPtr) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(jsval_layout),
+            "::",
+            stringify!(asUIntPtr)
+        )
+    );
 }
 impl Default for jsval_layout {
     fn default() -> Self {
@@ -549,6 +504,8 @@ pub struct Value {
 }
 #[test]
 fn bindgen_test_layout_Value() {
+    const UNINIT: ::std::mem::MaybeUninit<Value> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<Value>(),
         8usize,
@@ -559,23 +516,19 @@ fn bindgen_test_layout_Value() {
         8usize,
         concat!("Alignment of ", stringify!(Value))
     );
-    fn test_field_data() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Value>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).data) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(Value),
-                "::",
-                stringify!(data)
-            )
-        );
-    }
-    test_field_data();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).data) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(Value),
+            "::",
+            stringify!(data)
+        )
+    );
 }
 impl Default for Value {
     fn default() -> Self {

--- a/tests/expectations/tests/jsval_layout_opaque_1_0.rs
+++ b/tests/expectations/tests/jsval_layout_opaque_1_0.rs
@@ -330,6 +330,7 @@ fn bindgen_test_layout_jsval_layout__bindgen_ty_2__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<
         jsval_layout__bindgen_ty_2__bindgen_ty_1,
     > = ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<jsval_layout__bindgen_ty_2__bindgen_ty_1>(),
         4usize,
@@ -347,10 +348,7 @@ fn bindgen_test_layout_jsval_layout__bindgen_ty_2__bindgen_ty_1() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).i32_) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).i32_) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -360,10 +358,7 @@ fn bindgen_test_layout_jsval_layout__bindgen_ty_2__bindgen_ty_1() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).u32_) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).u32_) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -373,10 +368,7 @@ fn bindgen_test_layout_jsval_layout__bindgen_ty_2__bindgen_ty_1() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).why) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).why) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -395,6 +387,7 @@ impl Clone for jsval_layout__bindgen_ty_2__bindgen_ty_1 {
 fn bindgen_test_layout_jsval_layout__bindgen_ty_2() {
     const UNINIT: ::std::mem::MaybeUninit<jsval_layout__bindgen_ty_2> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<jsval_layout__bindgen_ty_2>(),
         4usize,
@@ -406,10 +399,7 @@ fn bindgen_test_layout_jsval_layout__bindgen_ty_2() {
         concat!("Alignment of ", stringify!(jsval_layout__bindgen_ty_2))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).payload) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).payload) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -428,6 +418,7 @@ impl Clone for jsval_layout__bindgen_ty_2 {
 fn bindgen_test_layout_jsval_layout() {
     const UNINIT: ::std::mem::MaybeUninit<jsval_layout> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<jsval_layout>(),
         8usize,
@@ -439,10 +430,7 @@ fn bindgen_test_layout_jsval_layout() {
         concat!("Alignment of ", stringify!(jsval_layout))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).asBits) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).asBits) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -453,7 +441,6 @@ fn bindgen_test_layout_jsval_layout() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).debugView) as usize - ptr as usize
         },
         0usize,
@@ -465,10 +452,7 @@ fn bindgen_test_layout_jsval_layout() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).s) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).s) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -479,7 +463,6 @@ fn bindgen_test_layout_jsval_layout() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).asDouble) as usize - ptr as usize
         },
         0usize,
@@ -491,10 +474,7 @@ fn bindgen_test_layout_jsval_layout() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).asPtr) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).asPtr) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -504,10 +484,7 @@ fn bindgen_test_layout_jsval_layout() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).asWord) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).asWord) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -518,7 +495,6 @@ fn bindgen_test_layout_jsval_layout() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).asUIntPtr) as usize - ptr as usize
         },
         0usize,
@@ -544,6 +520,7 @@ pub struct Value {
 fn bindgen_test_layout_Value() {
     const UNINIT: ::std::mem::MaybeUninit<Value> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<Value>(),
         8usize,
@@ -555,10 +532,7 @@ fn bindgen_test_layout_Value() {
         concat!("Alignment of ", stringify!(Value))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).data) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).data) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/jsval_layout_opaque_1_0.rs
+++ b/tests/expectations/tests/jsval_layout_opaque_1_0.rs
@@ -327,6 +327,9 @@ pub struct jsval_layout__bindgen_ty_2__bindgen_ty_1 {
 }
 #[test]
 fn bindgen_test_layout_jsval_layout__bindgen_ty_2__bindgen_ty_1() {
+    const UNINIT: ::std::mem::MaybeUninit<
+        jsval_layout__bindgen_ty_2__bindgen_ty_1,
+    > = ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<jsval_layout__bindgen_ty_2__bindgen_ty_1>(),
         4usize,
@@ -343,63 +346,45 @@ fn bindgen_test_layout_jsval_layout__bindgen_ty_2__bindgen_ty_1() {
             stringify!(jsval_layout__bindgen_ty_2__bindgen_ty_1)
         )
     );
-    fn test_field_i32() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<
-                    jsval_layout__bindgen_ty_2__bindgen_ty_1,
-                >::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).i32_) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(jsval_layout__bindgen_ty_2__bindgen_ty_1),
-                "::",
-                stringify!(i32_)
-            )
-        );
-    }
-    test_field_i32();
-    fn test_field_u32() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<
-                    jsval_layout__bindgen_ty_2__bindgen_ty_1,
-                >::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).u32_) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(jsval_layout__bindgen_ty_2__bindgen_ty_1),
-                "::",
-                stringify!(u32_)
-            )
-        );
-    }
-    test_field_u32();
-    fn test_field_why() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<
-                    jsval_layout__bindgen_ty_2__bindgen_ty_1,
-                >::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).why) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(jsval_layout__bindgen_ty_2__bindgen_ty_1),
-                "::",
-                stringify!(why)
-            )
-        );
-    }
-    test_field_why();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).i32_) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(jsval_layout__bindgen_ty_2__bindgen_ty_1),
+            "::",
+            stringify!(i32_)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).u32_) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(jsval_layout__bindgen_ty_2__bindgen_ty_1),
+            "::",
+            stringify!(u32_)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).why) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(jsval_layout__bindgen_ty_2__bindgen_ty_1),
+            "::",
+            stringify!(why)
+        )
+    );
 }
 impl Clone for jsval_layout__bindgen_ty_2__bindgen_ty_1 {
     fn clone(&self) -> Self {
@@ -408,6 +393,8 @@ impl Clone for jsval_layout__bindgen_ty_2__bindgen_ty_1 {
 }
 #[test]
 fn bindgen_test_layout_jsval_layout__bindgen_ty_2() {
+    const UNINIT: ::std::mem::MaybeUninit<jsval_layout__bindgen_ty_2> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<jsval_layout__bindgen_ty_2>(),
         4usize,
@@ -418,25 +405,19 @@ fn bindgen_test_layout_jsval_layout__bindgen_ty_2() {
         4usize,
         concat!("Alignment of ", stringify!(jsval_layout__bindgen_ty_2))
     );
-    fn test_field_payload() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<
-                    jsval_layout__bindgen_ty_2,
-                >::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).payload) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(jsval_layout__bindgen_ty_2),
-                "::",
-                stringify!(payload)
-            )
-        );
-    }
-    test_field_payload();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).payload) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(jsval_layout__bindgen_ty_2),
+            "::",
+            stringify!(payload)
+        )
+    );
 }
 impl Clone for jsval_layout__bindgen_ty_2 {
     fn clone(&self) -> Self {
@@ -445,6 +426,8 @@ impl Clone for jsval_layout__bindgen_ty_2 {
 }
 #[test]
 fn bindgen_test_layout_jsval_layout() {
+    const UNINIT: ::std::mem::MaybeUninit<jsval_layout> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<jsval_layout>(),
         8usize,
@@ -455,125 +438,97 @@ fn bindgen_test_layout_jsval_layout() {
         8usize,
         concat!("Alignment of ", stringify!(jsval_layout))
     );
-    fn test_field_asBits() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<jsval_layout>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).asBits) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(jsval_layout),
-                "::",
-                stringify!(asBits)
-            )
-        );
-    }
-    test_field_asBits();
-    fn test_field_debugView() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<jsval_layout>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).debugView) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(jsval_layout),
-                "::",
-                stringify!(debugView)
-            )
-        );
-    }
-    test_field_debugView();
-    fn test_field_s() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<jsval_layout>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).s) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(jsval_layout),
-                "::",
-                stringify!(s)
-            )
-        );
-    }
-    test_field_s();
-    fn test_field_asDouble() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<jsval_layout>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).asDouble) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(jsval_layout),
-                "::",
-                stringify!(asDouble)
-            )
-        );
-    }
-    test_field_asDouble();
-    fn test_field_asPtr() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<jsval_layout>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).asPtr) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(jsval_layout),
-                "::",
-                stringify!(asPtr)
-            )
-        );
-    }
-    test_field_asPtr();
-    fn test_field_asWord() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<jsval_layout>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).asWord) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(jsval_layout),
-                "::",
-                stringify!(asWord)
-            )
-        );
-    }
-    test_field_asWord();
-    fn test_field_asUIntPtr() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<jsval_layout>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).asUIntPtr) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(jsval_layout),
-                "::",
-                stringify!(asUIntPtr)
-            )
-        );
-    }
-    test_field_asUIntPtr();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).asBits) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(jsval_layout),
+            "::",
+            stringify!(asBits)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).debugView) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(jsval_layout),
+            "::",
+            stringify!(debugView)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).s) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(jsval_layout),
+            "::",
+            stringify!(s)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).asDouble) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(jsval_layout),
+            "::",
+            stringify!(asDouble)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).asPtr) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(jsval_layout),
+            "::",
+            stringify!(asPtr)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).asWord) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(jsval_layout),
+            "::",
+            stringify!(asWord)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).asUIntPtr) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(jsval_layout),
+            "::",
+            stringify!(asUIntPtr)
+        )
+    );
 }
 impl Clone for jsval_layout {
     fn clone(&self) -> Self {
@@ -587,6 +542,8 @@ pub struct Value {
 }
 #[test]
 fn bindgen_test_layout_Value() {
+    const UNINIT: ::std::mem::MaybeUninit<Value> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<Value>(),
         8usize,
@@ -597,23 +554,19 @@ fn bindgen_test_layout_Value() {
         8usize,
         concat!("Alignment of ", stringify!(Value))
     );
-    fn test_field_data() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Value>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).data) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(Value),
-                "::",
-                stringify!(data)
-            )
-        );
-    }
-    test_field_data();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).data) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(Value),
+            "::",
+            stringify!(data)
+        )
+    );
 }
 impl Clone for Value {
     fn clone(&self) -> Self {

--- a/tests/expectations/tests/layout_align.rs
+++ b/tests/expectations/tests/layout_align.rs
@@ -171,6 +171,7 @@ pub struct rte_eth_link {
 fn bindgen_test_layout_rte_eth_link() {
     const UNINIT: ::std::mem::MaybeUninit<rte_eth_link> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<rte_eth_link>(),
         8usize,
@@ -183,7 +184,6 @@ fn bindgen_test_layout_rte_eth_link() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).link_speed) as usize - ptr as usize
         },
         0usize,

--- a/tests/expectations/tests/layout_align.rs
+++ b/tests/expectations/tests/layout_align.rs
@@ -169,6 +169,8 @@ pub struct rte_eth_link {
 }
 #[test]
 fn bindgen_test_layout_rte_eth_link() {
+    const UNINIT: ::std::mem::MaybeUninit<rte_eth_link> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<rte_eth_link>(),
         8usize,
@@ -179,23 +181,19 @@ fn bindgen_test_layout_rte_eth_link() {
         8usize,
         concat!("Alignment of ", stringify!(rte_eth_link))
     );
-    fn test_field_link_speed() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<rte_eth_link>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).link_speed) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_link),
-                "::",
-                stringify!(link_speed)
-            )
-        );
-    }
-    test_field_link_speed();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).link_speed) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_link),
+            "::",
+            stringify!(link_speed)
+        )
+    );
 }
 impl rte_eth_link {
     #[inline]

--- a/tests/expectations/tests/layout_arp.rs
+++ b/tests/expectations/tests/layout_arp.rs
@@ -32,6 +32,7 @@ pub struct ether_addr {
 fn bindgen_test_layout_ether_addr() {
     const UNINIT: ::std::mem::MaybeUninit<ether_addr> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<ether_addr>(),
         6usize,
@@ -44,7 +45,6 @@ fn bindgen_test_layout_ether_addr() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).addr_bytes) as usize - ptr as usize
         },
         0usize,
@@ -73,6 +73,7 @@ pub struct arp_ipv4 {
 fn bindgen_test_layout_arp_ipv4() {
     const UNINIT: ::std::mem::MaybeUninit<arp_ipv4> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<arp_ipv4>(),
         20usize,
@@ -84,10 +85,7 @@ fn bindgen_test_layout_arp_ipv4() {
         concat!("Alignment of ", stringify!(arp_ipv4))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).arp_sha) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).arp_sha) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -97,10 +95,7 @@ fn bindgen_test_layout_arp_ipv4() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).arp_sip) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).arp_sip) as usize - ptr as usize },
         6usize,
         concat!(
             "Offset of field: ",
@@ -110,10 +105,7 @@ fn bindgen_test_layout_arp_ipv4() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).arp_tha) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).arp_tha) as usize - ptr as usize },
         10usize,
         concat!(
             "Offset of field: ",
@@ -123,10 +115,7 @@ fn bindgen_test_layout_arp_ipv4() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).arp_tip) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).arp_tip) as usize - ptr as usize },
         16usize,
         concat!(
             "Offset of field: ",
@@ -151,6 +140,7 @@ pub struct arp_hdr {
 fn bindgen_test_layout_arp_hdr() {
     const UNINIT: ::std::mem::MaybeUninit<arp_hdr> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<arp_hdr>(),
         28usize,
@@ -162,10 +152,7 @@ fn bindgen_test_layout_arp_hdr() {
         concat!("Alignment of ", stringify!(arp_hdr))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).arp_hrd) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).arp_hrd) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -175,10 +162,7 @@ fn bindgen_test_layout_arp_hdr() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).arp_pro) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).arp_pro) as usize - ptr as usize },
         2usize,
         concat!(
             "Offset of field: ",
@@ -188,10 +172,7 @@ fn bindgen_test_layout_arp_hdr() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).arp_hln) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).arp_hln) as usize - ptr as usize },
         4usize,
         concat!(
             "Offset of field: ",
@@ -201,10 +182,7 @@ fn bindgen_test_layout_arp_hdr() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).arp_pln) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).arp_pln) as usize - ptr as usize },
         5usize,
         concat!(
             "Offset of field: ",
@@ -214,10 +192,7 @@ fn bindgen_test_layout_arp_hdr() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).arp_op) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).arp_op) as usize - ptr as usize },
         6usize,
         concat!(
             "Offset of field: ",
@@ -228,7 +203,6 @@ fn bindgen_test_layout_arp_hdr() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).arp_data) as usize - ptr as usize
         },
         8usize,

--- a/tests/expectations/tests/layout_arp.rs
+++ b/tests/expectations/tests/layout_arp.rs
@@ -30,6 +30,8 @@ pub struct ether_addr {
 }
 #[test]
 fn bindgen_test_layout_ether_addr() {
+    const UNINIT: ::std::mem::MaybeUninit<ether_addr> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<ether_addr>(),
         6usize,
@@ -40,23 +42,19 @@ fn bindgen_test_layout_ether_addr() {
         1usize,
         concat!("Alignment of ", stringify!(ether_addr))
     );
-    fn test_field_addr_bytes() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<ether_addr>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).addr_bytes) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(ether_addr),
-                "::",
-                stringify!(addr_bytes)
-            )
-        );
-    }
-    test_field_addr_bytes();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).addr_bytes) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ether_addr),
+            "::",
+            stringify!(addr_bytes)
+        )
+    );
 }
 /// ARP header IPv4 payload.
 #[repr(C, packed)]
@@ -73,6 +71,8 @@ pub struct arp_ipv4 {
 }
 #[test]
 fn bindgen_test_layout_arp_ipv4() {
+    const UNINIT: ::std::mem::MaybeUninit<arp_ipv4> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<arp_ipv4>(),
         20usize,
@@ -83,74 +83,58 @@ fn bindgen_test_layout_arp_ipv4() {
         1usize,
         concat!("Alignment of ", stringify!(arp_ipv4))
     );
-    fn test_field_arp_sha() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<arp_ipv4>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).arp_sha) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(arp_ipv4),
-                "::",
-                stringify!(arp_sha)
-            )
-        );
-    }
-    test_field_arp_sha();
-    fn test_field_arp_sip() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<arp_ipv4>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).arp_sip) as usize - ptr as usize
-            },
-            6usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(arp_ipv4),
-                "::",
-                stringify!(arp_sip)
-            )
-        );
-    }
-    test_field_arp_sip();
-    fn test_field_arp_tha() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<arp_ipv4>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).arp_tha) as usize - ptr as usize
-            },
-            10usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(arp_ipv4),
-                "::",
-                stringify!(arp_tha)
-            )
-        );
-    }
-    test_field_arp_tha();
-    fn test_field_arp_tip() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<arp_ipv4>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).arp_tip) as usize - ptr as usize
-            },
-            16usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(arp_ipv4),
-                "::",
-                stringify!(arp_tip)
-            )
-        );
-    }
-    test_field_arp_tip();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).arp_sha) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(arp_ipv4),
+            "::",
+            stringify!(arp_sha)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).arp_sip) as usize - ptr as usize
+        },
+        6usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(arp_ipv4),
+            "::",
+            stringify!(arp_sip)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).arp_tha) as usize - ptr as usize
+        },
+        10usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(arp_ipv4),
+            "::",
+            stringify!(arp_tha)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).arp_tip) as usize - ptr as usize
+        },
+        16usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(arp_ipv4),
+            "::",
+            stringify!(arp_tip)
+        )
+    );
 }
 /// ARP header.
 #[repr(C, packed)]
@@ -165,6 +149,8 @@ pub struct arp_hdr {
 }
 #[test]
 fn bindgen_test_layout_arp_hdr() {
+    const UNINIT: ::std::mem::MaybeUninit<arp_hdr> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<arp_hdr>(),
         28usize,
@@ -175,106 +161,82 @@ fn bindgen_test_layout_arp_hdr() {
         1usize,
         concat!("Alignment of ", stringify!(arp_hdr))
     );
-    fn test_field_arp_hrd() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<arp_hdr>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).arp_hrd) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(arp_hdr),
-                "::",
-                stringify!(arp_hrd)
-            )
-        );
-    }
-    test_field_arp_hrd();
-    fn test_field_arp_pro() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<arp_hdr>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).arp_pro) as usize - ptr as usize
-            },
-            2usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(arp_hdr),
-                "::",
-                stringify!(arp_pro)
-            )
-        );
-    }
-    test_field_arp_pro();
-    fn test_field_arp_hln() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<arp_hdr>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).arp_hln) as usize - ptr as usize
-            },
-            4usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(arp_hdr),
-                "::",
-                stringify!(arp_hln)
-            )
-        );
-    }
-    test_field_arp_hln();
-    fn test_field_arp_pln() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<arp_hdr>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).arp_pln) as usize - ptr as usize
-            },
-            5usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(arp_hdr),
-                "::",
-                stringify!(arp_pln)
-            )
-        );
-    }
-    test_field_arp_pln();
-    fn test_field_arp_op() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<arp_hdr>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).arp_op) as usize - ptr as usize
-            },
-            6usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(arp_hdr),
-                "::",
-                stringify!(arp_op)
-            )
-        );
-    }
-    test_field_arp_op();
-    fn test_field_arp_data() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<arp_hdr>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).arp_data) as usize - ptr as usize
-            },
-            8usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(arp_hdr),
-                "::",
-                stringify!(arp_data)
-            )
-        );
-    }
-    test_field_arp_data();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).arp_hrd) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(arp_hdr),
+            "::",
+            stringify!(arp_hrd)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).arp_pro) as usize - ptr as usize
+        },
+        2usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(arp_hdr),
+            "::",
+            stringify!(arp_pro)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).arp_hln) as usize - ptr as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(arp_hdr),
+            "::",
+            stringify!(arp_hln)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).arp_pln) as usize - ptr as usize
+        },
+        5usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(arp_hdr),
+            "::",
+            stringify!(arp_pln)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).arp_op) as usize - ptr as usize
+        },
+        6usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(arp_hdr),
+            "::",
+            stringify!(arp_op)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).arp_data) as usize - ptr as usize
+        },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(arp_hdr),
+            "::",
+            stringify!(arp_data)
+        )
+    );
 }

--- a/tests/expectations/tests/layout_array.rs
+++ b/tests/expectations/tests/layout_array.rs
@@ -69,6 +69,8 @@ pub struct rte_mempool_ops {
 }
 #[test]
 fn bindgen_test_layout_rte_mempool_ops() {
+    const UNINIT: ::std::mem::MaybeUninit<rte_mempool_ops> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<rte_mempool_ops>(),
         128usize,
@@ -79,114 +81,84 @@ fn bindgen_test_layout_rte_mempool_ops() {
         64usize,
         concat!("Alignment of ", stringify!(rte_mempool_ops))
     );
-    fn test_field_name() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_mempool_ops>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).name) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_mempool_ops),
-                "::",
-                stringify!(name)
-            )
-        );
-    }
-    test_field_name();
-    fn test_field_alloc() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_mempool_ops>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).alloc) as usize - ptr as usize
-            },
-            32usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_mempool_ops),
-                "::",
-                stringify!(alloc)
-            )
-        );
-    }
-    test_field_alloc();
-    fn test_field_free() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_mempool_ops>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).free) as usize - ptr as usize
-            },
-            40usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_mempool_ops),
-                "::",
-                stringify!(free)
-            )
-        );
-    }
-    test_field_free();
-    fn test_field_enqueue() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_mempool_ops>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).enqueue) as usize - ptr as usize
-            },
-            48usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_mempool_ops),
-                "::",
-                stringify!(enqueue)
-            )
-        );
-    }
-    test_field_enqueue();
-    fn test_field_dequeue() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_mempool_ops>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).dequeue) as usize - ptr as usize
-            },
-            56usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_mempool_ops),
-                "::",
-                stringify!(dequeue)
-            )
-        );
-    }
-    test_field_dequeue();
-    fn test_field_get_count() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_mempool_ops>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).get_count) as usize - ptr as usize
-            },
-            64usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_mempool_ops),
-                "::",
-                stringify!(get_count)
-            )
-        );
-    }
-    test_field_get_count();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).name) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_mempool_ops),
+            "::",
+            stringify!(name)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).alloc) as usize - ptr as usize
+        },
+        32usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_mempool_ops),
+            "::",
+            stringify!(alloc)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).free) as usize - ptr as usize
+        },
+        40usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_mempool_ops),
+            "::",
+            stringify!(free)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).enqueue) as usize - ptr as usize
+        },
+        48usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_mempool_ops),
+            "::",
+            stringify!(enqueue)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).dequeue) as usize - ptr as usize
+        },
+        56usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_mempool_ops),
+            "::",
+            stringify!(dequeue)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).get_count) as usize - ptr as usize
+        },
+        64usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_mempool_ops),
+            "::",
+            stringify!(get_count)
+        )
+    );
 }
 impl Default for rte_mempool_ops {
     fn default() -> Self {
@@ -216,6 +188,8 @@ pub struct rte_spinlock_t {
 }
 #[test]
 fn bindgen_test_layout_rte_spinlock_t() {
+    const UNINIT: ::std::mem::MaybeUninit<rte_spinlock_t> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<rte_spinlock_t>(),
         4usize,
@@ -226,24 +200,19 @@ fn bindgen_test_layout_rte_spinlock_t() {
         4usize,
         concat!("Alignment of ", stringify!(rte_spinlock_t))
     );
-    fn test_field_locked() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_spinlock_t>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).locked) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_spinlock_t),
-                "::",
-                stringify!(locked)
-            )
-        );
-    }
-    test_field_locked();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).locked) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_spinlock_t),
+            "::",
+            stringify!(locked)
+        )
+    );
 }
 /// Structure storing the table of registered ops structs, each of which contain
 /// the function pointers for the mempool ops functions.
@@ -266,6 +235,8 @@ pub struct rte_mempool_ops_table {
 }
 #[test]
 fn bindgen_test_layout_rte_mempool_ops_table() {
+    const UNINIT: ::std::mem::MaybeUninit<rte_mempool_ops_table> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<rte_mempool_ops_table>(),
         2112usize,
@@ -276,60 +247,45 @@ fn bindgen_test_layout_rte_mempool_ops_table() {
         64usize,
         concat!("Alignment of ", stringify!(rte_mempool_ops_table))
     );
-    fn test_field_sl() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_mempool_ops_table>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).sl) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_mempool_ops_table),
-                "::",
-                stringify!(sl)
-            )
-        );
-    }
-    test_field_sl();
-    fn test_field_num_ops() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_mempool_ops_table>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).num_ops) as usize - ptr as usize
-            },
-            4usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_mempool_ops_table),
-                "::",
-                stringify!(num_ops)
-            )
-        );
-    }
-    test_field_num_ops();
-    fn test_field_ops() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_mempool_ops_table>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).ops) as usize - ptr as usize
-            },
-            64usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_mempool_ops_table),
-                "::",
-                stringify!(ops)
-            )
-        );
-    }
-    test_field_ops();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).sl) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_mempool_ops_table),
+            "::",
+            stringify!(sl)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).num_ops) as usize - ptr as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_mempool_ops_table),
+            "::",
+            stringify!(num_ops)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).ops) as usize - ptr as usize
+        },
+        64usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_mempool_ops_table),
+            "::",
+            stringify!(ops)
+        )
+    );
 }
 impl Default for rte_mempool_ops_table {
     fn default() -> Self {
@@ -357,6 +313,8 @@ pub struct malloc_heap__bindgen_ty_1 {
 }
 #[test]
 fn bindgen_test_layout_malloc_heap__bindgen_ty_1() {
+    const UNINIT: ::std::mem::MaybeUninit<malloc_heap__bindgen_ty_1> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<malloc_heap__bindgen_ty_1>(),
         8usize,
@@ -367,23 +325,19 @@ fn bindgen_test_layout_malloc_heap__bindgen_ty_1() {
         8usize,
         concat!("Alignment of ", stringify!(malloc_heap__bindgen_ty_1))
     );
-    fn test_field_lh_first() {
-        assert_eq!(
-            unsafe {
-                let uninit = :: std :: mem :: MaybeUninit :: < malloc_heap__bindgen_ty_1 > :: uninit () ;
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).lh_first) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(malloc_heap__bindgen_ty_1),
-                "::",
-                stringify!(lh_first)
-            )
-        );
-    }
-    test_field_lh_first();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).lh_first) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(malloc_heap__bindgen_ty_1),
+            "::",
+            stringify!(lh_first)
+        )
+    );
 }
 impl Default for malloc_heap__bindgen_ty_1 {
     fn default() -> Self {
@@ -396,6 +350,8 @@ impl Default for malloc_heap__bindgen_ty_1 {
 }
 #[test]
 fn bindgen_test_layout_malloc_heap() {
+    const UNINIT: ::std::mem::MaybeUninit<malloc_heap> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<malloc_heap>(),
         128usize,
@@ -406,74 +362,58 @@ fn bindgen_test_layout_malloc_heap() {
         64usize,
         concat!("Alignment of ", stringify!(malloc_heap))
     );
-    fn test_field_lock() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<malloc_heap>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).lock) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(malloc_heap),
-                "::",
-                stringify!(lock)
-            )
-        );
-    }
-    test_field_lock();
-    fn test_field_free_head() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<malloc_heap>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).free_head) as usize - ptr as usize
-            },
-            8usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(malloc_heap),
-                "::",
-                stringify!(free_head)
-            )
-        );
-    }
-    test_field_free_head();
-    fn test_field_alloc_count() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<malloc_heap>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).alloc_count) as usize - ptr as usize
-            },
-            112usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(malloc_heap),
-                "::",
-                stringify!(alloc_count)
-            )
-        );
-    }
-    test_field_alloc_count();
-    fn test_field_total_size() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<malloc_heap>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).total_size) as usize - ptr as usize
-            },
-            120usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(malloc_heap),
-                "::",
-                stringify!(total_size)
-            )
-        );
-    }
-    test_field_total_size();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).lock) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(malloc_heap),
+            "::",
+            stringify!(lock)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).free_head) as usize - ptr as usize
+        },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(malloc_heap),
+            "::",
+            stringify!(free_head)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).alloc_count) as usize - ptr as usize
+        },
+        112usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(malloc_heap),
+            "::",
+            stringify!(alloc_count)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).total_size) as usize - ptr as usize
+        },
+        120usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(malloc_heap),
+            "::",
+            stringify!(total_size)
+        )
+    );
 }
 impl Default for malloc_heap {
     fn default() -> Self {

--- a/tests/expectations/tests/layout_array.rs
+++ b/tests/expectations/tests/layout_array.rs
@@ -71,6 +71,7 @@ pub struct rte_mempool_ops {
 fn bindgen_test_layout_rte_mempool_ops() {
     const UNINIT: ::std::mem::MaybeUninit<rte_mempool_ops> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<rte_mempool_ops>(),
         128usize,
@@ -82,10 +83,7 @@ fn bindgen_test_layout_rte_mempool_ops() {
         concat!("Alignment of ", stringify!(rte_mempool_ops))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).name) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).name) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -95,10 +93,7 @@ fn bindgen_test_layout_rte_mempool_ops() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).alloc) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).alloc) as usize - ptr as usize },
         32usize,
         concat!(
             "Offset of field: ",
@@ -108,10 +103,7 @@ fn bindgen_test_layout_rte_mempool_ops() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).free) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).free) as usize - ptr as usize },
         40usize,
         concat!(
             "Offset of field: ",
@@ -121,10 +113,7 @@ fn bindgen_test_layout_rte_mempool_ops() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).enqueue) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).enqueue) as usize - ptr as usize },
         48usize,
         concat!(
             "Offset of field: ",
@@ -134,10 +123,7 @@ fn bindgen_test_layout_rte_mempool_ops() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).dequeue) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).dequeue) as usize - ptr as usize },
         56usize,
         concat!(
             "Offset of field: ",
@@ -148,7 +134,6 @@ fn bindgen_test_layout_rte_mempool_ops() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).get_count) as usize - ptr as usize
         },
         64usize,
@@ -190,6 +175,7 @@ pub struct rte_spinlock_t {
 fn bindgen_test_layout_rte_spinlock_t() {
     const UNINIT: ::std::mem::MaybeUninit<rte_spinlock_t> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<rte_spinlock_t>(),
         4usize,
@@ -201,10 +187,7 @@ fn bindgen_test_layout_rte_spinlock_t() {
         concat!("Alignment of ", stringify!(rte_spinlock_t))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).locked) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).locked) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -237,6 +220,7 @@ pub struct rte_mempool_ops_table {
 fn bindgen_test_layout_rte_mempool_ops_table() {
     const UNINIT: ::std::mem::MaybeUninit<rte_mempool_ops_table> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<rte_mempool_ops_table>(),
         2112usize,
@@ -248,10 +232,7 @@ fn bindgen_test_layout_rte_mempool_ops_table() {
         concat!("Alignment of ", stringify!(rte_mempool_ops_table))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).sl) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).sl) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -261,10 +242,7 @@ fn bindgen_test_layout_rte_mempool_ops_table() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).num_ops) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).num_ops) as usize - ptr as usize },
         4usize,
         concat!(
             "Offset of field: ",
@@ -274,10 +252,7 @@ fn bindgen_test_layout_rte_mempool_ops_table() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).ops) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).ops) as usize - ptr as usize },
         64usize,
         concat!(
             "Offset of field: ",
@@ -315,6 +290,7 @@ pub struct malloc_heap__bindgen_ty_1 {
 fn bindgen_test_layout_malloc_heap__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<malloc_heap__bindgen_ty_1> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<malloc_heap__bindgen_ty_1>(),
         8usize,
@@ -327,7 +303,6 @@ fn bindgen_test_layout_malloc_heap__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).lh_first) as usize - ptr as usize
         },
         0usize,
@@ -352,6 +327,7 @@ impl Default for malloc_heap__bindgen_ty_1 {
 fn bindgen_test_layout_malloc_heap() {
     const UNINIT: ::std::mem::MaybeUninit<malloc_heap> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<malloc_heap>(),
         128usize,
@@ -363,10 +339,7 @@ fn bindgen_test_layout_malloc_heap() {
         concat!("Alignment of ", stringify!(malloc_heap))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).lock) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).lock) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -377,7 +350,6 @@ fn bindgen_test_layout_malloc_heap() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).free_head) as usize - ptr as usize
         },
         8usize,
@@ -390,7 +362,6 @@ fn bindgen_test_layout_malloc_heap() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).alloc_count) as usize - ptr as usize
         },
         112usize,
@@ -403,7 +374,6 @@ fn bindgen_test_layout_malloc_heap() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).total_size) as usize - ptr as usize
         },
         120usize,

--- a/tests/expectations/tests/layout_array_too_long.rs
+++ b/tests/expectations/tests/layout_array_too_long.rs
@@ -35,6 +35,8 @@ pub struct ip_frag {
 }
 #[test]
 fn bindgen_test_layout_ip_frag() {
+    const UNINIT: ::std::mem::MaybeUninit<ip_frag> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<ip_frag>(),
         16usize,
@@ -45,57 +47,45 @@ fn bindgen_test_layout_ip_frag() {
         8usize,
         concat!("Alignment of ", stringify!(ip_frag))
     );
-    fn test_field_ofs() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<ip_frag>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).ofs) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(ip_frag),
-                "::",
-                stringify!(ofs)
-            )
-        );
-    }
-    test_field_ofs();
-    fn test_field_len() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<ip_frag>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).len) as usize - ptr as usize
-            },
-            2usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(ip_frag),
-                "::",
-                stringify!(len)
-            )
-        );
-    }
-    test_field_len();
-    fn test_field_mb() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<ip_frag>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).mb) as usize - ptr as usize
-            },
-            8usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(ip_frag),
-                "::",
-                stringify!(mb)
-            )
-        );
-    }
-    test_field_mb();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).ofs) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ip_frag),
+            "::",
+            stringify!(ofs)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).len) as usize - ptr as usize
+        },
+        2usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ip_frag),
+            "::",
+            stringify!(len)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).mb) as usize - ptr as usize
+        },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ip_frag),
+            "::",
+            stringify!(mb)
+        )
+    );
 }
 impl Default for ip_frag {
     fn default() -> Self {
@@ -119,6 +109,8 @@ pub struct ip_frag_key {
 }
 #[test]
 fn bindgen_test_layout_ip_frag_key() {
+    const UNINIT: ::std::mem::MaybeUninit<ip_frag_key> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<ip_frag_key>(),
         40usize,
@@ -129,57 +121,45 @@ fn bindgen_test_layout_ip_frag_key() {
         8usize,
         concat!("Alignment of ", stringify!(ip_frag_key))
     );
-    fn test_field_src_dst() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<ip_frag_key>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).src_dst) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(ip_frag_key),
-                "::",
-                stringify!(src_dst)
-            )
-        );
-    }
-    test_field_src_dst();
-    fn test_field_id() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<ip_frag_key>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).id) as usize - ptr as usize
-            },
-            32usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(ip_frag_key),
-                "::",
-                stringify!(id)
-            )
-        );
-    }
-    test_field_id();
-    fn test_field_key_len() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<ip_frag_key>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).key_len) as usize - ptr as usize
-            },
-            36usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(ip_frag_key),
-                "::",
-                stringify!(key_len)
-            )
-        );
-    }
-    test_field_key_len();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).src_dst) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ip_frag_key),
+            "::",
+            stringify!(src_dst)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).id) as usize - ptr as usize
+        },
+        32usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ip_frag_key),
+            "::",
+            stringify!(id)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).key_len) as usize - ptr as usize
+        },
+        36usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ip_frag_key),
+            "::",
+            stringify!(key_len)
+        )
+    );
 }
 /// @internal Fragmented packet to reassemble.
 /// First two entries in the frags[] array are for the last and first fragments.
@@ -210,6 +190,8 @@ pub struct ip_frag_pkt__bindgen_ty_1 {
 }
 #[test]
 fn bindgen_test_layout_ip_frag_pkt__bindgen_ty_1() {
+    const UNINIT: ::std::mem::MaybeUninit<ip_frag_pkt__bindgen_ty_1> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<ip_frag_pkt__bindgen_ty_1>(),
         16usize,
@@ -220,40 +202,32 @@ fn bindgen_test_layout_ip_frag_pkt__bindgen_ty_1() {
         8usize,
         concat!("Alignment of ", stringify!(ip_frag_pkt__bindgen_ty_1))
     );
-    fn test_field_tqe_next() {
-        assert_eq!(
-            unsafe {
-                let uninit = :: std :: mem :: MaybeUninit :: < ip_frag_pkt__bindgen_ty_1 > :: uninit () ;
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).tqe_next) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(ip_frag_pkt__bindgen_ty_1),
-                "::",
-                stringify!(tqe_next)
-            )
-        );
-    }
-    test_field_tqe_next();
-    fn test_field_tqe_prev() {
-        assert_eq!(
-            unsafe {
-                let uninit = :: std :: mem :: MaybeUninit :: < ip_frag_pkt__bindgen_ty_1 > :: uninit () ;
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).tqe_prev) as usize - ptr as usize
-            },
-            8usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(ip_frag_pkt__bindgen_ty_1),
-                "::",
-                stringify!(tqe_prev)
-            )
-        );
-    }
-    test_field_tqe_prev();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).tqe_next) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ip_frag_pkt__bindgen_ty_1),
+            "::",
+            stringify!(tqe_next)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).tqe_prev) as usize - ptr as usize
+        },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ip_frag_pkt__bindgen_ty_1),
+            "::",
+            stringify!(tqe_prev)
+        )
+    );
 }
 impl Default for ip_frag_pkt__bindgen_ty_1 {
     fn default() -> Self {
@@ -266,6 +240,8 @@ impl Default for ip_frag_pkt__bindgen_ty_1 {
 }
 #[test]
 fn bindgen_test_layout_ip_frag_pkt() {
+    const UNINIT: ::std::mem::MaybeUninit<ip_frag_pkt> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<ip_frag_pkt>(),
         192usize,
@@ -276,125 +252,97 @@ fn bindgen_test_layout_ip_frag_pkt() {
         64usize,
         concat!("Alignment of ", stringify!(ip_frag_pkt))
     );
-    fn test_field_lru() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<ip_frag_pkt>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).lru) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(ip_frag_pkt),
-                "::",
-                stringify!(lru)
-            )
-        );
-    }
-    test_field_lru();
-    fn test_field_key() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<ip_frag_pkt>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).key) as usize - ptr as usize
-            },
-            16usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(ip_frag_pkt),
-                "::",
-                stringify!(key)
-            )
-        );
-    }
-    test_field_key();
-    fn test_field_start() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<ip_frag_pkt>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).start) as usize - ptr as usize
-            },
-            56usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(ip_frag_pkt),
-                "::",
-                stringify!(start)
-            )
-        );
-    }
-    test_field_start();
-    fn test_field_total_size() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<ip_frag_pkt>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).total_size) as usize - ptr as usize
-            },
-            64usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(ip_frag_pkt),
-                "::",
-                stringify!(total_size)
-            )
-        );
-    }
-    test_field_total_size();
-    fn test_field_frag_size() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<ip_frag_pkt>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).frag_size) as usize - ptr as usize
-            },
-            68usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(ip_frag_pkt),
-                "::",
-                stringify!(frag_size)
-            )
-        );
-    }
-    test_field_frag_size();
-    fn test_field_last_idx() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<ip_frag_pkt>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).last_idx) as usize - ptr as usize
-            },
-            72usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(ip_frag_pkt),
-                "::",
-                stringify!(last_idx)
-            )
-        );
-    }
-    test_field_last_idx();
-    fn test_field_frags() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<ip_frag_pkt>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).frags) as usize - ptr as usize
-            },
-            80usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(ip_frag_pkt),
-                "::",
-                stringify!(frags)
-            )
-        );
-    }
-    test_field_frags();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).lru) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ip_frag_pkt),
+            "::",
+            stringify!(lru)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).key) as usize - ptr as usize
+        },
+        16usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ip_frag_pkt),
+            "::",
+            stringify!(key)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).start) as usize - ptr as usize
+        },
+        56usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ip_frag_pkt),
+            "::",
+            stringify!(start)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).total_size) as usize - ptr as usize
+        },
+        64usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ip_frag_pkt),
+            "::",
+            stringify!(total_size)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).frag_size) as usize - ptr as usize
+        },
+        68usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ip_frag_pkt),
+            "::",
+            stringify!(frag_size)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).last_idx) as usize - ptr as usize
+        },
+        72usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ip_frag_pkt),
+            "::",
+            stringify!(last_idx)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).frags) as usize - ptr as usize
+        },
+        80usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ip_frag_pkt),
+            "::",
+            stringify!(frags)
+        )
+    );
 }
 impl Default for ip_frag_pkt {
     fn default() -> Self {

--- a/tests/expectations/tests/layout_array_too_long.rs
+++ b/tests/expectations/tests/layout_array_too_long.rs
@@ -37,6 +37,7 @@ pub struct ip_frag {
 fn bindgen_test_layout_ip_frag() {
     const UNINIT: ::std::mem::MaybeUninit<ip_frag> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<ip_frag>(),
         16usize,
@@ -48,10 +49,7 @@ fn bindgen_test_layout_ip_frag() {
         concat!("Alignment of ", stringify!(ip_frag))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).ofs) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).ofs) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -61,10 +59,7 @@ fn bindgen_test_layout_ip_frag() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).len) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).len) as usize - ptr as usize },
         2usize,
         concat!(
             "Offset of field: ",
@@ -74,10 +69,7 @@ fn bindgen_test_layout_ip_frag() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mb) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).mb) as usize - ptr as usize },
         8usize,
         concat!(
             "Offset of field: ",
@@ -111,6 +103,7 @@ pub struct ip_frag_key {
 fn bindgen_test_layout_ip_frag_key() {
     const UNINIT: ::std::mem::MaybeUninit<ip_frag_key> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<ip_frag_key>(),
         40usize,
@@ -122,10 +115,7 @@ fn bindgen_test_layout_ip_frag_key() {
         concat!("Alignment of ", stringify!(ip_frag_key))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).src_dst) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).src_dst) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -135,10 +125,7 @@ fn bindgen_test_layout_ip_frag_key() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).id) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).id) as usize - ptr as usize },
         32usize,
         concat!(
             "Offset of field: ",
@@ -148,10 +135,7 @@ fn bindgen_test_layout_ip_frag_key() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).key_len) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).key_len) as usize - ptr as usize },
         36usize,
         concat!(
             "Offset of field: ",
@@ -192,6 +176,7 @@ pub struct ip_frag_pkt__bindgen_ty_1 {
 fn bindgen_test_layout_ip_frag_pkt__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<ip_frag_pkt__bindgen_ty_1> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<ip_frag_pkt__bindgen_ty_1>(),
         16usize,
@@ -204,7 +189,6 @@ fn bindgen_test_layout_ip_frag_pkt__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).tqe_next) as usize - ptr as usize
         },
         0usize,
@@ -217,7 +201,6 @@ fn bindgen_test_layout_ip_frag_pkt__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).tqe_prev) as usize - ptr as usize
         },
         8usize,
@@ -242,6 +225,7 @@ impl Default for ip_frag_pkt__bindgen_ty_1 {
 fn bindgen_test_layout_ip_frag_pkt() {
     const UNINIT: ::std::mem::MaybeUninit<ip_frag_pkt> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<ip_frag_pkt>(),
         192usize,
@@ -253,10 +237,7 @@ fn bindgen_test_layout_ip_frag_pkt() {
         concat!("Alignment of ", stringify!(ip_frag_pkt))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).lru) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).lru) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -266,10 +247,7 @@ fn bindgen_test_layout_ip_frag_pkt() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).key) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).key) as usize - ptr as usize },
         16usize,
         concat!(
             "Offset of field: ",
@@ -279,10 +257,7 @@ fn bindgen_test_layout_ip_frag_pkt() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).start) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).start) as usize - ptr as usize },
         56usize,
         concat!(
             "Offset of field: ",
@@ -293,7 +268,6 @@ fn bindgen_test_layout_ip_frag_pkt() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).total_size) as usize - ptr as usize
         },
         64usize,
@@ -306,7 +280,6 @@ fn bindgen_test_layout_ip_frag_pkt() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).frag_size) as usize - ptr as usize
         },
         68usize,
@@ -319,7 +292,6 @@ fn bindgen_test_layout_ip_frag_pkt() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).last_idx) as usize - ptr as usize
         },
         72usize,
@@ -331,10 +303,7 @@ fn bindgen_test_layout_ip_frag_pkt() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).frags) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).frags) as usize - ptr as usize },
         80usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/layout_cmdline_token.rs
+++ b/tests/expectations/tests/layout_cmdline_token.rs
@@ -17,6 +17,7 @@ pub struct cmdline_token_hdr {
 fn bindgen_test_layout_cmdline_token_hdr() {
     const UNINIT: ::std::mem::MaybeUninit<cmdline_token_hdr> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<cmdline_token_hdr>(),
         16usize,
@@ -28,10 +29,7 @@ fn bindgen_test_layout_cmdline_token_hdr() {
         concat!("Alignment of ", stringify!(cmdline_token_hdr))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).ops) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).ops) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -41,10 +39,7 @@ fn bindgen_test_layout_cmdline_token_hdr() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).offset) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).offset) as usize - ptr as usize },
         8usize,
         concat!(
             "Offset of field: ",
@@ -123,6 +118,7 @@ pub struct cmdline_token_ops {
 fn bindgen_test_layout_cmdline_token_ops() {
     const UNINIT: ::std::mem::MaybeUninit<cmdline_token_ops> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<cmdline_token_ops>(),
         32usize,
@@ -134,10 +130,7 @@ fn bindgen_test_layout_cmdline_token_ops() {
         concat!("Alignment of ", stringify!(cmdline_token_ops))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).parse) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).parse) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -148,7 +141,6 @@ fn bindgen_test_layout_cmdline_token_ops() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).complete_get_nb) as usize - ptr as usize
         },
         8usize,
@@ -161,7 +153,6 @@ fn bindgen_test_layout_cmdline_token_ops() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).complete_get_elt) as usize -
                 ptr as usize
         },
@@ -175,7 +166,6 @@ fn bindgen_test_layout_cmdline_token_ops() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).get_help) as usize - ptr as usize
         },
         24usize,
@@ -208,6 +198,7 @@ pub struct cmdline_token_num_data {
 fn bindgen_test_layout_cmdline_token_num_data() {
     const UNINIT: ::std::mem::MaybeUninit<cmdline_token_num_data> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<cmdline_token_num_data>(),
         4usize,
@@ -219,10 +210,7 @@ fn bindgen_test_layout_cmdline_token_num_data() {
         concat!("Alignment of ", stringify!(cmdline_token_num_data))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).type_) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).type_) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -251,6 +239,7 @@ pub struct cmdline_token_num {
 fn bindgen_test_layout_cmdline_token_num() {
     const UNINIT: ::std::mem::MaybeUninit<cmdline_token_num> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<cmdline_token_num>(),
         24usize,
@@ -262,10 +251,7 @@ fn bindgen_test_layout_cmdline_token_num() {
         concat!("Alignment of ", stringify!(cmdline_token_num))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).hdr) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).hdr) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -276,7 +262,6 @@ fn bindgen_test_layout_cmdline_token_num() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).num_data) as usize - ptr as usize
         },
         16usize,

--- a/tests/expectations/tests/layout_cmdline_token.rs
+++ b/tests/expectations/tests/layout_cmdline_token.rs
@@ -15,6 +15,8 @@ pub struct cmdline_token_hdr {
 }
 #[test]
 fn bindgen_test_layout_cmdline_token_hdr() {
+    const UNINIT: ::std::mem::MaybeUninit<cmdline_token_hdr> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<cmdline_token_hdr>(),
         16usize,
@@ -25,42 +27,32 @@ fn bindgen_test_layout_cmdline_token_hdr() {
         8usize,
         concat!("Alignment of ", stringify!(cmdline_token_hdr))
     );
-    fn test_field_ops() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<cmdline_token_hdr>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).ops) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(cmdline_token_hdr),
-                "::",
-                stringify!(ops)
-            )
-        );
-    }
-    test_field_ops();
-    fn test_field_offset() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<cmdline_token_hdr>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).offset) as usize - ptr as usize
-            },
-            8usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(cmdline_token_hdr),
-                "::",
-                stringify!(offset)
-            )
-        );
-    }
-    test_field_offset();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).ops) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(cmdline_token_hdr),
+            "::",
+            stringify!(ops)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).offset) as usize - ptr as usize
+        },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(cmdline_token_hdr),
+            "::",
+            stringify!(offset)
+        )
+    );
 }
 impl Default for cmdline_token_hdr {
     fn default() -> Self {
@@ -129,6 +121,8 @@ pub struct cmdline_token_ops {
 }
 #[test]
 fn bindgen_test_layout_cmdline_token_ops() {
+    const UNINIT: ::std::mem::MaybeUninit<cmdline_token_ops> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<cmdline_token_ops>(),
         32usize,
@@ -139,80 +133,59 @@ fn bindgen_test_layout_cmdline_token_ops() {
         8usize,
         concat!("Alignment of ", stringify!(cmdline_token_ops))
     );
-    fn test_field_parse() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<cmdline_token_ops>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).parse) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(cmdline_token_ops),
-                "::",
-                stringify!(parse)
-            )
-        );
-    }
-    test_field_parse();
-    fn test_field_complete_get_nb() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<cmdline_token_ops>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).complete_get_nb) as usize -
-                    ptr as usize
-            },
-            8usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(cmdline_token_ops),
-                "::",
-                stringify!(complete_get_nb)
-            )
-        );
-    }
-    test_field_complete_get_nb();
-    fn test_field_complete_get_elt() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<cmdline_token_ops>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).complete_get_elt) as usize -
-                    ptr as usize
-            },
-            16usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(cmdline_token_ops),
-                "::",
-                stringify!(complete_get_elt)
-            )
-        );
-    }
-    test_field_complete_get_elt();
-    fn test_field_get_help() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<cmdline_token_ops>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).get_help) as usize - ptr as usize
-            },
-            24usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(cmdline_token_ops),
-                "::",
-                stringify!(get_help)
-            )
-        );
-    }
-    test_field_get_help();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).parse) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(cmdline_token_ops),
+            "::",
+            stringify!(parse)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).complete_get_nb) as usize - ptr as usize
+        },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(cmdline_token_ops),
+            "::",
+            stringify!(complete_get_nb)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).complete_get_elt) as usize -
+                ptr as usize
+        },
+        16usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(cmdline_token_ops),
+            "::",
+            stringify!(complete_get_elt)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).get_help) as usize - ptr as usize
+        },
+        24usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(cmdline_token_ops),
+            "::",
+            stringify!(get_help)
+        )
+    );
 }
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -233,6 +206,8 @@ pub struct cmdline_token_num_data {
 }
 #[test]
 fn bindgen_test_layout_cmdline_token_num_data() {
+    const UNINIT: ::std::mem::MaybeUninit<cmdline_token_num_data> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<cmdline_token_num_data>(),
         4usize,
@@ -243,24 +218,19 @@ fn bindgen_test_layout_cmdline_token_num_data() {
         4usize,
         concat!("Alignment of ", stringify!(cmdline_token_num_data))
     );
-    fn test_field_type() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<cmdline_token_num_data>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).type_) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(cmdline_token_num_data),
-                "::",
-                stringify!(type_)
-            )
-        );
-    }
-    test_field_type();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).type_) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(cmdline_token_num_data),
+            "::",
+            stringify!(type_)
+        )
+    );
 }
 impl Default for cmdline_token_num_data {
     fn default() -> Self {
@@ -279,6 +249,8 @@ pub struct cmdline_token_num {
 }
 #[test]
 fn bindgen_test_layout_cmdline_token_num() {
+    const UNINIT: ::std::mem::MaybeUninit<cmdline_token_num> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<cmdline_token_num>(),
         24usize,
@@ -289,42 +261,32 @@ fn bindgen_test_layout_cmdline_token_num() {
         8usize,
         concat!("Alignment of ", stringify!(cmdline_token_num))
     );
-    fn test_field_hdr() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<cmdline_token_num>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).hdr) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(cmdline_token_num),
-                "::",
-                stringify!(hdr)
-            )
-        );
-    }
-    test_field_hdr();
-    fn test_field_num_data() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<cmdline_token_num>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).num_data) as usize - ptr as usize
-            },
-            16usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(cmdline_token_num),
-                "::",
-                stringify!(num_data)
-            )
-        );
-    }
-    test_field_num_data();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).hdr) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(cmdline_token_num),
+            "::",
+            stringify!(hdr)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).num_data) as usize - ptr as usize
+        },
+        16usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(cmdline_token_num),
+            "::",
+            stringify!(num_data)
+        )
+    );
 }
 impl Default for cmdline_token_num {
     fn default() -> Self {

--- a/tests/expectations/tests/layout_eth_conf.rs
+++ b/tests/expectations/tests/layout_eth_conf.rs
@@ -162,6 +162,7 @@ pub struct rte_eth_rxmode {
 fn bindgen_test_layout_rte_eth_rxmode() {
     const UNINIT: ::std::mem::MaybeUninit<rte_eth_rxmode> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<rte_eth_rxmode>(),
         12usize,
@@ -173,10 +174,7 @@ fn bindgen_test_layout_rte_eth_rxmode() {
         concat!("Alignment of ", stringify!(rte_eth_rxmode))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mq_mode) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).mq_mode) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -187,7 +185,6 @@ fn bindgen_test_layout_rte_eth_rxmode() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).max_rx_pkt_len) as usize - ptr as usize
         },
         4usize,
@@ -200,7 +197,6 @@ fn bindgen_test_layout_rte_eth_rxmode() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).split_hdr_size) as usize - ptr as usize
         },
         8usize,
@@ -429,6 +425,7 @@ pub struct rte_eth_txmode {
 fn bindgen_test_layout_rte_eth_txmode() {
     const UNINIT: ::std::mem::MaybeUninit<rte_eth_txmode> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<rte_eth_txmode>(),
         8usize,
@@ -440,10 +437,7 @@ fn bindgen_test_layout_rte_eth_txmode() {
         concat!("Alignment of ", stringify!(rte_eth_txmode))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mq_mode) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).mq_mode) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -453,10 +447,7 @@ fn bindgen_test_layout_rte_eth_txmode() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).pvid) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).pvid) as usize - ptr as usize },
         4usize,
         concat!(
             "Offset of field: ",
@@ -570,6 +561,7 @@ pub struct rte_eth_rss_conf {
 fn bindgen_test_layout_rte_eth_rss_conf() {
     const UNINIT: ::std::mem::MaybeUninit<rte_eth_rss_conf> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<rte_eth_rss_conf>(),
         24usize,
@@ -581,10 +573,7 @@ fn bindgen_test_layout_rte_eth_rss_conf() {
         concat!("Alignment of ", stringify!(rte_eth_rss_conf))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).rss_key) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).rss_key) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -595,7 +584,6 @@ fn bindgen_test_layout_rte_eth_rss_conf() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).rss_key_len) as usize - ptr as usize
         },
         8usize,
@@ -607,10 +595,7 @@ fn bindgen_test_layout_rte_eth_rss_conf() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).rss_hf) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).rss_hf) as usize - ptr as usize },
         16usize,
         concat!(
             "Offset of field: ",
@@ -689,6 +674,7 @@ pub struct rte_eth_vmdq_dcb_conf__bindgen_ty_1 {
 fn bindgen_test_layout_rte_eth_vmdq_dcb_conf__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<rte_eth_vmdq_dcb_conf__bindgen_ty_1> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<rte_eth_vmdq_dcb_conf__bindgen_ty_1>(),
         16usize,
@@ -703,10 +689,7 @@ fn bindgen_test_layout_rte_eth_vmdq_dcb_conf__bindgen_ty_1() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).vlan_id) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).vlan_id) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -716,10 +699,7 @@ fn bindgen_test_layout_rte_eth_vmdq_dcb_conf__bindgen_ty_1() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).pools) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).pools) as usize - ptr as usize },
         8usize,
         concat!(
             "Offset of field: ",
@@ -733,6 +713,7 @@ fn bindgen_test_layout_rte_eth_vmdq_dcb_conf__bindgen_ty_1() {
 fn bindgen_test_layout_rte_eth_vmdq_dcb_conf() {
     const UNINIT: ::std::mem::MaybeUninit<rte_eth_vmdq_dcb_conf> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<rte_eth_vmdq_dcb_conf>(),
         1040usize,
@@ -745,7 +726,6 @@ fn bindgen_test_layout_rte_eth_vmdq_dcb_conf() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).nb_queue_pools) as usize - ptr as usize
         },
         0usize,
@@ -758,7 +738,6 @@ fn bindgen_test_layout_rte_eth_vmdq_dcb_conf() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).enable_default_pool) as usize -
                 ptr as usize
         },
@@ -772,7 +751,6 @@ fn bindgen_test_layout_rte_eth_vmdq_dcb_conf() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).default_pool) as usize - ptr as usize
         },
         5usize,
@@ -785,7 +763,6 @@ fn bindgen_test_layout_rte_eth_vmdq_dcb_conf() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).nb_pool_maps) as usize - ptr as usize
         },
         6usize,
@@ -798,7 +775,6 @@ fn bindgen_test_layout_rte_eth_vmdq_dcb_conf() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).pool_map) as usize - ptr as usize
         },
         8usize,
@@ -810,10 +786,7 @@ fn bindgen_test_layout_rte_eth_vmdq_dcb_conf() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).dcb_tc) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).dcb_tc) as usize - ptr as usize },
         1032usize,
         concat!(
             "Offset of field: ",
@@ -844,6 +817,7 @@ pub struct rte_eth_dcb_rx_conf {
 fn bindgen_test_layout_rte_eth_dcb_rx_conf() {
     const UNINIT: ::std::mem::MaybeUninit<rte_eth_dcb_rx_conf> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<rte_eth_dcb_rx_conf>(),
         12usize,
@@ -855,10 +829,7 @@ fn bindgen_test_layout_rte_eth_dcb_rx_conf() {
         concat!("Alignment of ", stringify!(rte_eth_dcb_rx_conf))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).nb_tcs) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).nb_tcs) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -868,10 +839,7 @@ fn bindgen_test_layout_rte_eth_dcb_rx_conf() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).dcb_tc) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).dcb_tc) as usize - ptr as usize },
         4usize,
         concat!(
             "Offset of field: ",
@@ -902,6 +870,7 @@ pub struct rte_eth_vmdq_dcb_tx_conf {
 fn bindgen_test_layout_rte_eth_vmdq_dcb_tx_conf() {
     const UNINIT: ::std::mem::MaybeUninit<rte_eth_vmdq_dcb_tx_conf> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<rte_eth_vmdq_dcb_tx_conf>(),
         12usize,
@@ -914,7 +883,6 @@ fn bindgen_test_layout_rte_eth_vmdq_dcb_tx_conf() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).nb_queue_pools) as usize - ptr as usize
         },
         0usize,
@@ -926,10 +894,7 @@ fn bindgen_test_layout_rte_eth_vmdq_dcb_tx_conf() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).dcb_tc) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).dcb_tc) as usize - ptr as usize },
         4usize,
         concat!(
             "Offset of field: ",
@@ -960,6 +925,7 @@ pub struct rte_eth_dcb_tx_conf {
 fn bindgen_test_layout_rte_eth_dcb_tx_conf() {
     const UNINIT: ::std::mem::MaybeUninit<rte_eth_dcb_tx_conf> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<rte_eth_dcb_tx_conf>(),
         12usize,
@@ -971,10 +937,7 @@ fn bindgen_test_layout_rte_eth_dcb_tx_conf() {
         concat!("Alignment of ", stringify!(rte_eth_dcb_tx_conf))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).nb_tcs) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).nb_tcs) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -984,10 +947,7 @@ fn bindgen_test_layout_rte_eth_dcb_tx_conf() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).dcb_tc) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).dcb_tc) as usize - ptr as usize },
         4usize,
         concat!(
             "Offset of field: ",
@@ -1016,6 +976,7 @@ pub struct rte_eth_vmdq_tx_conf {
 fn bindgen_test_layout_rte_eth_vmdq_tx_conf() {
     const UNINIT: ::std::mem::MaybeUninit<rte_eth_vmdq_tx_conf> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<rte_eth_vmdq_tx_conf>(),
         4usize,
@@ -1028,7 +989,6 @@ fn bindgen_test_layout_rte_eth_vmdq_tx_conf() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).nb_queue_pools) as usize - ptr as usize
         },
         0usize,
@@ -1079,6 +1039,7 @@ pub struct rte_eth_vmdq_rx_conf__bindgen_ty_1 {
 fn bindgen_test_layout_rte_eth_vmdq_rx_conf__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<rte_eth_vmdq_rx_conf__bindgen_ty_1> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<rte_eth_vmdq_rx_conf__bindgen_ty_1>(),
         16usize,
@@ -1093,10 +1054,7 @@ fn bindgen_test_layout_rte_eth_vmdq_rx_conf__bindgen_ty_1() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).vlan_id) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).vlan_id) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -1106,10 +1064,7 @@ fn bindgen_test_layout_rte_eth_vmdq_rx_conf__bindgen_ty_1() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).pools) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).pools) as usize - ptr as usize },
         8usize,
         concat!(
             "Offset of field: ",
@@ -1123,6 +1078,7 @@ fn bindgen_test_layout_rte_eth_vmdq_rx_conf__bindgen_ty_1() {
 fn bindgen_test_layout_rte_eth_vmdq_rx_conf() {
     const UNINIT: ::std::mem::MaybeUninit<rte_eth_vmdq_rx_conf> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<rte_eth_vmdq_rx_conf>(),
         1040usize,
@@ -1135,7 +1091,6 @@ fn bindgen_test_layout_rte_eth_vmdq_rx_conf() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).nb_queue_pools) as usize - ptr as usize
         },
         0usize,
@@ -1148,7 +1103,6 @@ fn bindgen_test_layout_rte_eth_vmdq_rx_conf() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).enable_default_pool) as usize -
                 ptr as usize
         },
@@ -1162,7 +1116,6 @@ fn bindgen_test_layout_rte_eth_vmdq_rx_conf() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).default_pool) as usize - ptr as usize
         },
         5usize,
@@ -1175,7 +1128,6 @@ fn bindgen_test_layout_rte_eth_vmdq_rx_conf() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).enable_loop_back) as usize -
                 ptr as usize
         },
@@ -1189,7 +1141,6 @@ fn bindgen_test_layout_rte_eth_vmdq_rx_conf() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).nb_pool_maps) as usize - ptr as usize
         },
         7usize,
@@ -1201,10 +1152,7 @@ fn bindgen_test_layout_rte_eth_vmdq_rx_conf() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).rx_mode) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).rx_mode) as usize - ptr as usize },
         8usize,
         concat!(
             "Offset of field: ",
@@ -1215,7 +1163,6 @@ fn bindgen_test_layout_rte_eth_vmdq_rx_conf() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).pool_map) as usize - ptr as usize
         },
         16usize,
@@ -1293,6 +1240,7 @@ pub struct rte_eth_ipv4_flow {
 fn bindgen_test_layout_rte_eth_ipv4_flow() {
     const UNINIT: ::std::mem::MaybeUninit<rte_eth_ipv4_flow> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<rte_eth_ipv4_flow>(),
         12usize,
@@ -1304,10 +1252,7 @@ fn bindgen_test_layout_rte_eth_ipv4_flow() {
         concat!("Alignment of ", stringify!(rte_eth_ipv4_flow))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).src_ip) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).src_ip) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -1317,10 +1262,7 @@ fn bindgen_test_layout_rte_eth_ipv4_flow() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).dst_ip) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).dst_ip) as usize - ptr as usize },
         4usize,
         concat!(
             "Offset of field: ",
@@ -1330,10 +1272,7 @@ fn bindgen_test_layout_rte_eth_ipv4_flow() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).tos) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).tos) as usize - ptr as usize },
         8usize,
         concat!(
             "Offset of field: ",
@@ -1343,10 +1282,7 @@ fn bindgen_test_layout_rte_eth_ipv4_flow() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).ttl) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).ttl) as usize - ptr as usize },
         9usize,
         concat!(
             "Offset of field: ",
@@ -1356,10 +1292,7 @@ fn bindgen_test_layout_rte_eth_ipv4_flow() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).proto) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).proto) as usize - ptr as usize },
         10usize,
         concat!(
             "Offset of field: ",
@@ -1388,6 +1321,7 @@ pub struct rte_eth_ipv6_flow {
 fn bindgen_test_layout_rte_eth_ipv6_flow() {
     const UNINIT: ::std::mem::MaybeUninit<rte_eth_ipv6_flow> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<rte_eth_ipv6_flow>(),
         36usize,
@@ -1399,10 +1333,7 @@ fn bindgen_test_layout_rte_eth_ipv6_flow() {
         concat!("Alignment of ", stringify!(rte_eth_ipv6_flow))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).src_ip) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).src_ip) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -1412,10 +1343,7 @@ fn bindgen_test_layout_rte_eth_ipv6_flow() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).dst_ip) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).dst_ip) as usize - ptr as usize },
         16usize,
         concat!(
             "Offset of field: ",
@@ -1425,10 +1353,7 @@ fn bindgen_test_layout_rte_eth_ipv6_flow() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).tc) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).tc) as usize - ptr as usize },
         32usize,
         concat!(
             "Offset of field: ",
@@ -1438,10 +1363,7 @@ fn bindgen_test_layout_rte_eth_ipv6_flow() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).proto) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).proto) as usize - ptr as usize },
         33usize,
         concat!(
             "Offset of field: ",
@@ -1452,7 +1374,6 @@ fn bindgen_test_layout_rte_eth_ipv6_flow() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).hop_limits) as usize - ptr as usize
         },
         34usize,
@@ -1492,6 +1413,7 @@ pub struct rte_eth_fdir_masks {
 fn bindgen_test_layout_rte_eth_fdir_masks() {
     const UNINIT: ::std::mem::MaybeUninit<rte_eth_fdir_masks> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<rte_eth_fdir_masks>(),
         68usize,
@@ -1504,7 +1426,6 @@ fn bindgen_test_layout_rte_eth_fdir_masks() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).vlan_tci_mask) as usize - ptr as usize
         },
         0usize,
@@ -1517,7 +1438,6 @@ fn bindgen_test_layout_rte_eth_fdir_masks() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).ipv4_mask) as usize - ptr as usize
         },
         4usize,
@@ -1530,7 +1450,6 @@ fn bindgen_test_layout_rte_eth_fdir_masks() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).ipv6_mask) as usize - ptr as usize
         },
         16usize,
@@ -1543,7 +1462,6 @@ fn bindgen_test_layout_rte_eth_fdir_masks() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).src_port_mask) as usize - ptr as usize
         },
         52usize,
@@ -1556,7 +1474,6 @@ fn bindgen_test_layout_rte_eth_fdir_masks() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).dst_port_mask) as usize - ptr as usize
         },
         54usize,
@@ -1569,7 +1486,6 @@ fn bindgen_test_layout_rte_eth_fdir_masks() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).mac_addr_byte_mask) as usize -
                 ptr as usize
         },
@@ -1583,7 +1499,6 @@ fn bindgen_test_layout_rte_eth_fdir_masks() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).tunnel_id_mask) as usize - ptr as usize
         },
         60usize,
@@ -1596,7 +1511,6 @@ fn bindgen_test_layout_rte_eth_fdir_masks() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).tunnel_type_mask) as usize -
                 ptr as usize
         },
@@ -1633,6 +1547,7 @@ pub struct rte_eth_flex_payload_cfg {
 fn bindgen_test_layout_rte_eth_flex_payload_cfg() {
     const UNINIT: ::std::mem::MaybeUninit<rte_eth_flex_payload_cfg> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<rte_eth_flex_payload_cfg>(),
         36usize,
@@ -1644,10 +1559,7 @@ fn bindgen_test_layout_rte_eth_flex_payload_cfg() {
         concat!("Alignment of ", stringify!(rte_eth_flex_payload_cfg))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).type_) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).type_) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -1658,7 +1570,6 @@ fn bindgen_test_layout_rte_eth_flex_payload_cfg() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).src_offset) as usize - ptr as usize
         },
         4usize,
@@ -1691,6 +1602,7 @@ pub struct rte_eth_fdir_flex_mask {
 fn bindgen_test_layout_rte_eth_fdir_flex_mask() {
     const UNINIT: ::std::mem::MaybeUninit<rte_eth_fdir_flex_mask> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<rte_eth_fdir_flex_mask>(),
         18usize,
@@ -1703,7 +1615,6 @@ fn bindgen_test_layout_rte_eth_fdir_flex_mask() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).flow_type) as usize - ptr as usize
         },
         0usize,
@@ -1715,10 +1626,7 @@ fn bindgen_test_layout_rte_eth_fdir_flex_mask() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mask) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).mask) as usize - ptr as usize },
         2usize,
         concat!(
             "Offset of field: ",
@@ -1744,6 +1652,7 @@ pub struct rte_eth_fdir_flex_conf {
 fn bindgen_test_layout_rte_eth_fdir_flex_conf() {
     const UNINIT: ::std::mem::MaybeUninit<rte_eth_fdir_flex_conf> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<rte_eth_fdir_flex_conf>(),
         688usize,
@@ -1756,7 +1665,6 @@ fn bindgen_test_layout_rte_eth_fdir_flex_conf() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).nb_payloads) as usize - ptr as usize
         },
         0usize,
@@ -1769,7 +1677,6 @@ fn bindgen_test_layout_rte_eth_fdir_flex_conf() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).nb_flexmasks) as usize - ptr as usize
         },
         2usize,
@@ -1782,7 +1689,6 @@ fn bindgen_test_layout_rte_eth_fdir_flex_conf() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).flex_set) as usize - ptr as usize
         },
         4usize,
@@ -1795,7 +1701,6 @@ fn bindgen_test_layout_rte_eth_fdir_flex_conf() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).flex_mask) as usize - ptr as usize
         },
         292usize,
@@ -1838,6 +1743,7 @@ pub struct rte_fdir_conf {
 fn bindgen_test_layout_rte_fdir_conf() {
     const UNINIT: ::std::mem::MaybeUninit<rte_fdir_conf> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<rte_fdir_conf>(),
         772usize,
@@ -1849,10 +1755,7 @@ fn bindgen_test_layout_rte_fdir_conf() {
         concat!("Alignment of ", stringify!(rte_fdir_conf))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mode) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).mode) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -1862,10 +1765,7 @@ fn bindgen_test_layout_rte_fdir_conf() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).pballoc) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).pballoc) as usize - ptr as usize },
         4usize,
         concat!(
             "Offset of field: ",
@@ -1875,10 +1775,7 @@ fn bindgen_test_layout_rte_fdir_conf() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).status) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).status) as usize - ptr as usize },
         8usize,
         concat!(
             "Offset of field: ",
@@ -1889,7 +1786,6 @@ fn bindgen_test_layout_rte_fdir_conf() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).drop_queue) as usize - ptr as usize
         },
         12usize,
@@ -1901,10 +1797,7 @@ fn bindgen_test_layout_rte_fdir_conf() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mask) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).mask) as usize - ptr as usize },
         16usize,
         concat!(
             "Offset of field: ",
@@ -1915,7 +1808,6 @@ fn bindgen_test_layout_rte_fdir_conf() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).flex_conf) as usize - ptr as usize
         },
         84usize,
@@ -1949,6 +1841,7 @@ pub struct rte_intr_conf {
 fn bindgen_test_layout_rte_intr_conf() {
     const UNINIT: ::std::mem::MaybeUninit<rte_intr_conf> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<rte_intr_conf>(),
         4usize,
@@ -1960,10 +1853,7 @@ fn bindgen_test_layout_rte_intr_conf() {
         concat!("Alignment of ", stringify!(rte_intr_conf))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).lsc) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).lsc) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -1973,10 +1863,7 @@ fn bindgen_test_layout_rte_intr_conf() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).rxq) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).rxq) as usize - ptr as usize },
         2usize,
         concat!(
             "Offset of field: ",
@@ -2035,6 +1922,7 @@ pub struct rte_eth_conf__bindgen_ty_1 {
 fn bindgen_test_layout_rte_eth_conf__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<rte_eth_conf__bindgen_ty_1> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<rte_eth_conf__bindgen_ty_1>(),
         2120usize,
@@ -2047,7 +1935,6 @@ fn bindgen_test_layout_rte_eth_conf__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).rss_conf) as usize - ptr as usize
         },
         0usize,
@@ -2060,7 +1947,6 @@ fn bindgen_test_layout_rte_eth_conf__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).vmdq_dcb_conf) as usize - ptr as usize
         },
         24usize,
@@ -2073,7 +1959,6 @@ fn bindgen_test_layout_rte_eth_conf__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).dcb_rx_conf) as usize - ptr as usize
         },
         1064usize,
@@ -2086,7 +1971,6 @@ fn bindgen_test_layout_rte_eth_conf__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).vmdq_rx_conf) as usize - ptr as usize
         },
         1080usize,
@@ -2118,6 +2002,7 @@ pub union rte_eth_conf__bindgen_ty_2 {
 fn bindgen_test_layout_rte_eth_conf__bindgen_ty_2() {
     const UNINIT: ::std::mem::MaybeUninit<rte_eth_conf__bindgen_ty_2> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<rte_eth_conf__bindgen_ty_2>(),
         12usize,
@@ -2130,7 +2015,6 @@ fn bindgen_test_layout_rte_eth_conf__bindgen_ty_2() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).vmdq_dcb_tx_conf) as usize -
                 ptr as usize
         },
@@ -2144,7 +2028,6 @@ fn bindgen_test_layout_rte_eth_conf__bindgen_ty_2() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).dcb_tx_conf) as usize - ptr as usize
         },
         0usize,
@@ -2157,7 +2040,6 @@ fn bindgen_test_layout_rte_eth_conf__bindgen_ty_2() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).vmdq_tx_conf) as usize - ptr as usize
         },
         0usize,
@@ -2182,6 +2064,7 @@ impl Default for rte_eth_conf__bindgen_ty_2 {
 fn bindgen_test_layout_rte_eth_conf() {
     const UNINIT: ::std::mem::MaybeUninit<rte_eth_conf> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<rte_eth_conf>(),
         2944usize,
@@ -2194,7 +2077,6 @@ fn bindgen_test_layout_rte_eth_conf() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).link_speeds) as usize - ptr as usize
         },
         0usize,
@@ -2206,10 +2088,7 @@ fn bindgen_test_layout_rte_eth_conf() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).rxmode) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).rxmode) as usize - ptr as usize },
         4usize,
         concat!(
             "Offset of field: ",
@@ -2219,10 +2098,7 @@ fn bindgen_test_layout_rte_eth_conf() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).txmode) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).txmode) as usize - ptr as usize },
         16usize,
         concat!(
             "Offset of field: ",
@@ -2233,7 +2109,6 @@ fn bindgen_test_layout_rte_eth_conf() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).lpbk_mode) as usize - ptr as usize
         },
         24usize,
@@ -2246,7 +2121,6 @@ fn bindgen_test_layout_rte_eth_conf() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).rx_adv_conf) as usize - ptr as usize
         },
         32usize,
@@ -2259,7 +2133,6 @@ fn bindgen_test_layout_rte_eth_conf() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).tx_adv_conf) as usize - ptr as usize
         },
         2152usize,
@@ -2272,7 +2145,6 @@ fn bindgen_test_layout_rte_eth_conf() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).dcb_capability_en) as usize -
                 ptr as usize
         },
@@ -2286,7 +2158,6 @@ fn bindgen_test_layout_rte_eth_conf() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).fdir_conf) as usize - ptr as usize
         },
         2168usize,
@@ -2299,7 +2170,6 @@ fn bindgen_test_layout_rte_eth_conf() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).intr_conf) as usize - ptr as usize
         },
         2940usize,

--- a/tests/expectations/tests/layout_eth_conf.rs
+++ b/tests/expectations/tests/layout_eth_conf.rs
@@ -160,6 +160,8 @@ pub struct rte_eth_rxmode {
 }
 #[test]
 fn bindgen_test_layout_rte_eth_rxmode() {
+    const UNINIT: ::std::mem::MaybeUninit<rte_eth_rxmode> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<rte_eth_rxmode>(),
         12usize,
@@ -170,62 +172,45 @@ fn bindgen_test_layout_rte_eth_rxmode() {
         4usize,
         concat!("Alignment of ", stringify!(rte_eth_rxmode))
     );
-    fn test_field_mq_mode() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_eth_rxmode>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).mq_mode) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_rxmode),
-                "::",
-                stringify!(mq_mode)
-            )
-        );
-    }
-    test_field_mq_mode();
-    fn test_field_max_rx_pkt_len() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_eth_rxmode>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).max_rx_pkt_len) as usize -
-                    ptr as usize
-            },
-            4usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_rxmode),
-                "::",
-                stringify!(max_rx_pkt_len)
-            )
-        );
-    }
-    test_field_max_rx_pkt_len();
-    fn test_field_split_hdr_size() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_eth_rxmode>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).split_hdr_size) as usize -
-                    ptr as usize
-            },
-            8usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_rxmode),
-                "::",
-                stringify!(split_hdr_size)
-            )
-        );
-    }
-    test_field_split_hdr_size();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).mq_mode) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_rxmode),
+            "::",
+            stringify!(mq_mode)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).max_rx_pkt_len) as usize - ptr as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_rxmode),
+            "::",
+            stringify!(max_rx_pkt_len)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).split_hdr_size) as usize - ptr as usize
+        },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_rxmode),
+            "::",
+            stringify!(split_hdr_size)
+        )
+    );
 }
 impl Default for rte_eth_rxmode {
     fn default() -> Self {
@@ -442,6 +427,8 @@ pub struct rte_eth_txmode {
 }
 #[test]
 fn bindgen_test_layout_rte_eth_txmode() {
+    const UNINIT: ::std::mem::MaybeUninit<rte_eth_txmode> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<rte_eth_txmode>(),
         8usize,
@@ -452,42 +439,32 @@ fn bindgen_test_layout_rte_eth_txmode() {
         4usize,
         concat!("Alignment of ", stringify!(rte_eth_txmode))
     );
-    fn test_field_mq_mode() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_eth_txmode>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).mq_mode) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_txmode),
-                "::",
-                stringify!(mq_mode)
-            )
-        );
-    }
-    test_field_mq_mode();
-    fn test_field_pvid() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_eth_txmode>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).pvid) as usize - ptr as usize
-            },
-            4usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_txmode),
-                "::",
-                stringify!(pvid)
-            )
-        );
-    }
-    test_field_pvid();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).mq_mode) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_txmode),
+            "::",
+            stringify!(mq_mode)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).pvid) as usize - ptr as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_txmode),
+            "::",
+            stringify!(pvid)
+        )
+    );
 }
 impl Default for rte_eth_txmode {
     fn default() -> Self {
@@ -591,6 +568,8 @@ pub struct rte_eth_rss_conf {
 }
 #[test]
 fn bindgen_test_layout_rte_eth_rss_conf() {
+    const UNINIT: ::std::mem::MaybeUninit<rte_eth_rss_conf> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<rte_eth_rss_conf>(),
         24usize,
@@ -601,60 +580,45 @@ fn bindgen_test_layout_rte_eth_rss_conf() {
         8usize,
         concat!("Alignment of ", stringify!(rte_eth_rss_conf))
     );
-    fn test_field_rss_key() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_eth_rss_conf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).rss_key) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_rss_conf),
-                "::",
-                stringify!(rss_key)
-            )
-        );
-    }
-    test_field_rss_key();
-    fn test_field_rss_key_len() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_eth_rss_conf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).rss_key_len) as usize - ptr as usize
-            },
-            8usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_rss_conf),
-                "::",
-                stringify!(rss_key_len)
-            )
-        );
-    }
-    test_field_rss_key_len();
-    fn test_field_rss_hf() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_eth_rss_conf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).rss_hf) as usize - ptr as usize
-            },
-            16usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_rss_conf),
-                "::",
-                stringify!(rss_hf)
-            )
-        );
-    }
-    test_field_rss_hf();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).rss_key) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_rss_conf),
+            "::",
+            stringify!(rss_key)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).rss_key_len) as usize - ptr as usize
+        },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_rss_conf),
+            "::",
+            stringify!(rss_key_len)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).rss_hf) as usize - ptr as usize
+        },
+        16usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_rss_conf),
+            "::",
+            stringify!(rss_hf)
+        )
+    );
 }
 impl Default for rte_eth_rss_conf {
     fn default() -> Self {
@@ -723,6 +687,8 @@ pub struct rte_eth_vmdq_dcb_conf__bindgen_ty_1 {
 }
 #[test]
 fn bindgen_test_layout_rte_eth_vmdq_dcb_conf__bindgen_ty_1() {
+    const UNINIT: ::std::mem::MaybeUninit<rte_eth_vmdq_dcb_conf__bindgen_ty_1> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<rte_eth_vmdq_dcb_conf__bindgen_ty_1>(),
         16usize,
@@ -736,47 +702,37 @@ fn bindgen_test_layout_rte_eth_vmdq_dcb_conf__bindgen_ty_1() {
             stringify!(rte_eth_vmdq_dcb_conf__bindgen_ty_1)
         )
     );
-    fn test_field_vlan_id() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<
-                    rte_eth_vmdq_dcb_conf__bindgen_ty_1,
-                >::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).vlan_id) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_vmdq_dcb_conf__bindgen_ty_1),
-                "::",
-                stringify!(vlan_id)
-            )
-        );
-    }
-    test_field_vlan_id();
-    fn test_field_pools() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<
-                    rte_eth_vmdq_dcb_conf__bindgen_ty_1,
-                >::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).pools) as usize - ptr as usize
-            },
-            8usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_vmdq_dcb_conf__bindgen_ty_1),
-                "::",
-                stringify!(pools)
-            )
-        );
-    }
-    test_field_pools();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).vlan_id) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_vmdq_dcb_conf__bindgen_ty_1),
+            "::",
+            stringify!(vlan_id)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).pools) as usize - ptr as usize
+        },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_vmdq_dcb_conf__bindgen_ty_1),
+            "::",
+            stringify!(pools)
+        )
+    );
 }
 #[test]
 fn bindgen_test_layout_rte_eth_vmdq_dcb_conf() {
+    const UNINIT: ::std::mem::MaybeUninit<rte_eth_vmdq_dcb_conf> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<rte_eth_vmdq_dcb_conf>(),
         1040usize,
@@ -787,118 +743,85 @@ fn bindgen_test_layout_rte_eth_vmdq_dcb_conf() {
         8usize,
         concat!("Alignment of ", stringify!(rte_eth_vmdq_dcb_conf))
     );
-    fn test_field_nb_queue_pools() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_eth_vmdq_dcb_conf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).nb_queue_pools) as usize -
-                    ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_vmdq_dcb_conf),
-                "::",
-                stringify!(nb_queue_pools)
-            )
-        );
-    }
-    test_field_nb_queue_pools();
-    fn test_field_enable_default_pool() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_eth_vmdq_dcb_conf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).enable_default_pool) as usize -
-                    ptr as usize
-            },
-            4usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_vmdq_dcb_conf),
-                "::",
-                stringify!(enable_default_pool)
-            )
-        );
-    }
-    test_field_enable_default_pool();
-    fn test_field_default_pool() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_eth_vmdq_dcb_conf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).default_pool) as usize -
-                    ptr as usize
-            },
-            5usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_vmdq_dcb_conf),
-                "::",
-                stringify!(default_pool)
-            )
-        );
-    }
-    test_field_default_pool();
-    fn test_field_nb_pool_maps() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_eth_vmdq_dcb_conf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).nb_pool_maps) as usize -
-                    ptr as usize
-            },
-            6usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_vmdq_dcb_conf),
-                "::",
-                stringify!(nb_pool_maps)
-            )
-        );
-    }
-    test_field_nb_pool_maps();
-    fn test_field_pool_map() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_eth_vmdq_dcb_conf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).pool_map) as usize - ptr as usize
-            },
-            8usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_vmdq_dcb_conf),
-                "::",
-                stringify!(pool_map)
-            )
-        );
-    }
-    test_field_pool_map();
-    fn test_field_dcb_tc() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_eth_vmdq_dcb_conf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).dcb_tc) as usize - ptr as usize
-            },
-            1032usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_vmdq_dcb_conf),
-                "::",
-                stringify!(dcb_tc)
-            )
-        );
-    }
-    test_field_dcb_tc();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).nb_queue_pools) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_vmdq_dcb_conf),
+            "::",
+            stringify!(nb_queue_pools)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).enable_default_pool) as usize -
+                ptr as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_vmdq_dcb_conf),
+            "::",
+            stringify!(enable_default_pool)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).default_pool) as usize - ptr as usize
+        },
+        5usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_vmdq_dcb_conf),
+            "::",
+            stringify!(default_pool)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).nb_pool_maps) as usize - ptr as usize
+        },
+        6usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_vmdq_dcb_conf),
+            "::",
+            stringify!(nb_pool_maps)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).pool_map) as usize - ptr as usize
+        },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_vmdq_dcb_conf),
+            "::",
+            stringify!(pool_map)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).dcb_tc) as usize - ptr as usize
+        },
+        1032usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_vmdq_dcb_conf),
+            "::",
+            stringify!(dcb_tc)
+        )
+    );
 }
 impl Default for rte_eth_vmdq_dcb_conf {
     fn default() -> Self {
@@ -919,6 +842,8 @@ pub struct rte_eth_dcb_rx_conf {
 }
 #[test]
 fn bindgen_test_layout_rte_eth_dcb_rx_conf() {
+    const UNINIT: ::std::mem::MaybeUninit<rte_eth_dcb_rx_conf> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<rte_eth_dcb_rx_conf>(),
         12usize,
@@ -929,42 +854,32 @@ fn bindgen_test_layout_rte_eth_dcb_rx_conf() {
         4usize,
         concat!("Alignment of ", stringify!(rte_eth_dcb_rx_conf))
     );
-    fn test_field_nb_tcs() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_eth_dcb_rx_conf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).nb_tcs) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_dcb_rx_conf),
-                "::",
-                stringify!(nb_tcs)
-            )
-        );
-    }
-    test_field_nb_tcs();
-    fn test_field_dcb_tc() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_eth_dcb_rx_conf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).dcb_tc) as usize - ptr as usize
-            },
-            4usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_dcb_rx_conf),
-                "::",
-                stringify!(dcb_tc)
-            )
-        );
-    }
-    test_field_dcb_tc();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).nb_tcs) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_dcb_rx_conf),
+            "::",
+            stringify!(nb_tcs)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).dcb_tc) as usize - ptr as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_dcb_rx_conf),
+            "::",
+            stringify!(dcb_tc)
+        )
+    );
 }
 impl Default for rte_eth_dcb_rx_conf {
     fn default() -> Self {
@@ -985,6 +900,8 @@ pub struct rte_eth_vmdq_dcb_tx_conf {
 }
 #[test]
 fn bindgen_test_layout_rte_eth_vmdq_dcb_tx_conf() {
+    const UNINIT: ::std::mem::MaybeUninit<rte_eth_vmdq_dcb_tx_conf> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<rte_eth_vmdq_dcb_tx_conf>(),
         12usize,
@@ -995,45 +912,32 @@ fn bindgen_test_layout_rte_eth_vmdq_dcb_tx_conf() {
         4usize,
         concat!("Alignment of ", stringify!(rte_eth_vmdq_dcb_tx_conf))
     );
-    fn test_field_nb_queue_pools() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_eth_vmdq_dcb_tx_conf>::uninit(
-                    );
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).nb_queue_pools) as usize -
-                    ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_vmdq_dcb_tx_conf),
-                "::",
-                stringify!(nb_queue_pools)
-            )
-        );
-    }
-    test_field_nb_queue_pools();
-    fn test_field_dcb_tc() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_eth_vmdq_dcb_tx_conf>::uninit(
-                    );
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).dcb_tc) as usize - ptr as usize
-            },
-            4usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_vmdq_dcb_tx_conf),
-                "::",
-                stringify!(dcb_tc)
-            )
-        );
-    }
-    test_field_dcb_tc();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).nb_queue_pools) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_vmdq_dcb_tx_conf),
+            "::",
+            stringify!(nb_queue_pools)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).dcb_tc) as usize - ptr as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_vmdq_dcb_tx_conf),
+            "::",
+            stringify!(dcb_tc)
+        )
+    );
 }
 impl Default for rte_eth_vmdq_dcb_tx_conf {
     fn default() -> Self {
@@ -1054,6 +958,8 @@ pub struct rte_eth_dcb_tx_conf {
 }
 #[test]
 fn bindgen_test_layout_rte_eth_dcb_tx_conf() {
+    const UNINIT: ::std::mem::MaybeUninit<rte_eth_dcb_tx_conf> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<rte_eth_dcb_tx_conf>(),
         12usize,
@@ -1064,42 +970,32 @@ fn bindgen_test_layout_rte_eth_dcb_tx_conf() {
         4usize,
         concat!("Alignment of ", stringify!(rte_eth_dcb_tx_conf))
     );
-    fn test_field_nb_tcs() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_eth_dcb_tx_conf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).nb_tcs) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_dcb_tx_conf),
-                "::",
-                stringify!(nb_tcs)
-            )
-        );
-    }
-    test_field_nb_tcs();
-    fn test_field_dcb_tc() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_eth_dcb_tx_conf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).dcb_tc) as usize - ptr as usize
-            },
-            4usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_dcb_tx_conf),
-                "::",
-                stringify!(dcb_tc)
-            )
-        );
-    }
-    test_field_dcb_tc();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).nb_tcs) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_dcb_tx_conf),
+            "::",
+            stringify!(nb_tcs)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).dcb_tc) as usize - ptr as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_dcb_tx_conf),
+            "::",
+            stringify!(dcb_tc)
+        )
+    );
 }
 impl Default for rte_eth_dcb_tx_conf {
     fn default() -> Self {
@@ -1118,6 +1014,8 @@ pub struct rte_eth_vmdq_tx_conf {
 }
 #[test]
 fn bindgen_test_layout_rte_eth_vmdq_tx_conf() {
+    const UNINIT: ::std::mem::MaybeUninit<rte_eth_vmdq_tx_conf> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<rte_eth_vmdq_tx_conf>(),
         4usize,
@@ -1128,25 +1026,19 @@ fn bindgen_test_layout_rte_eth_vmdq_tx_conf() {
         4usize,
         concat!("Alignment of ", stringify!(rte_eth_vmdq_tx_conf))
     );
-    fn test_field_nb_queue_pools() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_eth_vmdq_tx_conf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).nb_queue_pools) as usize -
-                    ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_vmdq_tx_conf),
-                "::",
-                stringify!(nb_queue_pools)
-            )
-        );
-    }
-    test_field_nb_queue_pools();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).nb_queue_pools) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_vmdq_tx_conf),
+            "::",
+            stringify!(nb_queue_pools)
+        )
+    );
 }
 impl Default for rte_eth_vmdq_tx_conf {
     fn default() -> Self {
@@ -1185,6 +1077,8 @@ pub struct rte_eth_vmdq_rx_conf__bindgen_ty_1 {
 }
 #[test]
 fn bindgen_test_layout_rte_eth_vmdq_rx_conf__bindgen_ty_1() {
+    const UNINIT: ::std::mem::MaybeUninit<rte_eth_vmdq_rx_conf__bindgen_ty_1> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<rte_eth_vmdq_rx_conf__bindgen_ty_1>(),
         16usize,
@@ -1198,47 +1092,37 @@ fn bindgen_test_layout_rte_eth_vmdq_rx_conf__bindgen_ty_1() {
             stringify!(rte_eth_vmdq_rx_conf__bindgen_ty_1)
         )
     );
-    fn test_field_vlan_id() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<
-                    rte_eth_vmdq_rx_conf__bindgen_ty_1,
-                >::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).vlan_id) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_vmdq_rx_conf__bindgen_ty_1),
-                "::",
-                stringify!(vlan_id)
-            )
-        );
-    }
-    test_field_vlan_id();
-    fn test_field_pools() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<
-                    rte_eth_vmdq_rx_conf__bindgen_ty_1,
-                >::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).pools) as usize - ptr as usize
-            },
-            8usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_vmdq_rx_conf__bindgen_ty_1),
-                "::",
-                stringify!(pools)
-            )
-        );
-    }
-    test_field_pools();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).vlan_id) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_vmdq_rx_conf__bindgen_ty_1),
+            "::",
+            stringify!(vlan_id)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).pools) as usize - ptr as usize
+        },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_vmdq_rx_conf__bindgen_ty_1),
+            "::",
+            stringify!(pools)
+        )
+    );
 }
 #[test]
 fn bindgen_test_layout_rte_eth_vmdq_rx_conf() {
+    const UNINIT: ::std::mem::MaybeUninit<rte_eth_vmdq_rx_conf> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<rte_eth_vmdq_rx_conf>(),
         1040usize,
@@ -1249,137 +1133,99 @@ fn bindgen_test_layout_rte_eth_vmdq_rx_conf() {
         8usize,
         concat!("Alignment of ", stringify!(rte_eth_vmdq_rx_conf))
     );
-    fn test_field_nb_queue_pools() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_eth_vmdq_rx_conf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).nb_queue_pools) as usize -
-                    ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_vmdq_rx_conf),
-                "::",
-                stringify!(nb_queue_pools)
-            )
-        );
-    }
-    test_field_nb_queue_pools();
-    fn test_field_enable_default_pool() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_eth_vmdq_rx_conf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).enable_default_pool) as usize -
-                    ptr as usize
-            },
-            4usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_vmdq_rx_conf),
-                "::",
-                stringify!(enable_default_pool)
-            )
-        );
-    }
-    test_field_enable_default_pool();
-    fn test_field_default_pool() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_eth_vmdq_rx_conf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).default_pool) as usize -
-                    ptr as usize
-            },
-            5usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_vmdq_rx_conf),
-                "::",
-                stringify!(default_pool)
-            )
-        );
-    }
-    test_field_default_pool();
-    fn test_field_enable_loop_back() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_eth_vmdq_rx_conf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).enable_loop_back) as usize -
-                    ptr as usize
-            },
-            6usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_vmdq_rx_conf),
-                "::",
-                stringify!(enable_loop_back)
-            )
-        );
-    }
-    test_field_enable_loop_back();
-    fn test_field_nb_pool_maps() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_eth_vmdq_rx_conf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).nb_pool_maps) as usize -
-                    ptr as usize
-            },
-            7usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_vmdq_rx_conf),
-                "::",
-                stringify!(nb_pool_maps)
-            )
-        );
-    }
-    test_field_nb_pool_maps();
-    fn test_field_rx_mode() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_eth_vmdq_rx_conf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).rx_mode) as usize - ptr as usize
-            },
-            8usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_vmdq_rx_conf),
-                "::",
-                stringify!(rx_mode)
-            )
-        );
-    }
-    test_field_rx_mode();
-    fn test_field_pool_map() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_eth_vmdq_rx_conf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).pool_map) as usize - ptr as usize
-            },
-            16usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_vmdq_rx_conf),
-                "::",
-                stringify!(pool_map)
-            )
-        );
-    }
-    test_field_pool_map();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).nb_queue_pools) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_vmdq_rx_conf),
+            "::",
+            stringify!(nb_queue_pools)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).enable_default_pool) as usize -
+                ptr as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_vmdq_rx_conf),
+            "::",
+            stringify!(enable_default_pool)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).default_pool) as usize - ptr as usize
+        },
+        5usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_vmdq_rx_conf),
+            "::",
+            stringify!(default_pool)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).enable_loop_back) as usize -
+                ptr as usize
+        },
+        6usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_vmdq_rx_conf),
+            "::",
+            stringify!(enable_loop_back)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).nb_pool_maps) as usize - ptr as usize
+        },
+        7usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_vmdq_rx_conf),
+            "::",
+            stringify!(nb_pool_maps)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).rx_mode) as usize - ptr as usize
+        },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_vmdq_rx_conf),
+            "::",
+            stringify!(rx_mode)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).pool_map) as usize - ptr as usize
+        },
+        16usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_vmdq_rx_conf),
+            "::",
+            stringify!(pool_map)
+        )
+    );
 }
 impl Default for rte_eth_vmdq_rx_conf {
     fn default() -> Self {
@@ -1445,6 +1291,8 @@ pub struct rte_eth_ipv4_flow {
 }
 #[test]
 fn bindgen_test_layout_rte_eth_ipv4_flow() {
+    const UNINIT: ::std::mem::MaybeUninit<rte_eth_ipv4_flow> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<rte_eth_ipv4_flow>(),
         12usize,
@@ -1455,96 +1303,71 @@ fn bindgen_test_layout_rte_eth_ipv4_flow() {
         4usize,
         concat!("Alignment of ", stringify!(rte_eth_ipv4_flow))
     );
-    fn test_field_src_ip() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_eth_ipv4_flow>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).src_ip) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_ipv4_flow),
-                "::",
-                stringify!(src_ip)
-            )
-        );
-    }
-    test_field_src_ip();
-    fn test_field_dst_ip() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_eth_ipv4_flow>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).dst_ip) as usize - ptr as usize
-            },
-            4usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_ipv4_flow),
-                "::",
-                stringify!(dst_ip)
-            )
-        );
-    }
-    test_field_dst_ip();
-    fn test_field_tos() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_eth_ipv4_flow>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).tos) as usize - ptr as usize
-            },
-            8usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_ipv4_flow),
-                "::",
-                stringify!(tos)
-            )
-        );
-    }
-    test_field_tos();
-    fn test_field_ttl() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_eth_ipv4_flow>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).ttl) as usize - ptr as usize
-            },
-            9usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_ipv4_flow),
-                "::",
-                stringify!(ttl)
-            )
-        );
-    }
-    test_field_ttl();
-    fn test_field_proto() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_eth_ipv4_flow>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).proto) as usize - ptr as usize
-            },
-            10usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_ipv4_flow),
-                "::",
-                stringify!(proto)
-            )
-        );
-    }
-    test_field_proto();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).src_ip) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_ipv4_flow),
+            "::",
+            stringify!(src_ip)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).dst_ip) as usize - ptr as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_ipv4_flow),
+            "::",
+            stringify!(dst_ip)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).tos) as usize - ptr as usize
+        },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_ipv4_flow),
+            "::",
+            stringify!(tos)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).ttl) as usize - ptr as usize
+        },
+        9usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_ipv4_flow),
+            "::",
+            stringify!(ttl)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).proto) as usize - ptr as usize
+        },
+        10usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_ipv4_flow),
+            "::",
+            stringify!(proto)
+        )
+    );
 }
 /// A structure used to define the input for IPV6 flow
 #[repr(C)]
@@ -1563,6 +1386,8 @@ pub struct rte_eth_ipv6_flow {
 }
 #[test]
 fn bindgen_test_layout_rte_eth_ipv6_flow() {
+    const UNINIT: ::std::mem::MaybeUninit<rte_eth_ipv6_flow> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<rte_eth_ipv6_flow>(),
         36usize,
@@ -1573,96 +1398,71 @@ fn bindgen_test_layout_rte_eth_ipv6_flow() {
         4usize,
         concat!("Alignment of ", stringify!(rte_eth_ipv6_flow))
     );
-    fn test_field_src_ip() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_eth_ipv6_flow>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).src_ip) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_ipv6_flow),
-                "::",
-                stringify!(src_ip)
-            )
-        );
-    }
-    test_field_src_ip();
-    fn test_field_dst_ip() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_eth_ipv6_flow>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).dst_ip) as usize - ptr as usize
-            },
-            16usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_ipv6_flow),
-                "::",
-                stringify!(dst_ip)
-            )
-        );
-    }
-    test_field_dst_ip();
-    fn test_field_tc() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_eth_ipv6_flow>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).tc) as usize - ptr as usize
-            },
-            32usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_ipv6_flow),
-                "::",
-                stringify!(tc)
-            )
-        );
-    }
-    test_field_tc();
-    fn test_field_proto() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_eth_ipv6_flow>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).proto) as usize - ptr as usize
-            },
-            33usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_ipv6_flow),
-                "::",
-                stringify!(proto)
-            )
-        );
-    }
-    test_field_proto();
-    fn test_field_hop_limits() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_eth_ipv6_flow>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).hop_limits) as usize - ptr as usize
-            },
-            34usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_ipv6_flow),
-                "::",
-                stringify!(hop_limits)
-            )
-        );
-    }
-    test_field_hop_limits();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).src_ip) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_ipv6_flow),
+            "::",
+            stringify!(src_ip)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).dst_ip) as usize - ptr as usize
+        },
+        16usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_ipv6_flow),
+            "::",
+            stringify!(dst_ip)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).tc) as usize - ptr as usize
+        },
+        32usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_ipv6_flow),
+            "::",
+            stringify!(tc)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).proto) as usize - ptr as usize
+        },
+        33usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_ipv6_flow),
+            "::",
+            stringify!(proto)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).hop_limits) as usize - ptr as usize
+        },
+        34usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_ipv6_flow),
+            "::",
+            stringify!(hop_limits)
+        )
+    );
 }
 ///  A structure used to configure FDIR masks that are used by the device
 ///  to match the various fields of RX packet headers.
@@ -1690,6 +1490,8 @@ pub struct rte_eth_fdir_masks {
 }
 #[test]
 fn bindgen_test_layout_rte_eth_fdir_masks() {
+    const UNINIT: ::std::mem::MaybeUninit<rte_eth_fdir_masks> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<rte_eth_fdir_masks>(),
         68usize,
@@ -1700,156 +1502,112 @@ fn bindgen_test_layout_rte_eth_fdir_masks() {
         4usize,
         concat!("Alignment of ", stringify!(rte_eth_fdir_masks))
     );
-    fn test_field_vlan_tci_mask() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_eth_fdir_masks>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).vlan_tci_mask) as usize -
-                    ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_fdir_masks),
-                "::",
-                stringify!(vlan_tci_mask)
-            )
-        );
-    }
-    test_field_vlan_tci_mask();
-    fn test_field_ipv4_mask() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_eth_fdir_masks>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).ipv4_mask) as usize - ptr as usize
-            },
-            4usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_fdir_masks),
-                "::",
-                stringify!(ipv4_mask)
-            )
-        );
-    }
-    test_field_ipv4_mask();
-    fn test_field_ipv6_mask() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_eth_fdir_masks>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).ipv6_mask) as usize - ptr as usize
-            },
-            16usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_fdir_masks),
-                "::",
-                stringify!(ipv6_mask)
-            )
-        );
-    }
-    test_field_ipv6_mask();
-    fn test_field_src_port_mask() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_eth_fdir_masks>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).src_port_mask) as usize -
-                    ptr as usize
-            },
-            52usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_fdir_masks),
-                "::",
-                stringify!(src_port_mask)
-            )
-        );
-    }
-    test_field_src_port_mask();
-    fn test_field_dst_port_mask() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_eth_fdir_masks>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).dst_port_mask) as usize -
-                    ptr as usize
-            },
-            54usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_fdir_masks),
-                "::",
-                stringify!(dst_port_mask)
-            )
-        );
-    }
-    test_field_dst_port_mask();
-    fn test_field_mac_addr_byte_mask() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_eth_fdir_masks>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).mac_addr_byte_mask) as usize -
-                    ptr as usize
-            },
-            56usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_fdir_masks),
-                "::",
-                stringify!(mac_addr_byte_mask)
-            )
-        );
-    }
-    test_field_mac_addr_byte_mask();
-    fn test_field_tunnel_id_mask() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_eth_fdir_masks>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).tunnel_id_mask) as usize -
-                    ptr as usize
-            },
-            60usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_fdir_masks),
-                "::",
-                stringify!(tunnel_id_mask)
-            )
-        );
-    }
-    test_field_tunnel_id_mask();
-    fn test_field_tunnel_type_mask() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_eth_fdir_masks>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).tunnel_type_mask) as usize -
-                    ptr as usize
-            },
-            64usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_fdir_masks),
-                "::",
-                stringify!(tunnel_type_mask)
-            )
-        );
-    }
-    test_field_tunnel_type_mask();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).vlan_tci_mask) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_fdir_masks),
+            "::",
+            stringify!(vlan_tci_mask)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).ipv4_mask) as usize - ptr as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_fdir_masks),
+            "::",
+            stringify!(ipv4_mask)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).ipv6_mask) as usize - ptr as usize
+        },
+        16usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_fdir_masks),
+            "::",
+            stringify!(ipv6_mask)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).src_port_mask) as usize - ptr as usize
+        },
+        52usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_fdir_masks),
+            "::",
+            stringify!(src_port_mask)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).dst_port_mask) as usize - ptr as usize
+        },
+        54usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_fdir_masks),
+            "::",
+            stringify!(dst_port_mask)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).mac_addr_byte_mask) as usize -
+                ptr as usize
+        },
+        56usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_fdir_masks),
+            "::",
+            stringify!(mac_addr_byte_mask)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).tunnel_id_mask) as usize - ptr as usize
+        },
+        60usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_fdir_masks),
+            "::",
+            stringify!(tunnel_id_mask)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).tunnel_type_mask) as usize -
+                ptr as usize
+        },
+        64usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_fdir_masks),
+            "::",
+            stringify!(tunnel_type_mask)
+        )
+    );
 }
 #[repr(u32)]
 /// Payload type
@@ -1873,6 +1631,8 @@ pub struct rte_eth_flex_payload_cfg {
 }
 #[test]
 fn bindgen_test_layout_rte_eth_flex_payload_cfg() {
+    const UNINIT: ::std::mem::MaybeUninit<rte_eth_flex_payload_cfg> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<rte_eth_flex_payload_cfg>(),
         36usize,
@@ -1883,44 +1643,32 @@ fn bindgen_test_layout_rte_eth_flex_payload_cfg() {
         4usize,
         concat!("Alignment of ", stringify!(rte_eth_flex_payload_cfg))
     );
-    fn test_field_type() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_eth_flex_payload_cfg>::uninit(
-                    );
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).type_) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_flex_payload_cfg),
-                "::",
-                stringify!(type_)
-            )
-        );
-    }
-    test_field_type();
-    fn test_field_src_offset() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_eth_flex_payload_cfg>::uninit(
-                    );
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).src_offset) as usize - ptr as usize
-            },
-            4usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_flex_payload_cfg),
-                "::",
-                stringify!(src_offset)
-            )
-        );
-    }
-    test_field_src_offset();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).type_) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_flex_payload_cfg),
+            "::",
+            stringify!(type_)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).src_offset) as usize - ptr as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_flex_payload_cfg),
+            "::",
+            stringify!(src_offset)
+        )
+    );
 }
 impl Default for rte_eth_flex_payload_cfg {
     fn default() -> Self {
@@ -1941,6 +1689,8 @@ pub struct rte_eth_fdir_flex_mask {
 }
 #[test]
 fn bindgen_test_layout_rte_eth_fdir_flex_mask() {
+    const UNINIT: ::std::mem::MaybeUninit<rte_eth_fdir_flex_mask> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<rte_eth_fdir_flex_mask>(),
         18usize,
@@ -1951,42 +1701,32 @@ fn bindgen_test_layout_rte_eth_fdir_flex_mask() {
         2usize,
         concat!("Alignment of ", stringify!(rte_eth_fdir_flex_mask))
     );
-    fn test_field_flow_type() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_eth_fdir_flex_mask>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).flow_type) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_fdir_flex_mask),
-                "::",
-                stringify!(flow_type)
-            )
-        );
-    }
-    test_field_flow_type();
-    fn test_field_mask() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_eth_fdir_flex_mask>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).mask) as usize - ptr as usize
-            },
-            2usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_fdir_flex_mask),
-                "::",
-                stringify!(mask)
-            )
-        );
-    }
-    test_field_mask();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).flow_type) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_fdir_flex_mask),
+            "::",
+            stringify!(flow_type)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).mask) as usize - ptr as usize
+        },
+        2usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_fdir_flex_mask),
+            "::",
+            stringify!(mask)
+        )
+    );
 }
 /// A structure used to define all flexible payload related setting
 /// include flex payload and flex mask
@@ -2002,6 +1742,8 @@ pub struct rte_eth_fdir_flex_conf {
 }
 #[test]
 fn bindgen_test_layout_rte_eth_fdir_flex_conf() {
+    const UNINIT: ::std::mem::MaybeUninit<rte_eth_fdir_flex_conf> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<rte_eth_fdir_flex_conf>(),
         688usize,
@@ -2012,79 +1754,58 @@ fn bindgen_test_layout_rte_eth_fdir_flex_conf() {
         4usize,
         concat!("Alignment of ", stringify!(rte_eth_fdir_flex_conf))
     );
-    fn test_field_nb_payloads() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_eth_fdir_flex_conf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).nb_payloads) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_fdir_flex_conf),
-                "::",
-                stringify!(nb_payloads)
-            )
-        );
-    }
-    test_field_nb_payloads();
-    fn test_field_nb_flexmasks() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_eth_fdir_flex_conf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).nb_flexmasks) as usize -
-                    ptr as usize
-            },
-            2usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_fdir_flex_conf),
-                "::",
-                stringify!(nb_flexmasks)
-            )
-        );
-    }
-    test_field_nb_flexmasks();
-    fn test_field_flex_set() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_eth_fdir_flex_conf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).flex_set) as usize - ptr as usize
-            },
-            4usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_fdir_flex_conf),
-                "::",
-                stringify!(flex_set)
-            )
-        );
-    }
-    test_field_flex_set();
-    fn test_field_flex_mask() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_eth_fdir_flex_conf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).flex_mask) as usize - ptr as usize
-            },
-            292usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_fdir_flex_conf),
-                "::",
-                stringify!(flex_mask)
-            )
-        );
-    }
-    test_field_flex_mask();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).nb_payloads) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_fdir_flex_conf),
+            "::",
+            stringify!(nb_payloads)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).nb_flexmasks) as usize - ptr as usize
+        },
+        2usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_fdir_flex_conf),
+            "::",
+            stringify!(nb_flexmasks)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).flex_set) as usize - ptr as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_fdir_flex_conf),
+            "::",
+            stringify!(flex_set)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).flex_mask) as usize - ptr as usize
+        },
+        292usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_fdir_flex_conf),
+            "::",
+            stringify!(flex_mask)
+        )
+    );
 }
 impl Default for rte_eth_fdir_flex_conf {
     fn default() -> Self {
@@ -2115,6 +1836,8 @@ pub struct rte_fdir_conf {
 }
 #[test]
 fn bindgen_test_layout_rte_fdir_conf() {
+    const UNINIT: ::std::mem::MaybeUninit<rte_fdir_conf> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<rte_fdir_conf>(),
         772usize,
@@ -2125,108 +1848,84 @@ fn bindgen_test_layout_rte_fdir_conf() {
         4usize,
         concat!("Alignment of ", stringify!(rte_fdir_conf))
     );
-    fn test_field_mode() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<rte_fdir_conf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).mode) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_fdir_conf),
-                "::",
-                stringify!(mode)
-            )
-        );
-    }
-    test_field_mode();
-    fn test_field_pballoc() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<rte_fdir_conf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).pballoc) as usize - ptr as usize
-            },
-            4usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_fdir_conf),
-                "::",
-                stringify!(pballoc)
-            )
-        );
-    }
-    test_field_pballoc();
-    fn test_field_status() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<rte_fdir_conf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).status) as usize - ptr as usize
-            },
-            8usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_fdir_conf),
-                "::",
-                stringify!(status)
-            )
-        );
-    }
-    test_field_status();
-    fn test_field_drop_queue() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<rte_fdir_conf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).drop_queue) as usize - ptr as usize
-            },
-            12usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_fdir_conf),
-                "::",
-                stringify!(drop_queue)
-            )
-        );
-    }
-    test_field_drop_queue();
-    fn test_field_mask() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<rte_fdir_conf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).mask) as usize - ptr as usize
-            },
-            16usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_fdir_conf),
-                "::",
-                stringify!(mask)
-            )
-        );
-    }
-    test_field_mask();
-    fn test_field_flex_conf() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<rte_fdir_conf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).flex_conf) as usize - ptr as usize
-            },
-            84usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_fdir_conf),
-                "::",
-                stringify!(flex_conf)
-            )
-        );
-    }
-    test_field_flex_conf();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).mode) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_fdir_conf),
+            "::",
+            stringify!(mode)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).pballoc) as usize - ptr as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_fdir_conf),
+            "::",
+            stringify!(pballoc)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).status) as usize - ptr as usize
+        },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_fdir_conf),
+            "::",
+            stringify!(status)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).drop_queue) as usize - ptr as usize
+        },
+        12usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_fdir_conf),
+            "::",
+            stringify!(drop_queue)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).mask) as usize - ptr as usize
+        },
+        16usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_fdir_conf),
+            "::",
+            stringify!(mask)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).flex_conf) as usize - ptr as usize
+        },
+        84usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_fdir_conf),
+            "::",
+            stringify!(flex_conf)
+        )
+    );
 }
 impl Default for rte_fdir_conf {
     fn default() -> Self {
@@ -2248,6 +1947,8 @@ pub struct rte_intr_conf {
 }
 #[test]
 fn bindgen_test_layout_rte_intr_conf() {
+    const UNINIT: ::std::mem::MaybeUninit<rte_intr_conf> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<rte_intr_conf>(),
         4usize,
@@ -2258,40 +1959,32 @@ fn bindgen_test_layout_rte_intr_conf() {
         2usize,
         concat!("Alignment of ", stringify!(rte_intr_conf))
     );
-    fn test_field_lsc() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<rte_intr_conf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).lsc) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_intr_conf),
-                "::",
-                stringify!(lsc)
-            )
-        );
-    }
-    test_field_lsc();
-    fn test_field_rxq() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<rte_intr_conf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).rxq) as usize - ptr as usize
-            },
-            2usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_intr_conf),
-                "::",
-                stringify!(rxq)
-            )
-        );
-    }
-    test_field_rxq();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).lsc) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_intr_conf),
+            "::",
+            stringify!(lsc)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).rxq) as usize - ptr as usize
+        },
+        2usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_intr_conf),
+            "::",
+            stringify!(rxq)
+        )
+    );
 }
 /// A structure used to configure an Ethernet port.
 /// Depending upon the RX multi-queue mode, extra advanced
@@ -2340,6 +2033,8 @@ pub struct rte_eth_conf__bindgen_ty_1 {
 }
 #[test]
 fn bindgen_test_layout_rte_eth_conf__bindgen_ty_1() {
+    const UNINIT: ::std::mem::MaybeUninit<rte_eth_conf__bindgen_ty_1> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<rte_eth_conf__bindgen_ty_1>(),
         2120usize,
@@ -2350,84 +2045,58 @@ fn bindgen_test_layout_rte_eth_conf__bindgen_ty_1() {
         8usize,
         concat!("Alignment of ", stringify!(rte_eth_conf__bindgen_ty_1))
     );
-    fn test_field_rss_conf() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<
-                    rte_eth_conf__bindgen_ty_1,
-                >::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).rss_conf) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_conf__bindgen_ty_1),
-                "::",
-                stringify!(rss_conf)
-            )
-        );
-    }
-    test_field_rss_conf();
-    fn test_field_vmdq_dcb_conf() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<
-                    rte_eth_conf__bindgen_ty_1,
-                >::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).vmdq_dcb_conf) as usize -
-                    ptr as usize
-            },
-            24usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_conf__bindgen_ty_1),
-                "::",
-                stringify!(vmdq_dcb_conf)
-            )
-        );
-    }
-    test_field_vmdq_dcb_conf();
-    fn test_field_dcb_rx_conf() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<
-                    rte_eth_conf__bindgen_ty_1,
-                >::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).dcb_rx_conf) as usize - ptr as usize
-            },
-            1064usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_conf__bindgen_ty_1),
-                "::",
-                stringify!(dcb_rx_conf)
-            )
-        );
-    }
-    test_field_dcb_rx_conf();
-    fn test_field_vmdq_rx_conf() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<
-                    rte_eth_conf__bindgen_ty_1,
-                >::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).vmdq_rx_conf) as usize -
-                    ptr as usize
-            },
-            1080usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_conf__bindgen_ty_1),
-                "::",
-                stringify!(vmdq_rx_conf)
-            )
-        );
-    }
-    test_field_vmdq_rx_conf();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).rss_conf) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_conf__bindgen_ty_1),
+            "::",
+            stringify!(rss_conf)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).vmdq_dcb_conf) as usize - ptr as usize
+        },
+        24usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_conf__bindgen_ty_1),
+            "::",
+            stringify!(vmdq_dcb_conf)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).dcb_rx_conf) as usize - ptr as usize
+        },
+        1064usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_conf__bindgen_ty_1),
+            "::",
+            stringify!(dcb_rx_conf)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).vmdq_rx_conf) as usize - ptr as usize
+        },
+        1080usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_conf__bindgen_ty_1),
+            "::",
+            stringify!(vmdq_rx_conf)
+        )
+    );
 }
 impl Default for rte_eth_conf__bindgen_ty_1 {
     fn default() -> Self {
@@ -2447,6 +2116,8 @@ pub union rte_eth_conf__bindgen_ty_2 {
 }
 #[test]
 fn bindgen_test_layout_rte_eth_conf__bindgen_ty_2() {
+    const UNINIT: ::std::mem::MaybeUninit<rte_eth_conf__bindgen_ty_2> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<rte_eth_conf__bindgen_ty_2>(),
         12usize,
@@ -2457,65 +2128,46 @@ fn bindgen_test_layout_rte_eth_conf__bindgen_ty_2() {
         4usize,
         concat!("Alignment of ", stringify!(rte_eth_conf__bindgen_ty_2))
     );
-    fn test_field_vmdq_dcb_tx_conf() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<
-                    rte_eth_conf__bindgen_ty_2,
-                >::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).vmdq_dcb_tx_conf) as usize -
-                    ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_conf__bindgen_ty_2),
-                "::",
-                stringify!(vmdq_dcb_tx_conf)
-            )
-        );
-    }
-    test_field_vmdq_dcb_tx_conf();
-    fn test_field_dcb_tx_conf() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<
-                    rte_eth_conf__bindgen_ty_2,
-                >::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).dcb_tx_conf) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_conf__bindgen_ty_2),
-                "::",
-                stringify!(dcb_tx_conf)
-            )
-        );
-    }
-    test_field_dcb_tx_conf();
-    fn test_field_vmdq_tx_conf() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<
-                    rte_eth_conf__bindgen_ty_2,
-                >::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).vmdq_tx_conf) as usize -
-                    ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_conf__bindgen_ty_2),
-                "::",
-                stringify!(vmdq_tx_conf)
-            )
-        );
-    }
-    test_field_vmdq_tx_conf();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).vmdq_dcb_tx_conf) as usize -
+                ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_conf__bindgen_ty_2),
+            "::",
+            stringify!(vmdq_dcb_tx_conf)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).dcb_tx_conf) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_conf__bindgen_ty_2),
+            "::",
+            stringify!(dcb_tx_conf)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).vmdq_tx_conf) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_conf__bindgen_ty_2),
+            "::",
+            stringify!(vmdq_tx_conf)
+        )
+    );
 }
 impl Default for rte_eth_conf__bindgen_ty_2 {
     fn default() -> Self {
@@ -2528,6 +2180,8 @@ impl Default for rte_eth_conf__bindgen_ty_2 {
 }
 #[test]
 fn bindgen_test_layout_rte_eth_conf() {
+    const UNINIT: ::std::mem::MaybeUninit<rte_eth_conf> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<rte_eth_conf>(),
         2944usize,
@@ -2538,160 +2192,124 @@ fn bindgen_test_layout_rte_eth_conf() {
         8usize,
         concat!("Alignment of ", stringify!(rte_eth_conf))
     );
-    fn test_field_link_speeds() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<rte_eth_conf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).link_speeds) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_conf),
-                "::",
-                stringify!(link_speeds)
-            )
-        );
-    }
-    test_field_link_speeds();
-    fn test_field_rxmode() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<rte_eth_conf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).rxmode) as usize - ptr as usize
-            },
-            4usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_conf),
-                "::",
-                stringify!(rxmode)
-            )
-        );
-    }
-    test_field_rxmode();
-    fn test_field_txmode() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<rte_eth_conf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).txmode) as usize - ptr as usize
-            },
-            16usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_conf),
-                "::",
-                stringify!(txmode)
-            )
-        );
-    }
-    test_field_txmode();
-    fn test_field_lpbk_mode() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<rte_eth_conf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).lpbk_mode) as usize - ptr as usize
-            },
-            24usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_conf),
-                "::",
-                stringify!(lpbk_mode)
-            )
-        );
-    }
-    test_field_lpbk_mode();
-    fn test_field_rx_adv_conf() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<rte_eth_conf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).rx_adv_conf) as usize - ptr as usize
-            },
-            32usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_conf),
-                "::",
-                stringify!(rx_adv_conf)
-            )
-        );
-    }
-    test_field_rx_adv_conf();
-    fn test_field_tx_adv_conf() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<rte_eth_conf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).tx_adv_conf) as usize - ptr as usize
-            },
-            2152usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_conf),
-                "::",
-                stringify!(tx_adv_conf)
-            )
-        );
-    }
-    test_field_tx_adv_conf();
-    fn test_field_dcb_capability_en() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<rte_eth_conf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).dcb_capability_en) as usize -
-                    ptr as usize
-            },
-            2164usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_conf),
-                "::",
-                stringify!(dcb_capability_en)
-            )
-        );
-    }
-    test_field_dcb_capability_en();
-    fn test_field_fdir_conf() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<rte_eth_conf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).fdir_conf) as usize - ptr as usize
-            },
-            2168usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_conf),
-                "::",
-                stringify!(fdir_conf)
-            )
-        );
-    }
-    test_field_fdir_conf();
-    fn test_field_intr_conf() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<rte_eth_conf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).intr_conf) as usize - ptr as usize
-            },
-            2940usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_conf),
-                "::",
-                stringify!(intr_conf)
-            )
-        );
-    }
-    test_field_intr_conf();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).link_speeds) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_conf),
+            "::",
+            stringify!(link_speeds)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).rxmode) as usize - ptr as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_conf),
+            "::",
+            stringify!(rxmode)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).txmode) as usize - ptr as usize
+        },
+        16usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_conf),
+            "::",
+            stringify!(txmode)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).lpbk_mode) as usize - ptr as usize
+        },
+        24usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_conf),
+            "::",
+            stringify!(lpbk_mode)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).rx_adv_conf) as usize - ptr as usize
+        },
+        32usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_conf),
+            "::",
+            stringify!(rx_adv_conf)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).tx_adv_conf) as usize - ptr as usize
+        },
+        2152usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_conf),
+            "::",
+            stringify!(tx_adv_conf)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).dcb_capability_en) as usize -
+                ptr as usize
+        },
+        2164usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_conf),
+            "::",
+            stringify!(dcb_capability_en)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).fdir_conf) as usize - ptr as usize
+        },
+        2168usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_conf),
+            "::",
+            stringify!(fdir_conf)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).intr_conf) as usize - ptr as usize
+        },
+        2940usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_conf),
+            "::",
+            stringify!(intr_conf)
+        )
+    );
 }
 impl Default for rte_eth_conf {
     fn default() -> Self {

--- a/tests/expectations/tests/layout_eth_conf_1_0.rs
+++ b/tests/expectations/tests/layout_eth_conf_1_0.rs
@@ -203,6 +203,8 @@ pub struct rte_eth_rxmode {
 }
 #[test]
 fn bindgen_test_layout_rte_eth_rxmode() {
+    const UNINIT: ::std::mem::MaybeUninit<rte_eth_rxmode> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<rte_eth_rxmode>(),
         12usize,
@@ -213,62 +215,45 @@ fn bindgen_test_layout_rte_eth_rxmode() {
         4usize,
         concat!("Alignment of ", stringify!(rte_eth_rxmode))
     );
-    fn test_field_mq_mode() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_eth_rxmode>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).mq_mode) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_rxmode),
-                "::",
-                stringify!(mq_mode)
-            )
-        );
-    }
-    test_field_mq_mode();
-    fn test_field_max_rx_pkt_len() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_eth_rxmode>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).max_rx_pkt_len) as usize -
-                    ptr as usize
-            },
-            4usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_rxmode),
-                "::",
-                stringify!(max_rx_pkt_len)
-            )
-        );
-    }
-    test_field_max_rx_pkt_len();
-    fn test_field_split_hdr_size() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_eth_rxmode>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).split_hdr_size) as usize -
-                    ptr as usize
-            },
-            8usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_rxmode),
-                "::",
-                stringify!(split_hdr_size)
-            )
-        );
-    }
-    test_field_split_hdr_size();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).mq_mode) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_rxmode),
+            "::",
+            stringify!(mq_mode)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).max_rx_pkt_len) as usize - ptr as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_rxmode),
+            "::",
+            stringify!(max_rx_pkt_len)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).split_hdr_size) as usize - ptr as usize
+        },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_rxmode),
+            "::",
+            stringify!(split_hdr_size)
+        )
+    );
 }
 impl Clone for rte_eth_rxmode {
     fn clone(&self) -> Self {
@@ -490,6 +475,8 @@ pub struct rte_eth_txmode {
 }
 #[test]
 fn bindgen_test_layout_rte_eth_txmode() {
+    const UNINIT: ::std::mem::MaybeUninit<rte_eth_txmode> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<rte_eth_txmode>(),
         8usize,
@@ -500,42 +487,32 @@ fn bindgen_test_layout_rte_eth_txmode() {
         4usize,
         concat!("Alignment of ", stringify!(rte_eth_txmode))
     );
-    fn test_field_mq_mode() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_eth_txmode>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).mq_mode) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_txmode),
-                "::",
-                stringify!(mq_mode)
-            )
-        );
-    }
-    test_field_mq_mode();
-    fn test_field_pvid() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_eth_txmode>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).pvid) as usize - ptr as usize
-            },
-            4usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_txmode),
-                "::",
-                stringify!(pvid)
-            )
-        );
-    }
-    test_field_pvid();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).mq_mode) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_txmode),
+            "::",
+            stringify!(mq_mode)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).pvid) as usize - ptr as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_txmode),
+            "::",
+            stringify!(pvid)
+        )
+    );
 }
 impl Clone for rte_eth_txmode {
     fn clone(&self) -> Self {
@@ -644,6 +621,8 @@ pub struct rte_eth_rss_conf {
 }
 #[test]
 fn bindgen_test_layout_rte_eth_rss_conf() {
+    const UNINIT: ::std::mem::MaybeUninit<rte_eth_rss_conf> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<rte_eth_rss_conf>(),
         24usize,
@@ -654,60 +633,45 @@ fn bindgen_test_layout_rte_eth_rss_conf() {
         8usize,
         concat!("Alignment of ", stringify!(rte_eth_rss_conf))
     );
-    fn test_field_rss_key() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_eth_rss_conf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).rss_key) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_rss_conf),
-                "::",
-                stringify!(rss_key)
-            )
-        );
-    }
-    test_field_rss_key();
-    fn test_field_rss_key_len() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_eth_rss_conf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).rss_key_len) as usize - ptr as usize
-            },
-            8usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_rss_conf),
-                "::",
-                stringify!(rss_key_len)
-            )
-        );
-    }
-    test_field_rss_key_len();
-    fn test_field_rss_hf() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_eth_rss_conf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).rss_hf) as usize - ptr as usize
-            },
-            16usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_rss_conf),
-                "::",
-                stringify!(rss_hf)
-            )
-        );
-    }
-    test_field_rss_hf();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).rss_key) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_rss_conf),
+            "::",
+            stringify!(rss_key)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).rss_key_len) as usize - ptr as usize
+        },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_rss_conf),
+            "::",
+            stringify!(rss_key_len)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).rss_hf) as usize - ptr as usize
+        },
+        16usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_rss_conf),
+            "::",
+            stringify!(rss_hf)
+        )
+    );
 }
 impl Clone for rte_eth_rss_conf {
     fn clone(&self) -> Self {
@@ -781,6 +745,8 @@ pub struct rte_eth_vmdq_dcb_conf__bindgen_ty_1 {
 }
 #[test]
 fn bindgen_test_layout_rte_eth_vmdq_dcb_conf__bindgen_ty_1() {
+    const UNINIT: ::std::mem::MaybeUninit<rte_eth_vmdq_dcb_conf__bindgen_ty_1> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<rte_eth_vmdq_dcb_conf__bindgen_ty_1>(),
         16usize,
@@ -794,44 +760,32 @@ fn bindgen_test_layout_rte_eth_vmdq_dcb_conf__bindgen_ty_1() {
             stringify!(rte_eth_vmdq_dcb_conf__bindgen_ty_1)
         )
     );
-    fn test_field_vlan_id() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<
-                    rte_eth_vmdq_dcb_conf__bindgen_ty_1,
-                >::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).vlan_id) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_vmdq_dcb_conf__bindgen_ty_1),
-                "::",
-                stringify!(vlan_id)
-            )
-        );
-    }
-    test_field_vlan_id();
-    fn test_field_pools() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<
-                    rte_eth_vmdq_dcb_conf__bindgen_ty_1,
-                >::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).pools) as usize - ptr as usize
-            },
-            8usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_vmdq_dcb_conf__bindgen_ty_1),
-                "::",
-                stringify!(pools)
-            )
-        );
-    }
-    test_field_pools();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).vlan_id) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_vmdq_dcb_conf__bindgen_ty_1),
+            "::",
+            stringify!(vlan_id)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).pools) as usize - ptr as usize
+        },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_vmdq_dcb_conf__bindgen_ty_1),
+            "::",
+            stringify!(pools)
+        )
+    );
 }
 impl Clone for rte_eth_vmdq_dcb_conf__bindgen_ty_1 {
     fn clone(&self) -> Self {
@@ -840,6 +794,8 @@ impl Clone for rte_eth_vmdq_dcb_conf__bindgen_ty_1 {
 }
 #[test]
 fn bindgen_test_layout_rte_eth_vmdq_dcb_conf() {
+    const UNINIT: ::std::mem::MaybeUninit<rte_eth_vmdq_dcb_conf> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<rte_eth_vmdq_dcb_conf>(),
         1040usize,
@@ -850,118 +806,85 @@ fn bindgen_test_layout_rte_eth_vmdq_dcb_conf() {
         8usize,
         concat!("Alignment of ", stringify!(rte_eth_vmdq_dcb_conf))
     );
-    fn test_field_nb_queue_pools() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_eth_vmdq_dcb_conf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).nb_queue_pools) as usize -
-                    ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_vmdq_dcb_conf),
-                "::",
-                stringify!(nb_queue_pools)
-            )
-        );
-    }
-    test_field_nb_queue_pools();
-    fn test_field_enable_default_pool() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_eth_vmdq_dcb_conf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).enable_default_pool) as usize -
-                    ptr as usize
-            },
-            4usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_vmdq_dcb_conf),
-                "::",
-                stringify!(enable_default_pool)
-            )
-        );
-    }
-    test_field_enable_default_pool();
-    fn test_field_default_pool() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_eth_vmdq_dcb_conf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).default_pool) as usize -
-                    ptr as usize
-            },
-            5usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_vmdq_dcb_conf),
-                "::",
-                stringify!(default_pool)
-            )
-        );
-    }
-    test_field_default_pool();
-    fn test_field_nb_pool_maps() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_eth_vmdq_dcb_conf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).nb_pool_maps) as usize -
-                    ptr as usize
-            },
-            6usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_vmdq_dcb_conf),
-                "::",
-                stringify!(nb_pool_maps)
-            )
-        );
-    }
-    test_field_nb_pool_maps();
-    fn test_field_pool_map() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_eth_vmdq_dcb_conf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).pool_map) as usize - ptr as usize
-            },
-            8usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_vmdq_dcb_conf),
-                "::",
-                stringify!(pool_map)
-            )
-        );
-    }
-    test_field_pool_map();
-    fn test_field_dcb_tc() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_eth_vmdq_dcb_conf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).dcb_tc) as usize - ptr as usize
-            },
-            1032usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_vmdq_dcb_conf),
-                "::",
-                stringify!(dcb_tc)
-            )
-        );
-    }
-    test_field_dcb_tc();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).nb_queue_pools) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_vmdq_dcb_conf),
+            "::",
+            stringify!(nb_queue_pools)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).enable_default_pool) as usize -
+                ptr as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_vmdq_dcb_conf),
+            "::",
+            stringify!(enable_default_pool)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).default_pool) as usize - ptr as usize
+        },
+        5usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_vmdq_dcb_conf),
+            "::",
+            stringify!(default_pool)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).nb_pool_maps) as usize - ptr as usize
+        },
+        6usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_vmdq_dcb_conf),
+            "::",
+            stringify!(nb_pool_maps)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).pool_map) as usize - ptr as usize
+        },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_vmdq_dcb_conf),
+            "::",
+            stringify!(pool_map)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).dcb_tc) as usize - ptr as usize
+        },
+        1032usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_vmdq_dcb_conf),
+            "::",
+            stringify!(dcb_tc)
+        )
+    );
 }
 impl Clone for rte_eth_vmdq_dcb_conf {
     fn clone(&self) -> Self {
@@ -987,6 +910,8 @@ pub struct rte_eth_dcb_rx_conf {
 }
 #[test]
 fn bindgen_test_layout_rte_eth_dcb_rx_conf() {
+    const UNINIT: ::std::mem::MaybeUninit<rte_eth_dcb_rx_conf> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<rte_eth_dcb_rx_conf>(),
         12usize,
@@ -997,42 +922,32 @@ fn bindgen_test_layout_rte_eth_dcb_rx_conf() {
         4usize,
         concat!("Alignment of ", stringify!(rte_eth_dcb_rx_conf))
     );
-    fn test_field_nb_tcs() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_eth_dcb_rx_conf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).nb_tcs) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_dcb_rx_conf),
-                "::",
-                stringify!(nb_tcs)
-            )
-        );
-    }
-    test_field_nb_tcs();
-    fn test_field_dcb_tc() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_eth_dcb_rx_conf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).dcb_tc) as usize - ptr as usize
-            },
-            4usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_dcb_rx_conf),
-                "::",
-                stringify!(dcb_tc)
-            )
-        );
-    }
-    test_field_dcb_tc();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).nb_tcs) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_dcb_rx_conf),
+            "::",
+            stringify!(nb_tcs)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).dcb_tc) as usize - ptr as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_dcb_rx_conf),
+            "::",
+            stringify!(dcb_tc)
+        )
+    );
 }
 impl Clone for rte_eth_dcb_rx_conf {
     fn clone(&self) -> Self {
@@ -1058,6 +973,8 @@ pub struct rte_eth_vmdq_dcb_tx_conf {
 }
 #[test]
 fn bindgen_test_layout_rte_eth_vmdq_dcb_tx_conf() {
+    const UNINIT: ::std::mem::MaybeUninit<rte_eth_vmdq_dcb_tx_conf> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<rte_eth_vmdq_dcb_tx_conf>(),
         12usize,
@@ -1068,45 +985,32 @@ fn bindgen_test_layout_rte_eth_vmdq_dcb_tx_conf() {
         4usize,
         concat!("Alignment of ", stringify!(rte_eth_vmdq_dcb_tx_conf))
     );
-    fn test_field_nb_queue_pools() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_eth_vmdq_dcb_tx_conf>::uninit(
-                    );
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).nb_queue_pools) as usize -
-                    ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_vmdq_dcb_tx_conf),
-                "::",
-                stringify!(nb_queue_pools)
-            )
-        );
-    }
-    test_field_nb_queue_pools();
-    fn test_field_dcb_tc() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_eth_vmdq_dcb_tx_conf>::uninit(
-                    );
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).dcb_tc) as usize - ptr as usize
-            },
-            4usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_vmdq_dcb_tx_conf),
-                "::",
-                stringify!(dcb_tc)
-            )
-        );
-    }
-    test_field_dcb_tc();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).nb_queue_pools) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_vmdq_dcb_tx_conf),
+            "::",
+            stringify!(nb_queue_pools)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).dcb_tc) as usize - ptr as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_vmdq_dcb_tx_conf),
+            "::",
+            stringify!(dcb_tc)
+        )
+    );
 }
 impl Clone for rte_eth_vmdq_dcb_tx_conf {
     fn clone(&self) -> Self {
@@ -1132,6 +1036,8 @@ pub struct rte_eth_dcb_tx_conf {
 }
 #[test]
 fn bindgen_test_layout_rte_eth_dcb_tx_conf() {
+    const UNINIT: ::std::mem::MaybeUninit<rte_eth_dcb_tx_conf> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<rte_eth_dcb_tx_conf>(),
         12usize,
@@ -1142,42 +1048,32 @@ fn bindgen_test_layout_rte_eth_dcb_tx_conf() {
         4usize,
         concat!("Alignment of ", stringify!(rte_eth_dcb_tx_conf))
     );
-    fn test_field_nb_tcs() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_eth_dcb_tx_conf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).nb_tcs) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_dcb_tx_conf),
-                "::",
-                stringify!(nb_tcs)
-            )
-        );
-    }
-    test_field_nb_tcs();
-    fn test_field_dcb_tc() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_eth_dcb_tx_conf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).dcb_tc) as usize - ptr as usize
-            },
-            4usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_dcb_tx_conf),
-                "::",
-                stringify!(dcb_tc)
-            )
-        );
-    }
-    test_field_dcb_tc();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).nb_tcs) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_dcb_tx_conf),
+            "::",
+            stringify!(nb_tcs)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).dcb_tc) as usize - ptr as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_dcb_tx_conf),
+            "::",
+            stringify!(dcb_tc)
+        )
+    );
 }
 impl Clone for rte_eth_dcb_tx_conf {
     fn clone(&self) -> Self {
@@ -1201,6 +1097,8 @@ pub struct rte_eth_vmdq_tx_conf {
 }
 #[test]
 fn bindgen_test_layout_rte_eth_vmdq_tx_conf() {
+    const UNINIT: ::std::mem::MaybeUninit<rte_eth_vmdq_tx_conf> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<rte_eth_vmdq_tx_conf>(),
         4usize,
@@ -1211,25 +1109,19 @@ fn bindgen_test_layout_rte_eth_vmdq_tx_conf() {
         4usize,
         concat!("Alignment of ", stringify!(rte_eth_vmdq_tx_conf))
     );
-    fn test_field_nb_queue_pools() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_eth_vmdq_tx_conf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).nb_queue_pools) as usize -
-                    ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_vmdq_tx_conf),
-                "::",
-                stringify!(nb_queue_pools)
-            )
-        );
-    }
-    test_field_nb_queue_pools();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).nb_queue_pools) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_vmdq_tx_conf),
+            "::",
+            stringify!(nb_queue_pools)
+        )
+    );
 }
 impl Clone for rte_eth_vmdq_tx_conf {
     fn clone(&self) -> Self {
@@ -1273,6 +1165,8 @@ pub struct rte_eth_vmdq_rx_conf__bindgen_ty_1 {
 }
 #[test]
 fn bindgen_test_layout_rte_eth_vmdq_rx_conf__bindgen_ty_1() {
+    const UNINIT: ::std::mem::MaybeUninit<rte_eth_vmdq_rx_conf__bindgen_ty_1> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<rte_eth_vmdq_rx_conf__bindgen_ty_1>(),
         16usize,
@@ -1286,44 +1180,32 @@ fn bindgen_test_layout_rte_eth_vmdq_rx_conf__bindgen_ty_1() {
             stringify!(rte_eth_vmdq_rx_conf__bindgen_ty_1)
         )
     );
-    fn test_field_vlan_id() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<
-                    rte_eth_vmdq_rx_conf__bindgen_ty_1,
-                >::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).vlan_id) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_vmdq_rx_conf__bindgen_ty_1),
-                "::",
-                stringify!(vlan_id)
-            )
-        );
-    }
-    test_field_vlan_id();
-    fn test_field_pools() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<
-                    rte_eth_vmdq_rx_conf__bindgen_ty_1,
-                >::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).pools) as usize - ptr as usize
-            },
-            8usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_vmdq_rx_conf__bindgen_ty_1),
-                "::",
-                stringify!(pools)
-            )
-        );
-    }
-    test_field_pools();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).vlan_id) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_vmdq_rx_conf__bindgen_ty_1),
+            "::",
+            stringify!(vlan_id)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).pools) as usize - ptr as usize
+        },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_vmdq_rx_conf__bindgen_ty_1),
+            "::",
+            stringify!(pools)
+        )
+    );
 }
 impl Clone for rte_eth_vmdq_rx_conf__bindgen_ty_1 {
     fn clone(&self) -> Self {
@@ -1332,6 +1214,8 @@ impl Clone for rte_eth_vmdq_rx_conf__bindgen_ty_1 {
 }
 #[test]
 fn bindgen_test_layout_rte_eth_vmdq_rx_conf() {
+    const UNINIT: ::std::mem::MaybeUninit<rte_eth_vmdq_rx_conf> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<rte_eth_vmdq_rx_conf>(),
         1040usize,
@@ -1342,137 +1226,99 @@ fn bindgen_test_layout_rte_eth_vmdq_rx_conf() {
         8usize,
         concat!("Alignment of ", stringify!(rte_eth_vmdq_rx_conf))
     );
-    fn test_field_nb_queue_pools() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_eth_vmdq_rx_conf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).nb_queue_pools) as usize -
-                    ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_vmdq_rx_conf),
-                "::",
-                stringify!(nb_queue_pools)
-            )
-        );
-    }
-    test_field_nb_queue_pools();
-    fn test_field_enable_default_pool() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_eth_vmdq_rx_conf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).enable_default_pool) as usize -
-                    ptr as usize
-            },
-            4usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_vmdq_rx_conf),
-                "::",
-                stringify!(enable_default_pool)
-            )
-        );
-    }
-    test_field_enable_default_pool();
-    fn test_field_default_pool() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_eth_vmdq_rx_conf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).default_pool) as usize -
-                    ptr as usize
-            },
-            5usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_vmdq_rx_conf),
-                "::",
-                stringify!(default_pool)
-            )
-        );
-    }
-    test_field_default_pool();
-    fn test_field_enable_loop_back() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_eth_vmdq_rx_conf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).enable_loop_back) as usize -
-                    ptr as usize
-            },
-            6usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_vmdq_rx_conf),
-                "::",
-                stringify!(enable_loop_back)
-            )
-        );
-    }
-    test_field_enable_loop_back();
-    fn test_field_nb_pool_maps() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_eth_vmdq_rx_conf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).nb_pool_maps) as usize -
-                    ptr as usize
-            },
-            7usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_vmdq_rx_conf),
-                "::",
-                stringify!(nb_pool_maps)
-            )
-        );
-    }
-    test_field_nb_pool_maps();
-    fn test_field_rx_mode() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_eth_vmdq_rx_conf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).rx_mode) as usize - ptr as usize
-            },
-            8usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_vmdq_rx_conf),
-                "::",
-                stringify!(rx_mode)
-            )
-        );
-    }
-    test_field_rx_mode();
-    fn test_field_pool_map() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_eth_vmdq_rx_conf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).pool_map) as usize - ptr as usize
-            },
-            16usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_vmdq_rx_conf),
-                "::",
-                stringify!(pool_map)
-            )
-        );
-    }
-    test_field_pool_map();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).nb_queue_pools) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_vmdq_rx_conf),
+            "::",
+            stringify!(nb_queue_pools)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).enable_default_pool) as usize -
+                ptr as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_vmdq_rx_conf),
+            "::",
+            stringify!(enable_default_pool)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).default_pool) as usize - ptr as usize
+        },
+        5usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_vmdq_rx_conf),
+            "::",
+            stringify!(default_pool)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).enable_loop_back) as usize -
+                ptr as usize
+        },
+        6usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_vmdq_rx_conf),
+            "::",
+            stringify!(enable_loop_back)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).nb_pool_maps) as usize - ptr as usize
+        },
+        7usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_vmdq_rx_conf),
+            "::",
+            stringify!(nb_pool_maps)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).rx_mode) as usize - ptr as usize
+        },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_vmdq_rx_conf),
+            "::",
+            stringify!(rx_mode)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).pool_map) as usize - ptr as usize
+        },
+        16usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_vmdq_rx_conf),
+            "::",
+            stringify!(pool_map)
+        )
+    );
 }
 impl Clone for rte_eth_vmdq_rx_conf {
     fn clone(&self) -> Self {
@@ -1543,6 +1389,8 @@ pub struct rte_eth_ipv4_flow {
 }
 #[test]
 fn bindgen_test_layout_rte_eth_ipv4_flow() {
+    const UNINIT: ::std::mem::MaybeUninit<rte_eth_ipv4_flow> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<rte_eth_ipv4_flow>(),
         12usize,
@@ -1553,96 +1401,71 @@ fn bindgen_test_layout_rte_eth_ipv4_flow() {
         4usize,
         concat!("Alignment of ", stringify!(rte_eth_ipv4_flow))
     );
-    fn test_field_src_ip() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_eth_ipv4_flow>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).src_ip) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_ipv4_flow),
-                "::",
-                stringify!(src_ip)
-            )
-        );
-    }
-    test_field_src_ip();
-    fn test_field_dst_ip() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_eth_ipv4_flow>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).dst_ip) as usize - ptr as usize
-            },
-            4usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_ipv4_flow),
-                "::",
-                stringify!(dst_ip)
-            )
-        );
-    }
-    test_field_dst_ip();
-    fn test_field_tos() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_eth_ipv4_flow>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).tos) as usize - ptr as usize
-            },
-            8usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_ipv4_flow),
-                "::",
-                stringify!(tos)
-            )
-        );
-    }
-    test_field_tos();
-    fn test_field_ttl() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_eth_ipv4_flow>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).ttl) as usize - ptr as usize
-            },
-            9usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_ipv4_flow),
-                "::",
-                stringify!(ttl)
-            )
-        );
-    }
-    test_field_ttl();
-    fn test_field_proto() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_eth_ipv4_flow>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).proto) as usize - ptr as usize
-            },
-            10usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_ipv4_flow),
-                "::",
-                stringify!(proto)
-            )
-        );
-    }
-    test_field_proto();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).src_ip) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_ipv4_flow),
+            "::",
+            stringify!(src_ip)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).dst_ip) as usize - ptr as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_ipv4_flow),
+            "::",
+            stringify!(dst_ip)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).tos) as usize - ptr as usize
+        },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_ipv4_flow),
+            "::",
+            stringify!(tos)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).ttl) as usize - ptr as usize
+        },
+        9usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_ipv4_flow),
+            "::",
+            stringify!(ttl)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).proto) as usize - ptr as usize
+        },
+        10usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_ipv4_flow),
+            "::",
+            stringify!(proto)
+        )
+    );
 }
 impl Clone for rte_eth_ipv4_flow {
     fn clone(&self) -> Self {
@@ -1666,6 +1489,8 @@ pub struct rte_eth_ipv6_flow {
 }
 #[test]
 fn bindgen_test_layout_rte_eth_ipv6_flow() {
+    const UNINIT: ::std::mem::MaybeUninit<rte_eth_ipv6_flow> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<rte_eth_ipv6_flow>(),
         36usize,
@@ -1676,96 +1501,71 @@ fn bindgen_test_layout_rte_eth_ipv6_flow() {
         4usize,
         concat!("Alignment of ", stringify!(rte_eth_ipv6_flow))
     );
-    fn test_field_src_ip() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_eth_ipv6_flow>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).src_ip) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_ipv6_flow),
-                "::",
-                stringify!(src_ip)
-            )
-        );
-    }
-    test_field_src_ip();
-    fn test_field_dst_ip() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_eth_ipv6_flow>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).dst_ip) as usize - ptr as usize
-            },
-            16usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_ipv6_flow),
-                "::",
-                stringify!(dst_ip)
-            )
-        );
-    }
-    test_field_dst_ip();
-    fn test_field_tc() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_eth_ipv6_flow>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).tc) as usize - ptr as usize
-            },
-            32usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_ipv6_flow),
-                "::",
-                stringify!(tc)
-            )
-        );
-    }
-    test_field_tc();
-    fn test_field_proto() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_eth_ipv6_flow>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).proto) as usize - ptr as usize
-            },
-            33usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_ipv6_flow),
-                "::",
-                stringify!(proto)
-            )
-        );
-    }
-    test_field_proto();
-    fn test_field_hop_limits() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_eth_ipv6_flow>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).hop_limits) as usize - ptr as usize
-            },
-            34usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_ipv6_flow),
-                "::",
-                stringify!(hop_limits)
-            )
-        );
-    }
-    test_field_hop_limits();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).src_ip) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_ipv6_flow),
+            "::",
+            stringify!(src_ip)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).dst_ip) as usize - ptr as usize
+        },
+        16usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_ipv6_flow),
+            "::",
+            stringify!(dst_ip)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).tc) as usize - ptr as usize
+        },
+        32usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_ipv6_flow),
+            "::",
+            stringify!(tc)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).proto) as usize - ptr as usize
+        },
+        33usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_ipv6_flow),
+            "::",
+            stringify!(proto)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).hop_limits) as usize - ptr as usize
+        },
+        34usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_ipv6_flow),
+            "::",
+            stringify!(hop_limits)
+        )
+    );
 }
 impl Clone for rte_eth_ipv6_flow {
     fn clone(&self) -> Self {
@@ -1798,6 +1598,8 @@ pub struct rte_eth_fdir_masks {
 }
 #[test]
 fn bindgen_test_layout_rte_eth_fdir_masks() {
+    const UNINIT: ::std::mem::MaybeUninit<rte_eth_fdir_masks> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<rte_eth_fdir_masks>(),
         68usize,
@@ -1808,156 +1610,112 @@ fn bindgen_test_layout_rte_eth_fdir_masks() {
         4usize,
         concat!("Alignment of ", stringify!(rte_eth_fdir_masks))
     );
-    fn test_field_vlan_tci_mask() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_eth_fdir_masks>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).vlan_tci_mask) as usize -
-                    ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_fdir_masks),
-                "::",
-                stringify!(vlan_tci_mask)
-            )
-        );
-    }
-    test_field_vlan_tci_mask();
-    fn test_field_ipv4_mask() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_eth_fdir_masks>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).ipv4_mask) as usize - ptr as usize
-            },
-            4usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_fdir_masks),
-                "::",
-                stringify!(ipv4_mask)
-            )
-        );
-    }
-    test_field_ipv4_mask();
-    fn test_field_ipv6_mask() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_eth_fdir_masks>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).ipv6_mask) as usize - ptr as usize
-            },
-            16usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_fdir_masks),
-                "::",
-                stringify!(ipv6_mask)
-            )
-        );
-    }
-    test_field_ipv6_mask();
-    fn test_field_src_port_mask() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_eth_fdir_masks>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).src_port_mask) as usize -
-                    ptr as usize
-            },
-            52usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_fdir_masks),
-                "::",
-                stringify!(src_port_mask)
-            )
-        );
-    }
-    test_field_src_port_mask();
-    fn test_field_dst_port_mask() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_eth_fdir_masks>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).dst_port_mask) as usize -
-                    ptr as usize
-            },
-            54usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_fdir_masks),
-                "::",
-                stringify!(dst_port_mask)
-            )
-        );
-    }
-    test_field_dst_port_mask();
-    fn test_field_mac_addr_byte_mask() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_eth_fdir_masks>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).mac_addr_byte_mask) as usize -
-                    ptr as usize
-            },
-            56usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_fdir_masks),
-                "::",
-                stringify!(mac_addr_byte_mask)
-            )
-        );
-    }
-    test_field_mac_addr_byte_mask();
-    fn test_field_tunnel_id_mask() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_eth_fdir_masks>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).tunnel_id_mask) as usize -
-                    ptr as usize
-            },
-            60usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_fdir_masks),
-                "::",
-                stringify!(tunnel_id_mask)
-            )
-        );
-    }
-    test_field_tunnel_id_mask();
-    fn test_field_tunnel_type_mask() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_eth_fdir_masks>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).tunnel_type_mask) as usize -
-                    ptr as usize
-            },
-            64usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_fdir_masks),
-                "::",
-                stringify!(tunnel_type_mask)
-            )
-        );
-    }
-    test_field_tunnel_type_mask();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).vlan_tci_mask) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_fdir_masks),
+            "::",
+            stringify!(vlan_tci_mask)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).ipv4_mask) as usize - ptr as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_fdir_masks),
+            "::",
+            stringify!(ipv4_mask)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).ipv6_mask) as usize - ptr as usize
+        },
+        16usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_fdir_masks),
+            "::",
+            stringify!(ipv6_mask)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).src_port_mask) as usize - ptr as usize
+        },
+        52usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_fdir_masks),
+            "::",
+            stringify!(src_port_mask)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).dst_port_mask) as usize - ptr as usize
+        },
+        54usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_fdir_masks),
+            "::",
+            stringify!(dst_port_mask)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).mac_addr_byte_mask) as usize -
+                ptr as usize
+        },
+        56usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_fdir_masks),
+            "::",
+            stringify!(mac_addr_byte_mask)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).tunnel_id_mask) as usize - ptr as usize
+        },
+        60usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_fdir_masks),
+            "::",
+            stringify!(tunnel_id_mask)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).tunnel_type_mask) as usize -
+                ptr as usize
+        },
+        64usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_fdir_masks),
+            "::",
+            stringify!(tunnel_type_mask)
+        )
+    );
 }
 impl Clone for rte_eth_fdir_masks {
     fn clone(&self) -> Self {
@@ -1986,6 +1744,8 @@ pub struct rte_eth_flex_payload_cfg {
 }
 #[test]
 fn bindgen_test_layout_rte_eth_flex_payload_cfg() {
+    const UNINIT: ::std::mem::MaybeUninit<rte_eth_flex_payload_cfg> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<rte_eth_flex_payload_cfg>(),
         36usize,
@@ -1996,44 +1756,32 @@ fn bindgen_test_layout_rte_eth_flex_payload_cfg() {
         4usize,
         concat!("Alignment of ", stringify!(rte_eth_flex_payload_cfg))
     );
-    fn test_field_type() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_eth_flex_payload_cfg>::uninit(
-                    );
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).type_) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_flex_payload_cfg),
-                "::",
-                stringify!(type_)
-            )
-        );
-    }
-    test_field_type();
-    fn test_field_src_offset() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_eth_flex_payload_cfg>::uninit(
-                    );
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).src_offset) as usize - ptr as usize
-            },
-            4usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_flex_payload_cfg),
-                "::",
-                stringify!(src_offset)
-            )
-        );
-    }
-    test_field_src_offset();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).type_) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_flex_payload_cfg),
+            "::",
+            stringify!(type_)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).src_offset) as usize - ptr as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_flex_payload_cfg),
+            "::",
+            stringify!(src_offset)
+        )
+    );
 }
 impl Clone for rte_eth_flex_payload_cfg {
     fn clone(&self) -> Self {
@@ -2059,6 +1807,8 @@ pub struct rte_eth_fdir_flex_mask {
 }
 #[test]
 fn bindgen_test_layout_rte_eth_fdir_flex_mask() {
+    const UNINIT: ::std::mem::MaybeUninit<rte_eth_fdir_flex_mask> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<rte_eth_fdir_flex_mask>(),
         18usize,
@@ -2069,42 +1819,32 @@ fn bindgen_test_layout_rte_eth_fdir_flex_mask() {
         2usize,
         concat!("Alignment of ", stringify!(rte_eth_fdir_flex_mask))
     );
-    fn test_field_flow_type() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_eth_fdir_flex_mask>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).flow_type) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_fdir_flex_mask),
-                "::",
-                stringify!(flow_type)
-            )
-        );
-    }
-    test_field_flow_type();
-    fn test_field_mask() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_eth_fdir_flex_mask>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).mask) as usize - ptr as usize
-            },
-            2usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_fdir_flex_mask),
-                "::",
-                stringify!(mask)
-            )
-        );
-    }
-    test_field_mask();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).flow_type) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_fdir_flex_mask),
+            "::",
+            stringify!(flow_type)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).mask) as usize - ptr as usize
+        },
+        2usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_fdir_flex_mask),
+            "::",
+            stringify!(mask)
+        )
+    );
 }
 impl Clone for rte_eth_fdir_flex_mask {
     fn clone(&self) -> Self {
@@ -2125,6 +1865,8 @@ pub struct rte_eth_fdir_flex_conf {
 }
 #[test]
 fn bindgen_test_layout_rte_eth_fdir_flex_conf() {
+    const UNINIT: ::std::mem::MaybeUninit<rte_eth_fdir_flex_conf> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<rte_eth_fdir_flex_conf>(),
         688usize,
@@ -2135,79 +1877,58 @@ fn bindgen_test_layout_rte_eth_fdir_flex_conf() {
         4usize,
         concat!("Alignment of ", stringify!(rte_eth_fdir_flex_conf))
     );
-    fn test_field_nb_payloads() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_eth_fdir_flex_conf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).nb_payloads) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_fdir_flex_conf),
-                "::",
-                stringify!(nb_payloads)
-            )
-        );
-    }
-    test_field_nb_payloads();
-    fn test_field_nb_flexmasks() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_eth_fdir_flex_conf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).nb_flexmasks) as usize -
-                    ptr as usize
-            },
-            2usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_fdir_flex_conf),
-                "::",
-                stringify!(nb_flexmasks)
-            )
-        );
-    }
-    test_field_nb_flexmasks();
-    fn test_field_flex_set() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_eth_fdir_flex_conf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).flex_set) as usize - ptr as usize
-            },
-            4usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_fdir_flex_conf),
-                "::",
-                stringify!(flex_set)
-            )
-        );
-    }
-    test_field_flex_set();
-    fn test_field_flex_mask() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_eth_fdir_flex_conf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).flex_mask) as usize - ptr as usize
-            },
-            292usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_fdir_flex_conf),
-                "::",
-                stringify!(flex_mask)
-            )
-        );
-    }
-    test_field_flex_mask();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).nb_payloads) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_fdir_flex_conf),
+            "::",
+            stringify!(nb_payloads)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).nb_flexmasks) as usize - ptr as usize
+        },
+        2usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_fdir_flex_conf),
+            "::",
+            stringify!(nb_flexmasks)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).flex_set) as usize - ptr as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_fdir_flex_conf),
+            "::",
+            stringify!(flex_set)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).flex_mask) as usize - ptr as usize
+        },
+        292usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_fdir_flex_conf),
+            "::",
+            stringify!(flex_mask)
+        )
+    );
 }
 impl Clone for rte_eth_fdir_flex_conf {
     fn clone(&self) -> Self {
@@ -2243,6 +1964,8 @@ pub struct rte_fdir_conf {
 }
 #[test]
 fn bindgen_test_layout_rte_fdir_conf() {
+    const UNINIT: ::std::mem::MaybeUninit<rte_fdir_conf> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<rte_fdir_conf>(),
         772usize,
@@ -2253,108 +1976,84 @@ fn bindgen_test_layout_rte_fdir_conf() {
         4usize,
         concat!("Alignment of ", stringify!(rte_fdir_conf))
     );
-    fn test_field_mode() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<rte_fdir_conf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).mode) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_fdir_conf),
-                "::",
-                stringify!(mode)
-            )
-        );
-    }
-    test_field_mode();
-    fn test_field_pballoc() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<rte_fdir_conf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).pballoc) as usize - ptr as usize
-            },
-            4usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_fdir_conf),
-                "::",
-                stringify!(pballoc)
-            )
-        );
-    }
-    test_field_pballoc();
-    fn test_field_status() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<rte_fdir_conf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).status) as usize - ptr as usize
-            },
-            8usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_fdir_conf),
-                "::",
-                stringify!(status)
-            )
-        );
-    }
-    test_field_status();
-    fn test_field_drop_queue() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<rte_fdir_conf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).drop_queue) as usize - ptr as usize
-            },
-            12usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_fdir_conf),
-                "::",
-                stringify!(drop_queue)
-            )
-        );
-    }
-    test_field_drop_queue();
-    fn test_field_mask() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<rte_fdir_conf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).mask) as usize - ptr as usize
-            },
-            16usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_fdir_conf),
-                "::",
-                stringify!(mask)
-            )
-        );
-    }
-    test_field_mask();
-    fn test_field_flex_conf() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<rte_fdir_conf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).flex_conf) as usize - ptr as usize
-            },
-            84usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_fdir_conf),
-                "::",
-                stringify!(flex_conf)
-            )
-        );
-    }
-    test_field_flex_conf();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).mode) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_fdir_conf),
+            "::",
+            stringify!(mode)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).pballoc) as usize - ptr as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_fdir_conf),
+            "::",
+            stringify!(pballoc)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).status) as usize - ptr as usize
+        },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_fdir_conf),
+            "::",
+            stringify!(status)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).drop_queue) as usize - ptr as usize
+        },
+        12usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_fdir_conf),
+            "::",
+            stringify!(drop_queue)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).mask) as usize - ptr as usize
+        },
+        16usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_fdir_conf),
+            "::",
+            stringify!(mask)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).flex_conf) as usize - ptr as usize
+        },
+        84usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_fdir_conf),
+            "::",
+            stringify!(flex_conf)
+        )
+    );
 }
 impl Clone for rte_fdir_conf {
     fn clone(&self) -> Self {
@@ -2381,6 +2080,8 @@ pub struct rte_intr_conf {
 }
 #[test]
 fn bindgen_test_layout_rte_intr_conf() {
+    const UNINIT: ::std::mem::MaybeUninit<rte_intr_conf> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<rte_intr_conf>(),
         4usize,
@@ -2391,40 +2092,32 @@ fn bindgen_test_layout_rte_intr_conf() {
         2usize,
         concat!("Alignment of ", stringify!(rte_intr_conf))
     );
-    fn test_field_lsc() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<rte_intr_conf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).lsc) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_intr_conf),
-                "::",
-                stringify!(lsc)
-            )
-        );
-    }
-    test_field_lsc();
-    fn test_field_rxq() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<rte_intr_conf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).rxq) as usize - ptr as usize
-            },
-            2usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_intr_conf),
-                "::",
-                stringify!(rxq)
-            )
-        );
-    }
-    test_field_rxq();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).lsc) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_intr_conf),
+            "::",
+            stringify!(lsc)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).rxq) as usize - ptr as usize
+        },
+        2usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_intr_conf),
+            "::",
+            stringify!(rxq)
+        )
+    );
 }
 impl Clone for rte_intr_conf {
     fn clone(&self) -> Self {
@@ -2478,6 +2171,8 @@ pub struct rte_eth_conf__bindgen_ty_1 {
 }
 #[test]
 fn bindgen_test_layout_rte_eth_conf__bindgen_ty_1() {
+    const UNINIT: ::std::mem::MaybeUninit<rte_eth_conf__bindgen_ty_1> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<rte_eth_conf__bindgen_ty_1>(),
         2120usize,
@@ -2488,84 +2183,58 @@ fn bindgen_test_layout_rte_eth_conf__bindgen_ty_1() {
         8usize,
         concat!("Alignment of ", stringify!(rte_eth_conf__bindgen_ty_1))
     );
-    fn test_field_rss_conf() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<
-                    rte_eth_conf__bindgen_ty_1,
-                >::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).rss_conf) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_conf__bindgen_ty_1),
-                "::",
-                stringify!(rss_conf)
-            )
-        );
-    }
-    test_field_rss_conf();
-    fn test_field_vmdq_dcb_conf() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<
-                    rte_eth_conf__bindgen_ty_1,
-                >::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).vmdq_dcb_conf) as usize -
-                    ptr as usize
-            },
-            24usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_conf__bindgen_ty_1),
-                "::",
-                stringify!(vmdq_dcb_conf)
-            )
-        );
-    }
-    test_field_vmdq_dcb_conf();
-    fn test_field_dcb_rx_conf() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<
-                    rte_eth_conf__bindgen_ty_1,
-                >::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).dcb_rx_conf) as usize - ptr as usize
-            },
-            1064usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_conf__bindgen_ty_1),
-                "::",
-                stringify!(dcb_rx_conf)
-            )
-        );
-    }
-    test_field_dcb_rx_conf();
-    fn test_field_vmdq_rx_conf() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<
-                    rte_eth_conf__bindgen_ty_1,
-                >::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).vmdq_rx_conf) as usize -
-                    ptr as usize
-            },
-            1080usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_conf__bindgen_ty_1),
-                "::",
-                stringify!(vmdq_rx_conf)
-            )
-        );
-    }
-    test_field_vmdq_rx_conf();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).rss_conf) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_conf__bindgen_ty_1),
+            "::",
+            stringify!(rss_conf)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).vmdq_dcb_conf) as usize - ptr as usize
+        },
+        24usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_conf__bindgen_ty_1),
+            "::",
+            stringify!(vmdq_dcb_conf)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).dcb_rx_conf) as usize - ptr as usize
+        },
+        1064usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_conf__bindgen_ty_1),
+            "::",
+            stringify!(dcb_rx_conf)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).vmdq_rx_conf) as usize - ptr as usize
+        },
+        1080usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_conf__bindgen_ty_1),
+            "::",
+            stringify!(vmdq_rx_conf)
+        )
+    );
 }
 impl Clone for rte_eth_conf__bindgen_ty_1 {
     fn clone(&self) -> Self {
@@ -2591,6 +2260,8 @@ pub struct rte_eth_conf__bindgen_ty_2 {
 }
 #[test]
 fn bindgen_test_layout_rte_eth_conf__bindgen_ty_2() {
+    const UNINIT: ::std::mem::MaybeUninit<rte_eth_conf__bindgen_ty_2> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<rte_eth_conf__bindgen_ty_2>(),
         12usize,
@@ -2601,65 +2272,46 @@ fn bindgen_test_layout_rte_eth_conf__bindgen_ty_2() {
         4usize,
         concat!("Alignment of ", stringify!(rte_eth_conf__bindgen_ty_2))
     );
-    fn test_field_vmdq_dcb_tx_conf() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<
-                    rte_eth_conf__bindgen_ty_2,
-                >::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).vmdq_dcb_tx_conf) as usize -
-                    ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_conf__bindgen_ty_2),
-                "::",
-                stringify!(vmdq_dcb_tx_conf)
-            )
-        );
-    }
-    test_field_vmdq_dcb_tx_conf();
-    fn test_field_dcb_tx_conf() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<
-                    rte_eth_conf__bindgen_ty_2,
-                >::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).dcb_tx_conf) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_conf__bindgen_ty_2),
-                "::",
-                stringify!(dcb_tx_conf)
-            )
-        );
-    }
-    test_field_dcb_tx_conf();
-    fn test_field_vmdq_tx_conf() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<
-                    rte_eth_conf__bindgen_ty_2,
-                >::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).vmdq_tx_conf) as usize -
-                    ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_conf__bindgen_ty_2),
-                "::",
-                stringify!(vmdq_tx_conf)
-            )
-        );
-    }
-    test_field_vmdq_tx_conf();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).vmdq_dcb_tx_conf) as usize -
+                ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_conf__bindgen_ty_2),
+            "::",
+            stringify!(vmdq_dcb_tx_conf)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).dcb_tx_conf) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_conf__bindgen_ty_2),
+            "::",
+            stringify!(dcb_tx_conf)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).vmdq_tx_conf) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_conf__bindgen_ty_2),
+            "::",
+            stringify!(vmdq_tx_conf)
+        )
+    );
 }
 impl Clone for rte_eth_conf__bindgen_ty_2 {
     fn clone(&self) -> Self {
@@ -2668,6 +2320,8 @@ impl Clone for rte_eth_conf__bindgen_ty_2 {
 }
 #[test]
 fn bindgen_test_layout_rte_eth_conf() {
+    const UNINIT: ::std::mem::MaybeUninit<rte_eth_conf> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<rte_eth_conf>(),
         2944usize,
@@ -2678,160 +2332,124 @@ fn bindgen_test_layout_rte_eth_conf() {
         8usize,
         concat!("Alignment of ", stringify!(rte_eth_conf))
     );
-    fn test_field_link_speeds() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<rte_eth_conf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).link_speeds) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_conf),
-                "::",
-                stringify!(link_speeds)
-            )
-        );
-    }
-    test_field_link_speeds();
-    fn test_field_rxmode() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<rte_eth_conf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).rxmode) as usize - ptr as usize
-            },
-            4usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_conf),
-                "::",
-                stringify!(rxmode)
-            )
-        );
-    }
-    test_field_rxmode();
-    fn test_field_txmode() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<rte_eth_conf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).txmode) as usize - ptr as usize
-            },
-            16usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_conf),
-                "::",
-                stringify!(txmode)
-            )
-        );
-    }
-    test_field_txmode();
-    fn test_field_lpbk_mode() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<rte_eth_conf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).lpbk_mode) as usize - ptr as usize
-            },
-            24usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_conf),
-                "::",
-                stringify!(lpbk_mode)
-            )
-        );
-    }
-    test_field_lpbk_mode();
-    fn test_field_rx_adv_conf() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<rte_eth_conf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).rx_adv_conf) as usize - ptr as usize
-            },
-            32usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_conf),
-                "::",
-                stringify!(rx_adv_conf)
-            )
-        );
-    }
-    test_field_rx_adv_conf();
-    fn test_field_tx_adv_conf() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<rte_eth_conf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).tx_adv_conf) as usize - ptr as usize
-            },
-            2152usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_conf),
-                "::",
-                stringify!(tx_adv_conf)
-            )
-        );
-    }
-    test_field_tx_adv_conf();
-    fn test_field_dcb_capability_en() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<rte_eth_conf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).dcb_capability_en) as usize -
-                    ptr as usize
-            },
-            2164usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_conf),
-                "::",
-                stringify!(dcb_capability_en)
-            )
-        );
-    }
-    test_field_dcb_capability_en();
-    fn test_field_fdir_conf() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<rte_eth_conf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).fdir_conf) as usize - ptr as usize
-            },
-            2168usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_conf),
-                "::",
-                stringify!(fdir_conf)
-            )
-        );
-    }
-    test_field_fdir_conf();
-    fn test_field_intr_conf() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<rte_eth_conf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).intr_conf) as usize - ptr as usize
-            },
-            2940usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_conf),
-                "::",
-                stringify!(intr_conf)
-            )
-        );
-    }
-    test_field_intr_conf();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).link_speeds) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_conf),
+            "::",
+            stringify!(link_speeds)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).rxmode) as usize - ptr as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_conf),
+            "::",
+            stringify!(rxmode)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).txmode) as usize - ptr as usize
+        },
+        16usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_conf),
+            "::",
+            stringify!(txmode)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).lpbk_mode) as usize - ptr as usize
+        },
+        24usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_conf),
+            "::",
+            stringify!(lpbk_mode)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).rx_adv_conf) as usize - ptr as usize
+        },
+        32usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_conf),
+            "::",
+            stringify!(rx_adv_conf)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).tx_adv_conf) as usize - ptr as usize
+        },
+        2152usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_conf),
+            "::",
+            stringify!(tx_adv_conf)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).dcb_capability_en) as usize -
+                ptr as usize
+        },
+        2164usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_conf),
+            "::",
+            stringify!(dcb_capability_en)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).fdir_conf) as usize - ptr as usize
+        },
+        2168usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_conf),
+            "::",
+            stringify!(fdir_conf)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).intr_conf) as usize - ptr as usize
+        },
+        2940usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_conf),
+            "::",
+            stringify!(intr_conf)
+        )
+    );
 }
 impl Clone for rte_eth_conf {
     fn clone(&self) -> Self {

--- a/tests/expectations/tests/layout_eth_conf_1_0.rs
+++ b/tests/expectations/tests/layout_eth_conf_1_0.rs
@@ -205,6 +205,7 @@ pub struct rte_eth_rxmode {
 fn bindgen_test_layout_rte_eth_rxmode() {
     const UNINIT: ::std::mem::MaybeUninit<rte_eth_rxmode> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<rte_eth_rxmode>(),
         12usize,
@@ -216,10 +217,7 @@ fn bindgen_test_layout_rte_eth_rxmode() {
         concat!("Alignment of ", stringify!(rte_eth_rxmode))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mq_mode) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).mq_mode) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -230,7 +228,6 @@ fn bindgen_test_layout_rte_eth_rxmode() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).max_rx_pkt_len) as usize - ptr as usize
         },
         4usize,
@@ -243,7 +240,6 @@ fn bindgen_test_layout_rte_eth_rxmode() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).split_hdr_size) as usize - ptr as usize
         },
         8usize,
@@ -477,6 +473,7 @@ pub struct rte_eth_txmode {
 fn bindgen_test_layout_rte_eth_txmode() {
     const UNINIT: ::std::mem::MaybeUninit<rte_eth_txmode> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<rte_eth_txmode>(),
         8usize,
@@ -488,10 +485,7 @@ fn bindgen_test_layout_rte_eth_txmode() {
         concat!("Alignment of ", stringify!(rte_eth_txmode))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mq_mode) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).mq_mode) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -501,10 +495,7 @@ fn bindgen_test_layout_rte_eth_txmode() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).pvid) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).pvid) as usize - ptr as usize },
         4usize,
         concat!(
             "Offset of field: ",
@@ -623,6 +614,7 @@ pub struct rte_eth_rss_conf {
 fn bindgen_test_layout_rte_eth_rss_conf() {
     const UNINIT: ::std::mem::MaybeUninit<rte_eth_rss_conf> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<rte_eth_rss_conf>(),
         24usize,
@@ -634,10 +626,7 @@ fn bindgen_test_layout_rte_eth_rss_conf() {
         concat!("Alignment of ", stringify!(rte_eth_rss_conf))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).rss_key) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).rss_key) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -648,7 +637,6 @@ fn bindgen_test_layout_rte_eth_rss_conf() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).rss_key_len) as usize - ptr as usize
         },
         8usize,
@@ -660,10 +648,7 @@ fn bindgen_test_layout_rte_eth_rss_conf() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).rss_hf) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).rss_hf) as usize - ptr as usize },
         16usize,
         concat!(
             "Offset of field: ",
@@ -747,6 +732,7 @@ pub struct rte_eth_vmdq_dcb_conf__bindgen_ty_1 {
 fn bindgen_test_layout_rte_eth_vmdq_dcb_conf__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<rte_eth_vmdq_dcb_conf__bindgen_ty_1> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<rte_eth_vmdq_dcb_conf__bindgen_ty_1>(),
         16usize,
@@ -761,10 +747,7 @@ fn bindgen_test_layout_rte_eth_vmdq_dcb_conf__bindgen_ty_1() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).vlan_id) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).vlan_id) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -774,10 +757,7 @@ fn bindgen_test_layout_rte_eth_vmdq_dcb_conf__bindgen_ty_1() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).pools) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).pools) as usize - ptr as usize },
         8usize,
         concat!(
             "Offset of field: ",
@@ -796,6 +776,7 @@ impl Clone for rte_eth_vmdq_dcb_conf__bindgen_ty_1 {
 fn bindgen_test_layout_rte_eth_vmdq_dcb_conf() {
     const UNINIT: ::std::mem::MaybeUninit<rte_eth_vmdq_dcb_conf> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<rte_eth_vmdq_dcb_conf>(),
         1040usize,
@@ -808,7 +789,6 @@ fn bindgen_test_layout_rte_eth_vmdq_dcb_conf() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).nb_queue_pools) as usize - ptr as usize
         },
         0usize,
@@ -821,7 +801,6 @@ fn bindgen_test_layout_rte_eth_vmdq_dcb_conf() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).enable_default_pool) as usize -
                 ptr as usize
         },
@@ -835,7 +814,6 @@ fn bindgen_test_layout_rte_eth_vmdq_dcb_conf() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).default_pool) as usize - ptr as usize
         },
         5usize,
@@ -848,7 +826,6 @@ fn bindgen_test_layout_rte_eth_vmdq_dcb_conf() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).nb_pool_maps) as usize - ptr as usize
         },
         6usize,
@@ -861,7 +838,6 @@ fn bindgen_test_layout_rte_eth_vmdq_dcb_conf() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).pool_map) as usize - ptr as usize
         },
         8usize,
@@ -873,10 +849,7 @@ fn bindgen_test_layout_rte_eth_vmdq_dcb_conf() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).dcb_tc) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).dcb_tc) as usize - ptr as usize },
         1032usize,
         concat!(
             "Offset of field: ",
@@ -912,6 +885,7 @@ pub struct rte_eth_dcb_rx_conf {
 fn bindgen_test_layout_rte_eth_dcb_rx_conf() {
     const UNINIT: ::std::mem::MaybeUninit<rte_eth_dcb_rx_conf> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<rte_eth_dcb_rx_conf>(),
         12usize,
@@ -923,10 +897,7 @@ fn bindgen_test_layout_rte_eth_dcb_rx_conf() {
         concat!("Alignment of ", stringify!(rte_eth_dcb_rx_conf))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).nb_tcs) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).nb_tcs) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -936,10 +907,7 @@ fn bindgen_test_layout_rte_eth_dcb_rx_conf() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).dcb_tc) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).dcb_tc) as usize - ptr as usize },
         4usize,
         concat!(
             "Offset of field: ",
@@ -975,6 +943,7 @@ pub struct rte_eth_vmdq_dcb_tx_conf {
 fn bindgen_test_layout_rte_eth_vmdq_dcb_tx_conf() {
     const UNINIT: ::std::mem::MaybeUninit<rte_eth_vmdq_dcb_tx_conf> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<rte_eth_vmdq_dcb_tx_conf>(),
         12usize,
@@ -987,7 +956,6 @@ fn bindgen_test_layout_rte_eth_vmdq_dcb_tx_conf() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).nb_queue_pools) as usize - ptr as usize
         },
         0usize,
@@ -999,10 +967,7 @@ fn bindgen_test_layout_rte_eth_vmdq_dcb_tx_conf() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).dcb_tc) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).dcb_tc) as usize - ptr as usize },
         4usize,
         concat!(
             "Offset of field: ",
@@ -1038,6 +1003,7 @@ pub struct rte_eth_dcb_tx_conf {
 fn bindgen_test_layout_rte_eth_dcb_tx_conf() {
     const UNINIT: ::std::mem::MaybeUninit<rte_eth_dcb_tx_conf> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<rte_eth_dcb_tx_conf>(),
         12usize,
@@ -1049,10 +1015,7 @@ fn bindgen_test_layout_rte_eth_dcb_tx_conf() {
         concat!("Alignment of ", stringify!(rte_eth_dcb_tx_conf))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).nb_tcs) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).nb_tcs) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -1062,10 +1025,7 @@ fn bindgen_test_layout_rte_eth_dcb_tx_conf() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).dcb_tc) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).dcb_tc) as usize - ptr as usize },
         4usize,
         concat!(
             "Offset of field: ",
@@ -1099,6 +1059,7 @@ pub struct rte_eth_vmdq_tx_conf {
 fn bindgen_test_layout_rte_eth_vmdq_tx_conf() {
     const UNINIT: ::std::mem::MaybeUninit<rte_eth_vmdq_tx_conf> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<rte_eth_vmdq_tx_conf>(),
         4usize,
@@ -1111,7 +1072,6 @@ fn bindgen_test_layout_rte_eth_vmdq_tx_conf() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).nb_queue_pools) as usize - ptr as usize
         },
         0usize,
@@ -1167,6 +1127,7 @@ pub struct rte_eth_vmdq_rx_conf__bindgen_ty_1 {
 fn bindgen_test_layout_rte_eth_vmdq_rx_conf__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<rte_eth_vmdq_rx_conf__bindgen_ty_1> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<rte_eth_vmdq_rx_conf__bindgen_ty_1>(),
         16usize,
@@ -1181,10 +1142,7 @@ fn bindgen_test_layout_rte_eth_vmdq_rx_conf__bindgen_ty_1() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).vlan_id) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).vlan_id) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -1194,10 +1152,7 @@ fn bindgen_test_layout_rte_eth_vmdq_rx_conf__bindgen_ty_1() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).pools) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).pools) as usize - ptr as usize },
         8usize,
         concat!(
             "Offset of field: ",
@@ -1216,6 +1171,7 @@ impl Clone for rte_eth_vmdq_rx_conf__bindgen_ty_1 {
 fn bindgen_test_layout_rte_eth_vmdq_rx_conf() {
     const UNINIT: ::std::mem::MaybeUninit<rte_eth_vmdq_rx_conf> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<rte_eth_vmdq_rx_conf>(),
         1040usize,
@@ -1228,7 +1184,6 @@ fn bindgen_test_layout_rte_eth_vmdq_rx_conf() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).nb_queue_pools) as usize - ptr as usize
         },
         0usize,
@@ -1241,7 +1196,6 @@ fn bindgen_test_layout_rte_eth_vmdq_rx_conf() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).enable_default_pool) as usize -
                 ptr as usize
         },
@@ -1255,7 +1209,6 @@ fn bindgen_test_layout_rte_eth_vmdq_rx_conf() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).default_pool) as usize - ptr as usize
         },
         5usize,
@@ -1268,7 +1221,6 @@ fn bindgen_test_layout_rte_eth_vmdq_rx_conf() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).enable_loop_back) as usize -
                 ptr as usize
         },
@@ -1282,7 +1234,6 @@ fn bindgen_test_layout_rte_eth_vmdq_rx_conf() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).nb_pool_maps) as usize - ptr as usize
         },
         7usize,
@@ -1294,10 +1245,7 @@ fn bindgen_test_layout_rte_eth_vmdq_rx_conf() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).rx_mode) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).rx_mode) as usize - ptr as usize },
         8usize,
         concat!(
             "Offset of field: ",
@@ -1308,7 +1256,6 @@ fn bindgen_test_layout_rte_eth_vmdq_rx_conf() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).pool_map) as usize - ptr as usize
         },
         16usize,
@@ -1391,6 +1338,7 @@ pub struct rte_eth_ipv4_flow {
 fn bindgen_test_layout_rte_eth_ipv4_flow() {
     const UNINIT: ::std::mem::MaybeUninit<rte_eth_ipv4_flow> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<rte_eth_ipv4_flow>(),
         12usize,
@@ -1402,10 +1350,7 @@ fn bindgen_test_layout_rte_eth_ipv4_flow() {
         concat!("Alignment of ", stringify!(rte_eth_ipv4_flow))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).src_ip) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).src_ip) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -1415,10 +1360,7 @@ fn bindgen_test_layout_rte_eth_ipv4_flow() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).dst_ip) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).dst_ip) as usize - ptr as usize },
         4usize,
         concat!(
             "Offset of field: ",
@@ -1428,10 +1370,7 @@ fn bindgen_test_layout_rte_eth_ipv4_flow() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).tos) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).tos) as usize - ptr as usize },
         8usize,
         concat!(
             "Offset of field: ",
@@ -1441,10 +1380,7 @@ fn bindgen_test_layout_rte_eth_ipv4_flow() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).ttl) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).ttl) as usize - ptr as usize },
         9usize,
         concat!(
             "Offset of field: ",
@@ -1454,10 +1390,7 @@ fn bindgen_test_layout_rte_eth_ipv4_flow() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).proto) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).proto) as usize - ptr as usize },
         10usize,
         concat!(
             "Offset of field: ",
@@ -1491,6 +1424,7 @@ pub struct rte_eth_ipv6_flow {
 fn bindgen_test_layout_rte_eth_ipv6_flow() {
     const UNINIT: ::std::mem::MaybeUninit<rte_eth_ipv6_flow> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<rte_eth_ipv6_flow>(),
         36usize,
@@ -1502,10 +1436,7 @@ fn bindgen_test_layout_rte_eth_ipv6_flow() {
         concat!("Alignment of ", stringify!(rte_eth_ipv6_flow))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).src_ip) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).src_ip) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -1515,10 +1446,7 @@ fn bindgen_test_layout_rte_eth_ipv6_flow() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).dst_ip) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).dst_ip) as usize - ptr as usize },
         16usize,
         concat!(
             "Offset of field: ",
@@ -1528,10 +1456,7 @@ fn bindgen_test_layout_rte_eth_ipv6_flow() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).tc) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).tc) as usize - ptr as usize },
         32usize,
         concat!(
             "Offset of field: ",
@@ -1541,10 +1466,7 @@ fn bindgen_test_layout_rte_eth_ipv6_flow() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).proto) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).proto) as usize - ptr as usize },
         33usize,
         concat!(
             "Offset of field: ",
@@ -1555,7 +1477,6 @@ fn bindgen_test_layout_rte_eth_ipv6_flow() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).hop_limits) as usize - ptr as usize
         },
         34usize,
@@ -1600,6 +1521,7 @@ pub struct rte_eth_fdir_masks {
 fn bindgen_test_layout_rte_eth_fdir_masks() {
     const UNINIT: ::std::mem::MaybeUninit<rte_eth_fdir_masks> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<rte_eth_fdir_masks>(),
         68usize,
@@ -1612,7 +1534,6 @@ fn bindgen_test_layout_rte_eth_fdir_masks() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).vlan_tci_mask) as usize - ptr as usize
         },
         0usize,
@@ -1625,7 +1546,6 @@ fn bindgen_test_layout_rte_eth_fdir_masks() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).ipv4_mask) as usize - ptr as usize
         },
         4usize,
@@ -1638,7 +1558,6 @@ fn bindgen_test_layout_rte_eth_fdir_masks() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).ipv6_mask) as usize - ptr as usize
         },
         16usize,
@@ -1651,7 +1570,6 @@ fn bindgen_test_layout_rte_eth_fdir_masks() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).src_port_mask) as usize - ptr as usize
         },
         52usize,
@@ -1664,7 +1582,6 @@ fn bindgen_test_layout_rte_eth_fdir_masks() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).dst_port_mask) as usize - ptr as usize
         },
         54usize,
@@ -1677,7 +1594,6 @@ fn bindgen_test_layout_rte_eth_fdir_masks() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).mac_addr_byte_mask) as usize -
                 ptr as usize
         },
@@ -1691,7 +1607,6 @@ fn bindgen_test_layout_rte_eth_fdir_masks() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).tunnel_id_mask) as usize - ptr as usize
         },
         60usize,
@@ -1704,7 +1619,6 @@ fn bindgen_test_layout_rte_eth_fdir_masks() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).tunnel_type_mask) as usize -
                 ptr as usize
         },
@@ -1746,6 +1660,7 @@ pub struct rte_eth_flex_payload_cfg {
 fn bindgen_test_layout_rte_eth_flex_payload_cfg() {
     const UNINIT: ::std::mem::MaybeUninit<rte_eth_flex_payload_cfg> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<rte_eth_flex_payload_cfg>(),
         36usize,
@@ -1757,10 +1672,7 @@ fn bindgen_test_layout_rte_eth_flex_payload_cfg() {
         concat!("Alignment of ", stringify!(rte_eth_flex_payload_cfg))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).type_) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).type_) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -1771,7 +1683,6 @@ fn bindgen_test_layout_rte_eth_flex_payload_cfg() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).src_offset) as usize - ptr as usize
         },
         4usize,
@@ -1809,6 +1720,7 @@ pub struct rte_eth_fdir_flex_mask {
 fn bindgen_test_layout_rte_eth_fdir_flex_mask() {
     const UNINIT: ::std::mem::MaybeUninit<rte_eth_fdir_flex_mask> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<rte_eth_fdir_flex_mask>(),
         18usize,
@@ -1821,7 +1733,6 @@ fn bindgen_test_layout_rte_eth_fdir_flex_mask() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).flow_type) as usize - ptr as usize
         },
         0usize,
@@ -1833,10 +1744,7 @@ fn bindgen_test_layout_rte_eth_fdir_flex_mask() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mask) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).mask) as usize - ptr as usize },
         2usize,
         concat!(
             "Offset of field: ",
@@ -1867,6 +1775,7 @@ pub struct rte_eth_fdir_flex_conf {
 fn bindgen_test_layout_rte_eth_fdir_flex_conf() {
     const UNINIT: ::std::mem::MaybeUninit<rte_eth_fdir_flex_conf> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<rte_eth_fdir_flex_conf>(),
         688usize,
@@ -1879,7 +1788,6 @@ fn bindgen_test_layout_rte_eth_fdir_flex_conf() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).nb_payloads) as usize - ptr as usize
         },
         0usize,
@@ -1892,7 +1800,6 @@ fn bindgen_test_layout_rte_eth_fdir_flex_conf() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).nb_flexmasks) as usize - ptr as usize
         },
         2usize,
@@ -1905,7 +1812,6 @@ fn bindgen_test_layout_rte_eth_fdir_flex_conf() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).flex_set) as usize - ptr as usize
         },
         4usize,
@@ -1918,7 +1824,6 @@ fn bindgen_test_layout_rte_eth_fdir_flex_conf() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).flex_mask) as usize - ptr as usize
         },
         292usize,
@@ -1966,6 +1871,7 @@ pub struct rte_fdir_conf {
 fn bindgen_test_layout_rte_fdir_conf() {
     const UNINIT: ::std::mem::MaybeUninit<rte_fdir_conf> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<rte_fdir_conf>(),
         772usize,
@@ -1977,10 +1883,7 @@ fn bindgen_test_layout_rte_fdir_conf() {
         concat!("Alignment of ", stringify!(rte_fdir_conf))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mode) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).mode) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -1990,10 +1893,7 @@ fn bindgen_test_layout_rte_fdir_conf() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).pballoc) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).pballoc) as usize - ptr as usize },
         4usize,
         concat!(
             "Offset of field: ",
@@ -2003,10 +1903,7 @@ fn bindgen_test_layout_rte_fdir_conf() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).status) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).status) as usize - ptr as usize },
         8usize,
         concat!(
             "Offset of field: ",
@@ -2017,7 +1914,6 @@ fn bindgen_test_layout_rte_fdir_conf() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).drop_queue) as usize - ptr as usize
         },
         12usize,
@@ -2029,10 +1925,7 @@ fn bindgen_test_layout_rte_fdir_conf() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mask) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).mask) as usize - ptr as usize },
         16usize,
         concat!(
             "Offset of field: ",
@@ -2043,7 +1936,6 @@ fn bindgen_test_layout_rte_fdir_conf() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).flex_conf) as usize - ptr as usize
         },
         84usize,
@@ -2082,6 +1974,7 @@ pub struct rte_intr_conf {
 fn bindgen_test_layout_rte_intr_conf() {
     const UNINIT: ::std::mem::MaybeUninit<rte_intr_conf> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<rte_intr_conf>(),
         4usize,
@@ -2093,10 +1986,7 @@ fn bindgen_test_layout_rte_intr_conf() {
         concat!("Alignment of ", stringify!(rte_intr_conf))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).lsc) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).lsc) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -2106,10 +1996,7 @@ fn bindgen_test_layout_rte_intr_conf() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).rxq) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).rxq) as usize - ptr as usize },
         2usize,
         concat!(
             "Offset of field: ",
@@ -2173,6 +2060,7 @@ pub struct rte_eth_conf__bindgen_ty_1 {
 fn bindgen_test_layout_rte_eth_conf__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<rte_eth_conf__bindgen_ty_1> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<rte_eth_conf__bindgen_ty_1>(),
         2120usize,
@@ -2185,7 +2073,6 @@ fn bindgen_test_layout_rte_eth_conf__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).rss_conf) as usize - ptr as usize
         },
         0usize,
@@ -2198,7 +2085,6 @@ fn bindgen_test_layout_rte_eth_conf__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).vmdq_dcb_conf) as usize - ptr as usize
         },
         24usize,
@@ -2211,7 +2097,6 @@ fn bindgen_test_layout_rte_eth_conf__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).dcb_rx_conf) as usize - ptr as usize
         },
         1064usize,
@@ -2224,7 +2109,6 @@ fn bindgen_test_layout_rte_eth_conf__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).vmdq_rx_conf) as usize - ptr as usize
         },
         1080usize,
@@ -2262,6 +2146,7 @@ pub struct rte_eth_conf__bindgen_ty_2 {
 fn bindgen_test_layout_rte_eth_conf__bindgen_ty_2() {
     const UNINIT: ::std::mem::MaybeUninit<rte_eth_conf__bindgen_ty_2> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<rte_eth_conf__bindgen_ty_2>(),
         12usize,
@@ -2274,7 +2159,6 @@ fn bindgen_test_layout_rte_eth_conf__bindgen_ty_2() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).vmdq_dcb_tx_conf) as usize -
                 ptr as usize
         },
@@ -2288,7 +2172,6 @@ fn bindgen_test_layout_rte_eth_conf__bindgen_ty_2() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).dcb_tx_conf) as usize - ptr as usize
         },
         0usize,
@@ -2301,7 +2184,6 @@ fn bindgen_test_layout_rte_eth_conf__bindgen_ty_2() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).vmdq_tx_conf) as usize - ptr as usize
         },
         0usize,
@@ -2322,6 +2204,7 @@ impl Clone for rte_eth_conf__bindgen_ty_2 {
 fn bindgen_test_layout_rte_eth_conf() {
     const UNINIT: ::std::mem::MaybeUninit<rte_eth_conf> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<rte_eth_conf>(),
         2944usize,
@@ -2334,7 +2217,6 @@ fn bindgen_test_layout_rte_eth_conf() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).link_speeds) as usize - ptr as usize
         },
         0usize,
@@ -2346,10 +2228,7 @@ fn bindgen_test_layout_rte_eth_conf() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).rxmode) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).rxmode) as usize - ptr as usize },
         4usize,
         concat!(
             "Offset of field: ",
@@ -2359,10 +2238,7 @@ fn bindgen_test_layout_rte_eth_conf() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).txmode) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).txmode) as usize - ptr as usize },
         16usize,
         concat!(
             "Offset of field: ",
@@ -2373,7 +2249,6 @@ fn bindgen_test_layout_rte_eth_conf() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).lpbk_mode) as usize - ptr as usize
         },
         24usize,
@@ -2386,7 +2261,6 @@ fn bindgen_test_layout_rte_eth_conf() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).rx_adv_conf) as usize - ptr as usize
         },
         32usize,
@@ -2399,7 +2273,6 @@ fn bindgen_test_layout_rte_eth_conf() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).tx_adv_conf) as usize - ptr as usize
         },
         2152usize,
@@ -2412,7 +2285,6 @@ fn bindgen_test_layout_rte_eth_conf() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).dcb_capability_en) as usize -
                 ptr as usize
         },
@@ -2426,7 +2298,6 @@ fn bindgen_test_layout_rte_eth_conf() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).fdir_conf) as usize - ptr as usize
         },
         2168usize,
@@ -2439,7 +2310,6 @@ fn bindgen_test_layout_rte_eth_conf() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).intr_conf) as usize - ptr as usize
         },
         2940usize,

--- a/tests/expectations/tests/layout_kni_mbuf.rs
+++ b/tests/expectations/tests/layout_kni_mbuf.rs
@@ -36,6 +36,7 @@ pub struct rte_kni_mbuf {
 fn bindgen_test_layout_rte_kni_mbuf() {
     const UNINIT: ::std::mem::MaybeUninit<rte_kni_mbuf> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<rte_kni_mbuf>(),
         128usize,
@@ -48,7 +49,6 @@ fn bindgen_test_layout_rte_kni_mbuf() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).buf_addr) as usize - ptr as usize
         },
         0usize,
@@ -61,7 +61,6 @@ fn bindgen_test_layout_rte_kni_mbuf() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).buf_physaddr) as usize - ptr as usize
         },
         8usize,
@@ -73,10 +72,7 @@ fn bindgen_test_layout_rte_kni_mbuf() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).pad0) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).pad0) as usize - ptr as usize },
         16usize,
         concat!(
             "Offset of field: ",
@@ -87,7 +83,6 @@ fn bindgen_test_layout_rte_kni_mbuf() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).data_off) as usize - ptr as usize
         },
         18usize,
@@ -99,10 +94,7 @@ fn bindgen_test_layout_rte_kni_mbuf() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).pad1) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).pad1) as usize - ptr as usize },
         20usize,
         concat!(
             "Offset of field: ",
@@ -112,10 +104,7 @@ fn bindgen_test_layout_rte_kni_mbuf() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).nb_segs) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).nb_segs) as usize - ptr as usize },
         22usize,
         concat!(
             "Offset of field: ",
@@ -125,10 +114,7 @@ fn bindgen_test_layout_rte_kni_mbuf() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).pad4) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).pad4) as usize - ptr as usize },
         23usize,
         concat!(
             "Offset of field: ",
@@ -139,7 +125,6 @@ fn bindgen_test_layout_rte_kni_mbuf() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).ol_flags) as usize - ptr as usize
         },
         24usize,
@@ -151,10 +136,7 @@ fn bindgen_test_layout_rte_kni_mbuf() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).pad2) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).pad2) as usize - ptr as usize },
         32usize,
         concat!(
             "Offset of field: ",
@@ -164,10 +146,7 @@ fn bindgen_test_layout_rte_kni_mbuf() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).pkt_len) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).pkt_len) as usize - ptr as usize },
         36usize,
         concat!(
             "Offset of field: ",
@@ -178,7 +157,6 @@ fn bindgen_test_layout_rte_kni_mbuf() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).data_len) as usize - ptr as usize
         },
         40usize,
@@ -190,10 +168,7 @@ fn bindgen_test_layout_rte_kni_mbuf() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).pad3) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).pad3) as usize - ptr as usize },
         64usize,
         concat!(
             "Offset of field: ",
@@ -203,10 +178,7 @@ fn bindgen_test_layout_rte_kni_mbuf() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).pool) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).pool) as usize - ptr as usize },
         72usize,
         concat!(
             "Offset of field: ",
@@ -216,10 +188,7 @@ fn bindgen_test_layout_rte_kni_mbuf() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).next) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).next) as usize - ptr as usize },
         80usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/layout_kni_mbuf.rs
+++ b/tests/expectations/tests/layout_kni_mbuf.rs
@@ -34,6 +34,8 @@ pub struct rte_kni_mbuf {
 }
 #[test]
 fn bindgen_test_layout_rte_kni_mbuf() {
+    const UNINIT: ::std::mem::MaybeUninit<rte_kni_mbuf> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<rte_kni_mbuf>(),
         128usize,
@@ -44,245 +46,188 @@ fn bindgen_test_layout_rte_kni_mbuf() {
         64usize,
         concat!("Alignment of ", stringify!(rte_kni_mbuf))
     );
-    fn test_field_buf_addr() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<rte_kni_mbuf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).buf_addr) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_kni_mbuf),
-                "::",
-                stringify!(buf_addr)
-            )
-        );
-    }
-    test_field_buf_addr();
-    fn test_field_buf_physaddr() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<rte_kni_mbuf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).buf_physaddr) as usize -
-                    ptr as usize
-            },
-            8usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_kni_mbuf),
-                "::",
-                stringify!(buf_physaddr)
-            )
-        );
-    }
-    test_field_buf_physaddr();
-    fn test_field_pad0() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<rte_kni_mbuf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).pad0) as usize - ptr as usize
-            },
-            16usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_kni_mbuf),
-                "::",
-                stringify!(pad0)
-            )
-        );
-    }
-    test_field_pad0();
-    fn test_field_data_off() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<rte_kni_mbuf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).data_off) as usize - ptr as usize
-            },
-            18usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_kni_mbuf),
-                "::",
-                stringify!(data_off)
-            )
-        );
-    }
-    test_field_data_off();
-    fn test_field_pad1() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<rte_kni_mbuf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).pad1) as usize - ptr as usize
-            },
-            20usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_kni_mbuf),
-                "::",
-                stringify!(pad1)
-            )
-        );
-    }
-    test_field_pad1();
-    fn test_field_nb_segs() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<rte_kni_mbuf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).nb_segs) as usize - ptr as usize
-            },
-            22usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_kni_mbuf),
-                "::",
-                stringify!(nb_segs)
-            )
-        );
-    }
-    test_field_nb_segs();
-    fn test_field_pad4() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<rte_kni_mbuf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).pad4) as usize - ptr as usize
-            },
-            23usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_kni_mbuf),
-                "::",
-                stringify!(pad4)
-            )
-        );
-    }
-    test_field_pad4();
-    fn test_field_ol_flags() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<rte_kni_mbuf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).ol_flags) as usize - ptr as usize
-            },
-            24usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_kni_mbuf),
-                "::",
-                stringify!(ol_flags)
-            )
-        );
-    }
-    test_field_ol_flags();
-    fn test_field_pad2() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<rte_kni_mbuf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).pad2) as usize - ptr as usize
-            },
-            32usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_kni_mbuf),
-                "::",
-                stringify!(pad2)
-            )
-        );
-    }
-    test_field_pad2();
-    fn test_field_pkt_len() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<rte_kni_mbuf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).pkt_len) as usize - ptr as usize
-            },
-            36usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_kni_mbuf),
-                "::",
-                stringify!(pkt_len)
-            )
-        );
-    }
-    test_field_pkt_len();
-    fn test_field_data_len() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<rte_kni_mbuf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).data_len) as usize - ptr as usize
-            },
-            40usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_kni_mbuf),
-                "::",
-                stringify!(data_len)
-            )
-        );
-    }
-    test_field_data_len();
-    fn test_field_pad3() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<rte_kni_mbuf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).pad3) as usize - ptr as usize
-            },
-            64usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_kni_mbuf),
-                "::",
-                stringify!(pad3)
-            )
-        );
-    }
-    test_field_pad3();
-    fn test_field_pool() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<rte_kni_mbuf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).pool) as usize - ptr as usize
-            },
-            72usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_kni_mbuf),
-                "::",
-                stringify!(pool)
-            )
-        );
-    }
-    test_field_pool();
-    fn test_field_next() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<rte_kni_mbuf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).next) as usize - ptr as usize
-            },
-            80usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_kni_mbuf),
-                "::",
-                stringify!(next)
-            )
-        );
-    }
-    test_field_next();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).buf_addr) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_kni_mbuf),
+            "::",
+            stringify!(buf_addr)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).buf_physaddr) as usize - ptr as usize
+        },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_kni_mbuf),
+            "::",
+            stringify!(buf_physaddr)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).pad0) as usize - ptr as usize
+        },
+        16usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_kni_mbuf),
+            "::",
+            stringify!(pad0)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).data_off) as usize - ptr as usize
+        },
+        18usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_kni_mbuf),
+            "::",
+            stringify!(data_off)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).pad1) as usize - ptr as usize
+        },
+        20usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_kni_mbuf),
+            "::",
+            stringify!(pad1)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).nb_segs) as usize - ptr as usize
+        },
+        22usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_kni_mbuf),
+            "::",
+            stringify!(nb_segs)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).pad4) as usize - ptr as usize
+        },
+        23usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_kni_mbuf),
+            "::",
+            stringify!(pad4)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).ol_flags) as usize - ptr as usize
+        },
+        24usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_kni_mbuf),
+            "::",
+            stringify!(ol_flags)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).pad2) as usize - ptr as usize
+        },
+        32usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_kni_mbuf),
+            "::",
+            stringify!(pad2)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).pkt_len) as usize - ptr as usize
+        },
+        36usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_kni_mbuf),
+            "::",
+            stringify!(pkt_len)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).data_len) as usize - ptr as usize
+        },
+        40usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_kni_mbuf),
+            "::",
+            stringify!(data_len)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).pad3) as usize - ptr as usize
+        },
+        64usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_kni_mbuf),
+            "::",
+            stringify!(pad3)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).pool) as usize - ptr as usize
+        },
+        72usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_kni_mbuf),
+            "::",
+            stringify!(pool)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).next) as usize - ptr as usize
+        },
+        80usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_kni_mbuf),
+            "::",
+            stringify!(next)
+        )
+    );
 }
 impl Default for rte_kni_mbuf {
     fn default() -> Self {

--- a/tests/expectations/tests/layout_large_align_field.rs
+++ b/tests/expectations/tests/layout_large_align_field.rs
@@ -65,6 +65,8 @@ pub struct ip_frag {
 }
 #[test]
 fn bindgen_test_layout_ip_frag() {
+    const UNINIT: ::std::mem::MaybeUninit<ip_frag> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<ip_frag>(),
         16usize,
@@ -75,57 +77,45 @@ fn bindgen_test_layout_ip_frag() {
         8usize,
         concat!("Alignment of ", stringify!(ip_frag))
     );
-    fn test_field_ofs() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<ip_frag>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).ofs) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(ip_frag),
-                "::",
-                stringify!(ofs)
-            )
-        );
-    }
-    test_field_ofs();
-    fn test_field_len() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<ip_frag>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).len) as usize - ptr as usize
-            },
-            2usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(ip_frag),
-                "::",
-                stringify!(len)
-            )
-        );
-    }
-    test_field_len();
-    fn test_field_mb() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<ip_frag>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).mb) as usize - ptr as usize
-            },
-            8usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(ip_frag),
-                "::",
-                stringify!(mb)
-            )
-        );
-    }
-    test_field_mb();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).ofs) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ip_frag),
+            "::",
+            stringify!(ofs)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).len) as usize - ptr as usize
+        },
+        2usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ip_frag),
+            "::",
+            stringify!(len)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).mb) as usize - ptr as usize
+        },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ip_frag),
+            "::",
+            stringify!(mb)
+        )
+    );
 }
 impl Default for ip_frag {
     fn default() -> Self {
@@ -149,6 +139,8 @@ pub struct ip_frag_key {
 }
 #[test]
 fn bindgen_test_layout_ip_frag_key() {
+    const UNINIT: ::std::mem::MaybeUninit<ip_frag_key> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<ip_frag_key>(),
         40usize,
@@ -159,57 +151,45 @@ fn bindgen_test_layout_ip_frag_key() {
         8usize,
         concat!("Alignment of ", stringify!(ip_frag_key))
     );
-    fn test_field_src_dst() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<ip_frag_key>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).src_dst) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(ip_frag_key),
-                "::",
-                stringify!(src_dst)
-            )
-        );
-    }
-    test_field_src_dst();
-    fn test_field_id() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<ip_frag_key>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).id) as usize - ptr as usize
-            },
-            32usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(ip_frag_key),
-                "::",
-                stringify!(id)
-            )
-        );
-    }
-    test_field_id();
-    fn test_field_key_len() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<ip_frag_key>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).key_len) as usize - ptr as usize
-            },
-            36usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(ip_frag_key),
-                "::",
-                stringify!(key_len)
-            )
-        );
-    }
-    test_field_key_len();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).src_dst) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ip_frag_key),
+            "::",
+            stringify!(src_dst)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).id) as usize - ptr as usize
+        },
+        32usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ip_frag_key),
+            "::",
+            stringify!(id)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).key_len) as usize - ptr as usize
+        },
+        36usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ip_frag_key),
+            "::",
+            stringify!(key_len)
+        )
+    );
 }
 /// @internal Fragmented packet to reassemble.
 /// First two entries in the frags[] array are for the last and first fragments.
@@ -240,6 +220,8 @@ pub struct ip_frag_pkt__bindgen_ty_1 {
 }
 #[test]
 fn bindgen_test_layout_ip_frag_pkt__bindgen_ty_1() {
+    const UNINIT: ::std::mem::MaybeUninit<ip_frag_pkt__bindgen_ty_1> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<ip_frag_pkt__bindgen_ty_1>(),
         16usize,
@@ -250,40 +232,32 @@ fn bindgen_test_layout_ip_frag_pkt__bindgen_ty_1() {
         8usize,
         concat!("Alignment of ", stringify!(ip_frag_pkt__bindgen_ty_1))
     );
-    fn test_field_tqe_next() {
-        assert_eq!(
-            unsafe {
-                let uninit = :: std :: mem :: MaybeUninit :: < ip_frag_pkt__bindgen_ty_1 > :: uninit () ;
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).tqe_next) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(ip_frag_pkt__bindgen_ty_1),
-                "::",
-                stringify!(tqe_next)
-            )
-        );
-    }
-    test_field_tqe_next();
-    fn test_field_tqe_prev() {
-        assert_eq!(
-            unsafe {
-                let uninit = :: std :: mem :: MaybeUninit :: < ip_frag_pkt__bindgen_ty_1 > :: uninit () ;
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).tqe_prev) as usize - ptr as usize
-            },
-            8usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(ip_frag_pkt__bindgen_ty_1),
-                "::",
-                stringify!(tqe_prev)
-            )
-        );
-    }
-    test_field_tqe_prev();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).tqe_next) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ip_frag_pkt__bindgen_ty_1),
+            "::",
+            stringify!(tqe_next)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).tqe_prev) as usize - ptr as usize
+        },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ip_frag_pkt__bindgen_ty_1),
+            "::",
+            stringify!(tqe_prev)
+        )
+    );
 }
 impl Default for ip_frag_pkt__bindgen_ty_1 {
     fn default() -> Self {
@@ -296,6 +270,8 @@ impl Default for ip_frag_pkt__bindgen_ty_1 {
 }
 #[test]
 fn bindgen_test_layout_ip_frag_pkt() {
+    const UNINIT: ::std::mem::MaybeUninit<ip_frag_pkt> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<ip_frag_pkt>(),
         192usize,
@@ -306,125 +282,97 @@ fn bindgen_test_layout_ip_frag_pkt() {
         64usize,
         concat!("Alignment of ", stringify!(ip_frag_pkt))
     );
-    fn test_field_lru() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<ip_frag_pkt>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).lru) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(ip_frag_pkt),
-                "::",
-                stringify!(lru)
-            )
-        );
-    }
-    test_field_lru();
-    fn test_field_key() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<ip_frag_pkt>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).key) as usize - ptr as usize
-            },
-            16usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(ip_frag_pkt),
-                "::",
-                stringify!(key)
-            )
-        );
-    }
-    test_field_key();
-    fn test_field_start() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<ip_frag_pkt>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).start) as usize - ptr as usize
-            },
-            56usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(ip_frag_pkt),
-                "::",
-                stringify!(start)
-            )
-        );
-    }
-    test_field_start();
-    fn test_field_total_size() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<ip_frag_pkt>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).total_size) as usize - ptr as usize
-            },
-            64usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(ip_frag_pkt),
-                "::",
-                stringify!(total_size)
-            )
-        );
-    }
-    test_field_total_size();
-    fn test_field_frag_size() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<ip_frag_pkt>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).frag_size) as usize - ptr as usize
-            },
-            68usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(ip_frag_pkt),
-                "::",
-                stringify!(frag_size)
-            )
-        );
-    }
-    test_field_frag_size();
-    fn test_field_last_idx() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<ip_frag_pkt>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).last_idx) as usize - ptr as usize
-            },
-            72usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(ip_frag_pkt),
-                "::",
-                stringify!(last_idx)
-            )
-        );
-    }
-    test_field_last_idx();
-    fn test_field_frags() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<ip_frag_pkt>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).frags) as usize - ptr as usize
-            },
-            80usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(ip_frag_pkt),
-                "::",
-                stringify!(frags)
-            )
-        );
-    }
-    test_field_frags();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).lru) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ip_frag_pkt),
+            "::",
+            stringify!(lru)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).key) as usize - ptr as usize
+        },
+        16usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ip_frag_pkt),
+            "::",
+            stringify!(key)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).start) as usize - ptr as usize
+        },
+        56usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ip_frag_pkt),
+            "::",
+            stringify!(start)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).total_size) as usize - ptr as usize
+        },
+        64usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ip_frag_pkt),
+            "::",
+            stringify!(total_size)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).frag_size) as usize - ptr as usize
+        },
+        68usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ip_frag_pkt),
+            "::",
+            stringify!(frag_size)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).last_idx) as usize - ptr as usize
+        },
+        72usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ip_frag_pkt),
+            "::",
+            stringify!(last_idx)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).frags) as usize - ptr as usize
+        },
+        80usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ip_frag_pkt),
+            "::",
+            stringify!(frags)
+        )
+    );
 }
 impl Default for ip_frag_pkt {
     fn default() -> Self {
@@ -443,6 +391,8 @@ pub struct ip_pkt_list {
 }
 #[test]
 fn bindgen_test_layout_ip_pkt_list() {
+    const UNINIT: ::std::mem::MaybeUninit<ip_pkt_list> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<ip_pkt_list>(),
         16usize,
@@ -453,40 +403,32 @@ fn bindgen_test_layout_ip_pkt_list() {
         8usize,
         concat!("Alignment of ", stringify!(ip_pkt_list))
     );
-    fn test_field_tqh_first() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<ip_pkt_list>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).tqh_first) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(ip_pkt_list),
-                "::",
-                stringify!(tqh_first)
-            )
-        );
-    }
-    test_field_tqh_first();
-    fn test_field_tqh_last() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<ip_pkt_list>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).tqh_last) as usize - ptr as usize
-            },
-            8usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(ip_pkt_list),
-                "::",
-                stringify!(tqh_last)
-            )
-        );
-    }
-    test_field_tqh_last();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).tqh_first) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ip_pkt_list),
+            "::",
+            stringify!(tqh_first)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).tqh_last) as usize - ptr as usize
+        },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ip_pkt_list),
+            "::",
+            stringify!(tqh_last)
+        )
+    );
 }
 impl Default for ip_pkt_list {
     fn default() -> Self {
@@ -517,6 +459,8 @@ pub struct ip_frag_tbl_stat {
 }
 #[test]
 fn bindgen_test_layout_ip_frag_tbl_stat() {
+    const UNINIT: ::std::mem::MaybeUninit<ip_frag_tbl_stat> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<ip_frag_tbl_stat>(),
         64usize,
@@ -527,115 +471,84 @@ fn bindgen_test_layout_ip_frag_tbl_stat() {
         64usize,
         concat!("Alignment of ", stringify!(ip_frag_tbl_stat))
     );
-    fn test_field_find_num() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<ip_frag_tbl_stat>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).find_num) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(ip_frag_tbl_stat),
-                "::",
-                stringify!(find_num)
-            )
-        );
-    }
-    test_field_find_num();
-    fn test_field_add_num() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<ip_frag_tbl_stat>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).add_num) as usize - ptr as usize
-            },
-            8usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(ip_frag_tbl_stat),
-                "::",
-                stringify!(add_num)
-            )
-        );
-    }
-    test_field_add_num();
-    fn test_field_del_num() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<ip_frag_tbl_stat>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).del_num) as usize - ptr as usize
-            },
-            16usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(ip_frag_tbl_stat),
-                "::",
-                stringify!(del_num)
-            )
-        );
-    }
-    test_field_del_num();
-    fn test_field_reuse_num() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<ip_frag_tbl_stat>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).reuse_num) as usize - ptr as usize
-            },
-            24usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(ip_frag_tbl_stat),
-                "::",
-                stringify!(reuse_num)
-            )
-        );
-    }
-    test_field_reuse_num();
-    fn test_field_fail_total() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<ip_frag_tbl_stat>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).fail_total) as usize - ptr as usize
-            },
-            32usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(ip_frag_tbl_stat),
-                "::",
-                stringify!(fail_total)
-            )
-        );
-    }
-    test_field_fail_total();
-    fn test_field_fail_nospace() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<ip_frag_tbl_stat>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).fail_nospace) as usize -
-                    ptr as usize
-            },
-            40usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(ip_frag_tbl_stat),
-                "::",
-                stringify!(fail_nospace)
-            )
-        );
-    }
-    test_field_fail_nospace();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).find_num) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ip_frag_tbl_stat),
+            "::",
+            stringify!(find_num)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).add_num) as usize - ptr as usize
+        },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ip_frag_tbl_stat),
+            "::",
+            stringify!(add_num)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).del_num) as usize - ptr as usize
+        },
+        16usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ip_frag_tbl_stat),
+            "::",
+            stringify!(del_num)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).reuse_num) as usize - ptr as usize
+        },
+        24usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ip_frag_tbl_stat),
+            "::",
+            stringify!(reuse_num)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).fail_total) as usize - ptr as usize
+        },
+        32usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ip_frag_tbl_stat),
+            "::",
+            stringify!(fail_total)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).fail_nospace) as usize - ptr as usize
+        },
+        40usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ip_frag_tbl_stat),
+            "::",
+            stringify!(fail_nospace)
+        )
+    );
 }
 impl Default for ip_frag_tbl_stat {
     fn default() -> Self {
@@ -676,6 +589,8 @@ pub struct rte_ip_frag_tbl {
 }
 #[test]
 fn bindgen_test_layout_rte_ip_frag_tbl() {
+    const UNINIT: ::std::mem::MaybeUninit<rte_ip_frag_tbl> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<rte_ip_frag_tbl>(),
         128usize,
@@ -686,205 +601,149 @@ fn bindgen_test_layout_rte_ip_frag_tbl() {
         64usize,
         concat!("Alignment of ", stringify!(rte_ip_frag_tbl))
     );
-    fn test_field_max_cycles() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_ip_frag_tbl>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).max_cycles) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_ip_frag_tbl),
-                "::",
-                stringify!(max_cycles)
-            )
-        );
-    }
-    test_field_max_cycles();
-    fn test_field_entry_mask() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_ip_frag_tbl>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).entry_mask) as usize - ptr as usize
-            },
-            8usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_ip_frag_tbl),
-                "::",
-                stringify!(entry_mask)
-            )
-        );
-    }
-    test_field_entry_mask();
-    fn test_field_max_entries() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_ip_frag_tbl>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).max_entries) as usize - ptr as usize
-            },
-            12usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_ip_frag_tbl),
-                "::",
-                stringify!(max_entries)
-            )
-        );
-    }
-    test_field_max_entries();
-    fn test_field_use_entries() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_ip_frag_tbl>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).use_entries) as usize - ptr as usize
-            },
-            16usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_ip_frag_tbl),
-                "::",
-                stringify!(use_entries)
-            )
-        );
-    }
-    test_field_use_entries();
-    fn test_field_bucket_entries() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_ip_frag_tbl>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).bucket_entries) as usize -
-                    ptr as usize
-            },
-            20usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_ip_frag_tbl),
-                "::",
-                stringify!(bucket_entries)
-            )
-        );
-    }
-    test_field_bucket_entries();
-    fn test_field_nb_entries() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_ip_frag_tbl>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).nb_entries) as usize - ptr as usize
-            },
-            24usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_ip_frag_tbl),
-                "::",
-                stringify!(nb_entries)
-            )
-        );
-    }
-    test_field_nb_entries();
-    fn test_field_nb_buckets() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_ip_frag_tbl>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).nb_buckets) as usize - ptr as usize
-            },
-            28usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_ip_frag_tbl),
-                "::",
-                stringify!(nb_buckets)
-            )
-        );
-    }
-    test_field_nb_buckets();
-    fn test_field_last() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_ip_frag_tbl>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).last) as usize - ptr as usize
-            },
-            32usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_ip_frag_tbl),
-                "::",
-                stringify!(last)
-            )
-        );
-    }
-    test_field_last();
-    fn test_field_lru() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_ip_frag_tbl>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).lru) as usize - ptr as usize
-            },
-            40usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_ip_frag_tbl),
-                "::",
-                stringify!(lru)
-            )
-        );
-    }
-    test_field_lru();
-    fn test_field_stat() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_ip_frag_tbl>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).stat) as usize - ptr as usize
-            },
-            64usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_ip_frag_tbl),
-                "::",
-                stringify!(stat)
-            )
-        );
-    }
-    test_field_stat();
-    fn test_field_pkt() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_ip_frag_tbl>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).pkt) as usize - ptr as usize
-            },
-            128usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_ip_frag_tbl),
-                "::",
-                stringify!(pkt)
-            )
-        );
-    }
-    test_field_pkt();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).max_cycles) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_ip_frag_tbl),
+            "::",
+            stringify!(max_cycles)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).entry_mask) as usize - ptr as usize
+        },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_ip_frag_tbl),
+            "::",
+            stringify!(entry_mask)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).max_entries) as usize - ptr as usize
+        },
+        12usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_ip_frag_tbl),
+            "::",
+            stringify!(max_entries)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).use_entries) as usize - ptr as usize
+        },
+        16usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_ip_frag_tbl),
+            "::",
+            stringify!(use_entries)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).bucket_entries) as usize - ptr as usize
+        },
+        20usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_ip_frag_tbl),
+            "::",
+            stringify!(bucket_entries)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).nb_entries) as usize - ptr as usize
+        },
+        24usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_ip_frag_tbl),
+            "::",
+            stringify!(nb_entries)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).nb_buckets) as usize - ptr as usize
+        },
+        28usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_ip_frag_tbl),
+            "::",
+            stringify!(nb_buckets)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).last) as usize - ptr as usize
+        },
+        32usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_ip_frag_tbl),
+            "::",
+            stringify!(last)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).lru) as usize - ptr as usize
+        },
+        40usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_ip_frag_tbl),
+            "::",
+            stringify!(lru)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).stat) as usize - ptr as usize
+        },
+        64usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_ip_frag_tbl),
+            "::",
+            stringify!(stat)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).pkt) as usize - ptr as usize
+        },
+        128usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_ip_frag_tbl),
+            "::",
+            stringify!(pkt)
+        )
+    );
 }
 impl Default for rte_ip_frag_tbl {
     fn default() -> Self {

--- a/tests/expectations/tests/layout_large_align_field.rs
+++ b/tests/expectations/tests/layout_large_align_field.rs
@@ -67,6 +67,7 @@ pub struct ip_frag {
 fn bindgen_test_layout_ip_frag() {
     const UNINIT: ::std::mem::MaybeUninit<ip_frag> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<ip_frag>(),
         16usize,
@@ -78,10 +79,7 @@ fn bindgen_test_layout_ip_frag() {
         concat!("Alignment of ", stringify!(ip_frag))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).ofs) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).ofs) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -91,10 +89,7 @@ fn bindgen_test_layout_ip_frag() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).len) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).len) as usize - ptr as usize },
         2usize,
         concat!(
             "Offset of field: ",
@@ -104,10 +99,7 @@ fn bindgen_test_layout_ip_frag() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mb) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).mb) as usize - ptr as usize },
         8usize,
         concat!(
             "Offset of field: ",
@@ -141,6 +133,7 @@ pub struct ip_frag_key {
 fn bindgen_test_layout_ip_frag_key() {
     const UNINIT: ::std::mem::MaybeUninit<ip_frag_key> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<ip_frag_key>(),
         40usize,
@@ -152,10 +145,7 @@ fn bindgen_test_layout_ip_frag_key() {
         concat!("Alignment of ", stringify!(ip_frag_key))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).src_dst) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).src_dst) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -165,10 +155,7 @@ fn bindgen_test_layout_ip_frag_key() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).id) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).id) as usize - ptr as usize },
         32usize,
         concat!(
             "Offset of field: ",
@@ -178,10 +165,7 @@ fn bindgen_test_layout_ip_frag_key() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).key_len) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).key_len) as usize - ptr as usize },
         36usize,
         concat!(
             "Offset of field: ",
@@ -222,6 +206,7 @@ pub struct ip_frag_pkt__bindgen_ty_1 {
 fn bindgen_test_layout_ip_frag_pkt__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<ip_frag_pkt__bindgen_ty_1> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<ip_frag_pkt__bindgen_ty_1>(),
         16usize,
@@ -234,7 +219,6 @@ fn bindgen_test_layout_ip_frag_pkt__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).tqe_next) as usize - ptr as usize
         },
         0usize,
@@ -247,7 +231,6 @@ fn bindgen_test_layout_ip_frag_pkt__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).tqe_prev) as usize - ptr as usize
         },
         8usize,
@@ -272,6 +255,7 @@ impl Default for ip_frag_pkt__bindgen_ty_1 {
 fn bindgen_test_layout_ip_frag_pkt() {
     const UNINIT: ::std::mem::MaybeUninit<ip_frag_pkt> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<ip_frag_pkt>(),
         192usize,
@@ -283,10 +267,7 @@ fn bindgen_test_layout_ip_frag_pkt() {
         concat!("Alignment of ", stringify!(ip_frag_pkt))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).lru) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).lru) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -296,10 +277,7 @@ fn bindgen_test_layout_ip_frag_pkt() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).key) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).key) as usize - ptr as usize },
         16usize,
         concat!(
             "Offset of field: ",
@@ -309,10 +287,7 @@ fn bindgen_test_layout_ip_frag_pkt() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).start) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).start) as usize - ptr as usize },
         56usize,
         concat!(
             "Offset of field: ",
@@ -323,7 +298,6 @@ fn bindgen_test_layout_ip_frag_pkt() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).total_size) as usize - ptr as usize
         },
         64usize,
@@ -336,7 +310,6 @@ fn bindgen_test_layout_ip_frag_pkt() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).frag_size) as usize - ptr as usize
         },
         68usize,
@@ -349,7 +322,6 @@ fn bindgen_test_layout_ip_frag_pkt() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).last_idx) as usize - ptr as usize
         },
         72usize,
@@ -361,10 +333,7 @@ fn bindgen_test_layout_ip_frag_pkt() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).frags) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).frags) as usize - ptr as usize },
         80usize,
         concat!(
             "Offset of field: ",
@@ -393,6 +362,7 @@ pub struct ip_pkt_list {
 fn bindgen_test_layout_ip_pkt_list() {
     const UNINIT: ::std::mem::MaybeUninit<ip_pkt_list> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<ip_pkt_list>(),
         16usize,
@@ -405,7 +375,6 @@ fn bindgen_test_layout_ip_pkt_list() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).tqh_first) as usize - ptr as usize
         },
         0usize,
@@ -418,7 +387,6 @@ fn bindgen_test_layout_ip_pkt_list() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).tqh_last) as usize - ptr as usize
         },
         8usize,
@@ -461,6 +429,7 @@ pub struct ip_frag_tbl_stat {
 fn bindgen_test_layout_ip_frag_tbl_stat() {
     const UNINIT: ::std::mem::MaybeUninit<ip_frag_tbl_stat> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<ip_frag_tbl_stat>(),
         64usize,
@@ -473,7 +442,6 @@ fn bindgen_test_layout_ip_frag_tbl_stat() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).find_num) as usize - ptr as usize
         },
         0usize,
@@ -485,10 +453,7 @@ fn bindgen_test_layout_ip_frag_tbl_stat() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).add_num) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).add_num) as usize - ptr as usize },
         8usize,
         concat!(
             "Offset of field: ",
@@ -498,10 +463,7 @@ fn bindgen_test_layout_ip_frag_tbl_stat() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).del_num) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).del_num) as usize - ptr as usize },
         16usize,
         concat!(
             "Offset of field: ",
@@ -512,7 +474,6 @@ fn bindgen_test_layout_ip_frag_tbl_stat() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).reuse_num) as usize - ptr as usize
         },
         24usize,
@@ -525,7 +486,6 @@ fn bindgen_test_layout_ip_frag_tbl_stat() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).fail_total) as usize - ptr as usize
         },
         32usize,
@@ -538,7 +498,6 @@ fn bindgen_test_layout_ip_frag_tbl_stat() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).fail_nospace) as usize - ptr as usize
         },
         40usize,
@@ -591,6 +550,7 @@ pub struct rte_ip_frag_tbl {
 fn bindgen_test_layout_rte_ip_frag_tbl() {
     const UNINIT: ::std::mem::MaybeUninit<rte_ip_frag_tbl> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<rte_ip_frag_tbl>(),
         128usize,
@@ -603,7 +563,6 @@ fn bindgen_test_layout_rte_ip_frag_tbl() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).max_cycles) as usize - ptr as usize
         },
         0usize,
@@ -616,7 +575,6 @@ fn bindgen_test_layout_rte_ip_frag_tbl() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).entry_mask) as usize - ptr as usize
         },
         8usize,
@@ -629,7 +587,6 @@ fn bindgen_test_layout_rte_ip_frag_tbl() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).max_entries) as usize - ptr as usize
         },
         12usize,
@@ -642,7 +599,6 @@ fn bindgen_test_layout_rte_ip_frag_tbl() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).use_entries) as usize - ptr as usize
         },
         16usize,
@@ -655,7 +611,6 @@ fn bindgen_test_layout_rte_ip_frag_tbl() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).bucket_entries) as usize - ptr as usize
         },
         20usize,
@@ -668,7 +623,6 @@ fn bindgen_test_layout_rte_ip_frag_tbl() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).nb_entries) as usize - ptr as usize
         },
         24usize,
@@ -681,7 +635,6 @@ fn bindgen_test_layout_rte_ip_frag_tbl() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).nb_buckets) as usize - ptr as usize
         },
         28usize,
@@ -693,10 +646,7 @@ fn bindgen_test_layout_rte_ip_frag_tbl() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).last) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).last) as usize - ptr as usize },
         32usize,
         concat!(
             "Offset of field: ",
@@ -706,10 +656,7 @@ fn bindgen_test_layout_rte_ip_frag_tbl() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).lru) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).lru) as usize - ptr as usize },
         40usize,
         concat!(
             "Offset of field: ",
@@ -719,10 +666,7 @@ fn bindgen_test_layout_rte_ip_frag_tbl() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).stat) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).stat) as usize - ptr as usize },
         64usize,
         concat!(
             "Offset of field: ",
@@ -732,10 +676,7 @@ fn bindgen_test_layout_rte_ip_frag_tbl() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).pkt) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).pkt) as usize - ptr as usize },
         128usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/layout_mbuf.rs
+++ b/tests/expectations/tests/layout_mbuf.rs
@@ -108,6 +108,7 @@ pub struct rte_atomic16_t {
 fn bindgen_test_layout_rte_atomic16_t() {
     const UNINIT: ::std::mem::MaybeUninit<rte_atomic16_t> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<rte_atomic16_t>(),
         2usize,
@@ -119,10 +120,7 @@ fn bindgen_test_layout_rte_atomic16_t() {
         concat!("Alignment of ", stringify!(rte_atomic16_t))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).cnt) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).cnt) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -197,6 +195,7 @@ pub union rte_mbuf__bindgen_ty_1 {
 fn bindgen_test_layout_rte_mbuf__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<rte_mbuf__bindgen_ty_1> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<rte_mbuf__bindgen_ty_1>(),
         2usize,
@@ -209,7 +208,6 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).refcnt_atomic) as usize - ptr as usize
         },
         0usize,
@@ -221,10 +219,7 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_1() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).refcnt) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).refcnt) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -418,6 +413,7 @@ impl rte_mbuf__bindgen_ty_2__bindgen_ty_1 {
 fn bindgen_test_layout_rte_mbuf__bindgen_ty_2() {
     const UNINIT: ::std::mem::MaybeUninit<rte_mbuf__bindgen_ty_2> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<rte_mbuf__bindgen_ty_2>(),
         4usize,
@@ -430,7 +426,6 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_2() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).packet_type) as usize - ptr as usize
         },
         0usize,
@@ -488,16 +483,18 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindg
     const UNINIT: ::std::mem::MaybeUninit<
         rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1,
     > = ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq ! (:: std :: mem :: size_of :: < rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1 > () , 4usize , concat ! ("Size of: " , stringify ! (rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1)));
     assert_eq ! (:: std :: mem :: align_of :: < rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1 > () , 2usize , concat ! ("Alignment of " , stringify ! (rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1)));
-    assert_eq ! (unsafe { let ptr = UNINIT . as_ptr () ; :: std :: ptr :: addr_of ! ((* ptr) . hash) as usize - ptr as usize } , 0usize , concat ! ("Offset of field: " , stringify ! (rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1) , "::" , stringify ! (hash)));
-    assert_eq ! (unsafe { let ptr = UNINIT . as_ptr () ; :: std :: ptr :: addr_of ! ((* ptr) . id) as usize - ptr as usize } , 2usize , concat ! ("Offset of field: " , stringify ! (rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1) , "::" , stringify ! (id)));
+    assert_eq ! (unsafe { :: std :: ptr :: addr_of ! ((* ptr) . hash) as usize - ptr as usize } , 0usize , concat ! ("Offset of field: " , stringify ! (rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1) , "::" , stringify ! (hash)));
+    assert_eq ! (unsafe { :: std :: ptr :: addr_of ! ((* ptr) . id) as usize - ptr as usize } , 2usize , concat ! ("Offset of field: " , stringify ! (rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1) , "::" , stringify ! (id)));
 }
 #[test]
 fn bindgen_test_layout_rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<
         rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1,
     > = ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1>(
         ),
@@ -518,10 +515,7 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).lo) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).lo) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -545,6 +539,7 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_3__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<
         rte_mbuf__bindgen_ty_3__bindgen_ty_1,
     > = ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<rte_mbuf__bindgen_ty_3__bindgen_ty_1>(),
         8usize,
@@ -562,10 +557,7 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_3__bindgen_ty_1() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).hi) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).hi) as usize - ptr as usize },
         4usize,
         concat!(
             "Offset of field: ",
@@ -595,6 +587,7 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_3__bindgen_ty_2() {
     const UNINIT: ::std::mem::MaybeUninit<
         rte_mbuf__bindgen_ty_3__bindgen_ty_2,
     > = ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<rte_mbuf__bindgen_ty_3__bindgen_ty_2>(),
         8usize,
@@ -612,10 +605,7 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_3__bindgen_ty_2() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).lo) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).lo) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -625,10 +615,7 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_3__bindgen_ty_2() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).hi) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).hi) as usize - ptr as usize },
         4usize,
         concat!(
             "Offset of field: ",
@@ -642,6 +629,7 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_3__bindgen_ty_2() {
 fn bindgen_test_layout_rte_mbuf__bindgen_ty_3() {
     const UNINIT: ::std::mem::MaybeUninit<rte_mbuf__bindgen_ty_3> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<rte_mbuf__bindgen_ty_3>(),
         8usize,
@@ -653,10 +641,7 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_3() {
         concat!("Alignment of ", stringify!(rte_mbuf__bindgen_ty_3))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).rss) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).rss) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -666,10 +651,7 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_3() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).fdir) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).fdir) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -679,10 +661,7 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_3() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).sched) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).sched) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -692,10 +671,7 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_3() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).usr) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).usr) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -726,6 +702,7 @@ pub union rte_mbuf__bindgen_ty_4 {
 fn bindgen_test_layout_rte_mbuf__bindgen_ty_4() {
     const UNINIT: ::std::mem::MaybeUninit<rte_mbuf__bindgen_ty_4> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<rte_mbuf__bindgen_ty_4>(),
         8usize,
@@ -738,7 +715,6 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_4() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).userdata) as usize - ptr as usize
         },
         0usize,
@@ -750,10 +726,7 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_4() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).udata64) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).udata64) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -928,6 +901,7 @@ impl rte_mbuf__bindgen_ty_5__bindgen_ty_1 {
 fn bindgen_test_layout_rte_mbuf__bindgen_ty_5() {
     const UNINIT: ::std::mem::MaybeUninit<rte_mbuf__bindgen_ty_5> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<rte_mbuf__bindgen_ty_5>(),
         8usize,
@@ -940,7 +914,6 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_5() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).tx_offload) as usize - ptr as usize
         },
         0usize,
@@ -965,6 +938,7 @@ impl Default for rte_mbuf__bindgen_ty_5 {
 fn bindgen_test_layout_rte_mbuf() {
     const UNINIT: ::std::mem::MaybeUninit<rte_mbuf> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<rte_mbuf>(),
         128usize,
@@ -977,7 +951,6 @@ fn bindgen_test_layout_rte_mbuf() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).cacheline0) as usize - ptr as usize
         },
         0usize,
@@ -990,7 +963,6 @@ fn bindgen_test_layout_rte_mbuf() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).buf_addr) as usize - ptr as usize
         },
         0usize,
@@ -1003,7 +975,6 @@ fn bindgen_test_layout_rte_mbuf() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).buf_physaddr) as usize - ptr as usize
         },
         8usize,
@@ -1015,10 +986,7 @@ fn bindgen_test_layout_rte_mbuf() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).buf_len) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).buf_len) as usize - ptr as usize },
         16usize,
         concat!(
             "Offset of field: ",
@@ -1029,7 +997,6 @@ fn bindgen_test_layout_rte_mbuf() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).rearm_data) as usize - ptr as usize
         },
         18usize,
@@ -1042,7 +1009,6 @@ fn bindgen_test_layout_rte_mbuf() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).data_off) as usize - ptr as usize
         },
         18usize,
@@ -1054,10 +1020,7 @@ fn bindgen_test_layout_rte_mbuf() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).nb_segs) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).nb_segs) as usize - ptr as usize },
         22usize,
         concat!(
             "Offset of field: ",
@@ -1067,10 +1030,7 @@ fn bindgen_test_layout_rte_mbuf() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).port) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).port) as usize - ptr as usize },
         23usize,
         concat!(
             "Offset of field: ",
@@ -1081,7 +1041,6 @@ fn bindgen_test_layout_rte_mbuf() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).ol_flags) as usize - ptr as usize
         },
         24usize,
@@ -1094,7 +1053,6 @@ fn bindgen_test_layout_rte_mbuf() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).rx_descriptor_fields1) as usize -
                 ptr as usize
         },
@@ -1107,10 +1065,7 @@ fn bindgen_test_layout_rte_mbuf() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).pkt_len) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).pkt_len) as usize - ptr as usize },
         36usize,
         concat!(
             "Offset of field: ",
@@ -1121,7 +1076,6 @@ fn bindgen_test_layout_rte_mbuf() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).data_len) as usize - ptr as usize
         },
         40usize,
@@ -1134,7 +1088,6 @@ fn bindgen_test_layout_rte_mbuf() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).vlan_tci) as usize - ptr as usize
         },
         42usize,
@@ -1146,10 +1099,7 @@ fn bindgen_test_layout_rte_mbuf() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).hash) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).hash) as usize - ptr as usize },
         44usize,
         concat!(
             "Offset of field: ",
@@ -1159,10 +1109,7 @@ fn bindgen_test_layout_rte_mbuf() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).seqn) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).seqn) as usize - ptr as usize },
         52usize,
         concat!(
             "Offset of field: ",
@@ -1173,7 +1120,6 @@ fn bindgen_test_layout_rte_mbuf() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).vlan_tci_outer) as usize - ptr as usize
         },
         56usize,
@@ -1186,7 +1132,6 @@ fn bindgen_test_layout_rte_mbuf() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).cacheline1) as usize - ptr as usize
         },
         64usize,
@@ -1198,10 +1143,7 @@ fn bindgen_test_layout_rte_mbuf() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).pool) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).pool) as usize - ptr as usize },
         72usize,
         concat!(
             "Offset of field: ",
@@ -1211,10 +1153,7 @@ fn bindgen_test_layout_rte_mbuf() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).next) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).next) as usize - ptr as usize },
         80usize,
         concat!(
             "Offset of field: ",
@@ -1225,7 +1164,6 @@ fn bindgen_test_layout_rte_mbuf() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).priv_size) as usize - ptr as usize
         },
         96usize,
@@ -1238,7 +1176,6 @@ fn bindgen_test_layout_rte_mbuf() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).timesync) as usize - ptr as usize
         },
         98usize,

--- a/tests/expectations/tests/layout_mbuf.rs
+++ b/tests/expectations/tests/layout_mbuf.rs
@@ -106,6 +106,8 @@ pub struct rte_atomic16_t {
 }
 #[test]
 fn bindgen_test_layout_rte_atomic16_t() {
+    const UNINIT: ::std::mem::MaybeUninit<rte_atomic16_t> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<rte_atomic16_t>(),
         2usize,
@@ -116,24 +118,19 @@ fn bindgen_test_layout_rte_atomic16_t() {
         2usize,
         concat!("Alignment of ", stringify!(rte_atomic16_t))
     );
-    fn test_field_cnt() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_atomic16_t>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).cnt) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_atomic16_t),
-                "::",
-                stringify!(cnt)
-            )
-        );
-    }
-    test_field_cnt();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).cnt) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_atomic16_t),
+            "::",
+            stringify!(cnt)
+        )
+    );
 }
 /// The generic rte_mbuf, containing a packet mbuf.
 #[repr(C)]
@@ -198,6 +195,8 @@ pub union rte_mbuf__bindgen_ty_1 {
 }
 #[test]
 fn bindgen_test_layout_rte_mbuf__bindgen_ty_1() {
+    const UNINIT: ::std::mem::MaybeUninit<rte_mbuf__bindgen_ty_1> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<rte_mbuf__bindgen_ty_1>(),
         2usize,
@@ -208,43 +207,32 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_1() {
         2usize,
         concat!("Alignment of ", stringify!(rte_mbuf__bindgen_ty_1))
     );
-    fn test_field_refcnt_atomic() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_mbuf__bindgen_ty_1>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).refcnt_atomic) as usize -
-                    ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_mbuf__bindgen_ty_1),
-                "::",
-                stringify!(refcnt_atomic)
-            )
-        );
-    }
-    test_field_refcnt_atomic();
-    fn test_field_refcnt() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_mbuf__bindgen_ty_1>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).refcnt) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_mbuf__bindgen_ty_1),
-                "::",
-                stringify!(refcnt)
-            )
-        );
-    }
-    test_field_refcnt();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).refcnt_atomic) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_mbuf__bindgen_ty_1),
+            "::",
+            stringify!(refcnt_atomic)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).refcnt) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_mbuf__bindgen_ty_1),
+            "::",
+            stringify!(refcnt)
+        )
+    );
 }
 impl Default for rte_mbuf__bindgen_ty_1 {
     fn default() -> Self {
@@ -428,6 +416,8 @@ impl rte_mbuf__bindgen_ty_2__bindgen_ty_1 {
 }
 #[test]
 fn bindgen_test_layout_rte_mbuf__bindgen_ty_2() {
+    const UNINIT: ::std::mem::MaybeUninit<rte_mbuf__bindgen_ty_2> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<rte_mbuf__bindgen_ty_2>(),
         4usize,
@@ -438,24 +428,19 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_2() {
         4usize,
         concat!("Alignment of ", stringify!(rte_mbuf__bindgen_ty_2))
     );
-    fn test_field_packet_type() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_mbuf__bindgen_ty_2>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).packet_type) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_mbuf__bindgen_ty_2),
-                "::",
-                stringify!(packet_type)
-            )
-        );
-    }
-    test_field_packet_type();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).packet_type) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_mbuf__bindgen_ty_2),
+            "::",
+            stringify!(packet_type)
+        )
+    );
 }
 impl Default for rte_mbuf__bindgen_ty_2 {
     fn default() -> Self {
@@ -500,19 +485,19 @@ pub struct rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1 {
 #[test]
 fn bindgen_test_layout_rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1(
 ) {
+    const UNINIT: ::std::mem::MaybeUninit<
+        rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1,
+    > = ::std::mem::MaybeUninit::uninit();
     assert_eq ! (:: std :: mem :: size_of :: < rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1 > () , 4usize , concat ! ("Size of: " , stringify ! (rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1)));
     assert_eq ! (:: std :: mem :: align_of :: < rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1 > () , 2usize , concat ! ("Alignment of " , stringify ! (rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1)));
-    fn test_field_hash() {
-        assert_eq ! (unsafe { let uninit = :: std :: mem :: MaybeUninit :: < rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1 > :: uninit () ; let ptr = uninit . as_ptr () ; :: std :: ptr :: addr_of ! ((* ptr) . hash) as usize - ptr as usize } , 0usize , concat ! ("Offset of field: " , stringify ! (rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1) , "::" , stringify ! (hash)));
-    }
-    test_field_hash();
-    fn test_field_id() {
-        assert_eq ! (unsafe { let uninit = :: std :: mem :: MaybeUninit :: < rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1 > :: uninit () ; let ptr = uninit . as_ptr () ; :: std :: ptr :: addr_of ! ((* ptr) . id) as usize - ptr as usize } , 2usize , concat ! ("Offset of field: " , stringify ! (rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1) , "::" , stringify ! (id)));
-    }
-    test_field_id();
+    assert_eq ! (unsafe { let ptr = UNINIT . as_ptr () ; :: std :: ptr :: addr_of ! ((* ptr) . hash) as usize - ptr as usize } , 0usize , concat ! ("Offset of field: " , stringify ! (rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1) , "::" , stringify ! (hash)));
+    assert_eq ! (unsafe { let ptr = UNINIT . as_ptr () ; :: std :: ptr :: addr_of ! ((* ptr) . id) as usize - ptr as usize } , 2usize , concat ! ("Offset of field: " , stringify ! (rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1) , "::" , stringify ! (id)));
 }
 #[test]
 fn bindgen_test_layout_rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1() {
+    const UNINIT: ::std::mem::MaybeUninit<
+        rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1,
+    > = ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1>(
         ),
@@ -532,25 +517,19 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1() {
             stringify!(rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1)
         )
     );
-    fn test_field_lo() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<
-                    rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1,
-                >::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).lo) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1),
-                "::",
-                stringify!(lo)
-            )
-        );
-    }
-    test_field_lo();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).lo) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1),
+            "::",
+            stringify!(lo)
+        )
+    );
 }
 impl Default for rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1 {
     fn default() -> Self {
@@ -563,6 +542,9 @@ impl Default for rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1 {
 }
 #[test]
 fn bindgen_test_layout_rte_mbuf__bindgen_ty_3__bindgen_ty_1() {
+    const UNINIT: ::std::mem::MaybeUninit<
+        rte_mbuf__bindgen_ty_3__bindgen_ty_1,
+    > = ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<rte_mbuf__bindgen_ty_3__bindgen_ty_1>(),
         8usize,
@@ -579,25 +561,19 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_3__bindgen_ty_1() {
             stringify!(rte_mbuf__bindgen_ty_3__bindgen_ty_1)
         )
     );
-    fn test_field_hi() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<
-                    rte_mbuf__bindgen_ty_3__bindgen_ty_1,
-                >::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).hi) as usize - ptr as usize
-            },
-            4usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_mbuf__bindgen_ty_3__bindgen_ty_1),
-                "::",
-                stringify!(hi)
-            )
-        );
-    }
-    test_field_hi();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).hi) as usize - ptr as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_mbuf__bindgen_ty_3__bindgen_ty_1),
+            "::",
+            stringify!(hi)
+        )
+    );
 }
 impl Default for rte_mbuf__bindgen_ty_3__bindgen_ty_1 {
     fn default() -> Self {
@@ -616,6 +592,9 @@ pub struct rte_mbuf__bindgen_ty_3__bindgen_ty_2 {
 }
 #[test]
 fn bindgen_test_layout_rte_mbuf__bindgen_ty_3__bindgen_ty_2() {
+    const UNINIT: ::std::mem::MaybeUninit<
+        rte_mbuf__bindgen_ty_3__bindgen_ty_2,
+    > = ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<rte_mbuf__bindgen_ty_3__bindgen_ty_2>(),
         8usize,
@@ -632,47 +611,37 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_3__bindgen_ty_2() {
             stringify!(rte_mbuf__bindgen_ty_3__bindgen_ty_2)
         )
     );
-    fn test_field_lo() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<
-                    rte_mbuf__bindgen_ty_3__bindgen_ty_2,
-                >::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).lo) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_mbuf__bindgen_ty_3__bindgen_ty_2),
-                "::",
-                stringify!(lo)
-            )
-        );
-    }
-    test_field_lo();
-    fn test_field_hi() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<
-                    rte_mbuf__bindgen_ty_3__bindgen_ty_2,
-                >::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).hi) as usize - ptr as usize
-            },
-            4usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_mbuf__bindgen_ty_3__bindgen_ty_2),
-                "::",
-                stringify!(hi)
-            )
-        );
-    }
-    test_field_hi();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).lo) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_mbuf__bindgen_ty_3__bindgen_ty_2),
+            "::",
+            stringify!(lo)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).hi) as usize - ptr as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_mbuf__bindgen_ty_3__bindgen_ty_2),
+            "::",
+            stringify!(hi)
+        )
+    );
 }
 #[test]
 fn bindgen_test_layout_rte_mbuf__bindgen_ty_3() {
+    const UNINIT: ::std::mem::MaybeUninit<rte_mbuf__bindgen_ty_3> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<rte_mbuf__bindgen_ty_3>(),
         8usize,
@@ -683,78 +652,58 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_3() {
         4usize,
         concat!("Alignment of ", stringify!(rte_mbuf__bindgen_ty_3))
     );
-    fn test_field_rss() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_mbuf__bindgen_ty_3>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).rss) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_mbuf__bindgen_ty_3),
-                "::",
-                stringify!(rss)
-            )
-        );
-    }
-    test_field_rss();
-    fn test_field_fdir() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_mbuf__bindgen_ty_3>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).fdir) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_mbuf__bindgen_ty_3),
-                "::",
-                stringify!(fdir)
-            )
-        );
-    }
-    test_field_fdir();
-    fn test_field_sched() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_mbuf__bindgen_ty_3>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).sched) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_mbuf__bindgen_ty_3),
-                "::",
-                stringify!(sched)
-            )
-        );
-    }
-    test_field_sched();
-    fn test_field_usr() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_mbuf__bindgen_ty_3>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).usr) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_mbuf__bindgen_ty_3),
-                "::",
-                stringify!(usr)
-            )
-        );
-    }
-    test_field_usr();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).rss) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_mbuf__bindgen_ty_3),
+            "::",
+            stringify!(rss)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).fdir) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_mbuf__bindgen_ty_3),
+            "::",
+            stringify!(fdir)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).sched) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_mbuf__bindgen_ty_3),
+            "::",
+            stringify!(sched)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).usr) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_mbuf__bindgen_ty_3),
+            "::",
+            stringify!(usr)
+        )
+    );
 }
 impl Default for rte_mbuf__bindgen_ty_3 {
     fn default() -> Self {
@@ -775,6 +724,8 @@ pub union rte_mbuf__bindgen_ty_4 {
 }
 #[test]
 fn bindgen_test_layout_rte_mbuf__bindgen_ty_4() {
+    const UNINIT: ::std::mem::MaybeUninit<rte_mbuf__bindgen_ty_4> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<rte_mbuf__bindgen_ty_4>(),
         8usize,
@@ -785,42 +736,32 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_4() {
         8usize,
         concat!("Alignment of ", stringify!(rte_mbuf__bindgen_ty_4))
     );
-    fn test_field_userdata() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_mbuf__bindgen_ty_4>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).userdata) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_mbuf__bindgen_ty_4),
-                "::",
-                stringify!(userdata)
-            )
-        );
-    }
-    test_field_userdata();
-    fn test_field_udata64() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_mbuf__bindgen_ty_4>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).udata64) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_mbuf__bindgen_ty_4),
-                "::",
-                stringify!(udata64)
-            )
-        );
-    }
-    test_field_udata64();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).userdata) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_mbuf__bindgen_ty_4),
+            "::",
+            stringify!(userdata)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).udata64) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_mbuf__bindgen_ty_4),
+            "::",
+            stringify!(udata64)
+        )
+    );
 }
 impl Default for rte_mbuf__bindgen_ty_4 {
     fn default() -> Self {
@@ -985,6 +926,8 @@ impl rte_mbuf__bindgen_ty_5__bindgen_ty_1 {
 }
 #[test]
 fn bindgen_test_layout_rte_mbuf__bindgen_ty_5() {
+    const UNINIT: ::std::mem::MaybeUninit<rte_mbuf__bindgen_ty_5> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<rte_mbuf__bindgen_ty_5>(),
         8usize,
@@ -995,24 +938,19 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_5() {
         8usize,
         concat!("Alignment of ", stringify!(rte_mbuf__bindgen_ty_5))
     );
-    fn test_field_tx_offload() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_mbuf__bindgen_ty_5>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).tx_offload) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_mbuf__bindgen_ty_5),
-                "::",
-                stringify!(tx_offload)
-            )
-        );
-    }
-    test_field_tx_offload();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).tx_offload) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_mbuf__bindgen_ty_5),
+            "::",
+            stringify!(tx_offload)
+        )
+    );
 }
 impl Default for rte_mbuf__bindgen_ty_5 {
     fn default() -> Self {
@@ -1025,6 +963,8 @@ impl Default for rte_mbuf__bindgen_ty_5 {
 }
 #[test]
 fn bindgen_test_layout_rte_mbuf() {
+    const UNINIT: ::std::mem::MaybeUninit<rte_mbuf> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<rte_mbuf>(),
         128usize,
@@ -1035,366 +975,280 @@ fn bindgen_test_layout_rte_mbuf() {
         64usize,
         concat!("Alignment of ", stringify!(rte_mbuf))
     );
-    fn test_field_cacheline0() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<rte_mbuf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).cacheline0) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_mbuf),
-                "::",
-                stringify!(cacheline0)
-            )
-        );
-    }
-    test_field_cacheline0();
-    fn test_field_buf_addr() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<rte_mbuf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).buf_addr) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_mbuf),
-                "::",
-                stringify!(buf_addr)
-            )
-        );
-    }
-    test_field_buf_addr();
-    fn test_field_buf_physaddr() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<rte_mbuf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).buf_physaddr) as usize -
-                    ptr as usize
-            },
-            8usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_mbuf),
-                "::",
-                stringify!(buf_physaddr)
-            )
-        );
-    }
-    test_field_buf_physaddr();
-    fn test_field_buf_len() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<rte_mbuf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).buf_len) as usize - ptr as usize
-            },
-            16usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_mbuf),
-                "::",
-                stringify!(buf_len)
-            )
-        );
-    }
-    test_field_buf_len();
-    fn test_field_rearm_data() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<rte_mbuf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).rearm_data) as usize - ptr as usize
-            },
-            18usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_mbuf),
-                "::",
-                stringify!(rearm_data)
-            )
-        );
-    }
-    test_field_rearm_data();
-    fn test_field_data_off() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<rte_mbuf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).data_off) as usize - ptr as usize
-            },
-            18usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_mbuf),
-                "::",
-                stringify!(data_off)
-            )
-        );
-    }
-    test_field_data_off();
-    fn test_field_nb_segs() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<rte_mbuf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).nb_segs) as usize - ptr as usize
-            },
-            22usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_mbuf),
-                "::",
-                stringify!(nb_segs)
-            )
-        );
-    }
-    test_field_nb_segs();
-    fn test_field_port() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<rte_mbuf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).port) as usize - ptr as usize
-            },
-            23usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_mbuf),
-                "::",
-                stringify!(port)
-            )
-        );
-    }
-    test_field_port();
-    fn test_field_ol_flags() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<rte_mbuf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).ol_flags) as usize - ptr as usize
-            },
-            24usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_mbuf),
-                "::",
-                stringify!(ol_flags)
-            )
-        );
-    }
-    test_field_ol_flags();
-    fn test_field_rx_descriptor_fields1() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<rte_mbuf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).rx_descriptor_fields1) as usize -
-                    ptr as usize
-            },
-            32usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_mbuf),
-                "::",
-                stringify!(rx_descriptor_fields1)
-            )
-        );
-    }
-    test_field_rx_descriptor_fields1();
-    fn test_field_pkt_len() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<rte_mbuf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).pkt_len) as usize - ptr as usize
-            },
-            36usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_mbuf),
-                "::",
-                stringify!(pkt_len)
-            )
-        );
-    }
-    test_field_pkt_len();
-    fn test_field_data_len() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<rte_mbuf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).data_len) as usize - ptr as usize
-            },
-            40usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_mbuf),
-                "::",
-                stringify!(data_len)
-            )
-        );
-    }
-    test_field_data_len();
-    fn test_field_vlan_tci() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<rte_mbuf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).vlan_tci) as usize - ptr as usize
-            },
-            42usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_mbuf),
-                "::",
-                stringify!(vlan_tci)
-            )
-        );
-    }
-    test_field_vlan_tci();
-    fn test_field_hash() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<rte_mbuf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).hash) as usize - ptr as usize
-            },
-            44usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_mbuf),
-                "::",
-                stringify!(hash)
-            )
-        );
-    }
-    test_field_hash();
-    fn test_field_seqn() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<rte_mbuf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).seqn) as usize - ptr as usize
-            },
-            52usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_mbuf),
-                "::",
-                stringify!(seqn)
-            )
-        );
-    }
-    test_field_seqn();
-    fn test_field_vlan_tci_outer() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<rte_mbuf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).vlan_tci_outer) as usize -
-                    ptr as usize
-            },
-            56usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_mbuf),
-                "::",
-                stringify!(vlan_tci_outer)
-            )
-        );
-    }
-    test_field_vlan_tci_outer();
-    fn test_field_cacheline1() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<rte_mbuf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).cacheline1) as usize - ptr as usize
-            },
-            64usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_mbuf),
-                "::",
-                stringify!(cacheline1)
-            )
-        );
-    }
-    test_field_cacheline1();
-    fn test_field_pool() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<rte_mbuf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).pool) as usize - ptr as usize
-            },
-            72usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_mbuf),
-                "::",
-                stringify!(pool)
-            )
-        );
-    }
-    test_field_pool();
-    fn test_field_next() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<rte_mbuf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).next) as usize - ptr as usize
-            },
-            80usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_mbuf),
-                "::",
-                stringify!(next)
-            )
-        );
-    }
-    test_field_next();
-    fn test_field_priv_size() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<rte_mbuf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).priv_size) as usize - ptr as usize
-            },
-            96usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_mbuf),
-                "::",
-                stringify!(priv_size)
-            )
-        );
-    }
-    test_field_priv_size();
-    fn test_field_timesync() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<rte_mbuf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).timesync) as usize - ptr as usize
-            },
-            98usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_mbuf),
-                "::",
-                stringify!(timesync)
-            )
-        );
-    }
-    test_field_timesync();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).cacheline0) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_mbuf),
+            "::",
+            stringify!(cacheline0)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).buf_addr) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_mbuf),
+            "::",
+            stringify!(buf_addr)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).buf_physaddr) as usize - ptr as usize
+        },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_mbuf),
+            "::",
+            stringify!(buf_physaddr)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).buf_len) as usize - ptr as usize
+        },
+        16usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_mbuf),
+            "::",
+            stringify!(buf_len)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).rearm_data) as usize - ptr as usize
+        },
+        18usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_mbuf),
+            "::",
+            stringify!(rearm_data)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).data_off) as usize - ptr as usize
+        },
+        18usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_mbuf),
+            "::",
+            stringify!(data_off)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).nb_segs) as usize - ptr as usize
+        },
+        22usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_mbuf),
+            "::",
+            stringify!(nb_segs)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).port) as usize - ptr as usize
+        },
+        23usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_mbuf),
+            "::",
+            stringify!(port)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).ol_flags) as usize - ptr as usize
+        },
+        24usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_mbuf),
+            "::",
+            stringify!(ol_flags)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).rx_descriptor_fields1) as usize -
+                ptr as usize
+        },
+        32usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_mbuf),
+            "::",
+            stringify!(rx_descriptor_fields1)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).pkt_len) as usize - ptr as usize
+        },
+        36usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_mbuf),
+            "::",
+            stringify!(pkt_len)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).data_len) as usize - ptr as usize
+        },
+        40usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_mbuf),
+            "::",
+            stringify!(data_len)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).vlan_tci) as usize - ptr as usize
+        },
+        42usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_mbuf),
+            "::",
+            stringify!(vlan_tci)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).hash) as usize - ptr as usize
+        },
+        44usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_mbuf),
+            "::",
+            stringify!(hash)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).seqn) as usize - ptr as usize
+        },
+        52usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_mbuf),
+            "::",
+            stringify!(seqn)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).vlan_tci_outer) as usize - ptr as usize
+        },
+        56usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_mbuf),
+            "::",
+            stringify!(vlan_tci_outer)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).cacheline1) as usize - ptr as usize
+        },
+        64usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_mbuf),
+            "::",
+            stringify!(cacheline1)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).pool) as usize - ptr as usize
+        },
+        72usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_mbuf),
+            "::",
+            stringify!(pool)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).next) as usize - ptr as usize
+        },
+        80usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_mbuf),
+            "::",
+            stringify!(next)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).priv_size) as usize - ptr as usize
+        },
+        96usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_mbuf),
+            "::",
+            stringify!(priv_size)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).timesync) as usize - ptr as usize
+        },
+        98usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_mbuf),
+            "::",
+            stringify!(timesync)
+        )
+    );
 }
 impl Default for rte_mbuf {
     fn default() -> Self {

--- a/tests/expectations/tests/layout_mbuf_1_0.rs
+++ b/tests/expectations/tests/layout_mbuf_1_0.rs
@@ -151,6 +151,7 @@ pub struct rte_atomic16_t {
 fn bindgen_test_layout_rte_atomic16_t() {
     const UNINIT: ::std::mem::MaybeUninit<rte_atomic16_t> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<rte_atomic16_t>(),
         2usize,
@@ -162,10 +163,7 @@ fn bindgen_test_layout_rte_atomic16_t() {
         concat!("Alignment of ", stringify!(rte_atomic16_t))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).cnt) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).cnt) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -246,6 +244,7 @@ pub struct rte_mbuf__bindgen_ty_1 {
 fn bindgen_test_layout_rte_mbuf__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<rte_mbuf__bindgen_ty_1> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<rte_mbuf__bindgen_ty_1>(),
         2usize,
@@ -258,7 +257,6 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_1() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).refcnt_atomic) as usize - ptr as usize
         },
         0usize,
@@ -270,10 +268,7 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_1() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).refcnt) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).refcnt) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -470,6 +465,7 @@ impl rte_mbuf__bindgen_ty_2__bindgen_ty_1 {
 fn bindgen_test_layout_rte_mbuf__bindgen_ty_2() {
     const UNINIT: ::std::mem::MaybeUninit<rte_mbuf__bindgen_ty_2> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<rte_mbuf__bindgen_ty_2>(),
         4usize,
@@ -482,7 +478,6 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_2() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).packet_type) as usize - ptr as usize
         },
         0usize,
@@ -539,10 +534,11 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindg
     const UNINIT: ::std::mem::MaybeUninit<
         rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1,
     > = ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq ! (:: std :: mem :: size_of :: < rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1 > () , 4usize , concat ! ("Size of: " , stringify ! (rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1)));
     assert_eq ! (:: std :: mem :: align_of :: < rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1 > () , 2usize , concat ! ("Alignment of " , stringify ! (rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1)));
-    assert_eq ! (unsafe { let ptr = UNINIT . as_ptr () ; :: std :: ptr :: addr_of ! ((* ptr) . hash) as usize - ptr as usize } , 0usize , concat ! ("Offset of field: " , stringify ! (rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1) , "::" , stringify ! (hash)));
-    assert_eq ! (unsafe { let ptr = UNINIT . as_ptr () ; :: std :: ptr :: addr_of ! ((* ptr) . id) as usize - ptr as usize } , 2usize , concat ! ("Offset of field: " , stringify ! (rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1) , "::" , stringify ! (id)));
+    assert_eq ! (unsafe { :: std :: ptr :: addr_of ! ((* ptr) . hash) as usize - ptr as usize } , 0usize , concat ! ("Offset of field: " , stringify ! (rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1) , "::" , stringify ! (hash)));
+    assert_eq ! (unsafe { :: std :: ptr :: addr_of ! ((* ptr) . id) as usize - ptr as usize } , 2usize , concat ! ("Offset of field: " , stringify ! (rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1) , "::" , stringify ! (id)));
 }
 impl Clone
     for rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1
@@ -556,6 +552,7 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<
         rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1,
     > = ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1>(
         ),
@@ -576,10 +573,7 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).lo) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).lo) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -599,6 +593,7 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_3__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<
         rte_mbuf__bindgen_ty_3__bindgen_ty_1,
     > = ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<rte_mbuf__bindgen_ty_3__bindgen_ty_1>(),
         8usize,
@@ -616,10 +611,7 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_3__bindgen_ty_1() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).hi) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).hi) as usize - ptr as usize },
         4usize,
         concat!(
             "Offset of field: ",
@@ -645,6 +637,7 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_3__bindgen_ty_2() {
     const UNINIT: ::std::mem::MaybeUninit<
         rte_mbuf__bindgen_ty_3__bindgen_ty_2,
     > = ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<rte_mbuf__bindgen_ty_3__bindgen_ty_2>(),
         8usize,
@@ -662,10 +655,7 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_3__bindgen_ty_2() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).lo) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).lo) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -675,10 +665,7 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_3__bindgen_ty_2() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).hi) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).hi) as usize - ptr as usize },
         4usize,
         concat!(
             "Offset of field: ",
@@ -697,6 +684,7 @@ impl Clone for rte_mbuf__bindgen_ty_3__bindgen_ty_2 {
 fn bindgen_test_layout_rte_mbuf__bindgen_ty_3() {
     const UNINIT: ::std::mem::MaybeUninit<rte_mbuf__bindgen_ty_3> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<rte_mbuf__bindgen_ty_3>(),
         8usize,
@@ -708,10 +696,7 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_3() {
         concat!("Alignment of ", stringify!(rte_mbuf__bindgen_ty_3))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).rss) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).rss) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -721,10 +706,7 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_3() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).fdir) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).fdir) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -734,10 +716,7 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_3() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).sched) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).sched) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -747,10 +726,7 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_3() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).usr) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).usr) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -778,6 +754,7 @@ pub struct rte_mbuf__bindgen_ty_4 {
 fn bindgen_test_layout_rte_mbuf__bindgen_ty_4() {
     const UNINIT: ::std::mem::MaybeUninit<rte_mbuf__bindgen_ty_4> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<rte_mbuf__bindgen_ty_4>(),
         8usize,
@@ -790,7 +767,6 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_4() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).userdata) as usize - ptr as usize
         },
         0usize,
@@ -802,10 +778,7 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_4() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).udata64) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).udata64) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -983,6 +956,7 @@ impl rte_mbuf__bindgen_ty_5__bindgen_ty_1 {
 fn bindgen_test_layout_rte_mbuf__bindgen_ty_5() {
     const UNINIT: ::std::mem::MaybeUninit<rte_mbuf__bindgen_ty_5> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<rte_mbuf__bindgen_ty_5>(),
         8usize,
@@ -995,7 +969,6 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_5() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).tx_offload) as usize - ptr as usize
         },
         0usize,
@@ -1016,6 +989,7 @@ impl Clone for rte_mbuf__bindgen_ty_5 {
 fn bindgen_test_layout_rte_mbuf() {
     const UNINIT: ::std::mem::MaybeUninit<rte_mbuf> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<rte_mbuf>(),
         128usize,
@@ -1023,7 +997,6 @@ fn bindgen_test_layout_rte_mbuf() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).cacheline0) as usize - ptr as usize
         },
         0usize,
@@ -1036,7 +1009,6 @@ fn bindgen_test_layout_rte_mbuf() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).buf_addr) as usize - ptr as usize
         },
         0usize,
@@ -1049,7 +1021,6 @@ fn bindgen_test_layout_rte_mbuf() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).buf_physaddr) as usize - ptr as usize
         },
         8usize,
@@ -1061,10 +1032,7 @@ fn bindgen_test_layout_rte_mbuf() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).buf_len) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).buf_len) as usize - ptr as usize },
         16usize,
         concat!(
             "Offset of field: ",
@@ -1075,7 +1043,6 @@ fn bindgen_test_layout_rte_mbuf() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).rearm_data) as usize - ptr as usize
         },
         18usize,
@@ -1088,7 +1055,6 @@ fn bindgen_test_layout_rte_mbuf() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).data_off) as usize - ptr as usize
         },
         18usize,
@@ -1100,10 +1066,7 @@ fn bindgen_test_layout_rte_mbuf() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).nb_segs) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).nb_segs) as usize - ptr as usize },
         22usize,
         concat!(
             "Offset of field: ",
@@ -1113,10 +1076,7 @@ fn bindgen_test_layout_rte_mbuf() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).port) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).port) as usize - ptr as usize },
         23usize,
         concat!(
             "Offset of field: ",
@@ -1127,7 +1087,6 @@ fn bindgen_test_layout_rte_mbuf() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).ol_flags) as usize - ptr as usize
         },
         24usize,
@@ -1140,7 +1099,6 @@ fn bindgen_test_layout_rte_mbuf() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).rx_descriptor_fields1) as usize -
                 ptr as usize
         },
@@ -1153,10 +1111,7 @@ fn bindgen_test_layout_rte_mbuf() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).pkt_len) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).pkt_len) as usize - ptr as usize },
         36usize,
         concat!(
             "Offset of field: ",
@@ -1167,7 +1122,6 @@ fn bindgen_test_layout_rte_mbuf() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).data_len) as usize - ptr as usize
         },
         40usize,
@@ -1180,7 +1134,6 @@ fn bindgen_test_layout_rte_mbuf() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).vlan_tci) as usize - ptr as usize
         },
         42usize,
@@ -1192,10 +1145,7 @@ fn bindgen_test_layout_rte_mbuf() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).hash) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).hash) as usize - ptr as usize },
         44usize,
         concat!(
             "Offset of field: ",
@@ -1205,10 +1155,7 @@ fn bindgen_test_layout_rte_mbuf() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).seqn) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).seqn) as usize - ptr as usize },
         52usize,
         concat!(
             "Offset of field: ",
@@ -1219,7 +1166,6 @@ fn bindgen_test_layout_rte_mbuf() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).vlan_tci_outer) as usize - ptr as usize
         },
         56usize,
@@ -1232,7 +1178,6 @@ fn bindgen_test_layout_rte_mbuf() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).cacheline1) as usize - ptr as usize
         },
         64usize,
@@ -1244,10 +1189,7 @@ fn bindgen_test_layout_rte_mbuf() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).pool) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).pool) as usize - ptr as usize },
         72usize,
         concat!(
             "Offset of field: ",
@@ -1257,10 +1199,7 @@ fn bindgen_test_layout_rte_mbuf() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).next) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).next) as usize - ptr as usize },
         80usize,
         concat!(
             "Offset of field: ",
@@ -1271,7 +1210,6 @@ fn bindgen_test_layout_rte_mbuf() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).priv_size) as usize - ptr as usize
         },
         96usize,
@@ -1284,7 +1222,6 @@ fn bindgen_test_layout_rte_mbuf() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).timesync) as usize - ptr as usize
         },
         98usize,

--- a/tests/expectations/tests/layout_mbuf_1_0.rs
+++ b/tests/expectations/tests/layout_mbuf_1_0.rs
@@ -149,6 +149,8 @@ pub struct rte_atomic16_t {
 }
 #[test]
 fn bindgen_test_layout_rte_atomic16_t() {
+    const UNINIT: ::std::mem::MaybeUninit<rte_atomic16_t> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<rte_atomic16_t>(),
         2usize,
@@ -159,24 +161,19 @@ fn bindgen_test_layout_rte_atomic16_t() {
         2usize,
         concat!("Alignment of ", stringify!(rte_atomic16_t))
     );
-    fn test_field_cnt() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_atomic16_t>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).cnt) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_atomic16_t),
-                "::",
-                stringify!(cnt)
-            )
-        );
-    }
-    test_field_cnt();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).cnt) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_atomic16_t),
+            "::",
+            stringify!(cnt)
+        )
+    );
 }
 impl Clone for rte_atomic16_t {
     fn clone(&self) -> Self {
@@ -247,6 +244,8 @@ pub struct rte_mbuf__bindgen_ty_1 {
 }
 #[test]
 fn bindgen_test_layout_rte_mbuf__bindgen_ty_1() {
+    const UNINIT: ::std::mem::MaybeUninit<rte_mbuf__bindgen_ty_1> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<rte_mbuf__bindgen_ty_1>(),
         2usize,
@@ -257,43 +256,32 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_1() {
         2usize,
         concat!("Alignment of ", stringify!(rte_mbuf__bindgen_ty_1))
     );
-    fn test_field_refcnt_atomic() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_mbuf__bindgen_ty_1>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).refcnt_atomic) as usize -
-                    ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_mbuf__bindgen_ty_1),
-                "::",
-                stringify!(refcnt_atomic)
-            )
-        );
-    }
-    test_field_refcnt_atomic();
-    fn test_field_refcnt() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_mbuf__bindgen_ty_1>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).refcnt) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_mbuf__bindgen_ty_1),
-                "::",
-                stringify!(refcnt)
-            )
-        );
-    }
-    test_field_refcnt();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).refcnt_atomic) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_mbuf__bindgen_ty_1),
+            "::",
+            stringify!(refcnt_atomic)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).refcnt) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_mbuf__bindgen_ty_1),
+            "::",
+            stringify!(refcnt)
+        )
+    );
 }
 impl Clone for rte_mbuf__bindgen_ty_1 {
     fn clone(&self) -> Self {
@@ -480,6 +468,8 @@ impl rte_mbuf__bindgen_ty_2__bindgen_ty_1 {
 }
 #[test]
 fn bindgen_test_layout_rte_mbuf__bindgen_ty_2() {
+    const UNINIT: ::std::mem::MaybeUninit<rte_mbuf__bindgen_ty_2> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<rte_mbuf__bindgen_ty_2>(),
         4usize,
@@ -490,24 +480,19 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_2() {
         4usize,
         concat!("Alignment of ", stringify!(rte_mbuf__bindgen_ty_2))
     );
-    fn test_field_packet_type() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_mbuf__bindgen_ty_2>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).packet_type) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_mbuf__bindgen_ty_2),
-                "::",
-                stringify!(packet_type)
-            )
-        );
-    }
-    test_field_packet_type();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).packet_type) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_mbuf__bindgen_ty_2),
+            "::",
+            stringify!(packet_type)
+        )
+    );
 }
 impl Clone for rte_mbuf__bindgen_ty_2 {
     fn clone(&self) -> Self {
@@ -551,16 +536,13 @@ pub struct rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1 {
 #[test]
 fn bindgen_test_layout_rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1(
 ) {
+    const UNINIT: ::std::mem::MaybeUninit<
+        rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1,
+    > = ::std::mem::MaybeUninit::uninit();
     assert_eq ! (:: std :: mem :: size_of :: < rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1 > () , 4usize , concat ! ("Size of: " , stringify ! (rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1)));
     assert_eq ! (:: std :: mem :: align_of :: < rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1 > () , 2usize , concat ! ("Alignment of " , stringify ! (rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1)));
-    fn test_field_hash() {
-        assert_eq ! (unsafe { let uninit = :: std :: mem :: MaybeUninit :: < rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1 > :: uninit () ; let ptr = uninit . as_ptr () ; :: std :: ptr :: addr_of ! ((* ptr) . hash) as usize - ptr as usize } , 0usize , concat ! ("Offset of field: " , stringify ! (rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1) , "::" , stringify ! (hash)));
-    }
-    test_field_hash();
-    fn test_field_id() {
-        assert_eq ! (unsafe { let uninit = :: std :: mem :: MaybeUninit :: < rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1 > :: uninit () ; let ptr = uninit . as_ptr () ; :: std :: ptr :: addr_of ! ((* ptr) . id) as usize - ptr as usize } , 2usize , concat ! ("Offset of field: " , stringify ! (rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1) , "::" , stringify ! (id)));
-    }
-    test_field_id();
+    assert_eq ! (unsafe { let ptr = UNINIT . as_ptr () ; :: std :: ptr :: addr_of ! ((* ptr) . hash) as usize - ptr as usize } , 0usize , concat ! ("Offset of field: " , stringify ! (rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1) , "::" , stringify ! (hash)));
+    assert_eq ! (unsafe { let ptr = UNINIT . as_ptr () ; :: std :: ptr :: addr_of ! ((* ptr) . id) as usize - ptr as usize } , 2usize , concat ! ("Offset of field: " , stringify ! (rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1) , "::" , stringify ! (id)));
 }
 impl Clone
     for rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1
@@ -571,6 +553,9 @@ impl Clone
 }
 #[test]
 fn bindgen_test_layout_rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1() {
+    const UNINIT: ::std::mem::MaybeUninit<
+        rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1,
+    > = ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1>(
         ),
@@ -590,25 +575,19 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1() {
             stringify!(rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1)
         )
     );
-    fn test_field_lo() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<
-                    rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1,
-                >::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).lo) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1),
-                "::",
-                stringify!(lo)
-            )
-        );
-    }
-    test_field_lo();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).lo) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1),
+            "::",
+            stringify!(lo)
+        )
+    );
 }
 impl Clone for rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1 {
     fn clone(&self) -> Self {
@@ -617,6 +596,9 @@ impl Clone for rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1 {
 }
 #[test]
 fn bindgen_test_layout_rte_mbuf__bindgen_ty_3__bindgen_ty_1() {
+    const UNINIT: ::std::mem::MaybeUninit<
+        rte_mbuf__bindgen_ty_3__bindgen_ty_1,
+    > = ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<rte_mbuf__bindgen_ty_3__bindgen_ty_1>(),
         8usize,
@@ -633,25 +615,19 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_3__bindgen_ty_1() {
             stringify!(rte_mbuf__bindgen_ty_3__bindgen_ty_1)
         )
     );
-    fn test_field_hi() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<
-                    rte_mbuf__bindgen_ty_3__bindgen_ty_1,
-                >::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).hi) as usize - ptr as usize
-            },
-            4usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_mbuf__bindgen_ty_3__bindgen_ty_1),
-                "::",
-                stringify!(hi)
-            )
-        );
-    }
-    test_field_hi();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).hi) as usize - ptr as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_mbuf__bindgen_ty_3__bindgen_ty_1),
+            "::",
+            stringify!(hi)
+        )
+    );
 }
 impl Clone for rte_mbuf__bindgen_ty_3__bindgen_ty_1 {
     fn clone(&self) -> Self {
@@ -666,6 +642,9 @@ pub struct rte_mbuf__bindgen_ty_3__bindgen_ty_2 {
 }
 #[test]
 fn bindgen_test_layout_rte_mbuf__bindgen_ty_3__bindgen_ty_2() {
+    const UNINIT: ::std::mem::MaybeUninit<
+        rte_mbuf__bindgen_ty_3__bindgen_ty_2,
+    > = ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<rte_mbuf__bindgen_ty_3__bindgen_ty_2>(),
         8usize,
@@ -682,44 +661,32 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_3__bindgen_ty_2() {
             stringify!(rte_mbuf__bindgen_ty_3__bindgen_ty_2)
         )
     );
-    fn test_field_lo() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<
-                    rte_mbuf__bindgen_ty_3__bindgen_ty_2,
-                >::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).lo) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_mbuf__bindgen_ty_3__bindgen_ty_2),
-                "::",
-                stringify!(lo)
-            )
-        );
-    }
-    test_field_lo();
-    fn test_field_hi() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<
-                    rte_mbuf__bindgen_ty_3__bindgen_ty_2,
-                >::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).hi) as usize - ptr as usize
-            },
-            4usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_mbuf__bindgen_ty_3__bindgen_ty_2),
-                "::",
-                stringify!(hi)
-            )
-        );
-    }
-    test_field_hi();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).lo) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_mbuf__bindgen_ty_3__bindgen_ty_2),
+            "::",
+            stringify!(lo)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).hi) as usize - ptr as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_mbuf__bindgen_ty_3__bindgen_ty_2),
+            "::",
+            stringify!(hi)
+        )
+    );
 }
 impl Clone for rte_mbuf__bindgen_ty_3__bindgen_ty_2 {
     fn clone(&self) -> Self {
@@ -728,6 +695,8 @@ impl Clone for rte_mbuf__bindgen_ty_3__bindgen_ty_2 {
 }
 #[test]
 fn bindgen_test_layout_rte_mbuf__bindgen_ty_3() {
+    const UNINIT: ::std::mem::MaybeUninit<rte_mbuf__bindgen_ty_3> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<rte_mbuf__bindgen_ty_3>(),
         8usize,
@@ -738,78 +707,58 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_3() {
         4usize,
         concat!("Alignment of ", stringify!(rte_mbuf__bindgen_ty_3))
     );
-    fn test_field_rss() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_mbuf__bindgen_ty_3>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).rss) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_mbuf__bindgen_ty_3),
-                "::",
-                stringify!(rss)
-            )
-        );
-    }
-    test_field_rss();
-    fn test_field_fdir() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_mbuf__bindgen_ty_3>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).fdir) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_mbuf__bindgen_ty_3),
-                "::",
-                stringify!(fdir)
-            )
-        );
-    }
-    test_field_fdir();
-    fn test_field_sched() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_mbuf__bindgen_ty_3>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).sched) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_mbuf__bindgen_ty_3),
-                "::",
-                stringify!(sched)
-            )
-        );
-    }
-    test_field_sched();
-    fn test_field_usr() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_mbuf__bindgen_ty_3>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).usr) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_mbuf__bindgen_ty_3),
-                "::",
-                stringify!(usr)
-            )
-        );
-    }
-    test_field_usr();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).rss) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_mbuf__bindgen_ty_3),
+            "::",
+            stringify!(rss)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).fdir) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_mbuf__bindgen_ty_3),
+            "::",
+            stringify!(fdir)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).sched) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_mbuf__bindgen_ty_3),
+            "::",
+            stringify!(sched)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).usr) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_mbuf__bindgen_ty_3),
+            "::",
+            stringify!(usr)
+        )
+    );
 }
 impl Clone for rte_mbuf__bindgen_ty_3 {
     fn clone(&self) -> Self {
@@ -827,6 +776,8 @@ pub struct rte_mbuf__bindgen_ty_4 {
 }
 #[test]
 fn bindgen_test_layout_rte_mbuf__bindgen_ty_4() {
+    const UNINIT: ::std::mem::MaybeUninit<rte_mbuf__bindgen_ty_4> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<rte_mbuf__bindgen_ty_4>(),
         8usize,
@@ -837,42 +788,32 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_4() {
         8usize,
         concat!("Alignment of ", stringify!(rte_mbuf__bindgen_ty_4))
     );
-    fn test_field_userdata() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_mbuf__bindgen_ty_4>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).userdata) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_mbuf__bindgen_ty_4),
-                "::",
-                stringify!(userdata)
-            )
-        );
-    }
-    test_field_userdata();
-    fn test_field_udata64() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_mbuf__bindgen_ty_4>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).udata64) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_mbuf__bindgen_ty_4),
-                "::",
-                stringify!(udata64)
-            )
-        );
-    }
-    test_field_udata64();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).userdata) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_mbuf__bindgen_ty_4),
+            "::",
+            stringify!(userdata)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).udata64) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_mbuf__bindgen_ty_4),
+            "::",
+            stringify!(udata64)
+        )
+    );
 }
 impl Clone for rte_mbuf__bindgen_ty_4 {
     fn clone(&self) -> Self {
@@ -1040,6 +981,8 @@ impl rte_mbuf__bindgen_ty_5__bindgen_ty_1 {
 }
 #[test]
 fn bindgen_test_layout_rte_mbuf__bindgen_ty_5() {
+    const UNINIT: ::std::mem::MaybeUninit<rte_mbuf__bindgen_ty_5> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<rte_mbuf__bindgen_ty_5>(),
         8usize,
@@ -1050,24 +993,19 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_5() {
         8usize,
         concat!("Alignment of ", stringify!(rte_mbuf__bindgen_ty_5))
     );
-    fn test_field_tx_offload() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<rte_mbuf__bindgen_ty_5>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).tx_offload) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_mbuf__bindgen_ty_5),
-                "::",
-                stringify!(tx_offload)
-            )
-        );
-    }
-    test_field_tx_offload();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).tx_offload) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_mbuf__bindgen_ty_5),
+            "::",
+            stringify!(tx_offload)
+        )
+    );
 }
 impl Clone for rte_mbuf__bindgen_ty_5 {
     fn clone(&self) -> Self {
@@ -1076,371 +1014,287 @@ impl Clone for rte_mbuf__bindgen_ty_5 {
 }
 #[test]
 fn bindgen_test_layout_rte_mbuf() {
+    const UNINIT: ::std::mem::MaybeUninit<rte_mbuf> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<rte_mbuf>(),
         128usize,
         concat!("Size of: ", stringify!(rte_mbuf))
     );
-    fn test_field_cacheline0() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<rte_mbuf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).cacheline0) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_mbuf),
-                "::",
-                stringify!(cacheline0)
-            )
-        );
-    }
-    test_field_cacheline0();
-    fn test_field_buf_addr() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<rte_mbuf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).buf_addr) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_mbuf),
-                "::",
-                stringify!(buf_addr)
-            )
-        );
-    }
-    test_field_buf_addr();
-    fn test_field_buf_physaddr() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<rte_mbuf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).buf_physaddr) as usize -
-                    ptr as usize
-            },
-            8usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_mbuf),
-                "::",
-                stringify!(buf_physaddr)
-            )
-        );
-    }
-    test_field_buf_physaddr();
-    fn test_field_buf_len() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<rte_mbuf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).buf_len) as usize - ptr as usize
-            },
-            16usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_mbuf),
-                "::",
-                stringify!(buf_len)
-            )
-        );
-    }
-    test_field_buf_len();
-    fn test_field_rearm_data() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<rte_mbuf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).rearm_data) as usize - ptr as usize
-            },
-            18usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_mbuf),
-                "::",
-                stringify!(rearm_data)
-            )
-        );
-    }
-    test_field_rearm_data();
-    fn test_field_data_off() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<rte_mbuf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).data_off) as usize - ptr as usize
-            },
-            18usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_mbuf),
-                "::",
-                stringify!(data_off)
-            )
-        );
-    }
-    test_field_data_off();
-    fn test_field_nb_segs() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<rte_mbuf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).nb_segs) as usize - ptr as usize
-            },
-            22usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_mbuf),
-                "::",
-                stringify!(nb_segs)
-            )
-        );
-    }
-    test_field_nb_segs();
-    fn test_field_port() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<rte_mbuf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).port) as usize - ptr as usize
-            },
-            23usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_mbuf),
-                "::",
-                stringify!(port)
-            )
-        );
-    }
-    test_field_port();
-    fn test_field_ol_flags() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<rte_mbuf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).ol_flags) as usize - ptr as usize
-            },
-            24usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_mbuf),
-                "::",
-                stringify!(ol_flags)
-            )
-        );
-    }
-    test_field_ol_flags();
-    fn test_field_rx_descriptor_fields1() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<rte_mbuf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).rx_descriptor_fields1) as usize -
-                    ptr as usize
-            },
-            32usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_mbuf),
-                "::",
-                stringify!(rx_descriptor_fields1)
-            )
-        );
-    }
-    test_field_rx_descriptor_fields1();
-    fn test_field_pkt_len() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<rte_mbuf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).pkt_len) as usize - ptr as usize
-            },
-            36usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_mbuf),
-                "::",
-                stringify!(pkt_len)
-            )
-        );
-    }
-    test_field_pkt_len();
-    fn test_field_data_len() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<rte_mbuf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).data_len) as usize - ptr as usize
-            },
-            40usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_mbuf),
-                "::",
-                stringify!(data_len)
-            )
-        );
-    }
-    test_field_data_len();
-    fn test_field_vlan_tci() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<rte_mbuf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).vlan_tci) as usize - ptr as usize
-            },
-            42usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_mbuf),
-                "::",
-                stringify!(vlan_tci)
-            )
-        );
-    }
-    test_field_vlan_tci();
-    fn test_field_hash() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<rte_mbuf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).hash) as usize - ptr as usize
-            },
-            44usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_mbuf),
-                "::",
-                stringify!(hash)
-            )
-        );
-    }
-    test_field_hash();
-    fn test_field_seqn() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<rte_mbuf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).seqn) as usize - ptr as usize
-            },
-            52usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_mbuf),
-                "::",
-                stringify!(seqn)
-            )
-        );
-    }
-    test_field_seqn();
-    fn test_field_vlan_tci_outer() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<rte_mbuf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).vlan_tci_outer) as usize -
-                    ptr as usize
-            },
-            56usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_mbuf),
-                "::",
-                stringify!(vlan_tci_outer)
-            )
-        );
-    }
-    test_field_vlan_tci_outer();
-    fn test_field_cacheline1() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<rte_mbuf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).cacheline1) as usize - ptr as usize
-            },
-            64usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_mbuf),
-                "::",
-                stringify!(cacheline1)
-            )
-        );
-    }
-    test_field_cacheline1();
-    fn test_field_pool() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<rte_mbuf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).pool) as usize - ptr as usize
-            },
-            72usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_mbuf),
-                "::",
-                stringify!(pool)
-            )
-        );
-    }
-    test_field_pool();
-    fn test_field_next() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<rte_mbuf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).next) as usize - ptr as usize
-            },
-            80usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_mbuf),
-                "::",
-                stringify!(next)
-            )
-        );
-    }
-    test_field_next();
-    fn test_field_priv_size() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<rte_mbuf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).priv_size) as usize - ptr as usize
-            },
-            96usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_mbuf),
-                "::",
-                stringify!(priv_size)
-            )
-        );
-    }
-    test_field_priv_size();
-    fn test_field_timesync() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<rte_mbuf>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).timesync) as usize - ptr as usize
-            },
-            98usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_mbuf),
-                "::",
-                stringify!(timesync)
-            )
-        );
-    }
-    test_field_timesync();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).cacheline0) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_mbuf),
+            "::",
+            stringify!(cacheline0)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).buf_addr) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_mbuf),
+            "::",
+            stringify!(buf_addr)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).buf_physaddr) as usize - ptr as usize
+        },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_mbuf),
+            "::",
+            stringify!(buf_physaddr)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).buf_len) as usize - ptr as usize
+        },
+        16usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_mbuf),
+            "::",
+            stringify!(buf_len)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).rearm_data) as usize - ptr as usize
+        },
+        18usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_mbuf),
+            "::",
+            stringify!(rearm_data)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).data_off) as usize - ptr as usize
+        },
+        18usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_mbuf),
+            "::",
+            stringify!(data_off)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).nb_segs) as usize - ptr as usize
+        },
+        22usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_mbuf),
+            "::",
+            stringify!(nb_segs)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).port) as usize - ptr as usize
+        },
+        23usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_mbuf),
+            "::",
+            stringify!(port)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).ol_flags) as usize - ptr as usize
+        },
+        24usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_mbuf),
+            "::",
+            stringify!(ol_flags)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).rx_descriptor_fields1) as usize -
+                ptr as usize
+        },
+        32usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_mbuf),
+            "::",
+            stringify!(rx_descriptor_fields1)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).pkt_len) as usize - ptr as usize
+        },
+        36usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_mbuf),
+            "::",
+            stringify!(pkt_len)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).data_len) as usize - ptr as usize
+        },
+        40usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_mbuf),
+            "::",
+            stringify!(data_len)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).vlan_tci) as usize - ptr as usize
+        },
+        42usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_mbuf),
+            "::",
+            stringify!(vlan_tci)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).hash) as usize - ptr as usize
+        },
+        44usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_mbuf),
+            "::",
+            stringify!(hash)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).seqn) as usize - ptr as usize
+        },
+        52usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_mbuf),
+            "::",
+            stringify!(seqn)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).vlan_tci_outer) as usize - ptr as usize
+        },
+        56usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_mbuf),
+            "::",
+            stringify!(vlan_tci_outer)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).cacheline1) as usize - ptr as usize
+        },
+        64usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_mbuf),
+            "::",
+            stringify!(cacheline1)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).pool) as usize - ptr as usize
+        },
+        72usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_mbuf),
+            "::",
+            stringify!(pool)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).next) as usize - ptr as usize
+        },
+        80usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_mbuf),
+            "::",
+            stringify!(next)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).priv_size) as usize - ptr as usize
+        },
+        96usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_mbuf),
+            "::",
+            stringify!(priv_size)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).timesync) as usize - ptr as usize
+        },
+        98usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_mbuf),
+            "::",
+            stringify!(timesync)
+        )
+    );
 }
 impl Default for rte_mbuf {
     fn default() -> Self {

--- a/tests/expectations/tests/libclang-5/call-conv-field.rs
+++ b/tests/expectations/tests/libclang-5/call-conv-field.rs
@@ -18,6 +18,8 @@ pub struct JNINativeInterface_ {
 }
 #[test]
 fn bindgen_test_layout_JNINativeInterface_() {
+    const UNINIT: ::std::mem::MaybeUninit<JNINativeInterface_> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<JNINativeInterface_>(),
         16usize,
@@ -28,42 +30,32 @@ fn bindgen_test_layout_JNINativeInterface_() {
         8usize,
         concat!("Alignment of ", stringify!(JNINativeInterface_))
     );
-    fn test_field_GetVersion() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<JNINativeInterface_>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).GetVersion) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(JNINativeInterface_),
-                "::",
-                stringify!(GetVersion)
-            )
-        );
-    }
-    test_field_GetVersion();
-    fn test_field___hack() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<JNINativeInterface_>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).__hack) as usize - ptr as usize
-            },
-            8usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(JNINativeInterface_),
-                "::",
-                stringify!(__hack)
-            )
-        );
-    }
-    test_field___hack();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).GetVersion) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(JNINativeInterface_),
+            "::",
+            stringify!(GetVersion)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).__hack) as usize - ptr as usize
+        },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(JNINativeInterface_),
+            "::",
+            stringify!(__hack)
+        )
+    );
 }
 extern "stdcall" {
     pub fn bar();

--- a/tests/expectations/tests/libclang-5/call-conv-field.rs
+++ b/tests/expectations/tests/libclang-5/call-conv-field.rs
@@ -20,6 +20,7 @@ pub struct JNINativeInterface_ {
 fn bindgen_test_layout_JNINativeInterface_() {
     const UNINIT: ::std::mem::MaybeUninit<JNINativeInterface_> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<JNINativeInterface_>(),
         16usize,
@@ -32,7 +33,6 @@ fn bindgen_test_layout_JNINativeInterface_() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).GetVersion) as usize - ptr as usize
         },
         0usize,
@@ -44,10 +44,7 @@ fn bindgen_test_layout_JNINativeInterface_() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).__hack) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).__hack) as usize - ptr as usize },
         8usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/libclang-5/type_alias_template_specialized.rs
+++ b/tests/expectations/tests/libclang-5/type_alias_template_specialized.rs
@@ -12,6 +12,8 @@ pub struct Rooted {
 }
 #[test]
 fn bindgen_test_layout_Rooted() {
+    const UNINIT: ::std::mem::MaybeUninit<Rooted> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<Rooted>(),
         4usize,
@@ -22,23 +24,19 @@ fn bindgen_test_layout_Rooted() {
         4usize,
         concat!("Alignment of ", stringify!(Rooted))
     );
-    fn test_field_ptr() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Rooted>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).ptr) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(Rooted),
-                "::",
-                stringify!(ptr)
-            )
-        );
-    }
-    test_field_ptr();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).ptr) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(Rooted),
+            "::",
+            stringify!(ptr)
+        )
+    );
 }
 impl Default for Rooted {
     fn default() -> Self {

--- a/tests/expectations/tests/libclang-5/type_alias_template_specialized.rs
+++ b/tests/expectations/tests/libclang-5/type_alias_template_specialized.rs
@@ -14,6 +14,7 @@ pub struct Rooted {
 fn bindgen_test_layout_Rooted() {
     const UNINIT: ::std::mem::MaybeUninit<Rooted> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<Rooted>(),
         4usize,
@@ -25,10 +26,7 @@ fn bindgen_test_layout_Rooted() {
         concat!("Alignment of ", stringify!(Rooted))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).ptr) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).ptr) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/libclang-9/call-conv-field.rs
+++ b/tests/expectations/tests/libclang-9/call-conv-field.rs
@@ -18,6 +18,8 @@ pub struct JNINativeInterface_ {
 }
 #[test]
 fn bindgen_test_layout_JNINativeInterface_() {
+    const UNINIT: ::std::mem::MaybeUninit<JNINativeInterface_> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<JNINativeInterface_>(),
         16usize,
@@ -28,42 +30,32 @@ fn bindgen_test_layout_JNINativeInterface_() {
         8usize,
         concat!("Alignment of ", stringify!(JNINativeInterface_))
     );
-    fn test_field_GetVersion() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<JNINativeInterface_>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).GetVersion) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(JNINativeInterface_),
-                "::",
-                stringify!(GetVersion)
-            )
-        );
-    }
-    test_field_GetVersion();
-    fn test_field___hack() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<JNINativeInterface_>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).__hack) as usize - ptr as usize
-            },
-            8usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(JNINativeInterface_),
-                "::",
-                stringify!(__hack)
-            )
-        );
-    }
-    test_field___hack();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).GetVersion) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(JNINativeInterface_),
+            "::",
+            stringify!(GetVersion)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).__hack) as usize - ptr as usize
+        },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(JNINativeInterface_),
+            "::",
+            stringify!(__hack)
+        )
+    );
 }
 extern "stdcall" {
     pub fn bar();

--- a/tests/expectations/tests/libclang-9/call-conv-field.rs
+++ b/tests/expectations/tests/libclang-9/call-conv-field.rs
@@ -20,6 +20,7 @@ pub struct JNINativeInterface_ {
 fn bindgen_test_layout_JNINativeInterface_() {
     const UNINIT: ::std::mem::MaybeUninit<JNINativeInterface_> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<JNINativeInterface_>(),
         16usize,
@@ -32,7 +33,6 @@ fn bindgen_test_layout_JNINativeInterface_() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).GetVersion) as usize - ptr as usize
         },
         0usize,
@@ -44,10 +44,7 @@ fn bindgen_test_layout_JNINativeInterface_() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).__hack) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).__hack) as usize - ptr as usize },
         8usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/libclang-9/class.rs
+++ b/tests/expectations/tests/libclang-9/class.rs
@@ -43,6 +43,8 @@ pub struct C {
 }
 #[test]
 fn bindgen_test_layout_C() {
+    const UNINIT: ::std::mem::MaybeUninit<C> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<C>(),
         40usize,
@@ -53,35 +55,27 @@ fn bindgen_test_layout_C() {
         4usize,
         concat!("Alignment of ", stringify!(C))
     );
-    fn test_field_a() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<C>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-            },
-            0usize,
-            concat!("Offset of field: ", stringify!(C), "::", stringify!(a))
-        );
-    }
-    test_field_a();
-    fn test_field_big_array() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<C>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).big_array) as usize - ptr as usize
-            },
-            4usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(C),
-                "::",
-                stringify!(big_array)
-            )
-        );
-    }
-    test_field_big_array();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+        },
+        0usize,
+        concat!("Offset of field: ", stringify!(C), "::", stringify!(a))
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).big_array) as usize - ptr as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C),
+            "::",
+            stringify!(big_array)
+        )
+    );
 }
 impl Default for C {
     fn default() -> Self {
@@ -100,6 +94,8 @@ pub struct C_with_zero_length_array {
 }
 #[test]
 fn bindgen_test_layout_C_with_zero_length_array() {
+    const UNINIT: ::std::mem::MaybeUninit<C_with_zero_length_array> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<C_with_zero_length_array>(),
         40usize,
@@ -110,64 +106,46 @@ fn bindgen_test_layout_C_with_zero_length_array() {
         4usize,
         concat!("Alignment of ", stringify!(C_with_zero_length_array))
     );
-    fn test_field_a() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<C_with_zero_length_array>::uninit(
-                    );
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(C_with_zero_length_array),
-                "::",
-                stringify!(a)
-            )
-        );
-    }
-    test_field_a();
-    fn test_field_big_array() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<C_with_zero_length_array>::uninit(
-                    );
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).big_array) as usize - ptr as usize
-            },
-            4usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(C_with_zero_length_array),
-                "::",
-                stringify!(big_array)
-            )
-        );
-    }
-    test_field_big_array();
-    fn test_field_zero_length_array() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<C_with_zero_length_array>::uninit(
-                    );
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).zero_length_array) as usize -
-                    ptr as usize
-            },
-            37usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(C_with_zero_length_array),
-                "::",
-                stringify!(zero_length_array)
-            )
-        );
-    }
-    test_field_zero_length_array();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C_with_zero_length_array),
+            "::",
+            stringify!(a)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).big_array) as usize - ptr as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C_with_zero_length_array),
+            "::",
+            stringify!(big_array)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).zero_length_array) as usize -
+                ptr as usize
+        },
+        37usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C_with_zero_length_array),
+            "::",
+            stringify!(zero_length_array)
+        )
+    );
 }
 impl Default for C_with_zero_length_array {
     fn default() -> Self {
@@ -186,6 +164,8 @@ pub struct C_with_zero_length_array_2 {
 }
 #[test]
 fn bindgen_test_layout_C_with_zero_length_array_2() {
+    const UNINIT: ::std::mem::MaybeUninit<C_with_zero_length_array_2> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<C_with_zero_length_array_2>(),
         4usize,
@@ -196,45 +176,33 @@ fn bindgen_test_layout_C_with_zero_length_array_2() {
         4usize,
         concat!("Alignment of ", stringify!(C_with_zero_length_array_2))
     );
-    fn test_field_a() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<
-                    C_with_zero_length_array_2,
-                >::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(C_with_zero_length_array_2),
-                "::",
-                stringify!(a)
-            )
-        );
-    }
-    test_field_a();
-    fn test_field_zero_length_array() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<
-                    C_with_zero_length_array_2,
-                >::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).zero_length_array) as usize -
-                    ptr as usize
-            },
-            4usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(C_with_zero_length_array_2),
-                "::",
-                stringify!(zero_length_array)
-            )
-        );
-    }
-    test_field_zero_length_array();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C_with_zero_length_array_2),
+            "::",
+            stringify!(a)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).zero_length_array) as usize -
+                ptr as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C_with_zero_length_array_2),
+            "::",
+            stringify!(zero_length_array)
+        )
+    );
 }
 #[repr(C)]
 pub struct C_with_incomplete_array {
@@ -244,6 +212,8 @@ pub struct C_with_incomplete_array {
 }
 #[test]
 fn bindgen_test_layout_C_with_incomplete_array() {
+    const UNINIT: ::std::mem::MaybeUninit<C_with_incomplete_array> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<C_with_incomplete_array>(),
         40usize,
@@ -254,64 +224,46 @@ fn bindgen_test_layout_C_with_incomplete_array() {
         4usize,
         concat!("Alignment of ", stringify!(C_with_incomplete_array))
     );
-    fn test_field_a() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<C_with_incomplete_array>::uninit(
-                    );
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(C_with_incomplete_array),
-                "::",
-                stringify!(a)
-            )
-        );
-    }
-    test_field_a();
-    fn test_field_big_array() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<C_with_incomplete_array>::uninit(
-                    );
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).big_array) as usize - ptr as usize
-            },
-            4usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(C_with_incomplete_array),
-                "::",
-                stringify!(big_array)
-            )
-        );
-    }
-    test_field_big_array();
-    fn test_field_incomplete_array() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<C_with_incomplete_array>::uninit(
-                    );
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).incomplete_array) as usize -
-                    ptr as usize
-            },
-            37usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(C_with_incomplete_array),
-                "::",
-                stringify!(incomplete_array)
-            )
-        );
-    }
-    test_field_incomplete_array();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C_with_incomplete_array),
+            "::",
+            stringify!(a)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).big_array) as usize - ptr as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C_with_incomplete_array),
+            "::",
+            stringify!(big_array)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).incomplete_array) as usize -
+                ptr as usize
+        },
+        37usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C_with_incomplete_array),
+            "::",
+            stringify!(incomplete_array)
+        )
+    );
 }
 impl Default for C_with_incomplete_array {
     fn default() -> Self {
@@ -330,6 +282,8 @@ pub struct C_with_incomplete_array_2 {
 }
 #[test]
 fn bindgen_test_layout_C_with_incomplete_array_2() {
+    const UNINIT: ::std::mem::MaybeUninit<C_with_incomplete_array_2> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<C_with_incomplete_array_2>(),
         4usize,
@@ -340,41 +294,33 @@ fn bindgen_test_layout_C_with_incomplete_array_2() {
         4usize,
         concat!("Alignment of ", stringify!(C_with_incomplete_array_2))
     );
-    fn test_field_a() {
-        assert_eq!(
-            unsafe {
-                let uninit = :: std :: mem :: MaybeUninit :: < C_with_incomplete_array_2 > :: uninit () ;
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(C_with_incomplete_array_2),
-                "::",
-                stringify!(a)
-            )
-        );
-    }
-    test_field_a();
-    fn test_field_incomplete_array() {
-        assert_eq!(
-            unsafe {
-                let uninit = :: std :: mem :: MaybeUninit :: < C_with_incomplete_array_2 > :: uninit () ;
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).incomplete_array) as usize -
-                    ptr as usize
-            },
-            4usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(C_with_incomplete_array_2),
-                "::",
-                stringify!(incomplete_array)
-            )
-        );
-    }
-    test_field_incomplete_array();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C_with_incomplete_array_2),
+            "::",
+            stringify!(a)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).incomplete_array) as usize -
+                ptr as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C_with_incomplete_array_2),
+            "::",
+            stringify!(incomplete_array)
+        )
+    );
 }
 #[repr(C)]
 pub struct C_with_zero_length_array_and_incomplete_array {
@@ -385,6 +331,9 @@ pub struct C_with_zero_length_array_and_incomplete_array {
 }
 #[test]
 fn bindgen_test_layout_C_with_zero_length_array_and_incomplete_array() {
+    const UNINIT: ::std::mem::MaybeUninit<
+        C_with_zero_length_array_and_incomplete_array,
+    > = ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<C_with_zero_length_array_and_incomplete_array>(),
         40usize,
@@ -401,84 +350,60 @@ fn bindgen_test_layout_C_with_zero_length_array_and_incomplete_array() {
             stringify!(C_with_zero_length_array_and_incomplete_array)
         )
     );
-    fn test_field_a() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<
-                    C_with_zero_length_array_and_incomplete_array,
-                >::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(C_with_zero_length_array_and_incomplete_array),
-                "::",
-                stringify!(a)
-            )
-        );
-    }
-    test_field_a();
-    fn test_field_big_array() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<
-                    C_with_zero_length_array_and_incomplete_array,
-                >::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).big_array) as usize - ptr as usize
-            },
-            4usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(C_with_zero_length_array_and_incomplete_array),
-                "::",
-                stringify!(big_array)
-            )
-        );
-    }
-    test_field_big_array();
-    fn test_field_zero_length_array() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<
-                    C_with_zero_length_array_and_incomplete_array,
-                >::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).zero_length_array) as usize -
-                    ptr as usize
-            },
-            37usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(C_with_zero_length_array_and_incomplete_array),
-                "::",
-                stringify!(zero_length_array)
-            )
-        );
-    }
-    test_field_zero_length_array();
-    fn test_field_incomplete_array() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<
-                    C_with_zero_length_array_and_incomplete_array,
-                >::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).incomplete_array) as usize -
-                    ptr as usize
-            },
-            37usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(C_with_zero_length_array_and_incomplete_array),
-                "::",
-                stringify!(incomplete_array)
-            )
-        );
-    }
-    test_field_incomplete_array();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C_with_zero_length_array_and_incomplete_array),
+            "::",
+            stringify!(a)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).big_array) as usize - ptr as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C_with_zero_length_array_and_incomplete_array),
+            "::",
+            stringify!(big_array)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).zero_length_array) as usize -
+                ptr as usize
+        },
+        37usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C_with_zero_length_array_and_incomplete_array),
+            "::",
+            stringify!(zero_length_array)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).incomplete_array) as usize -
+                ptr as usize
+        },
+        37usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C_with_zero_length_array_and_incomplete_array),
+            "::",
+            stringify!(incomplete_array)
+        )
+    );
 }
 impl Default for C_with_zero_length_array_and_incomplete_array {
     fn default() -> Self {
@@ -498,6 +423,9 @@ pub struct C_with_zero_length_array_and_incomplete_array_2 {
 }
 #[test]
 fn bindgen_test_layout_C_with_zero_length_array_and_incomplete_array_2() {
+    const UNINIT: ::std::mem::MaybeUninit<
+        C_with_zero_length_array_and_incomplete_array_2,
+    > = ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<C_with_zero_length_array_and_incomplete_array_2>(
         ),
@@ -516,65 +444,47 @@ fn bindgen_test_layout_C_with_zero_length_array_and_incomplete_array_2() {
             stringify!(C_with_zero_length_array_and_incomplete_array_2)
         )
     );
-    fn test_field_a() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<
-                    C_with_zero_length_array_and_incomplete_array_2,
-                >::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(C_with_zero_length_array_and_incomplete_array_2),
-                "::",
-                stringify!(a)
-            )
-        );
-    }
-    test_field_a();
-    fn test_field_zero_length_array() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<
-                    C_with_zero_length_array_and_incomplete_array_2,
-                >::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).zero_length_array) as usize -
-                    ptr as usize
-            },
-            4usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(C_with_zero_length_array_and_incomplete_array_2),
-                "::",
-                stringify!(zero_length_array)
-            )
-        );
-    }
-    test_field_zero_length_array();
-    fn test_field_incomplete_array() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<
-                    C_with_zero_length_array_and_incomplete_array_2,
-                >::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).incomplete_array) as usize -
-                    ptr as usize
-            },
-            4usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(C_with_zero_length_array_and_incomplete_array_2),
-                "::",
-                stringify!(incomplete_array)
-            )
-        );
-    }
-    test_field_incomplete_array();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C_with_zero_length_array_and_incomplete_array_2),
+            "::",
+            stringify!(a)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).zero_length_array) as usize -
+                ptr as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C_with_zero_length_array_and_incomplete_array_2),
+            "::",
+            stringify!(zero_length_array)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).incomplete_array) as usize -
+                ptr as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C_with_zero_length_array_and_incomplete_array_2),
+            "::",
+            stringify!(incomplete_array)
+        )
+    );
 }
 #[repr(C)]
 #[derive(Debug, Default, Hash, PartialOrd, Ord, PartialEq, Eq)]
@@ -583,6 +493,8 @@ pub struct WithDtor {
 }
 #[test]
 fn bindgen_test_layout_WithDtor() {
+    const UNINIT: ::std::mem::MaybeUninit<WithDtor> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<WithDtor>(),
         4usize,
@@ -593,23 +505,19 @@ fn bindgen_test_layout_WithDtor() {
         4usize,
         concat!("Alignment of ", stringify!(WithDtor))
     );
-    fn test_field_b() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<WithDtor>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(WithDtor),
-                "::",
-                stringify!(b)
-            )
-        );
-    }
-    test_field_b();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(WithDtor),
+            "::",
+            stringify!(b)
+        )
+    );
 }
 #[repr(C)]
 pub struct IncompleteArrayNonCopiable {
@@ -618,6 +526,8 @@ pub struct IncompleteArrayNonCopiable {
 }
 #[test]
 fn bindgen_test_layout_IncompleteArrayNonCopiable() {
+    const UNINIT: ::std::mem::MaybeUninit<IncompleteArrayNonCopiable> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<IncompleteArrayNonCopiable>(),
         8usize,
@@ -628,45 +538,33 @@ fn bindgen_test_layout_IncompleteArrayNonCopiable() {
         8usize,
         concat!("Alignment of ", stringify!(IncompleteArrayNonCopiable))
     );
-    fn test_field_whatever() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<
-                    IncompleteArrayNonCopiable,
-                >::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).whatever) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(IncompleteArrayNonCopiable),
-                "::",
-                stringify!(whatever)
-            )
-        );
-    }
-    test_field_whatever();
-    fn test_field_incomplete_array() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<
-                    IncompleteArrayNonCopiable,
-                >::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).incomplete_array) as usize -
-                    ptr as usize
-            },
-            8usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(IncompleteArrayNonCopiable),
-                "::",
-                stringify!(incomplete_array)
-            )
-        );
-    }
-    test_field_incomplete_array();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).whatever) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(IncompleteArrayNonCopiable),
+            "::",
+            stringify!(whatever)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).incomplete_array) as usize -
+                ptr as usize
+        },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(IncompleteArrayNonCopiable),
+            "::",
+            stringify!(incomplete_array)
+        )
+    );
 }
 impl Default for IncompleteArrayNonCopiable {
     fn default() -> Self {
@@ -685,6 +583,8 @@ pub union Union {
 }
 #[test]
 fn bindgen_test_layout_Union() {
+    const UNINIT: ::std::mem::MaybeUninit<Union> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<Union>(),
         4usize,
@@ -695,40 +595,22 @@ fn bindgen_test_layout_Union() {
         4usize,
         concat!("Alignment of ", stringify!(Union))
     );
-    fn test_field_d() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Union>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(Union),
-                "::",
-                stringify!(d)
-            )
-        );
-    }
-    test_field_d();
-    fn test_field_i() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Union>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).i) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(Union),
-                "::",
-                stringify!(i)
-            )
-        );
-    }
-    test_field_i();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize
+        },
+        0usize,
+        concat!("Offset of field: ", stringify!(Union), "::", stringify!(d))
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).i) as usize - ptr as usize
+        },
+        0usize,
+        concat!("Offset of field: ", stringify!(Union), "::", stringify!(i))
+    );
 }
 impl Default for Union {
     fn default() -> Self {
@@ -746,6 +628,8 @@ pub struct WithUnion {
 }
 #[test]
 fn bindgen_test_layout_WithUnion() {
+    const UNINIT: ::std::mem::MaybeUninit<WithUnion> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<WithUnion>(),
         4usize,
@@ -756,23 +640,19 @@ fn bindgen_test_layout_WithUnion() {
         4usize,
         concat!("Alignment of ", stringify!(WithUnion))
     );
-    fn test_field_data() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<WithUnion>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).data) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(WithUnion),
-                "::",
-                stringify!(data)
-            )
-        );
-    }
-    test_field_data();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).data) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(WithUnion),
+            "::",
+            stringify!(data)
+        )
+    );
 }
 impl Default for WithUnion {
     fn default() -> Self {

--- a/tests/expectations/tests/libclang-9/class.rs
+++ b/tests/expectations/tests/libclang-9/class.rs
@@ -45,6 +45,7 @@ pub struct C {
 fn bindgen_test_layout_C() {
     const UNINIT: ::std::mem::MaybeUninit<C> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<C>(),
         40usize,
@@ -56,16 +57,12 @@ fn bindgen_test_layout_C() {
         concat!("Alignment of ", stringify!(C))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
         0usize,
         concat!("Offset of field: ", stringify!(C), "::", stringify!(a))
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).big_array) as usize - ptr as usize
         },
         4usize,
@@ -96,6 +93,7 @@ pub struct C_with_zero_length_array {
 fn bindgen_test_layout_C_with_zero_length_array() {
     const UNINIT: ::std::mem::MaybeUninit<C_with_zero_length_array> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<C_with_zero_length_array>(),
         40usize,
@@ -107,10 +105,7 @@ fn bindgen_test_layout_C_with_zero_length_array() {
         concat!("Alignment of ", stringify!(C_with_zero_length_array))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -121,7 +116,6 @@ fn bindgen_test_layout_C_with_zero_length_array() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).big_array) as usize - ptr as usize
         },
         4usize,
@@ -134,7 +128,6 @@ fn bindgen_test_layout_C_with_zero_length_array() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).zero_length_array) as usize -
                 ptr as usize
         },
@@ -166,6 +159,7 @@ pub struct C_with_zero_length_array_2 {
 fn bindgen_test_layout_C_with_zero_length_array_2() {
     const UNINIT: ::std::mem::MaybeUninit<C_with_zero_length_array_2> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<C_with_zero_length_array_2>(),
         4usize,
@@ -177,10 +171,7 @@ fn bindgen_test_layout_C_with_zero_length_array_2() {
         concat!("Alignment of ", stringify!(C_with_zero_length_array_2))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -191,7 +182,6 @@ fn bindgen_test_layout_C_with_zero_length_array_2() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).zero_length_array) as usize -
                 ptr as usize
         },
@@ -214,6 +204,7 @@ pub struct C_with_incomplete_array {
 fn bindgen_test_layout_C_with_incomplete_array() {
     const UNINIT: ::std::mem::MaybeUninit<C_with_incomplete_array> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<C_with_incomplete_array>(),
         40usize,
@@ -225,10 +216,7 @@ fn bindgen_test_layout_C_with_incomplete_array() {
         concat!("Alignment of ", stringify!(C_with_incomplete_array))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -239,7 +227,6 @@ fn bindgen_test_layout_C_with_incomplete_array() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).big_array) as usize - ptr as usize
         },
         4usize,
@@ -252,7 +239,6 @@ fn bindgen_test_layout_C_with_incomplete_array() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).incomplete_array) as usize -
                 ptr as usize
         },
@@ -284,6 +270,7 @@ pub struct C_with_incomplete_array_2 {
 fn bindgen_test_layout_C_with_incomplete_array_2() {
     const UNINIT: ::std::mem::MaybeUninit<C_with_incomplete_array_2> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<C_with_incomplete_array_2>(),
         4usize,
@@ -295,10 +282,7 @@ fn bindgen_test_layout_C_with_incomplete_array_2() {
         concat!("Alignment of ", stringify!(C_with_incomplete_array_2))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -309,7 +293,6 @@ fn bindgen_test_layout_C_with_incomplete_array_2() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).incomplete_array) as usize -
                 ptr as usize
         },
@@ -334,6 +317,7 @@ fn bindgen_test_layout_C_with_zero_length_array_and_incomplete_array() {
     const UNINIT: ::std::mem::MaybeUninit<
         C_with_zero_length_array_and_incomplete_array,
     > = ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<C_with_zero_length_array_and_incomplete_array>(),
         40usize,
@@ -351,10 +335,7 @@ fn bindgen_test_layout_C_with_zero_length_array_and_incomplete_array() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -365,7 +346,6 @@ fn bindgen_test_layout_C_with_zero_length_array_and_incomplete_array() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).big_array) as usize - ptr as usize
         },
         4usize,
@@ -378,7 +358,6 @@ fn bindgen_test_layout_C_with_zero_length_array_and_incomplete_array() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).zero_length_array) as usize -
                 ptr as usize
         },
@@ -392,7 +371,6 @@ fn bindgen_test_layout_C_with_zero_length_array_and_incomplete_array() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).incomplete_array) as usize -
                 ptr as usize
         },
@@ -426,6 +404,7 @@ fn bindgen_test_layout_C_with_zero_length_array_and_incomplete_array_2() {
     const UNINIT: ::std::mem::MaybeUninit<
         C_with_zero_length_array_and_incomplete_array_2,
     > = ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<C_with_zero_length_array_and_incomplete_array_2>(
         ),
@@ -445,10 +424,7 @@ fn bindgen_test_layout_C_with_zero_length_array_and_incomplete_array_2() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -459,7 +435,6 @@ fn bindgen_test_layout_C_with_zero_length_array_and_incomplete_array_2() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).zero_length_array) as usize -
                 ptr as usize
         },
@@ -473,7 +448,6 @@ fn bindgen_test_layout_C_with_zero_length_array_and_incomplete_array_2() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).incomplete_array) as usize -
                 ptr as usize
         },
@@ -495,6 +469,7 @@ pub struct WithDtor {
 fn bindgen_test_layout_WithDtor() {
     const UNINIT: ::std::mem::MaybeUninit<WithDtor> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<WithDtor>(),
         4usize,
@@ -506,10 +481,7 @@ fn bindgen_test_layout_WithDtor() {
         concat!("Alignment of ", stringify!(WithDtor))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -528,6 +500,7 @@ pub struct IncompleteArrayNonCopiable {
 fn bindgen_test_layout_IncompleteArrayNonCopiable() {
     const UNINIT: ::std::mem::MaybeUninit<IncompleteArrayNonCopiable> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<IncompleteArrayNonCopiable>(),
         8usize,
@@ -540,7 +513,6 @@ fn bindgen_test_layout_IncompleteArrayNonCopiable() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).whatever) as usize - ptr as usize
         },
         0usize,
@@ -553,7 +525,6 @@ fn bindgen_test_layout_IncompleteArrayNonCopiable() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).incomplete_array) as usize -
                 ptr as usize
         },
@@ -585,6 +556,7 @@ pub union Union {
 fn bindgen_test_layout_Union() {
     const UNINIT: ::std::mem::MaybeUninit<Union> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<Union>(),
         4usize,
@@ -596,18 +568,12 @@ fn bindgen_test_layout_Union() {
         concat!("Alignment of ", stringify!(Union))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize },
         0usize,
         concat!("Offset of field: ", stringify!(Union), "::", stringify!(d))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).i) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).i) as usize - ptr as usize },
         0usize,
         concat!("Offset of field: ", stringify!(Union), "::", stringify!(i))
     );
@@ -630,6 +596,7 @@ pub struct WithUnion {
 fn bindgen_test_layout_WithUnion() {
     const UNINIT: ::std::mem::MaybeUninit<WithUnion> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<WithUnion>(),
         4usize,
@@ -641,10 +608,7 @@ fn bindgen_test_layout_WithUnion() {
         concat!("Alignment of ", stringify!(WithUnion))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).data) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).data) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/libclang-9/class_1_0.rs
+++ b/tests/expectations/tests/libclang-9/class_1_0.rs
@@ -86,6 +86,8 @@ pub struct C {
 }
 #[test]
 fn bindgen_test_layout_C() {
+    const UNINIT: ::std::mem::MaybeUninit<C> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<C>(),
         40usize,
@@ -96,35 +98,27 @@ fn bindgen_test_layout_C() {
         4usize,
         concat!("Alignment of ", stringify!(C))
     );
-    fn test_field_a() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<C>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-            },
-            0usize,
-            concat!("Offset of field: ", stringify!(C), "::", stringify!(a))
-        );
-    }
-    test_field_a();
-    fn test_field_big_array() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<C>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).big_array) as usize - ptr as usize
-            },
-            4usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(C),
-                "::",
-                stringify!(big_array)
-            )
-        );
-    }
-    test_field_big_array();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+        },
+        0usize,
+        concat!("Offset of field: ", stringify!(C), "::", stringify!(a))
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).big_array) as usize - ptr as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C),
+            "::",
+            stringify!(big_array)
+        )
+    );
 }
 impl Clone for C {
     fn clone(&self) -> Self {
@@ -153,6 +147,8 @@ pub struct C_with_zero_length_array {
 }
 #[test]
 fn bindgen_test_layout_C_with_zero_length_array() {
+    const UNINIT: ::std::mem::MaybeUninit<C_with_zero_length_array> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<C_with_zero_length_array>(),
         40usize,
@@ -163,64 +159,46 @@ fn bindgen_test_layout_C_with_zero_length_array() {
         4usize,
         concat!("Alignment of ", stringify!(C_with_zero_length_array))
     );
-    fn test_field_a() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<C_with_zero_length_array>::uninit(
-                    );
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(C_with_zero_length_array),
-                "::",
-                stringify!(a)
-            )
-        );
-    }
-    test_field_a();
-    fn test_field_big_array() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<C_with_zero_length_array>::uninit(
-                    );
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).big_array) as usize - ptr as usize
-            },
-            4usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(C_with_zero_length_array),
-                "::",
-                stringify!(big_array)
-            )
-        );
-    }
-    test_field_big_array();
-    fn test_field_zero_length_array() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<C_with_zero_length_array>::uninit(
-                    );
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).zero_length_array) as usize -
-                    ptr as usize
-            },
-            37usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(C_with_zero_length_array),
-                "::",
-                stringify!(zero_length_array)
-            )
-        );
-    }
-    test_field_zero_length_array();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C_with_zero_length_array),
+            "::",
+            stringify!(a)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).big_array) as usize - ptr as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C_with_zero_length_array),
+            "::",
+            stringify!(big_array)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).zero_length_array) as usize -
+                ptr as usize
+        },
+        37usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C_with_zero_length_array),
+            "::",
+            stringify!(zero_length_array)
+        )
+    );
 }
 impl Default for C_with_zero_length_array {
     fn default() -> Self {
@@ -239,6 +217,8 @@ pub struct C_with_zero_length_array_2 {
 }
 #[test]
 fn bindgen_test_layout_C_with_zero_length_array_2() {
+    const UNINIT: ::std::mem::MaybeUninit<C_with_zero_length_array_2> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<C_with_zero_length_array_2>(),
         4usize,
@@ -249,45 +229,33 @@ fn bindgen_test_layout_C_with_zero_length_array_2() {
         4usize,
         concat!("Alignment of ", stringify!(C_with_zero_length_array_2))
     );
-    fn test_field_a() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<
-                    C_with_zero_length_array_2,
-                >::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(C_with_zero_length_array_2),
-                "::",
-                stringify!(a)
-            )
-        );
-    }
-    test_field_a();
-    fn test_field_zero_length_array() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<
-                    C_with_zero_length_array_2,
-                >::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).zero_length_array) as usize -
-                    ptr as usize
-            },
-            4usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(C_with_zero_length_array_2),
-                "::",
-                stringify!(zero_length_array)
-            )
-        );
-    }
-    test_field_zero_length_array();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C_with_zero_length_array_2),
+            "::",
+            stringify!(a)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).zero_length_array) as usize -
+                ptr as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C_with_zero_length_array_2),
+            "::",
+            stringify!(zero_length_array)
+        )
+    );
 }
 #[repr(C)]
 pub struct C_with_incomplete_array {
@@ -297,6 +265,8 @@ pub struct C_with_incomplete_array {
 }
 #[test]
 fn bindgen_test_layout_C_with_incomplete_array() {
+    const UNINIT: ::std::mem::MaybeUninit<C_with_incomplete_array> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<C_with_incomplete_array>(),
         40usize,
@@ -307,64 +277,46 @@ fn bindgen_test_layout_C_with_incomplete_array() {
         4usize,
         concat!("Alignment of ", stringify!(C_with_incomplete_array))
     );
-    fn test_field_a() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<C_with_incomplete_array>::uninit(
-                    );
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(C_with_incomplete_array),
-                "::",
-                stringify!(a)
-            )
-        );
-    }
-    test_field_a();
-    fn test_field_big_array() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<C_with_incomplete_array>::uninit(
-                    );
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).big_array) as usize - ptr as usize
-            },
-            4usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(C_with_incomplete_array),
-                "::",
-                stringify!(big_array)
-            )
-        );
-    }
-    test_field_big_array();
-    fn test_field_incomplete_array() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<C_with_incomplete_array>::uninit(
-                    );
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).incomplete_array) as usize -
-                    ptr as usize
-            },
-            37usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(C_with_incomplete_array),
-                "::",
-                stringify!(incomplete_array)
-            )
-        );
-    }
-    test_field_incomplete_array();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C_with_incomplete_array),
+            "::",
+            stringify!(a)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).big_array) as usize - ptr as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C_with_incomplete_array),
+            "::",
+            stringify!(big_array)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).incomplete_array) as usize -
+                ptr as usize
+        },
+        37usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C_with_incomplete_array),
+            "::",
+            stringify!(incomplete_array)
+        )
+    );
 }
 impl Default for C_with_incomplete_array {
     fn default() -> Self {
@@ -383,6 +335,8 @@ pub struct C_with_incomplete_array_2 {
 }
 #[test]
 fn bindgen_test_layout_C_with_incomplete_array_2() {
+    const UNINIT: ::std::mem::MaybeUninit<C_with_incomplete_array_2> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<C_with_incomplete_array_2>(),
         4usize,
@@ -393,41 +347,33 @@ fn bindgen_test_layout_C_with_incomplete_array_2() {
         4usize,
         concat!("Alignment of ", stringify!(C_with_incomplete_array_2))
     );
-    fn test_field_a() {
-        assert_eq!(
-            unsafe {
-                let uninit = :: std :: mem :: MaybeUninit :: < C_with_incomplete_array_2 > :: uninit () ;
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(C_with_incomplete_array_2),
-                "::",
-                stringify!(a)
-            )
-        );
-    }
-    test_field_a();
-    fn test_field_incomplete_array() {
-        assert_eq!(
-            unsafe {
-                let uninit = :: std :: mem :: MaybeUninit :: < C_with_incomplete_array_2 > :: uninit () ;
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).incomplete_array) as usize -
-                    ptr as usize
-            },
-            4usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(C_with_incomplete_array_2),
-                "::",
-                stringify!(incomplete_array)
-            )
-        );
-    }
-    test_field_incomplete_array();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C_with_incomplete_array_2),
+            "::",
+            stringify!(a)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).incomplete_array) as usize -
+                ptr as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C_with_incomplete_array_2),
+            "::",
+            stringify!(incomplete_array)
+        )
+    );
 }
 #[repr(C)]
 pub struct C_with_zero_length_array_and_incomplete_array {
@@ -438,6 +384,9 @@ pub struct C_with_zero_length_array_and_incomplete_array {
 }
 #[test]
 fn bindgen_test_layout_C_with_zero_length_array_and_incomplete_array() {
+    const UNINIT: ::std::mem::MaybeUninit<
+        C_with_zero_length_array_and_incomplete_array,
+    > = ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<C_with_zero_length_array_and_incomplete_array>(),
         40usize,
@@ -454,84 +403,60 @@ fn bindgen_test_layout_C_with_zero_length_array_and_incomplete_array() {
             stringify!(C_with_zero_length_array_and_incomplete_array)
         )
     );
-    fn test_field_a() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<
-                    C_with_zero_length_array_and_incomplete_array,
-                >::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(C_with_zero_length_array_and_incomplete_array),
-                "::",
-                stringify!(a)
-            )
-        );
-    }
-    test_field_a();
-    fn test_field_big_array() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<
-                    C_with_zero_length_array_and_incomplete_array,
-                >::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).big_array) as usize - ptr as usize
-            },
-            4usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(C_with_zero_length_array_and_incomplete_array),
-                "::",
-                stringify!(big_array)
-            )
-        );
-    }
-    test_field_big_array();
-    fn test_field_zero_length_array() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<
-                    C_with_zero_length_array_and_incomplete_array,
-                >::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).zero_length_array) as usize -
-                    ptr as usize
-            },
-            37usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(C_with_zero_length_array_and_incomplete_array),
-                "::",
-                stringify!(zero_length_array)
-            )
-        );
-    }
-    test_field_zero_length_array();
-    fn test_field_incomplete_array() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<
-                    C_with_zero_length_array_and_incomplete_array,
-                >::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).incomplete_array) as usize -
-                    ptr as usize
-            },
-            37usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(C_with_zero_length_array_and_incomplete_array),
-                "::",
-                stringify!(incomplete_array)
-            )
-        );
-    }
-    test_field_incomplete_array();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C_with_zero_length_array_and_incomplete_array),
+            "::",
+            stringify!(a)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).big_array) as usize - ptr as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C_with_zero_length_array_and_incomplete_array),
+            "::",
+            stringify!(big_array)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).zero_length_array) as usize -
+                ptr as usize
+        },
+        37usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C_with_zero_length_array_and_incomplete_array),
+            "::",
+            stringify!(zero_length_array)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).incomplete_array) as usize -
+                ptr as usize
+        },
+        37usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C_with_zero_length_array_and_incomplete_array),
+            "::",
+            stringify!(incomplete_array)
+        )
+    );
 }
 impl Default for C_with_zero_length_array_and_incomplete_array {
     fn default() -> Self {
@@ -551,6 +476,9 @@ pub struct C_with_zero_length_array_and_incomplete_array_2 {
 }
 #[test]
 fn bindgen_test_layout_C_with_zero_length_array_and_incomplete_array_2() {
+    const UNINIT: ::std::mem::MaybeUninit<
+        C_with_zero_length_array_and_incomplete_array_2,
+    > = ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<C_with_zero_length_array_and_incomplete_array_2>(
         ),
@@ -569,65 +497,47 @@ fn bindgen_test_layout_C_with_zero_length_array_and_incomplete_array_2() {
             stringify!(C_with_zero_length_array_and_incomplete_array_2)
         )
     );
-    fn test_field_a() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<
-                    C_with_zero_length_array_and_incomplete_array_2,
-                >::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(C_with_zero_length_array_and_incomplete_array_2),
-                "::",
-                stringify!(a)
-            )
-        );
-    }
-    test_field_a();
-    fn test_field_zero_length_array() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<
-                    C_with_zero_length_array_and_incomplete_array_2,
-                >::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).zero_length_array) as usize -
-                    ptr as usize
-            },
-            4usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(C_with_zero_length_array_and_incomplete_array_2),
-                "::",
-                stringify!(zero_length_array)
-            )
-        );
-    }
-    test_field_zero_length_array();
-    fn test_field_incomplete_array() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<
-                    C_with_zero_length_array_and_incomplete_array_2,
-                >::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).incomplete_array) as usize -
-                    ptr as usize
-            },
-            4usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(C_with_zero_length_array_and_incomplete_array_2),
-                "::",
-                stringify!(incomplete_array)
-            )
-        );
-    }
-    test_field_incomplete_array();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C_with_zero_length_array_and_incomplete_array_2),
+            "::",
+            stringify!(a)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).zero_length_array) as usize -
+                ptr as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C_with_zero_length_array_and_incomplete_array_2),
+            "::",
+            stringify!(zero_length_array)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).incomplete_array) as usize -
+                ptr as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C_with_zero_length_array_and_incomplete_array_2),
+            "::",
+            stringify!(incomplete_array)
+        )
+    );
 }
 #[repr(C)]
 #[derive(Debug, Default, Hash, PartialEq, Eq)]
@@ -636,6 +546,8 @@ pub struct WithDtor {
 }
 #[test]
 fn bindgen_test_layout_WithDtor() {
+    const UNINIT: ::std::mem::MaybeUninit<WithDtor> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<WithDtor>(),
         4usize,
@@ -646,23 +558,19 @@ fn bindgen_test_layout_WithDtor() {
         4usize,
         concat!("Alignment of ", stringify!(WithDtor))
     );
-    fn test_field_b() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<WithDtor>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(WithDtor),
-                "::",
-                stringify!(b)
-            )
-        );
-    }
-    test_field_b();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(WithDtor),
+            "::",
+            stringify!(b)
+        )
+    );
 }
 #[repr(C)]
 pub struct IncompleteArrayNonCopiable {
@@ -671,6 +579,8 @@ pub struct IncompleteArrayNonCopiable {
 }
 #[test]
 fn bindgen_test_layout_IncompleteArrayNonCopiable() {
+    const UNINIT: ::std::mem::MaybeUninit<IncompleteArrayNonCopiable> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<IncompleteArrayNonCopiable>(),
         8usize,
@@ -681,45 +591,33 @@ fn bindgen_test_layout_IncompleteArrayNonCopiable() {
         8usize,
         concat!("Alignment of ", stringify!(IncompleteArrayNonCopiable))
     );
-    fn test_field_whatever() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<
-                    IncompleteArrayNonCopiable,
-                >::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).whatever) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(IncompleteArrayNonCopiable),
-                "::",
-                stringify!(whatever)
-            )
-        );
-    }
-    test_field_whatever();
-    fn test_field_incomplete_array() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<
-                    IncompleteArrayNonCopiable,
-                >::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).incomplete_array) as usize -
-                    ptr as usize
-            },
-            8usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(IncompleteArrayNonCopiable),
-                "::",
-                stringify!(incomplete_array)
-            )
-        );
-    }
-    test_field_incomplete_array();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).whatever) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(IncompleteArrayNonCopiable),
+            "::",
+            stringify!(whatever)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).incomplete_array) as usize -
+                ptr as usize
+        },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(IncompleteArrayNonCopiable),
+            "::",
+            stringify!(incomplete_array)
+        )
+    );
 }
 impl Default for IncompleteArrayNonCopiable {
     fn default() -> Self {
@@ -739,6 +637,8 @@ pub struct Union {
 }
 #[test]
 fn bindgen_test_layout_Union() {
+    const UNINIT: ::std::mem::MaybeUninit<Union> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<Union>(),
         4usize,
@@ -749,40 +649,22 @@ fn bindgen_test_layout_Union() {
         4usize,
         concat!("Alignment of ", stringify!(Union))
     );
-    fn test_field_d() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Union>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(Union),
-                "::",
-                stringify!(d)
-            )
-        );
-    }
-    test_field_d();
-    fn test_field_i() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Union>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).i) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(Union),
-                "::",
-                stringify!(i)
-            )
-        );
-    }
-    test_field_i();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize
+        },
+        0usize,
+        concat!("Offset of field: ", stringify!(Union), "::", stringify!(d))
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).i) as usize - ptr as usize
+        },
+        0usize,
+        concat!("Offset of field: ", stringify!(Union), "::", stringify!(i))
+    );
 }
 impl Clone for Union {
     fn clone(&self) -> Self {
@@ -796,6 +678,8 @@ pub struct WithUnion {
 }
 #[test]
 fn bindgen_test_layout_WithUnion() {
+    const UNINIT: ::std::mem::MaybeUninit<WithUnion> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<WithUnion>(),
         4usize,
@@ -806,23 +690,19 @@ fn bindgen_test_layout_WithUnion() {
         4usize,
         concat!("Alignment of ", stringify!(WithUnion))
     );
-    fn test_field_data() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<WithUnion>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).data) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(WithUnion),
-                "::",
-                stringify!(data)
-            )
-        );
-    }
-    test_field_data();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).data) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(WithUnion),
+            "::",
+            stringify!(data)
+        )
+    );
 }
 impl Clone for WithUnion {
     fn clone(&self) -> Self {

--- a/tests/expectations/tests/libclang-9/class_1_0.rs
+++ b/tests/expectations/tests/libclang-9/class_1_0.rs
@@ -88,6 +88,7 @@ pub struct C {
 fn bindgen_test_layout_C() {
     const UNINIT: ::std::mem::MaybeUninit<C> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<C>(),
         40usize,
@@ -99,16 +100,12 @@ fn bindgen_test_layout_C() {
         concat!("Alignment of ", stringify!(C))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
         0usize,
         concat!("Offset of field: ", stringify!(C), "::", stringify!(a))
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).big_array) as usize - ptr as usize
         },
         4usize,
@@ -149,6 +146,7 @@ pub struct C_with_zero_length_array {
 fn bindgen_test_layout_C_with_zero_length_array() {
     const UNINIT: ::std::mem::MaybeUninit<C_with_zero_length_array> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<C_with_zero_length_array>(),
         40usize,
@@ -160,10 +158,7 @@ fn bindgen_test_layout_C_with_zero_length_array() {
         concat!("Alignment of ", stringify!(C_with_zero_length_array))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -174,7 +169,6 @@ fn bindgen_test_layout_C_with_zero_length_array() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).big_array) as usize - ptr as usize
         },
         4usize,
@@ -187,7 +181,6 @@ fn bindgen_test_layout_C_with_zero_length_array() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).zero_length_array) as usize -
                 ptr as usize
         },
@@ -219,6 +212,7 @@ pub struct C_with_zero_length_array_2 {
 fn bindgen_test_layout_C_with_zero_length_array_2() {
     const UNINIT: ::std::mem::MaybeUninit<C_with_zero_length_array_2> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<C_with_zero_length_array_2>(),
         4usize,
@@ -230,10 +224,7 @@ fn bindgen_test_layout_C_with_zero_length_array_2() {
         concat!("Alignment of ", stringify!(C_with_zero_length_array_2))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -244,7 +235,6 @@ fn bindgen_test_layout_C_with_zero_length_array_2() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).zero_length_array) as usize -
                 ptr as usize
         },
@@ -267,6 +257,7 @@ pub struct C_with_incomplete_array {
 fn bindgen_test_layout_C_with_incomplete_array() {
     const UNINIT: ::std::mem::MaybeUninit<C_with_incomplete_array> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<C_with_incomplete_array>(),
         40usize,
@@ -278,10 +269,7 @@ fn bindgen_test_layout_C_with_incomplete_array() {
         concat!("Alignment of ", stringify!(C_with_incomplete_array))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -292,7 +280,6 @@ fn bindgen_test_layout_C_with_incomplete_array() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).big_array) as usize - ptr as usize
         },
         4usize,
@@ -305,7 +292,6 @@ fn bindgen_test_layout_C_with_incomplete_array() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).incomplete_array) as usize -
                 ptr as usize
         },
@@ -337,6 +323,7 @@ pub struct C_with_incomplete_array_2 {
 fn bindgen_test_layout_C_with_incomplete_array_2() {
     const UNINIT: ::std::mem::MaybeUninit<C_with_incomplete_array_2> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<C_with_incomplete_array_2>(),
         4usize,
@@ -348,10 +335,7 @@ fn bindgen_test_layout_C_with_incomplete_array_2() {
         concat!("Alignment of ", stringify!(C_with_incomplete_array_2))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -362,7 +346,6 @@ fn bindgen_test_layout_C_with_incomplete_array_2() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).incomplete_array) as usize -
                 ptr as usize
         },
@@ -387,6 +370,7 @@ fn bindgen_test_layout_C_with_zero_length_array_and_incomplete_array() {
     const UNINIT: ::std::mem::MaybeUninit<
         C_with_zero_length_array_and_incomplete_array,
     > = ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<C_with_zero_length_array_and_incomplete_array>(),
         40usize,
@@ -404,10 +388,7 @@ fn bindgen_test_layout_C_with_zero_length_array_and_incomplete_array() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -418,7 +399,6 @@ fn bindgen_test_layout_C_with_zero_length_array_and_incomplete_array() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).big_array) as usize - ptr as usize
         },
         4usize,
@@ -431,7 +411,6 @@ fn bindgen_test_layout_C_with_zero_length_array_and_incomplete_array() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).zero_length_array) as usize -
                 ptr as usize
         },
@@ -445,7 +424,6 @@ fn bindgen_test_layout_C_with_zero_length_array_and_incomplete_array() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).incomplete_array) as usize -
                 ptr as usize
         },
@@ -479,6 +457,7 @@ fn bindgen_test_layout_C_with_zero_length_array_and_incomplete_array_2() {
     const UNINIT: ::std::mem::MaybeUninit<
         C_with_zero_length_array_and_incomplete_array_2,
     > = ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<C_with_zero_length_array_and_incomplete_array_2>(
         ),
@@ -498,10 +477,7 @@ fn bindgen_test_layout_C_with_zero_length_array_and_incomplete_array_2() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -512,7 +488,6 @@ fn bindgen_test_layout_C_with_zero_length_array_and_incomplete_array_2() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).zero_length_array) as usize -
                 ptr as usize
         },
@@ -526,7 +501,6 @@ fn bindgen_test_layout_C_with_zero_length_array_and_incomplete_array_2() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).incomplete_array) as usize -
                 ptr as usize
         },
@@ -548,6 +522,7 @@ pub struct WithDtor {
 fn bindgen_test_layout_WithDtor() {
     const UNINIT: ::std::mem::MaybeUninit<WithDtor> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<WithDtor>(),
         4usize,
@@ -559,10 +534,7 @@ fn bindgen_test_layout_WithDtor() {
         concat!("Alignment of ", stringify!(WithDtor))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -581,6 +553,7 @@ pub struct IncompleteArrayNonCopiable {
 fn bindgen_test_layout_IncompleteArrayNonCopiable() {
     const UNINIT: ::std::mem::MaybeUninit<IncompleteArrayNonCopiable> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<IncompleteArrayNonCopiable>(),
         8usize,
@@ -593,7 +566,6 @@ fn bindgen_test_layout_IncompleteArrayNonCopiable() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).whatever) as usize - ptr as usize
         },
         0usize,
@@ -606,7 +578,6 @@ fn bindgen_test_layout_IncompleteArrayNonCopiable() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).incomplete_array) as usize -
                 ptr as usize
         },
@@ -639,6 +610,7 @@ pub struct Union {
 fn bindgen_test_layout_Union() {
     const UNINIT: ::std::mem::MaybeUninit<Union> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<Union>(),
         4usize,
@@ -650,18 +622,12 @@ fn bindgen_test_layout_Union() {
         concat!("Alignment of ", stringify!(Union))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize },
         0usize,
         concat!("Offset of field: ", stringify!(Union), "::", stringify!(d))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).i) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).i) as usize - ptr as usize },
         0usize,
         concat!("Offset of field: ", stringify!(Union), "::", stringify!(i))
     );
@@ -680,6 +646,7 @@ pub struct WithUnion {
 fn bindgen_test_layout_WithUnion() {
     const UNINIT: ::std::mem::MaybeUninit<WithUnion> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<WithUnion>(),
         4usize,
@@ -691,10 +658,7 @@ fn bindgen_test_layout_WithUnion() {
         concat!("Alignment of ", stringify!(WithUnion))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).data) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).data) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/libclang-9/derive-hash-struct-with-incomplete-array.rs
+++ b/tests/expectations/tests/libclang-9/derive-hash-struct-with-incomplete-array.rs
@@ -43,6 +43,8 @@ pub struct test {
 }
 #[test]
 fn bindgen_test_layout_test() {
+    const UNINIT: ::std::mem::MaybeUninit<test> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<test>(),
         4usize,
@@ -53,36 +55,28 @@ fn bindgen_test_layout_test() {
         4usize,
         concat!("Alignment of ", stringify!(test))
     );
-    fn test_field_a() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<test>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-            },
-            0usize,
-            concat!("Offset of field: ", stringify!(test), "::", stringify!(a))
-        );
-    }
-    test_field_a();
-    fn test_field_zero_length_array() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<test>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).zero_length_array) as usize -
-                    ptr as usize
-            },
-            4usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(test),
-                "::",
-                stringify!(zero_length_array)
-            )
-        );
-    }
-    test_field_zero_length_array();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+        },
+        0usize,
+        concat!("Offset of field: ", stringify!(test), "::", stringify!(a))
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).zero_length_array) as usize -
+                ptr as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(test),
+            "::",
+            stringify!(zero_length_array)
+        )
+    );
 }
 #[repr(C)]
 #[derive(Debug, Default)]
@@ -92,6 +86,8 @@ pub struct test2 {
 }
 #[test]
 fn bindgen_test_layout_test2() {
+    const UNINIT: ::std::mem::MaybeUninit<test2> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<test2>(),
         4usize,
@@ -102,41 +98,28 @@ fn bindgen_test_layout_test2() {
         4usize,
         concat!("Alignment of ", stringify!(test2))
     );
-    fn test_field_a() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<test2>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(test2),
-                "::",
-                stringify!(a)
-            )
-        );
-    }
-    test_field_a();
-    fn test_field_incomplete_array() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<test2>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).incomplete_array) as usize -
-                    ptr as usize
-            },
-            4usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(test2),
-                "::",
-                stringify!(incomplete_array)
-            )
-        );
-    }
-    test_field_incomplete_array();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+        },
+        0usize,
+        concat!("Offset of field: ", stringify!(test2), "::", stringify!(a))
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).incomplete_array) as usize -
+                ptr as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(test2),
+            "::",
+            stringify!(incomplete_array)
+        )
+    );
 }
 #[repr(C)]
 #[derive(Debug, Default)]
@@ -147,6 +130,8 @@ pub struct test3 {
 }
 #[test]
 fn bindgen_test_layout_test3() {
+    const UNINIT: ::std::mem::MaybeUninit<test3> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<test3>(),
         4usize,
@@ -157,57 +142,40 @@ fn bindgen_test_layout_test3() {
         4usize,
         concat!("Alignment of ", stringify!(test3))
     );
-    fn test_field_a() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<test3>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(test3),
-                "::",
-                stringify!(a)
-            )
-        );
-    }
-    test_field_a();
-    fn test_field_zero_length_array() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<test3>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).zero_length_array) as usize -
-                    ptr as usize
-            },
-            4usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(test3),
-                "::",
-                stringify!(zero_length_array)
-            )
-        );
-    }
-    test_field_zero_length_array();
-    fn test_field_incomplete_array() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<test3>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).incomplete_array) as usize -
-                    ptr as usize
-            },
-            4usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(test3),
-                "::",
-                stringify!(incomplete_array)
-            )
-        );
-    }
-    test_field_incomplete_array();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+        },
+        0usize,
+        concat!("Offset of field: ", stringify!(test3), "::", stringify!(a))
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).zero_length_array) as usize -
+                ptr as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(test3),
+            "::",
+            stringify!(zero_length_array)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).incomplete_array) as usize -
+                ptr as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(test3),
+            "::",
+            stringify!(incomplete_array)
+        )
+    );
 }

--- a/tests/expectations/tests/libclang-9/derive-hash-struct-with-incomplete-array.rs
+++ b/tests/expectations/tests/libclang-9/derive-hash-struct-with-incomplete-array.rs
@@ -45,6 +45,7 @@ pub struct test {
 fn bindgen_test_layout_test() {
     const UNINIT: ::std::mem::MaybeUninit<test> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<test>(),
         4usize,
@@ -56,16 +57,12 @@ fn bindgen_test_layout_test() {
         concat!("Alignment of ", stringify!(test))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
         0usize,
         concat!("Offset of field: ", stringify!(test), "::", stringify!(a))
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).zero_length_array) as usize -
                 ptr as usize
         },
@@ -88,6 +85,7 @@ pub struct test2 {
 fn bindgen_test_layout_test2() {
     const UNINIT: ::std::mem::MaybeUninit<test2> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<test2>(),
         4usize,
@@ -99,16 +97,12 @@ fn bindgen_test_layout_test2() {
         concat!("Alignment of ", stringify!(test2))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
         0usize,
         concat!("Offset of field: ", stringify!(test2), "::", stringify!(a))
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).incomplete_array) as usize -
                 ptr as usize
         },
@@ -132,6 +126,7 @@ pub struct test3 {
 fn bindgen_test_layout_test3() {
     const UNINIT: ::std::mem::MaybeUninit<test3> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<test3>(),
         4usize,
@@ -143,16 +138,12 @@ fn bindgen_test_layout_test3() {
         concat!("Alignment of ", stringify!(test3))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
         0usize,
         concat!("Offset of field: ", stringify!(test3), "::", stringify!(a))
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).zero_length_array) as usize -
                 ptr as usize
         },
@@ -166,7 +157,6 @@ fn bindgen_test_layout_test3() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).incomplete_array) as usize -
                 ptr as usize
         },

--- a/tests/expectations/tests/libclang-9/incomplete-array-padding.rs
+++ b/tests/expectations/tests/libclang-9/incomplete-array-padding.rs
@@ -132,6 +132,7 @@ pub struct foo {
 fn bindgen_test_layout_foo() {
     const UNINIT: ::std::mem::MaybeUninit<foo> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<foo>(),
         8usize,
@@ -143,10 +144,7 @@ fn bindgen_test_layout_foo() {
         concat!("Alignment of ", stringify!(foo))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
         8usize,
         concat!("Offset of field: ", stringify!(foo), "::", stringify!(b))
     );

--- a/tests/expectations/tests/libclang-9/incomplete-array-padding.rs
+++ b/tests/expectations/tests/libclang-9/incomplete-array-padding.rs
@@ -130,6 +130,8 @@ pub struct foo {
 }
 #[test]
 fn bindgen_test_layout_foo() {
+    const UNINIT: ::std::mem::MaybeUninit<foo> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<foo>(),
         8usize,
@@ -140,18 +142,14 @@ fn bindgen_test_layout_foo() {
         8usize,
         concat!("Alignment of ", stringify!(foo))
     );
-    fn test_field_b() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<foo>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-            },
-            8usize,
-            concat!("Offset of field: ", stringify!(foo), "::", stringify!(b))
-        );
-    }
-    test_field_b();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
+        },
+        8usize,
+        concat!("Offset of field: ", stringify!(foo), "::", stringify!(b))
+    );
 }
 impl Default for foo {
     fn default() -> Self {

--- a/tests/expectations/tests/libclang-9/issue-643-inner-struct.rs
+++ b/tests/expectations/tests/libclang-9/issue-643-inner-struct.rs
@@ -50,6 +50,8 @@ pub struct rte_ring_prod {
 }
 #[test]
 fn bindgen_test_layout_rte_ring_prod() {
+    const UNINIT: ::std::mem::MaybeUninit<rte_ring_prod> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<rte_ring_prod>(),
         4usize,
@@ -60,23 +62,19 @@ fn bindgen_test_layout_rte_ring_prod() {
         4usize,
         concat!("Alignment of ", stringify!(rte_ring_prod))
     );
-    fn test_field_watermark() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<rte_ring_prod>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).watermark) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_ring_prod),
-                "::",
-                stringify!(watermark)
-            )
-        );
-    }
-    test_field_watermark();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).watermark) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_ring_prod),
+            "::",
+            stringify!(watermark)
+        )
+    );
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
@@ -85,6 +83,8 @@ pub struct rte_ring_cons {
 }
 #[test]
 fn bindgen_test_layout_rte_ring_cons() {
+    const UNINIT: ::std::mem::MaybeUninit<rte_ring_cons> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<rte_ring_cons>(),
         4usize,
@@ -95,26 +95,24 @@ fn bindgen_test_layout_rte_ring_cons() {
         4usize,
         concat!("Alignment of ", stringify!(rte_ring_cons))
     );
-    fn test_field_sc_dequeue() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<rte_ring_cons>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).sc_dequeue) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_ring_cons),
-                "::",
-                stringify!(sc_dequeue)
-            )
-        );
-    }
-    test_field_sc_dequeue();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).sc_dequeue) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_ring_cons),
+            "::",
+            stringify!(sc_dequeue)
+        )
+    );
 }
 #[test]
 fn bindgen_test_layout_rte_ring() {
+    const UNINIT: ::std::mem::MaybeUninit<rte_ring> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<rte_ring>(),
         16usize,
@@ -125,74 +123,58 @@ fn bindgen_test_layout_rte_ring() {
         8usize,
         concat!("Alignment of ", stringify!(rte_ring))
     );
-    fn test_field_memzone() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<rte_ring>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).memzone) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_ring),
-                "::",
-                stringify!(memzone)
-            )
-        );
-    }
-    test_field_memzone();
-    fn test_field_prod() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<rte_ring>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).prod) as usize - ptr as usize
-            },
-            8usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_ring),
-                "::",
-                stringify!(prod)
-            )
-        );
-    }
-    test_field_prod();
-    fn test_field_cons() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<rte_ring>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).cons) as usize - ptr as usize
-            },
-            12usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_ring),
-                "::",
-                stringify!(cons)
-            )
-        );
-    }
-    test_field_cons();
-    fn test_field_ring() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<rte_ring>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).ring) as usize - ptr as usize
-            },
-            16usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_ring),
-                "::",
-                stringify!(ring)
-            )
-        );
-    }
-    test_field_ring();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).memzone) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_ring),
+            "::",
+            stringify!(memzone)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).prod) as usize - ptr as usize
+        },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_ring),
+            "::",
+            stringify!(prod)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).cons) as usize - ptr as usize
+        },
+        12usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_ring),
+            "::",
+            stringify!(cons)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).ring) as usize - ptr as usize
+        },
+        16usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_ring),
+            "::",
+            stringify!(ring)
+        )
+    );
 }
 impl Default for rte_ring {
     fn default() -> Self {

--- a/tests/expectations/tests/libclang-9/issue-643-inner-struct.rs
+++ b/tests/expectations/tests/libclang-9/issue-643-inner-struct.rs
@@ -52,6 +52,7 @@ pub struct rte_ring_prod {
 fn bindgen_test_layout_rte_ring_prod() {
     const UNINIT: ::std::mem::MaybeUninit<rte_ring_prod> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<rte_ring_prod>(),
         4usize,
@@ -64,7 +65,6 @@ fn bindgen_test_layout_rte_ring_prod() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).watermark) as usize - ptr as usize
         },
         0usize,
@@ -85,6 +85,7 @@ pub struct rte_ring_cons {
 fn bindgen_test_layout_rte_ring_cons() {
     const UNINIT: ::std::mem::MaybeUninit<rte_ring_cons> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<rte_ring_cons>(),
         4usize,
@@ -97,7 +98,6 @@ fn bindgen_test_layout_rte_ring_cons() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).sc_dequeue) as usize - ptr as usize
         },
         0usize,
@@ -113,6 +113,7 @@ fn bindgen_test_layout_rte_ring_cons() {
 fn bindgen_test_layout_rte_ring() {
     const UNINIT: ::std::mem::MaybeUninit<rte_ring> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<rte_ring>(),
         16usize,
@@ -124,10 +125,7 @@ fn bindgen_test_layout_rte_ring() {
         concat!("Alignment of ", stringify!(rte_ring))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).memzone) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).memzone) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -137,10 +135,7 @@ fn bindgen_test_layout_rte_ring() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).prod) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).prod) as usize - ptr as usize },
         8usize,
         concat!(
             "Offset of field: ",
@@ -150,10 +145,7 @@ fn bindgen_test_layout_rte_ring() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).cons) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).cons) as usize - ptr as usize },
         12usize,
         concat!(
             "Offset of field: ",
@@ -163,10 +155,7 @@ fn bindgen_test_layout_rte_ring() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).ring) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).ring) as usize - ptr as usize },
         16usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/libclang-9/layout_align.rs
+++ b/tests/expectations/tests/libclang-9/layout_align.rs
@@ -137,6 +137,8 @@ pub struct rte_kni_fifo {
 }
 #[test]
 fn bindgen_test_layout_rte_kni_fifo() {
+    const UNINIT: ::std::mem::MaybeUninit<rte_kni_fifo> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<rte_kni_fifo>(),
         16usize,
@@ -147,91 +149,71 @@ fn bindgen_test_layout_rte_kni_fifo() {
         8usize,
         concat!("Alignment of ", stringify!(rte_kni_fifo))
     );
-    fn test_field_write() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<rte_kni_fifo>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).write) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_kni_fifo),
-                "::",
-                stringify!(write)
-            )
-        );
-    }
-    test_field_write();
-    fn test_field_read() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<rte_kni_fifo>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).read) as usize - ptr as usize
-            },
-            4usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_kni_fifo),
-                "::",
-                stringify!(read)
-            )
-        );
-    }
-    test_field_read();
-    fn test_field_len() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<rte_kni_fifo>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).len) as usize - ptr as usize
-            },
-            8usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_kni_fifo),
-                "::",
-                stringify!(len)
-            )
-        );
-    }
-    test_field_len();
-    fn test_field_elem_size() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<rte_kni_fifo>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).elem_size) as usize - ptr as usize
-            },
-            12usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_kni_fifo),
-                "::",
-                stringify!(elem_size)
-            )
-        );
-    }
-    test_field_elem_size();
-    fn test_field_buffer() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<rte_kni_fifo>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).buffer) as usize - ptr as usize
-            },
-            16usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_kni_fifo),
-                "::",
-                stringify!(buffer)
-            )
-        );
-    }
-    test_field_buffer();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).write) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_kni_fifo),
+            "::",
+            stringify!(write)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).read) as usize - ptr as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_kni_fifo),
+            "::",
+            stringify!(read)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).len) as usize - ptr as usize
+        },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_kni_fifo),
+            "::",
+            stringify!(len)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).elem_size) as usize - ptr as usize
+        },
+        12usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_kni_fifo),
+            "::",
+            stringify!(elem_size)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).buffer) as usize - ptr as usize
+        },
+        16usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_kni_fifo),
+            "::",
+            stringify!(buffer)
+        )
+    );
 }
 impl Default for rte_kni_fifo {
     fn default() -> Self {
@@ -254,6 +236,8 @@ pub struct rte_eth_link {
 }
 #[test]
 fn bindgen_test_layout_rte_eth_link() {
+    const UNINIT: ::std::mem::MaybeUninit<rte_eth_link> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<rte_eth_link>(),
         8usize,
@@ -264,23 +248,19 @@ fn bindgen_test_layout_rte_eth_link() {
         8usize,
         concat!("Alignment of ", stringify!(rte_eth_link))
     );
-    fn test_field_link_speed() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<rte_eth_link>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).link_speed) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(rte_eth_link),
-                "::",
-                stringify!(link_speed)
-            )
-        );
-    }
-    test_field_link_speed();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).link_speed) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_link),
+            "::",
+            stringify!(link_speed)
+        )
+    );
 }
 impl rte_eth_link {
     #[inline]

--- a/tests/expectations/tests/libclang-9/layout_align.rs
+++ b/tests/expectations/tests/libclang-9/layout_align.rs
@@ -139,6 +139,7 @@ pub struct rte_kni_fifo {
 fn bindgen_test_layout_rte_kni_fifo() {
     const UNINIT: ::std::mem::MaybeUninit<rte_kni_fifo> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<rte_kni_fifo>(),
         16usize,
@@ -150,10 +151,7 @@ fn bindgen_test_layout_rte_kni_fifo() {
         concat!("Alignment of ", stringify!(rte_kni_fifo))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).write) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).write) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -163,10 +161,7 @@ fn bindgen_test_layout_rte_kni_fifo() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).read) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).read) as usize - ptr as usize },
         4usize,
         concat!(
             "Offset of field: ",
@@ -176,10 +171,7 @@ fn bindgen_test_layout_rte_kni_fifo() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).len) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).len) as usize - ptr as usize },
         8usize,
         concat!(
             "Offset of field: ",
@@ -190,7 +182,6 @@ fn bindgen_test_layout_rte_kni_fifo() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).elem_size) as usize - ptr as usize
         },
         12usize,
@@ -202,10 +193,7 @@ fn bindgen_test_layout_rte_kni_fifo() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).buffer) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).buffer) as usize - ptr as usize },
         16usize,
         concat!(
             "Offset of field: ",
@@ -238,6 +226,7 @@ pub struct rte_eth_link {
 fn bindgen_test_layout_rte_eth_link() {
     const UNINIT: ::std::mem::MaybeUninit<rte_eth_link> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<rte_eth_link>(),
         8usize,
@@ -250,7 +239,6 @@ fn bindgen_test_layout_rte_eth_link() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).link_speed) as usize - ptr as usize
         },
         0usize,

--- a/tests/expectations/tests/libclang-9/type_alias_template_specialized.rs
+++ b/tests/expectations/tests/libclang-9/type_alias_template_specialized.rs
@@ -12,6 +12,8 @@ pub struct Rooted {
 }
 #[test]
 fn bindgen_test_layout_Rooted() {
+    const UNINIT: ::std::mem::MaybeUninit<Rooted> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<Rooted>(),
         4usize,
@@ -22,23 +24,19 @@ fn bindgen_test_layout_Rooted() {
         4usize,
         concat!("Alignment of ", stringify!(Rooted))
     );
-    fn test_field_ptr() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Rooted>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).ptr) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(Rooted),
-                "::",
-                stringify!(ptr)
-            )
-        );
-    }
-    test_field_ptr();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).ptr) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(Rooted),
+            "::",
+            stringify!(ptr)
+        )
+    );
 }
 impl Default for Rooted {
     fn default() -> Self {

--- a/tests/expectations/tests/libclang-9/type_alias_template_specialized.rs
+++ b/tests/expectations/tests/libclang-9/type_alias_template_specialized.rs
@@ -14,6 +14,7 @@ pub struct Rooted {
 fn bindgen_test_layout_Rooted() {
     const UNINIT: ::std::mem::MaybeUninit<Rooted> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<Rooted>(),
         4usize,
@@ -25,10 +26,7 @@ fn bindgen_test_layout_Rooted() {
         concat!("Alignment of ", stringify!(Rooted))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).ptr) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).ptr) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/libclang-9/zero-sized-array.rs
+++ b/tests/expectations/tests/libclang-9/zero-sized-array.rs
@@ -45,6 +45,7 @@ pub struct ZeroSizedArray {
 fn bindgen_test_layout_ZeroSizedArray() {
     const UNINIT: ::std::mem::MaybeUninit<ZeroSizedArray> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<ZeroSizedArray>(),
         0usize,
@@ -56,10 +57,7 @@ fn bindgen_test_layout_ZeroSizedArray() {
         concat!("Alignment of ", stringify!(ZeroSizedArray))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).arr) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).arr) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -79,6 +77,7 @@ pub struct ContainsZeroSizedArray {
 fn bindgen_test_layout_ContainsZeroSizedArray() {
     const UNINIT: ::std::mem::MaybeUninit<ContainsZeroSizedArray> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<ContainsZeroSizedArray>(),
         0usize,
@@ -90,10 +89,7 @@ fn bindgen_test_layout_ContainsZeroSizedArray() {
         concat!("Alignment of ", stringify!(ContainsZeroSizedArray))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).zsa) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).zsa) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -133,6 +129,7 @@ pub struct DynamicallySizedArray {
 fn bindgen_test_layout_DynamicallySizedArray() {
     const UNINIT: ::std::mem::MaybeUninit<DynamicallySizedArray> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<DynamicallySizedArray>(),
         0usize,
@@ -144,10 +141,7 @@ fn bindgen_test_layout_DynamicallySizedArray() {
         concat!("Alignment of ", stringify!(DynamicallySizedArray))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).arr) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).arr) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -167,6 +161,7 @@ pub struct ContainsDynamicallySizedArray {
 fn bindgen_test_layout_ContainsDynamicallySizedArray() {
     const UNINIT: ::std::mem::MaybeUninit<ContainsDynamicallySizedArray> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<ContainsDynamicallySizedArray>(),
         0usize,
@@ -178,10 +173,7 @@ fn bindgen_test_layout_ContainsDynamicallySizedArray() {
         concat!("Alignment of ", stringify!(ContainsDynamicallySizedArray))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).dsa) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).dsa) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/libclang-9/zero-sized-array.rs
+++ b/tests/expectations/tests/libclang-9/zero-sized-array.rs
@@ -43,6 +43,8 @@ pub struct ZeroSizedArray {
 }
 #[test]
 fn bindgen_test_layout_ZeroSizedArray() {
+    const UNINIT: ::std::mem::MaybeUninit<ZeroSizedArray> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<ZeroSizedArray>(),
         0usize,
@@ -53,24 +55,19 @@ fn bindgen_test_layout_ZeroSizedArray() {
         1usize,
         concat!("Alignment of ", stringify!(ZeroSizedArray))
     );
-    fn test_field_arr() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<ZeroSizedArray>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).arr) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(ZeroSizedArray),
-                "::",
-                stringify!(arr)
-            )
-        );
-    }
-    test_field_arr();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).arr) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ZeroSizedArray),
+            "::",
+            stringify!(arr)
+        )
+    );
 }
 /// And nor should this get an `_address` field.
 #[repr(C)]
@@ -80,6 +77,8 @@ pub struct ContainsZeroSizedArray {
 }
 #[test]
 fn bindgen_test_layout_ContainsZeroSizedArray() {
+    const UNINIT: ::std::mem::MaybeUninit<ContainsZeroSizedArray> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<ContainsZeroSizedArray>(),
         0usize,
@@ -90,24 +89,19 @@ fn bindgen_test_layout_ContainsZeroSizedArray() {
         1usize,
         concat!("Alignment of ", stringify!(ContainsZeroSizedArray))
     );
-    fn test_field_zsa() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<ContainsZeroSizedArray>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).zsa) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(ContainsZeroSizedArray),
-                "::",
-                stringify!(zsa)
-            )
-        );
-    }
-    test_field_zsa();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).zsa) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ContainsZeroSizedArray),
+            "::",
+            stringify!(zsa)
+        )
+    );
 }
 /// Inheriting from ZeroSizedArray shouldn't cause an `_address` to be inserted
 /// either.
@@ -137,6 +131,8 @@ pub struct DynamicallySizedArray {
 }
 #[test]
 fn bindgen_test_layout_DynamicallySizedArray() {
+    const UNINIT: ::std::mem::MaybeUninit<DynamicallySizedArray> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<DynamicallySizedArray>(),
         0usize,
@@ -147,24 +143,19 @@ fn bindgen_test_layout_DynamicallySizedArray() {
         1usize,
         concat!("Alignment of ", stringify!(DynamicallySizedArray))
     );
-    fn test_field_arr() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<DynamicallySizedArray>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).arr) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(DynamicallySizedArray),
-                "::",
-                stringify!(arr)
-            )
-        );
-    }
-    test_field_arr();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).arr) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(DynamicallySizedArray),
+            "::",
+            stringify!(arr)
+        )
+    );
 }
 /// No `_address` field here either.
 #[repr(C)]
@@ -174,6 +165,8 @@ pub struct ContainsDynamicallySizedArray {
 }
 #[test]
 fn bindgen_test_layout_ContainsDynamicallySizedArray() {
+    const UNINIT: ::std::mem::MaybeUninit<ContainsDynamicallySizedArray> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<ContainsDynamicallySizedArray>(),
         0usize,
@@ -184,23 +177,17 @@ fn bindgen_test_layout_ContainsDynamicallySizedArray() {
         1usize,
         concat!("Alignment of ", stringify!(ContainsDynamicallySizedArray))
     );
-    fn test_field_dsa() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<
-                    ContainsDynamicallySizedArray,
-                >::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).dsa) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(ContainsDynamicallySizedArray),
-                "::",
-                stringify!(dsa)
-            )
-        );
-    }
-    test_field_dsa();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).dsa) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ContainsDynamicallySizedArray),
+            "::",
+            stringify!(dsa)
+        )
+    );
 }

--- a/tests/expectations/tests/long_double.rs
+++ b/tests/expectations/tests/long_double.rs
@@ -15,6 +15,7 @@ pub struct foo {
 fn bindgen_test_layout_foo() {
     const UNINIT: ::std::mem::MaybeUninit<foo> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<foo>(),
         16usize,
@@ -26,10 +27,7 @@ fn bindgen_test_layout_foo() {
         concat!("Alignment of ", stringify!(foo))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize },
         0usize,
         concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar))
     );

--- a/tests/expectations/tests/long_double.rs
+++ b/tests/expectations/tests/long_double.rs
@@ -13,6 +13,8 @@ pub struct foo {
 }
 #[test]
 fn bindgen_test_layout_foo() {
+    const UNINIT: ::std::mem::MaybeUninit<foo> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<foo>(),
         16usize,
@@ -23,21 +25,12 @@ fn bindgen_test_layout_foo() {
         16usize,
         concat!("Alignment of ", stringify!(foo))
     );
-    fn test_field_bar() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<foo>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(foo),
-                "::",
-                stringify!(bar)
-            )
-        );
-    }
-    test_field_bar();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
+        },
+        0usize,
+        concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar))
+    );
 }

--- a/tests/expectations/tests/msvc-no-usr.rs
+++ b/tests/expectations/tests/msvc-no-usr.rs
@@ -13,6 +13,8 @@ pub struct A {
 }
 #[test]
 fn bindgen_test_layout_A() {
+    const UNINIT: ::std::mem::MaybeUninit<A> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<A>(),
         8usize,
@@ -23,16 +25,12 @@ fn bindgen_test_layout_A() {
         8usize,
         concat!("Alignment of ", stringify!(A))
     );
-    fn test_field_foo() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<A>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize
-            },
-            0usize,
-            concat!("Offset of field: ", stringify!(A), "::", stringify!(foo))
-        );
-    }
-    test_field_foo();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize
+        },
+        0usize,
+        concat!("Offset of field: ", stringify!(A), "::", stringify!(foo))
+    );
 }

--- a/tests/expectations/tests/msvc-no-usr.rs
+++ b/tests/expectations/tests/msvc-no-usr.rs
@@ -15,6 +15,7 @@ pub struct A {
 fn bindgen_test_layout_A() {
     const UNINIT: ::std::mem::MaybeUninit<A> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<A>(),
         8usize,
@@ -26,10 +27,7 @@ fn bindgen_test_layout_A() {
         concat!("Alignment of ", stringify!(A))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize },
         0usize,
         concat!("Offset of field: ", stringify!(A), "::", stringify!(foo))
     );

--- a/tests/expectations/tests/mutable.rs
+++ b/tests/expectations/tests/mutable.rs
@@ -13,6 +13,8 @@ pub struct C {
 }
 #[test]
 fn bindgen_test_layout_C() {
+    const UNINIT: ::std::mem::MaybeUninit<C> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<C>(),
         8usize,
@@ -23,40 +25,32 @@ fn bindgen_test_layout_C() {
         4usize,
         concat!("Alignment of ", stringify!(C))
     );
-    fn test_field_m_member() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<C>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).m_member) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(C),
-                "::",
-                stringify!(m_member)
-            )
-        );
-    }
-    test_field_m_member();
-    fn test_field_m_other() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<C>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).m_other) as usize - ptr as usize
-            },
-            4usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(C),
-                "::",
-                stringify!(m_other)
-            )
-        );
-    }
-    test_field_m_other();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).m_member) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C),
+            "::",
+            stringify!(m_member)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).m_other) as usize - ptr as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C),
+            "::",
+            stringify!(m_other)
+        )
+    );
 }
 #[repr(C)]
 #[derive(Debug, Default)]
@@ -65,6 +59,8 @@ pub struct NonCopiable {
 }
 #[test]
 fn bindgen_test_layout_NonCopiable() {
+    const UNINIT: ::std::mem::MaybeUninit<NonCopiable> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<NonCopiable>(),
         4usize,
@@ -75,23 +71,19 @@ fn bindgen_test_layout_NonCopiable() {
         4usize,
         concat!("Alignment of ", stringify!(NonCopiable))
     );
-    fn test_field_m_member() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<NonCopiable>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).m_member) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(NonCopiable),
-                "::",
-                stringify!(m_member)
-            )
-        );
-    }
-    test_field_m_member();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).m_member) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(NonCopiable),
+            "::",
+            stringify!(m_member)
+        )
+    );
 }
 #[repr(C)]
 #[derive(Debug, Default)]
@@ -100,6 +92,9 @@ pub struct NonCopiableWithNonCopiableMutableMember {
 }
 #[test]
 fn bindgen_test_layout_NonCopiableWithNonCopiableMutableMember() {
+    const UNINIT: ::std::mem::MaybeUninit<
+        NonCopiableWithNonCopiableMutableMember,
+    > = ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<NonCopiableWithNonCopiableMutableMember>(),
         4usize,
@@ -116,23 +111,17 @@ fn bindgen_test_layout_NonCopiableWithNonCopiableMutableMember() {
             stringify!(NonCopiableWithNonCopiableMutableMember)
         )
     );
-    fn test_field_m_member() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<
-                    NonCopiableWithNonCopiableMutableMember,
-                >::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).m_member) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(NonCopiableWithNonCopiableMutableMember),
-                "::",
-                stringify!(m_member)
-            )
-        );
-    }
-    test_field_m_member();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).m_member) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(NonCopiableWithNonCopiableMutableMember),
+            "::",
+            stringify!(m_member)
+        )
+    );
 }

--- a/tests/expectations/tests/mutable.rs
+++ b/tests/expectations/tests/mutable.rs
@@ -15,6 +15,7 @@ pub struct C {
 fn bindgen_test_layout_C() {
     const UNINIT: ::std::mem::MaybeUninit<C> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<C>(),
         8usize,
@@ -27,7 +28,6 @@ fn bindgen_test_layout_C() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).m_member) as usize - ptr as usize
         },
         0usize,
@@ -39,10 +39,7 @@ fn bindgen_test_layout_C() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).m_other) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).m_other) as usize - ptr as usize },
         4usize,
         concat!(
             "Offset of field: ",
@@ -61,6 +58,7 @@ pub struct NonCopiable {
 fn bindgen_test_layout_NonCopiable() {
     const UNINIT: ::std::mem::MaybeUninit<NonCopiable> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<NonCopiable>(),
         4usize,
@@ -73,7 +71,6 @@ fn bindgen_test_layout_NonCopiable() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).m_member) as usize - ptr as usize
         },
         0usize,
@@ -95,6 +92,7 @@ fn bindgen_test_layout_NonCopiableWithNonCopiableMutableMember() {
     const UNINIT: ::std::mem::MaybeUninit<
         NonCopiableWithNonCopiableMutableMember,
     > = ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<NonCopiableWithNonCopiableMutableMember>(),
         4usize,
@@ -113,7 +111,6 @@ fn bindgen_test_layout_NonCopiableWithNonCopiableMutableMember() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).m_member) as usize - ptr as usize
         },
         0usize,

--- a/tests/expectations/tests/namespace.rs
+++ b/tests/expectations/tests/namespace.rs
@@ -33,6 +33,8 @@ pub mod root {
         }
         #[test]
         fn bindgen_test_layout_A() {
+            const UNINIT: ::std::mem::MaybeUninit<A> =
+                ::std::mem::MaybeUninit::uninit();
             assert_eq!(
                 ::std::mem::size_of::<A>(),
                 4usize,
@@ -43,23 +45,19 @@ pub mod root {
                 4usize,
                 concat!("Alignment of ", stringify!(A))
             );
-            fn test_field_b() {
-                assert_eq!(
-                    unsafe {
-                        let uninit = ::std::mem::MaybeUninit::<A>::uninit();
-                        let ptr = uninit.as_ptr();
-                        ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-                    },
-                    0usize,
-                    concat!(
-                        "Offset of field: ",
-                        stringify!(A),
-                        "::",
-                        stringify!(b)
-                    )
-                );
-            }
-            test_field_b();
+            assert_eq!(
+                unsafe {
+                    let ptr = UNINIT.as_ptr();
+                    ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
+                },
+                0usize,
+                concat!(
+                    "Offset of field: ",
+                    stringify!(A),
+                    "::",
+                    stringify!(b)
+                )
+            );
         }
     }
     #[repr(C)]

--- a/tests/expectations/tests/namespace.rs
+++ b/tests/expectations/tests/namespace.rs
@@ -35,6 +35,7 @@ pub mod root {
         fn bindgen_test_layout_A() {
             const UNINIT: ::std::mem::MaybeUninit<A> =
                 ::std::mem::MaybeUninit::uninit();
+            let ptr = UNINIT.as_ptr();
             assert_eq!(
                 ::std::mem::size_of::<A>(),
                 4usize,
@@ -47,7 +48,6 @@ pub mod root {
             );
             assert_eq!(
                 unsafe {
-                    let ptr = UNINIT.as_ptr();
                     ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
                 },
                 0usize,

--- a/tests/expectations/tests/nested.rs
+++ b/tests/expectations/tests/nested.rs
@@ -14,6 +14,7 @@ pub struct Calc {
 fn bindgen_test_layout_Calc() {
     const UNINIT: ::std::mem::MaybeUninit<Calc> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<Calc>(),
         4usize,
@@ -25,10 +26,7 @@ fn bindgen_test_layout_Calc() {
         concat!("Alignment of ", stringify!(Calc))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).w) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).w) as usize - ptr as usize },
         0usize,
         concat!("Offset of field: ", stringify!(Calc), "::", stringify!(w))
     );
@@ -66,6 +64,7 @@ fn bindgen_test_layout_Test_Size_Dimension() {
 fn bindgen_test_layout_Test_Size() {
     const UNINIT: ::std::mem::MaybeUninit<Test_Size> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<Test_Size>(),
         8usize,
@@ -77,10 +76,7 @@ fn bindgen_test_layout_Test_Size() {
         concat!("Alignment of ", stringify!(Test_Size))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mWidth) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).mWidth) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -90,10 +86,7 @@ fn bindgen_test_layout_Test_Size() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mHeight) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).mHeight) as usize - ptr as usize },
         4usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/nested.rs
+++ b/tests/expectations/tests/nested.rs
@@ -12,6 +12,8 @@ pub struct Calc {
 }
 #[test]
 fn bindgen_test_layout_Calc() {
+    const UNINIT: ::std::mem::MaybeUninit<Calc> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<Calc>(),
         4usize,
@@ -22,18 +24,14 @@ fn bindgen_test_layout_Calc() {
         4usize,
         concat!("Alignment of ", stringify!(Calc))
     );
-    fn test_field_w() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Calc>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).w) as usize - ptr as usize
-            },
-            0usize,
-            concat!("Offset of field: ", stringify!(Calc), "::", stringify!(w))
-        );
-    }
-    test_field_w();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).w) as usize - ptr as usize
+        },
+        0usize,
+        concat!("Offset of field: ", stringify!(Calc), "::", stringify!(w))
+    );
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
@@ -66,6 +64,8 @@ fn bindgen_test_layout_Test_Size_Dimension() {
 }
 #[test]
 fn bindgen_test_layout_Test_Size() {
+    const UNINIT: ::std::mem::MaybeUninit<Test_Size> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<Test_Size>(),
         8usize,
@@ -76,40 +76,32 @@ fn bindgen_test_layout_Test_Size() {
         4usize,
         concat!("Alignment of ", stringify!(Test_Size))
     );
-    fn test_field_mWidth() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Test_Size>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).mWidth) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(Test_Size),
-                "::",
-                stringify!(mWidth)
-            )
-        );
-    }
-    test_field_mWidth();
-    fn test_field_mHeight() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Test_Size>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).mHeight) as usize - ptr as usize
-            },
-            4usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(Test_Size),
-                "::",
-                stringify!(mHeight)
-            )
-        );
-    }
-    test_field_mHeight();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).mWidth) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(Test_Size),
+            "::",
+            stringify!(mWidth)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).mHeight) as usize - ptr as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(Test_Size),
+            "::",
+            stringify!(mHeight)
+        )
+    );
 }
 #[test]
 fn bindgen_test_layout_Test() {

--- a/tests/expectations/tests/nested_within_namespace.rs
+++ b/tests/expectations/tests/nested_within_namespace.rs
@@ -24,6 +24,8 @@ pub mod root {
         }
         #[test]
         fn bindgen_test_layout_Bar_Baz() {
+            const UNINIT: ::std::mem::MaybeUninit<Bar_Baz> =
+                ::std::mem::MaybeUninit::uninit();
             assert_eq!(
                 ::std::mem::size_of::<Bar_Baz>(),
                 4usize,
@@ -34,27 +36,24 @@ pub mod root {
                 4usize,
                 concat!("Alignment of ", stringify!(Bar_Baz))
             );
-            fn test_field_foo() {
-                assert_eq!(
-                    unsafe {
-                        let uninit =
-                            ::std::mem::MaybeUninit::<Bar_Baz>::uninit();
-                        let ptr = uninit.as_ptr();
-                        ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize
-                    },
-                    0usize,
-                    concat!(
-                        "Offset of field: ",
-                        stringify!(Bar_Baz),
-                        "::",
-                        stringify!(foo)
-                    )
-                );
-            }
-            test_field_foo();
+            assert_eq!(
+                unsafe {
+                    let ptr = UNINIT.as_ptr();
+                    ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize
+                },
+                0usize,
+                concat!(
+                    "Offset of field: ",
+                    stringify!(Bar_Baz),
+                    "::",
+                    stringify!(foo)
+                )
+            );
         }
         #[test]
         fn bindgen_test_layout_Bar() {
+            const UNINIT: ::std::mem::MaybeUninit<Bar> =
+                ::std::mem::MaybeUninit::uninit();
             assert_eq!(
                 ::std::mem::size_of::<Bar>(),
                 4usize,
@@ -65,23 +64,19 @@ pub mod root {
                 4usize,
                 concat!("Alignment of ", stringify!(Bar))
             );
-            fn test_field_foo() {
-                assert_eq!(
-                    unsafe {
-                        let uninit = ::std::mem::MaybeUninit::<Bar>::uninit();
-                        let ptr = uninit.as_ptr();
-                        ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize
-                    },
-                    0usize,
-                    concat!(
-                        "Offset of field: ",
-                        stringify!(Bar),
-                        "::",
-                        stringify!(foo)
-                    )
-                );
-            }
-            test_field_foo();
+            assert_eq!(
+                unsafe {
+                    let ptr = UNINIT.as_ptr();
+                    ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize
+                },
+                0usize,
+                concat!(
+                    "Offset of field: ",
+                    stringify!(Bar),
+                    "::",
+                    stringify!(foo)
+                )
+            );
         }
         #[repr(C)]
         #[derive(Debug, Default, Copy, Clone)]
@@ -90,6 +85,8 @@ pub mod root {
         }
         #[test]
         fn bindgen_test_layout_Baz() {
+            const UNINIT: ::std::mem::MaybeUninit<Baz> =
+                ::std::mem::MaybeUninit::uninit();
             assert_eq!(
                 ::std::mem::size_of::<Baz>(),
                 4usize,
@@ -100,23 +97,19 @@ pub mod root {
                 4usize,
                 concat!("Alignment of ", stringify!(Baz))
             );
-            fn test_field_baz() {
-                assert_eq!(
-                    unsafe {
-                        let uninit = ::std::mem::MaybeUninit::<Baz>::uninit();
-                        let ptr = uninit.as_ptr();
-                        ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize
-                    },
-                    0usize,
-                    concat!(
-                        "Offset of field: ",
-                        stringify!(Baz),
-                        "::",
-                        stringify!(baz)
-                    )
-                );
-            }
-            test_field_baz();
+            assert_eq!(
+                unsafe {
+                    let ptr = UNINIT.as_ptr();
+                    ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize
+                },
+                0usize,
+                concat!(
+                    "Offset of field: ",
+                    stringify!(Baz),
+                    "::",
+                    stringify!(baz)
+                )
+            );
         }
     }
 }

--- a/tests/expectations/tests/nested_within_namespace.rs
+++ b/tests/expectations/tests/nested_within_namespace.rs
@@ -26,6 +26,7 @@ pub mod root {
         fn bindgen_test_layout_Bar_Baz() {
             const UNINIT: ::std::mem::MaybeUninit<Bar_Baz> =
                 ::std::mem::MaybeUninit::uninit();
+            let ptr = UNINIT.as_ptr();
             assert_eq!(
                 ::std::mem::size_of::<Bar_Baz>(),
                 4usize,
@@ -38,7 +39,6 @@ pub mod root {
             );
             assert_eq!(
                 unsafe {
-                    let ptr = UNINIT.as_ptr();
                     ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize
                 },
                 0usize,
@@ -54,6 +54,7 @@ pub mod root {
         fn bindgen_test_layout_Bar() {
             const UNINIT: ::std::mem::MaybeUninit<Bar> =
                 ::std::mem::MaybeUninit::uninit();
+            let ptr = UNINIT.as_ptr();
             assert_eq!(
                 ::std::mem::size_of::<Bar>(),
                 4usize,
@@ -66,7 +67,6 @@ pub mod root {
             );
             assert_eq!(
                 unsafe {
-                    let ptr = UNINIT.as_ptr();
                     ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize
                 },
                 0usize,
@@ -87,6 +87,7 @@ pub mod root {
         fn bindgen_test_layout_Baz() {
             const UNINIT: ::std::mem::MaybeUninit<Baz> =
                 ::std::mem::MaybeUninit::uninit();
+            let ptr = UNINIT.as_ptr();
             assert_eq!(
                 ::std::mem::size_of::<Baz>(),
                 4usize,
@@ -99,7 +100,6 @@ pub mod root {
             );
             assert_eq!(
                 unsafe {
-                    let ptr = UNINIT.as_ptr();
                     ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize
                 },
                 0usize,

--- a/tests/expectations/tests/no-comments.rs
+++ b/tests/expectations/tests/no-comments.rs
@@ -12,6 +12,8 @@ pub struct Foo {
 }
 #[test]
 fn bindgen_test_layout_Foo() {
+    const UNINIT: ::std::mem::MaybeUninit<Foo> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<Foo>(),
         4usize,
@@ -22,16 +24,12 @@ fn bindgen_test_layout_Foo() {
         4usize,
         concat!("Alignment of ", stringify!(Foo))
     );
-    fn test_field_s() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Foo>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).s) as usize - ptr as usize
-            },
-            0usize,
-            concat!("Offset of field: ", stringify!(Foo), "::", stringify!(s))
-        );
-    }
-    test_field_s();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).s) as usize - ptr as usize
+        },
+        0usize,
+        concat!("Offset of field: ", stringify!(Foo), "::", stringify!(s))
+    );
 }

--- a/tests/expectations/tests/no-comments.rs
+++ b/tests/expectations/tests/no-comments.rs
@@ -14,6 +14,7 @@ pub struct Foo {
 fn bindgen_test_layout_Foo() {
     const UNINIT: ::std::mem::MaybeUninit<Foo> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<Foo>(),
         4usize,
@@ -25,10 +26,7 @@ fn bindgen_test_layout_Foo() {
         concat!("Alignment of ", stringify!(Foo))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).s) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).s) as usize - ptr as usize },
         0usize,
         concat!("Offset of field: ", stringify!(Foo), "::", stringify!(s))
     );

--- a/tests/expectations/tests/no-derive-debug.rs
+++ b/tests/expectations/tests/no-derive-debug.rs
@@ -21,6 +21,8 @@ pub struct bar {
 }
 #[test]
 fn bindgen_test_layout_bar() {
+    const UNINIT: ::std::mem::MaybeUninit<bar> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<bar>(),
         8usize,
@@ -31,40 +33,22 @@ fn bindgen_test_layout_bar() {
         4usize,
         concat!("Alignment of ", stringify!(bar))
     );
-    fn test_field_foo() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<bar>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(bar),
-                "::",
-                stringify!(foo)
-            )
-        );
-    }
-    test_field_foo();
-    fn test_field_baz() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<bar>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize
-            },
-            4usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(bar),
-                "::",
-                stringify!(baz)
-            )
-        );
-    }
-    test_field_baz();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize
+        },
+        0usize,
+        concat!("Offset of field: ", stringify!(bar), "::", stringify!(foo))
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize
+        },
+        4usize,
+        concat!("Offset of field: ", stringify!(bar), "::", stringify!(baz))
+    );
 }
 impl Default for bar {
     fn default() -> Self {

--- a/tests/expectations/tests/no-derive-debug.rs
+++ b/tests/expectations/tests/no-derive-debug.rs
@@ -23,6 +23,7 @@ pub struct bar {
 fn bindgen_test_layout_bar() {
     const UNINIT: ::std::mem::MaybeUninit<bar> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<bar>(),
         8usize,
@@ -34,18 +35,12 @@ fn bindgen_test_layout_bar() {
         concat!("Alignment of ", stringify!(bar))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize },
         0usize,
         concat!("Offset of field: ", stringify!(bar), "::", stringify!(foo))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize },
         4usize,
         concat!("Offset of field: ", stringify!(bar), "::", stringify!(baz))
     );

--- a/tests/expectations/tests/no-derive-default.rs
+++ b/tests/expectations/tests/no-derive-default.rs
@@ -21,6 +21,8 @@ pub struct bar {
 }
 #[test]
 fn bindgen_test_layout_bar() {
+    const UNINIT: ::std::mem::MaybeUninit<bar> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<bar>(),
         8usize,
@@ -31,38 +33,20 @@ fn bindgen_test_layout_bar() {
         4usize,
         concat!("Alignment of ", stringify!(bar))
     );
-    fn test_field_foo() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<bar>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(bar),
-                "::",
-                stringify!(foo)
-            )
-        );
-    }
-    test_field_foo();
-    fn test_field_baz() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<bar>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize
-            },
-            4usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(bar),
-                "::",
-                stringify!(baz)
-            )
-        );
-    }
-    test_field_baz();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize
+        },
+        0usize,
+        concat!("Offset of field: ", stringify!(bar), "::", stringify!(foo))
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize
+        },
+        4usize,
+        concat!("Offset of field: ", stringify!(bar), "::", stringify!(baz))
+    );
 }

--- a/tests/expectations/tests/no-derive-default.rs
+++ b/tests/expectations/tests/no-derive-default.rs
@@ -23,6 +23,7 @@ pub struct bar {
 fn bindgen_test_layout_bar() {
     const UNINIT: ::std::mem::MaybeUninit<bar> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<bar>(),
         8usize,
@@ -34,18 +35,12 @@ fn bindgen_test_layout_bar() {
         concat!("Alignment of ", stringify!(bar))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize },
         0usize,
         concat!("Offset of field: ", stringify!(bar), "::", stringify!(foo))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize },
         4usize,
         concat!("Offset of field: ", stringify!(bar), "::", stringify!(baz))
     );

--- a/tests/expectations/tests/no-hash-allowlisted.rs
+++ b/tests/expectations/tests/no-hash-allowlisted.rs
@@ -14,6 +14,7 @@ pub struct NoHash {
 fn bindgen_test_layout_NoHash() {
     const UNINIT: ::std::mem::MaybeUninit<NoHash> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<NoHash>(),
         4usize,
@@ -25,10 +26,7 @@ fn bindgen_test_layout_NoHash() {
         concat!("Alignment of ", stringify!(NoHash))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).i) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).i) as usize - ptr as usize },
         0usize,
         concat!("Offset of field: ", stringify!(NoHash), "::", stringify!(i))
     );

--- a/tests/expectations/tests/no-hash-allowlisted.rs
+++ b/tests/expectations/tests/no-hash-allowlisted.rs
@@ -12,6 +12,8 @@ pub struct NoHash {
 }
 #[test]
 fn bindgen_test_layout_NoHash() {
+    const UNINIT: ::std::mem::MaybeUninit<NoHash> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<NoHash>(),
         4usize,
@@ -22,21 +24,12 @@ fn bindgen_test_layout_NoHash() {
         4usize,
         concat!("Alignment of ", stringify!(NoHash))
     );
-    fn test_field_i() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<NoHash>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).i) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(NoHash),
-                "::",
-                stringify!(i)
-            )
-        );
-    }
-    test_field_i();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).i) as usize - ptr as usize
+        },
+        0usize,
+        concat!("Offset of field: ", stringify!(NoHash), "::", stringify!(i))
+    );
 }

--- a/tests/expectations/tests/no-partialeq-allowlisted.rs
+++ b/tests/expectations/tests/no-partialeq-allowlisted.rs
@@ -12,6 +12,8 @@ pub struct NoPartialEq {
 }
 #[test]
 fn bindgen_test_layout_NoPartialEq() {
+    const UNINIT: ::std::mem::MaybeUninit<NoPartialEq> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<NoPartialEq>(),
         4usize,
@@ -22,21 +24,17 @@ fn bindgen_test_layout_NoPartialEq() {
         4usize,
         concat!("Alignment of ", stringify!(NoPartialEq))
     );
-    fn test_field_i() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<NoPartialEq>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).i) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(NoPartialEq),
-                "::",
-                stringify!(i)
-            )
-        );
-    }
-    test_field_i();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).i) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(NoPartialEq),
+            "::",
+            stringify!(i)
+        )
+    );
 }

--- a/tests/expectations/tests/no-partialeq-allowlisted.rs
+++ b/tests/expectations/tests/no-partialeq-allowlisted.rs
@@ -14,6 +14,7 @@ pub struct NoPartialEq {
 fn bindgen_test_layout_NoPartialEq() {
     const UNINIT: ::std::mem::MaybeUninit<NoPartialEq> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<NoPartialEq>(),
         4usize,
@@ -25,10 +26,7 @@ fn bindgen_test_layout_NoPartialEq() {
         concat!("Alignment of ", stringify!(NoPartialEq))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).i) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).i) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/no-recursive-allowlisting.rs
+++ b/tests/expectations/tests/no-recursive-allowlisting.rs
@@ -16,6 +16,7 @@ pub struct Foo {
 fn bindgen_test_layout_Foo() {
     const UNINIT: ::std::mem::MaybeUninit<Foo> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<Foo>(),
         8usize,
@@ -27,10 +28,7 @@ fn bindgen_test_layout_Foo() {
         concat!("Alignment of ", stringify!(Foo))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize },
         0usize,
         concat!("Offset of field: ", stringify!(Foo), "::", stringify!(baz))
     );

--- a/tests/expectations/tests/no-recursive-allowlisting.rs
+++ b/tests/expectations/tests/no-recursive-allowlisting.rs
@@ -14,6 +14,8 @@ pub struct Foo {
 }
 #[test]
 fn bindgen_test_layout_Foo() {
+    const UNINIT: ::std::mem::MaybeUninit<Foo> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<Foo>(),
         8usize,
@@ -24,23 +26,14 @@ fn bindgen_test_layout_Foo() {
         8usize,
         concat!("Alignment of ", stringify!(Foo))
     );
-    fn test_field_baz() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Foo>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(Foo),
-                "::",
-                stringify!(baz)
-            )
-        );
-    }
-    test_field_baz();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize
+        },
+        0usize,
+        concat!("Offset of field: ", stringify!(Foo), "::", stringify!(baz))
+    );
 }
 impl Default for Foo {
     fn default() -> Self {

--- a/tests/expectations/tests/no-std.rs
+++ b/tests/expectations/tests/no-std.rs
@@ -21,6 +21,7 @@ pub struct foo {
 fn bindgen_test_layout_foo() {
     const UNINIT: ::core::mem::MaybeUninit<foo> =
         ::core::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::core::mem::size_of::<foo>(),
         16usize,
@@ -32,26 +33,17 @@ fn bindgen_test_layout_foo() {
         concat!("Alignment of ", stringify!(foo))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::core::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
+        unsafe { ::core::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
         0usize,
         concat!("Offset of field: ", stringify!(foo), "::", stringify!(a))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::core::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-        },
+        unsafe { ::core::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
         4usize,
         concat!("Offset of field: ", stringify!(foo), "::", stringify!(b))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::core::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
-        },
+        unsafe { ::core::ptr::addr_of!((*ptr).bar) as usize - ptr as usize },
         8usize,
         concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar))
     );

--- a/tests/expectations/tests/no-std.rs
+++ b/tests/expectations/tests/no-std.rs
@@ -19,6 +19,8 @@ pub struct foo {
 }
 #[test]
 fn bindgen_test_layout_foo() {
+    const UNINIT: ::core::mem::MaybeUninit<foo> =
+        ::core::mem::MaybeUninit::uninit();
     assert_eq!(
         ::core::mem::size_of::<foo>(),
         16usize,
@@ -29,47 +31,30 @@ fn bindgen_test_layout_foo() {
         8usize,
         concat!("Alignment of ", stringify!(foo))
     );
-    fn test_field_a() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::core::mem::MaybeUninit::<foo>::uninit();
-                let ptr = uninit.as_ptr();
-                ::core::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-            },
-            0usize,
-            concat!("Offset of field: ", stringify!(foo), "::", stringify!(a))
-        );
-    }
-    test_field_a();
-    fn test_field_b() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::core::mem::MaybeUninit::<foo>::uninit();
-                let ptr = uninit.as_ptr();
-                ::core::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-            },
-            4usize,
-            concat!("Offset of field: ", stringify!(foo), "::", stringify!(b))
-        );
-    }
-    test_field_b();
-    fn test_field_bar() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::core::mem::MaybeUninit::<foo>::uninit();
-                let ptr = uninit.as_ptr();
-                ::core::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
-            },
-            8usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(foo),
-                "::",
-                stringify!(bar)
-            )
-        );
-    }
-    test_field_bar();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::core::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+        },
+        0usize,
+        concat!("Offset of field: ", stringify!(foo), "::", stringify!(a))
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::core::ptr::addr_of!((*ptr).b) as usize - ptr as usize
+        },
+        4usize,
+        concat!("Offset of field: ", stringify!(foo), "::", stringify!(b))
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::core::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
+        },
+        8usize,
+        concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar))
+    );
 }
 impl Default for foo {
     fn default() -> Self {

--- a/tests/expectations/tests/no_copy_allowlisted.rs
+++ b/tests/expectations/tests/no_copy_allowlisted.rs
@@ -12,6 +12,8 @@ pub struct NoCopy {
 }
 #[test]
 fn bindgen_test_layout_NoCopy() {
+    const UNINIT: ::std::mem::MaybeUninit<NoCopy> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<NoCopy>(),
         4usize,
@@ -22,21 +24,12 @@ fn bindgen_test_layout_NoCopy() {
         4usize,
         concat!("Alignment of ", stringify!(NoCopy))
     );
-    fn test_field_i() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<NoCopy>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).i) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(NoCopy),
-                "::",
-                stringify!(i)
-            )
-        );
-    }
-    test_field_i();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).i) as usize - ptr as usize
+        },
+        0usize,
+        concat!("Offset of field: ", stringify!(NoCopy), "::", stringify!(i))
+    );
 }

--- a/tests/expectations/tests/no_copy_allowlisted.rs
+++ b/tests/expectations/tests/no_copy_allowlisted.rs
@@ -14,6 +14,7 @@ pub struct NoCopy {
 fn bindgen_test_layout_NoCopy() {
     const UNINIT: ::std::mem::MaybeUninit<NoCopy> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<NoCopy>(),
         4usize,
@@ -25,10 +26,7 @@ fn bindgen_test_layout_NoCopy() {
         concat!("Alignment of ", stringify!(NoCopy))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).i) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).i) as usize - ptr as usize },
         0usize,
         concat!("Offset of field: ", stringify!(NoCopy), "::", stringify!(i))
     );

--- a/tests/expectations/tests/no_debug_allowlisted.rs
+++ b/tests/expectations/tests/no_debug_allowlisted.rs
@@ -12,6 +12,8 @@ pub struct NoDebug {
 }
 #[test]
 fn bindgen_test_layout_NoDebug() {
+    const UNINIT: ::std::mem::MaybeUninit<NoDebug> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<NoDebug>(),
         4usize,
@@ -22,21 +24,17 @@ fn bindgen_test_layout_NoDebug() {
         4usize,
         concat!("Alignment of ", stringify!(NoDebug))
     );
-    fn test_field_i() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<NoDebug>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).i) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(NoDebug),
-                "::",
-                stringify!(i)
-            )
-        );
-    }
-    test_field_i();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).i) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(NoDebug),
+            "::",
+            stringify!(i)
+        )
+    );
 }

--- a/tests/expectations/tests/no_debug_allowlisted.rs
+++ b/tests/expectations/tests/no_debug_allowlisted.rs
@@ -14,6 +14,7 @@ pub struct NoDebug {
 fn bindgen_test_layout_NoDebug() {
     const UNINIT: ::std::mem::MaybeUninit<NoDebug> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<NoDebug>(),
         4usize,
@@ -25,10 +26,7 @@ fn bindgen_test_layout_NoDebug() {
         concat!("Alignment of ", stringify!(NoDebug))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).i) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).i) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/no_default_allowlisted.rs
+++ b/tests/expectations/tests/no_default_allowlisted.rs
@@ -14,6 +14,7 @@ pub struct NoDefault {
 fn bindgen_test_layout_NoDefault() {
     const UNINIT: ::std::mem::MaybeUninit<NoDefault> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<NoDefault>(),
         4usize,
@@ -25,10 +26,7 @@ fn bindgen_test_layout_NoDefault() {
         concat!("Alignment of ", stringify!(NoDefault))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).i) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).i) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/no_default_allowlisted.rs
+++ b/tests/expectations/tests/no_default_allowlisted.rs
@@ -12,6 +12,8 @@ pub struct NoDefault {
 }
 #[test]
 fn bindgen_test_layout_NoDefault() {
+    const UNINIT: ::std::mem::MaybeUninit<NoDefault> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<NoDefault>(),
         4usize,
@@ -22,21 +24,17 @@ fn bindgen_test_layout_NoDefault() {
         4usize,
         concat!("Alignment of ", stringify!(NoDefault))
     );
-    fn test_field_i() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<NoDefault>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).i) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(NoDefault),
-                "::",
-                stringify!(i)
-            )
-        );
-    }
-    test_field_i();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).i) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(NoDefault),
+            "::",
+            stringify!(i)
+        )
+    );
 }

--- a/tests/expectations/tests/non-type-params.rs
+++ b/tests/expectations/tests/non-type-params.rs
@@ -18,6 +18,7 @@ pub struct UsesArray {
 fn bindgen_test_layout_UsesArray() {
     const UNINIT: ::std::mem::MaybeUninit<UsesArray> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<UsesArray>(),
         40usize,
@@ -30,7 +31,6 @@ fn bindgen_test_layout_UsesArray() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).array_char_16) as usize - ptr as usize
         },
         0usize,
@@ -43,7 +43,6 @@ fn bindgen_test_layout_UsesArray() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).array_bool_8) as usize - ptr as usize
         },
         16usize,
@@ -56,7 +55,6 @@ fn bindgen_test_layout_UsesArray() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).array_int_4) as usize - ptr as usize
         },
         24usize,

--- a/tests/expectations/tests/non-type-params.rs
+++ b/tests/expectations/tests/non-type-params.rs
@@ -16,6 +16,8 @@ pub struct UsesArray {
 }
 #[test]
 fn bindgen_test_layout_UsesArray() {
+    const UNINIT: ::std::mem::MaybeUninit<UsesArray> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<UsesArray>(),
         40usize,
@@ -26,57 +28,43 @@ fn bindgen_test_layout_UsesArray() {
         4usize,
         concat!("Alignment of ", stringify!(UsesArray))
     );
-    fn test_field_array_char_16() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<UsesArray>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).array_char_16) as usize -
-                    ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(UsesArray),
-                "::",
-                stringify!(array_char_16)
-            )
-        );
-    }
-    test_field_array_char_16();
-    fn test_field_array_bool_8() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<UsesArray>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).array_bool_8) as usize -
-                    ptr as usize
-            },
-            16usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(UsesArray),
-                "::",
-                stringify!(array_bool_8)
-            )
-        );
-    }
-    test_field_array_bool_8();
-    fn test_field_array_int_4() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<UsesArray>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).array_int_4) as usize - ptr as usize
-            },
-            24usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(UsesArray),
-                "::",
-                stringify!(array_int_4)
-            )
-        );
-    }
-    test_field_array_int_4();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).array_char_16) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(UsesArray),
+            "::",
+            stringify!(array_char_16)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).array_bool_8) as usize - ptr as usize
+        },
+        16usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(UsesArray),
+            "::",
+            stringify!(array_bool_8)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).array_int_4) as usize - ptr as usize
+        },
+        24usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(UsesArray),
+            "::",
+            stringify!(array_int_4)
+        )
+    );
 }

--- a/tests/expectations/tests/objc_interface_type.rs
+++ b/tests/expectations/tests/objc_interface_type.rs
@@ -35,6 +35,7 @@ pub struct FooStruct {
 fn bindgen_test_layout_FooStruct() {
     const UNINIT: ::std::mem::MaybeUninit<FooStruct> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<FooStruct>(),
         8usize,
@@ -46,10 +47,7 @@ fn bindgen_test_layout_FooStruct() {
         concat!("Alignment of ", stringify!(FooStruct))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/objc_interface_type.rs
+++ b/tests/expectations/tests/objc_interface_type.rs
@@ -33,6 +33,8 @@ pub struct FooStruct {
 }
 #[test]
 fn bindgen_test_layout_FooStruct() {
+    const UNINIT: ::std::mem::MaybeUninit<FooStruct> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<FooStruct>(),
         8usize,
@@ -43,23 +45,19 @@ fn bindgen_test_layout_FooStruct() {
         8usize,
         concat!("Alignment of ", stringify!(FooStruct))
     );
-    fn test_field_foo() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<FooStruct>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(FooStruct),
-                "::",
-                stringify!(foo)
-            )
-        );
-    }
-    test_field_foo();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(FooStruct),
+            "::",
+            stringify!(foo)
+        )
+    );
 }
 impl Default for FooStruct {
     fn default() -> Self {

--- a/tests/expectations/tests/opaque-template-inst-member-2.rs
+++ b/tests/expectations/tests/opaque-template-inst-member-2.rs
@@ -21,6 +21,8 @@ pub struct ContainsOpaqueTemplate {
 }
 #[test]
 fn bindgen_test_layout_ContainsOpaqueTemplate() {
+    const UNINIT: ::std::mem::MaybeUninit<ContainsOpaqueTemplate> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<ContainsOpaqueTemplate>(),
         8usize,
@@ -31,42 +33,32 @@ fn bindgen_test_layout_ContainsOpaqueTemplate() {
         4usize,
         concat!("Alignment of ", stringify!(ContainsOpaqueTemplate))
     );
-    fn test_field_mBlah() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<ContainsOpaqueTemplate>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).mBlah) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(ContainsOpaqueTemplate),
-                "::",
-                stringify!(mBlah)
-            )
-        );
-    }
-    test_field_mBlah();
-    fn test_field_mBaz() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<ContainsOpaqueTemplate>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).mBaz) as usize - ptr as usize
-            },
-            4usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(ContainsOpaqueTemplate),
-                "::",
-                stringify!(mBaz)
-            )
-        );
-    }
-    test_field_mBaz();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).mBlah) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ContainsOpaqueTemplate),
+            "::",
+            stringify!(mBlah)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).mBaz) as usize - ptr as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ContainsOpaqueTemplate),
+            "::",
+            stringify!(mBaz)
+        )
+    );
 }
 /// Should also derive Debug/Hash/PartialEq.
 #[repr(C)]
@@ -77,6 +69,8 @@ pub struct InheritsOpaqueTemplate {
 }
 #[test]
 fn bindgen_test_layout_InheritsOpaqueTemplate() {
+    const UNINIT: ::std::mem::MaybeUninit<InheritsOpaqueTemplate> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<InheritsOpaqueTemplate>(),
         16usize,
@@ -87,24 +81,19 @@ fn bindgen_test_layout_InheritsOpaqueTemplate() {
         8usize,
         concat!("Alignment of ", stringify!(InheritsOpaqueTemplate))
     );
-    fn test_field_wow() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<InheritsOpaqueTemplate>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).wow) as usize - ptr as usize
-            },
-            8usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(InheritsOpaqueTemplate),
-                "::",
-                stringify!(wow)
-            )
-        );
-    }
-    test_field_wow();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).wow) as usize - ptr as usize
+        },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(InheritsOpaqueTemplate),
+            "::",
+            stringify!(wow)
+        )
+    );
 }
 impl Default for InheritsOpaqueTemplate {
     fn default() -> Self {

--- a/tests/expectations/tests/opaque-template-inst-member-2.rs
+++ b/tests/expectations/tests/opaque-template-inst-member-2.rs
@@ -23,6 +23,7 @@ pub struct ContainsOpaqueTemplate {
 fn bindgen_test_layout_ContainsOpaqueTemplate() {
     const UNINIT: ::std::mem::MaybeUninit<ContainsOpaqueTemplate> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<ContainsOpaqueTemplate>(),
         8usize,
@@ -34,10 +35,7 @@ fn bindgen_test_layout_ContainsOpaqueTemplate() {
         concat!("Alignment of ", stringify!(ContainsOpaqueTemplate))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mBlah) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).mBlah) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -47,10 +45,7 @@ fn bindgen_test_layout_ContainsOpaqueTemplate() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mBaz) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).mBaz) as usize - ptr as usize },
         4usize,
         concat!(
             "Offset of field: ",
@@ -71,6 +66,7 @@ pub struct InheritsOpaqueTemplate {
 fn bindgen_test_layout_InheritsOpaqueTemplate() {
     const UNINIT: ::std::mem::MaybeUninit<InheritsOpaqueTemplate> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<InheritsOpaqueTemplate>(),
         16usize,
@@ -82,10 +78,7 @@ fn bindgen_test_layout_InheritsOpaqueTemplate() {
         concat!("Alignment of ", stringify!(InheritsOpaqueTemplate))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).wow) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).wow) as usize - ptr as usize },
         8usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/opaque-template-inst-member.rs
+++ b/tests/expectations/tests/opaque-template-inst-member.rs
@@ -21,6 +21,7 @@ pub struct ContainsOpaqueTemplate {
 fn bindgen_test_layout_ContainsOpaqueTemplate() {
     const UNINIT: ::std::mem::MaybeUninit<ContainsOpaqueTemplate> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<ContainsOpaqueTemplate>(),
         408usize,
@@ -32,10 +33,7 @@ fn bindgen_test_layout_ContainsOpaqueTemplate() {
         concat!("Alignment of ", stringify!(ContainsOpaqueTemplate))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mBlah) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).mBlah) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -45,10 +43,7 @@ fn bindgen_test_layout_ContainsOpaqueTemplate() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mBaz) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).mBaz) as usize - ptr as usize },
         404usize,
         concat!(
             "Offset of field: ",
@@ -83,6 +78,7 @@ pub struct InheritsOpaqueTemplate {
 fn bindgen_test_layout_InheritsOpaqueTemplate() {
     const UNINIT: ::std::mem::MaybeUninit<InheritsOpaqueTemplate> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<InheritsOpaqueTemplate>(),
         416usize,
@@ -94,10 +90,7 @@ fn bindgen_test_layout_InheritsOpaqueTemplate() {
         concat!("Alignment of ", stringify!(InheritsOpaqueTemplate))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).wow) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).wow) as usize - ptr as usize },
         408usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/opaque-template-inst-member.rs
+++ b/tests/expectations/tests/opaque-template-inst-member.rs
@@ -19,6 +19,8 @@ pub struct ContainsOpaqueTemplate {
 }
 #[test]
 fn bindgen_test_layout_ContainsOpaqueTemplate() {
+    const UNINIT: ::std::mem::MaybeUninit<ContainsOpaqueTemplate> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<ContainsOpaqueTemplate>(),
         408usize,
@@ -29,42 +31,32 @@ fn bindgen_test_layout_ContainsOpaqueTemplate() {
         4usize,
         concat!("Alignment of ", stringify!(ContainsOpaqueTemplate))
     );
-    fn test_field_mBlah() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<ContainsOpaqueTemplate>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).mBlah) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(ContainsOpaqueTemplate),
-                "::",
-                stringify!(mBlah)
-            )
-        );
-    }
-    test_field_mBlah();
-    fn test_field_mBaz() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<ContainsOpaqueTemplate>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).mBaz) as usize - ptr as usize
-            },
-            404usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(ContainsOpaqueTemplate),
-                "::",
-                stringify!(mBaz)
-            )
-        );
-    }
-    test_field_mBaz();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).mBlah) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ContainsOpaqueTemplate),
+            "::",
+            stringify!(mBlah)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).mBaz) as usize - ptr as usize
+        },
+        404usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ContainsOpaqueTemplate),
+            "::",
+            stringify!(mBaz)
+        )
+    );
 }
 impl Default for ContainsOpaqueTemplate {
     fn default() -> Self {
@@ -89,6 +81,8 @@ pub struct InheritsOpaqueTemplate {
 }
 #[test]
 fn bindgen_test_layout_InheritsOpaqueTemplate() {
+    const UNINIT: ::std::mem::MaybeUninit<InheritsOpaqueTemplate> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<InheritsOpaqueTemplate>(),
         416usize,
@@ -99,24 +93,19 @@ fn bindgen_test_layout_InheritsOpaqueTemplate() {
         8usize,
         concat!("Alignment of ", stringify!(InheritsOpaqueTemplate))
     );
-    fn test_field_wow() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<InheritsOpaqueTemplate>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).wow) as usize - ptr as usize
-            },
-            408usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(InheritsOpaqueTemplate),
-                "::",
-                stringify!(wow)
-            )
-        );
-    }
-    test_field_wow();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).wow) as usize - ptr as usize
+        },
+        408usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(InheritsOpaqueTemplate),
+            "::",
+            stringify!(wow)
+        )
+    );
 }
 impl Default for InheritsOpaqueTemplate {
     fn default() -> Self {

--- a/tests/expectations/tests/opaque-template-instantiation-namespaced.rs
+++ b/tests/expectations/tests/opaque-template-instantiation-namespaced.rs
@@ -35,6 +35,8 @@ pub mod root {
         }
         #[test]
         fn bindgen_test_layout_Foo() {
+            const UNINIT: ::std::mem::MaybeUninit<Foo> =
+                ::std::mem::MaybeUninit::uninit();
             assert_eq!(
                 ::std::mem::size_of::<Foo>(),
                 1usize,
@@ -45,23 +47,19 @@ pub mod root {
                 1usize,
                 concat!("Alignment of ", stringify!(Foo))
             );
-            fn test_field_c() {
-                assert_eq!(
-                    unsafe {
-                        let uninit = ::std::mem::MaybeUninit::<Foo>::uninit();
-                        let ptr = uninit.as_ptr();
-                        ::std::ptr::addr_of!((*ptr).c) as usize - ptr as usize
-                    },
-                    0usize,
-                    concat!(
-                        "Offset of field: ",
-                        stringify!(Foo),
-                        "::",
-                        stringify!(c)
-                    )
-                );
-            }
-            test_field_c();
+            assert_eq!(
+                unsafe {
+                    let ptr = UNINIT.as_ptr();
+                    ::std::ptr::addr_of!((*ptr).c) as usize - ptr as usize
+                },
+                0usize,
+                concat!(
+                    "Offset of field: ",
+                    stringify!(Foo),
+                    "::",
+                    stringify!(c)
+                )
+            );
         }
         #[repr(C)]
         #[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
@@ -70,6 +68,8 @@ pub mod root {
         }
         #[test]
         fn bindgen_test_layout_Bar() {
+            const UNINIT: ::std::mem::MaybeUninit<Bar> =
+                ::std::mem::MaybeUninit::uninit();
             assert_eq!(
                 ::std::mem::size_of::<Bar>(),
                 4usize,
@@ -80,23 +80,19 @@ pub mod root {
                 4usize,
                 concat!("Alignment of ", stringify!(Bar))
             );
-            fn test_field_i() {
-                assert_eq!(
-                    unsafe {
-                        let uninit = ::std::mem::MaybeUninit::<Bar>::uninit();
-                        let ptr = uninit.as_ptr();
-                        ::std::ptr::addr_of!((*ptr).i) as usize - ptr as usize
-                    },
-                    0usize,
-                    concat!(
-                        "Offset of field: ",
-                        stringify!(Bar),
-                        "::",
-                        stringify!(i)
-                    )
-                );
-            }
-            test_field_i();
+            assert_eq!(
+                unsafe {
+                    let ptr = UNINIT.as_ptr();
+                    ::std::ptr::addr_of!((*ptr).i) as usize - ptr as usize
+                },
+                0usize,
+                concat!(
+                    "Offset of field: ",
+                    stringify!(Bar),
+                    "::",
+                    stringify!(i)
+                )
+            );
         }
         #[repr(C)]
         #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -105,6 +101,8 @@ pub mod root {
         }
         #[test]
         fn bindgen_test_layout_ContainsInstantiation() {
+            const UNINIT: ::std::mem::MaybeUninit<ContainsInstantiation> =
+                ::std::mem::MaybeUninit::uninit();
             assert_eq!(
                 ::std::mem::size_of::<ContainsInstantiation>(),
                 1usize,
@@ -115,26 +113,20 @@ pub mod root {
                 1usize,
                 concat!("Alignment of ", stringify!(ContainsInstantiation))
             );
-            fn test_field_not_opaque() {
-                assert_eq!(
-                    unsafe {
-                        let uninit = ::std::mem::MaybeUninit::<
-                            ContainsInstantiation,
-                        >::uninit();
-                        let ptr = uninit.as_ptr();
-                        ::std::ptr::addr_of!((*ptr).not_opaque) as usize -
-                            ptr as usize
-                    },
-                    0usize,
-                    concat!(
-                        "Offset of field: ",
-                        stringify!(ContainsInstantiation),
-                        "::",
-                        stringify!(not_opaque)
-                    )
-                );
-            }
-            test_field_not_opaque();
+            assert_eq!(
+                unsafe {
+                    let ptr = UNINIT.as_ptr();
+                    ::std::ptr::addr_of!((*ptr).not_opaque) as usize -
+                        ptr as usize
+                },
+                0usize,
+                concat!(
+                    "Offset of field: ",
+                    stringify!(ContainsInstantiation),
+                    "::",
+                    stringify!(not_opaque)
+                )
+            );
         }
         impl Default for ContainsInstantiation {
             fn default() -> Self {
@@ -152,6 +144,8 @@ pub mod root {
         }
         #[test]
         fn bindgen_test_layout_ContainsOpaqueInstantiation() {
+            const UNINIT: ::std::mem::MaybeUninit<ContainsOpaqueInstantiation> =
+                ::std::mem::MaybeUninit::uninit();
             assert_eq!(
                 ::std::mem::size_of::<ContainsOpaqueInstantiation>(),
                 4usize,
@@ -165,26 +159,19 @@ pub mod root {
                     stringify!(ContainsOpaqueInstantiation)
                 )
             );
-            fn test_field_opaque() {
-                assert_eq!(
-                    unsafe {
-                        let uninit = ::std::mem::MaybeUninit::<
-                            ContainsOpaqueInstantiation,
-                        >::uninit();
-                        let ptr = uninit.as_ptr();
-                        ::std::ptr::addr_of!((*ptr).opaque) as usize -
-                            ptr as usize
-                    },
-                    0usize,
-                    concat!(
-                        "Offset of field: ",
-                        stringify!(ContainsOpaqueInstantiation),
-                        "::",
-                        stringify!(opaque)
-                    )
-                );
-            }
-            test_field_opaque();
+            assert_eq!(
+                unsafe {
+                    let ptr = UNINIT.as_ptr();
+                    ::std::ptr::addr_of!((*ptr).opaque) as usize - ptr as usize
+                },
+                0usize,
+                concat!(
+                    "Offset of field: ",
+                    stringify!(ContainsOpaqueInstantiation),
+                    "::",
+                    stringify!(opaque)
+                )
+            );
         }
     }
     #[test]

--- a/tests/expectations/tests/opaque-template-instantiation-namespaced.rs
+++ b/tests/expectations/tests/opaque-template-instantiation-namespaced.rs
@@ -37,6 +37,7 @@ pub mod root {
         fn bindgen_test_layout_Foo() {
             const UNINIT: ::std::mem::MaybeUninit<Foo> =
                 ::std::mem::MaybeUninit::uninit();
+            let ptr = UNINIT.as_ptr();
             assert_eq!(
                 ::std::mem::size_of::<Foo>(),
                 1usize,
@@ -49,7 +50,6 @@ pub mod root {
             );
             assert_eq!(
                 unsafe {
-                    let ptr = UNINIT.as_ptr();
                     ::std::ptr::addr_of!((*ptr).c) as usize - ptr as usize
                 },
                 0usize,
@@ -70,6 +70,7 @@ pub mod root {
         fn bindgen_test_layout_Bar() {
             const UNINIT: ::std::mem::MaybeUninit<Bar> =
                 ::std::mem::MaybeUninit::uninit();
+            let ptr = UNINIT.as_ptr();
             assert_eq!(
                 ::std::mem::size_of::<Bar>(),
                 4usize,
@@ -82,7 +83,6 @@ pub mod root {
             );
             assert_eq!(
                 unsafe {
-                    let ptr = UNINIT.as_ptr();
                     ::std::ptr::addr_of!((*ptr).i) as usize - ptr as usize
                 },
                 0usize,
@@ -103,6 +103,7 @@ pub mod root {
         fn bindgen_test_layout_ContainsInstantiation() {
             const UNINIT: ::std::mem::MaybeUninit<ContainsInstantiation> =
                 ::std::mem::MaybeUninit::uninit();
+            let ptr = UNINIT.as_ptr();
             assert_eq!(
                 ::std::mem::size_of::<ContainsInstantiation>(),
                 1usize,
@@ -115,7 +116,6 @@ pub mod root {
             );
             assert_eq!(
                 unsafe {
-                    let ptr = UNINIT.as_ptr();
                     ::std::ptr::addr_of!((*ptr).not_opaque) as usize -
                         ptr as usize
                 },
@@ -146,6 +146,7 @@ pub mod root {
         fn bindgen_test_layout_ContainsOpaqueInstantiation() {
             const UNINIT: ::std::mem::MaybeUninit<ContainsOpaqueInstantiation> =
                 ::std::mem::MaybeUninit::uninit();
+            let ptr = UNINIT.as_ptr();
             assert_eq!(
                 ::std::mem::size_of::<ContainsOpaqueInstantiation>(),
                 4usize,
@@ -161,7 +162,6 @@ pub mod root {
             );
             assert_eq!(
                 unsafe {
-                    let ptr = UNINIT.as_ptr();
                     ::std::ptr::addr_of!((*ptr).opaque) as usize - ptr as usize
                 },
                 0usize,

--- a/tests/expectations/tests/opaque-template-instantiation.rs
+++ b/tests/expectations/tests/opaque-template-instantiation.rs
@@ -27,6 +27,8 @@ pub struct ContainsInstantiation {
 }
 #[test]
 fn bindgen_test_layout_ContainsInstantiation() {
+    const UNINIT: ::std::mem::MaybeUninit<ContainsInstantiation> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<ContainsInstantiation>(),
         1usize,
@@ -37,24 +39,19 @@ fn bindgen_test_layout_ContainsInstantiation() {
         1usize,
         concat!("Alignment of ", stringify!(ContainsInstantiation))
     );
-    fn test_field_not_opaque() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<ContainsInstantiation>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).not_opaque) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(ContainsInstantiation),
-                "::",
-                stringify!(not_opaque)
-            )
-        );
-    }
-    test_field_not_opaque();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).not_opaque) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ContainsInstantiation),
+            "::",
+            stringify!(not_opaque)
+        )
+    );
 }
 impl Default for ContainsInstantiation {
     fn default() -> Self {
@@ -72,6 +69,8 @@ pub struct ContainsOpaqueInstantiation {
 }
 #[test]
 fn bindgen_test_layout_ContainsOpaqueInstantiation() {
+    const UNINIT: ::std::mem::MaybeUninit<ContainsOpaqueInstantiation> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<ContainsOpaqueInstantiation>(),
         4usize,
@@ -82,25 +81,19 @@ fn bindgen_test_layout_ContainsOpaqueInstantiation() {
         4usize,
         concat!("Alignment of ", stringify!(ContainsOpaqueInstantiation))
     );
-    fn test_field_opaque() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<
-                    ContainsOpaqueInstantiation,
-                >::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).opaque) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(ContainsOpaqueInstantiation),
-                "::",
-                stringify!(opaque)
-            )
-        );
-    }
-    test_field_opaque();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).opaque) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ContainsOpaqueInstantiation),
+            "::",
+            stringify!(opaque)
+        )
+    );
 }
 #[test]
 fn __bindgen_test_layout_Template_open0_char_close0_instantiation() {

--- a/tests/expectations/tests/opaque-template-instantiation.rs
+++ b/tests/expectations/tests/opaque-template-instantiation.rs
@@ -29,6 +29,7 @@ pub struct ContainsInstantiation {
 fn bindgen_test_layout_ContainsInstantiation() {
     const UNINIT: ::std::mem::MaybeUninit<ContainsInstantiation> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<ContainsInstantiation>(),
         1usize,
@@ -41,7 +42,6 @@ fn bindgen_test_layout_ContainsInstantiation() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).not_opaque) as usize - ptr as usize
         },
         0usize,
@@ -71,6 +71,7 @@ pub struct ContainsOpaqueInstantiation {
 fn bindgen_test_layout_ContainsOpaqueInstantiation() {
     const UNINIT: ::std::mem::MaybeUninit<ContainsOpaqueInstantiation> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<ContainsOpaqueInstantiation>(),
         4usize,
@@ -82,10 +83,7 @@ fn bindgen_test_layout_ContainsOpaqueInstantiation() {
         concat!("Alignment of ", stringify!(ContainsOpaqueInstantiation))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).opaque) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).opaque) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/opaque_in_struct.rs
+++ b/tests/expectations/tests/opaque_in_struct.rs
@@ -32,6 +32,8 @@ pub struct container {
 }
 #[test]
 fn bindgen_test_layout_container() {
+    const UNINIT: ::std::mem::MaybeUninit<container> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<container>(),
         4usize,
@@ -42,21 +44,17 @@ fn bindgen_test_layout_container() {
         4usize,
         concat!("Alignment of ", stringify!(container))
     );
-    fn test_field_contained() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<container>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).contained) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(container),
-                "::",
-                stringify!(contained)
-            )
-        );
-    }
-    test_field_contained();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).contained) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(container),
+            "::",
+            stringify!(contained)
+        )
+    );
 }

--- a/tests/expectations/tests/opaque_in_struct.rs
+++ b/tests/expectations/tests/opaque_in_struct.rs
@@ -34,6 +34,7 @@ pub struct container {
 fn bindgen_test_layout_container() {
     const UNINIT: ::std::mem::MaybeUninit<container> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<container>(),
         4usize,
@@ -46,7 +47,6 @@ fn bindgen_test_layout_container() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).contained) as usize - ptr as usize
         },
         0usize,

--- a/tests/expectations/tests/opaque_pointer.rs
+++ b/tests/expectations/tests/opaque_pointer.rs
@@ -42,6 +42,7 @@ pub struct WithOpaquePtr {
 fn bindgen_test_layout_WithOpaquePtr() {
     const UNINIT: ::std::mem::MaybeUninit<WithOpaquePtr> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<WithOpaquePtr>(),
         16usize,
@@ -54,7 +55,6 @@ fn bindgen_test_layout_WithOpaquePtr() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).whatever) as usize - ptr as usize
         },
         0usize,
@@ -66,10 +66,7 @@ fn bindgen_test_layout_WithOpaquePtr() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).other) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).other) as usize - ptr as usize },
         8usize,
         concat!(
             "Offset of field: ",
@@ -79,10 +76,7 @@ fn bindgen_test_layout_WithOpaquePtr() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).t) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).t) as usize - ptr as usize },
         12usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/opaque_pointer.rs
+++ b/tests/expectations/tests/opaque_pointer.rs
@@ -40,6 +40,8 @@ pub struct WithOpaquePtr {
 }
 #[test]
 fn bindgen_test_layout_WithOpaquePtr() {
+    const UNINIT: ::std::mem::MaybeUninit<WithOpaquePtr> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<WithOpaquePtr>(),
         16usize,
@@ -50,57 +52,45 @@ fn bindgen_test_layout_WithOpaquePtr() {
         8usize,
         concat!("Alignment of ", stringify!(WithOpaquePtr))
     );
-    fn test_field_whatever() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<WithOpaquePtr>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).whatever) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(WithOpaquePtr),
-                "::",
-                stringify!(whatever)
-            )
-        );
-    }
-    test_field_whatever();
-    fn test_field_other() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<WithOpaquePtr>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).other) as usize - ptr as usize
-            },
-            8usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(WithOpaquePtr),
-                "::",
-                stringify!(other)
-            )
-        );
-    }
-    test_field_other();
-    fn test_field_t() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<WithOpaquePtr>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).t) as usize - ptr as usize
-            },
-            12usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(WithOpaquePtr),
-                "::",
-                stringify!(t)
-            )
-        );
-    }
-    test_field_t();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).whatever) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(WithOpaquePtr),
+            "::",
+            stringify!(whatever)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).other) as usize - ptr as usize
+        },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(WithOpaquePtr),
+            "::",
+            stringify!(other)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).t) as usize - ptr as usize
+        },
+        12usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(WithOpaquePtr),
+            "::",
+            stringify!(t)
+        )
+    );
 }
 impl Default for WithOpaquePtr {
     fn default() -> Self {

--- a/tests/expectations/tests/packed-n-with-padding.rs
+++ b/tests/expectations/tests/packed-n-with-padding.rs
@@ -15,6 +15,8 @@ pub struct Packed {
 }
 #[test]
 fn bindgen_test_layout_Packed() {
+    const UNINIT: ::std::mem::MaybeUninit<Packed> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<Packed>(),
         10usize,
@@ -25,72 +27,36 @@ fn bindgen_test_layout_Packed() {
         2usize,
         concat!("Alignment of ", stringify!(Packed))
     );
-    fn test_field_a() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Packed>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(Packed),
-                "::",
-                stringify!(a)
-            )
-        );
-    }
-    test_field_a();
-    fn test_field_b() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Packed>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-            },
-            2usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(Packed),
-                "::",
-                stringify!(b)
-            )
-        );
-    }
-    test_field_b();
-    fn test_field_c() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Packed>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).c) as usize - ptr as usize
-            },
-            4usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(Packed),
-                "::",
-                stringify!(c)
-            )
-        );
-    }
-    test_field_c();
-    fn test_field_d() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Packed>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize
-            },
-            6usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(Packed),
-                "::",
-                stringify!(d)
-            )
-        );
-    }
-    test_field_d();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+        },
+        0usize,
+        concat!("Offset of field: ", stringify!(Packed), "::", stringify!(a))
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
+        },
+        2usize,
+        concat!("Offset of field: ", stringify!(Packed), "::", stringify!(b))
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).c) as usize - ptr as usize
+        },
+        4usize,
+        concat!("Offset of field: ", stringify!(Packed), "::", stringify!(c))
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize
+        },
+        6usize,
+        concat!("Offset of field: ", stringify!(Packed), "::", stringify!(d))
+    );
 }

--- a/tests/expectations/tests/packed-n-with-padding.rs
+++ b/tests/expectations/tests/packed-n-with-padding.rs
@@ -17,6 +17,7 @@ pub struct Packed {
 fn bindgen_test_layout_Packed() {
     const UNINIT: ::std::mem::MaybeUninit<Packed> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<Packed>(),
         10usize,
@@ -28,34 +29,22 @@ fn bindgen_test_layout_Packed() {
         concat!("Alignment of ", stringify!(Packed))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
         0usize,
         concat!("Offset of field: ", stringify!(Packed), "::", stringify!(a))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
         2usize,
         concat!("Offset of field: ", stringify!(Packed), "::", stringify!(b))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).c) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).c) as usize - ptr as usize },
         4usize,
         concat!("Offset of field: ", stringify!(Packed), "::", stringify!(c))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize },
         6usize,
         concat!("Offset of field: ", stringify!(Packed), "::", stringify!(d))
     );

--- a/tests/expectations/tests/private.rs
+++ b/tests/expectations/tests/private.rs
@@ -14,6 +14,8 @@ pub struct HasPrivate {
 }
 #[test]
 fn bindgen_test_layout_HasPrivate() {
+    const UNINIT: ::std::mem::MaybeUninit<HasPrivate> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<HasPrivate>(),
         8usize,
@@ -24,40 +26,32 @@ fn bindgen_test_layout_HasPrivate() {
         4usize,
         concat!("Alignment of ", stringify!(HasPrivate))
     );
-    fn test_field_mNotPrivate() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<HasPrivate>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).mNotPrivate) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(HasPrivate),
-                "::",
-                stringify!(mNotPrivate)
-            )
-        );
-    }
-    test_field_mNotPrivate();
-    fn test_field_mIsPrivate() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<HasPrivate>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).mIsPrivate) as usize - ptr as usize
-            },
-            4usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(HasPrivate),
-                "::",
-                stringify!(mIsPrivate)
-            )
-        );
-    }
-    test_field_mIsPrivate();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).mNotPrivate) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(HasPrivate),
+            "::",
+            stringify!(mNotPrivate)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).mIsPrivate) as usize - ptr as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(HasPrivate),
+            "::",
+            stringify!(mIsPrivate)
+        )
+    );
 }
 /// <div rustbindgen private></div>
 #[repr(C)]
@@ -68,6 +62,8 @@ pub struct VeryPrivate {
 }
 #[test]
 fn bindgen_test_layout_VeryPrivate() {
+    const UNINIT: ::std::mem::MaybeUninit<VeryPrivate> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<VeryPrivate>(),
         8usize,
@@ -78,41 +74,32 @@ fn bindgen_test_layout_VeryPrivate() {
         4usize,
         concat!("Alignment of ", stringify!(VeryPrivate))
     );
-    fn test_field_mIsPrivate() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<VeryPrivate>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).mIsPrivate) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(VeryPrivate),
-                "::",
-                stringify!(mIsPrivate)
-            )
-        );
-    }
-    test_field_mIsPrivate();
-    fn test_field_mIsAlsoPrivate() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<VeryPrivate>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).mIsAlsoPrivate) as usize -
-                    ptr as usize
-            },
-            4usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(VeryPrivate),
-                "::",
-                stringify!(mIsAlsoPrivate)
-            )
-        );
-    }
-    test_field_mIsAlsoPrivate();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).mIsPrivate) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(VeryPrivate),
+            "::",
+            stringify!(mIsPrivate)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).mIsAlsoPrivate) as usize - ptr as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(VeryPrivate),
+            "::",
+            stringify!(mIsAlsoPrivate)
+        )
+    );
 }
 /// <div rustbindgen private></div>
 #[repr(C)]
@@ -124,6 +111,8 @@ pub struct ContradictPrivate {
 }
 #[test]
 fn bindgen_test_layout_ContradictPrivate() {
+    const UNINIT: ::std::mem::MaybeUninit<ContradictPrivate> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<ContradictPrivate>(),
         8usize,
@@ -134,40 +123,30 @@ fn bindgen_test_layout_ContradictPrivate() {
         4usize,
         concat!("Alignment of ", stringify!(ContradictPrivate))
     );
-    fn test_field_mNotPrivate() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<ContradictPrivate>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).mNotPrivate) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(ContradictPrivate),
-                "::",
-                stringify!(mNotPrivate)
-            )
-        );
-    }
-    test_field_mNotPrivate();
-    fn test_field_mIsPrivate() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<ContradictPrivate>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).mIsPrivate) as usize - ptr as usize
-            },
-            4usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(ContradictPrivate),
-                "::",
-                stringify!(mIsPrivate)
-            )
-        );
-    }
-    test_field_mIsPrivate();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).mNotPrivate) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ContradictPrivate),
+            "::",
+            stringify!(mNotPrivate)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).mIsPrivate) as usize - ptr as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ContradictPrivate),
+            "::",
+            stringify!(mIsPrivate)
+        )
+    );
 }

--- a/tests/expectations/tests/private.rs
+++ b/tests/expectations/tests/private.rs
@@ -16,6 +16,7 @@ pub struct HasPrivate {
 fn bindgen_test_layout_HasPrivate() {
     const UNINIT: ::std::mem::MaybeUninit<HasPrivate> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<HasPrivate>(),
         8usize,
@@ -28,7 +29,6 @@ fn bindgen_test_layout_HasPrivate() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).mNotPrivate) as usize - ptr as usize
         },
         0usize,
@@ -41,7 +41,6 @@ fn bindgen_test_layout_HasPrivate() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).mIsPrivate) as usize - ptr as usize
         },
         4usize,
@@ -64,6 +63,7 @@ pub struct VeryPrivate {
 fn bindgen_test_layout_VeryPrivate() {
     const UNINIT: ::std::mem::MaybeUninit<VeryPrivate> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<VeryPrivate>(),
         8usize,
@@ -76,7 +76,6 @@ fn bindgen_test_layout_VeryPrivate() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).mIsPrivate) as usize - ptr as usize
         },
         0usize,
@@ -89,7 +88,6 @@ fn bindgen_test_layout_VeryPrivate() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).mIsAlsoPrivate) as usize - ptr as usize
         },
         4usize,
@@ -113,6 +111,7 @@ pub struct ContradictPrivate {
 fn bindgen_test_layout_ContradictPrivate() {
     const UNINIT: ::std::mem::MaybeUninit<ContradictPrivate> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<ContradictPrivate>(),
         8usize,
@@ -125,7 +124,6 @@ fn bindgen_test_layout_ContradictPrivate() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).mNotPrivate) as usize - ptr as usize
         },
         0usize,
@@ -138,7 +136,6 @@ fn bindgen_test_layout_ContradictPrivate() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).mIsPrivate) as usize - ptr as usize
         },
         4usize,

--- a/tests/expectations/tests/private_fields.rs
+++ b/tests/expectations/tests/private_fields.rs
@@ -101,6 +101,7 @@ pub struct PubPriv {
 fn bindgen_test_layout_PubPriv() {
     const UNINIT: ::std::mem::MaybeUninit<PubPriv> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<PubPriv>(),
         8usize,
@@ -112,10 +113,7 @@ fn bindgen_test_layout_PubPriv() {
         concat!("Alignment of ", stringify!(PubPriv))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -125,10 +123,7 @@ fn bindgen_test_layout_PubPriv() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).y) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).y) as usize - ptr as usize },
         4usize,
         concat!(
             "Offset of field: ",
@@ -345,6 +340,7 @@ pub struct Base {
 fn bindgen_test_layout_Base() {
     const UNINIT: ::std::mem::MaybeUninit<Base> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<Base>(),
         4usize,
@@ -356,10 +352,7 @@ fn bindgen_test_layout_Base() {
         concat!("Alignment of ", stringify!(Base))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).member) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).member) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -420,6 +413,7 @@ pub struct WithAnonStruct__bindgen_ty_1 {
 fn bindgen_test_layout_WithAnonStruct__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<WithAnonStruct__bindgen_ty_1> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<WithAnonStruct__bindgen_ty_1>(),
         4usize,
@@ -431,10 +425,7 @@ fn bindgen_test_layout_WithAnonStruct__bindgen_ty_1() {
         concat!("Alignment of ", stringify!(WithAnonStruct__bindgen_ty_1))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -453,6 +444,7 @@ pub struct WithAnonStruct__bindgen_ty_2 {
 fn bindgen_test_layout_WithAnonStruct__bindgen_ty_2() {
     const UNINIT: ::std::mem::MaybeUninit<WithAnonStruct__bindgen_ty_2> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<WithAnonStruct__bindgen_ty_2>(),
         4usize,
@@ -464,10 +456,7 @@ fn bindgen_test_layout_WithAnonStruct__bindgen_ty_2() {
         concat!("Alignment of ", stringify!(WithAnonStruct__bindgen_ty_2))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/private_fields.rs
+++ b/tests/expectations/tests/private_fields.rs
@@ -99,6 +99,8 @@ pub struct PubPriv {
 }
 #[test]
 fn bindgen_test_layout_PubPriv() {
+    const UNINIT: ::std::mem::MaybeUninit<PubPriv> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<PubPriv>(),
         8usize,
@@ -109,40 +111,32 @@ fn bindgen_test_layout_PubPriv() {
         4usize,
         concat!("Alignment of ", stringify!(PubPriv))
     );
-    fn test_field_x() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<PubPriv>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(PubPriv),
-                "::",
-                stringify!(x)
-            )
-        );
-    }
-    test_field_x();
-    fn test_field_y() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<PubPriv>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).y) as usize - ptr as usize
-            },
-            4usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(PubPriv),
-                "::",
-                stringify!(y)
-            )
-        );
-    }
-    test_field_y();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(PubPriv),
+            "::",
+            stringify!(x)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).y) as usize - ptr as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(PubPriv),
+            "::",
+            stringify!(y)
+        )
+    );
 }
 #[repr(C)]
 #[repr(align(4))]
@@ -349,6 +343,8 @@ pub struct Base {
 }
 #[test]
 fn bindgen_test_layout_Base() {
+    const UNINIT: ::std::mem::MaybeUninit<Base> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<Base>(),
         4usize,
@@ -359,23 +355,19 @@ fn bindgen_test_layout_Base() {
         4usize,
         concat!("Alignment of ", stringify!(Base))
     );
-    fn test_field_member() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Base>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).member) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(Base),
-                "::",
-                stringify!(member)
-            )
-        );
-    }
-    test_field_member();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).member) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(Base),
+            "::",
+            stringify!(member)
+        )
+    );
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
@@ -426,6 +418,8 @@ pub struct WithAnonStruct__bindgen_ty_1 {
 }
 #[test]
 fn bindgen_test_layout_WithAnonStruct__bindgen_ty_1() {
+    const UNINIT: ::std::mem::MaybeUninit<WithAnonStruct__bindgen_ty_1> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<WithAnonStruct__bindgen_ty_1>(),
         4usize,
@@ -436,25 +430,19 @@ fn bindgen_test_layout_WithAnonStruct__bindgen_ty_1() {
         4usize,
         concat!("Alignment of ", stringify!(WithAnonStruct__bindgen_ty_1))
     );
-    fn test_field_a() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<
-                    WithAnonStruct__bindgen_ty_1,
-                >::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(WithAnonStruct__bindgen_ty_1),
-                "::",
-                stringify!(a)
-            )
-        );
-    }
-    test_field_a();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(WithAnonStruct__bindgen_ty_1),
+            "::",
+            stringify!(a)
+        )
+    );
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
@@ -463,6 +451,8 @@ pub struct WithAnonStruct__bindgen_ty_2 {
 }
 #[test]
 fn bindgen_test_layout_WithAnonStruct__bindgen_ty_2() {
+    const UNINIT: ::std::mem::MaybeUninit<WithAnonStruct__bindgen_ty_2> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<WithAnonStruct__bindgen_ty_2>(),
         4usize,
@@ -473,25 +463,19 @@ fn bindgen_test_layout_WithAnonStruct__bindgen_ty_2() {
         4usize,
         concat!("Alignment of ", stringify!(WithAnonStruct__bindgen_ty_2))
     );
-    fn test_field_b() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<
-                    WithAnonStruct__bindgen_ty_2,
-                >::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(WithAnonStruct__bindgen_ty_2),
-                "::",
-                stringify!(b)
-            )
-        );
-    }
-    test_field_b();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(WithAnonStruct__bindgen_ty_2),
+            "::",
+            stringify!(b)
+        )
+    );
 }
 #[test]
 fn bindgen_test_layout_WithAnonStruct() {

--- a/tests/expectations/tests/reparented_replacement.rs
+++ b/tests/expectations/tests/reparented_replacement.rs
@@ -22,6 +22,7 @@ pub mod root {
         fn bindgen_test_layout_Bar() {
             const UNINIT: ::std::mem::MaybeUninit<Bar> =
                 ::std::mem::MaybeUninit::uninit();
+            let ptr = UNINIT.as_ptr();
             assert_eq!(
                 ::std::mem::size_of::<Bar>(),
                 4usize,
@@ -34,7 +35,6 @@ pub mod root {
             );
             assert_eq!(
                 unsafe {
-                    let ptr = UNINIT.as_ptr();
                     ::std::ptr::addr_of!((*ptr).bazz) as usize - ptr as usize
                 },
                 0usize,

--- a/tests/expectations/tests/reparented_replacement.rs
+++ b/tests/expectations/tests/reparented_replacement.rs
@@ -20,6 +20,8 @@ pub mod root {
         }
         #[test]
         fn bindgen_test_layout_Bar() {
+            const UNINIT: ::std::mem::MaybeUninit<Bar> =
+                ::std::mem::MaybeUninit::uninit();
             assert_eq!(
                 ::std::mem::size_of::<Bar>(),
                 4usize,
@@ -30,24 +32,19 @@ pub mod root {
                 4usize,
                 concat!("Alignment of ", stringify!(Bar))
             );
-            fn test_field_bazz() {
-                assert_eq!(
-                    unsafe {
-                        let uninit = ::std::mem::MaybeUninit::<Bar>::uninit();
-                        let ptr = uninit.as_ptr();
-                        ::std::ptr::addr_of!((*ptr).bazz) as usize -
-                            ptr as usize
-                    },
-                    0usize,
-                    concat!(
-                        "Offset of field: ",
-                        stringify!(Bar),
-                        "::",
-                        stringify!(bazz)
-                    )
-                );
-            }
-            test_field_bazz();
+            assert_eq!(
+                unsafe {
+                    let ptr = UNINIT.as_ptr();
+                    ::std::ptr::addr_of!((*ptr).bazz) as usize - ptr as usize
+                },
+                0usize,
+                concat!(
+                    "Offset of field: ",
+                    stringify!(Bar),
+                    "::",
+                    stringify!(bazz)
+                )
+            );
         }
     }
     pub type ReferencesBar = root::foo::Bar;

--- a/tests/expectations/tests/replace_use.rs
+++ b/tests/expectations/tests/replace_use.rs
@@ -20,6 +20,7 @@ pub struct Test {
 fn bindgen_test_layout_Test() {
     const UNINIT: ::std::mem::MaybeUninit<Test> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<Test>(),
         4usize,
@@ -31,10 +32,7 @@ fn bindgen_test_layout_Test() {
         concat!("Alignment of ", stringify!(Test))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
         0usize,
         concat!("Offset of field: ", stringify!(Test), "::", stringify!(a))
     );

--- a/tests/expectations/tests/replace_use.rs
+++ b/tests/expectations/tests/replace_use.rs
@@ -18,6 +18,8 @@ pub struct Test {
 }
 #[test]
 fn bindgen_test_layout_Test() {
+    const UNINIT: ::std::mem::MaybeUninit<Test> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<Test>(),
         4usize,
@@ -28,18 +30,14 @@ fn bindgen_test_layout_Test() {
         4usize,
         concat!("Alignment of ", stringify!(Test))
     );
-    fn test_field_a() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Test>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-            },
-            0usize,
-            concat!("Offset of field: ", stringify!(Test), "::", stringify!(a))
-        );
-    }
-    test_field_a();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+        },
+        0usize,
+        concat!("Offset of field: ", stringify!(Test), "::", stringify!(a))
+    );
 }
 #[test]
 fn __bindgen_test_layout_nsTArray_open0_long_close0_instantiation() {

--- a/tests/expectations/tests/repr-align.rs
+++ b/tests/expectations/tests/repr-align.rs
@@ -15,6 +15,8 @@ pub struct a {
 }
 #[test]
 fn bindgen_test_layout_a() {
+    const UNINIT: ::std::mem::MaybeUninit<a> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<a>(),
         8usize,
@@ -25,30 +27,22 @@ fn bindgen_test_layout_a() {
         8usize,
         concat!("Alignment of ", stringify!(a))
     );
-    fn test_field_b() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<a>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-            },
-            0usize,
-            concat!("Offset of field: ", stringify!(a), "::", stringify!(b))
-        );
-    }
-    test_field_b();
-    fn test_field_c() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<a>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).c) as usize - ptr as usize
-            },
-            4usize,
-            concat!("Offset of field: ", stringify!(a), "::", stringify!(c))
-        );
-    }
-    test_field_c();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
+        },
+        0usize,
+        concat!("Offset of field: ", stringify!(a), "::", stringify!(b))
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).c) as usize - ptr as usize
+        },
+        4usize,
+        concat!("Offset of field: ", stringify!(a), "::", stringify!(c))
+    );
 }
 #[repr(C)]
 #[repr(align(8))]
@@ -59,6 +53,8 @@ pub struct b {
 }
 #[test]
 fn bindgen_test_layout_b() {
+    const UNINIT: ::std::mem::MaybeUninit<b> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<b>(),
         8usize,
@@ -69,28 +65,20 @@ fn bindgen_test_layout_b() {
         8usize,
         concat!("Alignment of ", stringify!(b))
     );
-    fn test_field_b() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<b>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-            },
-            0usize,
-            concat!("Offset of field: ", stringify!(b), "::", stringify!(b))
-        );
-    }
-    test_field_b();
-    fn test_field_c() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<b>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).c) as usize - ptr as usize
-            },
-            4usize,
-            concat!("Offset of field: ", stringify!(b), "::", stringify!(c))
-        );
-    }
-    test_field_c();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
+        },
+        0usize,
+        concat!("Offset of field: ", stringify!(b), "::", stringify!(b))
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).c) as usize - ptr as usize
+        },
+        4usize,
+        concat!("Offset of field: ", stringify!(b), "::", stringify!(c))
+    );
 }

--- a/tests/expectations/tests/repr-align.rs
+++ b/tests/expectations/tests/repr-align.rs
@@ -17,6 +17,7 @@ pub struct a {
 fn bindgen_test_layout_a() {
     const UNINIT: ::std::mem::MaybeUninit<a> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<a>(),
         8usize,
@@ -28,18 +29,12 @@ fn bindgen_test_layout_a() {
         concat!("Alignment of ", stringify!(a))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
         0usize,
         concat!("Offset of field: ", stringify!(a), "::", stringify!(b))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).c) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).c) as usize - ptr as usize },
         4usize,
         concat!("Offset of field: ", stringify!(a), "::", stringify!(c))
     );
@@ -55,6 +50,7 @@ pub struct b {
 fn bindgen_test_layout_b() {
     const UNINIT: ::std::mem::MaybeUninit<b> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<b>(),
         8usize,
@@ -66,18 +62,12 @@ fn bindgen_test_layout_b() {
         concat!("Alignment of ", stringify!(b))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
         0usize,
         concat!("Offset of field: ", stringify!(b), "::", stringify!(b))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).c) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).c) as usize - ptr as usize },
         4usize,
         concat!("Offset of field: ", stringify!(b), "::", stringify!(c))
     );

--- a/tests/expectations/tests/same_struct_name_in_different_namespaces.rs
+++ b/tests/expectations/tests/same_struct_name_in_different_namespaces.rs
@@ -18,6 +18,8 @@ pub struct JS_shadow_Zone {
 }
 #[test]
 fn bindgen_test_layout_JS_shadow_Zone() {
+    const UNINIT: ::std::mem::MaybeUninit<JS_shadow_Zone> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<JS_shadow_Zone>(),
         8usize,
@@ -28,40 +30,30 @@ fn bindgen_test_layout_JS_shadow_Zone() {
         4usize,
         concat!("Alignment of ", stringify!(JS_shadow_Zone))
     );
-    fn test_field_x() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<JS_shadow_Zone>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(JS_shadow_Zone),
-                "::",
-                stringify!(x)
-            )
-        );
-    }
-    test_field_x();
-    fn test_field_y() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<JS_shadow_Zone>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).y) as usize - ptr as usize
-            },
-            4usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(JS_shadow_Zone),
-                "::",
-                stringify!(y)
-            )
-        );
-    }
-    test_field_y();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(JS_shadow_Zone),
+            "::",
+            stringify!(x)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).y) as usize - ptr as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(JS_shadow_Zone),
+            "::",
+            stringify!(y)
+        )
+    );
 }

--- a/tests/expectations/tests/same_struct_name_in_different_namespaces.rs
+++ b/tests/expectations/tests/same_struct_name_in_different_namespaces.rs
@@ -20,6 +20,7 @@ pub struct JS_shadow_Zone {
 fn bindgen_test_layout_JS_shadow_Zone() {
     const UNINIT: ::std::mem::MaybeUninit<JS_shadow_Zone> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<JS_shadow_Zone>(),
         8usize,
@@ -31,10 +32,7 @@ fn bindgen_test_layout_JS_shadow_Zone() {
         concat!("Alignment of ", stringify!(JS_shadow_Zone))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -44,10 +42,7 @@ fn bindgen_test_layout_JS_shadow_Zone() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).y) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).y) as usize - ptr as usize },
         4usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/sentry-defined-multiple-times.rs
+++ b/tests/expectations/tests/sentry-defined-multiple-times.rs
@@ -31,6 +31,7 @@ pub mod root {
         fn bindgen_test_layout_sentry() {
             const UNINIT: ::std::mem::MaybeUninit<sentry> =
                 ::std::mem::MaybeUninit::uninit();
+            let ptr = UNINIT.as_ptr();
             assert_eq!(
                 ::std::mem::size_of::<sentry>(),
                 1usize,
@@ -43,7 +44,6 @@ pub mod root {
             );
             assert_eq!(
                 unsafe {
-                    let ptr = UNINIT.as_ptr();
                     ::std::ptr::addr_of!((*ptr).i_am_plain_sentry) as usize -
                         ptr as usize
                 },
@@ -83,6 +83,7 @@ pub mod root {
         fn bindgen_test_layout_NotTemplateWrapper_sentry() {
             const UNINIT: ::std::mem::MaybeUninit<NotTemplateWrapper_sentry> =
                 ::std::mem::MaybeUninit::uninit();
+            let ptr = UNINIT.as_ptr();
             assert_eq!(
                 ::std::mem::size_of::<NotTemplateWrapper_sentry>(),
                 1usize,
@@ -95,7 +96,6 @@ pub mod root {
             );
             assert_eq!(
                 unsafe {
-                    let ptr = UNINIT.as_ptr();
                     ::std::ptr::addr_of!(
                         (*ptr).i_am_not_template_wrapper_sentry
                     ) as usize -
@@ -125,6 +125,7 @@ pub mod root {
             const UNINIT: ::std::mem::MaybeUninit<
                 InlineNotTemplateWrapper_sentry,
             > = ::std::mem::MaybeUninit::uninit();
+            let ptr = UNINIT.as_ptr();
             assert_eq!(
                 ::std::mem::size_of::<InlineNotTemplateWrapper_sentry>(),
                 1usize,
@@ -143,7 +144,6 @@ pub mod root {
             );
             assert_eq!(
                 unsafe {
-                    let ptr = UNINIT.as_ptr();
                     ::std::ptr::addr_of!(
                         (*ptr).i_am_inline_not_template_wrapper_sentry
                     ) as usize -
@@ -233,6 +233,7 @@ pub mod root {
             const UNINIT: ::std::mem::MaybeUninit<
                 OuterDoubleWrapper_InnerDoubleWrapper_sentry,
             > = ::std::mem::MaybeUninit::uninit();
+            let ptr = UNINIT.as_ptr();
             assert_eq!(
                 ::std::mem::size_of::<
                     OuterDoubleWrapper_InnerDoubleWrapper_sentry,
@@ -255,7 +256,6 @@ pub mod root {
             );
             assert_eq!(
                 unsafe {
-                    let ptr = UNINIT.as_ptr();
                     ::std::ptr::addr_of!((*ptr).i_am_double_wrapper_sentry)
                         as usize -
                         ptr as usize
@@ -290,9 +290,10 @@ pub mod root {
             const UNINIT: ::std::mem::MaybeUninit<
                 OuterDoubleInlineWrapper_InnerDoubleInlineWrapper_sentry,
             > = ::std::mem::MaybeUninit::uninit();
+            let ptr = UNINIT.as_ptr();
             assert_eq ! (:: std :: mem :: size_of :: < OuterDoubleInlineWrapper_InnerDoubleInlineWrapper_sentry > () , 4usize , concat ! ("Size of: " , stringify ! (OuterDoubleInlineWrapper_InnerDoubleInlineWrapper_sentry)));
             assert_eq ! (:: std :: mem :: align_of :: < OuterDoubleInlineWrapper_InnerDoubleInlineWrapper_sentry > () , 4usize , concat ! ("Alignment of " , stringify ! (OuterDoubleInlineWrapper_InnerDoubleInlineWrapper_sentry)));
-            assert_eq ! (unsafe { let ptr = UNINIT . as_ptr () ; :: std :: ptr :: addr_of ! ((* ptr) . i_am_double_wrapper_inline_sentry) as usize - ptr as usize } , 0usize , concat ! ("Offset of field: " , stringify ! (OuterDoubleInlineWrapper_InnerDoubleInlineWrapper_sentry) , "::" , stringify ! (i_am_double_wrapper_inline_sentry)));
+            assert_eq ! (unsafe { :: std :: ptr :: addr_of ! ((* ptr) . i_am_double_wrapper_inline_sentry) as usize - ptr as usize } , 0usize , concat ! ("Offset of field: " , stringify ! (OuterDoubleInlineWrapper_InnerDoubleInlineWrapper_sentry) , "::" , stringify ! (i_am_double_wrapper_inline_sentry)));
         }
         #[test]
         fn bindgen_test_layout_OuterDoubleInlineWrapper_InnerDoubleInlineWrapper(
@@ -355,6 +356,7 @@ pub mod root {
     fn bindgen_test_layout_sentry() {
         const UNINIT: ::std::mem::MaybeUninit<sentry> =
             ::std::mem::MaybeUninit::uninit();
+        let ptr = UNINIT.as_ptr();
         assert_eq!(
             ::std::mem::size_of::<sentry>(),
             4usize,
@@ -367,7 +369,6 @@ pub mod root {
         );
         assert_eq!(
             unsafe {
-                let ptr = UNINIT.as_ptr();
                 ::std::ptr::addr_of!((*ptr).i_am_outside_namespace_sentry)
                     as usize -
                     ptr as usize

--- a/tests/expectations/tests/sentry-defined-multiple-times.rs
+++ b/tests/expectations/tests/sentry-defined-multiple-times.rs
@@ -29,6 +29,8 @@ pub mod root {
         }
         #[test]
         fn bindgen_test_layout_sentry() {
+            const UNINIT: ::std::mem::MaybeUninit<sentry> =
+                ::std::mem::MaybeUninit::uninit();
             assert_eq!(
                 ::std::mem::size_of::<sentry>(),
                 1usize,
@@ -39,25 +41,20 @@ pub mod root {
                 1usize,
                 concat!("Alignment of ", stringify!(sentry))
             );
-            fn test_field_i_am_plain_sentry() {
-                assert_eq!(
-                    unsafe {
-                        let uninit =
-                            ::std::mem::MaybeUninit::<sentry>::uninit();
-                        let ptr = uninit.as_ptr();
-                        ::std::ptr::addr_of!((*ptr).i_am_plain_sentry) as usize -
-                            ptr as usize
-                    },
-                    0usize,
-                    concat!(
-                        "Offset of field: ",
-                        stringify!(sentry),
-                        "::",
-                        stringify!(i_am_plain_sentry)
-                    )
-                );
-            }
-            test_field_i_am_plain_sentry();
+            assert_eq!(
+                unsafe {
+                    let ptr = UNINIT.as_ptr();
+                    ::std::ptr::addr_of!((*ptr).i_am_plain_sentry) as usize -
+                        ptr as usize
+                },
+                0usize,
+                concat!(
+                    "Offset of field: ",
+                    stringify!(sentry),
+                    "::",
+                    stringify!(i_am_plain_sentry)
+                )
+            );
         }
         #[repr(C)]
         #[derive(Debug, Default, Copy, Clone)]
@@ -84,6 +81,8 @@ pub mod root {
         }
         #[test]
         fn bindgen_test_layout_NotTemplateWrapper_sentry() {
+            const UNINIT: ::std::mem::MaybeUninit<NotTemplateWrapper_sentry> =
+                ::std::mem::MaybeUninit::uninit();
             assert_eq!(
                 ::std::mem::size_of::<NotTemplateWrapper_sentry>(),
                 1usize,
@@ -94,28 +93,22 @@ pub mod root {
                 1usize,
                 concat!("Alignment of ", stringify!(NotTemplateWrapper_sentry))
             );
-            fn test_field_i_am_not_template_wrapper_sentry() {
-                assert_eq!(
-                    unsafe {
-                        let uninit = ::std::mem::MaybeUninit::<
-                            NotTemplateWrapper_sentry,
-                        >::uninit();
-                        let ptr = uninit.as_ptr();
-                        ::std::ptr::addr_of!(
-                            (*ptr).i_am_not_template_wrapper_sentry
-                        ) as usize -
-                            ptr as usize
-                    },
-                    0usize,
-                    concat!(
-                        "Offset of field: ",
-                        stringify!(NotTemplateWrapper_sentry),
-                        "::",
-                        stringify!(i_am_not_template_wrapper_sentry)
-                    )
-                );
-            }
-            test_field_i_am_not_template_wrapper_sentry();
+            assert_eq!(
+                unsafe {
+                    let ptr = UNINIT.as_ptr();
+                    ::std::ptr::addr_of!(
+                        (*ptr).i_am_not_template_wrapper_sentry
+                    ) as usize -
+                        ptr as usize
+                },
+                0usize,
+                concat!(
+                    "Offset of field: ",
+                    stringify!(NotTemplateWrapper_sentry),
+                    "::",
+                    stringify!(i_am_not_template_wrapper_sentry)
+                )
+            );
         }
         #[repr(C)]
         #[derive(Debug, Default, Copy, Clone)]
@@ -129,6 +122,9 @@ pub mod root {
         }
         #[test]
         fn bindgen_test_layout_InlineNotTemplateWrapper_sentry() {
+            const UNINIT: ::std::mem::MaybeUninit<
+                InlineNotTemplateWrapper_sentry,
+            > = ::std::mem::MaybeUninit::uninit();
             assert_eq!(
                 ::std::mem::size_of::<InlineNotTemplateWrapper_sentry>(),
                 1usize,
@@ -145,28 +141,22 @@ pub mod root {
                     stringify!(InlineNotTemplateWrapper_sentry)
                 )
             );
-            fn test_field_i_am_inline_not_template_wrapper_sentry() {
-                assert_eq!(
-                    unsafe {
-                        let uninit = ::std::mem::MaybeUninit::<
-                            InlineNotTemplateWrapper_sentry,
-                        >::uninit();
-                        let ptr = uninit.as_ptr();
-                        ::std::ptr::addr_of!(
-                            (*ptr).i_am_inline_not_template_wrapper_sentry
-                        ) as usize -
-                            ptr as usize
-                    },
-                    0usize,
-                    concat!(
-                        "Offset of field: ",
-                        stringify!(InlineNotTemplateWrapper_sentry),
-                        "::",
-                        stringify!(i_am_inline_not_template_wrapper_sentry)
-                    )
-                );
-            }
-            test_field_i_am_inline_not_template_wrapper_sentry();
+            assert_eq!(
+                unsafe {
+                    let ptr = UNINIT.as_ptr();
+                    ::std::ptr::addr_of!(
+                        (*ptr).i_am_inline_not_template_wrapper_sentry
+                    ) as usize -
+                        ptr as usize
+                },
+                0usize,
+                concat!(
+                    "Offset of field: ",
+                    stringify!(InlineNotTemplateWrapper_sentry),
+                    "::",
+                    stringify!(i_am_inline_not_template_wrapper_sentry)
+                )
+            );
         }
         #[test]
         fn bindgen_test_layout_InlineNotTemplateWrapper() {
@@ -240,6 +230,9 @@ pub mod root {
         }
         #[test]
         fn bindgen_test_layout_OuterDoubleWrapper_InnerDoubleWrapper_sentry() {
+            const UNINIT: ::std::mem::MaybeUninit<
+                OuterDoubleWrapper_InnerDoubleWrapper_sentry,
+            > = ::std::mem::MaybeUninit::uninit();
             assert_eq!(
                 ::std::mem::size_of::<
                     OuterDoubleWrapper_InnerDoubleWrapper_sentry,
@@ -260,29 +253,21 @@ pub mod root {
                     stringify!(OuterDoubleWrapper_InnerDoubleWrapper_sentry)
                 )
             );
-            fn test_field_i_am_double_wrapper_sentry() {
-                assert_eq!(
-                    unsafe {
-                        let uninit = ::std::mem::MaybeUninit::<
-                            OuterDoubleWrapper_InnerDoubleWrapper_sentry,
-                        >::uninit();
-                        let ptr = uninit.as_ptr();
-                        ::std::ptr::addr_of!((*ptr).i_am_double_wrapper_sentry)
-                            as usize -
-                            ptr as usize
-                    },
-                    0usize,
-                    concat!(
-                        "Offset of field: ",
-                        stringify!(
-                            OuterDoubleWrapper_InnerDoubleWrapper_sentry
-                        ),
-                        "::",
-                        stringify!(i_am_double_wrapper_sentry)
-                    )
-                );
-            }
-            test_field_i_am_double_wrapper_sentry();
+            assert_eq!(
+                unsafe {
+                    let ptr = UNINIT.as_ptr();
+                    ::std::ptr::addr_of!((*ptr).i_am_double_wrapper_sentry)
+                        as usize -
+                        ptr as usize
+                },
+                0usize,
+                concat!(
+                    "Offset of field: ",
+                    stringify!(OuterDoubleWrapper_InnerDoubleWrapper_sentry),
+                    "::",
+                    stringify!(i_am_double_wrapper_sentry)
+                )
+            );
         }
         #[repr(C)]
         #[derive(Debug, Default, Copy, Clone)]
@@ -302,12 +287,12 @@ pub mod root {
         #[test]
         fn bindgen_test_layout_OuterDoubleInlineWrapper_InnerDoubleInlineWrapper_sentry(
         ) {
+            const UNINIT: ::std::mem::MaybeUninit<
+                OuterDoubleInlineWrapper_InnerDoubleInlineWrapper_sentry,
+            > = ::std::mem::MaybeUninit::uninit();
             assert_eq ! (:: std :: mem :: size_of :: < OuterDoubleInlineWrapper_InnerDoubleInlineWrapper_sentry > () , 4usize , concat ! ("Size of: " , stringify ! (OuterDoubleInlineWrapper_InnerDoubleInlineWrapper_sentry)));
             assert_eq ! (:: std :: mem :: align_of :: < OuterDoubleInlineWrapper_InnerDoubleInlineWrapper_sentry > () , 4usize , concat ! ("Alignment of " , stringify ! (OuterDoubleInlineWrapper_InnerDoubleInlineWrapper_sentry)));
-            fn test_field_i_am_double_wrapper_inline_sentry() {
-                assert_eq ! (unsafe { let uninit = :: std :: mem :: MaybeUninit :: < OuterDoubleInlineWrapper_InnerDoubleInlineWrapper_sentry > :: uninit () ; let ptr = uninit . as_ptr () ; :: std :: ptr :: addr_of ! ((* ptr) . i_am_double_wrapper_inline_sentry) as usize - ptr as usize } , 0usize , concat ! ("Offset of field: " , stringify ! (OuterDoubleInlineWrapper_InnerDoubleInlineWrapper_sentry) , "::" , stringify ! (i_am_double_wrapper_inline_sentry)));
-            }
-            test_field_i_am_double_wrapper_inline_sentry();
+            assert_eq ! (unsafe { let ptr = UNINIT . as_ptr () ; :: std :: ptr :: addr_of ! ((* ptr) . i_am_double_wrapper_inline_sentry) as usize - ptr as usize } , 0usize , concat ! ("Offset of field: " , stringify ! (OuterDoubleInlineWrapper_InnerDoubleInlineWrapper_sentry) , "::" , stringify ! (i_am_double_wrapper_inline_sentry)));
         }
         #[test]
         fn bindgen_test_layout_OuterDoubleInlineWrapper_InnerDoubleInlineWrapper(
@@ -368,6 +353,8 @@ pub mod root {
     }
     #[test]
     fn bindgen_test_layout_sentry() {
+        const UNINIT: ::std::mem::MaybeUninit<sentry> =
+            ::std::mem::MaybeUninit::uninit();
         assert_eq!(
             ::std::mem::size_of::<sentry>(),
             4usize,
@@ -378,24 +365,20 @@ pub mod root {
             4usize,
             concat!("Alignment of ", stringify!(sentry))
         );
-        fn test_field_i_am_outside_namespace_sentry() {
-            assert_eq!(
-                unsafe {
-                    let uninit = ::std::mem::MaybeUninit::<sentry>::uninit();
-                    let ptr = uninit.as_ptr();
-                    ::std::ptr::addr_of!((*ptr).i_am_outside_namespace_sentry)
-                        as usize -
-                        ptr as usize
-                },
-                0usize,
-                concat!(
-                    "Offset of field: ",
-                    stringify!(sentry),
-                    "::",
-                    stringify!(i_am_outside_namespace_sentry)
-                )
-            );
-        }
-        test_field_i_am_outside_namespace_sentry();
+        assert_eq!(
+            unsafe {
+                let ptr = UNINIT.as_ptr();
+                ::std::ptr::addr_of!((*ptr).i_am_outside_namespace_sentry)
+                    as usize -
+                    ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(sentry),
+                "::",
+                stringify!(i_am_outside_namespace_sentry)
+            )
+        );
     }
 }

--- a/tests/expectations/tests/size_t_is_usize.rs
+++ b/tests/expectations/tests/size_t_is_usize.rs
@@ -16,6 +16,7 @@ pub struct A {
 fn bindgen_test_layout_A() {
     const UNINIT: ::std::mem::MaybeUninit<A> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<A>(),
         24usize,
@@ -27,26 +28,17 @@ fn bindgen_test_layout_A() {
         concat!("Alignment of ", stringify!(A))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).len) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).len) as usize - ptr as usize },
         0usize,
         concat!("Offset of field: ", stringify!(A), "::", stringify!(len))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).offset) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).offset) as usize - ptr as usize },
         8usize,
         concat!("Offset of field: ", stringify!(A), "::", stringify!(offset))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).next) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).next) as usize - ptr as usize },
         16usize,
         concat!("Offset of field: ", stringify!(A), "::", stringify!(next))
     );

--- a/tests/expectations/tests/size_t_is_usize.rs
+++ b/tests/expectations/tests/size_t_is_usize.rs
@@ -14,6 +14,8 @@ pub struct A {
 }
 #[test]
 fn bindgen_test_layout_A() {
+    const UNINIT: ::std::mem::MaybeUninit<A> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<A>(),
         24usize,
@@ -24,47 +26,30 @@ fn bindgen_test_layout_A() {
         8usize,
         concat!("Alignment of ", stringify!(A))
     );
-    fn test_field_len() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<A>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).len) as usize - ptr as usize
-            },
-            0usize,
-            concat!("Offset of field: ", stringify!(A), "::", stringify!(len))
-        );
-    }
-    test_field_len();
-    fn test_field_offset() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<A>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).offset) as usize - ptr as usize
-            },
-            8usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(A),
-                "::",
-                stringify!(offset)
-            )
-        );
-    }
-    test_field_offset();
-    fn test_field_next() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<A>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).next) as usize - ptr as usize
-            },
-            16usize,
-            concat!("Offset of field: ", stringify!(A), "::", stringify!(next))
-        );
-    }
-    test_field_next();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).len) as usize - ptr as usize
+        },
+        0usize,
+        concat!("Offset of field: ", stringify!(A), "::", stringify!(len))
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).offset) as usize - ptr as usize
+        },
+        8usize,
+        concat!("Offset of field: ", stringify!(A), "::", stringify!(offset))
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).next) as usize - ptr as usize
+        },
+        16usize,
+        concat!("Offset of field: ", stringify!(A), "::", stringify!(next))
+    );
 }
 impl Default for A {
     fn default() -> Self {

--- a/tests/expectations/tests/size_t_template.rs
+++ b/tests/expectations/tests/size_t_template.rs
@@ -12,6 +12,8 @@ pub struct C {
 }
 #[test]
 fn bindgen_test_layout_C() {
+    const UNINIT: ::std::mem::MaybeUninit<C> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<C>(),
         12usize,
@@ -22,16 +24,12 @@ fn bindgen_test_layout_C() {
         4usize,
         concat!("Alignment of ", stringify!(C))
     );
-    fn test_field_arr() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<C>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).arr) as usize - ptr as usize
-            },
-            0usize,
-            concat!("Offset of field: ", stringify!(C), "::", stringify!(arr))
-        );
-    }
-    test_field_arr();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).arr) as usize - ptr as usize
+        },
+        0usize,
+        concat!("Offset of field: ", stringify!(C), "::", stringify!(arr))
+    );
 }

--- a/tests/expectations/tests/size_t_template.rs
+++ b/tests/expectations/tests/size_t_template.rs
@@ -14,6 +14,7 @@ pub struct C {
 fn bindgen_test_layout_C() {
     const UNINIT: ::std::mem::MaybeUninit<C> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<C>(),
         12usize,
@@ -25,10 +26,7 @@ fn bindgen_test_layout_C() {
         concat!("Alignment of ", stringify!(C))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).arr) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).arr) as usize - ptr as usize },
         0usize,
         concat!("Offset of field: ", stringify!(C), "::", stringify!(arr))
     );

--- a/tests/expectations/tests/struct_containing_forward_declared_struct.rs
+++ b/tests/expectations/tests/struct_containing_forward_declared_struct.rs
@@ -12,6 +12,8 @@ pub struct a {
 }
 #[test]
 fn bindgen_test_layout_a() {
+    const UNINIT: ::std::mem::MaybeUninit<a> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<a>(),
         8usize,
@@ -22,23 +24,14 @@ fn bindgen_test_layout_a() {
         8usize,
         concat!("Alignment of ", stringify!(a))
     );
-    fn test_field_val_a() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<a>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).val_a) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(a),
-                "::",
-                stringify!(val_a)
-            )
-        );
-    }
-    test_field_val_a();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).val_a) as usize - ptr as usize
+        },
+        0usize,
+        concat!("Offset of field: ", stringify!(a), "::", stringify!(val_a))
+    );
 }
 impl Default for a {
     fn default() -> Self {
@@ -56,6 +49,8 @@ pub struct b {
 }
 #[test]
 fn bindgen_test_layout_b() {
+    const UNINIT: ::std::mem::MaybeUninit<b> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<b>(),
         4usize,
@@ -66,21 +61,12 @@ fn bindgen_test_layout_b() {
         4usize,
         concat!("Alignment of ", stringify!(b))
     );
-    fn test_field_val_b() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<b>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).val_b) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(b),
-                "::",
-                stringify!(val_b)
-            )
-        );
-    }
-    test_field_val_b();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).val_b) as usize - ptr as usize
+        },
+        0usize,
+        concat!("Offset of field: ", stringify!(b), "::", stringify!(val_b))
+    );
 }

--- a/tests/expectations/tests/struct_containing_forward_declared_struct.rs
+++ b/tests/expectations/tests/struct_containing_forward_declared_struct.rs
@@ -14,6 +14,7 @@ pub struct a {
 fn bindgen_test_layout_a() {
     const UNINIT: ::std::mem::MaybeUninit<a> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<a>(),
         8usize,
@@ -25,10 +26,7 @@ fn bindgen_test_layout_a() {
         concat!("Alignment of ", stringify!(a))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).val_a) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).val_a) as usize - ptr as usize },
         0usize,
         concat!("Offset of field: ", stringify!(a), "::", stringify!(val_a))
     );
@@ -51,6 +49,7 @@ pub struct b {
 fn bindgen_test_layout_b() {
     const UNINIT: ::std::mem::MaybeUninit<b> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<b>(),
         4usize,
@@ -62,10 +61,7 @@ fn bindgen_test_layout_b() {
         concat!("Alignment of ", stringify!(b))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).val_b) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).val_b) as usize - ptr as usize },
         0usize,
         concat!("Offset of field: ", stringify!(b), "::", stringify!(val_b))
     );

--- a/tests/expectations/tests/struct_typedef.rs
+++ b/tests/expectations/tests/struct_typedef.rs
@@ -12,6 +12,8 @@ pub struct typedef_named_struct {
 }
 #[test]
 fn bindgen_test_layout_typedef_named_struct() {
+    const UNINIT: ::std::mem::MaybeUninit<typedef_named_struct> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<typedef_named_struct>(),
         1usize,
@@ -22,24 +24,19 @@ fn bindgen_test_layout_typedef_named_struct() {
         1usize,
         concat!("Alignment of ", stringify!(typedef_named_struct))
     );
-    fn test_field_has_name() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<typedef_named_struct>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).has_name) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(typedef_named_struct),
-                "::",
-                stringify!(has_name)
-            )
-        );
-    }
-    test_field_has_name();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).has_name) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(typedef_named_struct),
+            "::",
+            stringify!(has_name)
+        )
+    );
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -48,6 +45,8 @@ pub struct _bindgen_ty_1 {
 }
 #[test]
 fn bindgen_test_layout__bindgen_ty_1() {
+    const UNINIT: ::std::mem::MaybeUninit<_bindgen_ty_1> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<_bindgen_ty_1>(),
         8usize,
@@ -58,23 +57,19 @@ fn bindgen_test_layout__bindgen_ty_1() {
         8usize,
         concat!("Alignment of ", stringify!(_bindgen_ty_1))
     );
-    fn test_field_no_name() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<_bindgen_ty_1>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).no_name) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(_bindgen_ty_1),
-                "::",
-                stringify!(no_name)
-            )
-        );
-    }
-    test_field_no_name();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).no_name) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(_bindgen_ty_1),
+            "::",
+            stringify!(no_name)
+        )
+    );
 }
 impl Default for _bindgen_ty_1 {
     fn default() -> Self {

--- a/tests/expectations/tests/struct_typedef.rs
+++ b/tests/expectations/tests/struct_typedef.rs
@@ -14,6 +14,7 @@ pub struct typedef_named_struct {
 fn bindgen_test_layout_typedef_named_struct() {
     const UNINIT: ::std::mem::MaybeUninit<typedef_named_struct> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<typedef_named_struct>(),
         1usize,
@@ -26,7 +27,6 @@ fn bindgen_test_layout_typedef_named_struct() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).has_name) as usize - ptr as usize
         },
         0usize,
@@ -47,6 +47,7 @@ pub struct _bindgen_ty_1 {
 fn bindgen_test_layout__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<_bindgen_ty_1> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<_bindgen_ty_1>(),
         8usize,
@@ -58,10 +59,7 @@ fn bindgen_test_layout__bindgen_ty_1() {
         concat!("Alignment of ", stringify!(_bindgen_ty_1))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).no_name) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).no_name) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/struct_typedef_ns.rs
+++ b/tests/expectations/tests/struct_typedef_ns.rs
@@ -21,6 +21,7 @@ pub mod root {
         fn bindgen_test_layout_typedef_struct() {
             const UNINIT: ::std::mem::MaybeUninit<typedef_struct> =
                 ::std::mem::MaybeUninit::uninit();
+            let ptr = UNINIT.as_ptr();
             assert_eq!(
                 ::std::mem::size_of::<typedef_struct>(),
                 4usize,
@@ -33,7 +34,6 @@ pub mod root {
             );
             assert_eq!(
                 unsafe {
-                    let ptr = UNINIT.as_ptr();
                     ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize
                 },
                 0usize,
@@ -63,6 +63,7 @@ pub mod root {
         fn bindgen_test_layout__bindgen_ty_1() {
             const UNINIT: ::std::mem::MaybeUninit<_bindgen_ty_1> =
                 ::std::mem::MaybeUninit::uninit();
+            let ptr = UNINIT.as_ptr();
             assert_eq!(
                 ::std::mem::size_of::<_bindgen_ty_1>(),
                 4usize,
@@ -75,7 +76,6 @@ pub mod root {
             );
             assert_eq!(
                 unsafe {
-                    let ptr = UNINIT.as_ptr();
                     ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize
                 },
                 0usize,

--- a/tests/expectations/tests/struct_typedef_ns.rs
+++ b/tests/expectations/tests/struct_typedef_ns.rs
@@ -19,6 +19,8 @@ pub mod root {
         }
         #[test]
         fn bindgen_test_layout_typedef_struct() {
+            const UNINIT: ::std::mem::MaybeUninit<typedef_struct> =
+                ::std::mem::MaybeUninit::uninit();
             assert_eq!(
                 ::std::mem::size_of::<typedef_struct>(),
                 4usize,
@@ -29,24 +31,19 @@ pub mod root {
                 4usize,
                 concat!("Alignment of ", stringify!(typedef_struct))
             );
-            fn test_field_foo() {
-                assert_eq!(
-                    unsafe {
-                        let uninit =
-                            ::std::mem::MaybeUninit::<typedef_struct>::uninit();
-                        let ptr = uninit.as_ptr();
-                        ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize
-                    },
-                    0usize,
-                    concat!(
-                        "Offset of field: ",
-                        stringify!(typedef_struct),
-                        "::",
-                        stringify!(foo)
-                    )
-                );
-            }
-            test_field_foo();
+            assert_eq!(
+                unsafe {
+                    let ptr = UNINIT.as_ptr();
+                    ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize
+                },
+                0usize,
+                concat!(
+                    "Offset of field: ",
+                    stringify!(typedef_struct),
+                    "::",
+                    stringify!(foo)
+                )
+            );
         }
         #[repr(u32)]
         #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -64,6 +61,8 @@ pub mod root {
         }
         #[test]
         fn bindgen_test_layout__bindgen_ty_1() {
+            const UNINIT: ::std::mem::MaybeUninit<_bindgen_ty_1> =
+                ::std::mem::MaybeUninit::uninit();
             assert_eq!(
                 ::std::mem::size_of::<_bindgen_ty_1>(),
                 4usize,
@@ -74,24 +73,19 @@ pub mod root {
                 4usize,
                 concat!("Alignment of ", stringify!(_bindgen_ty_1))
             );
-            fn test_field_foo() {
-                assert_eq!(
-                    unsafe {
-                        let uninit =
-                            ::std::mem::MaybeUninit::<_bindgen_ty_1>::uninit();
-                        let ptr = uninit.as_ptr();
-                        ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize
-                    },
-                    0usize,
-                    concat!(
-                        "Offset of field: ",
-                        stringify!(_bindgen_ty_1),
-                        "::",
-                        stringify!(foo)
-                    )
-                );
-            }
-            test_field_foo();
+            assert_eq!(
+                unsafe {
+                    let ptr = UNINIT.as_ptr();
+                    ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize
+                },
+                0usize,
+                concat!(
+                    "Offset of field: ",
+                    stringify!(_bindgen_ty_1),
+                    "::",
+                    stringify!(foo)
+                )
+            );
         }
         pub type typedef_struct = root::_bindgen_mod_id_12::_bindgen_ty_1;
         pub const _bindgen_mod_id_12_BAR:

--- a/tests/expectations/tests/struct_with_anon_struct.rs
+++ b/tests/expectations/tests/struct_with_anon_struct.rs
@@ -18,6 +18,8 @@ pub struct foo__bindgen_ty_1 {
 }
 #[test]
 fn bindgen_test_layout_foo__bindgen_ty_1() {
+    const UNINIT: ::std::mem::MaybeUninit<foo__bindgen_ty_1> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<foo__bindgen_ty_1>(),
         8usize,
@@ -28,45 +30,37 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
         4usize,
         concat!("Alignment of ", stringify!(foo__bindgen_ty_1))
     );
-    fn test_field_a() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<foo__bindgen_ty_1>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(foo__bindgen_ty_1),
-                "::",
-                stringify!(a)
-            )
-        );
-    }
-    test_field_a();
-    fn test_field_b() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<foo__bindgen_ty_1>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-            },
-            4usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(foo__bindgen_ty_1),
-                "::",
-                stringify!(b)
-            )
-        );
-    }
-    test_field_b();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(foo__bindgen_ty_1),
+            "::",
+            stringify!(a)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(foo__bindgen_ty_1),
+            "::",
+            stringify!(b)
+        )
+    );
 }
 #[test]
 fn bindgen_test_layout_foo() {
+    const UNINIT: ::std::mem::MaybeUninit<foo> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<foo>(),
         8usize,
@@ -77,21 +71,12 @@ fn bindgen_test_layout_foo() {
         4usize,
         concat!("Alignment of ", stringify!(foo))
     );
-    fn test_field_bar() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<foo>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(foo),
-                "::",
-                stringify!(bar)
-            )
-        );
-    }
-    test_field_bar();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
+        },
+        0usize,
+        concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar))
+    );
 }

--- a/tests/expectations/tests/struct_with_anon_struct.rs
+++ b/tests/expectations/tests/struct_with_anon_struct.rs
@@ -20,6 +20,7 @@ pub struct foo__bindgen_ty_1 {
 fn bindgen_test_layout_foo__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<foo__bindgen_ty_1> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<foo__bindgen_ty_1>(),
         8usize,
@@ -31,10 +32,7 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
         concat!("Alignment of ", stringify!(foo__bindgen_ty_1))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -44,10 +42,7 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
         4usize,
         concat!(
             "Offset of field: ",
@@ -61,6 +56,7 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
 fn bindgen_test_layout_foo() {
     const UNINIT: ::std::mem::MaybeUninit<foo> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<foo>(),
         8usize,
@@ -72,10 +68,7 @@ fn bindgen_test_layout_foo() {
         concat!("Alignment of ", stringify!(foo))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize },
         0usize,
         concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar))
     );

--- a/tests/expectations/tests/struct_with_anon_struct_array.rs
+++ b/tests/expectations/tests/struct_with_anon_struct_array.rs
@@ -21,6 +21,7 @@ pub struct foo__bindgen_ty_1 {
 fn bindgen_test_layout_foo__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<foo__bindgen_ty_1> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<foo__bindgen_ty_1>(),
         8usize,
@@ -32,10 +33,7 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
         concat!("Alignment of ", stringify!(foo__bindgen_ty_1))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -45,10 +43,7 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
         4usize,
         concat!(
             "Offset of field: ",
@@ -68,6 +63,7 @@ pub struct foo__bindgen_ty_2 {
 fn bindgen_test_layout_foo__bindgen_ty_2() {
     const UNINIT: ::std::mem::MaybeUninit<foo__bindgen_ty_2> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<foo__bindgen_ty_2>(),
         8usize,
@@ -79,10 +75,7 @@ fn bindgen_test_layout_foo__bindgen_ty_2() {
         concat!("Alignment of ", stringify!(foo__bindgen_ty_2))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -92,10 +85,7 @@ fn bindgen_test_layout_foo__bindgen_ty_2() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
         4usize,
         concat!(
             "Offset of field: ",
@@ -109,6 +99,7 @@ fn bindgen_test_layout_foo__bindgen_ty_2() {
 fn bindgen_test_layout_foo() {
     const UNINIT: ::std::mem::MaybeUninit<foo> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<foo>(),
         208usize,
@@ -120,18 +111,12 @@ fn bindgen_test_layout_foo() {
         concat!("Alignment of ", stringify!(foo))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize },
         0usize,
         concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize },
         16usize,
         concat!("Offset of field: ", stringify!(foo), "::", stringify!(baz))
     );

--- a/tests/expectations/tests/struct_with_anon_struct_array.rs
+++ b/tests/expectations/tests/struct_with_anon_struct_array.rs
@@ -19,6 +19,8 @@ pub struct foo__bindgen_ty_1 {
 }
 #[test]
 fn bindgen_test_layout_foo__bindgen_ty_1() {
+    const UNINIT: ::std::mem::MaybeUninit<foo__bindgen_ty_1> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<foo__bindgen_ty_1>(),
         8usize,
@@ -29,42 +31,32 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
         4usize,
         concat!("Alignment of ", stringify!(foo__bindgen_ty_1))
     );
-    fn test_field_a() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<foo__bindgen_ty_1>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(foo__bindgen_ty_1),
-                "::",
-                stringify!(a)
-            )
-        );
-    }
-    test_field_a();
-    fn test_field_b() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<foo__bindgen_ty_1>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-            },
-            4usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(foo__bindgen_ty_1),
-                "::",
-                stringify!(b)
-            )
-        );
-    }
-    test_field_b();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(foo__bindgen_ty_1),
+            "::",
+            stringify!(a)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(foo__bindgen_ty_1),
+            "::",
+            stringify!(b)
+        )
+    );
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
@@ -74,6 +66,8 @@ pub struct foo__bindgen_ty_2 {
 }
 #[test]
 fn bindgen_test_layout_foo__bindgen_ty_2() {
+    const UNINIT: ::std::mem::MaybeUninit<foo__bindgen_ty_2> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<foo__bindgen_ty_2>(),
         8usize,
@@ -84,45 +78,37 @@ fn bindgen_test_layout_foo__bindgen_ty_2() {
         4usize,
         concat!("Alignment of ", stringify!(foo__bindgen_ty_2))
     );
-    fn test_field_a() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<foo__bindgen_ty_2>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(foo__bindgen_ty_2),
-                "::",
-                stringify!(a)
-            )
-        );
-    }
-    test_field_a();
-    fn test_field_b() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<foo__bindgen_ty_2>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-            },
-            4usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(foo__bindgen_ty_2),
-                "::",
-                stringify!(b)
-            )
-        );
-    }
-    test_field_b();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(foo__bindgen_ty_2),
+            "::",
+            stringify!(a)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(foo__bindgen_ty_2),
+            "::",
+            stringify!(b)
+        )
+    );
 }
 #[test]
 fn bindgen_test_layout_foo() {
+    const UNINIT: ::std::mem::MaybeUninit<foo> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<foo>(),
         208usize,
@@ -133,38 +119,20 @@ fn bindgen_test_layout_foo() {
         4usize,
         concat!("Alignment of ", stringify!(foo))
     );
-    fn test_field_bar() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<foo>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(foo),
-                "::",
-                stringify!(bar)
-            )
-        );
-    }
-    test_field_bar();
-    fn test_field_baz() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<foo>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize
-            },
-            16usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(foo),
-                "::",
-                stringify!(baz)
-            )
-        );
-    }
-    test_field_baz();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
+        },
+        0usize,
+        concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar))
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize
+        },
+        16usize,
+        concat!("Offset of field: ", stringify!(foo), "::", stringify!(baz))
+    );
 }

--- a/tests/expectations/tests/struct_with_anon_struct_pointer.rs
+++ b/tests/expectations/tests/struct_with_anon_struct_pointer.rs
@@ -18,6 +18,8 @@ pub struct foo__bindgen_ty_1 {
 }
 #[test]
 fn bindgen_test_layout_foo__bindgen_ty_1() {
+    const UNINIT: ::std::mem::MaybeUninit<foo__bindgen_ty_1> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<foo__bindgen_ty_1>(),
         8usize,
@@ -28,45 +30,37 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
         4usize,
         concat!("Alignment of ", stringify!(foo__bindgen_ty_1))
     );
-    fn test_field_a() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<foo__bindgen_ty_1>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(foo__bindgen_ty_1),
-                "::",
-                stringify!(a)
-            )
-        );
-    }
-    test_field_a();
-    fn test_field_b() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<foo__bindgen_ty_1>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-            },
-            4usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(foo__bindgen_ty_1),
-                "::",
-                stringify!(b)
-            )
-        );
-    }
-    test_field_b();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(foo__bindgen_ty_1),
+            "::",
+            stringify!(a)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(foo__bindgen_ty_1),
+            "::",
+            stringify!(b)
+        )
+    );
 }
 #[test]
 fn bindgen_test_layout_foo() {
+    const UNINIT: ::std::mem::MaybeUninit<foo> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<foo>(),
         8usize,
@@ -77,23 +71,14 @@ fn bindgen_test_layout_foo() {
         8usize,
         concat!("Alignment of ", stringify!(foo))
     );
-    fn test_field_bar() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<foo>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(foo),
-                "::",
-                stringify!(bar)
-            )
-        );
-    }
-    test_field_bar();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
+        },
+        0usize,
+        concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar))
+    );
 }
 impl Default for foo {
     fn default() -> Self {

--- a/tests/expectations/tests/struct_with_anon_struct_pointer.rs
+++ b/tests/expectations/tests/struct_with_anon_struct_pointer.rs
@@ -20,6 +20,7 @@ pub struct foo__bindgen_ty_1 {
 fn bindgen_test_layout_foo__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<foo__bindgen_ty_1> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<foo__bindgen_ty_1>(),
         8usize,
@@ -31,10 +32,7 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
         concat!("Alignment of ", stringify!(foo__bindgen_ty_1))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -44,10 +42,7 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
         4usize,
         concat!(
             "Offset of field: ",
@@ -61,6 +56,7 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
 fn bindgen_test_layout_foo() {
     const UNINIT: ::std::mem::MaybeUninit<foo> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<foo>(),
         8usize,
@@ -72,10 +68,7 @@ fn bindgen_test_layout_foo() {
         concat!("Alignment of ", stringify!(foo))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize },
         0usize,
         concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar))
     );

--- a/tests/expectations/tests/struct_with_anon_union.rs
+++ b/tests/expectations/tests/struct_with_anon_union.rs
@@ -20,6 +20,7 @@ pub union foo__bindgen_ty_1 {
 fn bindgen_test_layout_foo__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<foo__bindgen_ty_1> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<foo__bindgen_ty_1>(),
         4usize,
@@ -31,10 +32,7 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
         concat!("Alignment of ", stringify!(foo__bindgen_ty_1))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -44,10 +42,7 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -70,6 +65,7 @@ impl Default for foo__bindgen_ty_1 {
 fn bindgen_test_layout_foo() {
     const UNINIT: ::std::mem::MaybeUninit<foo> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<foo>(),
         4usize,
@@ -81,10 +77,7 @@ fn bindgen_test_layout_foo() {
         concat!("Alignment of ", stringify!(foo))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize },
         0usize,
         concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar))
     );

--- a/tests/expectations/tests/struct_with_anon_union.rs
+++ b/tests/expectations/tests/struct_with_anon_union.rs
@@ -18,6 +18,8 @@ pub union foo__bindgen_ty_1 {
 }
 #[test]
 fn bindgen_test_layout_foo__bindgen_ty_1() {
+    const UNINIT: ::std::mem::MaybeUninit<foo__bindgen_ty_1> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<foo__bindgen_ty_1>(),
         4usize,
@@ -28,42 +30,32 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
         4usize,
         concat!("Alignment of ", stringify!(foo__bindgen_ty_1))
     );
-    fn test_field_a() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<foo__bindgen_ty_1>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(foo__bindgen_ty_1),
-                "::",
-                stringify!(a)
-            )
-        );
-    }
-    test_field_a();
-    fn test_field_b() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<foo__bindgen_ty_1>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(foo__bindgen_ty_1),
-                "::",
-                stringify!(b)
-            )
-        );
-    }
-    test_field_b();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(foo__bindgen_ty_1),
+            "::",
+            stringify!(a)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(foo__bindgen_ty_1),
+            "::",
+            stringify!(b)
+        )
+    );
 }
 impl Default for foo__bindgen_ty_1 {
     fn default() -> Self {
@@ -76,6 +68,8 @@ impl Default for foo__bindgen_ty_1 {
 }
 #[test]
 fn bindgen_test_layout_foo() {
+    const UNINIT: ::std::mem::MaybeUninit<foo> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<foo>(),
         4usize,
@@ -86,23 +80,14 @@ fn bindgen_test_layout_foo() {
         4usize,
         concat!("Alignment of ", stringify!(foo))
     );
-    fn test_field_bar() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<foo>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(foo),
-                "::",
-                stringify!(bar)
-            )
-        );
-    }
-    test_field_bar();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
+        },
+        0usize,
+        concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar))
+    );
 }
 impl Default for foo {
     fn default() -> Self {

--- a/tests/expectations/tests/struct_with_anon_union_1_0.rs
+++ b/tests/expectations/tests/struct_with_anon_union_1_0.rs
@@ -64,6 +64,7 @@ pub struct foo__bindgen_ty_1 {
 fn bindgen_test_layout_foo__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<foo__bindgen_ty_1> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<foo__bindgen_ty_1>(),
         4usize,
@@ -75,10 +76,7 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
         concat!("Alignment of ", stringify!(foo__bindgen_ty_1))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -88,10 +86,7 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -110,6 +105,7 @@ impl Clone for foo__bindgen_ty_1 {
 fn bindgen_test_layout_foo() {
     const UNINIT: ::std::mem::MaybeUninit<foo> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<foo>(),
         4usize,
@@ -121,10 +117,7 @@ fn bindgen_test_layout_foo() {
         concat!("Alignment of ", stringify!(foo))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize },
         0usize,
         concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar))
     );

--- a/tests/expectations/tests/struct_with_anon_union_1_0.rs
+++ b/tests/expectations/tests/struct_with_anon_union_1_0.rs
@@ -62,6 +62,8 @@ pub struct foo__bindgen_ty_1 {
 }
 #[test]
 fn bindgen_test_layout_foo__bindgen_ty_1() {
+    const UNINIT: ::std::mem::MaybeUninit<foo__bindgen_ty_1> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<foo__bindgen_ty_1>(),
         4usize,
@@ -72,42 +74,32 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
         4usize,
         concat!("Alignment of ", stringify!(foo__bindgen_ty_1))
     );
-    fn test_field_a() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<foo__bindgen_ty_1>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(foo__bindgen_ty_1),
-                "::",
-                stringify!(a)
-            )
-        );
-    }
-    test_field_a();
-    fn test_field_b() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<foo__bindgen_ty_1>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(foo__bindgen_ty_1),
-                "::",
-                stringify!(b)
-            )
-        );
-    }
-    test_field_b();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(foo__bindgen_ty_1),
+            "::",
+            stringify!(a)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(foo__bindgen_ty_1),
+            "::",
+            stringify!(b)
+        )
+    );
 }
 impl Clone for foo__bindgen_ty_1 {
     fn clone(&self) -> Self {
@@ -116,6 +108,8 @@ impl Clone for foo__bindgen_ty_1 {
 }
 #[test]
 fn bindgen_test_layout_foo() {
+    const UNINIT: ::std::mem::MaybeUninit<foo> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<foo>(),
         4usize,
@@ -126,23 +120,14 @@ fn bindgen_test_layout_foo() {
         4usize,
         concat!("Alignment of ", stringify!(foo))
     );
-    fn test_field_bar() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<foo>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(foo),
-                "::",
-                stringify!(bar)
-            )
-        );
-    }
-    test_field_bar();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
+        },
+        0usize,
+        concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar))
+    );
 }
 impl Clone for foo {
     fn clone(&self) -> Self {

--- a/tests/expectations/tests/struct_with_anon_unnamed_struct.rs
+++ b/tests/expectations/tests/struct_with_anon_unnamed_struct.rs
@@ -18,6 +18,8 @@ pub struct foo__bindgen_ty_1 {
 }
 #[test]
 fn bindgen_test_layout_foo__bindgen_ty_1() {
+    const UNINIT: ::std::mem::MaybeUninit<foo__bindgen_ty_1> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<foo__bindgen_ty_1>(),
         8usize,
@@ -28,42 +30,32 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
         4usize,
         concat!("Alignment of ", stringify!(foo__bindgen_ty_1))
     );
-    fn test_field_a() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<foo__bindgen_ty_1>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(foo__bindgen_ty_1),
-                "::",
-                stringify!(a)
-            )
-        );
-    }
-    test_field_a();
-    fn test_field_b() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<foo__bindgen_ty_1>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-            },
-            4usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(foo__bindgen_ty_1),
-                "::",
-                stringify!(b)
-            )
-        );
-    }
-    test_field_b();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(foo__bindgen_ty_1),
+            "::",
+            stringify!(a)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(foo__bindgen_ty_1),
+            "::",
+            stringify!(b)
+        )
+    );
 }
 #[test]
 fn bindgen_test_layout_foo() {

--- a/tests/expectations/tests/struct_with_anon_unnamed_struct.rs
+++ b/tests/expectations/tests/struct_with_anon_unnamed_struct.rs
@@ -20,6 +20,7 @@ pub struct foo__bindgen_ty_1 {
 fn bindgen_test_layout_foo__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<foo__bindgen_ty_1> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<foo__bindgen_ty_1>(),
         8usize,
@@ -31,10 +32,7 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
         concat!("Alignment of ", stringify!(foo__bindgen_ty_1))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -44,10 +42,7 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
         4usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/struct_with_anon_unnamed_union.rs
+++ b/tests/expectations/tests/struct_with_anon_unnamed_union.rs
@@ -20,6 +20,7 @@ pub union foo__bindgen_ty_1 {
 fn bindgen_test_layout_foo__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<foo__bindgen_ty_1> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<foo__bindgen_ty_1>(),
         4usize,
@@ -31,10 +32,7 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
         concat!("Alignment of ", stringify!(foo__bindgen_ty_1))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -44,10 +42,7 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/struct_with_anon_unnamed_union.rs
+++ b/tests/expectations/tests/struct_with_anon_unnamed_union.rs
@@ -18,6 +18,8 @@ pub union foo__bindgen_ty_1 {
 }
 #[test]
 fn bindgen_test_layout_foo__bindgen_ty_1() {
+    const UNINIT: ::std::mem::MaybeUninit<foo__bindgen_ty_1> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<foo__bindgen_ty_1>(),
         4usize,
@@ -28,42 +30,32 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
         4usize,
         concat!("Alignment of ", stringify!(foo__bindgen_ty_1))
     );
-    fn test_field_a() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<foo__bindgen_ty_1>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(foo__bindgen_ty_1),
-                "::",
-                stringify!(a)
-            )
-        );
-    }
-    test_field_a();
-    fn test_field_b() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<foo__bindgen_ty_1>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(foo__bindgen_ty_1),
-                "::",
-                stringify!(b)
-            )
-        );
-    }
-    test_field_b();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(foo__bindgen_ty_1),
+            "::",
+            stringify!(a)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(foo__bindgen_ty_1),
+            "::",
+            stringify!(b)
+        )
+    );
 }
 impl Default for foo__bindgen_ty_1 {
     fn default() -> Self {

--- a/tests/expectations/tests/struct_with_anon_unnamed_union_1_0.rs
+++ b/tests/expectations/tests/struct_with_anon_unnamed_union_1_0.rs
@@ -62,6 +62,8 @@ pub struct foo__bindgen_ty_1 {
 }
 #[test]
 fn bindgen_test_layout_foo__bindgen_ty_1() {
+    const UNINIT: ::std::mem::MaybeUninit<foo__bindgen_ty_1> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<foo__bindgen_ty_1>(),
         4usize,
@@ -72,42 +74,32 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
         4usize,
         concat!("Alignment of ", stringify!(foo__bindgen_ty_1))
     );
-    fn test_field_a() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<foo__bindgen_ty_1>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(foo__bindgen_ty_1),
-                "::",
-                stringify!(a)
-            )
-        );
-    }
-    test_field_a();
-    fn test_field_b() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<foo__bindgen_ty_1>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(foo__bindgen_ty_1),
-                "::",
-                stringify!(b)
-            )
-        );
-    }
-    test_field_b();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(foo__bindgen_ty_1),
+            "::",
+            stringify!(a)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(foo__bindgen_ty_1),
+            "::",
+            stringify!(b)
+        )
+    );
 }
 impl Clone for foo__bindgen_ty_1 {
     fn clone(&self) -> Self {

--- a/tests/expectations/tests/struct_with_anon_unnamed_union_1_0.rs
+++ b/tests/expectations/tests/struct_with_anon_unnamed_union_1_0.rs
@@ -64,6 +64,7 @@ pub struct foo__bindgen_ty_1 {
 fn bindgen_test_layout_foo__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<foo__bindgen_ty_1> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<foo__bindgen_ty_1>(),
         4usize,
@@ -75,10 +76,7 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
         concat!("Alignment of ", stringify!(foo__bindgen_ty_1))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -88,10 +86,7 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/struct_with_bitfields.rs
+++ b/tests/expectations/tests/struct_with_bitfields.rs
@@ -102,6 +102,8 @@ pub struct bitfield {
 }
 #[test]
 fn bindgen_test_layout_bitfield() {
+    const UNINIT: ::std::mem::MaybeUninit<bitfield> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<bitfield>(),
         16usize,
@@ -112,23 +114,19 @@ fn bindgen_test_layout_bitfield() {
         4usize,
         concat!("Alignment of ", stringify!(bitfield))
     );
-    fn test_field_e() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<bitfield>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).e) as usize - ptr as usize
-            },
-            4usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(bitfield),
-                "::",
-                stringify!(e)
-            )
-        );
-    }
-    test_field_e();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).e) as usize - ptr as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bitfield),
+            "::",
+            stringify!(e)
+        )
+    );
 }
 impl bitfield {
     #[inline]

--- a/tests/expectations/tests/struct_with_bitfields.rs
+++ b/tests/expectations/tests/struct_with_bitfields.rs
@@ -104,6 +104,7 @@ pub struct bitfield {
 fn bindgen_test_layout_bitfield() {
     const UNINIT: ::std::mem::MaybeUninit<bitfield> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<bitfield>(),
         16usize,
@@ -115,10 +116,7 @@ fn bindgen_test_layout_bitfield() {
         concat!("Alignment of ", stringify!(bitfield))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).e) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).e) as usize - ptr as usize },
         4usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/struct_with_derive_debug.rs
+++ b/tests/expectations/tests/struct_with_derive_debug.rs
@@ -12,6 +12,8 @@ pub struct LittleArray {
 }
 #[test]
 fn bindgen_test_layout_LittleArray() {
+    const UNINIT: ::std::mem::MaybeUninit<LittleArray> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<LittleArray>(),
         128usize,
@@ -22,23 +24,19 @@ fn bindgen_test_layout_LittleArray() {
         4usize,
         concat!("Alignment of ", stringify!(LittleArray))
     );
-    fn test_field_a() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<LittleArray>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(LittleArray),
-                "::",
-                stringify!(a)
-            )
-        );
-    }
-    test_field_a();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(LittleArray),
+            "::",
+            stringify!(a)
+        )
+    );
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -47,6 +45,8 @@ pub struct BigArray {
 }
 #[test]
 fn bindgen_test_layout_BigArray() {
+    const UNINIT: ::std::mem::MaybeUninit<BigArray> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<BigArray>(),
         132usize,
@@ -57,23 +57,19 @@ fn bindgen_test_layout_BigArray() {
         4usize,
         concat!("Alignment of ", stringify!(BigArray))
     );
-    fn test_field_a() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<BigArray>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(BigArray),
-                "::",
-                stringify!(a)
-            )
-        );
-    }
-    test_field_a();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(BigArray),
+            "::",
+            stringify!(a)
+        )
+    );
 }
 impl Default for BigArray {
     fn default() -> Self {
@@ -91,6 +87,8 @@ pub struct WithLittleArray {
 }
 #[test]
 fn bindgen_test_layout_WithLittleArray() {
+    const UNINIT: ::std::mem::MaybeUninit<WithLittleArray> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<WithLittleArray>(),
         128usize,
@@ -101,24 +99,19 @@ fn bindgen_test_layout_WithLittleArray() {
         4usize,
         concat!("Alignment of ", stringify!(WithLittleArray))
     );
-    fn test_field_a() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<WithLittleArray>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(WithLittleArray),
-                "::",
-                stringify!(a)
-            )
-        );
-    }
-    test_field_a();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(WithLittleArray),
+            "::",
+            stringify!(a)
+        )
+    );
 }
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -127,6 +120,8 @@ pub struct WithBigArray {
 }
 #[test]
 fn bindgen_test_layout_WithBigArray() {
+    const UNINIT: ::std::mem::MaybeUninit<WithBigArray> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<WithBigArray>(),
         132usize,
@@ -137,23 +132,19 @@ fn bindgen_test_layout_WithBigArray() {
         4usize,
         concat!("Alignment of ", stringify!(WithBigArray))
     );
-    fn test_field_a() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<WithBigArray>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(WithBigArray),
-                "::",
-                stringify!(a)
-            )
-        );
-    }
-    test_field_a();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(WithBigArray),
+            "::",
+            stringify!(a)
+        )
+    );
 }
 impl Default for WithBigArray {
     fn default() -> Self {

--- a/tests/expectations/tests/struct_with_derive_debug.rs
+++ b/tests/expectations/tests/struct_with_derive_debug.rs
@@ -14,6 +14,7 @@ pub struct LittleArray {
 fn bindgen_test_layout_LittleArray() {
     const UNINIT: ::std::mem::MaybeUninit<LittleArray> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<LittleArray>(),
         128usize,
@@ -25,10 +26,7 @@ fn bindgen_test_layout_LittleArray() {
         concat!("Alignment of ", stringify!(LittleArray))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -47,6 +45,7 @@ pub struct BigArray {
 fn bindgen_test_layout_BigArray() {
     const UNINIT: ::std::mem::MaybeUninit<BigArray> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<BigArray>(),
         132usize,
@@ -58,10 +57,7 @@ fn bindgen_test_layout_BigArray() {
         concat!("Alignment of ", stringify!(BigArray))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -89,6 +85,7 @@ pub struct WithLittleArray {
 fn bindgen_test_layout_WithLittleArray() {
     const UNINIT: ::std::mem::MaybeUninit<WithLittleArray> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<WithLittleArray>(),
         128usize,
@@ -100,10 +97,7 @@ fn bindgen_test_layout_WithLittleArray() {
         concat!("Alignment of ", stringify!(WithLittleArray))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -122,6 +116,7 @@ pub struct WithBigArray {
 fn bindgen_test_layout_WithBigArray() {
     const UNINIT: ::std::mem::MaybeUninit<WithBigArray> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<WithBigArray>(),
         132usize,
@@ -133,10 +128,7 @@ fn bindgen_test_layout_WithBigArray() {
         concat!("Alignment of ", stringify!(WithBigArray))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/struct_with_large_array.rs
+++ b/tests/expectations/tests/struct_with_large_array.rs
@@ -14,6 +14,7 @@ pub struct S {
 fn bindgen_test_layout_S() {
     const UNINIT: ::std::mem::MaybeUninit<S> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<S>(),
         33usize,
@@ -26,7 +27,6 @@ fn bindgen_test_layout_S() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).large_array) as usize - ptr as usize
         },
         0usize,

--- a/tests/expectations/tests/struct_with_large_array.rs
+++ b/tests/expectations/tests/struct_with_large_array.rs
@@ -12,6 +12,8 @@ pub struct S {
 }
 #[test]
 fn bindgen_test_layout_S() {
+    const UNINIT: ::std::mem::MaybeUninit<S> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<S>(),
         33usize,
@@ -22,23 +24,19 @@ fn bindgen_test_layout_S() {
         1usize,
         concat!("Alignment of ", stringify!(S))
     );
-    fn test_field_large_array() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<S>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).large_array) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(S),
-                "::",
-                stringify!(large_array)
-            )
-        );
-    }
-    test_field_large_array();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).large_array) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(S),
+            "::",
+            stringify!(large_array)
+        )
+    );
 }
 impl Default for S {
     fn default() -> Self {

--- a/tests/expectations/tests/struct_with_nesting.rs
+++ b/tests/expectations/tests/struct_with_nesting.rs
@@ -28,6 +28,7 @@ pub struct foo__bindgen_ty_1__bindgen_ty_1 {
 fn bindgen_test_layout_foo__bindgen_ty_1__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<foo__bindgen_ty_1__bindgen_ty_1> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<foo__bindgen_ty_1__bindgen_ty_1>(),
         4usize,
@@ -39,10 +40,7 @@ fn bindgen_test_layout_foo__bindgen_ty_1__bindgen_ty_1() {
         concat!("Alignment of ", stringify!(foo__bindgen_ty_1__bindgen_ty_1))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).c1) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).c1) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -52,10 +50,7 @@ fn bindgen_test_layout_foo__bindgen_ty_1__bindgen_ty_1() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).c2) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).c2) as usize - ptr as usize },
         2usize,
         concat!(
             "Offset of field: ",
@@ -77,6 +72,7 @@ pub struct foo__bindgen_ty_1__bindgen_ty_2 {
 fn bindgen_test_layout_foo__bindgen_ty_1__bindgen_ty_2() {
     const UNINIT: ::std::mem::MaybeUninit<foo__bindgen_ty_1__bindgen_ty_2> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<foo__bindgen_ty_1__bindgen_ty_2>(),
         4usize,
@@ -88,10 +84,7 @@ fn bindgen_test_layout_foo__bindgen_ty_1__bindgen_ty_2() {
         concat!("Alignment of ", stringify!(foo__bindgen_ty_1__bindgen_ty_2))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).d1) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).d1) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -101,10 +94,7 @@ fn bindgen_test_layout_foo__bindgen_ty_1__bindgen_ty_2() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).d2) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).d2) as usize - ptr as usize },
         1usize,
         concat!(
             "Offset of field: ",
@@ -114,10 +104,7 @@ fn bindgen_test_layout_foo__bindgen_ty_1__bindgen_ty_2() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).d3) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).d3) as usize - ptr as usize },
         2usize,
         concat!(
             "Offset of field: ",
@@ -127,10 +114,7 @@ fn bindgen_test_layout_foo__bindgen_ty_1__bindgen_ty_2() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).d4) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).d4) as usize - ptr as usize },
         3usize,
         concat!(
             "Offset of field: ",
@@ -144,6 +128,7 @@ fn bindgen_test_layout_foo__bindgen_ty_1__bindgen_ty_2() {
 fn bindgen_test_layout_foo__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<foo__bindgen_ty_1> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<foo__bindgen_ty_1>(),
         4usize,
@@ -155,10 +140,7 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
         concat!("Alignment of ", stringify!(foo__bindgen_ty_1))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -181,6 +163,7 @@ impl Default for foo__bindgen_ty_1 {
 fn bindgen_test_layout_foo() {
     const UNINIT: ::std::mem::MaybeUninit<foo> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<foo>(),
         8usize,
@@ -192,10 +175,7 @@ fn bindgen_test_layout_foo() {
         concat!("Alignment of ", stringify!(foo))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
         0usize,
         concat!("Offset of field: ", stringify!(foo), "::", stringify!(a))
     );

--- a/tests/expectations/tests/struct_with_nesting.rs
+++ b/tests/expectations/tests/struct_with_nesting.rs
@@ -26,6 +26,8 @@ pub struct foo__bindgen_ty_1__bindgen_ty_1 {
 }
 #[test]
 fn bindgen_test_layout_foo__bindgen_ty_1__bindgen_ty_1() {
+    const UNINIT: ::std::mem::MaybeUninit<foo__bindgen_ty_1__bindgen_ty_1> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<foo__bindgen_ty_1__bindgen_ty_1>(),
         4usize,
@@ -36,44 +38,32 @@ fn bindgen_test_layout_foo__bindgen_ty_1__bindgen_ty_1() {
         2usize,
         concat!("Alignment of ", stringify!(foo__bindgen_ty_1__bindgen_ty_1))
     );
-    fn test_field_c1() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<
-                    foo__bindgen_ty_1__bindgen_ty_1,
-                >::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).c1) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(foo__bindgen_ty_1__bindgen_ty_1),
-                "::",
-                stringify!(c1)
-            )
-        );
-    }
-    test_field_c1();
-    fn test_field_c2() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<
-                    foo__bindgen_ty_1__bindgen_ty_1,
-                >::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).c2) as usize - ptr as usize
-            },
-            2usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(foo__bindgen_ty_1__bindgen_ty_1),
-                "::",
-                stringify!(c2)
-            )
-        );
-    }
-    test_field_c2();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).c1) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(foo__bindgen_ty_1__bindgen_ty_1),
+            "::",
+            stringify!(c1)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).c2) as usize - ptr as usize
+        },
+        2usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(foo__bindgen_ty_1__bindgen_ty_1),
+            "::",
+            stringify!(c2)
+        )
+    );
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
@@ -85,6 +75,8 @@ pub struct foo__bindgen_ty_1__bindgen_ty_2 {
 }
 #[test]
 fn bindgen_test_layout_foo__bindgen_ty_1__bindgen_ty_2() {
+    const UNINIT: ::std::mem::MaybeUninit<foo__bindgen_ty_1__bindgen_ty_2> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<foo__bindgen_ty_1__bindgen_ty_2>(),
         4usize,
@@ -95,85 +87,63 @@ fn bindgen_test_layout_foo__bindgen_ty_1__bindgen_ty_2() {
         1usize,
         concat!("Alignment of ", stringify!(foo__bindgen_ty_1__bindgen_ty_2))
     );
-    fn test_field_d1() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<
-                    foo__bindgen_ty_1__bindgen_ty_2,
-                >::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).d1) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(foo__bindgen_ty_1__bindgen_ty_2),
-                "::",
-                stringify!(d1)
-            )
-        );
-    }
-    test_field_d1();
-    fn test_field_d2() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<
-                    foo__bindgen_ty_1__bindgen_ty_2,
-                >::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).d2) as usize - ptr as usize
-            },
-            1usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(foo__bindgen_ty_1__bindgen_ty_2),
-                "::",
-                stringify!(d2)
-            )
-        );
-    }
-    test_field_d2();
-    fn test_field_d3() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<
-                    foo__bindgen_ty_1__bindgen_ty_2,
-                >::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).d3) as usize - ptr as usize
-            },
-            2usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(foo__bindgen_ty_1__bindgen_ty_2),
-                "::",
-                stringify!(d3)
-            )
-        );
-    }
-    test_field_d3();
-    fn test_field_d4() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<
-                    foo__bindgen_ty_1__bindgen_ty_2,
-                >::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).d4) as usize - ptr as usize
-            },
-            3usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(foo__bindgen_ty_1__bindgen_ty_2),
-                "::",
-                stringify!(d4)
-            )
-        );
-    }
-    test_field_d4();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).d1) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(foo__bindgen_ty_1__bindgen_ty_2),
+            "::",
+            stringify!(d1)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).d2) as usize - ptr as usize
+        },
+        1usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(foo__bindgen_ty_1__bindgen_ty_2),
+            "::",
+            stringify!(d2)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).d3) as usize - ptr as usize
+        },
+        2usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(foo__bindgen_ty_1__bindgen_ty_2),
+            "::",
+            stringify!(d3)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).d4) as usize - ptr as usize
+        },
+        3usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(foo__bindgen_ty_1__bindgen_ty_2),
+            "::",
+            stringify!(d4)
+        )
+    );
 }
 #[test]
 fn bindgen_test_layout_foo__bindgen_ty_1() {
+    const UNINIT: ::std::mem::MaybeUninit<foo__bindgen_ty_1> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<foo__bindgen_ty_1>(),
         4usize,
@@ -184,24 +154,19 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
         4usize,
         concat!("Alignment of ", stringify!(foo__bindgen_ty_1))
     );
-    fn test_field_b() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<foo__bindgen_ty_1>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(foo__bindgen_ty_1),
-                "::",
-                stringify!(b)
-            )
-        );
-    }
-    test_field_b();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(foo__bindgen_ty_1),
+            "::",
+            stringify!(b)
+        )
+    );
 }
 impl Default for foo__bindgen_ty_1 {
     fn default() -> Self {
@@ -214,6 +179,8 @@ impl Default for foo__bindgen_ty_1 {
 }
 #[test]
 fn bindgen_test_layout_foo() {
+    const UNINIT: ::std::mem::MaybeUninit<foo> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<foo>(),
         8usize,
@@ -224,18 +191,14 @@ fn bindgen_test_layout_foo() {
         4usize,
         concat!("Alignment of ", stringify!(foo))
     );
-    fn test_field_a() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<foo>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-            },
-            0usize,
-            concat!("Offset of field: ", stringify!(foo), "::", stringify!(a))
-        );
-    }
-    test_field_a();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+        },
+        0usize,
+        concat!("Offset of field: ", stringify!(foo), "::", stringify!(a))
+    );
 }
 impl Default for foo {
     fn default() -> Self {

--- a/tests/expectations/tests/struct_with_nesting_1_0.rs
+++ b/tests/expectations/tests/struct_with_nesting_1_0.rs
@@ -72,6 +72,7 @@ pub struct foo__bindgen_ty_1__bindgen_ty_1 {
 fn bindgen_test_layout_foo__bindgen_ty_1__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<foo__bindgen_ty_1__bindgen_ty_1> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<foo__bindgen_ty_1__bindgen_ty_1>(),
         4usize,
@@ -83,10 +84,7 @@ fn bindgen_test_layout_foo__bindgen_ty_1__bindgen_ty_1() {
         concat!("Alignment of ", stringify!(foo__bindgen_ty_1__bindgen_ty_1))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).c1) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).c1) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -96,10 +94,7 @@ fn bindgen_test_layout_foo__bindgen_ty_1__bindgen_ty_1() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).c2) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).c2) as usize - ptr as usize },
         2usize,
         concat!(
             "Offset of field: ",
@@ -126,6 +121,7 @@ pub struct foo__bindgen_ty_1__bindgen_ty_2 {
 fn bindgen_test_layout_foo__bindgen_ty_1__bindgen_ty_2() {
     const UNINIT: ::std::mem::MaybeUninit<foo__bindgen_ty_1__bindgen_ty_2> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<foo__bindgen_ty_1__bindgen_ty_2>(),
         4usize,
@@ -137,10 +133,7 @@ fn bindgen_test_layout_foo__bindgen_ty_1__bindgen_ty_2() {
         concat!("Alignment of ", stringify!(foo__bindgen_ty_1__bindgen_ty_2))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).d1) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).d1) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -150,10 +143,7 @@ fn bindgen_test_layout_foo__bindgen_ty_1__bindgen_ty_2() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).d2) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).d2) as usize - ptr as usize },
         1usize,
         concat!(
             "Offset of field: ",
@@ -163,10 +153,7 @@ fn bindgen_test_layout_foo__bindgen_ty_1__bindgen_ty_2() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).d3) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).d3) as usize - ptr as usize },
         2usize,
         concat!(
             "Offset of field: ",
@@ -176,10 +163,7 @@ fn bindgen_test_layout_foo__bindgen_ty_1__bindgen_ty_2() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).d4) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).d4) as usize - ptr as usize },
         3usize,
         concat!(
             "Offset of field: ",
@@ -198,6 +182,7 @@ impl Clone for foo__bindgen_ty_1__bindgen_ty_2 {
 fn bindgen_test_layout_foo__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<foo__bindgen_ty_1> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<foo__bindgen_ty_1>(),
         4usize,
@@ -209,10 +194,7 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
         concat!("Alignment of ", stringify!(foo__bindgen_ty_1))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -231,6 +213,7 @@ impl Clone for foo__bindgen_ty_1 {
 fn bindgen_test_layout_foo() {
     const UNINIT: ::std::mem::MaybeUninit<foo> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<foo>(),
         8usize,
@@ -242,10 +225,7 @@ fn bindgen_test_layout_foo() {
         concat!("Alignment of ", stringify!(foo))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
         0usize,
         concat!("Offset of field: ", stringify!(foo), "::", stringify!(a))
     );

--- a/tests/expectations/tests/struct_with_nesting_1_0.rs
+++ b/tests/expectations/tests/struct_with_nesting_1_0.rs
@@ -70,6 +70,8 @@ pub struct foo__bindgen_ty_1__bindgen_ty_1 {
 }
 #[test]
 fn bindgen_test_layout_foo__bindgen_ty_1__bindgen_ty_1() {
+    const UNINIT: ::std::mem::MaybeUninit<foo__bindgen_ty_1__bindgen_ty_1> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<foo__bindgen_ty_1__bindgen_ty_1>(),
         4usize,
@@ -80,44 +82,32 @@ fn bindgen_test_layout_foo__bindgen_ty_1__bindgen_ty_1() {
         2usize,
         concat!("Alignment of ", stringify!(foo__bindgen_ty_1__bindgen_ty_1))
     );
-    fn test_field_c1() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<
-                    foo__bindgen_ty_1__bindgen_ty_1,
-                >::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).c1) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(foo__bindgen_ty_1__bindgen_ty_1),
-                "::",
-                stringify!(c1)
-            )
-        );
-    }
-    test_field_c1();
-    fn test_field_c2() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<
-                    foo__bindgen_ty_1__bindgen_ty_1,
-                >::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).c2) as usize - ptr as usize
-            },
-            2usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(foo__bindgen_ty_1__bindgen_ty_1),
-                "::",
-                stringify!(c2)
-            )
-        );
-    }
-    test_field_c2();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).c1) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(foo__bindgen_ty_1__bindgen_ty_1),
+            "::",
+            stringify!(c1)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).c2) as usize - ptr as usize
+        },
+        2usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(foo__bindgen_ty_1__bindgen_ty_1),
+            "::",
+            stringify!(c2)
+        )
+    );
 }
 impl Clone for foo__bindgen_ty_1__bindgen_ty_1 {
     fn clone(&self) -> Self {
@@ -134,6 +124,8 @@ pub struct foo__bindgen_ty_1__bindgen_ty_2 {
 }
 #[test]
 fn bindgen_test_layout_foo__bindgen_ty_1__bindgen_ty_2() {
+    const UNINIT: ::std::mem::MaybeUninit<foo__bindgen_ty_1__bindgen_ty_2> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<foo__bindgen_ty_1__bindgen_ty_2>(),
         4usize,
@@ -144,82 +136,58 @@ fn bindgen_test_layout_foo__bindgen_ty_1__bindgen_ty_2() {
         1usize,
         concat!("Alignment of ", stringify!(foo__bindgen_ty_1__bindgen_ty_2))
     );
-    fn test_field_d1() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<
-                    foo__bindgen_ty_1__bindgen_ty_2,
-                >::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).d1) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(foo__bindgen_ty_1__bindgen_ty_2),
-                "::",
-                stringify!(d1)
-            )
-        );
-    }
-    test_field_d1();
-    fn test_field_d2() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<
-                    foo__bindgen_ty_1__bindgen_ty_2,
-                >::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).d2) as usize - ptr as usize
-            },
-            1usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(foo__bindgen_ty_1__bindgen_ty_2),
-                "::",
-                stringify!(d2)
-            )
-        );
-    }
-    test_field_d2();
-    fn test_field_d3() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<
-                    foo__bindgen_ty_1__bindgen_ty_2,
-                >::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).d3) as usize - ptr as usize
-            },
-            2usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(foo__bindgen_ty_1__bindgen_ty_2),
-                "::",
-                stringify!(d3)
-            )
-        );
-    }
-    test_field_d3();
-    fn test_field_d4() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<
-                    foo__bindgen_ty_1__bindgen_ty_2,
-                >::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).d4) as usize - ptr as usize
-            },
-            3usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(foo__bindgen_ty_1__bindgen_ty_2),
-                "::",
-                stringify!(d4)
-            )
-        );
-    }
-    test_field_d4();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).d1) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(foo__bindgen_ty_1__bindgen_ty_2),
+            "::",
+            stringify!(d1)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).d2) as usize - ptr as usize
+        },
+        1usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(foo__bindgen_ty_1__bindgen_ty_2),
+            "::",
+            stringify!(d2)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).d3) as usize - ptr as usize
+        },
+        2usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(foo__bindgen_ty_1__bindgen_ty_2),
+            "::",
+            stringify!(d3)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).d4) as usize - ptr as usize
+        },
+        3usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(foo__bindgen_ty_1__bindgen_ty_2),
+            "::",
+            stringify!(d4)
+        )
+    );
 }
 impl Clone for foo__bindgen_ty_1__bindgen_ty_2 {
     fn clone(&self) -> Self {
@@ -228,6 +196,8 @@ impl Clone for foo__bindgen_ty_1__bindgen_ty_2 {
 }
 #[test]
 fn bindgen_test_layout_foo__bindgen_ty_1() {
+    const UNINIT: ::std::mem::MaybeUninit<foo__bindgen_ty_1> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<foo__bindgen_ty_1>(),
         4usize,
@@ -238,24 +208,19 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
         4usize,
         concat!("Alignment of ", stringify!(foo__bindgen_ty_1))
     );
-    fn test_field_b() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<foo__bindgen_ty_1>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(foo__bindgen_ty_1),
-                "::",
-                stringify!(b)
-            )
-        );
-    }
-    test_field_b();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(foo__bindgen_ty_1),
+            "::",
+            stringify!(b)
+        )
+    );
 }
 impl Clone for foo__bindgen_ty_1 {
     fn clone(&self) -> Self {
@@ -264,6 +229,8 @@ impl Clone for foo__bindgen_ty_1 {
 }
 #[test]
 fn bindgen_test_layout_foo() {
+    const UNINIT: ::std::mem::MaybeUninit<foo> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<foo>(),
         8usize,
@@ -274,18 +241,14 @@ fn bindgen_test_layout_foo() {
         4usize,
         concat!("Alignment of ", stringify!(foo))
     );
-    fn test_field_a() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<foo>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-            },
-            0usize,
-            concat!("Offset of field: ", stringify!(foo), "::", stringify!(a))
-        );
-    }
-    test_field_a();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+        },
+        0usize,
+        concat!("Offset of field: ", stringify!(foo), "::", stringify!(a))
+    );
 }
 impl Clone for foo {
     fn clone(&self) -> Self {

--- a/tests/expectations/tests/struct_with_packing.rs
+++ b/tests/expectations/tests/struct_with_packing.rs
@@ -13,6 +13,8 @@ pub struct a {
 }
 #[test]
 fn bindgen_test_layout_a() {
+    const UNINIT: ::std::mem::MaybeUninit<a> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<a>(),
         3usize,
@@ -23,28 +25,20 @@ fn bindgen_test_layout_a() {
         1usize,
         concat!("Alignment of ", stringify!(a))
     );
-    fn test_field_b() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<a>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-            },
-            0usize,
-            concat!("Offset of field: ", stringify!(a), "::", stringify!(b))
-        );
-    }
-    test_field_b();
-    fn test_field_c() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<a>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).c) as usize - ptr as usize
-            },
-            1usize,
-            concat!("Offset of field: ", stringify!(a), "::", stringify!(c))
-        );
-    }
-    test_field_c();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
+        },
+        0usize,
+        concat!("Offset of field: ", stringify!(a), "::", stringify!(b))
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).c) as usize - ptr as usize
+        },
+        1usize,
+        concat!("Offset of field: ", stringify!(a), "::", stringify!(c))
+    );
 }

--- a/tests/expectations/tests/struct_with_packing.rs
+++ b/tests/expectations/tests/struct_with_packing.rs
@@ -15,6 +15,7 @@ pub struct a {
 fn bindgen_test_layout_a() {
     const UNINIT: ::std::mem::MaybeUninit<a> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<a>(),
         3usize,
@@ -26,18 +27,12 @@ fn bindgen_test_layout_a() {
         concat!("Alignment of ", stringify!(a))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
         0usize,
         concat!("Offset of field: ", stringify!(a), "::", stringify!(b))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).c) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).c) as usize - ptr as usize },
         1usize,
         concat!("Offset of field: ", stringify!(a), "::", stringify!(c))
     );

--- a/tests/expectations/tests/struct_with_struct.rs
+++ b/tests/expectations/tests/struct_with_struct.rs
@@ -20,6 +20,7 @@ pub struct foo__bindgen_ty_1 {
 fn bindgen_test_layout_foo__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<foo__bindgen_ty_1> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<foo__bindgen_ty_1>(),
         8usize,
@@ -31,10 +32,7 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
         concat!("Alignment of ", stringify!(foo__bindgen_ty_1))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -44,10 +42,7 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).y) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).y) as usize - ptr as usize },
         4usize,
         concat!(
             "Offset of field: ",
@@ -61,6 +56,7 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
 fn bindgen_test_layout_foo() {
     const UNINIT: ::std::mem::MaybeUninit<foo> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<foo>(),
         8usize,
@@ -72,10 +68,7 @@ fn bindgen_test_layout_foo() {
         concat!("Alignment of ", stringify!(foo))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize },
         0usize,
         concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar))
     );

--- a/tests/expectations/tests/struct_with_struct.rs
+++ b/tests/expectations/tests/struct_with_struct.rs
@@ -18,6 +18,8 @@ pub struct foo__bindgen_ty_1 {
 }
 #[test]
 fn bindgen_test_layout_foo__bindgen_ty_1() {
+    const UNINIT: ::std::mem::MaybeUninit<foo__bindgen_ty_1> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<foo__bindgen_ty_1>(),
         8usize,
@@ -28,45 +30,37 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
         4usize,
         concat!("Alignment of ", stringify!(foo__bindgen_ty_1))
     );
-    fn test_field_x() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<foo__bindgen_ty_1>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(foo__bindgen_ty_1),
-                "::",
-                stringify!(x)
-            )
-        );
-    }
-    test_field_x();
-    fn test_field_y() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<foo__bindgen_ty_1>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).y) as usize - ptr as usize
-            },
-            4usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(foo__bindgen_ty_1),
-                "::",
-                stringify!(y)
-            )
-        );
-    }
-    test_field_y();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(foo__bindgen_ty_1),
+            "::",
+            stringify!(x)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).y) as usize - ptr as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(foo__bindgen_ty_1),
+            "::",
+            stringify!(y)
+        )
+    );
 }
 #[test]
 fn bindgen_test_layout_foo() {
+    const UNINIT: ::std::mem::MaybeUninit<foo> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<foo>(),
         8usize,
@@ -77,21 +71,12 @@ fn bindgen_test_layout_foo() {
         4usize,
         concat!("Alignment of ", stringify!(foo))
     );
-    fn test_field_bar() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<foo>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(foo),
-                "::",
-                stringify!(bar)
-            )
-        );
-    }
-    test_field_bar();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
+        },
+        0usize,
+        concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar))
+    );
 }

--- a/tests/expectations/tests/template.rs
+++ b/tests/expectations/tests/template.rs
@@ -70,6 +70,7 @@ pub struct C {
 fn bindgen_test_layout_C() {
     const UNINIT: ::std::mem::MaybeUninit<C> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<C>(),
         104usize,
@@ -81,16 +82,12 @@ fn bindgen_test_layout_C() {
         concat!("Alignment of ", stringify!(C))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mB) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).mB) as usize - ptr as usize },
         0usize,
         concat!("Offset of field: ", stringify!(C), "::", stringify!(mB))
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).mBConstPtr) as usize - ptr as usize
         },
         8usize,
@@ -103,7 +100,6 @@ fn bindgen_test_layout_C() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).mBConstStructPtr) as usize -
                 ptr as usize
         },
@@ -117,7 +113,6 @@ fn bindgen_test_layout_C() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).mBConstStructPtrArray) as usize -
                 ptr as usize
         },
@@ -130,10 +125,7 @@ fn bindgen_test_layout_C() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mBConst) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).mBConst) as usize - ptr as usize },
         32usize,
         concat!(
             "Offset of field: ",
@@ -144,7 +136,6 @@ fn bindgen_test_layout_C() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).mBVolatile) as usize - ptr as usize
         },
         36usize,
@@ -157,7 +148,6 @@ fn bindgen_test_layout_C() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).mBConstBool) as usize - ptr as usize
         },
         40usize,
@@ -170,7 +160,6 @@ fn bindgen_test_layout_C() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).mBConstChar) as usize - ptr as usize
         },
         42usize,
@@ -182,10 +171,7 @@ fn bindgen_test_layout_C() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mBArray) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).mBArray) as usize - ptr as usize },
         44usize,
         concat!(
             "Offset of field: ",
@@ -196,7 +182,6 @@ fn bindgen_test_layout_C() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).mBPtrArray) as usize - ptr as usize
         },
         48usize,
@@ -209,7 +194,6 @@ fn bindgen_test_layout_C() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).mBArrayPtr) as usize - ptr as usize
         },
         56usize,
@@ -221,16 +205,12 @@ fn bindgen_test_layout_C() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mBRef) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).mBRef) as usize - ptr as usize },
         64usize,
         concat!("Offset of field: ", stringify!(C), "::", stringify!(mBRef))
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).mBConstRef) as usize - ptr as usize
         },
         72usize,
@@ -242,10 +222,7 @@ fn bindgen_test_layout_C() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mPtrRef) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).mPtrRef) as usize - ptr as usize },
         80usize,
         concat!(
             "Offset of field: ",
@@ -256,7 +233,6 @@ fn bindgen_test_layout_C() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).mArrayRef) as usize - ptr as usize
         },
         88usize,
@@ -269,7 +245,6 @@ fn bindgen_test_layout_C() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).mBConstArray) as usize - ptr as usize
         },
         96usize,
@@ -347,6 +322,7 @@ pub struct RootedContainer {
 fn bindgen_test_layout_RootedContainer() {
     const UNINIT: ::std::mem::MaybeUninit<RootedContainer> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<RootedContainer>(),
         24usize,
@@ -358,10 +334,7 @@ fn bindgen_test_layout_RootedContainer() {
         concat!("Alignment of ", stringify!(RootedContainer))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).root) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).root) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -405,6 +378,7 @@ pub struct PODButContainsDtor {
 fn bindgen_test_layout_PODButContainsDtor() {
     const UNINIT: ::std::mem::MaybeUninit<PODButContainsDtor> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<PODButContainsDtor>(),
         4usize,
@@ -416,10 +390,7 @@ fn bindgen_test_layout_PODButContainsDtor() {
         concat!("Alignment of ", stringify!(PODButContainsDtor))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).member) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).member) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -453,6 +424,7 @@ pub struct POD {
 fn bindgen_test_layout_POD() {
     const UNINIT: ::std::mem::MaybeUninit<POD> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<POD>(),
         4usize,
@@ -465,7 +437,6 @@ fn bindgen_test_layout_POD() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).opaque_member) as usize - ptr as usize
         },
         0usize,

--- a/tests/expectations/tests/template.rs
+++ b/tests/expectations/tests/template.rs
@@ -68,6 +68,8 @@ pub struct C {
 }
 #[test]
 fn bindgen_test_layout_C() {
+    const UNINIT: ::std::mem::MaybeUninit<C> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<C>(),
         104usize,
@@ -78,276 +80,206 @@ fn bindgen_test_layout_C() {
         8usize,
         concat!("Alignment of ", stringify!(C))
     );
-    fn test_field_mB() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<C>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).mB) as usize - ptr as usize
-            },
-            0usize,
-            concat!("Offset of field: ", stringify!(C), "::", stringify!(mB))
-        );
-    }
-    test_field_mB();
-    fn test_field_mBConstPtr() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<C>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).mBConstPtr) as usize - ptr as usize
-            },
-            8usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(C),
-                "::",
-                stringify!(mBConstPtr)
-            )
-        );
-    }
-    test_field_mBConstPtr();
-    fn test_field_mBConstStructPtr() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<C>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).mBConstStructPtr) as usize -
-                    ptr as usize
-            },
-            16usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(C),
-                "::",
-                stringify!(mBConstStructPtr)
-            )
-        );
-    }
-    test_field_mBConstStructPtr();
-    fn test_field_mBConstStructPtrArray() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<C>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).mBConstStructPtrArray) as usize -
-                    ptr as usize
-            },
-            24usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(C),
-                "::",
-                stringify!(mBConstStructPtrArray)
-            )
-        );
-    }
-    test_field_mBConstStructPtrArray();
-    fn test_field_mBConst() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<C>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).mBConst) as usize - ptr as usize
-            },
-            32usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(C),
-                "::",
-                stringify!(mBConst)
-            )
-        );
-    }
-    test_field_mBConst();
-    fn test_field_mBVolatile() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<C>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).mBVolatile) as usize - ptr as usize
-            },
-            36usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(C),
-                "::",
-                stringify!(mBVolatile)
-            )
-        );
-    }
-    test_field_mBVolatile();
-    fn test_field_mBConstBool() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<C>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).mBConstBool) as usize - ptr as usize
-            },
-            40usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(C),
-                "::",
-                stringify!(mBConstBool)
-            )
-        );
-    }
-    test_field_mBConstBool();
-    fn test_field_mBConstChar() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<C>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).mBConstChar) as usize - ptr as usize
-            },
-            42usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(C),
-                "::",
-                stringify!(mBConstChar)
-            )
-        );
-    }
-    test_field_mBConstChar();
-    fn test_field_mBArray() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<C>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).mBArray) as usize - ptr as usize
-            },
-            44usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(C),
-                "::",
-                stringify!(mBArray)
-            )
-        );
-    }
-    test_field_mBArray();
-    fn test_field_mBPtrArray() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<C>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).mBPtrArray) as usize - ptr as usize
-            },
-            48usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(C),
-                "::",
-                stringify!(mBPtrArray)
-            )
-        );
-    }
-    test_field_mBPtrArray();
-    fn test_field_mBArrayPtr() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<C>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).mBArrayPtr) as usize - ptr as usize
-            },
-            56usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(C),
-                "::",
-                stringify!(mBArrayPtr)
-            )
-        );
-    }
-    test_field_mBArrayPtr();
-    fn test_field_mBRef() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<C>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).mBRef) as usize - ptr as usize
-            },
-            64usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(C),
-                "::",
-                stringify!(mBRef)
-            )
-        );
-    }
-    test_field_mBRef();
-    fn test_field_mBConstRef() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<C>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).mBConstRef) as usize - ptr as usize
-            },
-            72usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(C),
-                "::",
-                stringify!(mBConstRef)
-            )
-        );
-    }
-    test_field_mBConstRef();
-    fn test_field_mPtrRef() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<C>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).mPtrRef) as usize - ptr as usize
-            },
-            80usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(C),
-                "::",
-                stringify!(mPtrRef)
-            )
-        );
-    }
-    test_field_mPtrRef();
-    fn test_field_mArrayRef() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<C>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).mArrayRef) as usize - ptr as usize
-            },
-            88usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(C),
-                "::",
-                stringify!(mArrayRef)
-            )
-        );
-    }
-    test_field_mArrayRef();
-    fn test_field_mBConstArray() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<C>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).mBConstArray) as usize -
-                    ptr as usize
-            },
-            96usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(C),
-                "::",
-                stringify!(mBConstArray)
-            )
-        );
-    }
-    test_field_mBConstArray();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).mB) as usize - ptr as usize
+        },
+        0usize,
+        concat!("Offset of field: ", stringify!(C), "::", stringify!(mB))
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).mBConstPtr) as usize - ptr as usize
+        },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C),
+            "::",
+            stringify!(mBConstPtr)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).mBConstStructPtr) as usize -
+                ptr as usize
+        },
+        16usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C),
+            "::",
+            stringify!(mBConstStructPtr)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).mBConstStructPtrArray) as usize -
+                ptr as usize
+        },
+        24usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C),
+            "::",
+            stringify!(mBConstStructPtrArray)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).mBConst) as usize - ptr as usize
+        },
+        32usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C),
+            "::",
+            stringify!(mBConst)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).mBVolatile) as usize - ptr as usize
+        },
+        36usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C),
+            "::",
+            stringify!(mBVolatile)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).mBConstBool) as usize - ptr as usize
+        },
+        40usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C),
+            "::",
+            stringify!(mBConstBool)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).mBConstChar) as usize - ptr as usize
+        },
+        42usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C),
+            "::",
+            stringify!(mBConstChar)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).mBArray) as usize - ptr as usize
+        },
+        44usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C),
+            "::",
+            stringify!(mBArray)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).mBPtrArray) as usize - ptr as usize
+        },
+        48usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C),
+            "::",
+            stringify!(mBPtrArray)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).mBArrayPtr) as usize - ptr as usize
+        },
+        56usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C),
+            "::",
+            stringify!(mBArrayPtr)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).mBRef) as usize - ptr as usize
+        },
+        64usize,
+        concat!("Offset of field: ", stringify!(C), "::", stringify!(mBRef))
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).mBConstRef) as usize - ptr as usize
+        },
+        72usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C),
+            "::",
+            stringify!(mBConstRef)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).mPtrRef) as usize - ptr as usize
+        },
+        80usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C),
+            "::",
+            stringify!(mPtrRef)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).mArrayRef) as usize - ptr as usize
+        },
+        88usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C),
+            "::",
+            stringify!(mArrayRef)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).mBConstArray) as usize - ptr as usize
+        },
+        96usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C),
+            "::",
+            stringify!(mBConstArray)
+        )
+    );
 }
 impl Default for C {
     fn default() -> Self {
@@ -413,6 +345,8 @@ pub struct RootedContainer {
 }
 #[test]
 fn bindgen_test_layout_RootedContainer() {
+    const UNINIT: ::std::mem::MaybeUninit<RootedContainer> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<RootedContainer>(),
         24usize,
@@ -423,24 +357,19 @@ fn bindgen_test_layout_RootedContainer() {
         8usize,
         concat!("Alignment of ", stringify!(RootedContainer))
     );
-    fn test_field_root() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<RootedContainer>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).root) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(RootedContainer),
-                "::",
-                stringify!(root)
-            )
-        );
-    }
-    test_field_root();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).root) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(RootedContainer),
+            "::",
+            stringify!(root)
+        )
+    );
 }
 impl Default for RootedContainer {
     fn default() -> Self {
@@ -474,6 +403,8 @@ pub struct PODButContainsDtor {
 }
 #[test]
 fn bindgen_test_layout_PODButContainsDtor() {
+    const UNINIT: ::std::mem::MaybeUninit<PODButContainsDtor> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<PODButContainsDtor>(),
         4usize,
@@ -484,24 +415,19 @@ fn bindgen_test_layout_PODButContainsDtor() {
         4usize,
         concat!("Alignment of ", stringify!(PODButContainsDtor))
     );
-    fn test_field_member() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<PODButContainsDtor>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).member) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(PODButContainsDtor),
-                "::",
-                stringify!(member)
-            )
-        );
-    }
-    test_field_member();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).member) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(PODButContainsDtor),
+            "::",
+            stringify!(member)
+        )
+    );
 }
 impl Default for PODButContainsDtor {
     fn default() -> Self {
@@ -525,6 +451,8 @@ pub struct POD {
 }
 #[test]
 fn bindgen_test_layout_POD() {
+    const UNINIT: ::std::mem::MaybeUninit<POD> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<POD>(),
         4usize,
@@ -535,24 +463,19 @@ fn bindgen_test_layout_POD() {
         4usize,
         concat!("Alignment of ", stringify!(POD))
     );
-    fn test_field_opaque_member() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<POD>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).opaque_member) as usize -
-                    ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(POD),
-                "::",
-                stringify!(opaque_member)
-            )
-        );
-    }
-    test_field_opaque_member();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).opaque_member) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(POD),
+            "::",
+            stringify!(opaque_member)
+        )
+    );
 }
 /// <div rustbindgen replaces="NestedReplaced"></div>
 #[repr(C)]

--- a/tests/expectations/tests/test_mixed_header_and_header_contents.rs
+++ b/tests/expectations/tests/test_mixed_header_and_header_contents.rs
@@ -35,6 +35,7 @@ pub struct Test {
 fn bindgen_test_layout_Test() {
     const UNINIT: ::std::mem::MaybeUninit<Test> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<Test>(),
         12usize,
@@ -46,82 +47,52 @@ fn bindgen_test_layout_Test() {
         concat!("Alignment of ", stringify!(Test))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).ch) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).ch) as usize - ptr as usize },
         0usize,
         concat!("Offset of field: ", stringify!(Test), "::", stringify!(ch))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).u) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).u) as usize - ptr as usize },
         1usize,
         concat!("Offset of field: ", stringify!(Test), "::", stringify!(u))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize },
         2usize,
         concat!("Offset of field: ", stringify!(Test), "::", stringify!(d))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).cch) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).cch) as usize - ptr as usize },
         3usize,
         concat!("Offset of field: ", stringify!(Test), "::", stringify!(cch))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).cu) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).cu) as usize - ptr as usize },
         4usize,
         concat!("Offset of field: ", stringify!(Test), "::", stringify!(cu))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).cd) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).cd) as usize - ptr as usize },
         5usize,
         concat!("Offset of field: ", stringify!(Test), "::", stringify!(cd))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).Cch) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).Cch) as usize - ptr as usize },
         6usize,
         concat!("Offset of field: ", stringify!(Test), "::", stringify!(Cch))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).Cu) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).Cu) as usize - ptr as usize },
         7usize,
         concat!("Offset of field: ", stringify!(Test), "::", stringify!(Cu))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).Cd) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).Cd) as usize - ptr as usize },
         8usize,
         concat!("Offset of field: ", stringify!(Test), "::", stringify!(Cd))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).Ccch) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).Ccch) as usize - ptr as usize },
         9usize,
         concat!(
             "Offset of field: ",
@@ -131,18 +102,12 @@ fn bindgen_test_layout_Test() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).Ccu) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).Ccu) as usize - ptr as usize },
         10usize,
         concat!("Offset of field: ", stringify!(Test), "::", stringify!(Ccu))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).Ccd) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).Ccd) as usize - ptr as usize },
         11usize,
         concat!("Offset of field: ", stringify!(Test), "::", stringify!(Ccd))
     );

--- a/tests/expectations/tests/test_mixed_header_and_header_contents.rs
+++ b/tests/expectations/tests/test_mixed_header_and_header_contents.rs
@@ -33,6 +33,8 @@ pub struct Test {
 }
 #[test]
 fn bindgen_test_layout_Test() {
+    const UNINIT: ::std::mem::MaybeUninit<Test> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<Test>(),
         12usize,
@@ -43,198 +45,105 @@ fn bindgen_test_layout_Test() {
         1usize,
         concat!("Alignment of ", stringify!(Test))
     );
-    fn test_field_ch() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Test>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).ch) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(Test),
-                "::",
-                stringify!(ch)
-            )
-        );
-    }
-    test_field_ch();
-    fn test_field_u() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Test>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).u) as usize - ptr as usize
-            },
-            1usize,
-            concat!("Offset of field: ", stringify!(Test), "::", stringify!(u))
-        );
-    }
-    test_field_u();
-    fn test_field_d() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Test>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize
-            },
-            2usize,
-            concat!("Offset of field: ", stringify!(Test), "::", stringify!(d))
-        );
-    }
-    test_field_d();
-    fn test_field_cch() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Test>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).cch) as usize - ptr as usize
-            },
-            3usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(Test),
-                "::",
-                stringify!(cch)
-            )
-        );
-    }
-    test_field_cch();
-    fn test_field_cu() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Test>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).cu) as usize - ptr as usize
-            },
-            4usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(Test),
-                "::",
-                stringify!(cu)
-            )
-        );
-    }
-    test_field_cu();
-    fn test_field_cd() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Test>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).cd) as usize - ptr as usize
-            },
-            5usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(Test),
-                "::",
-                stringify!(cd)
-            )
-        );
-    }
-    test_field_cd();
-    fn test_field_Cch() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Test>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).Cch) as usize - ptr as usize
-            },
-            6usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(Test),
-                "::",
-                stringify!(Cch)
-            )
-        );
-    }
-    test_field_Cch();
-    fn test_field_Cu() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Test>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).Cu) as usize - ptr as usize
-            },
-            7usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(Test),
-                "::",
-                stringify!(Cu)
-            )
-        );
-    }
-    test_field_Cu();
-    fn test_field_Cd() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Test>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).Cd) as usize - ptr as usize
-            },
-            8usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(Test),
-                "::",
-                stringify!(Cd)
-            )
-        );
-    }
-    test_field_Cd();
-    fn test_field_Ccch() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Test>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).Ccch) as usize - ptr as usize
-            },
-            9usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(Test),
-                "::",
-                stringify!(Ccch)
-            )
-        );
-    }
-    test_field_Ccch();
-    fn test_field_Ccu() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Test>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).Ccu) as usize - ptr as usize
-            },
-            10usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(Test),
-                "::",
-                stringify!(Ccu)
-            )
-        );
-    }
-    test_field_Ccu();
-    fn test_field_Ccd() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Test>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).Ccd) as usize - ptr as usize
-            },
-            11usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(Test),
-                "::",
-                stringify!(Ccd)
-            )
-        );
-    }
-    test_field_Ccd();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).ch) as usize - ptr as usize
+        },
+        0usize,
+        concat!("Offset of field: ", stringify!(Test), "::", stringify!(ch))
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).u) as usize - ptr as usize
+        },
+        1usize,
+        concat!("Offset of field: ", stringify!(Test), "::", stringify!(u))
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize
+        },
+        2usize,
+        concat!("Offset of field: ", stringify!(Test), "::", stringify!(d))
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).cch) as usize - ptr as usize
+        },
+        3usize,
+        concat!("Offset of field: ", stringify!(Test), "::", stringify!(cch))
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).cu) as usize - ptr as usize
+        },
+        4usize,
+        concat!("Offset of field: ", stringify!(Test), "::", stringify!(cu))
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).cd) as usize - ptr as usize
+        },
+        5usize,
+        concat!("Offset of field: ", stringify!(Test), "::", stringify!(cd))
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).Cch) as usize - ptr as usize
+        },
+        6usize,
+        concat!("Offset of field: ", stringify!(Test), "::", stringify!(Cch))
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).Cu) as usize - ptr as usize
+        },
+        7usize,
+        concat!("Offset of field: ", stringify!(Test), "::", stringify!(Cu))
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).Cd) as usize - ptr as usize
+        },
+        8usize,
+        concat!("Offset of field: ", stringify!(Test), "::", stringify!(Cd))
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).Ccch) as usize - ptr as usize
+        },
+        9usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(Test),
+            "::",
+            stringify!(Ccch)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).Ccu) as usize - ptr as usize
+        },
+        10usize,
+        concat!("Offset of field: ", stringify!(Test), "::", stringify!(Ccu))
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).Ccd) as usize - ptr as usize
+        },
+        11usize,
+        concat!("Offset of field: ", stringify!(Test), "::", stringify!(Ccd))
+    );
 }

--- a/tests/expectations/tests/test_multiple_header_calls_in_builder.rs
+++ b/tests/expectations/tests/test_multiple_header_calls_in_builder.rs
@@ -29,6 +29,7 @@ pub struct Test {
 fn bindgen_test_layout_Test() {
     const UNINIT: ::std::mem::MaybeUninit<Test> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<Test>(),
         12usize,
@@ -40,82 +41,52 @@ fn bindgen_test_layout_Test() {
         concat!("Alignment of ", stringify!(Test))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).ch) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).ch) as usize - ptr as usize },
         0usize,
         concat!("Offset of field: ", stringify!(Test), "::", stringify!(ch))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).u) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).u) as usize - ptr as usize },
         1usize,
         concat!("Offset of field: ", stringify!(Test), "::", stringify!(u))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize },
         2usize,
         concat!("Offset of field: ", stringify!(Test), "::", stringify!(d))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).cch) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).cch) as usize - ptr as usize },
         3usize,
         concat!("Offset of field: ", stringify!(Test), "::", stringify!(cch))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).cu) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).cu) as usize - ptr as usize },
         4usize,
         concat!("Offset of field: ", stringify!(Test), "::", stringify!(cu))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).cd) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).cd) as usize - ptr as usize },
         5usize,
         concat!("Offset of field: ", stringify!(Test), "::", stringify!(cd))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).Cch) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).Cch) as usize - ptr as usize },
         6usize,
         concat!("Offset of field: ", stringify!(Test), "::", stringify!(Cch))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).Cu) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).Cu) as usize - ptr as usize },
         7usize,
         concat!("Offset of field: ", stringify!(Test), "::", stringify!(Cu))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).Cd) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).Cd) as usize - ptr as usize },
         8usize,
         concat!("Offset of field: ", stringify!(Test), "::", stringify!(Cd))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).Ccch) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).Ccch) as usize - ptr as usize },
         9usize,
         concat!(
             "Offset of field: ",
@@ -125,18 +96,12 @@ fn bindgen_test_layout_Test() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).Ccu) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).Ccu) as usize - ptr as usize },
         10usize,
         concat!("Offset of field: ", stringify!(Test), "::", stringify!(Ccu))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).Ccd) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).Ccd) as usize - ptr as usize },
         11usize,
         concat!("Offset of field: ", stringify!(Test), "::", stringify!(Ccd))
     );

--- a/tests/expectations/tests/test_multiple_header_calls_in_builder.rs
+++ b/tests/expectations/tests/test_multiple_header_calls_in_builder.rs
@@ -27,6 +27,8 @@ pub struct Test {
 }
 #[test]
 fn bindgen_test_layout_Test() {
+    const UNINIT: ::std::mem::MaybeUninit<Test> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<Test>(),
         12usize,
@@ -37,198 +39,105 @@ fn bindgen_test_layout_Test() {
         1usize,
         concat!("Alignment of ", stringify!(Test))
     );
-    fn test_field_ch() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Test>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).ch) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(Test),
-                "::",
-                stringify!(ch)
-            )
-        );
-    }
-    test_field_ch();
-    fn test_field_u() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Test>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).u) as usize - ptr as usize
-            },
-            1usize,
-            concat!("Offset of field: ", stringify!(Test), "::", stringify!(u))
-        );
-    }
-    test_field_u();
-    fn test_field_d() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Test>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize
-            },
-            2usize,
-            concat!("Offset of field: ", stringify!(Test), "::", stringify!(d))
-        );
-    }
-    test_field_d();
-    fn test_field_cch() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Test>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).cch) as usize - ptr as usize
-            },
-            3usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(Test),
-                "::",
-                stringify!(cch)
-            )
-        );
-    }
-    test_field_cch();
-    fn test_field_cu() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Test>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).cu) as usize - ptr as usize
-            },
-            4usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(Test),
-                "::",
-                stringify!(cu)
-            )
-        );
-    }
-    test_field_cu();
-    fn test_field_cd() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Test>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).cd) as usize - ptr as usize
-            },
-            5usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(Test),
-                "::",
-                stringify!(cd)
-            )
-        );
-    }
-    test_field_cd();
-    fn test_field_Cch() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Test>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).Cch) as usize - ptr as usize
-            },
-            6usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(Test),
-                "::",
-                stringify!(Cch)
-            )
-        );
-    }
-    test_field_Cch();
-    fn test_field_Cu() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Test>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).Cu) as usize - ptr as usize
-            },
-            7usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(Test),
-                "::",
-                stringify!(Cu)
-            )
-        );
-    }
-    test_field_Cu();
-    fn test_field_Cd() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Test>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).Cd) as usize - ptr as usize
-            },
-            8usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(Test),
-                "::",
-                stringify!(Cd)
-            )
-        );
-    }
-    test_field_Cd();
-    fn test_field_Ccch() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Test>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).Ccch) as usize - ptr as usize
-            },
-            9usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(Test),
-                "::",
-                stringify!(Ccch)
-            )
-        );
-    }
-    test_field_Ccch();
-    fn test_field_Ccu() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Test>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).Ccu) as usize - ptr as usize
-            },
-            10usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(Test),
-                "::",
-                stringify!(Ccu)
-            )
-        );
-    }
-    test_field_Ccu();
-    fn test_field_Ccd() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Test>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).Ccd) as usize - ptr as usize
-            },
-            11usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(Test),
-                "::",
-                stringify!(Ccd)
-            )
-        );
-    }
-    test_field_Ccd();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).ch) as usize - ptr as usize
+        },
+        0usize,
+        concat!("Offset of field: ", stringify!(Test), "::", stringify!(ch))
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).u) as usize - ptr as usize
+        },
+        1usize,
+        concat!("Offset of field: ", stringify!(Test), "::", stringify!(u))
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize
+        },
+        2usize,
+        concat!("Offset of field: ", stringify!(Test), "::", stringify!(d))
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).cch) as usize - ptr as usize
+        },
+        3usize,
+        concat!("Offset of field: ", stringify!(Test), "::", stringify!(cch))
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).cu) as usize - ptr as usize
+        },
+        4usize,
+        concat!("Offset of field: ", stringify!(Test), "::", stringify!(cu))
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).cd) as usize - ptr as usize
+        },
+        5usize,
+        concat!("Offset of field: ", stringify!(Test), "::", stringify!(cd))
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).Cch) as usize - ptr as usize
+        },
+        6usize,
+        concat!("Offset of field: ", stringify!(Test), "::", stringify!(Cch))
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).Cu) as usize - ptr as usize
+        },
+        7usize,
+        concat!("Offset of field: ", stringify!(Test), "::", stringify!(Cu))
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).Cd) as usize - ptr as usize
+        },
+        8usize,
+        concat!("Offset of field: ", stringify!(Test), "::", stringify!(Cd))
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).Ccch) as usize - ptr as usize
+        },
+        9usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(Test),
+            "::",
+            stringify!(Ccch)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).Ccu) as usize - ptr as usize
+        },
+        10usize,
+        concat!("Offset of field: ", stringify!(Test), "::", stringify!(Ccu))
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).Ccd) as usize - ptr as usize
+        },
+        11usize,
+        concat!("Offset of field: ", stringify!(Test), "::", stringify!(Ccd))
+    );
 }

--- a/tests/expectations/tests/timex.rs
+++ b/tests/expectations/tests/timex.rs
@@ -100,6 +100,8 @@ pub struct timex {
 }
 #[test]
 fn bindgen_test_layout_timex() {
+    const UNINIT: ::std::mem::MaybeUninit<timex> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<timex>(),
         48usize,
@@ -110,23 +112,19 @@ fn bindgen_test_layout_timex() {
         4usize,
         concat!("Alignment of ", stringify!(timex))
     );
-    fn test_field_tai() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<timex>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).tai) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(timex),
-                "::",
-                stringify!(tai)
-            )
-        );
-    }
-    test_field_tai();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).tai) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(timex),
+            "::",
+            stringify!(tai)
+        )
+    );
 }
 impl Default for timex {
     fn default() -> Self {
@@ -146,6 +144,8 @@ pub struct timex_named {
 }
 #[test]
 fn bindgen_test_layout_timex_named() {
+    const UNINIT: ::std::mem::MaybeUninit<timex_named> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<timex_named>(),
         48usize,
@@ -156,23 +156,19 @@ fn bindgen_test_layout_timex_named() {
         4usize,
         concat!("Alignment of ", stringify!(timex_named))
     );
-    fn test_field_tai() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<timex_named>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).tai) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(timex_named),
-                "::",
-                stringify!(tai)
-            )
-        );
-    }
-    test_field_tai();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).tai) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(timex_named),
+            "::",
+            stringify!(tai)
+        )
+    );
 }
 impl Default for timex_named {
     fn default() -> Self {

--- a/tests/expectations/tests/timex.rs
+++ b/tests/expectations/tests/timex.rs
@@ -102,6 +102,7 @@ pub struct timex {
 fn bindgen_test_layout_timex() {
     const UNINIT: ::std::mem::MaybeUninit<timex> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<timex>(),
         48usize,
@@ -113,10 +114,7 @@ fn bindgen_test_layout_timex() {
         concat!("Alignment of ", stringify!(timex))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).tai) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).tai) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -146,6 +144,7 @@ pub struct timex_named {
 fn bindgen_test_layout_timex_named() {
     const UNINIT: ::std::mem::MaybeUninit<timex_named> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<timex_named>(),
         48usize,
@@ -157,10 +156,7 @@ fn bindgen_test_layout_timex_named() {
         concat!("Alignment of ", stringify!(timex_named))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).tai) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).tai) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/type-referenced-by-allowlisted-function.rs
+++ b/tests/expectations/tests/type-referenced-by-allowlisted-function.rs
@@ -14,6 +14,7 @@ pub struct dl_phdr_info {
 fn bindgen_test_layout_dl_phdr_info() {
     const UNINIT: ::std::mem::MaybeUninit<dl_phdr_info> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<dl_phdr_info>(),
         4usize,
@@ -25,10 +26,7 @@ fn bindgen_test_layout_dl_phdr_info() {
         concat!("Alignment of ", stringify!(dl_phdr_info))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/type-referenced-by-allowlisted-function.rs
+++ b/tests/expectations/tests/type-referenced-by-allowlisted-function.rs
@@ -12,6 +12,8 @@ pub struct dl_phdr_info {
 }
 #[test]
 fn bindgen_test_layout_dl_phdr_info() {
+    const UNINIT: ::std::mem::MaybeUninit<dl_phdr_info> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<dl_phdr_info>(),
         4usize,
@@ -22,23 +24,19 @@ fn bindgen_test_layout_dl_phdr_info() {
         4usize,
         concat!("Alignment of ", stringify!(dl_phdr_info))
     );
-    fn test_field_x() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<dl_phdr_info>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(dl_phdr_info),
-                "::",
-                stringify!(x)
-            )
-        );
-    }
-    test_field_x();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(dl_phdr_info),
+            "::",
+            stringify!(x)
+        )
+    );
 }
 extern "C" {
     pub fn dl_iterate_phdr(arg1: *mut dl_phdr_info) -> ::std::os::raw::c_int;

--- a/tests/expectations/tests/typeref.rs
+++ b/tests/expectations/tests/typeref.rs
@@ -14,6 +14,7 @@ pub struct mozilla_FragmentOrURL {
 fn bindgen_test_layout_mozilla_FragmentOrURL() {
     const UNINIT: ::std::mem::MaybeUninit<mozilla_FragmentOrURL> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<mozilla_FragmentOrURL>(),
         1usize,
@@ -26,7 +27,6 @@ fn bindgen_test_layout_mozilla_FragmentOrURL() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).mIsLocalRef) as usize - ptr as usize
         },
         0usize,
@@ -92,6 +92,7 @@ pub struct Bar {
 fn bindgen_test_layout_Bar() {
     const UNINIT: ::std::mem::MaybeUninit<Bar> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<Bar>(),
         8usize,
@@ -103,10 +104,7 @@ fn bindgen_test_layout_Bar() {
         concat!("Alignment of ", stringify!(Bar))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mFoo) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).mFoo) as usize - ptr as usize },
         0usize,
         concat!("Offset of field: ", stringify!(Bar), "::", stringify!(mFoo))
     );
@@ -128,6 +126,7 @@ pub struct nsFoo {
 fn bindgen_test_layout_nsFoo() {
     const UNINIT: ::std::mem::MaybeUninit<nsFoo> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<nsFoo>(),
         8usize,
@@ -139,10 +138,7 @@ fn bindgen_test_layout_nsFoo() {
         concat!("Alignment of ", stringify!(nsFoo))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mBar) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).mBar) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/typeref.rs
+++ b/tests/expectations/tests/typeref.rs
@@ -12,6 +12,8 @@ pub struct mozilla_FragmentOrURL {
 }
 #[test]
 fn bindgen_test_layout_mozilla_FragmentOrURL() {
+    const UNINIT: ::std::mem::MaybeUninit<mozilla_FragmentOrURL> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<mozilla_FragmentOrURL>(),
         1usize,
@@ -22,24 +24,19 @@ fn bindgen_test_layout_mozilla_FragmentOrURL() {
         1usize,
         concat!("Alignment of ", stringify!(mozilla_FragmentOrURL))
     );
-    fn test_field_mIsLocalRef() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<mozilla_FragmentOrURL>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).mIsLocalRef) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(mozilla_FragmentOrURL),
-                "::",
-                stringify!(mIsLocalRef)
-            )
-        );
-    }
-    test_field_mIsLocalRef();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).mIsLocalRef) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(mozilla_FragmentOrURL),
+            "::",
+            stringify!(mIsLocalRef)
+        )
+    );
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
@@ -93,6 +90,8 @@ pub struct Bar {
 }
 #[test]
 fn bindgen_test_layout_Bar() {
+    const UNINIT: ::std::mem::MaybeUninit<Bar> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<Bar>(),
         8usize,
@@ -103,23 +102,14 @@ fn bindgen_test_layout_Bar() {
         8usize,
         concat!("Alignment of ", stringify!(Bar))
     );
-    fn test_field_mFoo() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Bar>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).mFoo) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(Bar),
-                "::",
-                stringify!(mFoo)
-            )
-        );
-    }
-    test_field_mFoo();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).mFoo) as usize - ptr as usize
+        },
+        0usize,
+        concat!("Offset of field: ", stringify!(Bar), "::", stringify!(mFoo))
+    );
 }
 impl Default for Bar {
     fn default() -> Self {
@@ -136,6 +126,8 @@ pub struct nsFoo {
 }
 #[test]
 fn bindgen_test_layout_nsFoo() {
+    const UNINIT: ::std::mem::MaybeUninit<nsFoo> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<nsFoo>(),
         8usize,
@@ -146,23 +138,19 @@ fn bindgen_test_layout_nsFoo() {
         8usize,
         concat!("Alignment of ", stringify!(nsFoo))
     );
-    fn test_field_mBar() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<nsFoo>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).mBar) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(nsFoo),
-                "::",
-                stringify!(mBar)
-            )
-        );
-    }
-    test_field_mBar();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).mBar) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(nsFoo),
+            "::",
+            stringify!(mBar)
+        )
+    );
 }
 impl Default for nsFoo {
     fn default() -> Self {

--- a/tests/expectations/tests/typeref_1_0.rs
+++ b/tests/expectations/tests/typeref_1_0.rs
@@ -57,6 +57,7 @@ pub struct mozilla_FragmentOrURL {
 fn bindgen_test_layout_mozilla_FragmentOrURL() {
     const UNINIT: ::std::mem::MaybeUninit<mozilla_FragmentOrURL> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<mozilla_FragmentOrURL>(),
         1usize,
@@ -69,7 +70,6 @@ fn bindgen_test_layout_mozilla_FragmentOrURL() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).mIsLocalRef) as usize - ptr as usize
         },
         0usize,
@@ -130,6 +130,7 @@ pub struct Bar {
 fn bindgen_test_layout_Bar() {
     const UNINIT: ::std::mem::MaybeUninit<Bar> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<Bar>(),
         8usize,
@@ -141,10 +142,7 @@ fn bindgen_test_layout_Bar() {
         concat!("Alignment of ", stringify!(Bar))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mFoo) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).mFoo) as usize - ptr as usize },
         0usize,
         concat!("Offset of field: ", stringify!(Bar), "::", stringify!(mFoo))
     );
@@ -172,6 +170,7 @@ pub struct nsFoo {
 fn bindgen_test_layout_nsFoo() {
     const UNINIT: ::std::mem::MaybeUninit<nsFoo> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<nsFoo>(),
         8usize,
@@ -183,10 +182,7 @@ fn bindgen_test_layout_nsFoo() {
         concat!("Alignment of ", stringify!(nsFoo))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mBar) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).mBar) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/typeref_1_0.rs
+++ b/tests/expectations/tests/typeref_1_0.rs
@@ -55,6 +55,8 @@ pub struct mozilla_FragmentOrURL {
 }
 #[test]
 fn bindgen_test_layout_mozilla_FragmentOrURL() {
+    const UNINIT: ::std::mem::MaybeUninit<mozilla_FragmentOrURL> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<mozilla_FragmentOrURL>(),
         1usize,
@@ -65,24 +67,19 @@ fn bindgen_test_layout_mozilla_FragmentOrURL() {
         1usize,
         concat!("Alignment of ", stringify!(mozilla_FragmentOrURL))
     );
-    fn test_field_mIsLocalRef() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<mozilla_FragmentOrURL>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).mIsLocalRef) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(mozilla_FragmentOrURL),
-                "::",
-                stringify!(mIsLocalRef)
-            )
-        );
-    }
-    test_field_mIsLocalRef();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).mIsLocalRef) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(mozilla_FragmentOrURL),
+            "::",
+            stringify!(mIsLocalRef)
+        )
+    );
 }
 impl Clone for mozilla_FragmentOrURL {
     fn clone(&self) -> Self {
@@ -131,6 +128,8 @@ pub struct Bar {
 }
 #[test]
 fn bindgen_test_layout_Bar() {
+    const UNINIT: ::std::mem::MaybeUninit<Bar> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<Bar>(),
         8usize,
@@ -141,23 +140,14 @@ fn bindgen_test_layout_Bar() {
         8usize,
         concat!("Alignment of ", stringify!(Bar))
     );
-    fn test_field_mFoo() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Bar>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).mFoo) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(Bar),
-                "::",
-                stringify!(mFoo)
-            )
-        );
-    }
-    test_field_mFoo();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).mFoo) as usize - ptr as usize
+        },
+        0usize,
+        concat!("Offset of field: ", stringify!(Bar), "::", stringify!(mFoo))
+    );
 }
 impl Clone for Bar {
     fn clone(&self) -> Self {
@@ -180,6 +170,8 @@ pub struct nsFoo {
 }
 #[test]
 fn bindgen_test_layout_nsFoo() {
+    const UNINIT: ::std::mem::MaybeUninit<nsFoo> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<nsFoo>(),
         8usize,
@@ -190,23 +182,19 @@ fn bindgen_test_layout_nsFoo() {
         8usize,
         concat!("Alignment of ", stringify!(nsFoo))
     );
-    fn test_field_mBar() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<nsFoo>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).mBar) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(nsFoo),
-                "::",
-                stringify!(mBar)
-            )
-        );
-    }
-    test_field_mBar();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).mBar) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(nsFoo),
+            "::",
+            stringify!(mBar)
+        )
+    );
 }
 impl Clone for nsFoo {
     fn clone(&self) -> Self {

--- a/tests/expectations/tests/underscore.rs
+++ b/tests/expectations/tests/underscore.rs
@@ -13,6 +13,8 @@ pub struct ptr_t {
 }
 #[test]
 fn bindgen_test_layout_ptr_t() {
+    const UNINIT: ::std::mem::MaybeUninit<ptr_t> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<ptr_t>(),
         8usize,
@@ -23,21 +25,12 @@ fn bindgen_test_layout_ptr_t() {
         1usize,
         concat!("Alignment of ", stringify!(ptr_t))
     );
-    fn test_field__() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<ptr_t>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).__) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(ptr_t),
-                "::",
-                stringify!(__)
-            )
-        );
-    }
-    test_field__();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).__) as usize - ptr as usize
+        },
+        0usize,
+        concat!("Offset of field: ", stringify!(ptr_t), "::", stringify!(__))
+    );
 }

--- a/tests/expectations/tests/underscore.rs
+++ b/tests/expectations/tests/underscore.rs
@@ -15,6 +15,7 @@ pub struct ptr_t {
 fn bindgen_test_layout_ptr_t() {
     const UNINIT: ::std::mem::MaybeUninit<ptr_t> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<ptr_t>(),
         8usize,
@@ -26,10 +27,7 @@ fn bindgen_test_layout_ptr_t() {
         concat!("Alignment of ", stringify!(ptr_t))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).__) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).__) as usize - ptr as usize },
         0usize,
         concat!("Offset of field: ", stringify!(ptr_t), "::", stringify!(__))
     );

--- a/tests/expectations/tests/union-align.rs
+++ b/tests/expectations/tests/union-align.rs
@@ -13,6 +13,8 @@ pub union Bar {
 }
 #[test]
 fn bindgen_test_layout_Bar() {
+    const UNINIT: ::std::mem::MaybeUninit<Bar> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<Bar>(),
         16usize,
@@ -23,23 +25,14 @@ fn bindgen_test_layout_Bar() {
         16usize,
         concat!("Alignment of ", stringify!(Bar))
     );
-    fn test_field_foo() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Bar>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(Bar),
-                "::",
-                stringify!(foo)
-            )
-        );
-    }
-    test_field_foo();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize
+        },
+        0usize,
+        concat!("Offset of field: ", stringify!(Bar), "::", stringify!(foo))
+    );
 }
 impl Default for Bar {
     fn default() -> Self {
@@ -58,6 +51,8 @@ pub union Baz {
 }
 #[test]
 fn bindgen_test_layout_Baz() {
+    const UNINIT: ::std::mem::MaybeUninit<Baz> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<Baz>(),
         16usize,
@@ -68,23 +63,14 @@ fn bindgen_test_layout_Baz() {
         16usize,
         concat!("Alignment of ", stringify!(Baz))
     );
-    fn test_field_bar() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Baz>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(Baz),
-                "::",
-                stringify!(bar)
-            )
-        );
-    }
-    test_field_bar();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
+        },
+        0usize,
+        concat!("Offset of field: ", stringify!(Baz), "::", stringify!(bar))
+    );
 }
 impl Default for Baz {
     fn default() -> Self {

--- a/tests/expectations/tests/union-align.rs
+++ b/tests/expectations/tests/union-align.rs
@@ -15,6 +15,7 @@ pub union Bar {
 fn bindgen_test_layout_Bar() {
     const UNINIT: ::std::mem::MaybeUninit<Bar> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<Bar>(),
         16usize,
@@ -26,10 +27,7 @@ fn bindgen_test_layout_Bar() {
         concat!("Alignment of ", stringify!(Bar))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize },
         0usize,
         concat!("Offset of field: ", stringify!(Bar), "::", stringify!(foo))
     );
@@ -53,6 +51,7 @@ pub union Baz {
 fn bindgen_test_layout_Baz() {
     const UNINIT: ::std::mem::MaybeUninit<Baz> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<Baz>(),
         16usize,
@@ -64,10 +63,7 @@ fn bindgen_test_layout_Baz() {
         concat!("Alignment of ", stringify!(Baz))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize },
         0usize,
         concat!("Offset of field: ", stringify!(Baz), "::", stringify!(bar))
     );

--- a/tests/expectations/tests/union-in-ns.rs
+++ b/tests/expectations/tests/union-in-ns.rs
@@ -18,6 +18,7 @@ pub mod root {
     fn bindgen_test_layout_bar() {
         const UNINIT: ::std::mem::MaybeUninit<bar> =
             ::std::mem::MaybeUninit::uninit();
+        let ptr = UNINIT.as_ptr();
         assert_eq!(
             ::std::mem::size_of::<bar>(),
             4usize,
@@ -29,10 +30,7 @@ pub mod root {
             concat!("Alignment of ", stringify!(bar))
         );
         assert_eq!(
-            unsafe {
-                let ptr = UNINIT.as_ptr();
-                ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize
-            },
+            unsafe { ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize },
             0usize,
             concat!(
                 "Offset of field: ",

--- a/tests/expectations/tests/union-in-ns.rs
+++ b/tests/expectations/tests/union-in-ns.rs
@@ -16,6 +16,8 @@ pub mod root {
     }
     #[test]
     fn bindgen_test_layout_bar() {
+        const UNINIT: ::std::mem::MaybeUninit<bar> =
+            ::std::mem::MaybeUninit::uninit();
         assert_eq!(
             ::std::mem::size_of::<bar>(),
             4usize,
@@ -26,23 +28,19 @@ pub mod root {
             4usize,
             concat!("Alignment of ", stringify!(bar))
         );
-        fn test_field_baz() {
-            assert_eq!(
-                unsafe {
-                    let uninit = ::std::mem::MaybeUninit::<bar>::uninit();
-                    let ptr = uninit.as_ptr();
-                    ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize
-                },
-                0usize,
-                concat!(
-                    "Offset of field: ",
-                    stringify!(bar),
-                    "::",
-                    stringify!(baz)
-                )
-            );
-        }
-        test_field_baz();
+        assert_eq!(
+            unsafe {
+                let ptr = UNINIT.as_ptr();
+                ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(bar),
+                "::",
+                stringify!(baz)
+            )
+        );
     }
     impl Default for bar {
         fn default() -> Self {

--- a/tests/expectations/tests/union-in-ns_1_0.rs
+++ b/tests/expectations/tests/union-in-ns_1_0.rs
@@ -63,6 +63,8 @@ pub mod root {
     }
     #[test]
     fn bindgen_test_layout_bar() {
+        const UNINIT: ::std::mem::MaybeUninit<bar> =
+            ::std::mem::MaybeUninit::uninit();
         assert_eq!(
             ::std::mem::size_of::<bar>(),
             4usize,
@@ -73,23 +75,19 @@ pub mod root {
             4usize,
             concat!("Alignment of ", stringify!(bar))
         );
-        fn test_field_baz() {
-            assert_eq!(
-                unsafe {
-                    let uninit = ::std::mem::MaybeUninit::<bar>::uninit();
-                    let ptr = uninit.as_ptr();
-                    ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize
-                },
-                0usize,
-                concat!(
-                    "Offset of field: ",
-                    stringify!(bar),
-                    "::",
-                    stringify!(baz)
-                )
-            );
-        }
-        test_field_baz();
+        assert_eq!(
+            unsafe {
+                let ptr = UNINIT.as_ptr();
+                ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(bar),
+                "::",
+                stringify!(baz)
+            )
+        );
     }
     impl Clone for bar {
         fn clone(&self) -> Self {

--- a/tests/expectations/tests/union-in-ns_1_0.rs
+++ b/tests/expectations/tests/union-in-ns_1_0.rs
@@ -65,6 +65,7 @@ pub mod root {
     fn bindgen_test_layout_bar() {
         const UNINIT: ::std::mem::MaybeUninit<bar> =
             ::std::mem::MaybeUninit::uninit();
+        let ptr = UNINIT.as_ptr();
         assert_eq!(
             ::std::mem::size_of::<bar>(),
             4usize,
@@ -76,10 +77,7 @@ pub mod root {
             concat!("Alignment of ", stringify!(bar))
         );
         assert_eq!(
-            unsafe {
-                let ptr = UNINIT.as_ptr();
-                ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize
-            },
+            unsafe { ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize },
             0usize,
             concat!(
                 "Offset of field: ",

--- a/tests/expectations/tests/union_dtor.rs
+++ b/tests/expectations/tests/union_dtor.rs
@@ -12,6 +12,8 @@ pub union UnionWithDtor {
 }
 #[test]
 fn bindgen_test_layout_UnionWithDtor() {
+    const UNINIT: ::std::mem::MaybeUninit<UnionWithDtor> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<UnionWithDtor>(),
         8usize,
@@ -22,40 +24,32 @@ fn bindgen_test_layout_UnionWithDtor() {
         8usize,
         concat!("Alignment of ", stringify!(UnionWithDtor))
     );
-    fn test_field_mFoo() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<UnionWithDtor>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).mFoo) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(UnionWithDtor),
-                "::",
-                stringify!(mFoo)
-            )
-        );
-    }
-    test_field_mFoo();
-    fn test_field_mBar() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<UnionWithDtor>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).mBar) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(UnionWithDtor),
-                "::",
-                stringify!(mBar)
-            )
-        );
-    }
-    test_field_mBar();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).mFoo) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(UnionWithDtor),
+            "::",
+            stringify!(mFoo)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).mBar) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(UnionWithDtor),
+            "::",
+            stringify!(mBar)
+        )
+    );
 }
 extern "C" {
     #[link_name = "\u{1}_ZN13UnionWithDtorD1Ev"]

--- a/tests/expectations/tests/union_dtor.rs
+++ b/tests/expectations/tests/union_dtor.rs
@@ -14,6 +14,7 @@ pub union UnionWithDtor {
 fn bindgen_test_layout_UnionWithDtor() {
     const UNINIT: ::std::mem::MaybeUninit<UnionWithDtor> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<UnionWithDtor>(),
         8usize,
@@ -25,10 +26,7 @@ fn bindgen_test_layout_UnionWithDtor() {
         concat!("Alignment of ", stringify!(UnionWithDtor))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mFoo) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).mFoo) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -38,10 +36,7 @@ fn bindgen_test_layout_UnionWithDtor() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mBar) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).mBar) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/union_dtor_1_0.rs
+++ b/tests/expectations/tests/union_dtor_1_0.rs
@@ -57,6 +57,8 @@ pub struct UnionWithDtor {
 }
 #[test]
 fn bindgen_test_layout_UnionWithDtor() {
+    const UNINIT: ::std::mem::MaybeUninit<UnionWithDtor> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<UnionWithDtor>(),
         8usize,
@@ -67,40 +69,32 @@ fn bindgen_test_layout_UnionWithDtor() {
         8usize,
         concat!("Alignment of ", stringify!(UnionWithDtor))
     );
-    fn test_field_mFoo() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<UnionWithDtor>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).mFoo) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(UnionWithDtor),
-                "::",
-                stringify!(mFoo)
-            )
-        );
-    }
-    test_field_mFoo();
-    fn test_field_mBar() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<UnionWithDtor>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).mBar) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(UnionWithDtor),
-                "::",
-                stringify!(mBar)
-            )
-        );
-    }
-    test_field_mBar();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).mFoo) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(UnionWithDtor),
+            "::",
+            stringify!(mFoo)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).mBar) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(UnionWithDtor),
+            "::",
+            stringify!(mBar)
+        )
+    );
 }
 extern "C" {
     #[link_name = "\u{1}_ZN13UnionWithDtorD1Ev"]

--- a/tests/expectations/tests/union_dtor_1_0.rs
+++ b/tests/expectations/tests/union_dtor_1_0.rs
@@ -59,6 +59,7 @@ pub struct UnionWithDtor {
 fn bindgen_test_layout_UnionWithDtor() {
     const UNINIT: ::std::mem::MaybeUninit<UnionWithDtor> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<UnionWithDtor>(),
         8usize,
@@ -70,10 +71,7 @@ fn bindgen_test_layout_UnionWithDtor() {
         concat!("Alignment of ", stringify!(UnionWithDtor))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mFoo) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).mFoo) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -83,10 +81,7 @@ fn bindgen_test_layout_UnionWithDtor() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mBar) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).mBar) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/union_fields.rs
+++ b/tests/expectations/tests/union_fields.rs
@@ -16,6 +16,7 @@ pub union nsStyleUnion {
 fn bindgen_test_layout_nsStyleUnion() {
     const UNINIT: ::std::mem::MaybeUninit<nsStyleUnion> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<nsStyleUnion>(),
         8usize,
@@ -27,10 +28,7 @@ fn bindgen_test_layout_nsStyleUnion() {
         concat!("Alignment of ", stringify!(nsStyleUnion))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mInt) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).mInt) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -40,10 +38,7 @@ fn bindgen_test_layout_nsStyleUnion() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mFloat) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).mFloat) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -54,7 +49,6 @@ fn bindgen_test_layout_nsStyleUnion() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).mPointer) as usize - ptr as usize
         },
         0usize,

--- a/tests/expectations/tests/union_fields.rs
+++ b/tests/expectations/tests/union_fields.rs
@@ -14,6 +14,8 @@ pub union nsStyleUnion {
 }
 #[test]
 fn bindgen_test_layout_nsStyleUnion() {
+    const UNINIT: ::std::mem::MaybeUninit<nsStyleUnion> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<nsStyleUnion>(),
         8usize,
@@ -24,57 +26,45 @@ fn bindgen_test_layout_nsStyleUnion() {
         8usize,
         concat!("Alignment of ", stringify!(nsStyleUnion))
     );
-    fn test_field_mInt() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<nsStyleUnion>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).mInt) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(nsStyleUnion),
-                "::",
-                stringify!(mInt)
-            )
-        );
-    }
-    test_field_mInt();
-    fn test_field_mFloat() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<nsStyleUnion>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).mFloat) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(nsStyleUnion),
-                "::",
-                stringify!(mFloat)
-            )
-        );
-    }
-    test_field_mFloat();
-    fn test_field_mPointer() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<nsStyleUnion>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).mPointer) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(nsStyleUnion),
-                "::",
-                stringify!(mPointer)
-            )
-        );
-    }
-    test_field_mPointer();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).mInt) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(nsStyleUnion),
+            "::",
+            stringify!(mInt)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).mFloat) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(nsStyleUnion),
+            "::",
+            stringify!(mFloat)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).mPointer) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(nsStyleUnion),
+            "::",
+            stringify!(mPointer)
+        )
+    );
 }
 impl Default for nsStyleUnion {
     fn default() -> Self {

--- a/tests/expectations/tests/union_fields_1_0.rs
+++ b/tests/expectations/tests/union_fields_1_0.rs
@@ -58,6 +58,8 @@ pub struct nsStyleUnion {
 }
 #[test]
 fn bindgen_test_layout_nsStyleUnion() {
+    const UNINIT: ::std::mem::MaybeUninit<nsStyleUnion> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<nsStyleUnion>(),
         8usize,
@@ -68,57 +70,45 @@ fn bindgen_test_layout_nsStyleUnion() {
         8usize,
         concat!("Alignment of ", stringify!(nsStyleUnion))
     );
-    fn test_field_mInt() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<nsStyleUnion>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).mInt) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(nsStyleUnion),
-                "::",
-                stringify!(mInt)
-            )
-        );
-    }
-    test_field_mInt();
-    fn test_field_mFloat() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<nsStyleUnion>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).mFloat) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(nsStyleUnion),
-                "::",
-                stringify!(mFloat)
-            )
-        );
-    }
-    test_field_mFloat();
-    fn test_field_mPointer() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<nsStyleUnion>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).mPointer) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(nsStyleUnion),
-                "::",
-                stringify!(mPointer)
-            )
-        );
-    }
-    test_field_mPointer();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).mInt) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(nsStyleUnion),
+            "::",
+            stringify!(mInt)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).mFloat) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(nsStyleUnion),
+            "::",
+            stringify!(mFloat)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).mPointer) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(nsStyleUnion),
+            "::",
+            stringify!(mPointer)
+        )
+    );
 }
 impl Clone for nsStyleUnion {
     fn clone(&self) -> Self {

--- a/tests/expectations/tests/union_fields_1_0.rs
+++ b/tests/expectations/tests/union_fields_1_0.rs
@@ -60,6 +60,7 @@ pub struct nsStyleUnion {
 fn bindgen_test_layout_nsStyleUnion() {
     const UNINIT: ::std::mem::MaybeUninit<nsStyleUnion> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<nsStyleUnion>(),
         8usize,
@@ -71,10 +72,7 @@ fn bindgen_test_layout_nsStyleUnion() {
         concat!("Alignment of ", stringify!(nsStyleUnion))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mInt) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).mInt) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -84,10 +82,7 @@ fn bindgen_test_layout_nsStyleUnion() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mFloat) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).mFloat) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -98,7 +93,6 @@ fn bindgen_test_layout_nsStyleUnion() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).mPointer) as usize - ptr as usize
         },
         0usize,

--- a/tests/expectations/tests/union_with_anon_struct.rs
+++ b/tests/expectations/tests/union_with_anon_struct.rs
@@ -18,6 +18,8 @@ pub struct foo__bindgen_ty_1 {
 }
 #[test]
 fn bindgen_test_layout_foo__bindgen_ty_1() {
+    const UNINIT: ::std::mem::MaybeUninit<foo__bindgen_ty_1> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<foo__bindgen_ty_1>(),
         8usize,
@@ -28,45 +30,37 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
         4usize,
         concat!("Alignment of ", stringify!(foo__bindgen_ty_1))
     );
-    fn test_field_a() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<foo__bindgen_ty_1>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(foo__bindgen_ty_1),
-                "::",
-                stringify!(a)
-            )
-        );
-    }
-    test_field_a();
-    fn test_field_b() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<foo__bindgen_ty_1>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-            },
-            4usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(foo__bindgen_ty_1),
-                "::",
-                stringify!(b)
-            )
-        );
-    }
-    test_field_b();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(foo__bindgen_ty_1),
+            "::",
+            stringify!(a)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(foo__bindgen_ty_1),
+            "::",
+            stringify!(b)
+        )
+    );
 }
 #[test]
 fn bindgen_test_layout_foo() {
+    const UNINIT: ::std::mem::MaybeUninit<foo> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<foo>(),
         8usize,
@@ -77,23 +71,14 @@ fn bindgen_test_layout_foo() {
         4usize,
         concat!("Alignment of ", stringify!(foo))
     );
-    fn test_field_bar() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<foo>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(foo),
-                "::",
-                stringify!(bar)
-            )
-        );
-    }
-    test_field_bar();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
+        },
+        0usize,
+        concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar))
+    );
 }
 impl Default for foo {
     fn default() -> Self {

--- a/tests/expectations/tests/union_with_anon_struct.rs
+++ b/tests/expectations/tests/union_with_anon_struct.rs
@@ -20,6 +20,7 @@ pub struct foo__bindgen_ty_1 {
 fn bindgen_test_layout_foo__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<foo__bindgen_ty_1> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<foo__bindgen_ty_1>(),
         8usize,
@@ -31,10 +32,7 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
         concat!("Alignment of ", stringify!(foo__bindgen_ty_1))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -44,10 +42,7 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
         4usize,
         concat!(
             "Offset of field: ",
@@ -61,6 +56,7 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
 fn bindgen_test_layout_foo() {
     const UNINIT: ::std::mem::MaybeUninit<foo> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<foo>(),
         8usize,
@@ -72,10 +68,7 @@ fn bindgen_test_layout_foo() {
         concat!("Alignment of ", stringify!(foo))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize },
         0usize,
         concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar))
     );

--- a/tests/expectations/tests/union_with_anon_struct_1_0.rs
+++ b/tests/expectations/tests/union_with_anon_struct_1_0.rs
@@ -62,6 +62,8 @@ pub struct foo__bindgen_ty_1 {
 }
 #[test]
 fn bindgen_test_layout_foo__bindgen_ty_1() {
+    const UNINIT: ::std::mem::MaybeUninit<foo__bindgen_ty_1> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<foo__bindgen_ty_1>(),
         8usize,
@@ -72,42 +74,32 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
         4usize,
         concat!("Alignment of ", stringify!(foo__bindgen_ty_1))
     );
-    fn test_field_a() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<foo__bindgen_ty_1>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(foo__bindgen_ty_1),
-                "::",
-                stringify!(a)
-            )
-        );
-    }
-    test_field_a();
-    fn test_field_b() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<foo__bindgen_ty_1>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-            },
-            4usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(foo__bindgen_ty_1),
-                "::",
-                stringify!(b)
-            )
-        );
-    }
-    test_field_b();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(foo__bindgen_ty_1),
+            "::",
+            stringify!(a)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(foo__bindgen_ty_1),
+            "::",
+            stringify!(b)
+        )
+    );
 }
 impl Clone for foo__bindgen_ty_1 {
     fn clone(&self) -> Self {
@@ -116,6 +108,8 @@ impl Clone for foo__bindgen_ty_1 {
 }
 #[test]
 fn bindgen_test_layout_foo() {
+    const UNINIT: ::std::mem::MaybeUninit<foo> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<foo>(),
         8usize,
@@ -126,23 +120,14 @@ fn bindgen_test_layout_foo() {
         4usize,
         concat!("Alignment of ", stringify!(foo))
     );
-    fn test_field_bar() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<foo>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(foo),
-                "::",
-                stringify!(bar)
-            )
-        );
-    }
-    test_field_bar();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
+        },
+        0usize,
+        concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar))
+    );
 }
 impl Clone for foo {
     fn clone(&self) -> Self {

--- a/tests/expectations/tests/union_with_anon_struct_1_0.rs
+++ b/tests/expectations/tests/union_with_anon_struct_1_0.rs
@@ -64,6 +64,7 @@ pub struct foo__bindgen_ty_1 {
 fn bindgen_test_layout_foo__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<foo__bindgen_ty_1> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<foo__bindgen_ty_1>(),
         8usize,
@@ -75,10 +76,7 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
         concat!("Alignment of ", stringify!(foo__bindgen_ty_1))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -88,10 +86,7 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
         4usize,
         concat!(
             "Offset of field: ",
@@ -110,6 +105,7 @@ impl Clone for foo__bindgen_ty_1 {
 fn bindgen_test_layout_foo() {
     const UNINIT: ::std::mem::MaybeUninit<foo> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<foo>(),
         8usize,
@@ -121,10 +117,7 @@ fn bindgen_test_layout_foo() {
         concat!("Alignment of ", stringify!(foo))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize },
         0usize,
         concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar))
     );

--- a/tests/expectations/tests/union_with_anon_struct_bitfield.rs
+++ b/tests/expectations/tests/union_with_anon_struct_bitfield.rs
@@ -164,6 +164,8 @@ impl foo__bindgen_ty_1 {
 }
 #[test]
 fn bindgen_test_layout_foo() {
+    const UNINIT: ::std::mem::MaybeUninit<foo> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<foo>(),
         4usize,
@@ -174,18 +176,14 @@ fn bindgen_test_layout_foo() {
         4usize,
         concat!("Alignment of ", stringify!(foo))
     );
-    fn test_field_a() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<foo>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-            },
-            0usize,
-            concat!("Offset of field: ", stringify!(foo), "::", stringify!(a))
-        );
-    }
-    test_field_a();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+        },
+        0usize,
+        concat!("Offset of field: ", stringify!(foo), "::", stringify!(a))
+    );
 }
 impl Default for foo {
     fn default() -> Self {

--- a/tests/expectations/tests/union_with_anon_struct_bitfield.rs
+++ b/tests/expectations/tests/union_with_anon_struct_bitfield.rs
@@ -166,6 +166,7 @@ impl foo__bindgen_ty_1 {
 fn bindgen_test_layout_foo() {
     const UNINIT: ::std::mem::MaybeUninit<foo> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<foo>(),
         4usize,
@@ -177,10 +178,7 @@ fn bindgen_test_layout_foo() {
         concat!("Alignment of ", stringify!(foo))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
         0usize,
         concat!("Offset of field: ", stringify!(foo), "::", stringify!(a))
     );

--- a/tests/expectations/tests/union_with_anon_struct_bitfield_1_0.rs
+++ b/tests/expectations/tests/union_with_anon_struct_bitfield_1_0.rs
@@ -213,6 +213,8 @@ impl foo__bindgen_ty_1 {
 }
 #[test]
 fn bindgen_test_layout_foo() {
+    const UNINIT: ::std::mem::MaybeUninit<foo> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<foo>(),
         4usize,
@@ -223,18 +225,14 @@ fn bindgen_test_layout_foo() {
         4usize,
         concat!("Alignment of ", stringify!(foo))
     );
-    fn test_field_a() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<foo>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-            },
-            0usize,
-            concat!("Offset of field: ", stringify!(foo), "::", stringify!(a))
-        );
-    }
-    test_field_a();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+        },
+        0usize,
+        concat!("Offset of field: ", stringify!(foo), "::", stringify!(a))
+    );
 }
 impl Clone for foo {
     fn clone(&self) -> Self {

--- a/tests/expectations/tests/union_with_anon_struct_bitfield_1_0.rs
+++ b/tests/expectations/tests/union_with_anon_struct_bitfield_1_0.rs
@@ -215,6 +215,7 @@ impl foo__bindgen_ty_1 {
 fn bindgen_test_layout_foo() {
     const UNINIT: ::std::mem::MaybeUninit<foo> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<foo>(),
         4usize,
@@ -226,10 +227,7 @@ fn bindgen_test_layout_foo() {
         concat!("Alignment of ", stringify!(foo))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
         0usize,
         concat!("Offset of field: ", stringify!(foo), "::", stringify!(a))
     );

--- a/tests/expectations/tests/union_with_anon_union.rs
+++ b/tests/expectations/tests/union_with_anon_union.rs
@@ -20,6 +20,7 @@ pub union foo__bindgen_ty_1 {
 fn bindgen_test_layout_foo__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<foo__bindgen_ty_1> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<foo__bindgen_ty_1>(),
         4usize,
@@ -31,10 +32,7 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
         concat!("Alignment of ", stringify!(foo__bindgen_ty_1))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -44,10 +42,7 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -70,6 +65,7 @@ impl Default for foo__bindgen_ty_1 {
 fn bindgen_test_layout_foo() {
     const UNINIT: ::std::mem::MaybeUninit<foo> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<foo>(),
         4usize,
@@ -81,10 +77,7 @@ fn bindgen_test_layout_foo() {
         concat!("Alignment of ", stringify!(foo))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize },
         0usize,
         concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar))
     );

--- a/tests/expectations/tests/union_with_anon_union.rs
+++ b/tests/expectations/tests/union_with_anon_union.rs
@@ -18,6 +18,8 @@ pub union foo__bindgen_ty_1 {
 }
 #[test]
 fn bindgen_test_layout_foo__bindgen_ty_1() {
+    const UNINIT: ::std::mem::MaybeUninit<foo__bindgen_ty_1> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<foo__bindgen_ty_1>(),
         4usize,
@@ -28,42 +30,32 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
         4usize,
         concat!("Alignment of ", stringify!(foo__bindgen_ty_1))
     );
-    fn test_field_a() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<foo__bindgen_ty_1>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(foo__bindgen_ty_1),
-                "::",
-                stringify!(a)
-            )
-        );
-    }
-    test_field_a();
-    fn test_field_b() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<foo__bindgen_ty_1>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(foo__bindgen_ty_1),
-                "::",
-                stringify!(b)
-            )
-        );
-    }
-    test_field_b();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(foo__bindgen_ty_1),
+            "::",
+            stringify!(a)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(foo__bindgen_ty_1),
+            "::",
+            stringify!(b)
+        )
+    );
 }
 impl Default for foo__bindgen_ty_1 {
     fn default() -> Self {
@@ -76,6 +68,8 @@ impl Default for foo__bindgen_ty_1 {
 }
 #[test]
 fn bindgen_test_layout_foo() {
+    const UNINIT: ::std::mem::MaybeUninit<foo> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<foo>(),
         4usize,
@@ -86,23 +80,14 @@ fn bindgen_test_layout_foo() {
         4usize,
         concat!("Alignment of ", stringify!(foo))
     );
-    fn test_field_bar() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<foo>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(foo),
-                "::",
-                stringify!(bar)
-            )
-        );
-    }
-    test_field_bar();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
+        },
+        0usize,
+        concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar))
+    );
 }
 impl Default for foo {
     fn default() -> Self {

--- a/tests/expectations/tests/union_with_anon_union_1_0.rs
+++ b/tests/expectations/tests/union_with_anon_union_1_0.rs
@@ -65,6 +65,7 @@ pub struct foo__bindgen_ty_1 {
 fn bindgen_test_layout_foo__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<foo__bindgen_ty_1> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<foo__bindgen_ty_1>(),
         4usize,
@@ -76,10 +77,7 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
         concat!("Alignment of ", stringify!(foo__bindgen_ty_1))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -89,10 +87,7 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -111,6 +106,7 @@ impl Clone for foo__bindgen_ty_1 {
 fn bindgen_test_layout_foo() {
     const UNINIT: ::std::mem::MaybeUninit<foo> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<foo>(),
         4usize,
@@ -122,10 +118,7 @@ fn bindgen_test_layout_foo() {
         concat!("Alignment of ", stringify!(foo))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize },
         0usize,
         concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar))
     );

--- a/tests/expectations/tests/union_with_anon_union_1_0.rs
+++ b/tests/expectations/tests/union_with_anon_union_1_0.rs
@@ -63,6 +63,8 @@ pub struct foo__bindgen_ty_1 {
 }
 #[test]
 fn bindgen_test_layout_foo__bindgen_ty_1() {
+    const UNINIT: ::std::mem::MaybeUninit<foo__bindgen_ty_1> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<foo__bindgen_ty_1>(),
         4usize,
@@ -73,42 +75,32 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
         4usize,
         concat!("Alignment of ", stringify!(foo__bindgen_ty_1))
     );
-    fn test_field_a() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<foo__bindgen_ty_1>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(foo__bindgen_ty_1),
-                "::",
-                stringify!(a)
-            )
-        );
-    }
-    test_field_a();
-    fn test_field_b() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<foo__bindgen_ty_1>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(foo__bindgen_ty_1),
-                "::",
-                stringify!(b)
-            )
-        );
-    }
-    test_field_b();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(foo__bindgen_ty_1),
+            "::",
+            stringify!(a)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(foo__bindgen_ty_1),
+            "::",
+            stringify!(b)
+        )
+    );
 }
 impl Clone for foo__bindgen_ty_1 {
     fn clone(&self) -> Self {
@@ -117,6 +109,8 @@ impl Clone for foo__bindgen_ty_1 {
 }
 #[test]
 fn bindgen_test_layout_foo() {
+    const UNINIT: ::std::mem::MaybeUninit<foo> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<foo>(),
         4usize,
@@ -127,23 +121,14 @@ fn bindgen_test_layout_foo() {
         4usize,
         concat!("Alignment of ", stringify!(foo))
     );
-    fn test_field_bar() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<foo>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(foo),
-                "::",
-                stringify!(bar)
-            )
-        );
-    }
-    test_field_bar();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
+        },
+        0usize,
+        concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar))
+    );
 }
 impl Clone for foo {
     fn clone(&self) -> Self {

--- a/tests/expectations/tests/union_with_anon_unnamed_struct.rs
+++ b/tests/expectations/tests/union_with_anon_unnamed_struct.rs
@@ -23,6 +23,7 @@ pub struct pixel__bindgen_ty_1 {
 fn bindgen_test_layout_pixel__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<pixel__bindgen_ty_1> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<pixel__bindgen_ty_1>(),
         4usize,
@@ -34,10 +35,7 @@ fn bindgen_test_layout_pixel__bindgen_ty_1() {
         concat!("Alignment of ", stringify!(pixel__bindgen_ty_1))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).r) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).r) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -47,10 +45,7 @@ fn bindgen_test_layout_pixel__bindgen_ty_1() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).g) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).g) as usize - ptr as usize },
         1usize,
         concat!(
             "Offset of field: ",
@@ -60,10 +55,7 @@ fn bindgen_test_layout_pixel__bindgen_ty_1() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
         2usize,
         concat!(
             "Offset of field: ",
@@ -73,10 +65,7 @@ fn bindgen_test_layout_pixel__bindgen_ty_1() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
         3usize,
         concat!(
             "Offset of field: ",
@@ -90,6 +79,7 @@ fn bindgen_test_layout_pixel__bindgen_ty_1() {
 fn bindgen_test_layout_pixel() {
     const UNINIT: ::std::mem::MaybeUninit<pixel> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<pixel>(),
         4usize,
@@ -101,10 +91,7 @@ fn bindgen_test_layout_pixel() {
         concat!("Alignment of ", stringify!(pixel))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).rgba) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).rgba) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/union_with_anon_unnamed_struct.rs
+++ b/tests/expectations/tests/union_with_anon_unnamed_struct.rs
@@ -21,6 +21,8 @@ pub struct pixel__bindgen_ty_1 {
 }
 #[test]
 fn bindgen_test_layout_pixel__bindgen_ty_1() {
+    const UNINIT: ::std::mem::MaybeUninit<pixel__bindgen_ty_1> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<pixel__bindgen_ty_1>(),
         4usize,
@@ -31,81 +33,63 @@ fn bindgen_test_layout_pixel__bindgen_ty_1() {
         1usize,
         concat!("Alignment of ", stringify!(pixel__bindgen_ty_1))
     );
-    fn test_field_r() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<pixel__bindgen_ty_1>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).r) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(pixel__bindgen_ty_1),
-                "::",
-                stringify!(r)
-            )
-        );
-    }
-    test_field_r();
-    fn test_field_g() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<pixel__bindgen_ty_1>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).g) as usize - ptr as usize
-            },
-            1usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(pixel__bindgen_ty_1),
-                "::",
-                stringify!(g)
-            )
-        );
-    }
-    test_field_g();
-    fn test_field_b() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<pixel__bindgen_ty_1>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-            },
-            2usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(pixel__bindgen_ty_1),
-                "::",
-                stringify!(b)
-            )
-        );
-    }
-    test_field_b();
-    fn test_field_a() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<pixel__bindgen_ty_1>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-            },
-            3usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(pixel__bindgen_ty_1),
-                "::",
-                stringify!(a)
-            )
-        );
-    }
-    test_field_a();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).r) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(pixel__bindgen_ty_1),
+            "::",
+            stringify!(r)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).g) as usize - ptr as usize
+        },
+        1usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(pixel__bindgen_ty_1),
+            "::",
+            stringify!(g)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
+        },
+        2usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(pixel__bindgen_ty_1),
+            "::",
+            stringify!(b)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+        },
+        3usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(pixel__bindgen_ty_1),
+            "::",
+            stringify!(a)
+        )
+    );
 }
 #[test]
 fn bindgen_test_layout_pixel() {
+    const UNINIT: ::std::mem::MaybeUninit<pixel> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<pixel>(),
         4usize,
@@ -116,23 +100,19 @@ fn bindgen_test_layout_pixel() {
         4usize,
         concat!("Alignment of ", stringify!(pixel))
     );
-    fn test_field_rgba() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<pixel>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).rgba) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(pixel),
-                "::",
-                stringify!(rgba)
-            )
-        );
-    }
-    test_field_rgba();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).rgba) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(pixel),
+            "::",
+            stringify!(rgba)
+        )
+    );
 }
 impl Default for pixel {
     fn default() -> Self {

--- a/tests/expectations/tests/union_with_anon_unnamed_struct_1_0.rs
+++ b/tests/expectations/tests/union_with_anon_unnamed_struct_1_0.rs
@@ -65,6 +65,8 @@ pub struct pixel__bindgen_ty_1 {
 }
 #[test]
 fn bindgen_test_layout_pixel__bindgen_ty_1() {
+    const UNINIT: ::std::mem::MaybeUninit<pixel__bindgen_ty_1> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<pixel__bindgen_ty_1>(),
         4usize,
@@ -75,78 +77,58 @@ fn bindgen_test_layout_pixel__bindgen_ty_1() {
         1usize,
         concat!("Alignment of ", stringify!(pixel__bindgen_ty_1))
     );
-    fn test_field_r() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<pixel__bindgen_ty_1>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).r) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(pixel__bindgen_ty_1),
-                "::",
-                stringify!(r)
-            )
-        );
-    }
-    test_field_r();
-    fn test_field_g() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<pixel__bindgen_ty_1>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).g) as usize - ptr as usize
-            },
-            1usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(pixel__bindgen_ty_1),
-                "::",
-                stringify!(g)
-            )
-        );
-    }
-    test_field_g();
-    fn test_field_b() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<pixel__bindgen_ty_1>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-            },
-            2usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(pixel__bindgen_ty_1),
-                "::",
-                stringify!(b)
-            )
-        );
-    }
-    test_field_b();
-    fn test_field_a() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<pixel__bindgen_ty_1>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-            },
-            3usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(pixel__bindgen_ty_1),
-                "::",
-                stringify!(a)
-            )
-        );
-    }
-    test_field_a();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).r) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(pixel__bindgen_ty_1),
+            "::",
+            stringify!(r)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).g) as usize - ptr as usize
+        },
+        1usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(pixel__bindgen_ty_1),
+            "::",
+            stringify!(g)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
+        },
+        2usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(pixel__bindgen_ty_1),
+            "::",
+            stringify!(b)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+        },
+        3usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(pixel__bindgen_ty_1),
+            "::",
+            stringify!(a)
+        )
+    );
 }
 impl Clone for pixel__bindgen_ty_1 {
     fn clone(&self) -> Self {
@@ -155,6 +137,8 @@ impl Clone for pixel__bindgen_ty_1 {
 }
 #[test]
 fn bindgen_test_layout_pixel() {
+    const UNINIT: ::std::mem::MaybeUninit<pixel> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<pixel>(),
         4usize,
@@ -165,23 +149,19 @@ fn bindgen_test_layout_pixel() {
         4usize,
         concat!("Alignment of ", stringify!(pixel))
     );
-    fn test_field_rgba() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<pixel>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).rgba) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(pixel),
-                "::",
-                stringify!(rgba)
-            )
-        );
-    }
-    test_field_rgba();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).rgba) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(pixel),
+            "::",
+            stringify!(rgba)
+        )
+    );
 }
 impl Clone for pixel {
     fn clone(&self) -> Self {

--- a/tests/expectations/tests/union_with_anon_unnamed_struct_1_0.rs
+++ b/tests/expectations/tests/union_with_anon_unnamed_struct_1_0.rs
@@ -67,6 +67,7 @@ pub struct pixel__bindgen_ty_1 {
 fn bindgen_test_layout_pixel__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<pixel__bindgen_ty_1> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<pixel__bindgen_ty_1>(),
         4usize,
@@ -78,10 +79,7 @@ fn bindgen_test_layout_pixel__bindgen_ty_1() {
         concat!("Alignment of ", stringify!(pixel__bindgen_ty_1))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).r) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).r) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -91,10 +89,7 @@ fn bindgen_test_layout_pixel__bindgen_ty_1() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).g) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).g) as usize - ptr as usize },
         1usize,
         concat!(
             "Offset of field: ",
@@ -104,10 +99,7 @@ fn bindgen_test_layout_pixel__bindgen_ty_1() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
         2usize,
         concat!(
             "Offset of field: ",
@@ -117,10 +109,7 @@ fn bindgen_test_layout_pixel__bindgen_ty_1() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
         3usize,
         concat!(
             "Offset of field: ",
@@ -139,6 +128,7 @@ impl Clone for pixel__bindgen_ty_1 {
 fn bindgen_test_layout_pixel() {
     const UNINIT: ::std::mem::MaybeUninit<pixel> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<pixel>(),
         4usize,
@@ -150,10 +140,7 @@ fn bindgen_test_layout_pixel() {
         concat!("Alignment of ", stringify!(pixel))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).rgba) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).rgba) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/union_with_anon_unnamed_union.rs
+++ b/tests/expectations/tests/union_with_anon_unnamed_union.rs
@@ -21,6 +21,7 @@ pub union foo__bindgen_ty_1 {
 fn bindgen_test_layout_foo__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<foo__bindgen_ty_1> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<foo__bindgen_ty_1>(),
         2usize,
@@ -32,10 +33,7 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
         concat!("Alignment of ", stringify!(foo__bindgen_ty_1))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -45,10 +43,7 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).c) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).c) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -71,6 +66,7 @@ impl Default for foo__bindgen_ty_1 {
 fn bindgen_test_layout_foo() {
     const UNINIT: ::std::mem::MaybeUninit<foo> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<foo>(),
         4usize,
@@ -82,10 +78,7 @@ fn bindgen_test_layout_foo() {
         concat!("Alignment of ", stringify!(foo))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
         0usize,
         concat!("Offset of field: ", stringify!(foo), "::", stringify!(a))
     );

--- a/tests/expectations/tests/union_with_anon_unnamed_union.rs
+++ b/tests/expectations/tests/union_with_anon_unnamed_union.rs
@@ -19,6 +19,8 @@ pub union foo__bindgen_ty_1 {
 }
 #[test]
 fn bindgen_test_layout_foo__bindgen_ty_1() {
+    const UNINIT: ::std::mem::MaybeUninit<foo__bindgen_ty_1> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<foo__bindgen_ty_1>(),
         2usize,
@@ -29,42 +31,32 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
         2usize,
         concat!("Alignment of ", stringify!(foo__bindgen_ty_1))
     );
-    fn test_field_b() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<foo__bindgen_ty_1>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(foo__bindgen_ty_1),
-                "::",
-                stringify!(b)
-            )
-        );
-    }
-    test_field_b();
-    fn test_field_c() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<foo__bindgen_ty_1>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).c) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(foo__bindgen_ty_1),
-                "::",
-                stringify!(c)
-            )
-        );
-    }
-    test_field_c();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(foo__bindgen_ty_1),
+            "::",
+            stringify!(b)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).c) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(foo__bindgen_ty_1),
+            "::",
+            stringify!(c)
+        )
+    );
 }
 impl Default for foo__bindgen_ty_1 {
     fn default() -> Self {
@@ -77,6 +69,8 @@ impl Default for foo__bindgen_ty_1 {
 }
 #[test]
 fn bindgen_test_layout_foo() {
+    const UNINIT: ::std::mem::MaybeUninit<foo> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<foo>(),
         4usize,
@@ -87,18 +81,14 @@ fn bindgen_test_layout_foo() {
         4usize,
         concat!("Alignment of ", stringify!(foo))
     );
-    fn test_field_a() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<foo>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-            },
-            0usize,
-            concat!("Offset of field: ", stringify!(foo), "::", stringify!(a))
-        );
-    }
-    test_field_a();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+        },
+        0usize,
+        concat!("Offset of field: ", stringify!(foo), "::", stringify!(a))
+    );
 }
 impl Default for foo {
     fn default() -> Self {

--- a/tests/expectations/tests/union_with_anon_unnamed_union_1_0.rs
+++ b/tests/expectations/tests/union_with_anon_unnamed_union_1_0.rs
@@ -66,6 +66,7 @@ pub struct foo__bindgen_ty_1 {
 fn bindgen_test_layout_foo__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<foo__bindgen_ty_1> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<foo__bindgen_ty_1>(),
         2usize,
@@ -77,10 +78,7 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
         concat!("Alignment of ", stringify!(foo__bindgen_ty_1))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -90,10 +88,7 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).c) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).c) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -112,6 +107,7 @@ impl Clone for foo__bindgen_ty_1 {
 fn bindgen_test_layout_foo() {
     const UNINIT: ::std::mem::MaybeUninit<foo> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<foo>(),
         4usize,
@@ -123,10 +119,7 @@ fn bindgen_test_layout_foo() {
         concat!("Alignment of ", stringify!(foo))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
         0usize,
         concat!("Offset of field: ", stringify!(foo), "::", stringify!(a))
     );

--- a/tests/expectations/tests/union_with_anon_unnamed_union_1_0.rs
+++ b/tests/expectations/tests/union_with_anon_unnamed_union_1_0.rs
@@ -64,6 +64,8 @@ pub struct foo__bindgen_ty_1 {
 }
 #[test]
 fn bindgen_test_layout_foo__bindgen_ty_1() {
+    const UNINIT: ::std::mem::MaybeUninit<foo__bindgen_ty_1> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<foo__bindgen_ty_1>(),
         2usize,
@@ -74,42 +76,32 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
         2usize,
         concat!("Alignment of ", stringify!(foo__bindgen_ty_1))
     );
-    fn test_field_b() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<foo__bindgen_ty_1>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(foo__bindgen_ty_1),
-                "::",
-                stringify!(b)
-            )
-        );
-    }
-    test_field_b();
-    fn test_field_c() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<foo__bindgen_ty_1>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).c) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(foo__bindgen_ty_1),
-                "::",
-                stringify!(c)
-            )
-        );
-    }
-    test_field_c();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(foo__bindgen_ty_1),
+            "::",
+            stringify!(b)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).c) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(foo__bindgen_ty_1),
+            "::",
+            stringify!(c)
+        )
+    );
 }
 impl Clone for foo__bindgen_ty_1 {
     fn clone(&self) -> Self {
@@ -118,6 +110,8 @@ impl Clone for foo__bindgen_ty_1 {
 }
 #[test]
 fn bindgen_test_layout_foo() {
+    const UNINIT: ::std::mem::MaybeUninit<foo> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<foo>(),
         4usize,
@@ -128,18 +122,14 @@ fn bindgen_test_layout_foo() {
         4usize,
         concat!("Alignment of ", stringify!(foo))
     );
-    fn test_field_a() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<foo>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-            },
-            0usize,
-            concat!("Offset of field: ", stringify!(foo), "::", stringify!(a))
-        );
-    }
-    test_field_a();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+        },
+        0usize,
+        concat!("Offset of field: ", stringify!(foo), "::", stringify!(a))
+    );
 }
 impl Clone for foo {
     fn clone(&self) -> Self {

--- a/tests/expectations/tests/union_with_big_member.rs
+++ b/tests/expectations/tests/union_with_big_member.rs
@@ -15,6 +15,7 @@ pub union WithBigArray {
 fn bindgen_test_layout_WithBigArray() {
     const UNINIT: ::std::mem::MaybeUninit<WithBigArray> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<WithBigArray>(),
         132usize,
@@ -26,10 +27,7 @@ fn bindgen_test_layout_WithBigArray() {
         concat!("Alignment of ", stringify!(WithBigArray))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -39,10 +37,7 @@ fn bindgen_test_layout_WithBigArray() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -71,6 +66,7 @@ pub union WithBigArray2 {
 fn bindgen_test_layout_WithBigArray2() {
     const UNINIT: ::std::mem::MaybeUninit<WithBigArray2> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<WithBigArray2>(),
         36usize,
@@ -82,10 +78,7 @@ fn bindgen_test_layout_WithBigArray2() {
         concat!("Alignment of ", stringify!(WithBigArray2))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -95,10 +88,7 @@ fn bindgen_test_layout_WithBigArray2() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -127,6 +117,7 @@ pub union WithBigMember {
 fn bindgen_test_layout_WithBigMember() {
     const UNINIT: ::std::mem::MaybeUninit<WithBigMember> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<WithBigMember>(),
         132usize,
@@ -138,10 +129,7 @@ fn bindgen_test_layout_WithBigMember() {
         concat!("Alignment of ", stringify!(WithBigMember))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -151,10 +139,7 @@ fn bindgen_test_layout_WithBigMember() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/union_with_big_member.rs
+++ b/tests/expectations/tests/union_with_big_member.rs
@@ -13,6 +13,8 @@ pub union WithBigArray {
 }
 #[test]
 fn bindgen_test_layout_WithBigArray() {
+    const UNINIT: ::std::mem::MaybeUninit<WithBigArray> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<WithBigArray>(),
         132usize,
@@ -23,40 +25,32 @@ fn bindgen_test_layout_WithBigArray() {
         4usize,
         concat!("Alignment of ", stringify!(WithBigArray))
     );
-    fn test_field_a() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<WithBigArray>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(WithBigArray),
-                "::",
-                stringify!(a)
-            )
-        );
-    }
-    test_field_a();
-    fn test_field_b() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<WithBigArray>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(WithBigArray),
-                "::",
-                stringify!(b)
-            )
-        );
-    }
-    test_field_b();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(WithBigArray),
+            "::",
+            stringify!(a)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(WithBigArray),
+            "::",
+            stringify!(b)
+        )
+    );
 }
 impl Default for WithBigArray {
     fn default() -> Self {
@@ -75,6 +69,8 @@ pub union WithBigArray2 {
 }
 #[test]
 fn bindgen_test_layout_WithBigArray2() {
+    const UNINIT: ::std::mem::MaybeUninit<WithBigArray2> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<WithBigArray2>(),
         36usize,
@@ -85,40 +81,32 @@ fn bindgen_test_layout_WithBigArray2() {
         4usize,
         concat!("Alignment of ", stringify!(WithBigArray2))
     );
-    fn test_field_a() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<WithBigArray2>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(WithBigArray2),
-                "::",
-                stringify!(a)
-            )
-        );
-    }
-    test_field_a();
-    fn test_field_b() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<WithBigArray2>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(WithBigArray2),
-                "::",
-                stringify!(b)
-            )
-        );
-    }
-    test_field_b();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(WithBigArray2),
+            "::",
+            stringify!(a)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(WithBigArray2),
+            "::",
+            stringify!(b)
+        )
+    );
 }
 impl Default for WithBigArray2 {
     fn default() -> Self {
@@ -137,6 +125,8 @@ pub union WithBigMember {
 }
 #[test]
 fn bindgen_test_layout_WithBigMember() {
+    const UNINIT: ::std::mem::MaybeUninit<WithBigMember> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<WithBigMember>(),
         132usize,
@@ -147,40 +137,32 @@ fn bindgen_test_layout_WithBigMember() {
         4usize,
         concat!("Alignment of ", stringify!(WithBigMember))
     );
-    fn test_field_a() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<WithBigMember>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(WithBigMember),
-                "::",
-                stringify!(a)
-            )
-        );
-    }
-    test_field_a();
-    fn test_field_b() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<WithBigMember>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(WithBigMember),
-                "::",
-                stringify!(b)
-            )
-        );
-    }
-    test_field_b();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(WithBigMember),
+            "::",
+            stringify!(a)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(WithBigMember),
+            "::",
+            stringify!(b)
+        )
+    );
 }
 impl Default for WithBigMember {
     fn default() -> Self {

--- a/tests/expectations/tests/union_with_big_member_1_0.rs
+++ b/tests/expectations/tests/union_with_big_member_1_0.rs
@@ -59,6 +59,7 @@ pub struct WithBigArray {
 fn bindgen_test_layout_WithBigArray() {
     const UNINIT: ::std::mem::MaybeUninit<WithBigArray> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<WithBigArray>(),
         132usize,
@@ -70,10 +71,7 @@ fn bindgen_test_layout_WithBigArray() {
         concat!("Alignment of ", stringify!(WithBigArray))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -83,10 +81,7 @@ fn bindgen_test_layout_WithBigArray() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -121,6 +116,7 @@ pub struct WithBigArray2 {
 fn bindgen_test_layout_WithBigArray2() {
     const UNINIT: ::std::mem::MaybeUninit<WithBigArray2> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<WithBigArray2>(),
         36usize,
@@ -132,10 +128,7 @@ fn bindgen_test_layout_WithBigArray2() {
         concat!("Alignment of ", stringify!(WithBigArray2))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -145,10 +138,7 @@ fn bindgen_test_layout_WithBigArray2() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -174,6 +164,7 @@ pub struct WithBigMember {
 fn bindgen_test_layout_WithBigMember() {
     const UNINIT: ::std::mem::MaybeUninit<WithBigMember> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<WithBigMember>(),
         132usize,
@@ -185,10 +176,7 @@ fn bindgen_test_layout_WithBigMember() {
         concat!("Alignment of ", stringify!(WithBigMember))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -198,10 +186,7 @@ fn bindgen_test_layout_WithBigMember() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/union_with_big_member_1_0.rs
+++ b/tests/expectations/tests/union_with_big_member_1_0.rs
@@ -57,6 +57,8 @@ pub struct WithBigArray {
 }
 #[test]
 fn bindgen_test_layout_WithBigArray() {
+    const UNINIT: ::std::mem::MaybeUninit<WithBigArray> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<WithBigArray>(),
         132usize,
@@ -67,40 +69,32 @@ fn bindgen_test_layout_WithBigArray() {
         4usize,
         concat!("Alignment of ", stringify!(WithBigArray))
     );
-    fn test_field_a() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<WithBigArray>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(WithBigArray),
-                "::",
-                stringify!(a)
-            )
-        );
-    }
-    test_field_a();
-    fn test_field_b() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<WithBigArray>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(WithBigArray),
-                "::",
-                stringify!(b)
-            )
-        );
-    }
-    test_field_b();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(WithBigArray),
+            "::",
+            stringify!(a)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(WithBigArray),
+            "::",
+            stringify!(b)
+        )
+    );
 }
 impl Clone for WithBigArray {
     fn clone(&self) -> Self {
@@ -125,6 +119,8 @@ pub struct WithBigArray2 {
 }
 #[test]
 fn bindgen_test_layout_WithBigArray2() {
+    const UNINIT: ::std::mem::MaybeUninit<WithBigArray2> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<WithBigArray2>(),
         36usize,
@@ -135,40 +131,32 @@ fn bindgen_test_layout_WithBigArray2() {
         4usize,
         concat!("Alignment of ", stringify!(WithBigArray2))
     );
-    fn test_field_a() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<WithBigArray2>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(WithBigArray2),
-                "::",
-                stringify!(a)
-            )
-        );
-    }
-    test_field_a();
-    fn test_field_b() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<WithBigArray2>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(WithBigArray2),
-                "::",
-                stringify!(b)
-            )
-        );
-    }
-    test_field_b();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(WithBigArray2),
+            "::",
+            stringify!(a)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(WithBigArray2),
+            "::",
+            stringify!(b)
+        )
+    );
 }
 impl Clone for WithBigArray2 {
     fn clone(&self) -> Self {
@@ -184,6 +172,8 @@ pub struct WithBigMember {
 }
 #[test]
 fn bindgen_test_layout_WithBigMember() {
+    const UNINIT: ::std::mem::MaybeUninit<WithBigMember> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<WithBigMember>(),
         132usize,
@@ -194,40 +184,32 @@ fn bindgen_test_layout_WithBigMember() {
         4usize,
         concat!("Alignment of ", stringify!(WithBigMember))
     );
-    fn test_field_a() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<WithBigMember>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(WithBigMember),
-                "::",
-                stringify!(a)
-            )
-        );
-    }
-    test_field_a();
-    fn test_field_b() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<WithBigMember>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(WithBigMember),
-                "::",
-                stringify!(b)
-            )
-        );
-    }
-    test_field_b();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(WithBigMember),
+            "::",
+            stringify!(a)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(WithBigMember),
+            "::",
+            stringify!(b)
+        )
+    );
 }
 impl Clone for WithBigMember {
     fn clone(&self) -> Self {

--- a/tests/expectations/tests/union_with_nesting.rs
+++ b/tests/expectations/tests/union_with_nesting.rs
@@ -25,6 +25,8 @@ pub union foo__bindgen_ty_1__bindgen_ty_1 {
 }
 #[test]
 fn bindgen_test_layout_foo__bindgen_ty_1__bindgen_ty_1() {
+    const UNINIT: ::std::mem::MaybeUninit<foo__bindgen_ty_1__bindgen_ty_1> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<foo__bindgen_ty_1__bindgen_ty_1>(),
         2usize,
@@ -35,44 +37,32 @@ fn bindgen_test_layout_foo__bindgen_ty_1__bindgen_ty_1() {
         2usize,
         concat!("Alignment of ", stringify!(foo__bindgen_ty_1__bindgen_ty_1))
     );
-    fn test_field_b1() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<
-                    foo__bindgen_ty_1__bindgen_ty_1,
-                >::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).b1) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(foo__bindgen_ty_1__bindgen_ty_1),
-                "::",
-                stringify!(b1)
-            )
-        );
-    }
-    test_field_b1();
-    fn test_field_b2() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<
-                    foo__bindgen_ty_1__bindgen_ty_1,
-                >::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).b2) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(foo__bindgen_ty_1__bindgen_ty_1),
-                "::",
-                stringify!(b2)
-            )
-        );
-    }
-    test_field_b2();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).b1) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(foo__bindgen_ty_1__bindgen_ty_1),
+            "::",
+            stringify!(b1)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).b2) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(foo__bindgen_ty_1__bindgen_ty_1),
+            "::",
+            stringify!(b2)
+        )
+    );
 }
 impl Default for foo__bindgen_ty_1__bindgen_ty_1 {
     fn default() -> Self {
@@ -91,6 +81,8 @@ pub union foo__bindgen_ty_1__bindgen_ty_2 {
 }
 #[test]
 fn bindgen_test_layout_foo__bindgen_ty_1__bindgen_ty_2() {
+    const UNINIT: ::std::mem::MaybeUninit<foo__bindgen_ty_1__bindgen_ty_2> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<foo__bindgen_ty_1__bindgen_ty_2>(),
         2usize,
@@ -101,44 +93,32 @@ fn bindgen_test_layout_foo__bindgen_ty_1__bindgen_ty_2() {
         2usize,
         concat!("Alignment of ", stringify!(foo__bindgen_ty_1__bindgen_ty_2))
     );
-    fn test_field_c1() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<
-                    foo__bindgen_ty_1__bindgen_ty_2,
-                >::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).c1) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(foo__bindgen_ty_1__bindgen_ty_2),
-                "::",
-                stringify!(c1)
-            )
-        );
-    }
-    test_field_c1();
-    fn test_field_c2() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<
-                    foo__bindgen_ty_1__bindgen_ty_2,
-                >::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).c2) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(foo__bindgen_ty_1__bindgen_ty_2),
-                "::",
-                stringify!(c2)
-            )
-        );
-    }
-    test_field_c2();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).c1) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(foo__bindgen_ty_1__bindgen_ty_2),
+            "::",
+            stringify!(c1)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).c2) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(foo__bindgen_ty_1__bindgen_ty_2),
+            "::",
+            stringify!(c2)
+        )
+    );
 }
 impl Default for foo__bindgen_ty_1__bindgen_ty_2 {
     fn default() -> Self {
@@ -173,6 +153,8 @@ impl Default for foo__bindgen_ty_1 {
 }
 #[test]
 fn bindgen_test_layout_foo() {
+    const UNINIT: ::std::mem::MaybeUninit<foo> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<foo>(),
         4usize,
@@ -183,18 +165,14 @@ fn bindgen_test_layout_foo() {
         4usize,
         concat!("Alignment of ", stringify!(foo))
     );
-    fn test_field_a() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<foo>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-            },
-            0usize,
-            concat!("Offset of field: ", stringify!(foo), "::", stringify!(a))
-        );
-    }
-    test_field_a();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+        },
+        0usize,
+        concat!("Offset of field: ", stringify!(foo), "::", stringify!(a))
+    );
 }
 impl Default for foo {
     fn default() -> Self {

--- a/tests/expectations/tests/union_with_nesting.rs
+++ b/tests/expectations/tests/union_with_nesting.rs
@@ -27,6 +27,7 @@ pub union foo__bindgen_ty_1__bindgen_ty_1 {
 fn bindgen_test_layout_foo__bindgen_ty_1__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<foo__bindgen_ty_1__bindgen_ty_1> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<foo__bindgen_ty_1__bindgen_ty_1>(),
         2usize,
@@ -38,10 +39,7 @@ fn bindgen_test_layout_foo__bindgen_ty_1__bindgen_ty_1() {
         concat!("Alignment of ", stringify!(foo__bindgen_ty_1__bindgen_ty_1))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).b1) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).b1) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -51,10 +49,7 @@ fn bindgen_test_layout_foo__bindgen_ty_1__bindgen_ty_1() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).b2) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).b2) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -83,6 +78,7 @@ pub union foo__bindgen_ty_1__bindgen_ty_2 {
 fn bindgen_test_layout_foo__bindgen_ty_1__bindgen_ty_2() {
     const UNINIT: ::std::mem::MaybeUninit<foo__bindgen_ty_1__bindgen_ty_2> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<foo__bindgen_ty_1__bindgen_ty_2>(),
         2usize,
@@ -94,10 +90,7 @@ fn bindgen_test_layout_foo__bindgen_ty_1__bindgen_ty_2() {
         concat!("Alignment of ", stringify!(foo__bindgen_ty_1__bindgen_ty_2))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).c1) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).c1) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -107,10 +100,7 @@ fn bindgen_test_layout_foo__bindgen_ty_1__bindgen_ty_2() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).c2) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).c2) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -155,6 +145,7 @@ impl Default for foo__bindgen_ty_1 {
 fn bindgen_test_layout_foo() {
     const UNINIT: ::std::mem::MaybeUninit<foo> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<foo>(),
         4usize,
@@ -166,10 +157,7 @@ fn bindgen_test_layout_foo() {
         concat!("Alignment of ", stringify!(foo))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
         0usize,
         concat!("Offset of field: ", stringify!(foo), "::", stringify!(a))
     );

--- a/tests/expectations/tests/union_with_nesting_1_0.rs
+++ b/tests/expectations/tests/union_with_nesting_1_0.rs
@@ -70,6 +70,8 @@ pub struct foo__bindgen_ty_1__bindgen_ty_1 {
 }
 #[test]
 fn bindgen_test_layout_foo__bindgen_ty_1__bindgen_ty_1() {
+    const UNINIT: ::std::mem::MaybeUninit<foo__bindgen_ty_1__bindgen_ty_1> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<foo__bindgen_ty_1__bindgen_ty_1>(),
         2usize,
@@ -80,44 +82,32 @@ fn bindgen_test_layout_foo__bindgen_ty_1__bindgen_ty_1() {
         2usize,
         concat!("Alignment of ", stringify!(foo__bindgen_ty_1__bindgen_ty_1))
     );
-    fn test_field_b1() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<
-                    foo__bindgen_ty_1__bindgen_ty_1,
-                >::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).b1) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(foo__bindgen_ty_1__bindgen_ty_1),
-                "::",
-                stringify!(b1)
-            )
-        );
-    }
-    test_field_b1();
-    fn test_field_b2() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<
-                    foo__bindgen_ty_1__bindgen_ty_1,
-                >::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).b2) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(foo__bindgen_ty_1__bindgen_ty_1),
-                "::",
-                stringify!(b2)
-            )
-        );
-    }
-    test_field_b2();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).b1) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(foo__bindgen_ty_1__bindgen_ty_1),
+            "::",
+            stringify!(b1)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).b2) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(foo__bindgen_ty_1__bindgen_ty_1),
+            "::",
+            stringify!(b2)
+        )
+    );
 }
 impl Clone for foo__bindgen_ty_1__bindgen_ty_1 {
     fn clone(&self) -> Self {
@@ -133,6 +123,8 @@ pub struct foo__bindgen_ty_1__bindgen_ty_2 {
 }
 #[test]
 fn bindgen_test_layout_foo__bindgen_ty_1__bindgen_ty_2() {
+    const UNINIT: ::std::mem::MaybeUninit<foo__bindgen_ty_1__bindgen_ty_2> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<foo__bindgen_ty_1__bindgen_ty_2>(),
         2usize,
@@ -143,44 +135,32 @@ fn bindgen_test_layout_foo__bindgen_ty_1__bindgen_ty_2() {
         2usize,
         concat!("Alignment of ", stringify!(foo__bindgen_ty_1__bindgen_ty_2))
     );
-    fn test_field_c1() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<
-                    foo__bindgen_ty_1__bindgen_ty_2,
-                >::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).c1) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(foo__bindgen_ty_1__bindgen_ty_2),
-                "::",
-                stringify!(c1)
-            )
-        );
-    }
-    test_field_c1();
-    fn test_field_c2() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<
-                    foo__bindgen_ty_1__bindgen_ty_2,
-                >::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).c2) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(foo__bindgen_ty_1__bindgen_ty_2),
-                "::",
-                stringify!(c2)
-            )
-        );
-    }
-    test_field_c2();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).c1) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(foo__bindgen_ty_1__bindgen_ty_2),
+            "::",
+            stringify!(c1)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).c2) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(foo__bindgen_ty_1__bindgen_ty_2),
+            "::",
+            stringify!(c2)
+        )
+    );
 }
 impl Clone for foo__bindgen_ty_1__bindgen_ty_2 {
     fn clone(&self) -> Self {
@@ -207,6 +187,8 @@ impl Clone for foo__bindgen_ty_1 {
 }
 #[test]
 fn bindgen_test_layout_foo() {
+    const UNINIT: ::std::mem::MaybeUninit<foo> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<foo>(),
         4usize,
@@ -217,18 +199,14 @@ fn bindgen_test_layout_foo() {
         4usize,
         concat!("Alignment of ", stringify!(foo))
     );
-    fn test_field_a() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<foo>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-            },
-            0usize,
-            concat!("Offset of field: ", stringify!(foo), "::", stringify!(a))
-        );
-    }
-    test_field_a();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+        },
+        0usize,
+        concat!("Offset of field: ", stringify!(foo), "::", stringify!(a))
+    );
 }
 impl Clone for foo {
     fn clone(&self) -> Self {

--- a/tests/expectations/tests/union_with_nesting_1_0.rs
+++ b/tests/expectations/tests/union_with_nesting_1_0.rs
@@ -72,6 +72,7 @@ pub struct foo__bindgen_ty_1__bindgen_ty_1 {
 fn bindgen_test_layout_foo__bindgen_ty_1__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<foo__bindgen_ty_1__bindgen_ty_1> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<foo__bindgen_ty_1__bindgen_ty_1>(),
         2usize,
@@ -83,10 +84,7 @@ fn bindgen_test_layout_foo__bindgen_ty_1__bindgen_ty_1() {
         concat!("Alignment of ", stringify!(foo__bindgen_ty_1__bindgen_ty_1))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).b1) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).b1) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -96,10 +94,7 @@ fn bindgen_test_layout_foo__bindgen_ty_1__bindgen_ty_1() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).b2) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).b2) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -125,6 +120,7 @@ pub struct foo__bindgen_ty_1__bindgen_ty_2 {
 fn bindgen_test_layout_foo__bindgen_ty_1__bindgen_ty_2() {
     const UNINIT: ::std::mem::MaybeUninit<foo__bindgen_ty_1__bindgen_ty_2> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<foo__bindgen_ty_1__bindgen_ty_2>(),
         2usize,
@@ -136,10 +132,7 @@ fn bindgen_test_layout_foo__bindgen_ty_1__bindgen_ty_2() {
         concat!("Alignment of ", stringify!(foo__bindgen_ty_1__bindgen_ty_2))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).c1) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).c1) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -149,10 +142,7 @@ fn bindgen_test_layout_foo__bindgen_ty_1__bindgen_ty_2() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).c2) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).c2) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -189,6 +179,7 @@ impl Clone for foo__bindgen_ty_1 {
 fn bindgen_test_layout_foo() {
     const UNINIT: ::std::mem::MaybeUninit<foo> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<foo>(),
         4usize,
@@ -200,10 +191,7 @@ fn bindgen_test_layout_foo() {
         concat!("Alignment of ", stringify!(foo))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
         0usize,
         concat!("Offset of field: ", stringify!(foo), "::", stringify!(a))
     );

--- a/tests/expectations/tests/unknown_attr.rs
+++ b/tests/expectations/tests/unknown_attr.rs
@@ -17,6 +17,7 @@ pub struct max_align_t {
 fn bindgen_test_layout_max_align_t() {
     const UNINIT: ::std::mem::MaybeUninit<max_align_t> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<max_align_t>(),
         32usize,
@@ -29,7 +30,6 @@ fn bindgen_test_layout_max_align_t() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).__clang_max_align_nonce1) as usize -
                 ptr as usize
         },
@@ -43,7 +43,6 @@ fn bindgen_test_layout_max_align_t() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).__clang_max_align_nonce2) as usize -
                 ptr as usize
         },

--- a/tests/expectations/tests/unknown_attr.rs
+++ b/tests/expectations/tests/unknown_attr.rs
@@ -15,6 +15,8 @@ pub struct max_align_t {
 }
 #[test]
 fn bindgen_test_layout_max_align_t() {
+    const UNINIT: ::std::mem::MaybeUninit<max_align_t> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<max_align_t>(),
         32usize,
@@ -25,40 +27,32 @@ fn bindgen_test_layout_max_align_t() {
         16usize,
         concat!("Alignment of ", stringify!(max_align_t))
     );
-    fn test_field___clang_max_align_nonce1() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<max_align_t>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).__clang_max_align_nonce1) as usize -
-                    ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(max_align_t),
-                "::",
-                stringify!(__clang_max_align_nonce1)
-            )
-        );
-    }
-    test_field___clang_max_align_nonce1();
-    fn test_field___clang_max_align_nonce2() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<max_align_t>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).__clang_max_align_nonce2) as usize -
-                    ptr as usize
-            },
-            16usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(max_align_t),
-                "::",
-                stringify!(__clang_max_align_nonce2)
-            )
-        );
-    }
-    test_field___clang_max_align_nonce2();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).__clang_max_align_nonce1) as usize -
+                ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(max_align_t),
+            "::",
+            stringify!(__clang_max_align_nonce1)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).__clang_max_align_nonce2) as usize -
+                ptr as usize
+        },
+        16usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(max_align_t),
+            "::",
+            stringify!(__clang_max_align_nonce2)
+        )
+    );
 }

--- a/tests/expectations/tests/use-core.rs
+++ b/tests/expectations/tests/use-core.rs
@@ -16,6 +16,8 @@ pub struct foo {
 }
 #[test]
 fn bindgen_test_layout_foo() {
+    const UNINIT: ::core::mem::MaybeUninit<foo> =
+        ::core::mem::MaybeUninit::uninit();
     assert_eq!(
         ::core::mem::size_of::<foo>(),
         16usize,
@@ -26,47 +28,30 @@ fn bindgen_test_layout_foo() {
         8usize,
         concat!("Alignment of ", stringify!(foo))
     );
-    fn test_field_a() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::core::mem::MaybeUninit::<foo>::uninit();
-                let ptr = uninit.as_ptr();
-                ::core::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-            },
-            0usize,
-            concat!("Offset of field: ", stringify!(foo), "::", stringify!(a))
-        );
-    }
-    test_field_a();
-    fn test_field_b() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::core::mem::MaybeUninit::<foo>::uninit();
-                let ptr = uninit.as_ptr();
-                ::core::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-            },
-            4usize,
-            concat!("Offset of field: ", stringify!(foo), "::", stringify!(b))
-        );
-    }
-    test_field_b();
-    fn test_field_bar() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::core::mem::MaybeUninit::<foo>::uninit();
-                let ptr = uninit.as_ptr();
-                ::core::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
-            },
-            8usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(foo),
-                "::",
-                stringify!(bar)
-            )
-        );
-    }
-    test_field_bar();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::core::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+        },
+        0usize,
+        concat!("Offset of field: ", stringify!(foo), "::", stringify!(a))
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::core::ptr::addr_of!((*ptr).b) as usize - ptr as usize
+        },
+        4usize,
+        concat!("Offset of field: ", stringify!(foo), "::", stringify!(b))
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::core::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
+        },
+        8usize,
+        concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar))
+    );
 }
 impl Default for foo {
     fn default() -> Self {
@@ -85,6 +70,8 @@ pub union _bindgen_ty_1 {
 }
 #[test]
 fn bindgen_test_layout__bindgen_ty_1() {
+    const UNINIT: ::core::mem::MaybeUninit<_bindgen_ty_1> =
+        ::core::mem::MaybeUninit::uninit();
     assert_eq!(
         ::core::mem::size_of::<_bindgen_ty_1>(),
         8usize,
@@ -95,42 +82,32 @@ fn bindgen_test_layout__bindgen_ty_1() {
         8usize,
         concat!("Alignment of ", stringify!(_bindgen_ty_1))
     );
-    fn test_field_bar() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::core::mem::MaybeUninit::<_bindgen_ty_1>::uninit();
-                let ptr = uninit.as_ptr();
-                ::core::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(_bindgen_ty_1),
-                "::",
-                stringify!(bar)
-            )
-        );
-    }
-    test_field_bar();
-    fn test_field_baz() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::core::mem::MaybeUninit::<_bindgen_ty_1>::uninit();
-                let ptr = uninit.as_ptr();
-                ::core::ptr::addr_of!((*ptr).baz) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(_bindgen_ty_1),
-                "::",
-                stringify!(baz)
-            )
-        );
-    }
-    test_field_baz();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::core::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(_bindgen_ty_1),
+            "::",
+            stringify!(bar)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::core::ptr::addr_of!((*ptr).baz) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(_bindgen_ty_1),
+            "::",
+            stringify!(baz)
+        )
+    );
 }
 impl Default for _bindgen_ty_1 {
     fn default() -> Self {

--- a/tests/expectations/tests/use-core.rs
+++ b/tests/expectations/tests/use-core.rs
@@ -18,6 +18,7 @@ pub struct foo {
 fn bindgen_test_layout_foo() {
     const UNINIT: ::core::mem::MaybeUninit<foo> =
         ::core::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::core::mem::size_of::<foo>(),
         16usize,
@@ -29,26 +30,17 @@ fn bindgen_test_layout_foo() {
         concat!("Alignment of ", stringify!(foo))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::core::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
+        unsafe { ::core::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
         0usize,
         concat!("Offset of field: ", stringify!(foo), "::", stringify!(a))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::core::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-        },
+        unsafe { ::core::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
         4usize,
         concat!("Offset of field: ", stringify!(foo), "::", stringify!(b))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::core::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
-        },
+        unsafe { ::core::ptr::addr_of!((*ptr).bar) as usize - ptr as usize },
         8usize,
         concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar))
     );
@@ -72,6 +64,7 @@ pub union _bindgen_ty_1 {
 fn bindgen_test_layout__bindgen_ty_1() {
     const UNINIT: ::core::mem::MaybeUninit<_bindgen_ty_1> =
         ::core::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::core::mem::size_of::<_bindgen_ty_1>(),
         8usize,
@@ -83,10 +76,7 @@ fn bindgen_test_layout__bindgen_ty_1() {
         concat!("Alignment of ", stringify!(_bindgen_ty_1))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::core::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
-        },
+        unsafe { ::core::ptr::addr_of!((*ptr).bar) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -96,10 +86,7 @@ fn bindgen_test_layout__bindgen_ty_1() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::core::ptr::addr_of!((*ptr).baz) as usize - ptr as usize
-        },
+        unsafe { ::core::ptr::addr_of!((*ptr).baz) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/use-core_1_0.rs
+++ b/tests/expectations/tests/use-core_1_0.rs
@@ -59,6 +59,8 @@ pub struct foo {
 }
 #[test]
 fn bindgen_test_layout_foo() {
+    const UNINIT: ::core::mem::MaybeUninit<foo> =
+        ::core::mem::MaybeUninit::uninit();
     assert_eq!(
         ::core::mem::size_of::<foo>(),
         16usize,
@@ -69,47 +71,30 @@ fn bindgen_test_layout_foo() {
         8usize,
         concat!("Alignment of ", stringify!(foo))
     );
-    fn test_field_a() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::core::mem::MaybeUninit::<foo>::uninit();
-                let ptr = uninit.as_ptr();
-                ::core::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-            },
-            0usize,
-            concat!("Offset of field: ", stringify!(foo), "::", stringify!(a))
-        );
-    }
-    test_field_a();
-    fn test_field_b() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::core::mem::MaybeUninit::<foo>::uninit();
-                let ptr = uninit.as_ptr();
-                ::core::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-            },
-            4usize,
-            concat!("Offset of field: ", stringify!(foo), "::", stringify!(b))
-        );
-    }
-    test_field_b();
-    fn test_field_bar() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::core::mem::MaybeUninit::<foo>::uninit();
-                let ptr = uninit.as_ptr();
-                ::core::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
-            },
-            8usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(foo),
-                "::",
-                stringify!(bar)
-            )
-        );
-    }
-    test_field_bar();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::core::ptr::addr_of!((*ptr).a) as usize - ptr as usize
+        },
+        0usize,
+        concat!("Offset of field: ", stringify!(foo), "::", stringify!(a))
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::core::ptr::addr_of!((*ptr).b) as usize - ptr as usize
+        },
+        4usize,
+        concat!("Offset of field: ", stringify!(foo), "::", stringify!(b))
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::core::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
+        },
+        8usize,
+        concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar))
+    );
 }
 impl Clone for foo {
     fn clone(&self) -> Self {
@@ -134,6 +119,8 @@ pub struct _bindgen_ty_1 {
 }
 #[test]
 fn bindgen_test_layout__bindgen_ty_1() {
+    const UNINIT: ::core::mem::MaybeUninit<_bindgen_ty_1> =
+        ::core::mem::MaybeUninit::uninit();
     assert_eq!(
         ::core::mem::size_of::<_bindgen_ty_1>(),
         8usize,
@@ -144,42 +131,32 @@ fn bindgen_test_layout__bindgen_ty_1() {
         8usize,
         concat!("Alignment of ", stringify!(_bindgen_ty_1))
     );
-    fn test_field_bar() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::core::mem::MaybeUninit::<_bindgen_ty_1>::uninit();
-                let ptr = uninit.as_ptr();
-                ::core::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(_bindgen_ty_1),
-                "::",
-                stringify!(bar)
-            )
-        );
-    }
-    test_field_bar();
-    fn test_field_baz() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::core::mem::MaybeUninit::<_bindgen_ty_1>::uninit();
-                let ptr = uninit.as_ptr();
-                ::core::ptr::addr_of!((*ptr).baz) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(_bindgen_ty_1),
-                "::",
-                stringify!(baz)
-            )
-        );
-    }
-    test_field_baz();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::core::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(_bindgen_ty_1),
+            "::",
+            stringify!(bar)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::core::ptr::addr_of!((*ptr).baz) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(_bindgen_ty_1),
+            "::",
+            stringify!(baz)
+        )
+    );
 }
 impl Clone for _bindgen_ty_1 {
     fn clone(&self) -> Self {

--- a/tests/expectations/tests/use-core_1_0.rs
+++ b/tests/expectations/tests/use-core_1_0.rs
@@ -61,6 +61,7 @@ pub struct foo {
 fn bindgen_test_layout_foo() {
     const UNINIT: ::core::mem::MaybeUninit<foo> =
         ::core::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::core::mem::size_of::<foo>(),
         16usize,
@@ -72,26 +73,17 @@ fn bindgen_test_layout_foo() {
         concat!("Alignment of ", stringify!(foo))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::core::ptr::addr_of!((*ptr).a) as usize - ptr as usize
-        },
+        unsafe { ::core::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
         0usize,
         concat!("Offset of field: ", stringify!(foo), "::", stringify!(a))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::core::ptr::addr_of!((*ptr).b) as usize - ptr as usize
-        },
+        unsafe { ::core::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
         4usize,
         concat!("Offset of field: ", stringify!(foo), "::", stringify!(b))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::core::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
-        },
+        unsafe { ::core::ptr::addr_of!((*ptr).bar) as usize - ptr as usize },
         8usize,
         concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar))
     );
@@ -121,6 +113,7 @@ pub struct _bindgen_ty_1 {
 fn bindgen_test_layout__bindgen_ty_1() {
     const UNINIT: ::core::mem::MaybeUninit<_bindgen_ty_1> =
         ::core::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::core::mem::size_of::<_bindgen_ty_1>(),
         8usize,
@@ -132,10 +125,7 @@ fn bindgen_test_layout__bindgen_ty_1() {
         concat!("Alignment of ", stringify!(_bindgen_ty_1))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::core::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
-        },
+        unsafe { ::core::ptr::addr_of!((*ptr).bar) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -145,10 +135,7 @@ fn bindgen_test_layout__bindgen_ty_1() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::core::ptr::addr_of!((*ptr).baz) as usize - ptr as usize
-        },
+        unsafe { ::core::ptr::addr_of!((*ptr).baz) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/var-tracing.rs
+++ b/tests/expectations/tests/var-tracing.rs
@@ -12,6 +12,8 @@ pub struct Bar {
 }
 #[test]
 fn bindgen_test_layout_Bar() {
+    const UNINIT: ::std::mem::MaybeUninit<Bar> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<Bar>(),
         4usize,
@@ -22,23 +24,19 @@ fn bindgen_test_layout_Bar() {
         4usize,
         concat!("Alignment of ", stringify!(Bar))
     );
-    fn test_field_m_baz() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Bar>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).m_baz) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(Bar),
-                "::",
-                stringify!(m_baz)
-            )
-        );
-    }
-    test_field_m_baz();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).m_baz) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(Bar),
+            "::",
+            stringify!(m_baz)
+        )
+    );
 }
 extern "C" {
     #[link_name = "\u{1}_ZN3BarC1Ei"]

--- a/tests/expectations/tests/var-tracing.rs
+++ b/tests/expectations/tests/var-tracing.rs
@@ -14,6 +14,7 @@ pub struct Bar {
 fn bindgen_test_layout_Bar() {
     const UNINIT: ::std::mem::MaybeUninit<Bar> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<Bar>(),
         4usize,
@@ -25,10 +26,7 @@ fn bindgen_test_layout_Bar() {
         concat!("Alignment of ", stringify!(Bar))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).m_baz) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).m_baz) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/vector.rs
+++ b/tests/expectations/tests/vector.rs
@@ -12,6 +12,8 @@ pub struct foo {
 }
 #[test]
 fn bindgen_test_layout_foo() {
+    const UNINIT: ::std::mem::MaybeUninit<foo> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<foo>(),
         8usize,
@@ -22,23 +24,19 @@ fn bindgen_test_layout_foo() {
         8usize,
         concat!("Alignment of ", stringify!(foo))
     );
-    fn test_field_mMember() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<foo>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).mMember) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(foo),
-                "::",
-                stringify!(mMember)
-            )
-        );
-    }
-    test_field_mMember();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).mMember) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(foo),
+            "::",
+            stringify!(mMember)
+        )
+    );
 }
 pub type __m128 = [f32; 4usize];
 pub type __m128d = [f64; 2usize];

--- a/tests/expectations/tests/vector.rs
+++ b/tests/expectations/tests/vector.rs
@@ -14,6 +14,7 @@ pub struct foo {
 fn bindgen_test_layout_foo() {
     const UNINIT: ::std::mem::MaybeUninit<foo> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<foo>(),
         8usize,
@@ -25,10 +26,7 @@ fn bindgen_test_layout_foo() {
         concat!("Alignment of ", stringify!(foo))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).mMember) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).mMember) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/virtual_inheritance.rs
+++ b/tests/expectations/tests/virtual_inheritance.rs
@@ -14,6 +14,7 @@ pub struct A {
 fn bindgen_test_layout_A() {
     const UNINIT: ::std::mem::MaybeUninit<A> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<A>(),
         4usize,
@@ -25,10 +26,7 @@ fn bindgen_test_layout_A() {
         concat!("Alignment of ", stringify!(A))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize },
         0usize,
         concat!("Offset of field: ", stringify!(A), "::", stringify!(foo))
     );
@@ -45,6 +43,7 @@ pub struct B {
 fn bindgen_test_layout_B() {
     const UNINIT: ::std::mem::MaybeUninit<B> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<B>(),
         16usize,
@@ -56,10 +55,7 @@ fn bindgen_test_layout_B() {
         concat!("Alignment of ", stringify!(B))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize },
         8usize,
         concat!("Offset of field: ", stringify!(B), "::", stringify!(bar))
     );
@@ -85,6 +81,7 @@ pub struct C {
 fn bindgen_test_layout_C() {
     const UNINIT: ::std::mem::MaybeUninit<C> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<C>(),
         16usize,
@@ -96,10 +93,7 @@ fn bindgen_test_layout_C() {
         concat!("Alignment of ", stringify!(C))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize },
         8usize,
         concat!("Offset of field: ", stringify!(C), "::", stringify!(baz))
     );

--- a/tests/expectations/tests/virtual_inheritance.rs
+++ b/tests/expectations/tests/virtual_inheritance.rs
@@ -12,6 +12,8 @@ pub struct A {
 }
 #[test]
 fn bindgen_test_layout_A() {
+    const UNINIT: ::std::mem::MaybeUninit<A> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<A>(),
         4usize,
@@ -22,18 +24,14 @@ fn bindgen_test_layout_A() {
         4usize,
         concat!("Alignment of ", stringify!(A))
     );
-    fn test_field_foo() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<A>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize
-            },
-            0usize,
-            concat!("Offset of field: ", stringify!(A), "::", stringify!(foo))
-        );
-    }
-    test_field_foo();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize
+        },
+        0usize,
+        concat!("Offset of field: ", stringify!(A), "::", stringify!(foo))
+    );
 }
 #[repr(C)]
 pub struct B__bindgen_vtable(::std::os::raw::c_void);
@@ -45,6 +43,8 @@ pub struct B {
 }
 #[test]
 fn bindgen_test_layout_B() {
+    const UNINIT: ::std::mem::MaybeUninit<B> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<B>(),
         16usize,
@@ -55,18 +55,14 @@ fn bindgen_test_layout_B() {
         8usize,
         concat!("Alignment of ", stringify!(B))
     );
-    fn test_field_bar() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<B>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
-            },
-            8usize,
-            concat!("Offset of field: ", stringify!(B), "::", stringify!(bar))
-        );
-    }
-    test_field_bar();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize
+        },
+        8usize,
+        concat!("Offset of field: ", stringify!(B), "::", stringify!(bar))
+    );
 }
 impl Default for B {
     fn default() -> Self {
@@ -87,6 +83,8 @@ pub struct C {
 }
 #[test]
 fn bindgen_test_layout_C() {
+    const UNINIT: ::std::mem::MaybeUninit<C> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<C>(),
         16usize,
@@ -97,18 +95,14 @@ fn bindgen_test_layout_C() {
         8usize,
         concat!("Alignment of ", stringify!(C))
     );
-    fn test_field_baz() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<C>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize
-            },
-            8usize,
-            concat!("Offset of field: ", stringify!(C), "::", stringify!(baz))
-        );
-    }
-    test_field_baz();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize
+        },
+        8usize,
+        concat!("Offset of field: ", stringify!(C), "::", stringify!(baz))
+    );
 }
 impl Default for C {
     fn default() -> Self {

--- a/tests/expectations/tests/weird_bitfields.rs
+++ b/tests/expectations/tests/weird_bitfields.rs
@@ -123,6 +123,7 @@ pub struct Weird {
 fn bindgen_test_layout_Weird() {
     const UNINIT: ::std::mem::MaybeUninit<Weird> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<Weird>(),
         24usize,
@@ -135,7 +136,6 @@ fn bindgen_test_layout_Weird() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).mStrokeDasharrayLength) as usize -
                 ptr as usize
         },
@@ -149,7 +149,6 @@ fn bindgen_test_layout_Weird() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).mClipRule) as usize - ptr as usize
         },
         8usize,
@@ -162,7 +161,6 @@ fn bindgen_test_layout_Weird() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).mColorInterpolation) as usize -
                 ptr as usize
         },
@@ -176,7 +174,6 @@ fn bindgen_test_layout_Weird() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).mColorInterpolationFilters) as usize -
                 ptr as usize
         },
@@ -190,7 +187,6 @@ fn bindgen_test_layout_Weird() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).mFillRule) as usize - ptr as usize
         },
         11usize,
@@ -203,7 +199,6 @@ fn bindgen_test_layout_Weird() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).mImageRendering) as usize - ptr as usize
         },
         12usize,
@@ -216,7 +211,6 @@ fn bindgen_test_layout_Weird() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).mPaintOrder) as usize - ptr as usize
         },
         13usize,
@@ -229,7 +223,6 @@ fn bindgen_test_layout_Weird() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).mShapeRendering) as usize - ptr as usize
         },
         14usize,
@@ -242,7 +235,6 @@ fn bindgen_test_layout_Weird() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).mStrokeLinecap) as usize - ptr as usize
         },
         15usize,
@@ -255,7 +247,6 @@ fn bindgen_test_layout_Weird() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).mStrokeLinejoin) as usize - ptr as usize
         },
         16usize,
@@ -268,7 +259,6 @@ fn bindgen_test_layout_Weird() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).mTextAnchor) as usize - ptr as usize
         },
         17usize,
@@ -281,7 +271,6 @@ fn bindgen_test_layout_Weird() {
     );
     assert_eq!(
         unsafe {
-            let ptr = UNINIT.as_ptr();
             ::std::ptr::addr_of!((*ptr).mTextRendering) as usize - ptr as usize
         },
         18usize,

--- a/tests/expectations/tests/weird_bitfields.rs
+++ b/tests/expectations/tests/weird_bitfields.rs
@@ -121,6 +121,8 @@ pub struct Weird {
 }
 #[test]
 fn bindgen_test_layout_Weird() {
+    const UNINIT: ::std::mem::MaybeUninit<Weird> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<Weird>(),
         24usize,
@@ -131,218 +133,165 @@ fn bindgen_test_layout_Weird() {
         4usize,
         concat!("Alignment of ", stringify!(Weird))
     );
-    fn test_field_mStrokeDasharrayLength() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Weird>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).mStrokeDasharrayLength) as usize -
-                    ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(Weird),
-                "::",
-                stringify!(mStrokeDasharrayLength)
-            )
-        );
-    }
-    test_field_mStrokeDasharrayLength();
-    fn test_field_mClipRule() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Weird>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).mClipRule) as usize - ptr as usize
-            },
-            8usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(Weird),
-                "::",
-                stringify!(mClipRule)
-            )
-        );
-    }
-    test_field_mClipRule();
-    fn test_field_mColorInterpolation() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Weird>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).mColorInterpolation) as usize -
-                    ptr as usize
-            },
-            9usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(Weird),
-                "::",
-                stringify!(mColorInterpolation)
-            )
-        );
-    }
-    test_field_mColorInterpolation();
-    fn test_field_mColorInterpolationFilters() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Weird>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).mColorInterpolationFilters) as usize -
-                    ptr as usize
-            },
-            10usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(Weird),
-                "::",
-                stringify!(mColorInterpolationFilters)
-            )
-        );
-    }
-    test_field_mColorInterpolationFilters();
-    fn test_field_mFillRule() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Weird>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).mFillRule) as usize - ptr as usize
-            },
-            11usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(Weird),
-                "::",
-                stringify!(mFillRule)
-            )
-        );
-    }
-    test_field_mFillRule();
-    fn test_field_mImageRendering() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Weird>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).mImageRendering) as usize -
-                    ptr as usize
-            },
-            12usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(Weird),
-                "::",
-                stringify!(mImageRendering)
-            )
-        );
-    }
-    test_field_mImageRendering();
-    fn test_field_mPaintOrder() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Weird>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).mPaintOrder) as usize - ptr as usize
-            },
-            13usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(Weird),
-                "::",
-                stringify!(mPaintOrder)
-            )
-        );
-    }
-    test_field_mPaintOrder();
-    fn test_field_mShapeRendering() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Weird>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).mShapeRendering) as usize -
-                    ptr as usize
-            },
-            14usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(Weird),
-                "::",
-                stringify!(mShapeRendering)
-            )
-        );
-    }
-    test_field_mShapeRendering();
-    fn test_field_mStrokeLinecap() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Weird>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).mStrokeLinecap) as usize -
-                    ptr as usize
-            },
-            15usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(Weird),
-                "::",
-                stringify!(mStrokeLinecap)
-            )
-        );
-    }
-    test_field_mStrokeLinecap();
-    fn test_field_mStrokeLinejoin() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Weird>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).mStrokeLinejoin) as usize -
-                    ptr as usize
-            },
-            16usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(Weird),
-                "::",
-                stringify!(mStrokeLinejoin)
-            )
-        );
-    }
-    test_field_mStrokeLinejoin();
-    fn test_field_mTextAnchor() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Weird>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).mTextAnchor) as usize - ptr as usize
-            },
-            17usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(Weird),
-                "::",
-                stringify!(mTextAnchor)
-            )
-        );
-    }
-    test_field_mTextAnchor();
-    fn test_field_mTextRendering() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<Weird>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).mTextRendering) as usize -
-                    ptr as usize
-            },
-            18usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(Weird),
-                "::",
-                stringify!(mTextRendering)
-            )
-        );
-    }
-    test_field_mTextRendering();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).mStrokeDasharrayLength) as usize -
+                ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(Weird),
+            "::",
+            stringify!(mStrokeDasharrayLength)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).mClipRule) as usize - ptr as usize
+        },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(Weird),
+            "::",
+            stringify!(mClipRule)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).mColorInterpolation) as usize -
+                ptr as usize
+        },
+        9usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(Weird),
+            "::",
+            stringify!(mColorInterpolation)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).mColorInterpolationFilters) as usize -
+                ptr as usize
+        },
+        10usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(Weird),
+            "::",
+            stringify!(mColorInterpolationFilters)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).mFillRule) as usize - ptr as usize
+        },
+        11usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(Weird),
+            "::",
+            stringify!(mFillRule)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).mImageRendering) as usize - ptr as usize
+        },
+        12usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(Weird),
+            "::",
+            stringify!(mImageRendering)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).mPaintOrder) as usize - ptr as usize
+        },
+        13usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(Weird),
+            "::",
+            stringify!(mPaintOrder)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).mShapeRendering) as usize - ptr as usize
+        },
+        14usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(Weird),
+            "::",
+            stringify!(mShapeRendering)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).mStrokeLinecap) as usize - ptr as usize
+        },
+        15usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(Weird),
+            "::",
+            stringify!(mStrokeLinecap)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).mStrokeLinejoin) as usize - ptr as usize
+        },
+        16usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(Weird),
+            "::",
+            stringify!(mStrokeLinejoin)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).mTextAnchor) as usize - ptr as usize
+        },
+        17usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(Weird),
+            "::",
+            stringify!(mTextAnchor)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).mTextRendering) as usize - ptr as usize
+        },
+        18usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(Weird),
+            "::",
+            stringify!(mTextRendering)
+        )
+    );
 }
 impl Default for Weird {
     fn default() -> Self {

--- a/tests/expectations/tests/zero-size-array-align.rs
+++ b/tests/expectations/tests/zero-size-array-align.rs
@@ -44,6 +44,8 @@ pub struct dm_deps {
 }
 #[test]
 fn bindgen_test_layout_dm_deps() {
+    const UNINIT: ::std::mem::MaybeUninit<dm_deps> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<dm_deps>(),
         8usize,
@@ -54,55 +56,43 @@ fn bindgen_test_layout_dm_deps() {
         8usize,
         concat!("Alignment of ", stringify!(dm_deps))
     );
-    fn test_field_count() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<dm_deps>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).count) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(dm_deps),
-                "::",
-                stringify!(count)
-            )
-        );
-    }
-    test_field_count();
-    fn test_field_filler() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<dm_deps>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).filler) as usize - ptr as usize
-            },
-            4usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(dm_deps),
-                "::",
-                stringify!(filler)
-            )
-        );
-    }
-    test_field_filler();
-    fn test_field_device() {
-        assert_eq!(
-            unsafe {
-                let uninit = ::std::mem::MaybeUninit::<dm_deps>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).device) as usize - ptr as usize
-            },
-            8usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(dm_deps),
-                "::",
-                stringify!(device)
-            )
-        );
-    }
-    test_field_device();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).count) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(dm_deps),
+            "::",
+            stringify!(count)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).filler) as usize - ptr as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(dm_deps),
+            "::",
+            stringify!(filler)
+        )
+    );
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).device) as usize - ptr as usize
+        },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(dm_deps),
+            "::",
+            stringify!(device)
+        )
+    );
 }

--- a/tests/expectations/tests/zero-size-array-align.rs
+++ b/tests/expectations/tests/zero-size-array-align.rs
@@ -46,6 +46,7 @@ pub struct dm_deps {
 fn bindgen_test_layout_dm_deps() {
     const UNINIT: ::std::mem::MaybeUninit<dm_deps> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<dm_deps>(),
         8usize,
@@ -57,10 +58,7 @@ fn bindgen_test_layout_dm_deps() {
         concat!("Alignment of ", stringify!(dm_deps))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).count) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).count) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -70,10 +68,7 @@ fn bindgen_test_layout_dm_deps() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).filler) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).filler) as usize - ptr as usize },
         4usize,
         concat!(
             "Offset of field: ",
@@ -83,10 +78,7 @@ fn bindgen_test_layout_dm_deps() {
         )
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).device) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).device) as usize - ptr as usize },
         8usize,
         concat!(
             "Offset of field: ",

--- a/tests/expectations/tests/zero-sized-array.rs
+++ b/tests/expectations/tests/zero-sized-array.rs
@@ -43,6 +43,8 @@ pub struct ZeroSizedArray {
 }
 #[test]
 fn bindgen_test_layout_ZeroSizedArray() {
+    const UNINIT: ::std::mem::MaybeUninit<ZeroSizedArray> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<ZeroSizedArray>(),
         0usize,
@@ -53,24 +55,19 @@ fn bindgen_test_layout_ZeroSizedArray() {
         1usize,
         concat!("Alignment of ", stringify!(ZeroSizedArray))
     );
-    fn test_field_arr() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<ZeroSizedArray>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).arr) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(ZeroSizedArray),
-                "::",
-                stringify!(arr)
-            )
-        );
-    }
-    test_field_arr();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).arr) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ZeroSizedArray),
+            "::",
+            stringify!(arr)
+        )
+    );
 }
 /// And nor should this get an `_address` field.
 #[repr(C)]
@@ -80,6 +77,8 @@ pub struct ContainsZeroSizedArray {
 }
 #[test]
 fn bindgen_test_layout_ContainsZeroSizedArray() {
+    const UNINIT: ::std::mem::MaybeUninit<ContainsZeroSizedArray> =
+        ::std::mem::MaybeUninit::uninit();
     assert_eq!(
         ::std::mem::size_of::<ContainsZeroSizedArray>(),
         0usize,
@@ -90,24 +89,19 @@ fn bindgen_test_layout_ContainsZeroSizedArray() {
         1usize,
         concat!("Alignment of ", stringify!(ContainsZeroSizedArray))
     );
-    fn test_field_zsa() {
-        assert_eq!(
-            unsafe {
-                let uninit =
-                    ::std::mem::MaybeUninit::<ContainsZeroSizedArray>::uninit();
-                let ptr = uninit.as_ptr();
-                ::std::ptr::addr_of!((*ptr).zsa) as usize - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(ContainsZeroSizedArray),
-                "::",
-                stringify!(zsa)
-            )
-        );
-    }
-    test_field_zsa();
+    assert_eq!(
+        unsafe {
+            let ptr = UNINIT.as_ptr();
+            ::std::ptr::addr_of!((*ptr).zsa) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ContainsZeroSizedArray),
+            "::",
+            stringify!(zsa)
+        )
+    );
 }
 /// Inheriting from ZeroSizedArray shouldn't cause an `_address` to be inserted
 /// either.

--- a/tests/expectations/tests/zero-sized-array.rs
+++ b/tests/expectations/tests/zero-sized-array.rs
@@ -45,6 +45,7 @@ pub struct ZeroSizedArray {
 fn bindgen_test_layout_ZeroSizedArray() {
     const UNINIT: ::std::mem::MaybeUninit<ZeroSizedArray> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<ZeroSizedArray>(),
         0usize,
@@ -56,10 +57,7 @@ fn bindgen_test_layout_ZeroSizedArray() {
         concat!("Alignment of ", stringify!(ZeroSizedArray))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).arr) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).arr) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",
@@ -79,6 +77,7 @@ pub struct ContainsZeroSizedArray {
 fn bindgen_test_layout_ContainsZeroSizedArray() {
     const UNINIT: ::std::mem::MaybeUninit<ContainsZeroSizedArray> =
         ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
     assert_eq!(
         ::std::mem::size_of::<ContainsZeroSizedArray>(),
         0usize,
@@ -90,10 +89,7 @@ fn bindgen_test_layout_ContainsZeroSizedArray() {
         concat!("Alignment of ", stringify!(ContainsZeroSizedArray))
     );
     assert_eq!(
-        unsafe {
-            let ptr = UNINIT.as_ptr();
-            ::std::ptr::addr_of!((*ptr).zsa) as usize - ptr as usize
-        },
+        unsafe { ::std::ptr::addr_of!((*ptr).zsa) as usize - ptr as usize },
         0usize,
         concat!(
             "Offset of field: ",


### PR DESCRIPTION
The bugfix in ae1b386f865e048b1ba2dbea93c621c6a68dfdf1 seems to trigger `clippy::items_after_statements` lints in tests. ~Reordering the field alignment test functions before the invocations resolves this.~ Using a common `MaybeUninit` for all field tests prevents overflowing the stack and removes the need for defining items.

If functions are preferred, a simpler method than that in d6b60d2b6ed5e4671e2dcb90257f96059f02b1cf would be to collect the field alignment tests together with their invocations (to remove the need for two repetitions), but I would imagine having the struct-level tests ordered before the field tests is the semantically more correct option. I am not partial either way, though.