### PR TITLE
Fix duplicated function names

### DIFF
--- a/bindgen-tests/tests/expectations/tests/duplicated-definition-count.rs
+++ b/bindgen-tests/tests/expectations/tests/duplicated-definition-count.rs
@@ -1,0 +1,67 @@
+#![allow(
+    dead_code,
+    non_snake_case,
+    non_camel_case_types,
+    non_upper_case_globals
+)]
+
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct BitStream {
+    pub _address: u8,
+}
+#[test]
+fn bindgen_test_layout_BitStream() {
+    assert_eq!(
+        ::std::mem::size_of::<BitStream>(),
+        1usize,
+        concat!("Size of: ", stringify!(BitStream))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<BitStream>(),
+        1usize,
+        concat!("Alignment of ", stringify!(BitStream))
+    );
+}
+extern "C" {
+    #[link_name = "\u{1}_ZN9BitStream5WriteEPKcj"]
+    pub fn BitStream_Write(
+        this: *mut BitStream,
+        inputByteArray: *const ::std::os::raw::c_char,
+        numberOfBytes: ::std::os::raw::c_uint,
+    );
+}
+extern "C" {
+    #[link_name = "\u{1}_ZN9BitStream5WriteEPS_j"]
+    pub fn BitStream_Write1(
+        this: *mut BitStream,
+        bitStream: *mut BitStream,
+        numberOfBits: ::std::os::raw::c_uint,
+    );
+}
+extern "C" {
+    #[link_name = "\u{1}_ZN9BitStream6Write1Ev"]
+    pub fn BitStream_Write11(this: *mut BitStream);
+}
+impl BitStream {
+    #[inline]
+    pub unsafe fn Write(
+        &mut self,
+        inputByteArray: *const ::std::os::raw::c_char,
+        numberOfBytes: ::std::os::raw::c_uint,
+    ) {
+        unsafe { BitStream_Write(self, inputByteArray, numberOfBytes) }
+    }
+    #[inline]
+    pub unsafe fn Write1(
+        &mut self,
+        bitStream: *mut BitStream,
+        numberOfBits: ::std::os::raw::c_uint,
+    ) {
+        unsafe { BitStream_Write1(self, bitStream, numberOfBits) }
+    }
+    #[inline]
+    pub unsafe fn Write11(&mut self) {
+        unsafe { BitStream_Write11(self) }
+    }
+}

--- a/bindgen-tests/tests/headers/duplicated-definition-count.hpp
+++ b/bindgen-tests/tests/headers/duplicated-definition-count.hpp
@@ -1,0 +1,6 @@
+class BitStream {
+ public:
+  void Write(const char *inputByteArray, unsigned int numberOfBytes);
+  void Write(BitStream *bitStream, unsigned numberOfBits);
+  void Write1();
+};


### PR DESCRIPTION
Even though this change does name deduplication in a slower way, it avoids name collisions without any breaking changes in the test suite.

Fixes #2202