### PR TITLE
ir: Don't crash with built-in unexposed types from libclang.

### DIFF
--- a/bindgen/ir/ty.rs
+++ b/bindgen/ir/ty.rs
@@ -1145,8 +1145,7 @@ impl Type {
                         location,
                         None,
                         ctx,
-                    )
-                    .expect("Not able to resolve vector element?");
+                    )?;
                     TypeKind::Vector(inner, ty.num_elements().unwrap())
                 }
                 CXType_ConstantArray => {

--- a/bindgen/ir/var.rs
+++ b/bindgen/ir/var.rs
@@ -293,11 +293,11 @@ impl ClangSubItemParser for Var {
                 let ty = match Item::from_ty(&ty, cursor, None, ctx) {
                     Ok(ty) => ty,
                     Err(e) => {
-                        assert_eq!(
-                            ty.kind(),
-                            CXType_Auto,
+                        assert!(
+                            matches!(ty.kind(), CXType_Auto | CXType_Unexposed),
                             "Couldn't resolve constant type, and it \
-                             wasn't an nondeductible auto type!"
+                             wasn't an nondeductible auto type or unexposed \
+                             type!"
                         );
                         return Err(e);
                     }


### PR DESCRIPTION
This fixes #2325.

The issue is that `__bf16` is not exposed at all by libclang, which causes us to crash. It's a bit of a shame libclang doesn't expose it but there's no rust equivalent I think, so this should be ok for now.

Unfortunately no test because the header crashes older clang versions.