### PR TITLE
Allow callback composition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -154,6 +154,8 @@
  * Regex inputs are sanitized so alternation (`a|b`) is handled correctly but
    wildcard patterns (`*`) are now considered invalid.
  * the `ParseCallbacks`trait does not require to implement `UnwindSafe`.
+ * the `Builder::parse_callbacks` method no longer overwrites previously added
+   callbacks and composes them in a last-to-first manner.
 
 ## Removed
 

--- a/bindgen/codegen/mod.rs
+++ b/bindgen/codegen/mod.rs
@@ -2112,12 +2112,9 @@ impl CodeGenerator for CompInfo {
 
         // The custom derives callback may return a list of derive attributes;
         // add them to the end of the list.
-        let custom_derives;
-        if let Some(cb) = &ctx.options().parse_callbacks {
-            custom_derives = cb.add_derives(&canonical_name);
-            // In most cases this will be a no-op, since custom_derives will be empty.
-            derives.extend(custom_derives.iter().map(|s| s.as_str()));
-        };
+        let custom_derives = ctx.options().parse_callbacks.iter().flat_map(|cb| cb.add_derives(&canonical_name)).collect::<Vec<String>>();
+        // In most cases this will be a no-op, since custom_derives will be empty.
+        derives.extend(custom_derives.iter().map(|s| s.as_str()));
 
         if !derives.is_empty() {
             attributes.push(attributes::derives(&derives))
@@ -3152,12 +3149,9 @@ impl CodeGenerator for Enum {
 
             // The custom derives callback may return a list of derive attributes;
             // add them to the end of the list.
-            let custom_derives;
-            if let Some(cb) = &ctx.options().parse_callbacks {
-                custom_derives = cb.add_derives(&name);
-                // In most cases this will be a no-op, since custom_derives will be empty.
-                derives.extend(custom_derives.iter().map(|s| s.as_str()));
-            };
+            let custom_derives = ctx.options().parse_callbacks.iter().flat_map(|cb| cb.add_derives(&name)).collect::<Vec<String>>();
+            // In most cases this will be a no-op, since custom_derives will be empty.
+            derives.extend(custom_derives.iter().map(|s| s.as_str()));
 
             attrs.push(attributes::derives(&derives));
         }

--- a/bindgen/ir/enum_ty.rs
+++ b/bindgen/ir/enum_ty.rs
@@ -103,7 +103,7 @@ impl Enum {
                     let annotations = Annotations::new(&cursor);
                     let custom_behavior = ctx
                         .parse_callbacks()
-                        .and_then(|callbacks| {
+                        .find_map(|callbacks| {
                             callbacks
                                 .enum_variant_behavior(type_name, &name, val)
                         })
@@ -120,7 +120,7 @@ impl Enum {
 
                     let new_name = ctx
                         .parse_callbacks()
-                        .and_then(|callbacks| {
+                        .find_map(|callbacks| {
                             callbacks.enum_variant_name(type_name, &name, val)
                         })
                         .or_else(|| {

--- a/bindgen/ir/function.rs
+++ b/bindgen/ir/function.rs
@@ -664,10 +664,11 @@ impl ClangSubItemParser for Function {
             // but seems easy enough to handle it here.
             name.push_str("_destructor");
         }
-        if let Some(callbacks) = context.parse_callbacks() {
-            if let Some(nm) = callbacks.generated_name_override(&name) {
-                name = nm;
-            }
+        if let Some(nm) = context
+            .parse_callbacks()
+            .find_map(|callbacks| callbacks.generated_name_override(&name))
+        {
+            name = nm;
         }
         assert!(!name.is_empty(), "Empty function name.");
 

--- a/bindgen/ir/item.rs
+++ b/bindgen/ir/item.rs
@@ -933,7 +933,7 @@ impl Item {
 
         let name = if opt.user_mangled == UserMangled::Yes {
             ctx.parse_callbacks()
-                .and_then(|callbacks| callbacks.item_name(&name))
+                .find_map(|callbacks| callbacks.item_name(&name))
                 .unwrap_or(name)
         } else {
             name

--- a/bindgen/ir/var.rs
+++ b/bindgen/ir/var.rs
@@ -182,7 +182,7 @@ impl ClangSubItemParser for Var {
         use clang_sys::*;
         match cursor.kind() {
             CXCursor_MacroDefinition => {
-                if let Some(callbacks) = ctx.parse_callbacks() {
+                for callbacks in ctx.parse_callbacks() {
                     match callbacks.will_parse_macro(&cursor.spelling()) {
                         MacroParsingBehavior::Ignore => {
                             return Err(ParseError::Continue);
@@ -249,7 +249,7 @@ impl ClangSubItemParser for Var {
                             true,
                             ctx,
                         );
-                        if let Some(callbacks) = ctx.parse_callbacks() {
+                        for callbacks in ctx.parse_callbacks() {
                             callbacks.str_macro(&name, &val);
                         }
                         (TypeKind::Pointer(char_ty), VarType::String(val))
@@ -257,7 +257,7 @@ impl ClangSubItemParser for Var {
                     EvalResult::Int(Wrapping(value)) => {
                         let kind = ctx
                             .parse_callbacks()
-                            .and_then(|c| c.int_macro(&name, value))
+                            .find_map(|c| c.int_macro(&name, value))
                             .unwrap_or_else(|| {
                                 default_macro_constant_type(ctx, value)
                             });

--- a/bindgen/lib.rs
+++ b/bindgen/lib.rs
@@ -1464,7 +1464,7 @@ impl Builder {
         mut self,
         cb: Box<dyn callbacks::ParseCallbacks>,
     ) -> Self {
-        self.options.parse_callbacks = Some(Rc::from(cb));
+        self.options.parse_callbacks.push(Rc::from(cb));
         self
     }
 
@@ -1982,7 +1982,7 @@ struct BindgenOptions {
 
     /// A user-provided visitor to allow customizing different kinds of
     /// situations.
-    parse_callbacks: Option<Rc<dyn callbacks::ParseCallbacks>>,
+    parse_callbacks: Vec<Rc<dyn callbacks::ParseCallbacks>>,
 
     /// Which kind of items should we generate? By default, we'll generate all
     /// of them.
@@ -2146,6 +2146,9 @@ impl BindgenOptions {
         for regex_set in &mut regex_sets {
             regex_set.build(record_matches);
         }
+
+        // Reverse parse callbacks to have a last-to-first priority.
+        self.parse_callbacks.reverse();
     }
 
     /// Update rust target version
@@ -2225,7 +2228,7 @@ impl Default for BindgenOptions {
             clang_args: vec![],
             input_headers: vec![],
             input_header_contents: Default::default(),
-            parse_callbacks: None,
+            parse_callbacks: Default::default(),
             codegen_config: CodegenConfig::all(),
             conservative_inline_namespaces: false,
             generate_comments: true,


### PR DESCRIPTION
Store all the callbacks added to the builder in a `Vec` so bindgen invokes each one of them in a last-to-first manner.