### PR TITLE
Document visibility annotation

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -20,6 +20,7 @@
     - [Preventing the Derivation of `Debug`](./nodebug.md)
     - [Preventing the Derivation of `Default`](./nodefault.md)
     - [Annotating types with `#[must-use]`](./must-use-types.md)
+    - [Field visibility](./visibility.md)
 - [Generating Bindings to C++](./cpp.md)
 - [Generating Bindings to Objective-c](./objc.md)
 - [Using Unions](./using-unions.md)

--- a/book/src/visibility.md
+++ b/book/src/visibility.md
@@ -23,8 +23,14 @@ struct MostFieldsPrivate {
 Then in Rust:
 
 ```rust
+# #[repr(C)]
+# pub struct OneFieldPrivate {
+#     s: *const ::std::os::raw::c_char,
+#     pub b: bool,
+# }
+
 impl OneFieldPrivate {
-    pub fn new(s: &'static core::ffi::CStr, b: bool) -> Self {
+    pub fn new(s: &'static std::ffi::CStr, b: bool) -> Self {
         OneFieldPrivate { s: s.as_ptr(), b }
     }
 }

--- a/book/src/visibility.md
+++ b/book/src/visibility.md
@@ -1,0 +1,31 @@
+# Making fields private
+
+Fields can be made private for various reasons. You may wish to enforce some invariant on the fields of a structure, which cannot be achieved if the field is public and can be set by any code. For example, you may wish to ensure that a pointer always points to something appropriate.
+
+### Annotation
+
+```c
+struct OneFieldPrivate {
+    /** Null-terminated, static string. <div rustbindgen private> */
+    const char *s;
+    bool b;
+};
+
+/** <div rustbindgen private> */
+struct MostFieldsPrivate {
+    int a;
+    bool b;
+    /** <div rustbindgen private="false"></div> */
+    char c;
+};
+```
+
+Then in Rust:
+
+```rust
+impl OneFieldPrivate {
+    pub fn new(s: &'static core::ffi::CStr, b: bool) -> Self {
+        OneFieldPrivate { s: s.as_ptr(), b }
+    }
+}
+```


### PR DESCRIPTION
I can't see any existing documentation on the `<div rustbindgen private>` documentation so I have added some to the book, demonstrating with examples based on the examples in bindgen-tests/tests/headers/private.hpp.