### PR TITLE
Handle incomplete external array constants

### DIFF
--- a/bindgen-tests/tests/expectations/tests/var-tracing.rs
+++ b/bindgen-tests/tests/expectations/tests/var-tracing.rs
@@ -55,7 +55,7 @@ pub struct Baz {
 }
 extern "C" {
     #[link_name = "\u{1}_ZN3Baz3FOOE"]
-    pub static mut Baz_FOO: [Bar; 0usize];
+    pub static Baz_FOO: [Bar; 0usize];
 }
 #[test]
 fn bindgen_test_layout_Baz() {

--- a/bindgen/ir/var.rs
+++ b/bindgen/ir/var.rs
@@ -285,7 +285,8 @@ impl ClangSubItemParser for Var {
                 // TODO(emilio): do we have to special-case constant arrays in
                 // some other places?
                 let is_const = ty.is_const() ||
-                    (ty.kind() == CXType_ConstantArray &&
+                    ([CXType_ConstantArray, CXType_IncompleteArray]
+                        .contains(&ty.kind()) &&
                         ty.elem_type()
                             .map_or(false, |element| element.is_const()));
 


### PR DESCRIPTION
This adds a new special case for constants like:
```c
extern const char some_static_string[];
```
so `bindgen` emits a `static` instead of a `static mut` for them.

Fixes: #2290