### PR TITLE
Fix `--newtype-global-enum` option

### DIFF
--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -2814,24 +2814,19 @@ impl<'a> EnumBuilder<'a> {
                 is_global,
                 ..
             } => {
-                if ctx.options().rust_features().associated_const && is_ty_named
+                if ctx.options().rust_features().associated_const &&
+                    is_ty_named &&
+                    !is_global
                 {
                     let enum_ident = ctx.rust_ident(canonical_name);
                     let variant_ident = ctx.rust_ident(variant_name);
-                    let tokens = quote! {
-                        #doc
-                        pub const #variant_ident : #rust_ty = #rust_ty ( #expr );
-                    };
 
-                    if is_global {
-                        result.push(tokens);
-                    } else {
-                        result.push(quote! {
-                            impl #enum_ident {
-                                #tokens
-                            }
-                        });
-                    }
+                    result.push(quote! {
+                        impl #enum_ident {
+                            #doc
+                            pub const #variant_ident : #rust_ty = #rust_ty ( #expr );
+                        }
+                    });
                 } else {
                     let ident = ctx.rust_ident(match mangling_prefix {
                         Some(prefix) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -315,6 +315,7 @@ impl Builder {
         let regex_sets = &[
             (&self.options.bitfield_enums, "--bitfield-enum"),
             (&self.options.newtype_enums, "--newtype-enum"),
+            (&self.options.newtype_global_enums, "--newtype-global-enum"),
             (&self.options.rustified_enums, "--rustified-enum"),
             (
                 &self.options.rustified_non_exhaustive_enums,
@@ -2072,6 +2073,7 @@ impl BindgenOptions {
             &mut self.constified_enums,
             &mut self.constified_enum_modules,
             &mut self.newtype_enums,
+            &mut self.newtype_global_enums,
             &mut self.rustified_enums,
             &mut self.rustified_non_exhaustive_enums,
             &mut self.type_alias,

--- a/tests/expectations/tests/newtype-global-enum.rs
+++ b/tests/expectations/tests/newtype-global-enum.rs
@@ -5,8 +5,10 @@
     non_upper_case_globals
 )]
 
-pub const Foo_Bar: Foo = 2;
-pub const Foo_Baz: Foo = 4;
-pub const Foo_Duplicated: Foo = 4;
-pub const Foo_Negative: Foo = -3;
-pub type Foo = ::std::os::raw::c_int;
+pub const Foo_Bar: Foo = Foo(2);
+pub const Foo_Baz: Foo = Foo(4);
+pub const Foo_Duplicated: Foo = Foo(4);
+pub const Foo_Negative: Foo = Foo(-3);
+#[repr(transparent)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub struct Foo(pub ::std::os::raw::c_int);


### PR DESCRIPTION
Apparently https://github.com/rust-lang/rust-bindgen/pull/2270 introduced several bugs:

- The `RegexSet` for `--newtype-global-enum` was not initialized correctly.
- The flag was not emitted when the option was used either.
- The generated bindings did not use a newtype.

All three have been fixed here.