### PR TITLE
docs(CONTRIBUTING): add a note for single test run

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -152,6 +152,9 @@ $ cargo test
 
 ### Testing a Single Header's Bindings Generation and Compiling its Bindings
 
+Note: You will to need to install [Graphviz](https://graphviz.org/) since that
+is a dependency for running `test-one.sh`.
+
 Sometimes its useful to work with one test header from start (generating
 bindings for it) to finish (compiling the bindings and running their layout
 tests). This can be done with the `tests/test-one.sh` script. It supports fuzzy


### PR DESCRIPTION
test-one.sh needs to run `dot` command which is installed via Graphviz.
Else, running the script throws error - `dot` command not found.

cc @pvdrz