### PR TITLE
Add `ParseCallbacks::process_comment`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -152,6 +152,8 @@
    matching a regular expression.
  * new feature: allow using the `C-unwind` ABI in `--override-abi` on nightly
    rust.
+ * new feature: `process_comments` method to the `ParseCallbacks` trait to
+   handle source code comments.
 
 ## Changed
 

--- a/bindgen/callbacks.rs
+++ b/bindgen/callbacks.rs
@@ -110,11 +110,7 @@ pub trait ParseCallbacks: fmt::Debug {
     }
 
     /// Process a source code comment.
-    fn process_comment(
-        &self,
-        _comment: &str,
-        _indentation_level: usize,
-    ) -> Option<String> {
+    fn process_comment(&self, _comment: &str) -> Option<String> {
         None
     }
 }

--- a/bindgen/callbacks.rs
+++ b/bindgen/callbacks.rs
@@ -108,4 +108,13 @@ pub trait ParseCallbacks: fmt::Debug {
     fn add_derives(&self, _name: &str) -> Vec<String> {
         vec![]
     }
+
+    /// Process a source code comment.
+    fn process_comment(
+        &self,
+        _comment: &str,
+        _indentation_level: usize,
+    ) -> Option<String> {
+        None
+    }
 }

--- a/bindgen/codegen/helpers.rs
+++ b/bindgen/codegen/helpers.rs
@@ -55,9 +55,11 @@ pub mod attributes {
     }
 
     pub fn doc(comment: String) -> TokenStream {
-        // NOTE(emilio): By this point comments are already preprocessed and in
-        // `///` form. Quote turns them into `#[doc]` comments, but oh well.
-        TokenStream::from_str(&comment).unwrap()
+        if comment.is_empty() {
+            quote!()
+        } else {
+            quote!(#[doc = #comment])
+        }
     }
 
     pub fn link_name(name: &str) -> TokenStream {

--- a/bindgen/codegen/mod.rs
+++ b/bindgen/codegen/mod.rs
@@ -20,7 +20,6 @@ use super::BindgenOptions;
 
 use crate::ir::analysis::{HasVtable, Sizedness};
 use crate::ir::annotations::FieldAccessorKind;
-use crate::ir::comment;
 use crate::ir::comp::{
     Bitfield, BitfieldUnit, CompInfo, CompKind, Field, FieldData, FieldMethods,
     Method, MethodKind,
@@ -1392,8 +1391,9 @@ impl<'a> FieldCodegen<'a> for FieldData {
         let mut field = quote! {};
         if ctx.options().generate_comments {
             if let Some(raw_comment) = self.comment() {
-                let comment =
-                    comment::preprocess(raw_comment, codegen_depth + 1);
+                let comment = ctx
+                    .options()
+                    .process_comment(raw_comment, codegen_depth + 1);
                 field = attributes::doc(comment);
             }
         }
@@ -2837,8 +2837,9 @@ impl<'a> EnumBuilder<'a> {
         let mut doc = quote! {};
         if ctx.options().generate_comments {
             if let Some(raw_comment) = variant.comment() {
-                let comment =
-                    comment::preprocess(raw_comment, self.codegen_depth());
+                let comment = ctx
+                    .options()
+                    .process_comment(raw_comment, self.codegen_depth());
                 doc = attributes::doc(comment);
             }
         }

--- a/bindgen/ir/item.rs
+++ b/bindgen/ir/item.rs
@@ -514,10 +514,9 @@ impl Item {
             return None;
         }
 
-        self.comment.as_ref().map(|comment| {
-            ctx.options()
-                .process_comment(comment, self.codegen_depth(ctx))
-        })
+        self.comment
+            .as_ref()
+            .map(|comment| ctx.options().process_comment(comment))
     }
 
     /// What kind of item is this?

--- a/bindgen/ir/item.rs
+++ b/bindgen/ir/item.rs
@@ -3,7 +3,6 @@
 use super::super::codegen::{EnumVariation, CONSTIFIED_ENUM_MODULE_REPR_NAME};
 use super::analysis::{HasVtable, HasVtableResult, Sizedness, SizednessResult};
 use super::annotations::Annotations;
-use super::comment;
 use super::comp::{CompKind, MethodKind};
 use super::context::{BindgenContext, ItemId, PartialType, TypeId};
 use super::derive::{
@@ -516,7 +515,8 @@ impl Item {
         }
 
         self.comment.as_ref().map(|comment| {
-            comment::preprocess(comment, self.codegen_depth(ctx))
+            ctx.options()
+                .process_comment(comment, self.codegen_depth(ctx))
         })
     }
 

--- a/bindgen/lib.rs
+++ b/bindgen/lib.rs
@@ -2274,11 +2274,12 @@ impl BindgenOptions {
             .collect()
     }
 
-    fn process_comment(&self, comment: &str, indent: usize) -> String {
+    fn process_comment(&self, comment: &str) -> String {
+        let comment = comment::preprocess(comment);
         self.parse_callbacks
             .last()
-            .and_then(|cb| cb.process_comment(comment, indent))
-            .unwrap_or_else(|| comment::preprocess(comment, indent))
+            .and_then(|cb| cb.process_comment(&comment))
+            .unwrap_or(comment)
     }
 }
 

--- a/bindgen/lib.rs
+++ b/bindgen/lib.rs
@@ -78,6 +78,8 @@ doc_mod!(ir, ir_docs);
 doc_mod!(parse, parse_docs);
 doc_mod!(regex_set, regex_set_docs);
 
+use ir::comment;
+
 pub use crate::codegen::{
     AliasVariation, EnumVariation, MacroTypeVariation, NonCopyUnionStyle,
 };
@@ -2270,6 +2272,13 @@ impl BindgenOptions {
             .iter()
             .flat_map(|cb| f(cb.as_ref()))
             .collect()
+    }
+
+    fn process_comment(&self, comment: &str, indent: usize) -> String {
+        self.parse_callbacks
+            .last()
+            .and_then(|cb| cb.process_comment(comment, indent))
+            .unwrap_or_else(|| comment::preprocess(comment, indent))
     }
 }
 


### PR DESCRIPTION
This method can be used to process comments and replace them with whatever the user wants.