### PR TITLE
Use panic hooks instead of using `catch_unwind`

### DIFF
--- a/bindgen/callbacks.rs
+++ b/bindgen/callbacks.rs
@@ -5,7 +5,6 @@ pub use crate::ir::derive::CanDerive as ImplementsTrait;
 pub use crate::ir::enum_ty::{EnumVariantCustomBehavior, EnumVariantValue};
 pub use crate::ir::int::IntKind;
 use std::fmt;
-use std::panic::UnwindSafe;
 
 /// An enum to allow ignoring parsing of macros.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
@@ -25,7 +24,7 @@ impl Default for MacroParsingBehavior {
 
 /// A trait to allow configuring different kinds of types in different
 /// situations.
-pub trait ParseCallbacks: fmt::Debug + UnwindSafe {
+pub trait ParseCallbacks: fmt::Debug {
     /// This function will be run on every macro that is identified.
     fn will_parse_macro(&self, _name: &str) -> MacroParsingBehavior {
         MacroParsingBehavior::Default

--- a/bindgen/lib.rs
+++ b/bindgen/lib.rs
@@ -2103,11 +2103,6 @@ struct BindgenOptions {
     merge_extern_blocks: bool,
 }
 
-/// TODO(emilio): This is sort of a lie (see the error message that results from
-/// removing this), but since we don't share references across panic boundaries
-/// it's ok.
-impl ::std::panic::UnwindSafe for BindgenOptions {}
-
 impl BindgenOptions {
     fn build(&mut self) {
         let mut regex_sets = [


### PR DESCRIPTION
One of the advantages of doing this is that `ParseCallbacks` no longer needs to implement `UnwindSafe` which means that users can rely on `RefCell` and `Cell` to extract information from the callbacks.

Users relying on `catch_unwind` can still achieve similar behavior using `std::thread::spawn`.

Fixes #2147.