### PR TITLE
Add the `--override-abi` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -148,6 +148,8 @@
 # Unreleased
 
 ## Added
+ * new feature: `--override-abi` flag to override the ABI used by functions
+   matching a regular expression.
 
 ## Changed
 

--- a/bindgen-cli/options.rs
+++ b/bindgen-cli/options.rs
@@ -1096,9 +1096,10 @@ where
 
     if let Some(abi_overrides) = matches.values_of("override-abi") {
         for abi_override in abi_overrides {
+            let abi_override = abi_override.strip_prefix('[').expect("Invalid ABI override: Missing `[`");
             let (abi_str, regex) =
-                abi_override.split_once(":").expect("Invalid ABI override");
-            let abi = abi_str.parse().unwrap();
+                abi_override.split_once("]").expect("Invalid ABI override: Missing `]`");
+            let abi = abi_str.parse().unwrap_or_else(|err| panic!("Invalid ABI override: {}", err));
             builder = builder.override_abi(abi, regex);
         }
     }

--- a/bindgen-cli/options.rs
+++ b/bindgen-cli/options.rs
@@ -568,6 +568,12 @@ where
             Arg::new("merge-extern-blocks")
                 .long("merge-extern-blocks")
                 .help("Deduplicates extern blocks."),
+            Arg::new("override-abi")
+                .long("override-abi")
+                .help("Overrides the ABI of functions matching <regex>. The <override> value must be of the shape <abi>:<regex> where <abi> can be one of C, stdcall, fastcall, thiscall, aapcs or win64.")
+                .value_name("override")
+                .multiple_occurrences(true)
+                .number_of_values(1),
             Arg::new("V")
                 .long("version")
                 .help("Prints the version, and exits"),
@@ -1086,6 +1092,15 @@ where
 
     if matches.is_present("merge-extern-blocks") {
         builder = builder.merge_extern_blocks(true);
+    }
+
+    if let Some(abi_overrides) = matches.values_of("override-abi") {
+        for abi_override in abi_overrides {
+            let (abi_str, regex) =
+                abi_override.split_once(":").expect("Invalid ABI override");
+            let abi = abi_str.parse().unwrap();
+            builder = builder.override_abi(abi, regex);
+        }
     }
 
     Ok((builder, output, verbose))

