### PR TITLE
fix cli installation instructions

### DIFF
--- a/book/src/command-line-usage.md
+++ b/book/src/command-line-usage.md
@@ -3,7 +3,7 @@
 Install the `bindgen` executable with `cargo`:
 
 ```bash
-$ cargo install bindgen-cli
+$ cargo install bindgen
 ```
 
 The `bindgen` executable is installed to `~/.cargo/bin`. You have to add that


### PR DESCRIPTION
The [cli crate on crates.io](https://crates.io/crates/bindgen) is called `bindgen`, not `bindgen-cli`.