### PR TITLE
Update to clap 4.

### DIFF
--- a/.github/workflows/bindgen.yml
+++ b/.github/workflows/bindgen.yml
@@ -48,11 +48,11 @@ jobs:
           profile: minimal
           # MSRV below is documented in Cargo.toml and README.md, please update those if you
           # change this.
-          toolchain: 1.57.0
+          toolchain: 1.60.0
           override: true
 
       - name: Build with msrv
-        run: rm Cargo.lock && cargo +1.57.0 build --lib
+        run: rm Cargo.lock && cargo +1.60.0 build --lib
 
   quickchecking:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -160,7 +160,8 @@
    argument instead of a `&str`.
  * Updated the `clang-sys` crate version to 1.4.0 to support clang 15.
  * The return type is now ommited in signatures of functions returning `void`.
- 
+ * Updated the `clap` dependency for `bindgen-cli` to 4.
+
 ## Removed
 
 ## Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,16 +35,10 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.1.19",
  "libc",
  "winapi 0.3.9",
 ]
-
-[[package]]
-name = "autocfg"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "bindgen"
@@ -71,7 +65,7 @@ name = "bindgen-cli"
 version = "0.63.0"
 dependencies = [
  "bindgen",
- "clap 3.2.12",
+ "clap 4.0.32",
  "env_logger 0.9.0",
  "log 0.4.14",
  "shlex",
@@ -90,7 +84,7 @@ name = "bindgen-tests"
 version = "0.1.0"
 dependencies = [
  "bindgen",
- "clap 3.2.12",
+ "clap 4.0.32",
  "diff",
  "shlex",
  "tempfile",
@@ -150,31 +144,29 @@ dependencies = [
  "atty",
  "bitflags",
  "strsim 0.8.0",
- "textwrap 0.11.0",
+ "textwrap",
  "unicode-width",
  "vec_map",
 ]
 
 [[package]]
 name = "clap"
-version = "3.2.12"
+version = "4.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab8b79fe3946ceb4a0b1c080b4018992b8d27e9ff363644c1c9b6387c854614d"
+checksum = "a7db700bc935f9e43e88d00b0850dae18a63773cfbec6d8e070fccf7fef89a39"
 dependencies = [
- "atty",
  "bitflags",
  "clap_lex",
- "indexmap",
+ "is-terminal",
  "strsim 0.10.0",
  "termcolor",
- "textwrap 0.15.0",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.2.4"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+checksum = "0d4198f73e42b4936b35b5bb248d81d2b595ecb170da0bac7655c54eedfa8da8"
 dependencies = [
  "os_str_bytes",
 ]
@@ -215,6 +207,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "errno"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "fuchsia-cprng"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -238,16 +251,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
-name = "hashbrown"
-version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "607c8a29735385251a339424dd462993c0fed8fa09d378f259377df08c126022"
-
-[[package]]
 name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "hermit-abi"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
 dependencies = [
  "libc",
 ]
@@ -259,13 +275,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
-name = "indexmap"
-version = "1.9.1"
+name = "io-lifetimes"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
+checksum = "46112a93252b123d31a119a8d1a1ac19deac4fac6e0e8b0df58f0d4e5870e63c"
 dependencies = [
- "autocfg",
- "hashbrown",
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dfb6c8100ccc63462345b67d1bbc3679177c75ee4bf59bf29c8b1d110b8189"
+dependencies = [
+ "hermit-abi 0.2.6",
+ "io-lifetimes",
+ "rustix",
+ "windows-sys",
 ]
 
 [[package]]
@@ -292,9 +320,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.126"
+version = "0.2.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
+checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
 name = "libloading"
@@ -315,6 +343,12 @@ dependencies = [
  "cfg-if",
  "winapi 0.3.9",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
 
 [[package]]
 name = "log"
@@ -590,6 +624,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
+name = "rustix"
+version = "0.36.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4feacf7db682c6c329c4ede12649cd36ecab0f3be5b7d74e6a20304725db4549"
+dependencies = [
+ "bitflags",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
 name = "shlex"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -668,12 +716,6 @@ checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
  "unicode-width",
 ]
-
-[[package]]
-name = "textwrap"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "thread-id"
@@ -783,3 +825,60 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d2aa71f6f0cbe00ae5167d90ef3cfe66527d6f613ca78ac8024c3ccab9a19e"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd0f252f5a35cac83d6311b2e795981f5ee6e67eb1f9a7f64eb4500fbc4dcdb4"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbeae19f6716841636c28d695375df17562ca208b2b7d0dc47635a50ae6c5de7"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84c12f65daa39dd2babe6e442988fc329d6243fdce47d7d2d155b8d874862246"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf7b1b21b5362cbc318f686150e5bcea75ecedc74dd157d874d754a2ca44b0ed"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09d525d2ba30eeb3297665bd434a54297e4170c7f1a44cad4ef58095b4cd2028"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ extern "C" {
 
 ## MSRV
 
-The minimum supported Rust version is **1.57.0**.
+The minimum supported Rust version is **1.60.0**.
 
 No MSRV bump policy has been established yet, so MSRV may increase in any release.
 

--- a/bindgen-cli/Cargo.toml
+++ b/bindgen-cli/Cargo.toml
@@ -23,7 +23,7 @@ name = "bindgen"
 [dependencies]
 bindgen = { path = "../bindgen", version = "=0.63.0" }
 shlex = "1"
-clap = "3"
+clap = "4"
 env_logger = { version = "0.9.0", optional = true }
 log = { version = "0.4", optional = true }
 

--- a/bindgen-cli/Cargo.toml
+++ b/bindgen-cli/Cargo.toml
@@ -14,7 +14,7 @@ homepage = "https://rust-lang.github.io/rust-bindgen/"
 version = "0.63.0"
 edition = "2018"
 # If you change this, also update README.md and msrv in .github/workflows/bindgen.yml
-rust-version = "1.57.0"
+rust-version = "1.60.0"
 
 [[bin]]
 path = "main.rs"

--- a/bindgen-cli/options.rs
+++ b/bindgen-cli/options.rs
@@ -3,7 +3,7 @@ use bindgen::{
     MacroTypeVariation, NonCopyUnionStyle, RustTarget,
     DEFAULT_ANON_FIELDS_PREFIX, RUST_TARGET_STRINGS,
 };
-use clap::{App, Arg};
+use clap::{builder::PossibleValuesParser, Arg, ArgAction, Command};
 use std::fs::File;
 use std::io::{self, Error, ErrorKind};
 use std::path::PathBuf;
@@ -22,9 +22,9 @@ where
         String::from(RustTarget::default())
     );
 
-    let matches = App::new("bindgen")
+    let matches = Command::new("bindgen")
         .about("Generates Rust bindings from C/C++ headers.")
-        .setting(clap::AppSettings::NoAutoVersion)
+        .disable_version_flag(true)
         .override_usage("bindgen [FLAGS] [OPTIONS] <header> -- <clang-args>...")
         .args(&[
             Arg::new("header")
@@ -32,22 +32,22 @@ where
                 .required_unless_present("V"),
             Arg::new("depfile")
                 .long("depfile")
-                .takes_value(true)
+                .action(ArgAction::Set)
                 .help("Path to write depfile to"),
             Arg::new("default-enum-style")
                 .long("default-enum-style")
                 .help("The default style of code used to generate enums.")
                 .value_name("variant")
                 .default_value("consts")
-                .possible_values([
+                .value_parser(PossibleValuesParser::new([
                     "consts",
                     "moduleconsts",
                     "bitfield",
                     "newtype",
                     "rust",
                     "rust_non_exhaustive",
-                ])
-                .multiple_occurrences(false),
+                ]))
+                .action(ArgAction::Set),
             Arg::new("bitfield-enum")
                 .long("bitfield-enum")
                 .help(
@@ -55,25 +55,25 @@ where
                      bitfield flags.",
                 )
                 .value_name("regex")
-                .multiple_occurrences(true)
+                .action(ArgAction::Append)
                 .number_of_values(1),
             Arg::new("newtype-enum")
                 .long("newtype-enum")
                 .help("Mark any enum whose name matches <regex> as a newtype.")
                 .value_name("regex")
-                .multiple_occurrences(true)
+                .action(ArgAction::Append)
                 .number_of_values(1),
             Arg::new("newtype-global-enum")
                 .long("newtype-global-enum")
                 .help("Mark any enum whose name matches <regex> as a global newtype.")
                 .value_name("regex")
-                .multiple_occurrences(true)
+                .action(ArgAction::Append)
                 .number_of_values(1),
             Arg::new("rustified-enum")
                 .long("rustified-enum")
                 .help("Mark any enum whose name matches <regex> as a Rust enum.")
                 .value_name("regex")
-                .multiple_occurrences(true)
+                .action(ArgAction::Append)
                 .number_of_values(1),
             Arg::new("constified-enum")
                 .long("constified-enum")
@@ -82,7 +82,7 @@ where
                      constants.",
                 )
                 .value_name("regex")
-                .multiple_occurrences(true)
+                .action(ArgAction::Append)
                 .number_of_values(1),
             Arg::new("constified-enum-module")
                 .long("constified-enum-module")
@@ -91,26 +91,26 @@ where
                      constants.",
                 )
                 .value_name("regex")
-                .multiple_occurrences(true)
+                .action(ArgAction::Append)
                 .number_of_values(1),
             Arg::new("default-macro-constant-type")
                 .long("default-macro-constant-type")
                 .help("The default signed/unsigned type for C macro constants.")
                 .value_name("variant")
                 .default_value("unsigned")
-                .possible_values(["signed", "unsigned"])
-                .multiple_occurrences(false),
+                .value_parser(PossibleValuesParser::new(["signed", "unsigned"]))
+                .action(ArgAction::Set),
             Arg::new("default-alias-style")
                 .long("default-alias-style")
                 .help("The default style of code used to generate typedefs.")
                 .value_name("variant")
                 .default_value("type_alias")
-                .possible_values([
+                .value_parser(PossibleValuesParser::new([
                     "type_alias",
                     "new_type",
                     "new_type_deref",
-                ])
-                .multiple_occurrences(false),
+                ]))
+                .action(ArgAction::Set),
             Arg::new("normal-alias")
                 .long("normal-alias")
                 .help(
@@ -118,7 +118,7 @@ where
                      normal type aliasing.",
                 )
                 .value_name("regex")
-                .multiple_occurrences(true)
+                .action(ArgAction::Append)
                 .number_of_values(1),
              Arg::new("new-type-alias")
                 .long("new-type-alias")
@@ -127,7 +127,7 @@ where
                      a new type generated for it.",
                 )
                 .value_name("regex")
-                .multiple_occurrences(true)
+                .action(ArgAction::Append)
                 .number_of_values(1),
              Arg::new("new-type-alias-deref")
                 .long("new-type-alias-deref")
@@ -136,7 +136,7 @@ where
                      a new type with Deref and DerefMut to the inner type.",
                 )
                 .value_name("regex")
-                .multiple_occurrences(true)
+                .action(ArgAction::Append)
                 .number_of_values(1),
             Arg::new("default-non-copy-union-style")
                 .long("default-non-copy-union-style")
@@ -147,11 +147,11 @@ where
                 )
                 .value_name("style")
                 .default_value("bindgen_wrapper")
-                .possible_values([
+                .value_parser(PossibleValuesParser::new([
                     "bindgen_wrapper",
                     "manually_drop",
-                ])
-                .multiple_occurrences(false),
+                ]))
+                .action(ArgAction::Set),
             Arg::new("bindgen-wrapper-union")
                 .long("bindgen-wrapper-union")
                 .help(
@@ -160,8 +160,7 @@ where
                      fields.",
                 )
                 .value_name("regex")
-                .takes_value(true)
-                .multiple_occurrences(true)
+                .action(ArgAction::Append)
                 .number_of_values(1),
             Arg::new("manually-drop-union")
                 .long("manually-drop-union")
@@ -171,86 +170,98 @@ where
                      1.20.0) for fields.",
                 )
                 .value_name("regex")
