### PR TITLE
Allow to set default visibility of struct fields.

### DIFF
--- a/bindgen-cli/options.rs
+++ b/bindgen-cli/options.rs
@@ -2,7 +2,7 @@ use bindgen::callbacks::TypeKind;
 use bindgen::{
     builder, AliasVariation, Builder, CodegenConfig, EnumVariation,
     MacroTypeVariation, NonCopyUnionStyle, RegexSet, RustTarget,
-    DEFAULT_ANON_FIELDS_PREFIX, RUST_TARGET_STRINGS,
+    DEFAULT_ANON_FIELDS_PREFIX, RUST_TARGET_STRINGS, FieldVisibilityKind,
 };
 use clap::Parser;
 use std::fs::File;
@@ -358,6 +358,9 @@ struct BindgenCommand {
     /// inline` functions.
     #[arg(long, requires = "experimental", value_name = "SUFFIX")]
     wrap_static_fns_suffix: Option<String>,
+    /// Sets the default visibility for fields.
+    #[arg(long, value_name = "VISIBILITY")]
+    default_visibility: Option<FieldVisibilityKind>,
     /// Enables experimental features.
     #[arg(long)]
     experimental: bool,
@@ -482,6 +485,7 @@ where
         wrap_static_fns,
         wrap_static_fns_path,
         wrap_static_fns_suffix,
+        default_visibility,
         experimental: _,
         version,
         clang_args,
@@ -1013,6 +1017,10 @@ where
 
     if let Some(suffix) = wrap_static_fns_suffix {
         builder = builder.wrap_static_fns_suffix(suffix);
+    }
+
+    if let Some(visibility) = default_visibility {
+        builder = builder.default_visibility(visibility);
     }
 
     Ok((builder, output, verbose))

--- a/bindgen-cli/options.rs
+++ b/bindgen-cli/options.rs
@@ -1,8 +1,8 @@
 use bindgen::callbacks::TypeKind;
 use bindgen::{
     builder, AliasVariation, Builder, CodegenConfig, EnumVariation,
-    MacroTypeVariation, NonCopyUnionStyle, RegexSet, RustTarget,
-    DEFAULT_ANON_FIELDS_PREFIX, RUST_TARGET_STRINGS, FieldVisibilityKind,
+    FieldVisibilityKind, MacroTypeVariation, NonCopyUnionStyle, RegexSet,
+    RustTarget, DEFAULT_ANON_FIELDS_PREFIX, RUST_TARGET_STRINGS,
 };
 use clap::Parser;
 use std::fs::File;

--- a/bindgen-cli/options.rs
+++ b/bindgen-cli/options.rs
@@ -358,7 +358,8 @@ struct BindgenCommand {
     /// inline` functions.
     #[arg(long, requires = "experimental", value_name = "SUFFIX")]
     wrap_static_fns_suffix: Option<String>,
-    /// Sets the default visibility for fields.
+    /// Set the default visibility of fields, including bitfields and accessor methods for
+    /// bitfields. This flag is ignored if the `--respect-cxx-access-specs` flag is used.
     #[arg(long, value_name = "VISIBILITY")]
     default_visibility: Option<FieldVisibilityKind>,
     /// Enables experimental features.

--- a/bindgen-tests/tests/expectations/tests/default_visibility_crate.rs
+++ b/bindgen-tests/tests/expectations/tests/default_visibility_crate.rs
@@ -1,0 +1,13 @@
+#![allow(
+    dead_code,
+    non_snake_case,
+    non_camel_case_types,
+    non_upper_case_globals
+)]
+
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct Point {
+    pub(crate) x: ::std::os::raw::c_int,
+    pub(crate) y: ::std::os::raw::c_int,
+}

--- a/bindgen-tests/tests/expectations/tests/default_visibility_private.rs
+++ b/bindgen-tests/tests/expectations/tests/default_visibility_private.rs
@@ -1,0 +1,13 @@
+#![allow(
+    dead_code,
+    non_snake_case,
+    non_camel_case_types,
+    non_upper_case_globals
+)]
+
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct Point {
+    x: ::std::os::raw::c_int,
+    y: ::std::os::raw::c_int,
+}

--- a/bindgen-tests/tests/expectations/tests/default_visibility_private_respects_cxx_access_spec.rs
+++ b/bindgen-tests/tests/expectations/tests/default_visibility_private_respects_cxx_access_spec.rs
@@ -1,0 +1,13 @@
+#![allow(
+    dead_code,
+    non_snake_case,
+    non_camel_case_types,
+    non_upper_case_globals
+)]
+
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct Point {
+    pub x: ::std::os::raw::c_int,
+    pub y: ::std::os::raw::c_int,
+}

