### PR TITLE
clang: Detect anonymous items explicitly, rather than relying on empty names.

### DIFF
--- a/bindgen/clang.rs
+++ b/bindgen/clang.rs
@@ -86,6 +86,11 @@ impl Cursor {
         unsafe { clang_isDeclaration(self.kind()) != 0 }
     }
 
+    /// Is this cursor's referent an anonymous record or so?
+    pub fn is_anonymous(&self) -> bool {
+        unsafe { clang_Cursor_isAnonymous(self.x) != 0 }
+    }
+
     /// Get this cursor's referent's spelling.
     pub fn spelling(&self) -> String {
         unsafe { cxstring_into_string(clang_getCursorSpelling(self.x)) }

--- a/bindgen/ir/comp.rs
+++ b/bindgen/ir/comp.rs
@@ -1422,8 +1422,7 @@ impl CompInfo {
 
                         // A declaration of an union or a struct without name
                         // could also be an unnamed field, unfortunately.
-                        if cur.spelling().is_empty() &&
-                            cur.kind() != CXCursor_EnumDecl
+                        if cur.is_anonymous() && cur.kind() != CXCursor_EnumDecl
                         {
                             let ty = cur.cur_type();
                             let public = cur.public_accessible();


### PR DESCRIPTION
In Clang 16, anonymous items may return names like `(anonymous union at ..)` rather than empty names.

The right way to detect them is using clang_Cursor_isAnonymous.

Fixes #2312
Closes #2316