### PR TITLE
Fix inline function identification

### DIFF
--- a/bindgen-tests/tests/expectations/tests/public-dtor.rs
+++ b/bindgen-tests/tests/expectations/tests/public-dtor.rs
@@ -7,29 +7,47 @@
 
 #[repr(C)]
 #[derive(Debug, Default)]
-pub struct cv_String {
+pub struct cv_Foo {
     pub _address: u8,
 }
 #[test]
-fn bindgen_test_layout_cv_String() {
+fn bindgen_test_layout_cv_Foo() {
     assert_eq!(
-        ::std::mem::size_of::<cv_String>(),
+        ::std::mem::size_of::<cv_Foo>(),
         1usize,
-        concat!("Size of: ", stringify!(cv_String))
+        concat!("Size of: ", stringify!(cv_Foo))
     );
     assert_eq!(
-        ::std::mem::align_of::<cv_String>(),
+        ::std::mem::align_of::<cv_Foo>(),
         1usize,
-        concat!("Alignment of ", stringify!(cv_String))
+        concat!("Alignment of ", stringify!(cv_Foo))
     );
 }
 extern "C" {
-    #[link_name = "\u{1}_ZN2cv6StringD1Ev"]
-    pub fn cv_String_String_destructor(this: *mut cv_String);
+    #[link_name = "\u{1}_ZN2cv3FooD1Ev"]
+    pub fn cv_Foo_Foo_destructor(this: *mut cv_Foo);
 }
-impl cv_String {
+impl cv_Foo {
     #[inline]
     pub unsafe fn destruct(&mut self) {
-        unsafe { cv_String_String_destructor(self) }
+        unsafe { cv_Foo_Foo_destructor(self) }
     }
+}
+#[repr(C)]
+#[derive(Debug, Default)]
+pub struct cv_Bar {
+    pub _address: u8,
+}
+#[test]
+fn bindgen_test_layout_cv_Bar() {
+    assert_eq!(
+        ::std::mem::size_of::<cv_Bar>(),
+        1usize,
+        concat!("Size of: ", stringify!(cv_Bar))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<cv_Bar>(),
+        1usize,
+        concat!("Alignment of ", stringify!(cv_Bar))
+    );
 }

--- a/bindgen-tests/tests/headers/constructor-tp.hpp
+++ b/bindgen-tests/tests/headers/constructor-tp.hpp
@@ -8,7 +8,7 @@ public:
 };
 
 template<typename T>
-inline void
+void
 Foo<T>::doBaz() {
 }
 
@@ -21,6 +21,5 @@ template<typename T>
 Foo<T>::Foo() {
 }
 
-inline
 Bar::Bar() {
 }

--- a/bindgen-tests/tests/headers/public-dtor.hpp
+++ b/bindgen-tests/tests/headers/public-dtor.hpp
@@ -1,15 +1,18 @@
 
-
 namespace cv {
-class String {
-public:
-  ~String();
-};
+  class Foo {
+  public:
+      ~Foo();
+  };
 
+  Foo::~Foo() {}
 
-inline
-String::~String()
-{
-}
+  class Bar {
+  public:
+      ~Bar();
+  };
+
+  inline
+  Bar::~Bar() {}
 
 }

--- a/bindgen/ir/function.rs
+++ b/bindgen/ir/function.rs
@@ -675,7 +675,11 @@ impl ClangSubItemParser for Function {
             return Err(ParseError::Continue);
         }
 
-        if cursor.is_inlined_function() {
+        if cursor.is_inlined_function() ||
+            cursor
+                .definition()
+                .map_or(false, |x| x.is_inlined_function())
+        {
             if !context.options().generate_inline_functions {
                 return Err(ParseError::Continue);
             }


### PR DESCRIPTION
Fixes #2158

Checks if definition contains `inline` even if declaration doesn't
Tests have been adjusted