### PR TITLE
Consider alignment contribution from bitfields

### DIFF
--- a/bindgen-tests/tests/expectations/tests/bitfield-32bit-overflow.rs
+++ b/bindgen-tests/tests/expectations/tests/bitfield-32bit-overflow.rs
@@ -91,7 +91,7 @@ where
         }
     }
 }
-#[repr(C, packed)]
+#[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct MuchBitfield {
     pub _bitfield_align_1: [u8; 0],

--- a/bindgen-tests/tests/expectations/tests/bitfield-method-same-name.rs
+++ b/bindgen-tests/tests/expectations/tests/bitfield-method-same-name.rs
@@ -91,7 +91,7 @@ where
         }
     }
 }
-#[repr(C, packed)]
+#[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct Foo {
     pub _bitfield_align_1: [u8; 0],

--- a/bindgen-tests/tests/expectations/tests/bitfield_align.rs
+++ b/bindgen-tests/tests/expectations/tests/bitfield_align.rs
@@ -316,7 +316,6 @@ impl A {
     }
 }
 #[repr(C)]
-#[repr(align(4))]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct B {
     pub _bitfield_align_1: [u32; 0],

--- a/bindgen-tests/tests/expectations/tests/bitfield_align_2.rs
+++ b/bindgen-tests/tests/expectations/tests/bitfield_align_2.rs
@@ -101,7 +101,6 @@ pub enum MyEnum {
     FOUR = 3,
 }
 #[repr(C)]
-#[repr(align(8))]
 #[derive(Debug, Copy, Clone)]
 pub struct TaggedPtr {
     pub _bitfield_align_1: [u64; 0],

--- a/bindgen-tests/tests/expectations/tests/bitfield_method_mangling.rs
+++ b/bindgen-tests/tests/expectations/tests/bitfield_method_mangling.rs
@@ -92,7 +92,6 @@ where
     }
 }
 #[repr(C)]
-#[repr(align(4))]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct mach_msg_type_descriptor_t {
     pub _bitfield_align_1: [u32; 0],

--- a/bindgen-tests/tests/expectations/tests/bitfield_pragma_packed.rs
+++ b/bindgen-tests/tests/expectations/tests/bitfield_pragma_packed.rs
@@ -209,3 +209,98 @@ impl Struct {
         __bindgen_bitfield_unit
     }
 }
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct Inner {
+    pub _bitfield_align_1: [u16; 0],
+    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
+}
+#[test]
+fn bindgen_test_layout_Inner() {
+    assert_eq!(
+        ::std::mem::size_of::<Inner>(),
+        4usize,
+        concat!("Size of: ", stringify!(Inner))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<Inner>(),
+        2usize,
+        concat!("Alignment of ", stringify!(Inner))
+    );
+}
+impl Inner {
+    #[inline]
+    pub fn a(&self) -> ::std::os::raw::c_ushort {
+        unsafe {
+            ::std::mem::transmute(self._bitfield_1.get(0usize, 16u8) as u16)
+        }
+    }
+    #[inline]
+    pub fn set_a(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set(0usize, 16u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn b(&self) -> ::std::os::raw::c_ushort {
+        unsafe {
+            ::std::mem::transmute(self._bitfield_1.get(16usize, 16u8) as u16)
+        }
+    }
+    #[inline]
+    pub fn set_b(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set(16usize, 16u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn new_bitfield_1(
+        a: ::std::os::raw::c_ushort,
+        b: ::std::os::raw::c_ushort,
+    ) -> __BindgenBitfieldUnit<[u8; 4usize]> {
+        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> =
+            Default::default();
+        __bindgen_bitfield_unit.set(0usize, 16u8, {
+            let a: u16 = unsafe { ::std::mem::transmute(a) };
+            a as u64
+        });
+        __bindgen_bitfield_unit.set(16usize, 16u8, {
+            let b: u16 = unsafe { ::std::mem::transmute(b) };
+            b as u64
+        });
+        __bindgen_bitfield_unit
+    }
+}
+#[repr(C, packed)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct Outer {
+    pub inner: Inner,
+}
+#[test]
+fn bindgen_test_layout_Outer() {
+    const UNINIT: ::std::mem::MaybeUninit<Outer> =
+        ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
+    assert_eq!(
+        ::std::mem::size_of::<Outer>(),
+        4usize,
+        concat!("Size of: ", stringify!(Outer))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<Outer>(),
+        1usize,
+        concat!("Alignment of ", stringify!(Outer))
+    );
+    assert_eq!(
+        unsafe { ::std::ptr::addr_of!((*ptr).inner) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(Outer),
+            "::",
+            stringify!(inner)
+        )
+    );
+}

--- a/bindgen-tests/tests/expectations/tests/bitfield_pragma_packed.rs
+++ b/bindgen-tests/tests/expectations/tests/bitfield_pragma_packed.rs
@@ -91,7 +91,7 @@ where
         }
     }
 }
-#[repr(C, packed)]
+#[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct Struct {
     pub _bitfield_align_1: [u8; 0],

--- a/bindgen-tests/tests/expectations/tests/issue-1034.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-1034.rs
@@ -91,7 +91,7 @@ where
         }
     }
 }
-#[repr(C, packed)]
+#[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct S2 {
     pub _bitfield_align_1: [u8; 0],

