### PR TITLE
Generate opaque type for template param dependent bit field width

### DIFF
--- a/src/ir/comp.rs
+++ b/src/ir/comp.rs
@@ -1045,6 +1045,11 @@ pub struct CompInfo {
     /// size_t)
     has_non_type_template_params: bool,
 
+    /// Whether this type has a bit field member whose width couldn't be
+    /// evaluated (e.g. if it depends on a template parameter). We generate an
+    /// opaque type in this case.
+    has_unevaluable_bit_field_width: bool,
+
     /// Whether we saw `__attribute__((packed))` on or within this type.
     packed_attr: bool,
 
@@ -1078,6 +1083,7 @@ impl CompInfo {
             has_destructor: false,
             has_nonempty_base: false,
             has_non_type_template_params: false,
+            has_unevaluable_bit_field_width: false,
             packed_attr: false,
             found_unknown_attr: false,
             is_forward_declaration: false,
@@ -1317,7 +1323,21 @@ impl CompInfo {
                         }
                     }
 
-                    let bit_width = cur.bit_width();
+                    let bit_width = if cur.is_bit_field() {
+                        let width = cur.bit_width();
+
+                        // Make opaque type if the bit width couldn't be
+                        // evaluated.
+                        if width.is_none() {
+                            ci.has_unevaluable_bit_field_width = true;
+                            return CXChildVisit_Break;
+                        }
+
+                        width
+                    } else {
+                        None
+                    };
+
                     let field_type = Item::from_ty_or_ref(
                         cur.cur_type(),
                         cur,
@@ -1753,7 +1773,9 @@ impl IsOpaque for CompInfo {
     type Extra = Option<Layout>;
 
     fn is_opaque(&self, ctx: &BindgenContext, layout: &Option<Layout>) -> bool {
-        if self.has_non_type_template_params {
+        if self.has_non_type_template_params ||
+            self.has_unevaluable_bit_field_width
+        {
             return true;
         }
 

--- a/tests/expectations/tests/issue-2239-template-dependent-bit-width.rs
+++ b/tests/expectations/tests/issue-2239-template-dependent-bit-width.rs
@@ -1,0 +1,19 @@
+#![allow(
+    dead_code,
+    non_snake_case,
+    non_camel_case_types,
+    non_upper_case_globals
+)]
+
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct b {
+    pub _address: u8,
+}
+pub type b_td<a> = a;
+pub type b_ta<a> = a;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct b_foo {
+    pub _address: u8,
+}

--- a/tests/headers/issue-2239-template-dependent-bit-width.hpp
+++ b/tests/headers/issue-2239-template-dependent-bit-width.hpp
@@ -1,0 +1,10 @@
+template <class a> class b {
+    typedef a td;
+    using ta = a;
+    struct foo {
+        a foo : sizeof(a);
+        a : sizeof(a);
+        td : sizeof(td);
+        ta : sizeof(ta);
+    };
+};


### PR DESCRIPTION
libclang's API does not provide a straightforward way to check for this, and calling clang_getFieldDeclBitWidth is actively unsafe in this case. See https://github.com/llvm/llvm-project/issues/56644

We probably can't generate reasonable bindings for such a type, so make the binding opaque.

Ideally libclang would report if the bit width could not be evaluated. Unfortunately making such a change would mean bumping the minimum libclang version from 6.0 to 15.0.

Instead, add logic to traverse the AST subtree starting from the field's bit width specifier looking for template parameters. If we find one, we make the resulting type opaque

Workaround for https://github.com/rust-lang/rust-bindgen/issues/2239