-                .takes_value(true)
-                .multiple_occurrences(true)
+                .action(ArgAction::Append)
                 .number_of_values(1),
             Arg::new("blocklist-type")
                 .long("blocklist-type")
                 .help("Mark <type> as hidden.")
                 .value_name("type")
-                .multiple_occurrences(true)
+                .action(ArgAction::Append)
                 .number_of_values(1),
             Arg::new("blocklist-function")
                 .long("blocklist-function")
                 .help("Mark <function> as hidden.")
                 .value_name("function")
-                .multiple_occurrences(true)
+                .action(ArgAction::Append)
                 .number_of_values(1),
             Arg::new("blocklist-item")
                 .long("blocklist-item")
                 .help("Mark <item> as hidden.")
                 .value_name("item")
-                .multiple_occurrences(true)
+                .action(ArgAction::Append)
                 .number_of_values(1),
             Arg::new("blocklist-file")
                 .long("blocklist-file")
                 .help("Mark all contents of <path> as hidden.")
                 .value_name("path")
-                .multiple_occurrences(true)
+                .action(ArgAction::Append)
                 .number_of_values(1),
             Arg::new("no-layout-tests")
                 .long("no-layout-tests")
-                .help("Avoid generating layout tests for any type."),
+                .help("Avoid generating layout tests for any type.")
+                .action(ArgAction::SetTrue),
             Arg::new("no-derive-copy")
                 .long("no-derive-copy")
