### PR TITLE
Don't traverse through special-cased <stdint.h> types.

### DIFF
--- a/src/ir/ty.rs
+++ b/src/ir/ty.rs
@@ -1206,6 +1206,13 @@ impl Trace for Type {
     where
         T: Tracer,
     {
+        if self
+            .name()
+            .map_or(false, |name| context.is_stdint_type(name))
+        {
+            // These types are special-cased in codegen and don't need to be traversed.
+            return;
+        }
         match *self.kind() {
             TypeKind::Pointer(inner) |
             TypeKind::Reference(inner) |

--- a/tests/expectations/tests/stdint_typedef.rs
+++ b/tests/expectations/tests/stdint_typedef.rs
@@ -1,0 +1,41 @@
+#![allow(
+    dead_code,
+    non_snake_case,
+    non_camel_case_types,
+    non_upper_case_globals
+)]
+
+extern "C" {
+    pub fn fun() -> u64;
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct Struct {
+    pub field: u64,
+}
+#[test]
+fn bindgen_test_layout_Struct() {
+    const UNINIT: ::std::mem::MaybeUninit<Struct> =
+        ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
+    assert_eq!(
+        ::std::mem::size_of::<Struct>(),
+        8usize,
+        concat!("Size of: ", stringify!(Struct))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<Struct>(),
+        8usize,
+        concat!("Alignment of ", stringify!(Struct))
+    );
+    assert_eq!(
+        unsafe { ::std::ptr::addr_of!((*ptr).field) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(Struct),
+            "::",
+            stringify!(field)
+        )
+    );
+}

--- a/tests/headers/stdint_typedef.h
+++ b/tests/headers/stdint_typedef.h
@@ -1,0 +1,10 @@
+// bindgen-flags: --allowlist-type="Struct" --allowlist-function="fun"
+
+// no typedef should be emitted for `__uint64_t`
+typedef unsigned long long __uint64_t;
+typedef __uint64_t uint64_t;
+
+uint64_t fun();
+struct Struct {
+	uint64_t field;
+};


### PR DESCRIPTION
Fixes #1663.

Not sure if this is too special-casey, but there's already a bunch of this stuff strewn about. Seems like it would be cleanest to add a new `TypeKind` for stdint types populated in `from_clang_ty` but that seemed like a ton of work for relatively little gain.