### PR TITLE
Fix name collision between C enum and typedef

### DIFF
--- a/bindgen-tests/tests/expectations/tests/enum-typedef.rs
+++ b/bindgen-tests/tests/expectations/tests/enum-typedef.rs
@@ -6,8 +6,6 @@
 )]
 
 pub const Enum_Variant: Enum = 0;
-pub type Enum = ::std::os::raw::c_uint;
 pub type Enum = i16;
 pub type TypedefFirst = i16;
 pub const TypedefFirst_Variant2: TypedefFirst = 0;
-pub type TypedefFirst = ::std::os::raw::c_uint;

--- a/bindgen-tests/tests/expectations/tests/enum-typedef.rs
+++ b/bindgen-tests/tests/expectations/tests/enum-typedef.rs
@@ -1,0 +1,13 @@
+#![allow(
+    dead_code,
+    non_snake_case,
+    non_camel_case_types,
+    non_upper_case_globals
+)]
+
+pub const Enum_Variant: Enum = 0;
+pub type Enum = ::std::os::raw::c_uint;
+pub type Enum = i16;
+pub type TypedefFirst = i16;
+pub const TypedefFirst_Variant2: TypedefFirst = 0;
+pub type TypedefFirst = ::std::os::raw::c_uint;

--- a/bindgen-tests/tests/headers/enum-typedef.h
+++ b/bindgen-tests/tests/headers/enum-typedef.h
@@ -1,0 +1,18 @@
+typedef short int16_t;
+
+// `cbindgen` emits this C idiom as the translation of:
+//
+//     #[repr(i16)]
+//     pub enum Enum {
+//         Variant,
+//     }
+enum Enum {
+  Variant,
+};
+typedef int16_t Enum;
+
+// C is also fine with the typedef coming before the enum.
+typedef int16_t TypedefFirst;
+enum TypedefFirst {
+  Variant2,
+};

--- a/bindgen/ir/ty.rs
+++ b/bindgen/ir/ty.rs
@@ -95,6 +95,11 @@ impl Type {
         matches!(self.kind, TypeKind::BlockPointer(..))
     }
 
+    /// Is this an integer type, including `bool` or `char`?
+    pub fn is_int(&self) -> bool {
+        matches!(self.kind, TypeKind::Int(_))
+    }
+
     /// Is this a compound type?
     pub fn is_comp(&self) -> bool {
         matches!(self.kind, TypeKind::Comp(..))


### PR DESCRIPTION
Fixes #2008.

Example:

```c
enum Enum { Variant };
typedef int16_t Enum;
```

This is valid and idiomatic C (though not valid C++). `cbindgen` uses this idiom as the default C translation of Rust enums, the equivalent of what would be `enum Enum : int16_t { Variant };` in C++.

`bindgen header.h` before:

```rust
pub const Enum_Variant: Enum = 0;
pub type Enum = ::std::os::raw::c_uint;
pub type Enum = i16;
```

```console
error[E0428]: the name `Enum` is defined multiple times
 --> generated.rs:3:1
  |
2 | pub type Enum = ::std::os::raw::c_uint;
  | --------------------------------------- previous definition of the type `Enum` here
3 | pub type Enum = i16;
  | ^^^^^^^^^^^^^^^^^^^^ `Enum` redefined here
  |
  = note: `Enum` must be defined only once in the type namespace of this module
```

After:

```rust

pub const Enum_Variant: Enum = 0;
pub type Enum = i16;
```