### PR TITLE
Introduce `DeriveInfo`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -155,6 +155,9 @@
 
 ## Changed
 
+ * Replace the `name: &str` argument for `ParseCallbacks::add_derives` by
+   `info: DeriveInfo`.
+
 ## Removed
 
  * The following deprecated methods and their equivalent CLI arguments were

--- a/bindgen-integration/build.rs
+++ b/bindgen-integration/build.rs
@@ -123,7 +123,7 @@ impl ParseCallbacks for MacroCallback {
     }
 
     // Test the "custom derives" capability by adding `PartialEq` to the `Test` struct.
-    fn add_derives(&self, info: DeriveInfo<'_>) -> Vec<String> {
+    fn add_derives(&self, info: &DeriveInfo<'_>) -> Vec<String> {
         if info.name == "Test" {
             vec!["PartialEq".into()]
         } else if info.name == "MyOrderedEnum" {

--- a/bindgen-integration/build.rs
+++ b/bindgen-integration/build.rs
@@ -1,7 +1,9 @@
 extern crate bindgen;
 extern crate cc;
 
-use bindgen::callbacks::{IntKind, MacroParsingBehavior, ParseCallbacks};
+use bindgen::callbacks::{
+    DeriveInfo, IntKind, MacroParsingBehavior, ParseCallbacks,
+};
 use bindgen::{Builder, EnumVariation};
 use std::collections::HashSet;
 use std::env;
@@ -121,10 +123,10 @@ impl ParseCallbacks for MacroCallback {
     }
 
     // Test the "custom derives" capability by adding `PartialEq` to the `Test` struct.
-    fn add_derives(&self, name: &str) -> Vec<String> {
-        if name == "Test" {
+    fn add_derives(&self, info: DeriveInfo<'_>) -> Vec<String> {
+        if info.name == "Test" {
             vec!["PartialEq".into()]
-        } else if name == "MyOrderedEnum" {
+        } else if info.name == "MyOrderedEnum" {
             vec!["std::cmp::PartialOrd".into()]
         } else {
             vec![]

--- a/bindgen/callbacks.rs
+++ b/bindgen/callbacks.rs
@@ -105,7 +105,7 @@ pub trait ParseCallbacks: fmt::Debug {
     ///
     /// If no additional attributes are wanted, this function should return an
     /// empty `Vec`.
-    fn add_derives(&self, _info: DeriveInfo<'_>) -> Vec<String> {
+    fn add_derives(&self, _info: &DeriveInfo<'_>) -> Vec<String> {
         vec![]
     }
 }

--- a/bindgen/callbacks.rs
+++ b/bindgen/callbacks.rs
@@ -105,7 +105,15 @@ pub trait ParseCallbacks: fmt::Debug {
     ///
     /// If no additional attributes are wanted, this function should return an
     /// empty `Vec`.
-    fn add_derives(&self, _name: &str) -> Vec<String> {
+    fn add_derives(&self, _info: DeriveInfo<'_>) -> Vec<String> {
         vec![]
     }
+}
+
+/// Relevant information about a type to which new derive attributes will be added using
+/// [`ParseCallbacks::add_derives`].
+#[non_exhaustive]
+pub struct DeriveInfo<'a> {
+    /// The name of the type.
+    pub name: &'a str,
 }

--- a/bindgen/codegen/mod.rs
+++ b/bindgen/codegen/mod.rs
@@ -2114,9 +2114,11 @@ impl CodeGenerator for CompInfo {
 
         // The custom derives callback may return a list of derive attributes;
         // add them to the end of the list.
-        let custom_derives = ctx
-            .options()
-            .all_callbacks(|cb| cb.add_derives(&canonical_name));
+        let custom_derives = ctx.options().all_callbacks(|cb| {
+            cb.add_derives(crate::callbacks::DeriveInfo {
+                name: &canonical_name,
+            })
+        });
         // In most cases this will be a no-op, since custom_derives will be empty.
         derives.extend(custom_derives.iter().map(|s| s.as_str()));
 
@@ -3168,8 +3170,9 @@ impl CodeGenerator for Enum {
 
             // The custom derives callback may return a list of derive attributes;
             // add them to the end of the list.
-            let custom_derives =
-                ctx.options().all_callbacks(|cb| cb.add_derives(&name));
+            let custom_derives = ctx.options().all_callbacks(|cb| {
+                cb.add_derives(crate::callbacks::DeriveInfo { name: &name })
+            });
             // In most cases this will be a no-op, since custom_derives will be empty.
             derives.extend(custom_derives.iter().map(|s| s.as_str()));
 

--- a/bindgen/codegen/mod.rs
+++ b/bindgen/codegen/mod.rs
@@ -2115,7 +2115,7 @@ impl CodeGenerator for CompInfo {
         // The custom derives callback may return a list of derive attributes;
         // add them to the end of the list.
         let custom_derives = ctx.options().all_callbacks(|cb| {
-            cb.add_derives(crate::callbacks::DeriveInfo {
+            cb.add_derives(&crate::callbacks::DeriveInfo {
                 name: &canonical_name,
             })
         });
@@ -3171,7 +3171,7 @@ impl CodeGenerator for Enum {
             // The custom derives callback may return a list of derive attributes;
             // add them to the end of the list.
             let custom_derives = ctx.options().all_callbacks(|cb| {
-                cb.add_derives(crate::callbacks::DeriveInfo { name: &name })
+                cb.add_derives(&crate::callbacks::DeriveInfo { name: &name })
             });
             // In most cases this will be a no-op, since custom_derives will be empty.
             derives.extend(custom_derives.iter().map(|s| s.as_str()));


### PR DESCRIPTION
This PR introduces a new non-exhaustive `struct` called `DeriveInfo` to be used as the sole argument of `ParseCallbacks::add_derives` with the purpose of being able to extend the information passed to this method in a backwards-compatible manner, meaning that adding new fields to `DeriveInfo` won't be a breaking change when releasing a new version.

Some candidates to new fields have been requested already:
- https://github.com/rust-lang/rust-bindgen/issues/2168: Requests for a way to know if a type is PoD and can be safely transmuted from/to bytes.
- https://github.com/rust-lang/rust-bindgen/pull/2328: Could be simplified if the kind of the type (whether a type is a `struct`, `enum` or `union`)  were included.