### PR TITLE
Print warnings when allowlist doesn't match anything

### DIFF
--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -4329,7 +4329,7 @@ impl CodeGenerator for ObjCInterface {
 
 pub(crate) fn codegen(
     context: BindgenContext,
-) -> (Vec<proc_macro2::TokenStream>, BindgenOptions) {
+) -> (Vec<proc_macro2::TokenStream>, BindgenOptions, Vec<String>) {
     context.gen(|context| {
         let _t = context.timer("codegen");
         let counter = Cell::new(0);

--- a/src/ir/context.rs
+++ b/src/ir/context.rs
@@ -2440,7 +2440,8 @@ If you encounter an error missing from this list, please file an issue or a PR!"
         let mut warnings = Vec::new();
 
         for item in self.options().allowlisted_functions.unmatched_items() {
-            warnings.push(format!("unused option: --allowlist-function {}", item));
+            warnings
+                .push(format!("unused option: --allowlist-function {}", item));
         }
 
         for item in self.options().allowlisted_vars.unmatched_items() {

--- a/src/ir/context.rs
+++ b/src/ir/context.rs
@@ -2440,24 +2440,21 @@ If you encounter an error missing from this list, please file an issue or a PR!"
         let mut warnings = Vec::new();
 
         for item in self.options().allowlisted_functions.unmatched_items() {
-            let warn = format!("unused option: --allowlist-function {}", item);
-            warn!("{}", warn);
-            warnings.push(warn);
+            warnings.push(format!("unused option: --allowlist-function {}", item));
         }
 
         for item in self.options().allowlisted_vars.unmatched_items() {
-            let warn = format!("unused option: --allowlist-var {}", item);
-            warn!("{}", warn);
-            warnings.push(warn);
+            warnings.push(format!("unused option: --allowlist-var {}", item));
         }
 
         for item in self.options().allowlisted_types.unmatched_items() {
-            let warn = format!("unused option: --allowlist-type {}", item);
-            warn!("{}", warn);
-            warnings.push(warn);
+            warnings.push(format!("unused option: --allowlist-type {}", item));
         }
 
-        self.warnings.extend(warnings);
+        for msg in warnings {
+            warn!("{}", msg);
+            self.warnings.push(msg);
+        }
     }
 
     /// Convenient method for getting the prefix to use for most traits in

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,19 +33,6 @@ mod log_stubs;
 #[macro_use]
 mod extra_assertions;
 
-/// Print all the warning messages raised while generating the bindings in a build script.
-///
-/// If you are using `bindgen` outside of a build script you should use [`Bindings::take_warnings`]
-/// directly instead.
-#[macro_export]
-macro_rules! print_warnings {
-    ($bindings:expr) => {
-        for message in $bindings.take_warnings() {
-            println!("cargo:warning={}", message);
-        }
-    };
-}
-
 // A macro to declare an internal module for which we *must* provide
 // documentation for. If we are building with the "testing_only_docs" feature,
 // then the module is declared public, and our `#![deny(missing_docs)]` pragma
@@ -2599,10 +2586,21 @@ impl Bindings {
         }
     }
 
-    /// Take all the warning messages.
+    /// Emit all the warning messages raised while generating the bindings in a build script.
+    ///
+    /// If you are using `bindgen` outside of a build script you should use [`Bindings::warnings`]
+    /// and handle the messages accordingly instead.
     #[inline]
-    pub fn take_warnings(&mut self) -> impl Iterator<Item = String> + '_ {
-        self.warnings.drain(..)
+    pub fn emit_warnings(&self) {
+        for message in &self.warnings {
+            println!("cargo:warning={}", message);
+        }
+    }
+
+    /// Return all the warning messages raised while generating the bindings.
+    #[inline]
+    pub fn warnings(&self) -> &[String] {
+        &self.warnings
     }
 }
 

--- a/tests/expectations/tests/allowlist_warnings.rs
+++ b/tests/expectations/tests/allowlist_warnings.rs
@@ -1,0 +1,6 @@
+#![allow(
+    dead_code,
+    non_snake_case,
+    non_camel_case_types,
+    non_upper_case_globals
+)]

--- a/tests/headers/allowlist_warnings.h
+++ b/tests/headers/allowlist_warnings.h
@@ -1,0 +1,2 @@
+// bindgen-flags: --allowlist-function "doesnt_match_anything"
+int non_matched_function(int arg);

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -678,11 +678,11 @@ fn allowlist_warnings() {
         "/tests/headers/allowlist_warnings.h"
     );
 
-    let mut bindings = builder()
+    let bindings = builder()
         .header(header)
         .allowlist_function("doesnt_match_anything")
         .generate()
         .expect("unable to generate bindings");
 
-    assert_eq!(1, bindings.take_warnings().count());
+    assert_eq!(1, bindings.warnings().len());
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -670,3 +670,19 @@ fn dump_preprocessed_input() {
         "cpp-empty-layout.hpp is in the preprocessed file"
     );
 }
+
+#[test]
+fn allowlist_warnings() {
+    let header = concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/tests/headers/allowlist_warnings.h"
+    );
+
+    let mut bindings = builder()
+        .header(header)
+        .allowlist_function("doesnt_match_anything")
+        .generate()
+        .expect("unable to generate bindings");
+
+    assert_eq!(1, bindings.take_warnings().count());
+}


### PR DESCRIPTION
This PR introduces a way to store warning messages inside `Bindings` so they can be emitted later. This allows `bindgen` to use `cargo:warnining=MESSAGE` in build scripts to show warnings and still produce warning log entries (which means this PR would fix https://github.com/rust-lang/rust-bindgen/issues/2167). 

We still have some questions about this that we would like to resolve before promoting this to a non-draft PR:
- [x] Should we emit log entries AND build scripts warnings at the same time? or should we favor one over the other?
  Apparently cargo won't print warnings for crates.io dependencies unless `-vv` is passed (https://github.com/rust-lang/cargo/issues/3777). I decided to float the warning messages all the way up and add a `Bindings::take_warnings` method so the user can print them directly in the build script. I also added a `print_warnings` macro to ease this process.

- [x] Is there any functionality in the test suite to capture stdout/stderr to be able to test that the warnings are being printed correctly?

cc @amanjeev

Edit: As pointed out by @kulp (thanks!), the warning log entries are still emitted..