### PR TITLE
Add option to avoid wrapping function pointer fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -152,6 +152,8 @@
 # Unreleased
 
 ## Added
+ * Do not wrap function pointer fields in `Option` if the new
+   `--dont-wrap-fn-ptr-fields` option is enabled.
 
 ## Changed
 

--- a/bindgen-cli/options.rs
+++ b/bindgen-cli/options.rs
@@ -565,6 +565,9 @@ where
             Arg::new("wrap-unsafe-ops")
                 .long("wrap-unsafe-ops")
                 .help("Wrap unsafe operations in unsafe blocks."),
+            Arg::new("dont-wrap-fn-ptr-fields")
+                .long("dont-wrap-fn-ptr-fields")
+                .help("Do not wrap function pointer fields in `Option`."),
             Arg::new("V")
                 .long("version")
                 .help("Prints the version, and exits"),
@@ -1090,6 +1093,10 @@ where
 
     if matches.is_present("wrap-unsafe-ops") {
         builder = builder.wrap_unsafe_ops(true);
+    }
+
+    if matches.is_present("dont-wrap-fn-ptr-fields") {
+        builder = builder.wrap_fn_ptr_fields(false);
     }
 
     Ok((builder, output, verbose))

--- a/bindgen-tests/tests/expectations/tests/dont-wrap-fn-ptr-fields.rs
+++ b/bindgen-tests/tests/expectations/tests/dont-wrap-fn-ptr-fields.rs
@@ -1,0 +1,33 @@
+#![allow(
+    dead_code,
+    non_snake_case,
+    non_camel_case_types,
+    non_upper_case_globals
+)]
+
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct foo {
+    pub bar: unsafe extern "C" fn() -> ::std::os::raw::c_int,
+}
+#[test]
+fn bindgen_test_layout_foo() {
+    const UNINIT: ::std::mem::MaybeUninit<foo> =
+        ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
+    assert_eq!(
+        ::std::mem::size_of::<foo>(),
+        8usize,
+        concat!("Size of: ", stringify!(foo))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<foo>(),
+        8usize,
+        concat!("Alignment of ", stringify!(foo))
+    );
+    assert_eq!(
+        unsafe { ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar))
+    );
+}

--- a/bindgen-tests/tests/expectations/tests/dont-wrap-fn-ptr-fields.rs
+++ b/bindgen-tests/tests/expectations/tests/dont-wrap-fn-ptr-fields.rs
@@ -6,7 +6,7 @@
 )]
 
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct foo {
     pub bar: unsafe extern "C" fn() -> ::std::os::raw::c_int,
 }

--- a/bindgen-tests/tests/headers/dont-wrap-fn-ptr-fields.h
+++ b/bindgen-tests/tests/headers/dont-wrap-fn-ptr-fields.h
@@ -1,4 +1,4 @@
-// bindgen-flags: --dont-wrap-fn-ptr-fields
+// bindgen-flags: --dont-wrap-fn-ptr-fields --no-default="foo"
 
 typedef struct foo {
     int (*bar)();

--- a/bindgen-tests/tests/headers/dont-wrap-fn-ptr-fields.h
+++ b/bindgen-tests/tests/headers/dont-wrap-fn-ptr-fields.h
@@ -1,0 +1,5 @@
+// bindgen-flags: --dont-wrap-fn-ptr-fields
+
+typedef struct foo {
+    int (*bar)();
+} foo;

--- a/bindgen/codegen/mod.rs
+++ b/bindgen/codegen/mod.rs
@@ -3762,10 +3762,12 @@ impl TryToRustTy for Type {
                 // variant here.
                 let ty = fs.try_to_rust_ty(ctx, &())?;
 
-                let prefix = ctx.trait_prefix();
-                Ok(quote! {
-                    ::#prefix::option::Option<#ty>
-                })
+                if ctx.options().wrap_fn_ptr_fields {
+                    let prefix = ctx.trait_prefix();
+                    Ok(quote!(::#prefix::option::Option<#ty>))
+                } else {
+                    Ok(quote!(#ty))
+                }
             }
             TypeKind::Array(item, len) | TypeKind::Vector(item, len) => {
                 let ty = item.try_to_rust_ty(ctx, &())?;

--- a/bindgen/lib.rs
+++ b/bindgen/lib.rs
@@ -649,6 +649,10 @@ impl Builder {
             output_vector.push("--wrap-unsafe-ops".into());
         }
 
+        if !self.options.wrap_fn_ptr_fields {
+            output_vector.push("--dont-wrap-fn-ptr-fields".into());
+        }
+
         // Add clang arguments
 
         output_vector.push("--".into());
@@ -1787,6 +1791,12 @@ impl Builder {
         self.options.wrap_unsafe_ops = doit;
         self
     }
+
+    /// If true, wraps function pointer fields in `Option`.
+    pub fn wrap_fn_ptr_fields(mut self, doit: bool) -> Self {
+        self.options.wrap_fn_ptr_fields = doit;
+        self
+    }
 }
 
 /// Configuration options for generated bindings.
@@ -2127,6 +2137,9 @@ struct BindgenOptions {
 
     /// Whether to wrap unsafe operations in unsafe blocks or not.
     wrap_unsafe_ops: bool,
+
+    /// Whether to wrap function pointer fields in `Option` or not.
+    wrap_fn_ptr_fields: bool,
 }
 
 impl BindgenOptions {
@@ -2238,6 +2251,7 @@ impl Default for BindgenOptions {
             record_matches: true,
             rustfmt_bindings: true,
             size_t_is_usize: true,
+            wrap_fn_ptr_fields: true,
 
             --default-fields--
             blocklisted_types,


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust-bindgen/issues/1278