### PR TITLE
Add trigger for push to `main` branch for sync'ing with `master`

### DIFF
--- a/.github/workflows/sync-master-from-main.yml
+++ b/.github/workflows/sync-master-from-main.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    branches:
-      - main
 
 jobs:
   sync-branches:

--- a/.github/workflows/sync-master-from-main.yml
+++ b/.github/workflows/sync-master-from-main.yml
@@ -1,0 +1,24 @@
+name: sync master from main
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  sync-branches:
+    runs-on: ubuntu-latest
+    name: Keep master and main in sync until master is done
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Merge master <- main
+        uses: devmasx/merge-branch@master
+        with:
+          type: now
+          from_branch: main
+          target_branch: master
+          github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Thank you for paying attention to this issue.  This is the first PR which we will merge into `master`.  I believe we can then open another PR for `main` and at that time switch the default branch to `main`.

#2286 