### PR TITLE
Wrap unsafe function's bodies in unsafe blocks

### DIFF
--- a/.github/workflows/bindgen.yml
+++ b/.github/workflows/bindgen.yml
@@ -89,6 +89,8 @@ jobs:
 
       - name: Test expectations
         run: cd bindgen-tests/tests/expectations && cargo test
+        env:
+          RUSTFLAGS: "-D unsafe_op_in_unsafe_fn"
 
   test:
     runs-on: ${{matrix.os}}

--- a/.github/workflows/bindgen.yml
+++ b/.github/workflows/bindgen.yml
@@ -90,7 +90,7 @@ jobs:
       - name: Test expectations
         run: cd bindgen-tests/tests/expectations && cargo test
         env:
-          RUSTFLAGS: "-D unsafe_op_in_unsafe_fn,unused_unsafe"
+          RUSTFLAGS: "-D unsafe_op_in_unsafe_fn -D unused_unsafe"
 
   test:
     runs-on: ${{matrix.os}}

--- a/.github/workflows/bindgen.yml
+++ b/.github/workflows/bindgen.yml
@@ -90,7 +90,7 @@ jobs:
       - name: Test expectations
         run: cd bindgen-tests/tests/expectations && cargo test
         env:
-          RUSTFLAGS: "-D unsafe_op_in_unsafe_fn"
+          RUSTFLAGS: "-D unsafe_op_in_unsafe_fn,unused_unsafe"
 
   test:
     runs-on: ${{matrix.os}}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -160,6 +160,8 @@
  * the `ParseCallbacks`trait does not require to implement `UnwindSafe`.
  * the `Builder::parse_callbacks` method no longer overwrites previously added
    callbacks and composes them in a last-to-first manner.
+ * any generated rust code containing unsafe operations inside unsafe functions
+   is wrapped in unsafe blocks now.
 
 ## Removed
 

