### PR TITLE
Avoid suppressing panic messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -153,6 +153,7 @@
 
  * Regex inputs are sanitized so alternation (`a|b`) is handled correctly but
    wildcard patterns (`*`) are now considered invalid.
+ * the `ParseCallbacks`trait does not require to implement `UnwindSafe`.
 
 ## Removed
 

--- a/bindgen-cli/main.rs
+++ b/bindgen-cli/main.rs
@@ -41,10 +41,11 @@ pub fn main() {
             #[cfg(feature = "logging")]
             clang_version_check();
 
-            std::panic::set_hook(Box::new(move |_info| {
+            std::panic::set_hook(Box::new(move |info| {
                 if verbose {
                     print_verbose_err()
                 }
+                println!("{}", info);
             }));
 
             let bindings =


### PR DESCRIPTION
Apparently I forgot this tiny detail when removing the `catch_unwind` logic. Which means bindgen was suppressing all the panic messages :grimacing: 