### PR TITLE
Disable feature logging and clap on default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,7 +72,7 @@ optional = true
 version = "0.4"
 
 [features]
-default = ["logging", "clap", "runtime", "which-rustfmt"]
+default = ["runtime", "which-rustfmt"]
 logging = ["env_logger", "log"]
 static = ["clang-sys/static"]
 runtime = ["clang-sys/runtime"]


### PR DESCRIPTION
This crate is very popular and depends by a lot of other crates, which uses the default feature set of this crate.

However, by default, bindgen pulls in clap and logging, two features that never get used when using as a build-dev but just waste more time to compile.

Thus I remove it from the default feature set.

Signed-off-by: Jiahao XU <Jiahao_XU@outlook.com>