-                .help("Avoid deriving Copy on any type."),
+                .help("Avoid deriving Copy on any type.")
+                .action(ArgAction::SetTrue),
             Arg::new("no-derive-debug")
                 .long("no-derive-debug")
-                .help("Avoid deriving Debug on any type."),
+                .help("Avoid deriving Debug on any type.")
+                .action(ArgAction::SetTrue),
             Arg::new("no-derive-default")
                 .long("no-derive-default")
                 .hide(true)
-                .help("Avoid deriving Default on any type."),
+                .help("Avoid deriving Default on any type.")
+                .action(ArgAction::SetTrue),
             Arg::new("impl-debug").long("impl-debug").help(
                 "Create Debug implementation, if it can not be derived \
                  automatically.",
-            ),
+            )
+            .action(ArgAction::SetTrue),
             Arg::new("impl-partialeq")
                 .long("impl-partialeq")
                 .help(
                     "Create PartialEq implementation, if it can not be derived \
                      automatically.",
-                ),
+                )
+                .action(ArgAction::SetTrue),
             Arg::new("with-derive-default")
                 .long("with-derive-default")
-                .help("Derive Default on any type."),
+                .help("Derive Default on any type.")
+                .action(ArgAction::SetTrue),
             Arg::new("with-derive-hash")
                 .long("with-derive-hash")
-                .help("Derive hash on any type."),
+                .help("Derive hash on any type.")
+                .action(ArgAction::SetTrue),
             Arg::new("with-derive-partialeq")
                 .long("with-derive-partialeq")
-                .help("Derive partialeq on any type."),
+                .help("Derive partialeq on any type.")
+                .action(ArgAction::SetTrue),
             Arg::new("with-derive-partialord")
                 .long("with-derive-partialord")
-                .help("Derive partialord on any type."),
+                .help("Derive partialord on any type.")
+                .action(ArgAction::SetTrue),
             Arg::new("with-derive-eq")
                 .long("with-derive-eq")
                 .help(
                     "Derive eq on any type. Enable this option also \
                      enables --with-derive-partialeq",
-                ),
+                )
+                .action(ArgAction::SetTrue),
             Arg::new("with-derive-ord")
                 .long("with-derive-ord")
                 .help(
                     "Derive ord on any type. Enable this option also \
                      enables --with-derive-partialord",
-                ),
+                )
+                .action(ArgAction::SetTrue),
             Arg::new("no-doc-comments")
                 .long("no-doc-comments")
                 .help(
                     "Avoid including doc comments in the output, see: \
                      https://github.com/rust-lang/rust-bindgen/issues/426",
-                ),
+                )
+                .action(ArgAction::SetTrue),
             Arg::new("no-recursive-allowlist")
                 .long("no-recursive-allowlist")
                 .help(
@@ -258,23 +269,29 @@ where
                      bindgen to emit Rust code that won't compile! See the \
                      `bindgen::Builder::allowlist_recursively` method's \
                      documentation for details.",
-                ),
+                )
+                .action(ArgAction::SetTrue),
             Arg::new("objc-extern-crate")
                 .long("objc-extern-crate")
-                .help("Use extern crate instead of use for objc."),
+                .help("Use extern crate instead of use for objc.")
+                .action(ArgAction::SetTrue),
             Arg::new("generate-block")
                 .long("generate-block")
-                .help("Generate block signatures instead of void pointers."),
+                .help("Generate block signatures instead of void pointers.")
+                .action(ArgAction::SetTrue),
             Arg::new("block-extern-crate")
                 .long("block-extern-crate")
-                .help("Use extern crate instead of use for block."),
+                .help("Use extern crate instead of use for block.")
+                .action(ArgAction::SetTrue),
             Arg::new("distrust-clang-mangling")
                 .long("distrust-clang-mangling")
-                .help("Do not trust the libclang-provided mangling"),
+                .help("Do not trust the libclang-provided mangling")
+                .action(ArgAction::SetTrue),
             Arg::new("builtins").long("builtins").help(
                 "Output bindings for builtin definitions, e.g. \
                  __builtin_va_list.",
-            ),
+            )
+            .action(ArgAction::SetTrue),
             Arg::new("ctypes-prefix")
                 .long("ctypes-prefix")
                 .help(
@@ -289,51 +306,59 @@ where
                 .default_value(DEFAULT_ANON_FIELDS_PREFIX),
             Arg::new("time-phases")
                 .long("time-phases")
-                .help("Time the different bindgen phases and print to stderr"),
+                .help("Time the different bindgen phases and print to stderr")
+                .action(ArgAction::SetTrue),
             // All positional arguments after the end of options marker, `--`
-            Arg::new("clang-args").last(true).multiple_occurrences(true),
+            Arg::new("clang-args").last(true).action(ArgAction::Append),
             Arg::new("emit-clang-ast")
                 .long("emit-clang-ast")
-                .help("Output the Clang AST for debugging purposes."),
+                .help("Output the Clang AST for debugging purposes.")
+                .action(ArgAction::SetTrue),
             Arg::new("emit-ir")
                 .long("emit-ir")
-                .help("Output our internal IR for debugging purposes."),
+                .help("Output our internal IR for debugging purposes.")
+                .action(ArgAction::SetTrue),
             Arg::new("emit-ir-graphviz")
                 .long("emit-ir-graphviz")
                 .help("Dump graphviz dot file.")
                 .value_name("path"),
             Arg::new("enable-cxx-namespaces")
                 .long("enable-cxx-namespaces")
-                .help("Enable support for C++ namespaces."),
+                .help("Enable support for C++ namespaces.")
+                .action(ArgAction::SetTrue),
             Arg::new("disable-name-namespacing")
                 .long("disable-name-namespacing")
                 .help(
                     "Disable namespacing via mangling, causing bindgen to \
                      generate names like \"Baz\" instead of \"foo_bar_Baz\" \
                      for an input name \"foo::bar::Baz\".",
-                ),
+                )
+                .action(ArgAction::SetTrue),
             Arg::new("disable-nested-struct-naming")
                 .long("disable-nested-struct-naming")
                 .help(
                     "Disable nested struct naming, causing bindgen to generate \
                      names like \"bar\" instead of \"foo_bar\" for a nested \
                      definition \"struct foo { struct bar { } b; };\"."
-                ),
+                )
+                .action(ArgAction::SetTrue),
             Arg::new("disable-untagged-union")
                 .long("disable-untagged-union")
                 .help(
                     "Disable support for native Rust unions.",
-                ),
+                )
+                .action(ArgAction::SetTrue),
             Arg::new("disable-header-comment")
                 .long("disable-header-comment")
                 .help("Suppress insertion of bindgen's version identifier into generated bindings.")
