### PR TITLE
Implement `Clone` for `Builder`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -159,6 +159,7 @@
  * new feature: `--merge-extern-blocks` flag to merge several `extern` blocks
    that have the same ABI.
  * new feature: `--no-size_t-is-usize` flag to not bind `size_t` as `usize`.
+ * new feature: `Builder` implements `Clone`.
 
 ## Changed
 

--- a/bindgen/clang.rs
+++ b/bindgen/clang.rs
@@ -1823,7 +1823,7 @@ pub struct UnsavedFile {
 
 impl UnsavedFile {
     /// Construct a new unsaved file with the given `name` and `contents`.
-    pub fn new(name: &str, contents: &str) -> UnsavedFile {
+    pub fn new(name: String, contents: String) -> UnsavedFile {
         let name = CString::new(name).unwrap();
         let contents = CString::new(contents).unwrap();
         let x = CXUnsavedFile {

--- a/bindgen/ir/context.rs
+++ b/bindgen/ir/context.rs
@@ -541,11 +541,7 @@ If you encounter an error missing from this list, please file an issue or a PR!"
         let root_module_id = root_module.id().as_module_id_unchecked();
 
         // depfiles need to include the explicitly listed headers too
-        let mut deps = BTreeSet::default();
-        if let Some(filename) = &options.input_header {
-            deps.insert(filename.clone());
-        }
-        deps.extend(options.extra_input_headers.iter().cloned());
+        let deps = options.input_headers.iter().cloned().collect();
 
         BindgenContext {
             items: vec![Some(root_module)],


### PR DESCRIPTION
This is done by moving all the remaining `Builder` state into `BindgenOptions` so any internal logic that affects `Builder` state only runs once the builder is consumed by `Builder::generate`:

- move `input_headers` to `BindgenOptions`.
- move `input_header_contents` to `BindgenOptions`.
- derive `Clone` for `Builder`.

Fixes: https://github.com/rust-lang/rust-bindgen/issues/2132