--- a/bindgen-tests/tests/expectations/tests/issue-1076-unnamed-bitfield-alignment.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-1076-unnamed-bitfield-alignment.rs
@@ -91,7 +91,7 @@ where
         }
     }
 }
-#[repr(C, packed)]
+#[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct S1 {
     pub _bitfield_align_1: [u8; 0],

--- a/bindgen-tests/tests/expectations/tests/issue-1947.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-1947.rs
@@ -94,7 +94,6 @@ where
 pub type U8 = ::std::os::raw::c_uchar;
 pub type U16 = ::std::os::raw::c_ushort;
 #[repr(C)]
-#[repr(align(2))]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct V56AMDY {
     pub _bitfield_align_1: [u16; 0],

--- a/bindgen-tests/tests/expectations/tests/issue-739-pointer-wide-bitfield.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-739-pointer-wide-bitfield.rs
@@ -93,7 +93,6 @@ where
     }
 }
 #[repr(C)]
-#[repr(align(8))]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct Foo {
     pub _bitfield_align_1: [u64; 0],

--- a/bindgen-tests/tests/expectations/tests/jsval_layout_opaque.rs
+++ b/bindgen-tests/tests/expectations/tests/jsval_layout_opaque.rs
@@ -189,7 +189,6 @@ pub union jsval_layout {
     pub asUIntPtr: usize,
 }
 #[repr(C)]
-#[repr(align(8))]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct jsval_layout__bindgen_ty_1 {
     pub _bitfield_align_1: [u64; 0],

--- a/bindgen-tests/tests/expectations/tests/jsval_layout_opaque_1_0.rs
+++ b/bindgen-tests/tests/expectations/tests/jsval_layout_opaque_1_0.rs
@@ -237,7 +237,6 @@ pub struct jsval_layout {
 pub struct jsval_layout__bindgen_ty_1 {
     pub _bitfield_align_1: [u64; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 8usize]>,
-    pub __bindgen_align: [u64; 0usize],
 }
 #[test]
 fn bindgen_test_layout_jsval_layout__bindgen_ty_1() {

--- a/bindgen-tests/tests/expectations/tests/only_bitfields.rs
+++ b/bindgen-tests/tests/expectations/tests/only_bitfields.rs
@@ -91,7 +91,7 @@ where
         }
     }
 }
-#[repr(C, packed)]
+#[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct C {
     pub _bitfield_align_1: [u8; 0],

--- a/bindgen-tests/tests/expectations/tests/union_bitfield.rs
+++ b/bindgen-tests/tests/expectations/tests/union_bitfield.rs
@@ -148,7 +148,6 @@ impl U4 {
     }
 }
 #[repr(C)]
-#[repr(align(4))]
 #[derive(Copy, Clone)]
 pub union B {
     pub _bitfield_align_1: [u32; 0],

--- a/bindgen-tests/tests/expectations/tests/union_with_anon_struct_bitfield.rs
+++ b/bindgen-tests/tests/expectations/tests/union_with_anon_struct_bitfield.rs
@@ -98,7 +98,6 @@ pub union foo {
     pub __bindgen_anon_1: foo__bindgen_ty_1,
 }
 #[repr(C)]
-#[repr(align(4))]
 #[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct foo__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],

--- a/bindgen-tests/tests/expectations/tests/union_with_anon_struct_bitfield_1_0.rs
+++ b/bindgen-tests/tests/expectations/tests/union_with_anon_struct_bitfield_1_0.rs
@@ -146,7 +146,6 @@ pub struct foo {
 pub struct foo__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
-    pub __bindgen_align: [u32; 0usize],
 }
 #[test]
 fn bindgen_test_layout_foo__bindgen_ty_1() {

--- a/bindgen-tests/tests/headers/bitfield_pragma_packed.h
+++ b/bindgen-tests/tests/headers/bitfield_pragma_packed.h
@@ -7,3 +7,14 @@ struct Struct {
     unsigned char e : 8;
 };
 #pragma pack(pop)
+
+struct Inner {
+    unsigned short a: 16;
+    unsigned short b: 16;
+};
+
+#pragma pack(push, 1)
+struct Outer {
+    struct Inner inner;
+};
+#pragma pop

--- a/bindgen/codegen/struct_layout.rs
+++ b/bindgen/codegen/struct_layout.rs
@@ -152,9 +152,7 @@ impl<'a> StructLayoutTracker<'a> {
 
         self.latest_field_layout = Some(layout);
         self.last_field_was_bitfield = true;
-        // NB: We intentionally don't update the max_field_align here, since our
-        // bitfields code doesn't necessarily guarantee it, so we need to
-        // actually generate the dummy alignment.
+        self.max_field_align = cmp::max(self.max_field_align, layout.align);
     }
 
     /// Returns a padding field if necessary for a given new field _before_


### PR DESCRIPTION
Partial fix to https://lore.kernel.org/rust-for-linux/Y8Ax%2FI5qOcVDZljG@zn.tnic/ (not a full fix, because it `short` below is replaced with a `int` then the code still fails to compile)

Currently binding for code like this wouldn't compile:
```c
struct outer {
    struct {
        short a: 16;
        short b: 16;
    };
} __attribute__((packed));
```
because bindgen sticks an extra `#[repr(align(2))]` on the inner struct.

This extra alignment is not necessary and can be removed. The removed NB line in this PR is no longer relevant because of the addition _bitfield_align field generated starting in #1950.

cc @emilio @ojeda