### PR TITLE
use `#[feature(core_ffi_c)]` when available

### DIFF
--- a/src/codegen/helpers.rs
+++ b/src/codegen/helpers.rs
@@ -166,9 +166,19 @@ pub mod ast_ty {
                     #prefix::#ident
                 }
             }
-            None => quote! {
-                ::std::os::raw::#ident
-            },
+            None => {
+                if ctx.options().use_core &&
+                    ctx.options().rust_features().core_ffi_c
+                {
+                    quote! {
+                        ::core::ffi::#ident
+                    }
+                } else {
+                    quote! {
+                        ::std::os::raw::#ident
+                    }
+                }
+            }
         }
     }
 

--- a/src/features.rs
+++ b/src/features.rs
@@ -130,6 +130,7 @@ macro_rules! rust_target_base {
             /// Nightly rust
             ///  * `thiscall` calling convention ([Tracking issue](https://github.com/rust-lang/rust/issues/42202))
             ///  * `vectorcall` calling convention (no tracking issue)
+            ///  * `core_ffi_c` ([Tracking issue](https://github.com/rust-lang/rust/issues/94501))
             => Nightly => nightly;
         );
     }
@@ -236,6 +237,7 @@ rust_feature_def!(
     Nightly {
         => thiscall_abi;
         => vectorcall_abi;
+        => core_ffi_c;
     }
 );
 

--- a/src/features.rs
+++ b/src/features.rs
@@ -127,10 +127,12 @@ macro_rules! rust_target_base {
             /// Rust stable 1.47
             /// * `larger_arrays` ([Tracking issue](https://github.com/rust-lang/rust/pull/74060))
             => Stable_1_47 => 1.47;
+            /// Rust stable 1.64
+            ///  * `core_ffi_c` ([Tracking issue](https://github.com/rust-lang/rust/issues/94501))
+            => Stable_1_64 => 1.64;
             /// Nightly rust
             ///  * `thiscall` calling convention ([Tracking issue](https://github.com/rust-lang/rust/issues/42202))
             ///  * `vectorcall` calling convention (no tracking issue)
-            ///  * `core_ffi_c` ([Tracking issue](https://github.com/rust-lang/rust/issues/94501))
             => Nightly => nightly;
         );
     }
@@ -234,10 +236,12 @@ rust_feature_def!(
     Stable_1_47 {
         => larger_arrays;
     }
+    Stable_1_64 {
+        => core_ffi_c;
+    }
     Nightly {
         => thiscall_abi;
         => vectorcall_abi;
-        => core_ffi_c;
     }
 );
 

--- a/tests/expectations/tests/core_ffi_c.rs
+++ b/tests/expectations/tests/core_ffi_c.rs
@@ -1,0 +1,20 @@
+#![allow(
+    dead_code,
+    non_snake_case,
+    non_camel_case_types,
+    non_upper_case_globals
+)]
+
+pub type c_char = ::core::ffi::c_char;
+pub type c_double = ::core::ffi::c_double;
+pub type c_float = ::core::ffi::c_float;
+pub type c_int = ::core::ffi::c_int;
+pub type c_long = ::core::ffi::c_long;
+pub type c_longlong = ::core::ffi::c_longlong;
+pub type c_schar = ::core::ffi::c_schar;
+pub type c_short = ::core::ffi::c_short;
+pub type c_uchar = ::core::ffi::c_uchar;
+pub type c_uint = ::core::ffi::c_uint;
+pub type c_ulong = ::core::ffi::c_ulong;
+pub type c_ulonglong = ::core::ffi::c_ulonglong;
+pub type c_ushort = ::core::ffi::c_ushort;

--- a/tests/expectations/tests/core_ffi_c.rs
+++ b/tests/expectations/tests/core_ffi_c.rs
@@ -4,6 +4,7 @@
     non_camel_case_types,
     non_upper_case_globals
 )]
+#![cfg(feature = "nightly")]
 
 pub type c_char = ::core::ffi::c_char;
 pub type c_double = ::core::ffi::c_double;

--- a/tests/expectations/tests/core_ffi_c.rs
+++ b/tests/expectations/tests/core_ffi_c.rs
@@ -4,7 +4,6 @@
     non_camel_case_types,
     non_upper_case_globals
 )]
-#![cfg(feature = "nightly")]
 
 pub type c_char = ::core::ffi::c_char;
 pub type c_double = ::core::ffi::c_double;

--- a/tests/headers/core_ffi_c.h
+++ b/tests/headers/core_ffi_c.h
@@ -1,0 +1,14 @@
+// bindgen-flags: --rust-target nightly --use-core --no-convert-floats
+typedef char c_char;
+typedef double c_double;
+typedef float c_float;
+typedef int c_int;
+typedef long c_long;
+typedef long long c_longlong;
+typedef signed char c_schar;
+typedef short c_short;
+typedef unsigned char c_uchar;
+typedef unsigned int c_uint;
+typedef unsigned long c_ulong;
+typedef unsigned long long c_ulonglong;
+typedef unsigned short c_ushort;

--- a/tests/headers/core_ffi_c.h
+++ b/tests/headers/core_ffi_c.h
@@ -1,4 +1,4 @@
-// bindgen-flags: --rust-target nightly --raw-line '#![cfg(feature = "nightly")]' --use-core --no-convert-floats
+// bindgen-flags: --use-core --rust-target 1.64 --no-convert-floats
 typedef char c_char;
 typedef double c_double;
 typedef float c_float;

--- a/tests/headers/core_ffi_c.h
+++ b/tests/headers/core_ffi_c.h
@@ -1,4 +1,4 @@
-// bindgen-flags: --rust-target nightly --use-core --no-convert-floats
+// bindgen-flags: --rust-target nightly --raw-line '#![cfg(feature = "nightly")]' --use-core --no-convert-floats
 typedef char c_char;
 typedef double c_double;
 typedef float c_float;


### PR DESCRIPTION
Partially fixes: https://github.com/rust-lang/rust-bindgen/issues/2231

r? @emilio @amanjeev 