### PR TITLE
Remove Travis-CI badges from Cargo.toml

### DIFF
--- a/bindgen-cli/Cargo.toml
+++ b/bindgen-cli/Cargo.toml
@@ -20,9 +20,6 @@ rust-version = "1.57.0"
 path = "main.rs"
 name = "bindgen"
 
-[badges]
-travis-ci = { repository = "rust-lang/rust-bindgen" }
-
 [dependencies]
 bindgen = { path = "../bindgen" }
 shlex = "1"

--- a/bindgen/Cargo.toml
+++ b/bindgen/Cargo.toml
@@ -24,9 +24,6 @@ rust-version = "1.57.0"
 name = "bindgen"
 path = "./lib.rs"
 
-[badges]
-travis-ci = { repository = "rust-lang/rust-bindgen" }
-
 [dependencies]
 bitflags = "1.0.3"
 cexpr = "0.6"


### PR DESCRIPTION
Travis-CI was fully removed as of faf8b3edbaeb591315fc6f370c1228b8caf9860f.

The only badge now [mentioned in the Cargo book][1] is `maintenance`. The `travis-ci` badge reference was [removed from Cargo two years ago][2]. The Cargo book advises putting badges in README.md instead.

[1]: https://doc.rust-lang.org/cargo/reference/manifest.html#the-badges-section
[2]: https://github.com/rust-lang/cargo/commit/60779a006f98fba1680182c174134363d08e0a9b