-                .multiple_occurrences(true),
+                .action(ArgAction::SetTrue),
             Arg::new("ignore-functions")
                 .long("ignore-functions")
                 .help(
                     "Do not generate bindings for functions or methods. This \
                      is useful when you only care about struct layouts.",
-                ),
+                )
+                .action(ArgAction::SetTrue),
             Arg::new("generate")
                 .long("generate")
                 .help(
@@ -341,60 +366,68 @@ where
                      Valid values are \"functions\",\"types\", \"vars\", \
                      \"methods\", \"constructors\" and \"destructors\".",
                 )
-                .takes_value(true),
+                .action(ArgAction::Set),
             Arg::new("ignore-methods")
                 .long("ignore-methods")
-                .help("Do not generate bindings for methods."),
+                .help("Do not generate bindings for methods.")
+                .action(ArgAction::SetTrue),
             Arg::new("no-convert-floats")
                 .long("no-convert-floats")
-                .help("Do not automatically convert floats to f32/f64."),
+                .help("Do not automatically convert floats to f32/f64.")
+                .action(ArgAction::SetTrue),
             Arg::new("no-prepend-enum-name")
                 .long("no-prepend-enum-name")
-                .help("Do not prepend the enum name to constant or newtype variants."),
+                .help("Do not prepend the enum name to constant or newtype variants.")
+                .action(ArgAction::SetTrue),
             Arg::new("no-include-path-detection")
                 .long("no-include-path-detection")
-                .help("Do not try to detect default include paths"),
+                .help("Do not try to detect default include paths")
+                .action(ArgAction::SetTrue),
             Arg::new("fit-macro-constant-types")
                 .long("fit-macro-constant-types")
-                .help("Try to fit macro constants into types smaller than u32/i32"),
+                .help("Try to fit macro constants into types smaller than u32/i32")
+                .action(ArgAction::SetTrue),
             Arg::new("opaque-type")
                 .long("opaque-type")
                 .help("Mark <type> as opaque.")
                 .value_name("type")
-                .multiple_occurrences(true)
+                .action(ArgAction::Append)
                 .number_of_values(1),
             Arg::new("output")
                 .short('o')
                 .long("output")
                 .help("Write Rust bindings to <output>.")
-                .takes_value(true),
+                .action(ArgAction::Set),
             Arg::new("raw-line")
                 .long("raw-line")
                 .help("Add a raw line of Rust code at the beginning of output.")
-                .multiple_occurrences(true)
+                .action(ArgAction::Append)
                 .number_of_values(1),
             Arg::new("module-raw-line")
                 .long("module-raw-line")
                 .help("Add a raw line of Rust code to a given module.")
-                .multiple_occurrences(true)
+                .action(ArgAction::Append)
                 .number_of_values(2)
                 .value_names(&["module-name", "raw-line"]),
             Arg::new("rust-target")
                 .long("rust-target")
-                .help(rust_target_help.as_ref())
-                .takes_value(true),
+                .help(&rust_target_help)
+                .action(ArgAction::Set),
             Arg::new("use-core")
                 .long("use-core")
-                .help("Use types from Rust core instead of std."),
+                .help("Use types from Rust core instead of std.")
+                .action(ArgAction::SetTrue),
             Arg::new("conservative-inline-namespaces")
                 .long("conservative-inline-namespaces")
                 .help(
                     "Conservatively generate inline namespaces to avoid name \
                      conflicts.",
-                ),
+                )
+                .action(ArgAction::SetTrue),
             Arg::new("use-msvc-mangling")
                 .long("use-msvc-mangling")
-                .help("MSVC C++ ABI mangling. DEPRECATED: Has no effect."),
+                .help("MSVC C++ ABI mangling. DEPRECATED: Has no effect.")
+                .action(ArgAction::SetTrue),
             Arg::new("allowlist-function")
                 .long("allowlist-function")
                 .help(
@@ -403,11 +436,12 @@ where
                      generated.",
                 )
                 .value_name("regex")
-                .multiple_occurrences(true)
+                .action(ArgAction::Append)
                 .number_of_values(1),
             Arg::new("generate-inline-functions")
                 .long("generate-inline-functions")
-                .help("Generate inline functions."),
+                .help("Generate inline functions.")
+                .action(ArgAction::SetTrue),
             Arg::new("allowlist-type")
                 .long("allowlist-type")
                 .help(
@@ -415,7 +449,7 @@ where
                      not be generated.",
                 )
                 .value_name("regex")
-                .multiple_occurrences(true)
+                .action(ArgAction::Append)
                 .number_of_values(1),
             Arg::new("allowlist-var")
                 .long("allowlist-var")
@@ -425,18 +459,19 @@ where
                      generated.",
                 )
                 .value_name("regex")
-                .multiple_occurrences(true)
+                .action(ArgAction::Append)
                 .number_of_values(1),
             Arg::new("allowlist-file")
                 .alias("allowlist-file")
                 .long("allowlist-file")
                 .help("Allowlist all contents of <path>.")
                 .value_name("path")
-                .multiple_occurrences(true)
+                .action(ArgAction::Append)
                 .number_of_values(1),
             Arg::new("verbose")
                 .long("verbose")
-                .help("Print verbose error messages."),
+                .help("Print verbose error messages.")
+                .action(ArgAction::SetTrue),
             Arg::new("dump-preprocessed-input")
                 .long("dump-preprocessed-input")
                 .help(
@@ -444,24 +479,29 @@ where
                      Useful when debugging bindgen, using C-Reduce, or when \
                      filing issues. The resulting file will be named \
                      something like `__bindgen.i` or `__bindgen.ii`.",
-                ),
+                )
+                .action(ArgAction::SetTrue),
             Arg::new("no-record-matches")
                 .long("no-record-matches")
                 .help(
                     "Do not record matching items in the regex sets. \
                      This disables reporting of unused items.",
-                ),
+                )
+                .action(ArgAction::SetTrue),
             Arg::new("size_t-is-usize")
                 .long("size_t-is-usize")
                 .help("Ignored - this is enabled by default.")
-                .hidden(true),
-            Arg::with_name("no-size_t-is-usize")
+                .hide(true)
+                .action(ArgAction::SetTrue),
+            Arg::new("no-size_t-is-usize")
                 .long("no-size_t-is-usize")
                 .help("Do not bind size_t as usize (useful on platforms \
-                       where those types are incompatible)."),
+                       where those types are incompatible).")
+                .action(ArgAction::SetTrue),
             Arg::new("no-rustfmt-bindings")
                 .long("no-rustfmt-bindings")
-                .help("Do not format the generated bindings with rustfmt."),
+                .help("Do not format the generated bindings with rustfmt.")
+                .action(ArgAction::SetTrue),
             Arg::new("rustfmt-bindings")
                 .long("rustfmt-bindings")
                 .help(
@@ -477,102 +517,114 @@ where
                      This parameter is incompatible with --no-rustfmt-bindings.",
                 )
                 .value_name("path")
