### PR TITLE
ty: Use canonical type to access pointee.

### DIFF
--- a/src/ir/ty.rs
+++ b/src/ir/ty.rs
@@ -1031,7 +1031,16 @@ impl Type {
                 CXType_ObjCObjectPointer |
                 CXType_MemberPointer |
                 CXType_Pointer => {
-                    let pointee = ty.pointee_type().unwrap();
+                    let mut pointee = ty.pointee_type().unwrap();
+                    if *ty != canonical_ty {
+                        let canonical_pointee =
+                            canonical_ty.pointee_type().unwrap();
+                        // clang sometimes loses pointee constness here, see
+                        // #2244.
+                        if canonical_pointee.is_const() != pointee.is_const() {
+                            pointee = canonical_pointee;
+                        }
+                    }
                     let inner =
                         Item::from_ty_or_ref(pointee, location, None, ctx);
                     TypeKind::Pointer(inner)

--- a/tests/expectations/tests/pointer-attr.rs
+++ b/tests/expectations/tests/pointer-attr.rs
@@ -1,0 +1,10 @@
+#![allow(
+    dead_code,
+    non_snake_case,
+    non_camel_case_types,
+    non_upper_case_globals
+)]
+
+extern "C" {
+    pub fn a(arg1: *const ::std::os::raw::c_char);
+}

--- a/tests/headers/pointer-attr.h
+++ b/tests/headers/pointer-attr.h
@@ -1,0 +1,1 @@
+void a(const char __attribute__((btf_type_tag("a"))) *);


### PR DESCRIPTION
Using the canonical type fixes this but changes the output of some tests
(in particular, pointer to typedefs now point to the underlying type).
So do this only in known-bad cases.

Fixes #2244