### PR TITLE
 Disallow constant values that were changed in clang 15 

### DIFF
--- a/bindgen/codegen/serialize.rs
+++ b/bindgen/codegen/serialize.rs
@@ -44,12 +44,10 @@ impl<'a> CSerialize<'a> for Item {
             ItemKind::Function(func) => {
                 func.serialize(ctx, self, stack, writer)
             }
-            kind => {
-                return Err(CodegenError::Serialize {
-                    msg: format!("Cannot serialize item kind {:?}", kind),
-                    loc: get_loc(self),
-                });
-            }
+            kind => Err(CodegenError::Serialize {
+                msg: format!("Cannot serialize item kind {:?}", kind),
+                loc: get_loc(self),
+            }),
         }
     }
 }

--- a/bindgen/lib.rs
+++ b/bindgen/lib.rs
@@ -9,6 +9,7 @@
 //! additional documentation.
 #![deny(missing_docs)]
 #![deny(unused_extern_crates)]
+#![deny(clippy::disallowed_methods)]
 // To avoid rather annoying warnings when matching with CXCursor_xxx as a
 // constant.
 #![allow(non_upper_case_globals)]

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,4 @@
+disallowed-methods = [
+    { path = "clang_sys::CXCursor_TranslationUnit", reason = "This value was changed in clang 15"},
+    { path = "clang_sys::CXCursor_LastStmt", reason = "This value was changed in clang 15"}
+]


### PR DESCRIPTION
This is a temporary fix for https://github.com/rust-lang/rust-bindgen/issues/2409 in case someone decides to use one of the values that changed in clang 15.

If we really need such values we should figure out how to enable the `clang_sys/clang_15`  feature if clang 15 is present in the system.