### PR TITLE
Emulate variadic methods using tuples

### DIFF
--- a/bindgen-cli/options.rs
+++ b/bindgen-cli/options.rs
@@ -568,6 +568,7 @@ where
             Arg::new("merge-extern-blocks")
                 .long("merge-extern-blocks")
                 .help("Deduplicates extern blocks."),
+            Arg::new("tuple-varargs-len").long("tuple-varargs-len").takes_value(true).help("Enables using tuples to emulate variadic arguments up to a certain tuple length"),
             Arg::new("V")
                 .long("version")
                 .help("Prints the version, and exits"),
@@ -1086,6 +1087,20 @@ where
 
     if matches.is_present("merge-extern-blocks") {
         builder = builder.merge_extern_blocks(true);
+    }
+
+    if let Some(len) = matches.value_of("tuple-varargs-len") {
+        let len = match len.parse() {
+            Ok(len) => len,
+            Err(err) => {
+                return Err(io::Error::new(
+                    io::ErrorKind::Other,
+                    format!("invalid length: {}", err),
+                ))
+            }
+        };
+
+        builder = builder.tuple_varargs_len(len);
     }
 
     Ok((builder, output, verbose))

--- a/bindgen-tests/tests/expectations/tests/variadic-method.rs
+++ b/bindgen-tests/tests/expectations/tests/variadic-method.rs
@@ -31,3 +31,80 @@ extern "C" {
     #[link_name = "\u{1}_ZN3Bar3fooEPKcz"]
     pub fn Bar_foo(this: *mut Bar, fmt: *const ::std::os::raw::c_char, ...);
 }
+impl Bar {
+    #[inline]
+    pub unsafe fn foo(
+        &mut self,
+        fmt: *const ::std::os::raw::c_char,
+        var_args: impl VarArgs,
+    ) {
+        var_args.call_Bar_foo(self, fmt)
+    }
+}
+pub trait VarArgs {
+    unsafe fn call_Bar_foo(
+        self,
+        this: *mut Bar,
+        fmt: *const ::std::os::raw::c_char,
+    );
+}
+impl VarArgs for () {
+    unsafe fn call_Bar_foo(
+        self,
+        this: *mut Bar,
+        fmt: *const ::std::os::raw::c_char,
+    ) {
+        let () = self;
+        Bar_foo(this, fmt)
+    }
+}
+impl<T0> VarArgs for (T0,) {
+    unsafe fn call_Bar_foo(
+        self,
+        this: *mut Bar,
+        fmt: *const ::std::os::raw::c_char,
+    ) {
+        let (t0,) = self;
+        Bar_foo(this, fmt, t0)
+    }
+}
+impl<T0, T1> VarArgs for (T0, T1) {
+    unsafe fn call_Bar_foo(
+        self,
+        this: *mut Bar,
+        fmt: *const ::std::os::raw::c_char,
+    ) {
+        let (t0, t1) = self;
+        Bar_foo(this, fmt, t0, t1)
+    }
+}
+impl<T0, T1, T2> VarArgs for (T0, T1, T2) {
+    unsafe fn call_Bar_foo(
+        self,
+        this: *mut Bar,
+        fmt: *const ::std::os::raw::c_char,
+    ) {
+        let (t0, t1, t2) = self;
+        Bar_foo(this, fmt, t0, t1, t2)
+    }
+}
+impl<T0, T1, T2, T3> VarArgs for (T0, T1, T2, T3) {
+    unsafe fn call_Bar_foo(
+        self,
+        this: *mut Bar,
+        fmt: *const ::std::os::raw::c_char,
+    ) {
+        let (t0, t1, t2, t3) = self;
+        Bar_foo(this, fmt, t0, t1, t2, t3)
+    }
+}
+impl<T0, T1, T2, T3, T4> VarArgs for (T0, T1, T2, T3, T4) {
+    unsafe fn call_Bar_foo(
+        self,
+        this: *mut Bar,
+        fmt: *const ::std::os::raw::c_char,
+    ) {
+        let (t0, t1, t2, t3, t4) = self;
+        Bar_foo(this, fmt, t0, t1, t2, t3, t4)
+    }
+}

