### PR TITLE
Bump MSRV to 1.57.0

### DIFF
--- a/.github/workflows/bindgen.yml
+++ b/.github/workflows/bindgen.yml
@@ -48,11 +48,11 @@ jobs:
           profile: minimal
           # MSRV below is documented in Cargo.toml and README.md, please update those if you
           # change this.
-          toolchain: 1.56.1
+          toolchain: 1.57.0
           override: true
 
       - name: Build with msrv
-        run: rm Cargo.lock && cargo +1.56.1 build --lib
+        run: rm Cargo.lock && cargo +1.57.0 build --lib
 
   quickchecking:
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ version = "0.60.1"
 edition = "2018"
 build = "build.rs"
 # If you change this, also update README.md and msrv in .github/workflows/bindgen.yml
-rust-version = "1.56.1"
+rust-version = "1.57.0"
 
 include = [
   "LICENSE",

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ extern "C" {
 
 ## MSRV
 
-The minimum supported Rust version is **1.56.1**.
+The minimum supported Rust version is **1.57.0**.
 
 No MSRV bump policy has been established yet, so MSRV may increase in any release.
 


### PR DESCRIPTION
Fixes #2235.

bindgen depends upon `clap` 3.0.4 which depends upon [`os_str_bytes` ^6.0.0][o]. The latter released [version 6.2.0][s] a few hours ago and its MSRV increased to 1.57.0.

Technically bindgen's MSRV does not have to increase (because its [`Cargo.lock` pins `os_str_bytes` to version 6.0.0][pin]) but the way that the bindgen MSRV CI job is written suggests that updating the MSRV of bindgen is the simplest and most expected solution.

I elected not to make any changes to `Cargo.lock` in this PR, but maybe they could be made in a separate one.

[o]: https://crates.io/crates/clap/3.0.4/dependencies
[s]: https://crates.io/crates/os_str_bytes/versions
[pin]: https://github.com/rust-lang/rust-bindgen/blob/master/Cargo.lock#L234-L236
