### PR TITLE
Add test coverage for 'await' and 'async' keywords

### DIFF
--- a/tests/expectations/tests/keywords.rs
+++ b/tests/expectations/tests/keywords.rs
@@ -70,6 +70,14 @@ extern "C" {
     pub static mut as_: ::std::os::raw::c_int;
 }
 extern "C" {
+    #[link_name = "\u{1}async"]
+    pub static mut async_: ::std::os::raw::c_int;
+}
+extern "C" {
+    #[link_name = "\u{1}await"]
+    pub static mut await_: ::std::os::raw::c_int;
+}
+extern "C" {
     #[link_name = "\u{1}box"]
     pub static mut box_: ::std::os::raw::c_int;
 }

--- a/tests/headers/keywords.h
+++ b/tests/headers/keywords.h
@@ -15,6 +15,8 @@ int str;
 int dyn;
 
 int as;
+int async;
+int await;
 int box;
 int crate;
 int false;


### PR DESCRIPTION
Add declarations for 'await' and 'async' variables to keywords.h and update the expectations in keywords.rs.