### PR TITLE
ty: Deal with using shadow types.

### DIFF
--- a/bindgen-tests/tests/expectations/tests/constified-enum-module-overflow.rs
+++ b/bindgen-tests/tests/expectations/tests/constified-enum-module-overflow.rs
@@ -19,7 +19,7 @@ pub type C_U = B;
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct A {
-    pub u: u8,
+    pub u: B,
 }
 #[test]
 fn bindgen_test_layout_A() {
@@ -53,5 +53,18 @@ fn __bindgen_test_layout_C_open0_A_close0_instantiation() {
         ::std::mem::align_of::<C>(),
         1usize,
         concat!("Alignment of template specialization: ", stringify!(C))
+    );
+}
+#[test]
+fn __bindgen_test_layout_B_open0_A_close0_instantiation() {
+    assert_eq!(
+        ::std::mem::size_of::<B>(),
+        1usize,
+        concat!("Size of template specialization: ", stringify!(B))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<B>(),
+        1usize,
+        concat!("Alignment of template specialization: ", stringify!(B))
     );
 }

--- a/bindgen-tests/tests/expectations/tests/issue-544-stylo-creduce-2.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-544-stylo-creduce-2.rs
@@ -10,7 +10,7 @@ pub struct Foo {
     pub member: Foo_SecondAlias,
 }
 pub type Foo_FirstAlias = [u8; 0usize];
-pub type Foo_SecondAlias = [u8; 0usize];
+pub type Foo_SecondAlias = Foo;
 impl Default for Foo {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();

--- a/bindgen-tests/tests/expectations/tests/struct_typedef_ns.rs
+++ b/bindgen-tests/tests/expectations/tests/struct_typedef_ns.rs
@@ -56,23 +56,23 @@ pub mod root {
         use self::super::super::root;
         #[repr(C)]
         #[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
-        pub struct _bindgen_ty_1 {
+        pub struct typedef_struct {
             pub foo: ::std::os::raw::c_int,
         }
         #[test]
-        fn bindgen_test_layout__bindgen_ty_1() {
-            const UNINIT: ::std::mem::MaybeUninit<_bindgen_ty_1> =
+        fn bindgen_test_layout_typedef_struct() {
+            const UNINIT: ::std::mem::MaybeUninit<typedef_struct> =
                 ::std::mem::MaybeUninit::uninit();
             let ptr = UNINIT.as_ptr();
             assert_eq!(
-                ::std::mem::size_of::<_bindgen_ty_1>(),
+                ::std::mem::size_of::<typedef_struct>(),
                 4usize,
-                concat!("Size of: ", stringify!(_bindgen_ty_1))
+                concat!("Size of: ", stringify!(typedef_struct))
             );
             assert_eq!(
-                ::std::mem::align_of::<_bindgen_ty_1>(),
+                ::std::mem::align_of::<typedef_struct>(),
                 4usize,
-                concat!("Alignment of ", stringify!(_bindgen_ty_1))
+                concat!("Alignment of ", stringify!(typedef_struct))
             );
             assert_eq!(
                 unsafe {
@@ -81,20 +81,16 @@ pub mod root {
                 0usize,
                 concat!(
                     "Offset of field: ",
-                    stringify!(_bindgen_ty_1),
+                    stringify!(typedef_struct),
                     "::",
                     stringify!(foo)
                 )
             );
         }
-        pub type typedef_struct = root::_bindgen_mod_id_12::_bindgen_ty_1;
-        pub const _bindgen_mod_id_12_BAR:
-            root::_bindgen_mod_id_12::_bindgen_ty_2 = _bindgen_ty_2::BAR;
         #[repr(u32)]
         #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
-        pub enum _bindgen_ty_2 {
+        pub enum typedef_enum {
             BAR = 1,
         }
-        pub use self::super::super::root::_bindgen_mod_id_12::_bindgen_ty_2 as typedef_enum;
     }
 }

--- a/bindgen-tests/tests/expectations/tests/using-typedef-size-t.rs
+++ b/bindgen-tests/tests/expectations/tests/using-typedef-size-t.rs
@@ -1,0 +1,19 @@
+#![allow(
+    dead_code,
+    non_snake_case,
+    non_camel_case_types,
+    non_upper_case_globals
+)]
+
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct mozilla_MarkerSchema {
+    _unused: [u8; 0],
+}
+extern "C" {
+    pub fn gecko_profiler_marker_schema_set_chart_label(
+        schema: *mut mozilla_MarkerSchema,
+        label: *const ::std::os::raw::c_char,
+        len: usize,
+    );
+}

--- a/bindgen-tests/tests/headers/using-typedef-size-t.hpp
+++ b/bindgen-tests/tests/headers/using-typedef-size-t.hpp
@@ -1,0 +1,15 @@
+// #define WORKS
+
+namespace std {
+typedef unsigned long size_t;
+}
+using std::size_t;
+
+namespace mozilla {
+class MarkerSchema;
+}
+
+extern "C" {
+void gecko_profiler_marker_schema_set_chart_label(
+    mozilla::MarkerSchema* schema, const char* label, size_t len);
+}

--- a/bindgen/ir/ty.rs
+++ b/bindgen/ir/ty.rs
@@ -1200,6 +1200,32 @@ impl Type {
                 CXType_Dependent => {
                     return Err(ParseError::Continue);
                 }
+                179 /* CXType_Using */ => {
+                    let decl_ty = ty.declaration().cur_type();
+                    if decl_ty.is_valid() {
+                        if let Ok(ty) = Self::from_clang_ty(
+                            potential_id,
+                            &decl_ty,
+                            location,
+                            parent_id,
+                            ctx
+                        ) {
+                            return Ok(ty);
+                        }
+                    }
+                    if canonical_ty.is_valid() {
+                        if let Ok(ty) = Self::from_clang_ty(
+                            potential_id,
+                            &canonical_ty,
+                            location,
+                            parent_id,
+                            ctx
+                        ) {
+                            return Ok(ty);
+                        }
+                    }
+                    return Err(ParseError::Continue);
+                },
                 _ => {
                     warn!(
                         "unsupported type: kind = {:?}; ty = {:?}; at {:?}",


### PR DESCRIPTION
Bindgen will fail to detect the size_t typedef if it comes from a using declaration, because we'd try to to look at the canonical type.

This is the root cause of
https://bugzilla.mozilla.org/show_bug.cgi?id=1795899, an https://bugzilla.mozilla.org/show_bug.cgi?id=1795899#c30 is the reduced test-case.

This patch requires an llvm patch to expose the shadow declarations, which I'll submit upstream. This also shows some other progressions as well.