-                .multiple_occurrences(false)
+                .action(ArgAction::Set)
                 .number_of_values(1),
             Arg::new("no-partialeq")
                 .long("no-partialeq")
                 .help("Avoid deriving PartialEq for types matching <regex>.")
                 .value_name("regex")
-                .multiple_occurrences(true)
+                .action(ArgAction::Append)
                 .number_of_values(1),
             Arg::new("no-copy")
                 .long("no-copy")
                 .help("Avoid deriving Copy for types matching <regex>.")
                 .value_name("regex")
-                .multiple_occurrences(true)
+                .action(ArgAction::Append)
                 .number_of_values(1),
             Arg::new("no-debug")
                 .long("no-debug")
                 .help("Avoid deriving Debug for types matching <regex>.")
                 .value_name("regex")
-                .multiple_occurrences(true)
+                .action(ArgAction::Append)
                 .number_of_values(1),
             Arg::new("no-default")
                 .long("no-default")
                 .help("Avoid deriving/implement Default for types matching <regex>.")
                 .value_name("regex")
-                .multiple_occurrences(true)
+                .action(ArgAction::Append)
                 .number_of_values(1),
             Arg::new("no-hash")
                 .long("no-hash")
                 .help("Avoid deriving Hash for types matching <regex>.")
                 .value_name("regex")
-                .multiple_occurrences(true)
+                .action(ArgAction::Append)
                 .number_of_values(1),
             Arg::new("must-use-type")
                 .long("must-use-type")
                 .help("Add #[must_use] annotation to types matching <regex>.")
                 .value_name("regex")
-                .multiple_occurrences(true)
+                .action(ArgAction::Append)
                 .number_of_values(1),
             Arg::new("enable-function-attribute-detection")
                 .long("enable-function-attribute-detection")
                 .help(
                     "Enables detecting unexposed attributes in functions (slow).
                        Used to generate #[must_use] annotations.",
-                ),
+                )
+                .action(ArgAction::SetTrue),
             Arg::new("use-array-pointers-in-arguments")
                 .long("use-array-pointers-in-arguments")
-                .help("Use `*const [T; size]` instead of `*const T` for C arrays"),
+                .help("Use `*const [T; size]` instead of `*const T` for C arrays")
+                .action(ArgAction::SetTrue),
             Arg::new("wasm-import-module-name")
                 .long("wasm-import-module-name")
                 .value_name("name")
                 .help("The name to be used in a #[link(wasm_import_module = ...)] statement"),
             Arg::new("dynamic-loading")
                 .long("dynamic-loading")
-                .takes_value(true)
+                .action(ArgAction::Set)
                 .help("Use dynamic loading mode with the given library name."),
             Arg::new("dynamic-link-require-all")
                 .long("dynamic-link-require-all")
-                .help("Require successful linkage to all functions in the library."),
+                .help("Require successful linkage to all functions in the library.")
+                .action(ArgAction::SetTrue),
             Arg::new("respect-cxx-access-specs")
                 .long("respect-cxx-access-specs")
-                .help("Makes generated bindings `pub` only for items if the items are publically accessible in C++."),
+                .help("Makes generated bindings `pub` only for items if the items are publically accessible in C++.")
+                .action(ArgAction::SetTrue),
             Arg::new("translate-enum-integer-types")
                 .long("translate-enum-integer-types")
-                .help("Always translate enum integer types to native Rust integer types."),
+                .help("Always translate enum integer types to native Rust integer types.")
+                .action(ArgAction::SetTrue),
             Arg::new("c-naming")
                 .long("c-naming")
-                .help("Generate types with C style naming."),
+                .help("Generate types with C style naming.")
+                .action(ArgAction::SetTrue),
             Arg::new("explicit-padding")
                 .long("explicit-padding")
-                .help("Always output explicit padding fields."),
+                .help("Always output explicit padding fields.")
+                .action(ArgAction::SetTrue),
             Arg::new("vtable-generation")
                 .long("vtable-generation")
-                .help("Enables generation of vtable functions."),
+                .help("Enables generation of vtable functions.")
+                .action(ArgAction::SetTrue),
             Arg::new("sort-semantically")
                 .long("sort-semantically")
-                .help("Enables sorting of code generation in a predefined manner."),
+                .help("Enables sorting of code generation in a predefined manner.")
+                .action(ArgAction::SetTrue),
             Arg::new("merge-extern-blocks")
                 .long("merge-extern-blocks")
-                .help("Deduplicates extern blocks."),
+                .help("Deduplicates extern blocks.")
+                .action(ArgAction::SetTrue),
             Arg::new("override-abi")
                 .long("override-abi")
                 .help("Overrides the ABI of functions matching <regex>. The <override> value must be of the shape <regex>=<abi> where <abi> can be one of C, stdcall, fastcall, thiscall, aapcs, win64 or C-unwind.")
                 .value_name("override")
-                .multiple_occurrences(true)
+                .action(ArgAction::Append)
                 .number_of_values(1),
             Arg::new("wrap-unsafe-ops")
                 .long("wrap-unsafe-ops")
-                .help("Wrap unsafe operations in unsafe blocks."),
+                .help("Wrap unsafe operations in unsafe blocks.")
+                .action(ArgAction::SetTrue),
             Arg::new("V")
                 .long("version")
-                .help("Prints the version, and exits"),
+                .help("Prints the version, and exits")
+                .action(ArgAction::SetTrue),
         ]) // .args()
         .get_matches_from(args);
 
