### PR TITLE
fix(book): fixed wrong cargo install command

### DIFF
--- a/book/src/command-line-usage.md
+++ b/book/src/command-line-usage.md
@@ -3,7 +3,7 @@
 Install the `bindgen` executable with `cargo`:
 
 ```bash
-$ cargo install bindgen-cli
+$ cargo install bindgen
 ```
 
 The `bindgen` executable is installed to `~/.cargo/bin`. You have to add that


### PR DESCRIPTION
CommandLineUsage page had the incorrect command `cargo install bindgen-cli`, which was changed to `cargo install bindgen`