--- a/bindgen-tests/tests/headers/variadic-method.hpp
+++ b/bindgen-tests/tests/headers/variadic-method.hpp
@@ -1,3 +1,4 @@
+// bindgen-flags: --tuple-varargs-len 5
 
 void foo(const char* fmt, ...);
 

--- a/bindgen/lib.rs
+++ b/bindgen/lib.rs
@@ -619,6 +619,10 @@ impl Builder {
             output_vector.push("--merge-extern-blocks".into());
         }
 
+        if let Some(len) = self.options.tuple_varargs_len {
+            output_vector.push(format!("--tuple-varargs-len={}", len));
+        }
+
         // Add clang arguments
 
         output_vector.push("--".into());
@@ -1560,6 +1564,12 @@ impl Builder {
         self
     }
 
+    /// Sets the maximum tuple length that can be used to emulate variadic arguments,
+    pub fn tuple_varargs_len(mut self, len: usize) -> Self {
+        self.options.tuple_varargs_len = Some(len);
+        self
+    }
+
     /// Generate the Rust bindings using the options built up thus far.
     pub fn generate(mut self) -> Result<Bindings, BindgenError> {
         // Add any extra arguments from the environment to the clang command line.
@@ -2105,6 +2115,9 @@ struct BindgenOptions {
 
     /// Deduplicate `extern` blocks.
     merge_extern_blocks: bool,
+
+    /// The maximum tuple length that can be used to emulate variadic arguments.
+    tuple_varargs_len: Option<usize>,
 }
 
 /// TODO(emilio): This is sort of a lie (see the error message that results from
@@ -2261,6 +2274,7 @@ impl Default for BindgenOptions {
             vtable_generation: false,
             sort_semantically: false,
             merge_extern_blocks: false,
+            tuple_varargs_len: Default::default(),
         }
     }
 }


### PR DESCRIPTION
This PR introduces a new flag `--tuple-varargs-len=<LEN>` which can be used to emulate variadic methods using tuples of length up to `<LEN>`.

# Example
If the generated function signature for a variadic method is:
```rust
extern "C" {
    fn foo_bar(foo: &Foo, a: A, ...);
}
```
and the `--tuple-varargs-len` flag is set. A new method for the type `Foo` is introduced:
```rust
impl Foo {
    unsafe fn bar(&self, a: A, varargs: impl VarArgs) {
        varargs.call_foo_bar(self, a)
    }
}
```
The user would use such method like this:
```rust
foo.bar(a, ()); // 0 variadic args
foo.bar(a, (10,)); // 1 variadic arg
foo.bar(a, (10, b"hello")); // 2 variadic args
foo.bar(a, (10, b"hello", false)); // 3 variadic args
...
```
To do this, the `VarArgs` trait is declared and implemented automatically up to the value of `--tuple-varargs-len`:
```rust
trait VarArgs {
    unsafe fn call_foo_bar(self, foo: &Foo, a: A);
}

impl VarArgs for () {
    unsafe fn call_foo_bar(self, foo: &Foo, a: A) {
        let () = self;
        foo_bar(foo, a)
    }
}

impl<T0> VarArgs for (T0,) {
    unsafe fn call_foo_bar(self, foo: &Foo, a: A) {
        let (t0, ) = self;
        foo_bar(foo, a, t0)
    }
}

impl<T0, T1> VarArgs for (T0, T1) {
    unsafe fn call_foo_bar(self, foo: &Foo, a: A) {
        let (t0, t1) = self;
        foo_bar(foo, a, t0, t1)
    }
}
```
This has some disadvantages, such as the user not being able to just do `foo.bar(a)` or `foo,bar(a, v)` without getting somewhat confusing errors but this could be mitigated by properly documenting the `VarArgs` trait.

Fixes #407