--- a/bindgen-tests/tests/headers/default_visibility_crate.h
+++ b/bindgen-tests/tests/headers/default_visibility_crate.h
@@ -1,0 +1,6 @@
+// bindgen-flags: --no-layout-tests --default-visibility=crate 
+
+struct Point {
+    int x;
+    int y;
+};

--- a/bindgen-tests/tests/headers/default_visibility_private.h
+++ b/bindgen-tests/tests/headers/default_visibility_private.h
@@ -1,0 +1,6 @@
+// bindgen-flags: --no-layout-tests --default-visibility=private 
+
+struct Point {
+    int x;
+    int y;
+};

--- a/bindgen-tests/tests/headers/default_visibility_private_respects_cxx_access_spec.h
+++ b/bindgen-tests/tests/headers/default_visibility_private_respects_cxx_access_spec.h
@@ -1,0 +1,7 @@
+// bindgen-flags: --respect-cxx-access-specs --no-layout-tests --default-visibility=private 
+
+struct Point {
+    int x;
+    int y;
+};
+

--- a/bindgen/codegen/mod.rs
+++ b/bindgen/codegen/mod.rs
@@ -1601,7 +1601,7 @@ fn compute_visibility(
     match (
         is_declared_public,
         ctx.options().respect_cxx_access_specs,
-        annotations.and_then(|e| e.visibility_kind())
+        annotations.and_then(|e| e.visibility_kind()),
     ) {
         (true, true, annotated_visibility) => {
             // declared as public, cxx specs are respected

--- a/bindgen/codegen/mod.rs
+++ b/bindgen/codegen/mod.rs
@@ -1601,7 +1601,7 @@ fn compute_visibility(
     match (
         is_declared_public,
         ctx.options().respect_cxx_access_specs,
-        annotations.map(|e| e.visibility_kind()).flatten(),
+        annotations.and_then(|e| e.visibility_kind())
     ) {
         (true, true, annotated_visibility) => {
             // declared as public, cxx specs are respected

--- a/bindgen/codegen/mod.rs
+++ b/bindgen/codegen/mod.rs
@@ -21,7 +21,9 @@ use super::BindgenOptions;
 
 use crate::callbacks::{DeriveInfo, TypeKind as DeriveTypeKind};
 use crate::ir::analysis::{HasVtable, Sizedness};
-use crate::ir::annotations::FieldAccessorKind;
+use crate::ir::annotations::{
+    Annotations, FieldAccessorKind, FieldVisibilityKind,
+};
 use crate::ir::comp::{
     Bitfield, BitfieldUnit, CompInfo, CompKind, Field, FieldData, FieldMethods,
     Method, MethodKind,
@@ -1275,7 +1277,7 @@ trait FieldCodegen<'a> {
     fn codegen<F, M>(
         &self,
         ctx: &BindgenContext,
-        fields_should_be_private: bool,
+        visibility_kind: FieldVisibilityKind,
         accessor_kind: FieldAccessorKind,
         parent: &CompInfo,
         result: &mut CodegenResult,
@@ -1294,7 +1296,7 @@ impl<'a> FieldCodegen<'a> for Field {
     fn codegen<F, M>(
         &self,
         ctx: &BindgenContext,
-        fields_should_be_private: bool,
+        visibility_kind: FieldVisibilityKind,
         accessor_kind: FieldAccessorKind,
         parent: &CompInfo,
         result: &mut CodegenResult,
@@ -1310,7 +1312,7 @@ impl<'a> FieldCodegen<'a> for Field {
             Field::DataMember(ref data) => {
                 data.codegen(
                     ctx,
-                    fields_should_be_private,
+                    visibility_kind,
                     accessor_kind,
                     parent,
                     result,
@@ -1323,7 +1325,7 @@ impl<'a> FieldCodegen<'a> for Field {
             Field::Bitfields(ref unit) => {
                 unit.codegen(
                     ctx,
-                    fields_should_be_private,
+                    visibility_kind,
                     accessor_kind,
                     parent,
                     result,
@@ -1372,7 +1374,7 @@ impl<'a> FieldCodegen<'a> for FieldData {
     fn codegen<F, M>(
         &self,
         ctx: &BindgenContext,
-        fields_should_be_private: bool,
+        parent_visibility_kind: FieldVisibilityKind,
         accessor_kind: FieldAccessorKind,
         parent: &CompInfo,
         result: &mut CodegenResult,
@@ -1435,23 +1437,31 @@ impl<'a> FieldCodegen<'a> for FieldData {
             fields.extend(Some(padding_field));
         }
 
-        let is_private = (!self.is_public() &&
-            ctx.options().respect_cxx_access_specs) ||
-            self.annotations()
-                .private_fields()
-                .unwrap_or(fields_should_be_private);
-
+        let visibility = compute_visibility(
+            ctx,
+            self.is_public(),
+            Some(self.annotations()),
+            parent_visibility_kind,
+        );
         let accessor_kind =
             self.annotations().accessor_kind().unwrap_or(accessor_kind);
 
-        if is_private {
-            field.append_all(quote! {
-                #field_ident : #ty ,
-            });
-        } else {
-            field.append_all(quote! {
-                pub #field_ident : #ty ,
-            });
+        match visibility {
+            FieldVisibilityKind::Private => {
+                field.append_all(quote! {
+                    #field_ident : #ty ,
+                });
+            }
+            FieldVisibilityKind::PublicCrate => {
+                field.append_all(quote! {
+                    pub(crate) #field_ident : #ty ,
+                });
+            }
+            FieldVisibilityKind::Public => {
+                field.append_all(quote! {
+                    pub #field_ident : #ty ,
+                });
+            }
         }
 
         fields.extend(Some(field));
@@ -1561,13 +1571,48 @@ impl Bitfield {
 }
 
 fn access_specifier(
-    ctx: &BindgenContext,
-    is_pub: bool,
+    visibility: FieldVisibilityKind,
 ) -> proc_macro2::TokenStream {
-    if is_pub || !ctx.options().respect_cxx_access_specs {
-        quote! { pub }
-    } else {
-        quote! {}
+    match visibility {
+        FieldVisibilityKind::Private => quote! {},
+        FieldVisibilityKind::PublicCrate => quote! { pub(crate) },
+        FieldVisibilityKind::Public => quote! { pub },
+    }
+}
+
+/// Compute a fields or structs visibility based on multiple conditions.
+/// 1. If the element was declared public, and we respect such CXX accesses specs
+/// (context option) => By default Public, but this can be overruled by an `annotation`.
+///
+/// 2. If the element was declared private, and we respect such CXX accesses specs
+/// (context option) => By default Private, but this can be overruled by an `annotation`.
+///
+/// 3. If we do not respect visibility modifiers, the result depends on the `annotation`,
+/// if any, or the passed `default_kind`.
+///
+fn compute_visibility(
+    ctx: &BindgenContext,
+    is_declared_public: bool,
+    annotations: Option<&Annotations>,
+    default_kind: FieldVisibilityKind,
+) -> FieldVisibilityKind {
+    match (
+        is_declared_public,
+        ctx.options().respect_cxx_access_specs,
+        annotations.map(|e| e.visibility_kind()).flatten(),
+    ) {
+        (true, true, annotated_visibility) => {
+            // declared as public, cxx specs are respected
+            annotated_visibility.unwrap_or(FieldVisibilityKind::Public)
+        }
+        (false, true, annotated_visibility) => {
+            // declared as private, cxx specs are respected
+            annotated_visibility.unwrap_or(FieldVisibilityKind::Private)
+        }
+        (_, false, annotated_visibility) => {
+            // cxx specs are not respected, declaration does not matter.
+            annotated_visibility.unwrap_or(default_kind)
+        }
     }
 }
 
@@ -1577,7 +1622,7 @@ impl<'a> FieldCodegen<'a> for BitfieldUnit {
     fn codegen<F, M>(
         &self,
         ctx: &BindgenContext,
-        fields_should_be_private: bool,
+        visibility_kind: FieldVisibilityKind,
         accessor_kind: FieldAccessorKind,
         parent: &CompInfo,
         result: &mut CodegenResult,
@@ -1618,8 +1663,9 @@ impl<'a> FieldCodegen<'a> for BitfieldUnit {
                 2 => quote! { u16 },
                 _ => quote! { u8  },
             };
+            let access_spec = access_specifier(visibility_kind);
             let align_field = quote! {
-                pub #align_field_ident: [#align_ty; 0],
+                #access_spec #align_field_ident: [#align_ty; 0],
             };
             fields.extend(Some(align_field));
         }
@@ -1638,7 +1684,7 @@ impl<'a> FieldCodegen<'a> for BitfieldUnit {
         // the 32 items limitation.
         let mut generate_ctor = layout.size <= RUST_DERIVE_IN_ARRAY_LIMIT;
 
-        let mut access_spec = !fields_should_be_private;
+        let mut all_fields_declared_as_public = true;
         for bf in self.bitfields() {
             // Codegen not allowed for anonymous bitfields
             if bf.name().is_none() {
@@ -1651,12 +1697,11 @@ impl<'a> FieldCodegen<'a> for BitfieldUnit {
                 continue;
             }
 
-            access_spec &= bf.is_public();
+            all_fields_declared_as_public &= bf.is_public();
             let mut bitfield_representable_as_int = true;
-
             bf.codegen(
                 ctx,
-                fields_should_be_private,
+                visibility_kind,
                 accessor_kind,
                 parent,
                 result,
@@ -1684,7 +1729,13 @@ impl<'a> FieldCodegen<'a> for BitfieldUnit {
             ctor_impl = bf.extend_ctor_impl(ctx, param_name, ctor_impl);
         }
 
-        let access_spec = access_specifier(ctx, access_spec);
+        let visibility_kind = compute_visibility(
+            ctx,
+            all_fields_declared_as_public,
+            None,
+            visibility_kind,
+        );
+        let access_spec = access_specifier(visibility_kind);
 
         let field = quote! {
             #access_spec #unit_field_ident : #field_ty ,
@@ -1730,7 +1781,7 @@ impl<'a> FieldCodegen<'a> for Bitfield {
     fn codegen<F, M>(
         &self,
         ctx: &BindgenContext,
-        fields_should_be_private: bool,
+        visibility_kind: FieldVisibilityKind,
         _accessor_kind: FieldAccessorKind,
         parent: &CompInfo,
         _result: &mut CodegenResult,
@@ -1770,10 +1821,14 @@ impl<'a> FieldCodegen<'a> for Bitfield {
 
         let offset = self.offset_into_unit();
         let width = self.width() as u8;
-        let access_spec = access_specifier(
+
+        let visibility_kind = compute_visibility(
             ctx,
-            self.is_public() && !fields_should_be_private,
+            self.is_public(),
+            Some(self.annotations()),
+            visibility_kind,
         );
+        let access_spec = access_specifier(visibility_kind);
 
         if parent.is_union() && !struct_layout.is_rust_union() {
             methods.extend(Some(quote! {
@@ -1899,7 +1954,16 @@ impl CodeGenerator for CompInfo {
 
                 struct_layout.saw_base(inner_item.expect_type());
 
-                let access_spec = access_specifier(ctx, base.is_public());
+                let visibility = match (
+                    base.is_public(),
+                    ctx.options().respect_cxx_access_specs,
+                ) {
+                    (true, true) => FieldVisibilityKind::Public,
+                    (false, true) => FieldVisibilityKind::Private,
+                    _ => ctx.options().default_visibility,
+                };
+
+                let access_spec = access_specifier(visibility);
                 fields.push(quote! {
                     #access_spec #field_name: #inner,
                 });
@@ -1908,8 +1972,10 @@ impl CodeGenerator for CompInfo {
 
         let mut methods = vec![];
         if !is_opaque {
-            let fields_should_be_private =
-                item.annotations().private_fields().unwrap_or(false);
+            let visibility = item
+                .annotations()
+                .visibility_kind()
+                .unwrap_or(ctx.options().default_visibility);
             let struct_accessor_kind = item
                 .annotations()
                 .accessor_kind()
@@ -1917,7 +1983,7 @@ impl CodeGenerator for CompInfo {
             for field in self.fields() {
                 field.codegen(
                     ctx,
-                    fields_should_be_private,
+                    visibility,
                     struct_accessor_kind,
                     self,
                     result,

--- a/bindgen/codegen/mod.rs
+++ b/bindgen/codegen/mod.rs
@@ -1040,13 +1040,15 @@ impl CodeGenerator for Type {
                     });
                 }
 
+                let access_spec =
+                    access_specifier(ctx.options().default_visibility);
                 tokens.append_all(match alias_style {
                     AliasVariation::TypeAlias => quote! {
                         = #inner_rust_type ;
                     },
                     AliasVariation::NewType | AliasVariation::NewTypeDeref => {
                         quote! {
-                            (pub #inner_rust_type) ;
+                            (#access_spec #inner_rust_type) ;
                         }
                     }
                 });

--- a/bindgen/ir/annotations.rs
+++ b/bindgen/ir/annotations.rs
@@ -27,8 +27,20 @@ impl FromStr for FieldVisibilityKind {
             "private" => Ok(Self::Private),
             "crate" => Ok(Self::PublicCrate),
             "public" => Ok(Self::Public),
-            _ => Err(format!("Invalid visibility kind: `{}`", s))
+            _ => Err(format!("Invalid visibility kind: `{}`", s)),
         }
+    }
+}
+
+impl std::fmt::Display for FieldVisibilityKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            FieldVisibilityKind::Private => "private",
+            FieldVisibilityKind::PublicCrate => "crate",
+            FieldVisibilityKind::Public => "public",
+        };
+
+        s.fmt(f)
     }
 }
 

--- a/bindgen/ir/annotations.rs
+++ b/bindgen/ir/annotations.rs
@@ -4,6 +4,8 @@
 //! replace other types with, mark as opaque, etc. This module deals with all of
 //! that stuff.
 
+use std::str::FromStr;
+
 use crate::clang;
 
 /// What kind of visibility modifer should be used for a struct or field?
@@ -15,6 +17,19 @@ pub enum FieldVisibilityKind {
     PublicCrate,
     /// Fields are marked as public, i.e., struct Foo {pub bar: bool}
     Public,
+}
+
+impl FromStr for FieldVisibilityKind {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "private" => Ok(Self::Private),
+            "crate" => Ok(Self::PublicCrate),
+            "public" => Ok(Self::Public),
+            _ => Err(format!("Invalid visibility kind: `{}`", s))
+        }
+    }
 }
 
 impl Default for FieldVisibilityKind {

--- a/bindgen/lib.rs
+++ b/bindgen/lib.rs
@@ -61,6 +61,8 @@ mod regex_set;
 use codegen::CodegenError;
 use ir::comment;
 
+pub use ir::annotations::FieldVisibilityKind;
+
 pub use crate::codegen::{
     AliasVariation, EnumVariation, MacroTypeVariation, NonCopyUnionStyle,
 };
@@ -1813,6 +1815,15 @@ impl Builder {
         self.options.wrap_static_fns_suffix = Some(suffix.as_ref().to_owned());
         self
     }
+
+    /// Mark struct fields as private by default.
+    pub fn default_visibility(
+        mut self,
+        visibility: FieldVisibilityKind,
+    ) -> Self {
+        self.options.default_visibility = visibility;
+        self
+    }
 }
 
 /// Configuration options for generated bindings.
@@ -2159,6 +2170,9 @@ struct BindgenOptions {
     wrap_static_fns_suffix: Option<String>,
 
     wrap_static_fns_path: Option<PathBuf>,
+
+    /// Default visibility of structs and their fields.
+    default_visibility: FieldVisibilityKind,
 }
 
 impl BindgenOptions {
@@ -2354,6 +2368,7 @@ impl Default for BindgenOptions {
             wrap_static_fns,
             wrap_static_fns_suffix,
             wrap_static_fns_path,
+            default_visibility,
         }
     }
 }

--- a/bindgen/lib.rs
+++ b/bindgen/lib.rs
@@ -655,6 +655,11 @@ impl Builder {
             output_vector.push(suffix.clone());
         }
 
+        if self.options.default_visibility != FieldVisibilityKind::Public {
+            output_vector.push("--default-visibility".into());
+            output_vector.push(self.options.default_visibility.to_string());
+        }
+
         if cfg!(feature = "experimental") {
             output_vector.push("--experimental".into());
         }

--- a/bindgen/lib.rs
+++ b/bindgen/lib.rs
@@ -1821,7 +1821,10 @@ impl Builder {
         self
     }
 
-    /// Mark struct fields as private by default.
+    /// Set the default visibility of fields, including bitfields and accessor methods for
+    /// bitfields.
+    ///
+    /// This option is ignored if the [`Builder::respect_cxx_access_specs`] method is enabled.
     pub fn default_visibility(
         mut self,
         visibility: FieldVisibilityKind,


### PR DESCRIPTION
Hello, I started to implement a feature to provide more fine gained control over the visibility of ~~`structs` and their corresponding~~ fields. Is there any particular reason why this is not already part of the API, or is it worth continuing the implementation to make this mergeable into mainline? 

Any thoughts and tips are welcome. 

- [ ] Write tests
- [ ] Compare output for big projects, to ensure backward compatibility (maybe this is done by CI?)
- [ ] Add flags for the CLI (also to the CLI flag builder thingy)

Best,
Nils