-    let verbose = matches.is_present("verbose");
-    if matches.is_present("V") {
+    let verbose = matches.get_flag("verbose");
+    if matches.get_flag("V") {
         println!(
             "bindgen {}",
             option_env!("CARGO_PKG_VERSION").unwrap_or("unknown")
@@ -585,215 +637,229 @@ where
 
     let mut builder = builder();
 
-    if let Some(header) = matches.value_of("header") {
+    if let Some(header) = matches.get_one::<String>("header") {
         builder = builder.header(header);
     } else {
         return Err(Error::new(ErrorKind::Other, "Header not found"));
     }
 
-    if let Some(rust_target) = matches.value_of("rust-target") {
+    if let Some(rust_target) = matches.get_one::<String>("rust-target") {
         builder = builder.rust_target(RustTarget::from_str(rust_target)?);
     }
 
-    if let Some(variant) = matches.value_of("default-enum-style") {
+    if let Some(variant) = matches.get_one::<String>("default-enum-style") {
         builder = builder.default_enum_style(EnumVariation::from_str(variant)?)
     }
 
-    if let Some(bitfields) = matches.values_of("bitfield-enum") {
+    if let Some(bitfields) = matches.get_many::<String>("bitfield-enum") {
         for regex in bitfields {
             builder = builder.bitfield_enum(regex);
         }
     }
 
-    if let Some(newtypes) = matches.values_of("newtype-enum") {
+    if let Some(newtypes) = matches.get_many::<String>("newtype-enum") {
         for regex in newtypes {
             builder = builder.newtype_enum(regex);
         }
     }
 
-    if let Some(newtypes) = matches.values_of("newtype-global-enum") {
+    if let Some(newtypes) = matches.get_many::<String>("newtype-global-enum") {
         for regex in newtypes {
             builder = builder.newtype_global_enum(regex);
         }
     }
 
-    if let Some(rustifieds) = matches.values_of("rustified-enum") {
+    if let Some(rustifieds) = matches.get_many::<String>("rustified-enum") {
         for regex in rustifieds {
             builder = builder.rustified_enum(regex);
         }
     }
 
-    if let Some(const_enums) = matches.values_of("constified-enum") {
+    if let Some(const_enums) = matches.get_many::<String>("constified-enum") {
         for regex in const_enums {
             builder = builder.constified_enum(regex);
         }
     }
 
-    if let Some(constified_mods) = matches.values_of("constified-enum-module") {
+    if let Some(constified_mods) =
+        matches.get_many::<String>("constified-enum-module")
+    {
         for regex in constified_mods {
             builder = builder.constified_enum_module(regex);
         }
     }
 
-    if let Some(variant) = matches.value_of("default-macro-constant-type") {
+    if let Some(variant) =
+        matches.get_one::<String>("default-macro-constant-type")
+    {
         builder = builder
             .default_macro_constant_type(MacroTypeVariation::from_str(variant)?)
     }
 
-    if let Some(variant) = matches.value_of("default-alias-style") {
+    if let Some(variant) = matches.get_one::<String>("default-alias-style") {
         builder =
             builder.default_alias_style(AliasVariation::from_str(variant)?);
     }
 
-    if let Some(type_alias) = matches.values_of("normal-alias") {
+    if let Some(type_alias) = matches.get_many::<String>("normal-alias") {
         for regex in type_alias {
             builder = builder.type_alias(regex);
         }
     }
 
-    if let Some(new_type) = matches.values_of("new-type-alias") {
+    if let Some(new_type) = matches.get_many::<String>("new-type-alias") {
         for regex in new_type {
             builder = builder.new_type_alias(regex);
         }
     }
 
-    if let Some(new_type_deref) = matches.values_of("new-type-alias-deref") {
+    if let Some(new_type_deref) =
+        matches.get_many::<String>("new-type-alias-deref")
+    {
         for regex in new_type_deref {
             builder = builder.new_type_alias_deref(regex);
         }
     }
 
-    if let Some(variant) = matches.value_of("default-non-copy-union-style") {
+    if let Some(variant) =
+        matches.get_one::<String>("default-non-copy-union-style")
+    {
         builder = builder.default_non_copy_union_style(
             NonCopyUnionStyle::from_str(variant)?,
         );
     }
 
     if let Some(bindgen_wrapper_union) =
-        matches.values_of("bindgen-wrapper-union")
+        matches.get_many::<String>("bindgen-wrapper-union")
     {
         for regex in bindgen_wrapper_union {
             builder = builder.bindgen_wrapper_union(regex);
         }
     }
 
-    if let Some(manually_drop_union) = matches.values_of("manually-drop-union")
+    if let Some(manually_drop_union) =
+        matches.get_many::<String>("manually-drop-union")
     {
         for regex in manually_drop_union {
             builder = builder.manually_drop_union(regex);
         }
     }
 
-    if let Some(hidden_types) = matches.values_of("blocklist-type") {
+    if let Some(hidden_types) = matches.get_many::<String>("blocklist-type") {
         for ty in hidden_types {
             builder = builder.blocklist_type(ty);
         }
     }
 
-    if let Some(hidden_functions) = matches.values_of("blocklist-function") {
+    if let Some(hidden_functions) =
+        matches.get_many::<String>("blocklist-function")
+    {
         for fun in hidden_functions {
             builder = builder.blocklist_function(fun);
         }
     }
 
-    if let Some(hidden_identifiers) = matches.values_of("blocklist-item") {
+    if let Some(hidden_identifiers) =
+        matches.get_many::<String>("blocklist-item")
+    {
         for id in hidden_identifiers {
             builder = builder.blocklist_item(id);
         }
     }
 
-    if let Some(hidden_files) = matches.values_of("blocklist-file") {
+    if let Some(hidden_files) = matches.get_many::<String>("blocklist-file") {
         for file in hidden_files {
             builder = builder.blocklist_file(file);
         }
     }
 
-    if matches.is_present("builtins") {
+    if matches.get_flag("builtins") {
         builder = builder.emit_builtins();
     }
 
-    if matches.is_present("no-layout-tests") {
+    if matches.get_flag("no-layout-tests") {
         builder = builder.layout_tests(false);
     }
 
-    if matches.is_present("no-derive-copy") {
+    if matches.get_flag("no-derive-copy") {
         builder = builder.derive_copy(false);
     }
 
-    if matches.is_present("no-derive-debug") {
+    if matches.get_flag("no-derive-debug") {
         builder = builder.derive_debug(false);
     }
 
-    if matches.is_present("impl-debug") {
+    if matches.get_flag("impl-debug") {
         builder = builder.impl_debug(true);
     }
 
-    if matches.is_present("impl-partialeq") {
+    if matches.get_flag("impl-partialeq") {
         builder = builder.impl_partialeq(true);
     }
 
-    if matches.is_present("with-derive-default") {
+    if matches.get_flag("with-derive-default") {
         builder = builder.derive_default(true);
     }
 
-    if matches.is_present("with-derive-hash") {
+    if matches.get_flag("with-derive-hash") {
         builder = builder.derive_hash(true);
     }
 
-    if matches.is_present("with-derive-partialeq") {
+    if matches.get_flag("with-derive-partialeq") {
         builder = builder.derive_partialeq(true);
     }
 
-    if matches.is_present("with-derive-partialord") {
+    if matches.get_flag("with-derive-partialord") {
         builder = builder.derive_partialord(true);
     }
 
-    if matches.is_present("with-derive-eq") {
+    if matches.get_flag("with-derive-eq") {
         builder = builder.derive_eq(true);
     }
 
-    if matches.is_present("with-derive-ord") {
+    if matches.get_flag("with-derive-ord") {
         builder = builder.derive_ord(true);
     }
 
-    if matches.is_present("no-derive-default") {
+    if matches.get_flag("no-derive-default") {
         builder = builder.derive_default(false);
     }
 
-    if matches.is_present("no-prepend-enum-name") {
+    if matches.get_flag("no-prepend-enum-name") {
         builder = builder.prepend_enum_name(false);
     }
 
-    if matches.is_present("no-include-path-detection") {
+    if matches.get_flag("no-include-path-detection") {
         builder = builder.detect_include_paths(false);
     }
 
-    if matches.is_present("fit-macro-constant-types") {
+    if matches.get_flag("fit-macro-constant-types") {
         builder = builder.fit_macro_constants(true);
     }
 
-    if matches.is_present("time-phases") {
+    if matches.get_flag("time-phases") {
         builder = builder.time_phases(true);
     }
 
-    if matches.is_present("use-array-pointers-in-arguments") {
+    if matches.get_flag("use-array-pointers-in-arguments") {
         builder = builder.array_pointers_in_arguments(true);
     }
 
-    if let Some(wasm_import_name) = matches.value_of("wasm-import-module-name")
+    if let Some(wasm_import_name) =
+        matches.get_one::<String>("wasm-import-module-name")
     {
         builder = builder.wasm_import_module_name(wasm_import_name);
     }
 
-    if let Some(prefix) = matches.value_of("ctypes-prefix") {
+    if let Some(prefix) = matches.get_one::<String>("ctypes-prefix") {
         builder = builder.ctypes_prefix(prefix);
     }
 
-    if let Some(prefix) = matches.value_of("anon-fields-prefix") {
+    if let Some(prefix) = matches.get_one::<String>("anon-fields-prefix") {
         builder = builder.anon_fields_prefix(prefix);
     }
 
-    if let Some(what_to_generate) = matches.value_of("generate") {
+    if let Some(what_to_generate) = matches.get_one::<String>("generate") {
         let mut config = CodegenConfig::empty();
         for what in what_to_generate.split(',') {
             match what {
@@ -814,170 +880,172 @@ where
         builder = builder.with_codegen_config(config);
     }
 
-    if matches.is_present("emit-clang-ast") {
+    if matches.get_flag("emit-clang-ast") {
         builder = builder.emit_clang_ast();
     }
 
-    if matches.is_present("emit-ir") {
+    if matches.get_flag("emit-ir") {
         builder = builder.emit_ir();
     }
 
-    if let Some(path) = matches.value_of("emit-ir-graphviz") {
+    if let Some(path) = matches.get_one::<String>("emit-ir-graphviz") {
         builder = builder.emit_ir_graphviz(path);
     }
 
-    if matches.is_present("enable-cxx-namespaces") {
+    if matches.get_flag("enable-cxx-namespaces") {
         builder = builder.enable_cxx_namespaces();
     }
 
-    if matches.is_present("enable-function-attribute-detection") {
+    if matches.get_flag("enable-function-attribute-detection") {
         builder = builder.enable_function_attribute_detection();
     }
 
-    if matches.is_present("disable-name-namespacing") {
+    if matches.get_flag("disable-name-namespacing") {
         builder = builder.disable_name_namespacing();
     }
 
-    if matches.is_present("disable-nested-struct-naming") {
+    if matches.get_flag("disable-nested-struct-naming") {
         builder = builder.disable_nested_struct_naming();
     }
 
-    if matches.is_present("disable-untagged-union") {
+    if matches.get_flag("disable-untagged-union") {
         builder = builder.disable_untagged_union();
     }
 
-    if matches.is_present("disable-header-comment") {
+    if matches.get_flag("disable-header-comment") {
         builder = builder.disable_header_comment();
     }
 
-    if matches.is_present("ignore-functions") {
+    if matches.get_flag("ignore-functions") {
         builder = builder.ignore_functions();
     }
 
-    if matches.is_present("ignore-methods") {
+    if matches.get_flag("ignore-methods") {
         builder = builder.ignore_methods();
     }
 
-    if matches.is_present("no-convert-floats") {
+    if matches.get_flag("no-convert-floats") {
         builder = builder.no_convert_floats();
     }
 
-    if matches.is_present("no-doc-comments") {
+    if matches.get_flag("no-doc-comments") {
         builder = builder.generate_comments(false);
     }
 
-    if matches.is_present("no-recursive-allowlist") {
+    if matches.get_flag("no-recursive-allowlist") {
         builder = builder.allowlist_recursively(false);
     }
 
-    if matches.is_present("objc-extern-crate") {
+    if matches.get_flag("objc-extern-crate") {
         builder = builder.objc_extern_crate(true);
     }
 
-    if matches.is_present("generate-block") {
+    if matches.get_flag("generate-block") {
         builder = builder.generate_block(true);
     }
 
-    if matches.is_present("block-extern-crate") {
+    if matches.get_flag("block-extern-crate") {
         builder = builder.block_extern_crate(true);
     }
 
-    if let Some(opaque_types) = matches.values_of("opaque-type") {
+    if let Some(opaque_types) = matches.get_many::<String>("opaque-type") {
         for ty in opaque_types {
             builder = builder.opaque_type(ty);
         }
     }
 
-    if let Some(lines) = matches.values_of("raw-line") {
+    if let Some(lines) = matches.get_many::<String>("raw-line") {
         for line in lines {
             builder = builder.raw_line(line);
         }
     }
 
-    if let Some(mut values) = matches.values_of("module-raw-line") {
+    if let Some(mut values) = matches.get_many::<String>("module-raw-line") {
         while let Some(module) = values.next() {
             let line = values.next().unwrap();
             builder = builder.module_raw_line(module, line);
         }
     }
 
-    if matches.is_present("use-core") {
+    if matches.get_flag("use-core") {
         builder = builder.use_core();
     }
 
-    if matches.is_present("distrust-clang-mangling") {
+    if matches.get_flag("distrust-clang-mangling") {
         builder = builder.trust_clang_mangling(false);
     }
 
-    if matches.is_present("conservative-inline-namespaces") {
+    if matches.get_flag("conservative-inline-namespaces") {
         builder = builder.conservative_inline_namespaces();
     }
 
-    if matches.is_present("generate-inline-functions") {
+    if matches.get_flag("generate-inline-functions") {
         builder = builder.generate_inline_functions(true);
     }
 
-    if let Some(allowlist) = matches.values_of("allowlist-function") {
+    if let Some(allowlist) = matches.get_many::<String>("allowlist-function") {
         for regex in allowlist {
             builder = builder.allowlist_function(regex);
         }
     }
 
-    if let Some(allowlist) = matches.values_of("allowlist-type") {
+    if let Some(allowlist) = matches.get_many::<String>("allowlist-type") {
         for regex in allowlist {
             builder = builder.allowlist_type(regex);
         }
     }
 
-    if let Some(allowlist) = matches.values_of("allowlist-var") {
+    if let Some(allowlist) = matches.get_many::<String>("allowlist-var") {
         for regex in allowlist {
             builder = builder.allowlist_var(regex);
         }
     }
 
-    if let Some(hidden_files) = matches.values_of("allowlist-file") {
+    if let Some(hidden_files) = matches.get_many::<String>("allowlist-file") {
         for file in hidden_files {
             builder = builder.allowlist_file(file);
         }
     }
 
-    if let Some(args) = matches.values_of("clang-args") {
+    if let Some(args) = matches.get_many::<String>("clang-args") {
         for arg in args {
             builder = builder.clang_arg(arg);
         }
     }
 
-    let output = if let Some(path) = matches.value_of("output") {
+    let output = if let Some(path) = matches.get_one::<String>("output") {
         let file = File::create(path)?;
-        if let Some(depfile) = matches.value_of("depfile") {
+        if let Some(depfile) = matches.get_one::<String>("depfile") {
             builder = builder.depfile(path, depfile);
         }
         Box::new(io::BufWriter::new(file)) as Box<dyn io::Write>
     } else {
-        if let Some(depfile) = matches.value_of("depfile") {
+        if let Some(depfile) = matches.get_one::<String>("depfile") {
             builder = builder.depfile("-", depfile);
         }
         Box::new(io::BufWriter::new(io::stdout())) as Box<dyn io::Write>
     };
 
-    if matches.is_present("dump-preprocessed-input") {
+    if matches.get_flag("dump-preprocessed-input") {
         builder.dump_preprocessed_input()?;
     }
 
-    if matches.is_present("no-record-matches") {
+    if matches.get_flag("no-record-matches") {
         builder = builder.record_matches(false);
     }
 
-    if matches.is_present("no-size_t-is-usize") {
+    if matches.get_flag("no-size_t-is-usize") {
         builder = builder.size_t_is_usize(false);
     }
 
-    let no_rustfmt_bindings = matches.is_present("no-rustfmt-bindings");
+    let no_rustfmt_bindings = matches.get_flag("no-rustfmt-bindings");
     if no_rustfmt_bindings {
         builder = builder.rustfmt_bindings(false);
     }
 
-    if let Some(path_str) = matches.value_of("rustfmt-configuration-file") {
+    if let Some(path_str) =
+        matches.get_one::<String>("rustfmt-configuration-file")
+    {
         let path = PathBuf::from(path_str);
 
         if no_rustfmt_bindings {
@@ -1004,79 +1072,81 @@ where
         builder = builder.rustfmt_configuration_file(Some(path));
     }
 
-    if let Some(no_partialeq) = matches.values_of("no-partialeq") {
+    if let Some(no_partialeq) = matches.get_many::<String>("no-partialeq") {
         for regex in no_partialeq {
             builder = builder.no_partialeq(regex);
         }
     }
 
-    if let Some(no_copy) = matches.values_of("no-copy") {
+    if let Some(no_copy) = matches.get_many::<String>("no-copy") {
         for regex in no_copy {
             builder = builder.no_copy(regex);
         }
     }
 
-    if let Some(no_debug) = matches.values_of("no-debug") {
+    if let Some(no_debug) = matches.get_many::<String>("no-debug") {
         for regex in no_debug {
             builder = builder.no_debug(regex);
         }
     }
 
-    if let Some(no_default) = matches.values_of("no-default") {
+    if let Some(no_default) = matches.get_many::<String>("no-default") {
         for regex in no_default {
             builder = builder.no_default(regex);
         }
     }
 
-    if let Some(no_hash) = matches.values_of("no-hash") {
+    if let Some(no_hash) = matches.get_many::<String>("no-hash") {
         for regex in no_hash {
             builder = builder.no_hash(regex);
         }
     }
 
-    if let Some(must_use_type) = matches.values_of("must-use-type") {
+    if let Some(must_use_type) = matches.get_many::<String>("must-use-type") {
         for regex in must_use_type {
             builder = builder.must_use_type(regex);
         }
     }
 
-    if let Some(dynamic_library_name) = matches.value_of("dynamic-loading") {
+    if let Some(dynamic_library_name) =
+        matches.get_one::<String>("dynamic-loading")
+    {
         builder = builder.dynamic_library_name(dynamic_library_name);
     }
 
-    if matches.is_present("dynamic-link-require-all") {
+    if matches.get_flag("dynamic-link-require-all") {
         builder = builder.dynamic_link_require_all(true);
     }
 
-    if matches.is_present("respect-cxx-access-specs") {
+    if matches.get_flag("respect-cxx-access-specs") {
         builder = builder.respect_cxx_access_specs(true);
     }
 
-    if matches.is_present("translate-enum-integer-types") {
+    if matches.get_flag("translate-enum-integer-types") {
         builder = builder.translate_enum_integer_types(true);
     }
 
-    if matches.is_present("c-naming") {
+    if matches.get_flag("c-naming") {
         builder = builder.c_naming(true);
     }
 
-    if matches.is_present("explicit-padding") {
+    if matches.get_flag("explicit-padding") {
         builder = builder.explicit_padding(true);
     }
 
-    if matches.is_present("vtable-generation") {
+    if matches.get_flag("vtable-generation") {
         builder = builder.vtable_generation(true);
     }
 
-    if matches.is_present("sort-semantically") {
+    if matches.get_flag("sort-semantically") {
         builder = builder.sort_semantically(true);
     }
 
-    if matches.is_present("merge-extern-blocks") {
+    if matches.get_flag("merge-extern-blocks") {
         builder = builder.merge_extern_blocks(true);
     }
 
-    if let Some(abi_overrides) = matches.values_of("override-abi") {
+    if let Some(abi_overrides) = matches.get_many::<String>("override-abi") {
         for abi_override in abi_overrides {
             let (regex, abi_str) = abi_override
                 .rsplit_once('=')
@@ -1088,7 +1158,7 @@ where
         }
     }
 
-    if matches.is_present("wrap-unsafe-ops") {
+    if matches.get_flag("wrap-unsafe-ops") {
         builder = builder.wrap_unsafe_ops(true);
     }
 

--- a/bindgen-tests/Cargo.toml
+++ b/bindgen-tests/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 bindgen = { path = "../bindgen" }
 diff = "0.1"
 shlex = "1"
-clap = "3"
+clap = "4"
 tempfile = "3"
 
 [features]

--- a/bindgen/Cargo.toml
+++ b/bindgen/Cargo.toml
@@ -18,7 +18,7 @@ version = "0.63.0"
 edition = "2018"
 build = "build.rs"
 # If you change this, also update README.md and msrv in .github/workflows/bindgen.yml
-rust-version = "1.57.0"
+rust-version = "1.60.0"
 
 [lib]
 name = "bindgen"


### PR DESCRIPTION
Most other crates (including `cxx`) use clap 4 by now, and bindgen using clap 3 results in multiple versions needing to be maintained in projects which vendor dependencies.