### PR TITLE
Add warning section to build dependency tutorial doc

### DIFF
--- a/book/src/tutorial-1.md
+++ b/book/src/tutorial-1.md
@@ -13,3 +13,9 @@ you're unsure.
 [build-dependencies]
 bindgen = "0.53.1"
 ```
+
+> ⚠️ **Warning**
+>
+> `bindgen` needs to be added to the `[build-dependencies]` section, not the normal
+> `[dependencies]` section. If you add it as a regular dependency, you will get
+> errors like the following: `` error[E0463]: can't find crate for `bindgen` ``


### PR DESCRIPTION
Users (such as myself) that have enough experience to know to copy dependencies into the `Cargo.toml` file, but not enough to know that they should not add it under `[dependencies]`. Note that searching for the error does point you directly to [this thread](https://users.rust-lang.org/t/bindgen-basic-help/11478) which has a solution, so not like it's particularly difficult to resolve.

I chose this style of block for the warning since it looks alright and by default, neither standard Markdown nor mdbook supports admonishments (though if we really wanted, we could add a preprocessor like [mdbook-admonish](https://tommilligan.github.io/mdbook-admonish/), but that seems like overkill).

Also added the actual error message both for reference and to boost the likelihood that this will capture search traffic

Finally, there is the question of whether we want to add this at all, or if it just adds noise to the docs. I will defer to reviewers judgement, but I would argue that `bindgen` would be a very common first build-time crate that a dev will encounter when learning Rust, so this is a great opportunity to highlight the distinction and link to the Cargo docs.

Included is a screenshot of what this looks like on localhost:
<img width="1043" alt="image" src="https://user-images.githubusercontent.com/102886067/218278498-29679393-eec8-498f-84be-8fd827ef8277.png">

