### PR TITLE
clang_6 and clang_15 features to make bindgen working with clang >= 15

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -131,9 +131,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clang-sys"
-version = "1.3.3"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a050e2153c5be08febd6734e29298e844fdb0fa21aeddd63b4eb7baa106c69b"
+checksum = "fa2e27ae6ab525c3d369ded447057bca5438d86dc3a68f6faafb8269ba82ebf3"
 dependencies = [
  "glob",
  "libc",

--- a/bindgen/Cargo.toml
+++ b/bindgen/Cargo.toml
@@ -27,7 +27,7 @@ path = "./lib.rs"
 [dependencies]
 bitflags = "1.0.3"
 cexpr = "0.6"
-clang-sys = { version = "1", features = ["clang_6_0"] }
+clang-sys = "1.4"
 lazycell = "1"
 lazy_static = "1"
 peeking_take_while = "0.1.2"
@@ -41,12 +41,17 @@ proc-macro2 = { version = "1", default-features = false }
 log = { version = "0.4", optional = true }
 
 [features]
-default = ["logging", "runtime", "which-rustfmt"]
+default = ["logging", "runtime", "which-rustfmt", "clang_6"]
 logging = ["log"]
 static = ["clang-sys/static"]
 runtime = ["clang-sys/runtime"]
 # Dynamically discover a `rustfmt` binary using the `which` crate
 which-rustfmt = ["which"]
+
+# By default, accept clang versions between 6 and 14
+clang_6 = ["clang-sys/clang_6_0"]
+# To use clang >= 15, this feature must be specified
+clang_15 = ["clang-sys/clang_15_0"]
 
 # These features only exist for CI testing -- don't use them if you're not hacking
 # on bindgen!


### PR DESCRIPTION
bindgen is currently broken with recent clang versions due to a breaking change to the [EntityKind enum](https://github.com/llvm/llvm-project/commit/bb83f8e70bd1d56152f02307adacd718cd67e312#diff-674613a0e47f4e66cc19061e28e3296d39be2d124dceefb68237b30b8e241e7c) as explained in the [clang-sys](https://github.com/KyleMayes/clang-sys) readme.

My fix is to expose two features in bindgen, clang_6 that it is also the default to continue to use bidgen with clang >= 6 and clang_15 to use it with clang >= 15.