### PR TITLE
bindgen::ParseCallbacks: support tracking env variable usage for cargo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,7 +65,7 @@
   - [Fixed](#fixed-13)
 - [0.54.1](#0541)
   - [Added](#added-12)
-  - [Changed](#changed-10)
+  - [Changed](#chainged-10)
   - [Fixed](#fixed-14)
 - [0.54.0](#0540)
   - [Added](#added-13)
@@ -174,6 +174,8 @@
  * Added the `Builder::emit_diagnostics` method and the  `--emit-diagnostics`
    flag to enable emission of diagnostic messages.
  * Added support for the `"efiapi"` calling convention.
+ * Added the `ParseCallbacks::read_env_var` method which runs everytime
+   `bindgen` reads and environment variable.
 
 ## Changed
  * Static functions with no arguments use `void` as their single argument

--- a/bindgen/callbacks.rs
+++ b/bindgen/callbacks.rs
@@ -102,6 +102,10 @@ pub trait ParseCallbacks: fmt::Debug {
     /// This will be called on every file inclusion, with the full path of the included file.
     fn include_file(&self, _filename: &str) {}
 
+    /// This will be called every time an environment variable is read (whether or not it has any
+    /// content), with the name of the env variable.
+    fn read_env_var(&self, _key: &str) {}
+
     /// This will be called to determine whether a particular blocklisted type
     /// implements a trait or not. This will be used to implement traits on
     /// other types containing the blocklisted type.

--- a/bindgen/callbacks.rs
+++ b/bindgen/callbacks.rs
@@ -102,8 +102,8 @@ pub trait ParseCallbacks: fmt::Debug {
     /// This will be called on every file inclusion, with the full path of the included file.
     fn include_file(&self, _filename: &str) {}
 
-    /// This will be called every time an environment variable is read (whether or not it has any
-    /// content), with the name of the env variable.
+    /// This will be called every time `bindgen` reads an environment variable whether it has any
+    /// content or not.
     fn read_env_var(&self, _key: &str) {}
 
     /// This will be called to determine whether a particular blocklisted type

--- a/bindgen/lib.rs
+++ b/bindgen/lib.rs
@@ -73,8 +73,8 @@ use std::fs::{File, OpenOptions};
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
-use std::str::FromStr;
 use std::rc::Rc;
+use std::str::FromStr;
 
 // Some convenient typedefs for a fast hash map and hash set.
 type HashMap<K, V> = rustc_hash::FxHashMap<K, V>;


### PR DESCRIPTION
bindgen currently has a `bindgen/build.rs` which attempts to have cargo rebuild bindgen when `TARGET` specific env variables change, specifically `BINDGEN_EXTRA_CLANG_ARGS_<target>`. Unfortunately, this doesn't have the desired effect in most cases.

Specifically, when a crate `A` has `bindgen` in `build-dependencies`, and we're cross compiling `A` for target `T` on a host `H`, `bindgen`'s `build.rs` will observe `TARGET` set to `H` (the host target name) instead of `T` (because `bindgen` itself is being built for `H` and not `T`). Then, within the build script of crate `A`, one would use `bindgen` to generate bindings, and now `TARGET` is set to `T`, so different env variables are used.

Allow crates using `bindgen` in build scripts to correctly handle env variable changes by adding `ParseCallbacks::read_env_var()` to track env var reads and adding a basic implimentation to `CargoCallbacks` to emit `cargo:rerun-if-env-changed` lines.