### PR TITLE
Fix typo in bitfields documentation

### DIFF
--- a/book/src/using-bitfields.md
+++ b/book/src/using-bitfields.md
@@ -5,7 +5,7 @@
 As Rust does not support bitfields, Bindgen generates a struct for each with the following characteristics
 * Immutable getter functions for each bitfield named ```<bitfield>```
 * Setter functions for each contiguous block of bitfields named ```set_<bitfield>```
-* Far each contiguous block of bitfields, Bindgen emits an opaque physical field that contains one or more logical bitfields
+* For each contiguous block of bitfields, Bindgen emits an opaque physical field that contains one or more logical bitfields
 * A static constructor  ```new_bitfield_{1, 2, ...}``` with a parameter for each bitfield contained within the opaque physical field.
 
 ## Bitfield examples


### PR DESCRIPTION
Simple fix for a typo in the docs: "Far each ..." should be "For each ...".

First time opening a PR here, let me know if there is anything else that needs to be done!