### PR TITLE
adds 'await' to list of matches in 'rust_mangle'

### DIFF
--- a/src/ir/context.rs
+++ b/src/ir/context.rs
@@ -821,7 +821,7 @@ If you encounter an error missing from this list, please file an issue or a PR!"
             name.contains('$') ||
             matches!(
                 name,
-                "abstract" | "alignof" | "as" | "async" | "become" |
+                "abstract" | "alignof" | "as" | "async" | "await" | "become" |
                     "box" | "break" | "const" | "continue" | "crate" | "do" |
                     "dyn" | "else" | "enum" | "extern" | "false" | "final" |
                     "fn" | "for" | "if" | "impl" | "in" | "let" | "loop" |


### PR DESCRIPTION
While compiling bindings for libdevmapper (the device-mapper userspace library) using rust-bindgen 0.59.0 I get a rustc error due to the headers using a Rust reserved word, `await`:

```
   Compiling libdevmapper v0.1.0 (/home/breeves/rust/libdevmapper)
error: expected identifier, found keyword `await`
    --> /home/breeves/rust/libdevmapper/target/debug/build/libdevmapper-9675fe9b031b9984/out/bindings.rs:9118:9
     |
9118 |         await: *mut f64,
     |         ^^^^^ expected identifier, found keyword
     |
help: escape `await` to use it as an identifier
     |
9118 |         r#await: *mut f64,
     |         ++

error: expected identifier, found keyword `await`
    --> /home/breeves/rust/libdevmapper/target/debug/build/libdevmapper-9675fe9b031b9984/out/bindings.rs:9126:9
     |
9126 |         await: *mut f64,
     |         ^^^^^ expected identifier, found keyword
     |
help: escape `await` to use it as an identifier
     |
9126 |         r#await: *mut f64,
     |         ++

error: expected identifier, found keyword `await`
    --> /home/breeves/rust/libdevmapper/target/debug/build/libdevmapper-9675fe9b031b9984/out/bindings.rs:9134:9
     |
9134 |         await: *mut f64,
     |         ^^^^^ expected identifier, found keyword
     |
help: escape `await` to use it as an identifier
     |
9134 |         r#await: *mut f64,
     |         ++

error: could not compile `libdevmapper` due to 3 previous errors
```

Adding the `await` keyword to the mangling list in `rust_mangle` allows the build to complete without errors.