### PR TITLE
Add `--disable-whole-symbol-regex` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -152,6 +152,8 @@
    matching a regular expression.
  * new feature: allow using the `C-unwind` ABI in `--override-abi` on nightly
    rust.
+ * new feature: `--disable-whole-symbol-regex` flag to avoid parentesizing and
+   wrapping any regex argument with `^` and `$`.
 
 ## Changed
 

--- a/bindgen-cli/options.rs
+++ b/bindgen-cli/options.rs
@@ -574,6 +574,9 @@ where
                 .value_name("override")
                 .multiple_occurrences(true)
                 .number_of_values(1),
+            Arg::new("disable-whole-symbol-regex")
+                .long("disable-whole-symbol-regex")
+                .help("Avoids parentesizing and surrounding any regex arguments with ^ and $."),
             Arg::new("V")
                 .long("version")
                 .help("Prints the version, and exits"),
@@ -1104,6 +1107,10 @@ where
                 .unwrap_or_else(|err| panic!("Invalid ABI override: {}", err));
             builder = builder.override_abi(abi, regex);
         }
+    }
+
+    if matches.is_present("disable-whole-symbol-regex") {
+        builder = builder.whole_symbol_regex(false);
     }
 
     Ok((builder, output, verbose))

--- a/bindgen-tests/tests/expectations/tests/disable-whole-symbol-regex.rs
+++ b/bindgen-tests/tests/expectations/tests/disable-whole-symbol-regex.rs
@@ -1,0 +1,13 @@
+#![allow(
+    dead_code,
+    non_snake_case,
+    non_camel_case_types,
+    non_upper_case_globals
+)]
+
+extern "C" {
+    pub fn foo() -> ::std::os::raw::c_int;
+}
+extern "C" {
+    pub fn foo_bar() -> ::std::os::raw::c_int;
+}

--- a/bindgen-tests/tests/headers/disable-whole-symbol-regex.h
+++ b/bindgen-tests/tests/headers/disable-whole-symbol-regex.h
@@ -1,0 +1,6 @@
+// bindgen-flags: --disable-whole-symbol-regex --allowlist-function="^foo"
+
+int foo();
+int foo_bar();
+int bar_foo();
+int bar_foo_baz();

--- a/bindgen/lib.rs
+++ b/bindgen/lib.rs
@@ -624,6 +624,10 @@ impl Builder {
             output_vector.push("--merge-extern-blocks".into());
         }
 
+        if !self.options.whole_symbol_regex {
+            output_vector.push("--disable-whole-symbol-regex".into());
+        }
+
         // Add clang arguments
 
         output_vector.push("--".into());
@@ -1792,6 +1796,14 @@ impl Builder {
             .insert(arg.into());
         self
     }
+
+    /// If true, parenthesize and surround any regex argument with `^` and `$`.
+    ///
+    /// This option is enabled by default.
+    pub fn whole_symbol_regex(mut self, doit: bool) -> Self {
+        self.options.whole_symbol_regex = doit;
+        self
+    }
 }
 
 /// Configuration options for generated bindings.
@@ -2129,6 +2141,8 @@ struct BindgenOptions {
     merge_extern_blocks: bool,
 
     abi_overrides: HashMap<Abi, RegexSet>,
+
+    whole_symbol_regex: bool,
 }
 
 impl BindgenOptions {
@@ -2163,8 +2177,9 @@ impl BindgenOptions {
             &mut self.must_use_types,
         ];
         let record_matches = self.record_matches;
+        let whole_symbol_regex = self.whole_symbol_regex;
         for regex_set in self.abi_overrides.values_mut().chain(regex_sets) {
-            regex_set.build(record_matches);
+            regex_set.build(record_matches, whole_symbol_regex);
         }
     }
 
@@ -2232,6 +2247,7 @@ impl Default for BindgenOptions {
             record_matches: true,
             rustfmt_bindings: true,
             size_t_is_usize: true,
+            whole_symbol_regex: true,
 
             --default-fields--
             blocklisted_types,

--- a/bindgen/regex_set.rs
+++ b/bindgen/regex_set.rs
@@ -57,7 +57,7 @@ impl RegexSet {
         let f = if whole_symbol_regex {
             (|item| {
                 if item == "*" {
-                    warn!("using wildcard patterns (`*`) with the `--whole-symbol-regex` option enabled is not considered valid. Use `.*` instead");
+                    warn!("using wildcard patterns (`*`) without the `--disable-whole-symbol-regex` flag is not considered valid. Use `.*` instead");
                 }
                 format!("^({})$", item)
             }) as fn(&String) -> String


### PR DESCRIPTION
When this option is enabled, `bindgen` won't parenthesize and surround any regex with `^` and `$`.

Fixes #1783