--- a/bindgen-tests/tests/expectations/tests/16-byte-alignment_1_0.rs
+++ b/bindgen-tests/tests/expectations/tests/16-byte-alignment_1_0.rs
@@ -14,11 +14,11 @@ impl<T> __BindgenUnionField<T> {
     }
     #[inline]
     pub unsafe fn as_ref(&self) -> &T {
-        ::std::mem::transmute(self)
+        unsafe { ::std::mem::transmute(self) }
     }
     #[inline]
     pub unsafe fn as_mut(&mut self) -> &mut T {
-        ::std::mem::transmute(self)
+        unsafe { ::std::mem::transmute(self) }
     }
 }
 impl<T> ::std::default::Default for __BindgenUnionField<T> {

--- a/bindgen-tests/tests/expectations/tests/allowlist-file.rs
+++ b/bindgen-tests/tests/expectations/tests/allowlist-file.rs
@@ -41,7 +41,7 @@ extern "C" {
 impl someClass {
     #[inline]
     pub unsafe fn somePublicMethod(&mut self, foo: ::std::os::raw::c_int) {
-        someClass_somePublicMethod(self, foo)
+        unsafe { someClass_somePublicMethod(self, foo) }
     }
 }
 extern "C" {

--- a/bindgen-tests/tests/expectations/tests/anon_struct_in_union_1_0.rs
+++ b/bindgen-tests/tests/expectations/tests/anon_struct_in_union_1_0.rs
@@ -14,11 +14,11 @@ impl<T> __BindgenUnionField<T> {
     }
     #[inline]
     pub unsafe fn as_ref(&self) -> &T {
-        ::std::mem::transmute(self)
+        unsafe { ::std::mem::transmute(self) }
     }
     #[inline]
     pub unsafe fn as_mut(&mut self) -> &mut T {
-        ::std::mem::transmute(self)
+        unsafe { ::std::mem::transmute(self) }
     }
 }
 impl<T> ::std::default::Default for __BindgenUnionField<T> {

--- a/bindgen-tests/tests/expectations/tests/anon_union_1_0.rs
+++ b/bindgen-tests/tests/expectations/tests/anon_union_1_0.rs
@@ -14,11 +14,11 @@ impl<T> __BindgenUnionField<T> {
     }
     #[inline]
     pub unsafe fn as_ref(&self) -> &T {
-        ::std::mem::transmute(self)
+        unsafe { ::std::mem::transmute(self) }
     }
     #[inline]
     pub unsafe fn as_mut(&mut self) -> &mut T {
-        ::std::mem::transmute(self)
+        unsafe { ::std::mem::transmute(self) }
     }
 }
 impl<T> ::std::default::Default for __BindgenUnionField<T> {

--- a/bindgen-tests/tests/expectations/tests/attribute_warn_unused_result.rs
+++ b/bindgen-tests/tests/expectations/tests/attribute_warn_unused_result.rs
@@ -38,7 +38,7 @@ impl Foo {
         &mut self,
         arg1: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int {
-        Foo_foo(self, arg1)
+        unsafe { Foo_foo(self, arg1) }
     }
 }
 extern "C" {

--- a/bindgen-tests/tests/expectations/tests/attribute_warn_unused_result_no_attribute_detection.rs
+++ b/bindgen-tests/tests/expectations/tests/attribute_warn_unused_result_no_attribute_detection.rs
@@ -36,7 +36,7 @@ impl Foo {
         &mut self,
         arg1: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int {
-        Foo_foo(self, arg1)
+        unsafe { Foo_foo(self, arg1) }
     }
 }
 extern "C" {

--- a/bindgen-tests/tests/expectations/tests/attribute_warn_unused_result_pre_1_27.rs
+++ b/bindgen-tests/tests/expectations/tests/attribute_warn_unused_result_pre_1_27.rs
@@ -36,7 +36,7 @@ impl Foo {
         &mut self,
         arg1: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int {
-        Foo_foo(self, arg1)
+        unsafe { Foo_foo(self, arg1) }
     }
 }
 extern "C" {

--- a/bindgen-tests/tests/expectations/tests/bindgen-union-inside-namespace.rs
+++ b/bindgen-tests/tests/expectations/tests/bindgen-union-inside-namespace.rs
@@ -16,11 +16,11 @@ pub mod root {
         }
         #[inline]
         pub unsafe fn as_ref(&self) -> &T {
-            ::std::mem::transmute(self)
+            unsafe { ::std::mem::transmute(self) }
         }
         #[inline]
         pub unsafe fn as_mut(&mut self) -> &mut T {
-            ::std::mem::transmute(self)
+            unsafe { ::std::mem::transmute(self) }
         }
     }
     impl<T> ::std::default::Default for __BindgenUnionField<T> {

--- a/bindgen-tests/tests/expectations/tests/bitfield-method-same-name.rs
+++ b/bindgen-tests/tests/expectations/tests/bitfield-method-same-name.rs
@@ -151,14 +151,14 @@ impl Foo {
     }
     #[inline]
     pub unsafe fn type_(&mut self) -> ::std::os::raw::c_char {
-        Foo_type(self)
+        unsafe { Foo_type(self) }
     }
     #[inline]
     pub unsafe fn set_type_(&mut self, c: ::std::os::raw::c_char) {
-        Foo_set_type_(self, c)
+        unsafe { Foo_set_type_(self, c) }
     }
     #[inline]
     pub unsafe fn set_type(&mut self, c: ::std::os::raw::c_char) {
-        Foo_set_type(self, c)
+        unsafe { Foo_set_type(self, c) }
     }
 }

--- a/bindgen-tests/tests/expectations/tests/class.rs
+++ b/bindgen-tests/tests/expectations/tests/class.rs
@@ -23,11 +23,11 @@ impl<T> __IncompleteArrayField<T> {
     }
     #[inline]
     pub unsafe fn as_slice(&self, len: usize) -> &[T] {
-        ::std::slice::from_raw_parts(self.as_ptr(), len)
+        unsafe { ::std::slice::from_raw_parts(self.as_ptr(), len) }
     }
     #[inline]
     pub unsafe fn as_mut_slice(&mut self, len: usize) -> &mut [T] {
-        ::std::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
+        unsafe { ::std::slice::from_raw_parts_mut(self.as_mut_ptr(), len) }
     }
 }
 impl<T> ::std::fmt::Debug for __IncompleteArrayField<T> {
@@ -490,18 +490,18 @@ extern "C" {
 impl RealAbstractionWithTonsOfMethods {
     #[inline]
     pub unsafe fn bar(&self) {
-        RealAbstractionWithTonsOfMethods_bar(self)
+        unsafe { RealAbstractionWithTonsOfMethods_bar(self) }
     }
     #[inline]
     pub unsafe fn bar1(&mut self) {
-        RealAbstractionWithTonsOfMethods_bar1(self)
+        unsafe { RealAbstractionWithTonsOfMethods_bar1(self) }
     }
     #[inline]
     pub unsafe fn bar2(&mut self, foo: ::std::os::raw::c_int) {
-        RealAbstractionWithTonsOfMethods_bar2(self, foo)
+        unsafe { RealAbstractionWithTonsOfMethods_bar2(self, foo) }
     }
     #[inline]
     pub unsafe fn sta() {
-        RealAbstractionWithTonsOfMethods_sta()
+        unsafe { RealAbstractionWithTonsOfMethods_sta() }
     }
 }

--- a/bindgen-tests/tests/expectations/tests/class_1_0.rs
+++ b/bindgen-tests/tests/expectations/tests/class_1_0.rs
@@ -23,11 +23,11 @@ impl<T> __IncompleteArrayField<T> {
     }
     #[inline]
     pub unsafe fn as_slice(&self, len: usize) -> &[T] {
-        ::std::slice::from_raw_parts(self.as_ptr(), len)
+        unsafe { ::std::slice::from_raw_parts(self.as_ptr(), len) }
     }
     #[inline]
     pub unsafe fn as_mut_slice(&mut self, len: usize) -> &mut [T] {
-        ::std::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
+        unsafe { ::std::slice::from_raw_parts_mut(self.as_mut_ptr(), len) }
     }
 }
 impl<T> ::std::fmt::Debug for __IncompleteArrayField<T> {
@@ -44,11 +44,11 @@ impl<T> __BindgenUnionField<T> {
     }
     #[inline]
     pub unsafe fn as_ref(&self) -> &T {
-        ::std::mem::transmute(self)
+        unsafe { ::std::mem::transmute(self) }
     }
     #[inline]
     pub unsafe fn as_mut(&mut self) -> &mut T {
-        ::std::mem::transmute(self)
+        unsafe { ::std::mem::transmute(self) }
     }
 }
 impl<T> ::std::default::Default for __BindgenUnionField<T> {
@@ -541,18 +541,18 @@ impl Clone for RealAbstractionWithTonsOfMethods {
 impl RealAbstractionWithTonsOfMethods {
     #[inline]
     pub unsafe fn bar(&self) {
-        RealAbstractionWithTonsOfMethods_bar(self)
+        unsafe { RealAbstractionWithTonsOfMethods_bar(self) }
     }
     #[inline]
     pub unsafe fn bar1(&mut self) {
-        RealAbstractionWithTonsOfMethods_bar1(self)
+        unsafe { RealAbstractionWithTonsOfMethods_bar1(self) }
     }
     #[inline]
     pub unsafe fn bar2(&mut self, foo: ::std::os::raw::c_int) {
-        RealAbstractionWithTonsOfMethods_bar2(self, foo)
+        unsafe { RealAbstractionWithTonsOfMethods_bar2(self, foo) }
     }
     #[inline]
     pub unsafe fn sta() {
-        RealAbstractionWithTonsOfMethods_sta()
+        unsafe { RealAbstractionWithTonsOfMethods_sta() }
     }
 }

--- a/bindgen-tests/tests/expectations/tests/class_with_inner_struct_1_0.rs
+++ b/bindgen-tests/tests/expectations/tests/class_with_inner_struct_1_0.rs
@@ -14,11 +14,11 @@ impl<T> __BindgenUnionField<T> {
     }
     #[inline]
     pub unsafe fn as_ref(&self) -> &T {
-        ::std::mem::transmute(self)
+        unsafe { ::std::mem::transmute(self) }
     }
     #[inline]
     pub unsafe fn as_mut(&mut self) -> &mut T {
-        ::std::mem::transmute(self)
+        unsafe { ::std::mem::transmute(self) }
     }
 }
 impl<T> ::std::default::Default for __BindgenUnionField<T> {

--- a/bindgen-tests/tests/expectations/tests/class_with_typedef.rs
+++ b/bindgen-tests/tests/expectations/tests/class_with_typedef.rs
@@ -93,19 +93,19 @@ impl Default for C {
 impl C {
     #[inline]
     pub unsafe fn method(&mut self, c: C_MyInt) {
-        C_method(self, c)
+        unsafe { C_method(self, c) }
     }
     #[inline]
     pub unsafe fn methodRef(&mut self, c: *mut C_MyInt) {
-        C_methodRef(self, c)
+        unsafe { C_methodRef(self, c) }
     }
     #[inline]
     pub unsafe fn complexMethodRef(&mut self, c: *mut C_Lookup) {
-        C_complexMethodRef(self, c)
+        unsafe { C_complexMethodRef(self, c) }
     }
     #[inline]
     pub unsafe fn anotherMethod(&mut self, c: AnotherInt) {
-        C_anotherMethod(self, c)
+        unsafe { C_anotherMethod(self, c) }
     }
 }
 #[repr(C)]

--- a/bindgen-tests/tests/expectations/tests/constructor-tp.rs
+++ b/bindgen-tests/tests/expectations/tests/constructor-tp.rs
@@ -35,8 +35,10 @@ extern "C" {
 impl Bar {
     #[inline]
     pub unsafe fn new() -> Self {
-        let mut __bindgen_tmp = ::std::mem::MaybeUninit::uninit();
-        Bar_Bar(__bindgen_tmp.as_mut_ptr());
-        __bindgen_tmp.assume_init()
+        unsafe {
+            let mut __bindgen_tmp = ::std::mem::MaybeUninit::uninit();
+            Bar_Bar(__bindgen_tmp.as_mut_ptr());
+            __bindgen_tmp.assume_init()
+        }
     }
 }

--- a/bindgen-tests/tests/expectations/tests/constructors.rs
+++ b/bindgen-tests/tests/expectations/tests/constructors.rs
@@ -37,15 +37,19 @@ extern "C" {
 impl TestOverload {
     #[inline]
     pub unsafe fn new(arg1: ::std::os::raw::c_int) -> Self {
-        let mut __bindgen_tmp = ::std::mem::MaybeUninit::uninit();
-        TestOverload_TestOverload(__bindgen_tmp.as_mut_ptr(), arg1);
-        __bindgen_tmp.assume_init()
+        unsafe {
+            let mut __bindgen_tmp = ::std::mem::MaybeUninit::uninit();
+            TestOverload_TestOverload(__bindgen_tmp.as_mut_ptr(), arg1);
+            __bindgen_tmp.assume_init()
+        }
     }
     #[inline]
     pub unsafe fn new1(arg1: f64) -> Self {
-        let mut __bindgen_tmp = ::std::mem::MaybeUninit::uninit();
-        TestOverload_TestOverload1(__bindgen_tmp.as_mut_ptr(), arg1);
-        __bindgen_tmp.assume_init()
+        unsafe {
+            let mut __bindgen_tmp = ::std::mem::MaybeUninit::uninit();
+            TestOverload_TestOverload1(__bindgen_tmp.as_mut_ptr(), arg1);
+            __bindgen_tmp.assume_init()
+        }
     }
 }
 #[repr(C)]
@@ -73,8 +77,10 @@ extern "C" {
 impl TestPublicNoArgs {
     #[inline]
     pub unsafe fn new() -> Self {
-        let mut __bindgen_tmp = ::std::mem::MaybeUninit::uninit();
-        TestPublicNoArgs_TestPublicNoArgs(__bindgen_tmp.as_mut_ptr());
-        __bindgen_tmp.assume_init()
+        unsafe {
+            let mut __bindgen_tmp = ::std::mem::MaybeUninit::uninit();
+            TestPublicNoArgs_TestPublicNoArgs(__bindgen_tmp.as_mut_ptr());
+            __bindgen_tmp.assume_init()
+        }
     }
 }

--- a/bindgen-tests/tests/expectations/tests/constructors_1_33.rs
+++ b/bindgen-tests/tests/expectations/tests/constructors_1_33.rs
@@ -39,15 +39,19 @@ extern "C" {
 impl TestOverload {
     #[inline]
     pub unsafe fn new(arg1: ::std::os::raw::c_int) -> Self {
-        let mut __bindgen_tmp = ::std::mem::uninitialized();
-        TestOverload_TestOverload(&mut __bindgen_tmp, arg1);
-        __bindgen_tmp
+        unsafe {
+            let mut __bindgen_tmp = ::std::mem::uninitialized();
+            TestOverload_TestOverload(&mut __bindgen_tmp, arg1);
+            __bindgen_tmp
+        }
     }
     #[inline]
     pub unsafe fn new1(arg1: f64) -> Self {
-        let mut __bindgen_tmp = ::std::mem::uninitialized();
-        TestOverload_TestOverload1(&mut __bindgen_tmp, arg1);
-        __bindgen_tmp
+        unsafe {
+            let mut __bindgen_tmp = ::std::mem::uninitialized();
+            TestOverload_TestOverload1(&mut __bindgen_tmp, arg1);
+            __bindgen_tmp
+        }
     }
 }
 #[repr(C)]
@@ -75,8 +79,10 @@ extern "C" {
 impl TestPublicNoArgs {
     #[inline]
     pub unsafe fn new() -> Self {
-        let mut __bindgen_tmp = ::std::mem::uninitialized();
-        TestPublicNoArgs_TestPublicNoArgs(&mut __bindgen_tmp);
-        __bindgen_tmp
+        unsafe {
+            let mut __bindgen_tmp = ::std::mem::uninitialized();
+            TestPublicNoArgs_TestPublicNoArgs(&mut __bindgen_tmp);
+            __bindgen_tmp
+        }
     }
 }

--- a/bindgen-tests/tests/expectations/tests/deleted-function.rs
+++ b/bindgen-tests/tests/expectations/tests/deleted-function.rs
@@ -34,11 +34,11 @@ extern "C" {
 impl A {
     #[inline]
     pub unsafe fn inline_definition(&mut self) {
-        A_inline_definition(self)
+        unsafe { A_inline_definition(self) }
     }
     #[inline]
     pub unsafe fn out_of_line_definition(&mut self) {
-        A_out_of_line_definition(self)
+        unsafe { A_out_of_line_definition(self) }
     }
 }
 #[repr(C)]
@@ -84,8 +84,10 @@ extern "C" {
 impl C {
     #[inline]
     pub unsafe fn new(arg1: *mut C) -> Self {
-        let mut __bindgen_tmp = ::std::mem::MaybeUninit::uninit();
-        C_C(__bindgen_tmp.as_mut_ptr(), arg1);
-        __bindgen_tmp.assume_init()
+        unsafe {
+            let mut __bindgen_tmp = ::std::mem::MaybeUninit::uninit();
+            C_C(__bindgen_tmp.as_mut_ptr(), arg1);
+            __bindgen_tmp.assume_init()
+        }
     }
 }

--- a/bindgen-tests/tests/expectations/tests/derive-bitfield-method-same-name.rs
+++ b/bindgen-tests/tests/expectations/tests/derive-bitfield-method-same-name.rs
@@ -202,14 +202,14 @@ impl Foo {
     }
     #[inline]
     pub unsafe fn type_(&mut self) -> ::std::os::raw::c_char {
-        Foo_type(self)
+        unsafe { Foo_type(self) }
     }
     #[inline]
     pub unsafe fn set_type_(&mut self, c: ::std::os::raw::c_char) {
-        Foo_set_type_(self, c)
+        unsafe { Foo_set_type_(self, c) }
     }
     #[inline]
     pub unsafe fn set_type(&mut self, c: ::std::os::raw::c_char) {
-        Foo_set_type(self, c)
+        unsafe { Foo_set_type(self, c) }
     }
 }

--- a/bindgen-tests/tests/expectations/tests/derive-hash-struct-with-incomplete-array.rs
+++ b/bindgen-tests/tests/expectations/tests/derive-hash-struct-with-incomplete-array.rs
@@ -23,11 +23,11 @@ impl<T> __IncompleteArrayField<T> {
     }
     #[inline]
     pub unsafe fn as_slice(&self, len: usize) -> &[T] {
-        ::std::slice::from_raw_parts(self.as_ptr(), len)
+        unsafe { ::std::slice::from_raw_parts(self.as_ptr(), len) }
     }
     #[inline]
     pub unsafe fn as_mut_slice(&mut self, len: usize) -> &mut [T] {
-        ::std::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
+        unsafe { ::std::slice::from_raw_parts_mut(self.as_mut_ptr(), len) }
     }
 }
 impl<T> ::std::fmt::Debug for __IncompleteArrayField<T> {

--- a/bindgen-tests/tests/expectations/tests/derive-partialeq-union_1_0.rs
+++ b/bindgen-tests/tests/expectations/tests/derive-partialeq-union_1_0.rs
@@ -14,11 +14,11 @@ impl<T> __BindgenUnionField<T> {
     }
     #[inline]
     pub unsafe fn as_ref(&self) -> &T {
-        ::std::mem::transmute(self)
+        unsafe { ::std::mem::transmute(self) }
     }
     #[inline]
     pub unsafe fn as_mut(&mut self) -> &mut T {
-        ::std::mem::transmute(self)
+        unsafe { ::std::mem::transmute(self) }
     }
 }
 impl<T> ::std::default::Default for __BindgenUnionField<T> {

--- a/bindgen-tests/tests/expectations/tests/disable-untagged-union.rs
+++ b/bindgen-tests/tests/expectations/tests/disable-untagged-union.rs
@@ -14,11 +14,11 @@ impl<T> __BindgenUnionField<T> {
     }
     #[inline]
     pub unsafe fn as_ref(&self) -> &T {
-        ::std::mem::transmute(self)
+        unsafe { ::std::mem::transmute(self) }
     }
     #[inline]
     pub unsafe fn as_mut(&mut self) -> &mut T {
-        ::std::mem::transmute(self)
+        unsafe { ::std::mem::transmute(self) }
     }
 }
 impl<T> ::std::default::Default for __BindgenUnionField<T> {

--- a/bindgen-tests/tests/expectations/tests/dynamic_loading_attributes.rs
+++ b/bindgen-tests/tests/expectations/tests/dynamic_loading_attributes.rs
@@ -20,7 +20,7 @@ impl TestLib {
         P: AsRef<::std::ffi::OsStr>,
     {
         let library = ::libloading::Library::new(path)?;
-        Self::from_library(library)
+        unsafe { Self::from_library(library) }
     }
     pub unsafe fn from_library<L>(
         library: L,
@@ -29,8 +29,8 @@ impl TestLib {
         L: Into<::libloading::Library>,
     {
         let __library = library.into();
-        let foo = __library.get(b"foo\0").map(|sym| *sym)?;
-        let baz = __library.get(b"baz\0").map(|sym| *sym)?;
+        let foo = unsafe { __library.get(b"foo\0") }.map(|sym| *sym)?;
+        let baz = unsafe { __library.get(b"baz\0") }.map(|sym| *sym)?;
         Ok(TestLib {
             __library,
             foo,
@@ -48,9 +48,9 @@ impl TestLib {
         x: ::std::os::raw::c_int,
         y: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int {
-        (self.foo)(x, y)
+        unsafe { (self.foo)(x, y) }
     }
     pub unsafe fn baz(&self) -> ::std::os::raw::c_int {
-        (self.baz)()
+        unsafe { (self.baz)() }
     }
 }

--- a/bindgen-tests/tests/expectations/tests/dynamic_loading_required.rs
+++ b/bindgen-tests/tests/expectations/tests/dynamic_loading_required.rs
@@ -23,7 +23,7 @@ impl TestLib {
         P: AsRef<::std::ffi::OsStr>,
     {
         let library = ::libloading::Library::new(path)?;
-        Self::from_library(library)
+        unsafe { Self::from_library(library) }
     }
     pub unsafe fn from_library<L>(
         library: L,
@@ -32,9 +32,9 @@ impl TestLib {
         L: Into<::libloading::Library>,
     {
         let __library = library.into();
-        let foo = __library.get(b"foo\0").map(|sym| *sym)?;
-        let bar = __library.get(b"bar\0").map(|sym| *sym)?;
-        let baz = __library.get(b"baz\0").map(|sym| *sym)?;
+        let foo = unsafe { __library.get(b"foo\0") }.map(|sym| *sym)?;
+        let bar = unsafe { __library.get(b"bar\0") }.map(|sym| *sym)?;
+        let baz = unsafe { __library.get(b"baz\0") }.map(|sym| *sym)?;
         Ok(TestLib {
             __library,
             foo,
@@ -47,15 +47,15 @@ impl TestLib {
         x: ::std::os::raw::c_int,
         y: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int {
-        (self.foo)(x, y)
+        unsafe { (self.foo)(x, y) }
     }
     pub unsafe fn bar(
         &self,
         x: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int {
-        (self.bar)(x)
+        unsafe { (self.bar)(x) }
     }
     pub unsafe fn baz(&self) -> ::std::os::raw::c_int {
-        (self.baz)()
+        unsafe { (self.baz)() }
     }
 }

--- a/bindgen-tests/tests/expectations/tests/dynamic_loading_simple.rs
+++ b/bindgen-tests/tests/expectations/tests/dynamic_loading_simple.rs
@@ -32,7 +32,7 @@ impl TestLib {
         P: AsRef<::std::ffi::OsStr>,
     {
         let library = ::libloading::Library::new(path)?;
-        Self::from_library(library)
+        unsafe { Self::from_library(library) }
     }
     pub unsafe fn from_library<L>(
         library: L,
@@ -41,9 +41,9 @@ impl TestLib {
         L: Into<::libloading::Library>,
     {
         let __library = library.into();
-        let foo = __library.get(b"foo\0").map(|sym| *sym);
-        let bar = __library.get(b"bar\0").map(|sym| *sym);
-        let baz = __library.get(b"baz\0").map(|sym| *sym);
+        let foo = unsafe { __library.get(b"foo\0") }.map(|sym| *sym);
+        let bar = unsafe { __library.get(b"bar\0") }.map(|sym| *sym);
+        let baz = unsafe { __library.get(b"baz\0") }.map(|sym| *sym);
         Ok(TestLib {
             __library,
             foo,
@@ -56,15 +56,19 @@ impl TestLib {
         x: ::std::os::raw::c_int,
         y: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int {
-        (self.foo.as_ref().expect("Expected function, got error."))(x, y)
+        unsafe {
+            (self.foo.as_ref().expect("Expected function, got error."))(x, y)
+        }
     }
     pub unsafe fn bar(
         &self,
         x: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int {
-        (self.bar.as_ref().expect("Expected function, got error."))(x)
+        unsafe {
+            (self.bar.as_ref().expect("Expected function, got error."))(x)
+        }
     }
     pub unsafe fn baz(&self) -> ::std::os::raw::c_int {
-        (self.baz.as_ref().expect("Expected function, got error."))()
+        unsafe { (self.baz.as_ref().expect("Expected function, got error."))() }
     }
 }

--- a/bindgen-tests/tests/expectations/tests/dynamic_loading_template.rs
+++ b/bindgen-tests/tests/expectations/tests/dynamic_loading_template.rs
@@ -20,7 +20,7 @@ impl TestLib {
         P: AsRef<::std::ffi::OsStr>,
     {
         let library = ::libloading::Library::new(path)?;
-        Self::from_library(library)
+        unsafe { Self::from_library(library) }
     }
     pub unsafe fn from_library<L>(
         library: L,
@@ -29,8 +29,8 @@ impl TestLib {
         L: Into<::libloading::Library>,
     {
         let __library = library.into();
-        let foo = __library.get(b"foo\0").map(|sym| *sym);
-        let foo1 = __library.get(b"foo1\0").map(|sym| *sym);
+        let foo = unsafe { __library.get(b"foo\0") }.map(|sym| *sym);
+        let foo1 = unsafe { __library.get(b"foo1\0") }.map(|sym| *sym);
         Ok(TestLib {
             __library,
             foo,
@@ -41,9 +41,13 @@ impl TestLib {
         &self,
         x: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int {
-        (self.foo.as_ref().expect("Expected function, got error."))(x)
+        unsafe {
+            (self.foo.as_ref().expect("Expected function, got error."))(x)
+        }
     }
     pub unsafe fn foo1(&self, x: f32) -> f32 {
-        (self.foo1.as_ref().expect("Expected function, got error."))(x)
+        unsafe {
+            (self.foo1.as_ref().expect("Expected function, got error."))(x)
+        }
     }
 }

--- a/bindgen-tests/tests/expectations/tests/dynamic_loading_with_allowlist.rs
+++ b/bindgen-tests/tests/expectations/tests/dynamic_loading_with_allowlist.rs
@@ -34,7 +34,7 @@ impl TestLib {
         P: AsRef<::std::ffi::OsStr>,
     {
         let library = ::libloading::Library::new(path)?;
-        Self::from_library(library)
+        unsafe { Self::from_library(library) }
     }
     pub unsafe fn from_library<L>(
         library: L,
@@ -43,9 +43,9 @@ impl TestLib {
         L: Into<::libloading::Library>,
     {
         let __library = library.into();
-        let foo = __library.get(b"foo\0").map(|sym| *sym);
-        let baz = __library.get(b"baz\0").map(|sym| *sym);
-        let bazz = __library.get(b"bazz\0").map(|sym| *sym);
+        let foo = unsafe { __library.get(b"foo\0") }.map(|sym| *sym);
+        let baz = unsafe { __library.get(b"baz\0") }.map(|sym| *sym);
+        let bazz = unsafe { __library.get(b"bazz\0") }.map(|sym| *sym);
         Ok(TestLib {
             __library,
             foo,
@@ -57,12 +57,16 @@ impl TestLib {
         &self,
         x: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int {
-        (self.foo.as_ref().expect("Expected function, got error."))(x)
+        unsafe {
+            (self.foo.as_ref().expect("Expected function, got error."))(x)
+        }
     }
     pub unsafe fn baz(
         &self,
         x: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int {
-        (self.baz.as_ref().expect("Expected function, got error."))(x)
+        unsafe {
+            (self.baz.as_ref().expect("Expected function, got error."))(x)
+        }
     }
 }

--- a/bindgen-tests/tests/expectations/tests/dynamic_loading_with_blocklist.rs
+++ b/bindgen-tests/tests/expectations/tests/dynamic_loading_with_blocklist.rs
@@ -46,17 +46,19 @@ extern "C" {
 impl X {
     #[inline]
     pub unsafe fn some_function(&mut self) {
-        X_some_function(self)
+        unsafe { X_some_function(self) }
     }
     #[inline]
     pub unsafe fn some_other_function(&mut self) {
-        X_some_other_function(self)
+        unsafe { X_some_other_function(self) }
     }
     #[inline]
     pub unsafe fn new(x: ::std::os::raw::c_int) -> Self {
-        let mut __bindgen_tmp = ::std::mem::MaybeUninit::uninit();
-        X_X(__bindgen_tmp.as_mut_ptr(), x);
-        __bindgen_tmp.assume_init()
+        unsafe {
+            let mut __bindgen_tmp = ::std::mem::MaybeUninit::uninit();
+            X_X(__bindgen_tmp.as_mut_ptr(), x);
+            __bindgen_tmp.assume_init()
+        }
     }
 }
 extern crate libloading;
@@ -81,7 +83,7 @@ impl TestLib {
         P: AsRef<::std::ffi::OsStr>,
     {
         let library = ::libloading::Library::new(path)?;
-        Self::from_library(library)
+        unsafe { Self::from_library(library) }
     }
     pub unsafe fn from_library<L>(
         library: L,
@@ -90,8 +92,8 @@ impl TestLib {
         L: Into<::libloading::Library>,
     {
         let __library = library.into();
-        let foo = __library.get(b"foo\0").map(|sym| *sym);
-        let bar = __library.get(b"bar\0").map(|sym| *sym);
+        let foo = unsafe { __library.get(b"foo\0") }.map(|sym| *sym);
+        let bar = unsafe { __library.get(b"bar\0") }.map(|sym| *sym);
         Ok(TestLib {
             __library,
             foo,
@@ -102,12 +104,16 @@ impl TestLib {
         &self,
         x: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int {
-        (self.foo.as_ref().expect("Expected function, got error."))(x)
+        unsafe {
+            (self.foo.as_ref().expect("Expected function, got error."))(x)
+        }
     }
     pub unsafe fn bar(
         &self,
         x: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int {
-        (self.bar.as_ref().expect("Expected function, got error."))(x)
+        unsafe {
+            (self.bar.as_ref().expect("Expected function, got error."))(x)
+        }
     }
 }

--- a/bindgen-tests/tests/expectations/tests/dynamic_loading_with_class.rs
+++ b/bindgen-tests/tests/expectations/tests/dynamic_loading_with_class.rs
@@ -46,17 +46,19 @@ extern "C" {
 impl A {
     #[inline]
     pub unsafe fn some_function(&mut self) {
-        A_some_function(self)
+        unsafe { A_some_function(self) }
     }
     #[inline]
     pub unsafe fn some_other_function(&mut self) {
-        A_some_other_function(self)
+        unsafe { A_some_other_function(self) }
     }
     #[inline]
     pub unsafe fn new(x: ::std::os::raw::c_int) -> Self {
-        let mut __bindgen_tmp = ::std::mem::MaybeUninit::uninit();
-        A_A(__bindgen_tmp.as_mut_ptr(), x);
-        __bindgen_tmp.assume_init()
+        unsafe {
+            let mut __bindgen_tmp = ::std::mem::MaybeUninit::uninit();
+            A_A(__bindgen_tmp.as_mut_ptr(), x);
+            __bindgen_tmp.assume_init()
+        }
     }
 }
 extern crate libloading;
@@ -76,7 +78,7 @@ impl TestLib {
         P: AsRef<::std::ffi::OsStr>,
     {
         let library = ::libloading::Library::new(path)?;
-        Self::from_library(library)
+        unsafe { Self::from_library(library) }
     }
     pub unsafe fn from_library<L>(
         library: L,
@@ -85,8 +87,8 @@ impl TestLib {
         L: Into<::libloading::Library>,
     {
         let __library = library.into();
-        let foo = __library.get(b"foo\0").map(|sym| *sym);
-        let bar = __library.get(b"bar\0").map(|sym| *sym);
+        let foo = unsafe { __library.get(b"foo\0") }.map(|sym| *sym);
+        let bar = unsafe { __library.get(b"bar\0") }.map(|sym| *sym);
         Ok(TestLib {
             __library,
             foo,
@@ -97,9 +99,11 @@ impl TestLib {
         &self,
         x: *mut ::std::os::raw::c_void,
     ) -> ::std::os::raw::c_int {
-        (self.foo.as_ref().expect("Expected function, got error."))(x)
+        unsafe {
+            (self.foo.as_ref().expect("Expected function, got error."))(x)
+        }
     }
     pub unsafe fn bar(&self) -> () {
-        (self.bar.as_ref().expect("Expected function, got error."))()
+        unsafe { (self.bar.as_ref().expect("Expected function, got error."))() }
     }
 }

--- a/bindgen-tests/tests/expectations/tests/gen-constructors.rs
+++ b/bindgen-tests/tests/expectations/tests/gen-constructors.rs
@@ -30,8 +30,10 @@ extern "C" {
 impl Foo {
     #[inline]
     pub unsafe fn new(a: ::std::os::raw::c_int) -> Self {
-        let mut __bindgen_tmp = ::std::mem::MaybeUninit::uninit();
-        Foo_Foo(__bindgen_tmp.as_mut_ptr(), a);
-        __bindgen_tmp.assume_init()
+        unsafe {
+            let mut __bindgen_tmp = ::std::mem::MaybeUninit::uninit();
+            Foo_Foo(__bindgen_tmp.as_mut_ptr(), a);
+            __bindgen_tmp.assume_init()
+        }
     }
 }

--- a/bindgen-tests/tests/expectations/tests/gen-destructors.rs
+++ b/bindgen-tests/tests/expectations/tests/gen-destructors.rs
@@ -38,6 +38,6 @@ extern "C" {
 impl Foo {
     #[inline]
     pub unsafe fn destruct(&mut self) {
-        Foo_Foo_destructor(self)
+        unsafe { Foo_Foo_destructor(self) }
     }
 }

--- a/bindgen-tests/tests/expectations/tests/generate-inline.rs
+++ b/bindgen-tests/tests/expectations/tests/generate-inline.rs
@@ -30,7 +30,7 @@ extern "C" {
 impl Foo {
     #[inline]
     pub unsafe fn bar() -> ::std::os::raw::c_int {
-        Foo_bar()
+        unsafe { Foo_bar() }
     }
 }
 extern "C" {

--- a/bindgen-tests/tests/expectations/tests/incomplete-array-padding.rs
+++ b/bindgen-tests/tests/expectations/tests/incomplete-array-padding.rs
@@ -109,11 +109,11 @@ impl<T> __IncompleteArrayField<T> {
     }
     #[inline]
     pub unsafe fn as_slice(&self, len: usize) -> &[T] {
-        ::std::slice::from_raw_parts(self.as_ptr(), len)
+        unsafe { ::std::slice::from_raw_parts(self.as_ptr(), len) }
     }
     #[inline]
     pub unsafe fn as_mut_slice(&mut self, len: usize) -> &mut [T] {
-        ::std::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
+        unsafe { ::std::slice::from_raw_parts_mut(self.as_mut_ptr(), len) }
     }
 }
 impl<T> ::std::fmt::Debug for __IncompleteArrayField<T> {

--- a/bindgen-tests/tests/expectations/tests/issue-2019.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-2019.rs
@@ -38,7 +38,7 @@ extern "C" {
 impl A {
     #[inline]
     pub unsafe fn make() -> A {
-        make()
+        unsafe { make() }
     }
 }
 #[repr(C)]
@@ -74,6 +74,6 @@ extern "C" {
 impl B {
     #[inline]
     pub unsafe fn make() -> B {
-        make1()
+        unsafe { make1() }
     }
 }

--- a/bindgen-tests/tests/expectations/tests/issue-410.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-410.rs
@@ -37,7 +37,7 @@ pub mod root {
         impl Value {
             #[inline]
             pub unsafe fn a(&mut self, arg1: root::JSWhyMagic) {
-                Value_a(self, arg1)
+                unsafe { Value_a(self, arg1) }
             }
         }
     }

--- a/bindgen-tests/tests/expectations/tests/issue-447.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-447.rs
@@ -65,12 +65,14 @@ pub mod root {
         pub unsafe fn new(
             arg1: root::mozilla::detail::GuardObjectNotifier,
         ) -> Self {
-            let mut __bindgen_tmp = ::std::mem::MaybeUninit::uninit();
-            JSAutoCompartment_JSAutoCompartment(
-                __bindgen_tmp.as_mut_ptr(),
-                arg1,
-            );
-            __bindgen_tmp.assume_init()
+            unsafe {
+                let mut __bindgen_tmp = ::std::mem::MaybeUninit::uninit();
+                JSAutoCompartment_JSAutoCompartment(
+                    __bindgen_tmp.as_mut_ptr(),
+                    arg1,
+                );
+                __bindgen_tmp.assume_init()
+            }
         }
     }
 }

--- a/bindgen-tests/tests/expectations/tests/issue-493.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-493.rs
@@ -14,11 +14,11 @@ impl<T> __BindgenUnionField<T> {
     }
     #[inline]
     pub unsafe fn as_ref(&self) -> &T {
-        ::std::mem::transmute(self)
+        unsafe { ::std::mem::transmute(self) }
     }
     #[inline]
     pub unsafe fn as_mut(&mut self) -> &mut T {
-        ::std::mem::transmute(self)
+        unsafe { ::std::mem::transmute(self) }
     }
 }
 impl<T> ::std::default::Default for __BindgenUnionField<T> {

--- a/bindgen-tests/tests/expectations/tests/issue-493_1_0.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-493_1_0.rs
@@ -14,11 +14,11 @@ impl<T> __BindgenUnionField<T> {
     }
     #[inline]
     pub unsafe fn as_ref(&self) -> &T {
-        ::std::mem::transmute(self)
+        unsafe { ::std::mem::transmute(self) }
     }
     #[inline]
     pub unsafe fn as_mut(&mut self) -> &mut T {
-        ::std::mem::transmute(self)
+        unsafe { ::std::mem::transmute(self) }
     }
 }
 impl<T> ::std::default::Default for __BindgenUnionField<T> {

--- a/bindgen-tests/tests/expectations/tests/issue-643-inner-struct.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-643-inner-struct.rs
@@ -23,11 +23,11 @@ impl<T> __IncompleteArrayField<T> {
     }
     #[inline]
     pub unsafe fn as_slice(&self, len: usize) -> &[T] {
-        ::std::slice::from_raw_parts(self.as_ptr(), len)
+        unsafe { ::std::slice::from_raw_parts(self.as_ptr(), len) }
     }
     #[inline]
     pub unsafe fn as_mut_slice(&mut self, len: usize) -> &mut [T] {
-        ::std::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
+        unsafe { ::std::slice::from_raw_parts_mut(self.as_mut_ptr(), len) }
     }
 }
 impl<T> ::std::fmt::Debug for __IncompleteArrayField<T> {

--- a/bindgen-tests/tests/expectations/tests/issue-807-opaque-types-methods-being-generated.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-807-opaque-types-methods-being-generated.rs
@@ -89,13 +89,15 @@ extern "C" {
 impl Opaque {
     #[inline]
     pub unsafe fn eleven_out_of_ten(&mut self) -> SuchWow {
-        Opaque_eleven_out_of_ten(self)
+        unsafe { Opaque_eleven_out_of_ten(self) }
     }
     #[inline]
     pub unsafe fn new(pup: Pupper) -> Self {
-        let mut __bindgen_tmp = ::std::mem::MaybeUninit::uninit();
-        Opaque_Opaque(__bindgen_tmp.as_mut_ptr(), pup);
-        __bindgen_tmp.assume_init()
+        unsafe {
+            let mut __bindgen_tmp = ::std::mem::MaybeUninit::uninit();
+            Opaque_Opaque(__bindgen_tmp.as_mut_ptr(), pup);
+            __bindgen_tmp.assume_init()
+        }
     }
 }
 extern "C" {

--- a/bindgen-tests/tests/expectations/tests/jsval_layout_opaque_1_0.rs
+++ b/bindgen-tests/tests/expectations/tests/jsval_layout_opaque_1_0.rs
@@ -100,11 +100,11 @@ impl<T> __BindgenUnionField<T> {
     }
     #[inline]
     pub unsafe fn as_ref(&self) -> &T {
-        ::std::mem::transmute(self)
+        unsafe { ::std::mem::transmute(self) }
     }
     #[inline]
     pub unsafe fn as_mut(&mut self) -> &mut T {
-        ::std::mem::transmute(self)
+        unsafe { ::std::mem::transmute(self) }
     }
 }
 impl<T> ::std::default::Default for __BindgenUnionField<T> {

--- a/bindgen-tests/tests/expectations/tests/layout_align.rs
+++ b/bindgen-tests/tests/expectations/tests/layout_align.rs
@@ -109,11 +109,11 @@ impl<T> __IncompleteArrayField<T> {
     }
     #[inline]
     pub unsafe fn as_slice(&self, len: usize) -> &[T] {
-        ::std::slice::from_raw_parts(self.as_ptr(), len)
+        unsafe { ::std::slice::from_raw_parts(self.as_ptr(), len) }
     }
     #[inline]
     pub unsafe fn as_mut_slice(&mut self, len: usize) -> &mut [T] {
-        ::std::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
+        unsafe { ::std::slice::from_raw_parts_mut(self.as_mut_ptr(), len) }
     }
 }
 impl<T> ::std::fmt::Debug for __IncompleteArrayField<T> {

--- a/bindgen-tests/tests/expectations/tests/layout_eth_conf_1_0.rs
+++ b/bindgen-tests/tests/expectations/tests/layout_eth_conf_1_0.rs
@@ -100,11 +100,11 @@ impl<T> __BindgenUnionField<T> {
     }
     #[inline]
     pub unsafe fn as_ref(&self) -> &T {
-        ::std::mem::transmute(self)
+        unsafe { ::std::mem::transmute(self) }
     }
     #[inline]
     pub unsafe fn as_mut(&mut self) -> &mut T {
-        ::std::mem::transmute(self)
+        unsafe { ::std::mem::transmute(self) }
     }
 }
 impl<T> ::std::default::Default for __BindgenUnionField<T> {

--- a/bindgen-tests/tests/expectations/tests/layout_large_align_field.rs
+++ b/bindgen-tests/tests/expectations/tests/layout_large_align_field.rs
@@ -23,11 +23,11 @@ impl<T> __IncompleteArrayField<T> {
     }
     #[inline]
     pub unsafe fn as_slice(&self, len: usize) -> &[T] {
-        ::std::slice::from_raw_parts(self.as_ptr(), len)
+        unsafe { ::std::slice::from_raw_parts(self.as_ptr(), len) }
     }
     #[inline]
     pub unsafe fn as_mut_slice(&mut self, len: usize) -> &mut [T] {
-        ::std::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
+        unsafe { ::std::slice::from_raw_parts_mut(self.as_mut_ptr(), len) }
     }
 }
 impl<T> ::std::fmt::Debug for __IncompleteArrayField<T> {

--- a/bindgen-tests/tests/expectations/tests/layout_mbuf_1_0.rs
+++ b/bindgen-tests/tests/expectations/tests/layout_mbuf_1_0.rs
@@ -100,11 +100,11 @@ impl<T> __BindgenUnionField<T> {
     }
     #[inline]
     pub unsafe fn as_ref(&self) -> &T {
-        ::std::mem::transmute(self)
+        unsafe { ::std::mem::transmute(self) }
     }
     #[inline]
     pub unsafe fn as_mut(&mut self) -> &mut T {
-        ::std::mem::transmute(self)
+        unsafe { ::std::mem::transmute(self) }
     }
 }
 impl<T> ::std::default::Default for __BindgenUnionField<T> {

--- a/bindgen-tests/tests/expectations/tests/libclang-5/objc_template.rs
+++ b/bindgen-tests/tests/expectations/tests/libclang-5/objc_template.rs
@@ -30,7 +30,7 @@ pub trait IFoo<ObjectType: 'static>: Sized + std::ops::Deref {
     where
         <Self as std::ops::Deref>::Target: objc::Message + Sized,
     {
-        msg_send!(*self, get)
+        unsafe { msg_send!(*self, get) }
     }
 }
 #[repr(transparent)]
@@ -59,6 +59,6 @@ pub trait IFooMultiGeneric<KeyType: 'static, ObjectType: 'static>:
     where
         <Self as std::ops::Deref>::Target: objc::Message + Sized,
     {
-        msg_send!(*self, objectForKey: key)
+        unsafe { msg_send!(*self, objectForKey: key) }
     }
 }

--- a/bindgen-tests/tests/expectations/tests/libclang-9/class.rs
+++ b/bindgen-tests/tests/expectations/tests/libclang-9/class.rs
@@ -23,11 +23,11 @@ impl<T> __IncompleteArrayField<T> {
     }
     #[inline]
     pub unsafe fn as_slice(&self, len: usize) -> &[T] {
-        ::std::slice::from_raw_parts(self.as_ptr(), len)
+        unsafe { ::std::slice::from_raw_parts(self.as_ptr(), len) }
     }
     #[inline]
     pub unsafe fn as_mut_slice(&mut self, len: usize) -> &mut [T] {
-        ::std::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
+        unsafe { ::std::slice::from_raw_parts_mut(self.as_mut_ptr(), len) }
     }
 }
 impl<T> ::std::fmt::Debug for __IncompleteArrayField<T> {
@@ -674,18 +674,18 @@ extern "C" {
 impl RealAbstractionWithTonsOfMethods {
     #[inline]
     pub unsafe fn bar(&self) {
-        RealAbstractionWithTonsOfMethods_bar(self)
+        unsafe { RealAbstractionWithTonsOfMethods_bar(self) }
     }
     #[inline]
     pub unsafe fn bar1(&mut self) {
-        RealAbstractionWithTonsOfMethods_bar1(self)
+        unsafe { RealAbstractionWithTonsOfMethods_bar1(self) }
     }
     #[inline]
     pub unsafe fn bar2(&mut self, foo: ::std::os::raw::c_int) {
-        RealAbstractionWithTonsOfMethods_bar2(self, foo)
+        unsafe { RealAbstractionWithTonsOfMethods_bar2(self, foo) }
     }
     #[inline]
     pub unsafe fn sta() {
-        RealAbstractionWithTonsOfMethods_sta()
+        unsafe { RealAbstractionWithTonsOfMethods_sta() }
     }
 }

--- a/bindgen-tests/tests/expectations/tests/libclang-9/class_1_0.rs
+++ b/bindgen-tests/tests/expectations/tests/libclang-9/class_1_0.rs
@@ -23,11 +23,11 @@ impl<T> __IncompleteArrayField<T> {
     }
     #[inline]
     pub unsafe fn as_slice(&self, len: usize) -> &[T] {
-        ::std::slice::from_raw_parts(self.as_ptr(), len)
+        unsafe { ::std::slice::from_raw_parts(self.as_ptr(), len) }
     }
     #[inline]
     pub unsafe fn as_mut_slice(&mut self, len: usize) -> &mut [T] {
-        ::std::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
+        unsafe { ::std::slice::from_raw_parts_mut(self.as_mut_ptr(), len) }
     }
 }
 impl<T> ::std::fmt::Debug for __IncompleteArrayField<T> {
@@ -44,11 +44,11 @@ impl<T> __BindgenUnionField<T> {
     }
     #[inline]
     pub unsafe fn as_ref(&self) -> &T {
-        ::std::mem::transmute(self)
+        unsafe { ::std::mem::transmute(self) }
     }
     #[inline]
     pub unsafe fn as_mut(&mut self) -> &mut T {
-        ::std::mem::transmute(self)
+        unsafe { ::std::mem::transmute(self) }
     }
 }
 impl<T> ::std::default::Default for __BindgenUnionField<T> {
@@ -725,18 +725,18 @@ impl Clone for RealAbstractionWithTonsOfMethods {
 impl RealAbstractionWithTonsOfMethods {
     #[inline]
     pub unsafe fn bar(&self) {
-        RealAbstractionWithTonsOfMethods_bar(self)
+        unsafe { RealAbstractionWithTonsOfMethods_bar(self) }
     }
     #[inline]
     pub unsafe fn bar1(&mut self) {
-        RealAbstractionWithTonsOfMethods_bar1(self)
+        unsafe { RealAbstractionWithTonsOfMethods_bar1(self) }
     }
     #[inline]
     pub unsafe fn bar2(&mut self, foo: ::std::os::raw::c_int) {
-        RealAbstractionWithTonsOfMethods_bar2(self, foo)
+        unsafe { RealAbstractionWithTonsOfMethods_bar2(self, foo) }
     }
     #[inline]
     pub unsafe fn sta() {
-        RealAbstractionWithTonsOfMethods_sta()
+        unsafe { RealAbstractionWithTonsOfMethods_sta() }
     }
 }

--- a/bindgen-tests/tests/expectations/tests/libclang-9/derive-hash-struct-with-incomplete-array.rs
+++ b/bindgen-tests/tests/expectations/tests/libclang-9/derive-hash-struct-with-incomplete-array.rs
@@ -23,11 +23,11 @@ impl<T> __IncompleteArrayField<T> {
     }
     #[inline]
     pub unsafe fn as_slice(&self, len: usize) -> &[T] {
-        ::std::slice::from_raw_parts(self.as_ptr(), len)
+        unsafe { ::std::slice::from_raw_parts(self.as_ptr(), len) }
     }
     #[inline]
     pub unsafe fn as_mut_slice(&mut self, len: usize) -> &mut [T] {
-        ::std::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
+        unsafe { ::std::slice::from_raw_parts_mut(self.as_mut_ptr(), len) }
     }
 }
 impl<T> ::std::fmt::Debug for __IncompleteArrayField<T> {

--- a/bindgen-tests/tests/expectations/tests/libclang-9/incomplete-array-padding.rs
+++ b/bindgen-tests/tests/expectations/tests/libclang-9/incomplete-array-padding.rs
@@ -109,11 +109,11 @@ impl<T> __IncompleteArrayField<T> {
     }
     #[inline]
     pub unsafe fn as_slice(&self, len: usize) -> &[T] {
-        ::std::slice::from_raw_parts(self.as_ptr(), len)
+        unsafe { ::std::slice::from_raw_parts(self.as_ptr(), len) }
     }
     #[inline]
     pub unsafe fn as_mut_slice(&mut self, len: usize) -> &mut [T] {
-        ::std::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
+        unsafe { ::std::slice::from_raw_parts_mut(self.as_mut_ptr(), len) }
     }
 }
 impl<T> ::std::fmt::Debug for __IncompleteArrayField<T> {

--- a/bindgen-tests/tests/expectations/tests/libclang-9/issue-643-inner-struct.rs
+++ b/bindgen-tests/tests/expectations/tests/libclang-9/issue-643-inner-struct.rs
@@ -23,11 +23,11 @@ impl<T> __IncompleteArrayField<T> {
     }
     #[inline]
     pub unsafe fn as_slice(&self, len: usize) -> &[T] {
-        ::std::slice::from_raw_parts(self.as_ptr(), len)
+        unsafe { ::std::slice::from_raw_parts(self.as_ptr(), len) }
     }
     #[inline]
     pub unsafe fn as_mut_slice(&mut self, len: usize) -> &mut [T] {
-        ::std::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
+        unsafe { ::std::slice::from_raw_parts_mut(self.as_mut_ptr(), len) }
     }
 }
 impl<T> ::std::fmt::Debug for __IncompleteArrayField<T> {

--- a/bindgen-tests/tests/expectations/tests/libclang-9/layout_align.rs
+++ b/bindgen-tests/tests/expectations/tests/libclang-9/layout_align.rs
@@ -109,11 +109,11 @@ impl<T> __IncompleteArrayField<T> {
     }
     #[inline]
     pub unsafe fn as_slice(&self, len: usize) -> &[T] {
-        ::std::slice::from_raw_parts(self.as_ptr(), len)
+        unsafe { ::std::slice::from_raw_parts(self.as_ptr(), len) }
     }
     #[inline]
     pub unsafe fn as_mut_slice(&mut self, len: usize) -> &mut [T] {
-        ::std::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
+        unsafe { ::std::slice::from_raw_parts_mut(self.as_mut_ptr(), len) }
     }
 }
 impl<T> ::std::fmt::Debug for __IncompleteArrayField<T> {
@@ -151,56 +151,56 @@ fn bindgen_test_layout_rte_kni_fifo() {
         concat!("Alignment of ", stringify!(rte_kni_fifo))
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).write) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_kni_fifo),
-            "::",
-            stringify!(write)
-        )
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).read) as usize - ptr as usize },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_kni_fifo),
-            "::",
-            stringify!(read)
-        )
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).len) as usize - ptr as usize },
-        8usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_kni_fifo),
-            "::",
-            stringify!(len)
-        )
-    );
-    assert_eq!(
-        unsafe {
-            ::std::ptr::addr_of!((*ptr).elem_size) as usize - ptr as usize
-        },
-        12usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_kni_fifo),
-            "::",
-            stringify!(elem_size)
-        )
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).buffer) as usize - ptr as usize },
-        16usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_kni_fifo),
-            "::",
-            stringify!(buffer)
-        )
+       unsafe { ::std::ptr::addr_of!((*ptr).write) as usize - ptr as usize },
+       0usize,
+       concat!(
+           "Offset of field: ",
+           stringify!(rte_kni_fifo),
+           "::",
+           stringify!(write)
+       )
+   );
+   assert_eq!(
+       unsafe { ::std::ptr::addr_of!((*ptr).read) as usize - ptr as usize },
+       4usize,
+       concat!(
+           "Offset of field: ",
+           stringify!(rte_kni_fifo),
+           "::",
+           stringify!(read)
+       )
+   );
+   assert_eq!(
+       unsafe { ::std::ptr::addr_of!((*ptr).len) as usize - ptr as usize },
+       8usize,
+       concat!(
+           "Offset of field: ",
+           stringify!(rte_kni_fifo),
+           "::",
+           stringify!(len)
+       )
+   );
+   assert_eq!(
+       unsafe {
+           ::std::ptr::addr_of!((*ptr).elem_size) as usize - ptr as usize
+       },
+       12usize,
+       concat!(
+           "Offset of field: ",
+           stringify!(rte_kni_fifo),
+           "::",
+           stringify!(elem_size)
+       )
+   );
+   assert_eq!(
+       unsafe { ::std::ptr::addr_of!((*ptr).buffer) as usize - ptr as usize },
+       16usize,
+       concat!(
+           "Offset of field: ",
+           stringify!(rte_kni_fifo),
+           "::",
+           stringify!(buffer)
+       )
     );
 }
 impl Default for rte_kni_fifo {

--- a/bindgen-tests/tests/expectations/tests/libclang-9/objc_template.rs
+++ b/bindgen-tests/tests/expectations/tests/libclang-9/objc_template.rs
@@ -30,7 +30,7 @@ pub trait IFoo<ObjectType: 'static>: Sized + std::ops::Deref {
     where
         <Self as std::ops::Deref>::Target: objc::Message + Sized,
     {
-        msg_send!(*self, get)
+        unsafe { msg_send!(*self, get) }
     }
 }
 #[repr(transparent)]
@@ -59,6 +59,6 @@ pub trait IFooMultiGeneric<KeyType: 'static, ObjectType: 'static>:
     where
         <Self as std::ops::Deref>::Target: objc::Message + Sized,
     {
-        msg_send!(*self, objectForKey: key)
+        unsafe { msg_send!(*self, objectForKey: key) }
     }
 }

--- a/bindgen-tests/tests/expectations/tests/libclang-9/zero-sized-array.rs
+++ b/bindgen-tests/tests/expectations/tests/libclang-9/zero-sized-array.rs
@@ -23,11 +23,11 @@ impl<T> __IncompleteArrayField<T> {
     }
     #[inline]
     pub unsafe fn as_slice(&self, len: usize) -> &[T] {
-        ::std::slice::from_raw_parts(self.as_ptr(), len)
+        unsafe { ::std::slice::from_raw_parts(self.as_ptr(), len) }
     }
     #[inline]
     pub unsafe fn as_mut_slice(&mut self, len: usize) -> &mut [T] {
-        ::std::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
+        unsafe { ::std::slice::from_raw_parts_mut(self.as_mut_ptr(), len) }
     }
 }
 impl<T> ::std::fmt::Debug for __IncompleteArrayField<T> {

--- a/bindgen-tests/tests/expectations/tests/method-mangling.rs
+++ b/bindgen-tests/tests/expectations/tests/method-mangling.rs
@@ -30,6 +30,6 @@ extern "C" {
 impl Foo {
     #[inline]
     pub unsafe fn type_(&mut self) -> ::std::os::raw::c_int {
-        Foo_type(self)
+        unsafe { Foo_type(self) }
     }
 }

--- a/bindgen-tests/tests/expectations/tests/objc_allowlist.rs
+++ b/bindgen-tests/tests/expectations/tests/objc_allowlist.rs
@@ -14,13 +14,13 @@ pub trait PSomeProtocol: Sized + std::ops::Deref {
     where
         <Self as std::ops::Deref>::Target: objc::Message + Sized,
     {
-        msg_send!(*self, protocolMethod)
+        unsafe { msg_send!(*self, protocolMethod) }
     }
     unsafe fn protocolClassMethod()
     where
         <Self as std::ops::Deref>::Target: objc::Message + Sized,
     {
-        msg_send!(class!(SomeProtocol), protocolClassMethod)
+        unsafe { msg_send!(class!(SomeProtocol), protocolClassMethod) }
     }
 }
 #[repr(transparent)]
@@ -45,13 +45,13 @@ pub trait IAllowlistMe: Sized + std::ops::Deref {
     where
         <Self as std::ops::Deref>::Target: objc::Message + Sized,
     {
-        msg_send!(*self, method)
+        unsafe { msg_send!(*self, method) }
     }
     unsafe fn classMethod()
     where
         <Self as std::ops::Deref>::Target: objc::Message + Sized,
     {
-        msg_send!(class!(AllowlistMe), classMethod)
+        unsafe { msg_send!(class!(AllowlistMe), classMethod) }
     }
 }
 impl AllowlistMe_InterestingCategory for AllowlistMe {}

--- a/bindgen-tests/tests/expectations/tests/objc_blocklist.rs
+++ b/bindgen-tests/tests/expectations/tests/objc_blocklist.rs
@@ -31,12 +31,12 @@ pub trait ISomeClass: Sized + std::ops::Deref {
     where
         <Self as std::ops::Deref>::Target: objc::Message + Sized,
     {
-        msg_send!(*self, ambiguouslyBlockedMethod)
+        unsafe { msg_send!(*self, ambiguouslyBlockedMethod) }
     }
     unsafe fn instanceMethod(&self)
     where
         <Self as std::ops::Deref>::Target: objc::Message + Sized,
     {
-        msg_send!(*self, instanceMethod)
+        unsafe { msg_send!(*self, instanceMethod) }
     }
 }

--- a/bindgen-tests/tests/expectations/tests/objc_category.rs
+++ b/bindgen-tests/tests/expectations/tests/objc_category.rs
@@ -30,7 +30,7 @@ pub trait IFoo: Sized + std::ops::Deref {
     where
         <Self as std::ops::Deref>::Target: objc::Message + Sized,
     {
-        msg_send!(*self, method)
+        unsafe { msg_send!(*self, method) }
     }
 }
 impl Foo_BarCategory for Foo {}
@@ -39,6 +39,6 @@ pub trait Foo_BarCategory: Sized + std::ops::Deref {
     where
         <Self as std::ops::Deref>::Target: objc::Message + Sized,
     {
-        msg_send!(*self, categoryMethod)
+        unsafe { msg_send!(*self, categoryMethod) }
     }
 }

--- a/bindgen-tests/tests/expectations/tests/objc_class.rs
+++ b/bindgen-tests/tests/expectations/tests/objc_class.rs
@@ -33,6 +33,6 @@ pub trait IFoo: Sized + std::ops::Deref {
     where
         <Self as std::ops::Deref>::Target: objc::Message + Sized,
     {
-        msg_send!(*self, method)
+        unsafe { msg_send!(*self, method) }
     }
 }

--- a/bindgen-tests/tests/expectations/tests/objc_class_method.rs
+++ b/bindgen-tests/tests/expectations/tests/objc_class_method.rs
@@ -30,31 +30,31 @@ pub trait IFoo: Sized + std::ops::Deref {
     where
         <Self as std::ops::Deref>::Target: objc::Message + Sized,
     {
-        msg_send!(class!(Foo), method)
+        unsafe { msg_send!(class!(Foo), method) }
     }
     unsafe fn methodWithInt_(foo: ::std::os::raw::c_int)
     where
         <Self as std::ops::Deref>::Target: objc::Message + Sized,
     {
-        msg_send!(class!(Foo), methodWithInt: foo)
+        unsafe { msg_send!(class!(Foo), methodWithInt: foo) }
     }
     unsafe fn methodWithFoo_(foo: Foo)
     where
         <Self as std::ops::Deref>::Target: objc::Message + Sized,
     {
-        msg_send!(class!(Foo), methodWithFoo: foo)
+        unsafe { msg_send!(class!(Foo), methodWithFoo: foo) }
     }
     unsafe fn methodReturningInt() -> ::std::os::raw::c_int
     where
         <Self as std::ops::Deref>::Target: objc::Message + Sized,
     {
-        msg_send!(class!(Foo), methodReturningInt)
+        unsafe { msg_send!(class!(Foo), methodReturningInt) }
     }
     unsafe fn methodReturningFoo() -> Foo
     where
         <Self as std::ops::Deref>::Target: objc::Message + Sized,
     {
-        msg_send!(class!(Foo), methodReturningFoo)
+        unsafe { msg_send!(class!(Foo), methodReturningFoo) }
     }
     unsafe fn methodWithArg1_andArg2_andArg3_(
         intvalue: ::std::os::raw::c_int,
@@ -63,6 +63,8 @@ pub trait IFoo: Sized + std::ops::Deref {
     ) where
         <Self as std::ops::Deref>::Target: objc::Message + Sized,
     {
-        msg_send ! (class ! (Foo) , methodWithArg1 : intvalue andArg2 : ptr andArg3 : floatvalue)
+        unsafe {
+            msg_send ! (class ! (Foo) , methodWithArg1 : intvalue andArg2 : ptr andArg3 : floatvalue)
+        }
     }
 }

--- a/bindgen-tests/tests/expectations/tests/objc_method.rs
+++ b/bindgen-tests/tests/expectations/tests/objc_method.rs
@@ -30,31 +30,31 @@ pub trait IFoo: Sized + std::ops::Deref {
     where
         <Self as std::ops::Deref>::Target: objc::Message + Sized,
     {
-        msg_send!(*self, method)
+        unsafe { msg_send!(*self, method) }
     }
     unsafe fn methodWithInt_(&self, foo: ::std::os::raw::c_int)
     where
         <Self as std::ops::Deref>::Target: objc::Message + Sized,
     {
-        msg_send!(*self, methodWithInt: foo)
+        unsafe { msg_send!(*self, methodWithInt: foo) }
     }
     unsafe fn methodWithFoo_(&self, foo: Foo)
     where
         <Self as std::ops::Deref>::Target: objc::Message + Sized,
     {
-        msg_send!(*self, methodWithFoo: foo)
+        unsafe { msg_send!(*self, methodWithFoo: foo) }
     }
     unsafe fn methodReturningInt(&self) -> ::std::os::raw::c_int
     where
         <Self as std::ops::Deref>::Target: objc::Message + Sized,
     {
-        msg_send!(*self, methodReturningInt)
+        unsafe { msg_send!(*self, methodReturningInt) }
     }
     unsafe fn methodReturningFoo(&self) -> Foo
     where
         <Self as std::ops::Deref>::Target: objc::Message + Sized,
     {
-        msg_send!(*self, methodReturningFoo)
+        unsafe { msg_send!(*self, methodReturningFoo) }
     }
     unsafe fn methodWithArg1_andArg2_andArg3_(
         &self,
@@ -64,7 +64,9 @@ pub trait IFoo: Sized + std::ops::Deref {
     ) where
         <Self as std::ops::Deref>::Target: objc::Message + Sized,
     {
-        msg_send ! (* self , methodWithArg1 : intvalue andArg2 : ptr andArg3 : floatvalue)
+        unsafe {
+            msg_send ! (* self , methodWithArg1 : intvalue andArg2 : ptr andArg3 : floatvalue)
+        }
     }
     unsafe fn methodWithAndWithoutKeywords_arg2Name__arg4Name_(
         &self,
@@ -76,7 +78,9 @@ pub trait IFoo: Sized + std::ops::Deref {
     where
         <Self as std::ops::Deref>::Target: objc::Message + Sized,
     {
-        msg_send ! (* self , methodWithAndWithoutKeywords : arg1 arg2Name : arg2 arg3 : arg3 arg4Name : arg4)
+        unsafe {
+            msg_send ! (* self , methodWithAndWithoutKeywords : arg1 arg2Name : arg2 arg3 : arg3 arg4Name : arg4)
+        }
     }
 }
 pub type instancetype = id;

--- a/bindgen-tests/tests/expectations/tests/objc_method_clash.rs
+++ b/bindgen-tests/tests/expectations/tests/objc_method_clash.rs
@@ -30,12 +30,12 @@ pub trait IFoo: Sized + std::ops::Deref {
     where
         <Self as std::ops::Deref>::Target: objc::Message + Sized,
     {
-        msg_send!(*self, foo)
+        unsafe { msg_send!(*self, foo) }
     }
     unsafe fn class_foo()
     where
         <Self as std::ops::Deref>::Target: objc::Message + Sized,
     {
-        msg_send!(class!(Foo), foo)
+        unsafe { msg_send!(class!(Foo), foo) }
     }
 }

--- a/bindgen-tests/tests/expectations/tests/objc_pointer_return_types.rs
+++ b/bindgen-tests/tests/expectations/tests/objc_pointer_return_types.rs
@@ -47,12 +47,12 @@ pub trait IFoo: Sized + std::ops::Deref {
     where
         <Self as std::ops::Deref>::Target: objc::Message + Sized,
     {
-        msg_send!(*self, methodUsingBar: my_bar)
+        unsafe { msg_send!(*self, methodUsingBar: my_bar) }
     }
     unsafe fn methodReturningBar() -> Bar
     where
         <Self as std::ops::Deref>::Target: objc::Message + Sized,
     {
-        msg_send!(class!(Foo), methodReturningBar)
+        unsafe { msg_send!(class!(Foo), methodReturningBar) }
     }
 }

--- a/bindgen-tests/tests/expectations/tests/objc_property_fnptr.rs
+++ b/bindgen-tests/tests/expectations/tests/objc_property_fnptr.rs
@@ -38,7 +38,7 @@ pub trait IFoo: Sized + std::ops::Deref {
     where
         <Self as std::ops::Deref>::Target: objc::Message + Sized,
     {
-        msg_send!(*self, func)
+        unsafe { msg_send!(*self, func) }
     }
     unsafe fn setFunc_(
         &self,
@@ -52,6 +52,6 @@ pub trait IFoo: Sized + std::ops::Deref {
     ) where
         <Self as std::ops::Deref>::Target: objc::Message + Sized,
     {
-        msg_send!(*self, setFunc: func)
+        unsafe { msg_send!(*self, setFunc: func) }
     }
 }

--- a/bindgen-tests/tests/expectations/tests/parm-union.rs
+++ b/bindgen-tests/tests/expectations/tests/parm-union.rs
@@ -30,7 +30,7 @@ extern "C" {
 impl Struct {
     #[inline]
     pub unsafe fn Function(&mut self, arg1: *mut Union) {
-        Struct_Function(self, arg1)
+        unsafe { Struct_Function(self, arg1) }
     }
 }
 #[repr(C)]

--- a/bindgen-tests/tests/expectations/tests/public-dtor.rs
+++ b/bindgen-tests/tests/expectations/tests/public-dtor.rs
@@ -30,6 +30,6 @@ extern "C" {
 impl cv_String {
     #[inline]
     pub unsafe fn destruct(&mut self) {
-        cv_String_String_destructor(self)
+        unsafe { cv_String_String_destructor(self) }
     }
 }

--- a/bindgen-tests/tests/expectations/tests/struct_with_anon_union_1_0.rs
+++ b/bindgen-tests/tests/expectations/tests/struct_with_anon_union_1_0.rs
@@ -14,11 +14,11 @@ impl<T> __BindgenUnionField<T> {
     }
     #[inline]
     pub unsafe fn as_ref(&self) -> &T {
-        ::std::mem::transmute(self)
+        unsafe { ::std::mem::transmute(self) }
     }
     #[inline]
     pub unsafe fn as_mut(&mut self) -> &mut T {
-        ::std::mem::transmute(self)
+        unsafe { ::std::mem::transmute(self) }
     }
 }
 impl<T> ::std::default::Default for __BindgenUnionField<T> {

--- a/bindgen-tests/tests/expectations/tests/struct_with_anon_unnamed_union_1_0.rs
+++ b/bindgen-tests/tests/expectations/tests/struct_with_anon_unnamed_union_1_0.rs
@@ -14,11 +14,11 @@ impl<T> __BindgenUnionField<T> {
     }
     #[inline]
     pub unsafe fn as_ref(&self) -> &T {
-        ::std::mem::transmute(self)
+        unsafe { ::std::mem::transmute(self) }
     }
     #[inline]
     pub unsafe fn as_mut(&mut self) -> &mut T {
-        ::std::mem::transmute(self)
+        unsafe { ::std::mem::transmute(self) }
     }
 }
 impl<T> ::std::default::Default for __BindgenUnionField<T> {

--- a/bindgen-tests/tests/expectations/tests/struct_with_nesting_1_0.rs
+++ b/bindgen-tests/tests/expectations/tests/struct_with_nesting_1_0.rs
@@ -14,11 +14,11 @@ impl<T> __BindgenUnionField<T> {
     }
     #[inline]
     pub unsafe fn as_ref(&self) -> &T {
-        ::std::mem::transmute(self)
+        unsafe { ::std::mem::transmute(self) }
     }
     #[inline]
     pub unsafe fn as_mut(&mut self) -> &mut T {
-        ::std::mem::transmute(self)
+        unsafe { ::std::mem::transmute(self) }
     }
 }
 impl<T> ::std::default::Default for __BindgenUnionField<T> {

--- a/bindgen-tests/tests/expectations/tests/transform-op.rs
+++ b/bindgen-tests/tests/expectations/tests/transform-op.rs
@@ -14,11 +14,11 @@ impl<T> __BindgenUnionField<T> {
     }
     #[inline]
     pub unsafe fn as_ref(&self) -> &T {
-        ::std::mem::transmute(self)
+        unsafe { ::std::mem::transmute(self) }
     }
     #[inline]
     pub unsafe fn as_mut(&mut self) -> &mut T {
-        ::std::mem::transmute(self)
+        unsafe { ::std::mem::transmute(self) }
     }
 }
 impl<T> ::std::default::Default for __BindgenUnionField<T> {

--- a/bindgen-tests/tests/expectations/tests/typeref_1_0.rs
+++ b/bindgen-tests/tests/expectations/tests/typeref_1_0.rs
@@ -14,11 +14,11 @@ impl<T> __BindgenUnionField<T> {
     }
     #[inline]
     pub unsafe fn as_ref(&self) -> &T {
-        ::std::mem::transmute(self)
+        unsafe { ::std::mem::transmute(self) }
     }
     #[inline]
     pub unsafe fn as_mut(&mut self) -> &mut T {
-        ::std::mem::transmute(self)
+        unsafe { ::std::mem::transmute(self) }
     }
 }
 impl<T> ::std::default::Default for __BindgenUnionField<T> {

--- a/bindgen-tests/tests/expectations/tests/union-in-ns_1_0.rs
+++ b/bindgen-tests/tests/expectations/tests/union-in-ns_1_0.rs
@@ -16,11 +16,11 @@ pub mod root {
         }
         #[inline]
         pub unsafe fn as_ref(&self) -> &T {
-            ::std::mem::transmute(self)
+            unsafe { ::std::mem::transmute(self) }
         }
         #[inline]
         pub unsafe fn as_mut(&mut self) -> &mut T {
-            ::std::mem::transmute(self)
+            unsafe { ::std::mem::transmute(self) }
         }
     }
     impl<T> ::std::default::Default for __BindgenUnionField<T> {

--- a/bindgen-tests/tests/expectations/tests/union_bitfield_1_0.rs
+++ b/bindgen-tests/tests/expectations/tests/union_bitfield_1_0.rs
@@ -100,11 +100,11 @@ impl<T> __BindgenUnionField<T> {
     }
     #[inline]
     pub unsafe fn as_ref(&self) -> &T {
-        ::std::mem::transmute(self)
+        unsafe { ::std::mem::transmute(self) }
     }
     #[inline]
     pub unsafe fn as_mut(&mut self) -> &mut T {
-        ::std::mem::transmute(self)
+        unsafe { ::std::mem::transmute(self) }
     }
 }
 impl<T> ::std::default::Default for __BindgenUnionField<T> {

--- a/bindgen-tests/tests/expectations/tests/union_dtor.rs
+++ b/bindgen-tests/tests/expectations/tests/union_dtor.rs
@@ -62,6 +62,6 @@ impl Default for UnionWithDtor {
 impl UnionWithDtor {
     #[inline]
     pub unsafe fn destruct(&mut self) {
-        UnionWithDtor_UnionWithDtor_destructor(self)
+        unsafe { UnionWithDtor_UnionWithDtor_destructor(self) }
     }
 }

--- a/bindgen-tests/tests/expectations/tests/union_dtor_1_0.rs
+++ b/bindgen-tests/tests/expectations/tests/union_dtor_1_0.rs
@@ -14,11 +14,11 @@ impl<T> __BindgenUnionField<T> {
     }
     #[inline]
     pub unsafe fn as_ref(&self) -> &T {
-        ::std::mem::transmute(self)
+        unsafe { ::std::mem::transmute(self) }
     }
     #[inline]
     pub unsafe fn as_mut(&mut self) -> &mut T {
-        ::std::mem::transmute(self)
+        unsafe { ::std::mem::transmute(self) }
     }
 }
 impl<T> ::std::default::Default for __BindgenUnionField<T> {
@@ -98,6 +98,6 @@ extern "C" {
 impl UnionWithDtor {
     #[inline]
     pub unsafe fn destruct(&mut self) {
-        UnionWithDtor_UnionWithDtor_destructor(self)
+        unsafe { UnionWithDtor_UnionWithDtor_destructor(self) }
     }
 }

--- a/bindgen-tests/tests/expectations/tests/union_fields_1_0.rs
+++ b/bindgen-tests/tests/expectations/tests/union_fields_1_0.rs
@@ -14,11 +14,11 @@ impl<T> __BindgenUnionField<T> {
     }
     #[inline]
     pub unsafe fn as_ref(&self) -> &T {
-        ::std::mem::transmute(self)
+        unsafe { ::std::mem::transmute(self) }
     }
     #[inline]
     pub unsafe fn as_mut(&mut self) -> &mut T {
-        ::std::mem::transmute(self)
+        unsafe { ::std::mem::transmute(self) }
     }
 }
 impl<T> ::std::default::Default for __BindgenUnionField<T> {

--- a/bindgen-tests/tests/expectations/tests/union_template_1_0.rs
+++ b/bindgen-tests/tests/expectations/tests/union_template_1_0.rs
@@ -14,11 +14,11 @@ impl<T> __BindgenUnionField<T> {
     }
     #[inline]
     pub unsafe fn as_ref(&self) -> &T {
-        ::std::mem::transmute(self)
+        unsafe { ::std::mem::transmute(self) }
     }
     #[inline]
     pub unsafe fn as_mut(&mut self) -> &mut T {
-        ::std::mem::transmute(self)
+        unsafe { ::std::mem::transmute(self) }
     }
 }
 impl<T> ::std::default::Default for __BindgenUnionField<T> {

--- a/bindgen-tests/tests/expectations/tests/union_with_anon_struct_1_0.rs
+++ b/bindgen-tests/tests/expectations/tests/union_with_anon_struct_1_0.rs
@@ -14,11 +14,11 @@ impl<T> __BindgenUnionField<T> {
     }
     #[inline]
     pub unsafe fn as_ref(&self) -> &T {
-        ::std::mem::transmute(self)
+        unsafe { ::std::mem::transmute(self) }
     }
     #[inline]
     pub unsafe fn as_mut(&mut self) -> &mut T {
-        ::std::mem::transmute(self)
+        unsafe { ::std::mem::transmute(self) }
     }
 }
 impl<T> ::std::default::Default for __BindgenUnionField<T> {

--- a/bindgen-tests/tests/expectations/tests/union_with_anon_struct_bitfield_1_0.rs
+++ b/bindgen-tests/tests/expectations/tests/union_with_anon_struct_bitfield_1_0.rs
@@ -100,11 +100,11 @@ impl<T> __BindgenUnionField<T> {
     }
     #[inline]
     pub unsafe fn as_ref(&self) -> &T {
-        ::std::mem::transmute(self)
+        unsafe { ::std::mem::transmute(self) }
     }
     #[inline]
     pub unsafe fn as_mut(&mut self) -> &mut T {
-        ::std::mem::transmute(self)
+        unsafe { ::std::mem::transmute(self) }
     }
 }
 impl<T> ::std::default::Default for __BindgenUnionField<T> {

--- a/bindgen-tests/tests/expectations/tests/union_with_anon_union_1_0.rs
+++ b/bindgen-tests/tests/expectations/tests/union_with_anon_union_1_0.rs
@@ -14,11 +14,11 @@ impl<T> __BindgenUnionField<T> {
     }
     #[inline]
     pub unsafe fn as_ref(&self) -> &T {
-        ::std::mem::transmute(self)
+        unsafe { ::std::mem::transmute(self) }
     }
     #[inline]
     pub unsafe fn as_mut(&mut self) -> &mut T {
-        ::std::mem::transmute(self)
+        unsafe { ::std::mem::transmute(self) }
     }
 }
 impl<T> ::std::default::Default for __BindgenUnionField<T> {

--- a/bindgen-tests/tests/expectations/tests/union_with_anon_unnamed_struct_1_0.rs
+++ b/bindgen-tests/tests/expectations/tests/union_with_anon_unnamed_struct_1_0.rs
@@ -14,11 +14,11 @@ impl<T> __BindgenUnionField<T> {
     }
     #[inline]
     pub unsafe fn as_ref(&self) -> &T {
-        ::std::mem::transmute(self)
+        unsafe { ::std::mem::transmute(self) }
     }
     #[inline]
     pub unsafe fn as_mut(&mut self) -> &mut T {
-        ::std::mem::transmute(self)
+        unsafe { ::std::mem::transmute(self) }
     }
 }
 impl<T> ::std::default::Default for __BindgenUnionField<T> {

--- a/bindgen-tests/tests/expectations/tests/union_with_anon_unnamed_union_1_0.rs
+++ b/bindgen-tests/tests/expectations/tests/union_with_anon_unnamed_union_1_0.rs
@@ -14,11 +14,11 @@ impl<T> __BindgenUnionField<T> {
     }
     #[inline]
     pub unsafe fn as_ref(&self) -> &T {
-        ::std::mem::transmute(self)
+        unsafe { ::std::mem::transmute(self) }
     }
     #[inline]
     pub unsafe fn as_mut(&mut self) -> &mut T {
-        ::std::mem::transmute(self)
+        unsafe { ::std::mem::transmute(self) }
     }
 }
 impl<T> ::std::default::Default for __BindgenUnionField<T> {

--- a/bindgen-tests/tests/expectations/tests/union_with_big_member_1_0.rs
+++ b/bindgen-tests/tests/expectations/tests/union_with_big_member_1_0.rs
@@ -14,11 +14,11 @@ impl<T> __BindgenUnionField<T> {
     }
     #[inline]
     pub unsafe fn as_ref(&self) -> &T {
-        ::std::mem::transmute(self)
+        unsafe { ::std::mem::transmute(self) }
     }
     #[inline]
     pub unsafe fn as_mut(&mut self) -> &mut T {
-        ::std::mem::transmute(self)
+        unsafe { ::std::mem::transmute(self) }
     }
 }
 impl<T> ::std::default::Default for __BindgenUnionField<T> {

--- a/bindgen-tests/tests/expectations/tests/union_with_nesting_1_0.rs
+++ b/bindgen-tests/tests/expectations/tests/union_with_nesting_1_0.rs
@@ -14,11 +14,11 @@ impl<T> __BindgenUnionField<T> {
     }
     #[inline]
     pub unsafe fn as_ref(&self) -> &T {
-        ::std::mem::transmute(self)
+        unsafe { ::std::mem::transmute(self) }
     }
     #[inline]
     pub unsafe fn as_mut(&mut self) -> &mut T {
-        ::std::mem::transmute(self)
+        unsafe { ::std::mem::transmute(self) }
     }
 }
 impl<T> ::std::default::Default for __BindgenUnionField<T> {

--- a/bindgen-tests/tests/expectations/tests/union_with_non_copy_member.rs
+++ b/bindgen-tests/tests/expectations/tests/union_with_non_copy_member.rs
@@ -14,11 +14,11 @@ impl<T> __BindgenUnionField<T> {
     }
     #[inline]
     pub unsafe fn as_ref(&self) -> &T {
-        ::std::mem::transmute(self)
+        unsafe { ::std::mem::transmute(self) }
     }
     #[inline]
     pub unsafe fn as_mut(&mut self) -> &mut T {
-        ::std::mem::transmute(self)
+        unsafe { ::std::mem::transmute(self) }
     }
 }
 impl<T> ::std::default::Default for __BindgenUnionField<T> {

--- a/bindgen-tests/tests/expectations/tests/use-core_1_0.rs
+++ b/bindgen-tests/tests/expectations/tests/use-core_1_0.rs
@@ -16,11 +16,11 @@ impl<T> __BindgenUnionField<T> {
     }
     #[inline]
     pub unsafe fn as_ref(&self) -> &T {
-        ::core::mem::transmute(self)
+        unsafe { ::core::mem::transmute(self) }
     }
     #[inline]
     pub unsafe fn as_mut(&mut self) -> &mut T {
-        ::core::mem::transmute(self)
+        unsafe { ::core::mem::transmute(self) }
     }
 }
 impl<T> ::core::default::Default for __BindgenUnionField<T> {

--- a/bindgen-tests/tests/expectations/tests/var-tracing.rs
+++ b/bindgen-tests/tests/expectations/tests/var-tracing.rs
@@ -43,9 +43,11 @@ extern "C" {
 impl Bar {
     #[inline]
     pub unsafe fn new(baz: ::std::os::raw::c_int) -> Self {
-        let mut __bindgen_tmp = ::std::mem::MaybeUninit::uninit();
-        Bar_Bar(__bindgen_tmp.as_mut_ptr(), baz);
-        __bindgen_tmp.assume_init()
+        unsafe {
+            let mut __bindgen_tmp = ::std::mem::MaybeUninit::uninit();
+            Bar_Bar(__bindgen_tmp.as_mut_ptr(), baz);
+            __bindgen_tmp.assume_init()
+        }
     }
 }
 #[repr(C)]

--- a/bindgen-tests/tests/expectations/tests/wasm-constructor-returns.rs
+++ b/bindgen-tests/tests/expectations/tests/wasm-constructor-returns.rs
@@ -33,8 +33,10 @@ extern "C" {
 impl Foo {
     #[inline]
     pub unsafe fn new(var: ::std::os::raw::c_int) -> Self {
-        let mut __bindgen_tmp = ::std::mem::MaybeUninit::uninit();
-        Foo_Foo(__bindgen_tmp.as_mut_ptr(), var);
-        __bindgen_tmp.assume_init()
+        unsafe {
+            let mut __bindgen_tmp = ::std::mem::MaybeUninit::uninit();
+            Foo_Foo(__bindgen_tmp.as_mut_ptr(), var);
+            __bindgen_tmp.assume_init()
+        }
     }
 }

--- a/bindgen-tests/tests/expectations/tests/win32-thiscall_nightly.rs
+++ b/bindgen-tests/tests/expectations/tests/win32-thiscall_nightly.rs
@@ -39,13 +39,13 @@ extern "thiscall" {
 impl Foo {
     #[inline]
     pub unsafe fn test(&mut self) {
-        Foo_test(self)
+        unsafe { Foo_test(self) }
     }
     #[inline]
     pub unsafe fn test2(
         &mut self,
         var: ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int {
-        Foo_test2(self, var)
+        unsafe { Foo_test2(self, var) }
     }
 }

--- a/bindgen-tests/tests/expectations/tests/zero-size-array-align.rs
+++ b/bindgen-tests/tests/expectations/tests/zero-size-array-align.rs
@@ -23,11 +23,11 @@ impl<T> __IncompleteArrayField<T> {
     }
     #[inline]
     pub unsafe fn as_slice(&self, len: usize) -> &[T] {
-        ::std::slice::from_raw_parts(self.as_ptr(), len)
+        unsafe { ::std::slice::from_raw_parts(self.as_ptr(), len) }
     }
     #[inline]
     pub unsafe fn as_mut_slice(&mut self, len: usize) -> &mut [T] {
-        ::std::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
+        unsafe { ::std::slice::from_raw_parts_mut(self.as_mut_ptr(), len) }
     }
 }
 impl<T> ::std::fmt::Debug for __IncompleteArrayField<T> {

--- a/bindgen-tests/tests/expectations/tests/zero-sized-array.rs
+++ b/bindgen-tests/tests/expectations/tests/zero-sized-array.rs
@@ -23,11 +23,11 @@ impl<T> __IncompleteArrayField<T> {
     }
     #[inline]
     pub unsafe fn as_slice(&self, len: usize) -> &[T] {
-        ::std::slice::from_raw_parts(self.as_ptr(), len)
+        unsafe { ::std::slice::from_raw_parts(self.as_ptr(), len) }
     }
     #[inline]
     pub unsafe fn as_mut_slice(&mut self, len: usize) -> &mut [T] {
-        ::std::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
+        unsafe { ::std::slice::from_raw_parts_mut(self.as_mut_ptr(), len) }
     }
 }
 impl<T> ::std::fmt::Debug for __IncompleteArrayField<T> {

--- a/bindgen/codegen/dyngen.rs
+++ b/bindgen/codegen/dyngen.rs
@@ -92,7 +92,9 @@ impl DynamicItems {
                 ) -> Result<Self, ::libloading::Error>
                 where P: AsRef<::std::ffi::OsStr> {
                     let library = ::libloading::Library::new(path)?;
-                    Self::from_library(library)
+                    unsafe {
+                        Self::from_library(library)
+                    }
                 }
 
                 pub unsafe fn from_library<L>(
@@ -157,7 +159,9 @@ impl DynamicItems {
             self.struct_implementation.push(quote! {
                 #(#attributes)*
                 pub unsafe fn #ident ( &self, #( #args ),* ) -> #ret_ty {
-                    #call_body
+                    unsafe {
+                        #call_body
+                    }
                 }
             });
         }
@@ -166,11 +170,11 @@ impl DynamicItems {
         let ident_str = codegen::helpers::ast_ty::cstr_expr(ident.to_string());
         self.constructor_inits.push(if is_required {
             quote! {
-                let #ident = __library.get(#ident_str).map(|sym| *sym)?;
+                let #ident = unsafe { __library.get(#ident_str) }.map(|sym| *sym)?;
             }
         } else {
             quote! {
-                let #ident = __library.get(#ident_str).map(|sym| *sym);
+                let #ident = unsafe { __library.get(#ident_str) }.map(|sym| *sym);
             }
         });
 

--- a/bindgen/codegen/mod.rs
+++ b/bindgen/codegen/mod.rs
@@ -2605,7 +2605,9 @@ impl MethodCodegen for Method {
         methods.push(quote! {
             #(#attrs)*
             pub unsafe fn #name ( #( #args ),* ) #ret {
-                #block
+                unsafe {
+                    #block
+                }
             }
         });
     }
@@ -4263,7 +4265,9 @@ fn objc_method_codegen(
 
     methods.push(quote! {
         unsafe fn #method_name #sig where <Self as std::ops::Deref>::Target: objc::Message + Sized {
-            #body
+            unsafe {
+                #body
+            }
         }
     });
 }
@@ -4638,12 +4642,16 @@ pub mod utils {
 
                 #[inline]
                 pub unsafe fn as_ref(&self) -> &T {
-                    ::#prefix::mem::transmute(self)
+                    unsafe {
+                        ::#prefix::mem::transmute(self)
+                    }
                 }
 
                 #[inline]
                 pub unsafe fn as_mut(&mut self) -> &mut T {
-                    ::#prefix::mem::transmute(self)
+                    unsafe {
+                        ::#prefix::mem::transmute(self)
+                    }
                 }
             }
         };
@@ -4757,12 +4765,16 @@ pub mod utils {
 
                 #[inline]
                 pub unsafe fn as_slice(&self, len: usize) -> &[T] {
-                    ::#prefix::slice::from_raw_parts(self.as_ptr(), len)
+                    unsafe {
+                        ::#prefix::slice::from_raw_parts(self.as_ptr(), len)
+                    }
                 }
 
                 #[inline]
                 pub unsafe fn as_mut_slice(&mut self, len: usize) -> &mut [T] {
-                    ::#prefix::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
+                    unsafe {
+                        ::#prefix::slice::from_raw_parts_mut(self.as_mut_ptr(), len)
+                    }
                 }
             }
         };


### PR DESCRIPTION
This PR adds a new option `--unsafe-blocks` which wraps all the bodies of generated `unsafe` functions in `unsafe` blocks.

Fixes: #2063 
~~Blocked by: #2265~~