--- a/bindgen-cli/options.rs
+++ b/bindgen-cli/options.rs
@@ -1096,12 +1096,9 @@ where
 
     if let Some(abi_overrides) = matches.values_of("override-abi") {
         for abi_override in abi_overrides {
-            let abi_override = abi_override
-                .strip_prefix('[')
-                .expect("Invalid ABI override: Missing `[`");
-            let (abi_str, regex) = abi_override
-                .split_once("]")
-                .expect("Invalid ABI override: Missing `]`");
+            let (regex, abi_str) = abi_override
+                .rsplit_once("=")
+                .expect("Invalid ABI override: Missing `=`");
             let abi = abi_str
                 .parse()
                 .unwrap_or_else(|err| panic!("Invalid ABI override: {}", err));

--- a/bindgen-cli/options.rs
+++ b/bindgen-cli/options.rs
@@ -1096,10 +1096,15 @@ where
 
     if let Some(abi_overrides) = matches.values_of("override-abi") {
         for abi_override in abi_overrides {
-            let abi_override = abi_override.strip_prefix('[').expect("Invalid ABI override: Missing `[`");
-            let (abi_str, regex) =
-                abi_override.split_once("]").expect("Invalid ABI override: Missing `]`");
-            let abi = abi_str.parse().unwrap_or_else(|err| panic!("Invalid ABI override: {}", err));
+            let abi_override = abi_override
+                .strip_prefix('[')
+                .expect("Invalid ABI override: Missing `[`");
+            let (abi_str, regex) = abi_override
+                .split_once("]")
+                .expect("Invalid ABI override: Missing `]`");
+            let abi = abi_str
+                .parse()
+                .unwrap_or_else(|err| panic!("Invalid ABI override: {}", err));
             builder = builder.override_abi(abi, regex);
         }
     }

--- a/bindgen-tests/tests/expectations/tests/abi-override.rs
+++ b/bindgen-tests/tests/expectations/tests/abi-override.rs
@@ -8,7 +8,7 @@
 extern "fastcall" {
     pub fn foo();
 }
-extern "aapcs" {
+extern "stdcall" {
     pub fn bar();
 }
 extern "C" {

--- a/bindgen-tests/tests/expectations/tests/abi-override.rs
+++ b/bindgen-tests/tests/expectations/tests/abi-override.rs
@@ -1,0 +1,16 @@
+#![allow(
+    dead_code,
+    non_snake_case,
+    non_camel_case_types,
+    non_upper_case_globals
+)]
+
+extern "fastcall" {
+    pub fn foo();
+}
+extern "aapcs" {
+    pub fn bar();
+}
+extern "C" {
+    pub fn baz();
+}

--- a/bindgen-tests/tests/headers/abi-override.h
+++ b/bindgen-tests/tests/headers/abi-override.h
@@ -1,4 +1,4 @@
-// bindgen-flags: --override-abi=[fastcall]foo --override-abi=[stdcall]bar
+// bindgen-flags: --override-abi=foo=fastcall --override-abi=bar=stdcall
 
 void foo();
 void bar();

--- a/bindgen-tests/tests/headers/abi-override.h
+++ b/bindgen-tests/tests/headers/abi-override.h
@@ -1,4 +1,4 @@
-// bindgen-flags: --override-abi=fastcall:foo --override-abi=aapcs:bar
+// bindgen-flags: --override-abi=fastcall:foo --override-abi=stdcall:bar
 
 void foo();
 void bar();

--- a/bindgen-tests/tests/headers/abi-override.h
+++ b/bindgen-tests/tests/headers/abi-override.h
@@ -1,4 +1,4 @@
-// bindgen-flags: --override-abi=fastcall:foo --override-abi=stdcall:bar
+// bindgen-flags: --override-abi=[fastcall]foo --override-abi=[stdcall]bar
 
 void foo();
 void bar();

--- a/bindgen-tests/tests/headers/abi-override.h
+++ b/bindgen-tests/tests/headers/abi-override.h
@@ -1,0 +1,5 @@
+// bindgen-flags: --override-abi=fastcall:foo --override-abi=aapcs:bar
+
+void foo();
+void bar();
+void baz();

--- a/bindgen/codegen/dyngen.rs
+++ b/bindgen/codegen/dyngen.rs
@@ -1,5 +1,5 @@
 use crate::codegen;
-use crate::ir::function::Abi;
+use crate::ir::function::ClangAbi;
 use proc_macro2::Ident;
 
 /// Used to build the output tokens for dynamic bindings.
@@ -113,10 +113,10 @@ impl DynamicItems {
     }
 
     #[allow(clippy::too_many_arguments)]
-    pub fn push(
+    pub(crate) fn push(
         &mut self,
         ident: Ident,
-        abi: Abi,
+        abi: ClangAbi,
         is_variadic: bool,
         is_required: bool,
         args: Vec<proc_macro2::TokenStream>,

--- a/bindgen/codegen/mod.rs
+++ b/bindgen/codegen/mod.rs
@@ -3797,8 +3797,7 @@ impl TryToRustTy for Type {
                 // sizeof(NonZero<_>) optimization with opaque blobs (because
                 // they aren't NonZero), so don't *ever* use an or_opaque
                 // variant here.
-                let ty = fs
-                    .try_to_rust_ty(ctx, &self.name().map(|x| x.to_string()))?;
+                let ty = fs.try_to_rust_ty(ctx, &())?;
 
                 let prefix = ctx.trait_prefix();
                 Ok(quote! {
@@ -3988,17 +3987,17 @@ impl TryToRustTy for TemplateInstantiation {
 }
 
 impl TryToRustTy for FunctionSig {
-    type Extra = Option<String>;
+    type Extra = ();
 
     fn try_to_rust_ty(
         &self,
         ctx: &BindgenContext,
-        name: &Option<String>,
+        _: &(),
     ) -> error::Result<proc_macro2::TokenStream> {
         // TODO: we might want to consider ignoring the reference return value.
         let ret = utils::fnsig_return_ty(ctx, self);
         let arguments = utils::fnsig_arguments(ctx, self);
-        let abi = self.abi(ctx, name.as_deref());
+        let abi = self.abi(ctx, None);
 
         match abi {
             ClangAbi::Known(Abi::ThisCall)

--- a/bindgen/ir/function.rs
+++ b/bindgen/ir/function.rs
@@ -202,7 +202,7 @@ impl FromStr for Abi {
             "vectorcall" => Ok(Self::Vectorcall),
             "aapcs" => Ok(Self::Aapcs),
             "win64" => Ok(Self::Win64),
-            _ => Err(format!("Invalid ABI {:?}", s)),
+            _ => Err(format!("Invalid or unknown ABI {:?}", s)),
         }
     }
 }

--- a/bindgen/lib.rs
+++ b/bindgen/lib.rs
@@ -368,7 +368,7 @@ impl Builder {
         for (abi, set) in &self.options.abi_overrides {
             for item in set.get_items() {
                 output_vector.push("--override-abi".to_owned());
-                output_vector.push(format!("[{}]{}", abi, item));
+                output_vector.push(format!("{}={}", item, abi));
             }
         }
 

--- a/bindgen/lib.rs
+++ b/bindgen/lib.rs
@@ -368,7 +368,7 @@ impl Builder {
         for (abi, set) in &self.options.abi_overrides {
             for item in set.get_items() {
                 output_vector.push("--override-abi".to_owned());
-                output_vector.push(format!("{}:{}", abi, item));
+                output_vector.push(format!("[{}]{}", abi, item));
             }
         }
 


### PR DESCRIPTION
This option can be used from the CLI with the <abi>:<regex> syntax and it overrides the ABI of a function if it matches <regex>.

Fixes #2257 as the `".*"` regex can be used to match every function.