### PR TITLE
Add support for enums with the wrapped static functions feature

### DIFF
--- a/bindgen-tests/tests/expectations/tests/generated/wrap_static_fns.c
+++ b/bindgen-tests/tests/expectations/tests/generated/wrap_static_fns.c
@@ -12,3 +12,5 @@ int takes_alias__extern(func f) asm("takes_alias__extern");
 int takes_alias__extern(func f) { return takes_alias(f); }
 int takes_qualified__extern(const int *const *arg) asm("takes_qualified__extern");
 int takes_qualified__extern(const int *const *arg) { return takes_qualified(arg); }
+enum foo takes_enum__extern(const enum foo f) asm("takes_enum__extern");
+enum foo takes_enum__extern(const enum foo f) { return takes_enum(f); }

--- a/bindgen-tests/tests/expectations/tests/wrap-static-fns.rs
+++ b/bindgen-tests/tests/expectations/tests/wrap-static-fns.rs
@@ -50,3 +50,9 @@ extern "C" {
         arg: *const *const ::std::os::raw::c_int,
     ) -> ::std::os::raw::c_int;
 }
+pub const foo_BAR: foo = 0;
+pub type foo = ::std::os::raw::c_uint;
+extern "C" {
+    #[link_name = "\u{1}takes_enum__extern"]
+    pub fn takes_enum(f: foo) -> foo;
+}

--- a/bindgen-tests/tests/headers/wrap-static-fns.h
+++ b/bindgen-tests/tests/headers/wrap-static-fns.h
@@ -31,3 +31,11 @@ static inline int takes_alias(func f) {
 static inline int takes_qualified(const int *const *arg) {
     return **arg;
 }
+
+enum foo {
+    BAR = 0x0,
+};
+
+static inline enum foo takes_enum(const enum foo f) {
+    return f;
+}

--- a/bindgen/codegen/serialize.rs
+++ b/bindgen/codegen/serialize.rs
@@ -311,6 +311,14 @@ impl<'a> CSerialize<'a> for Type {
                     CompKind::Union => write!(writer, "union {}", name)?,
                 };
             }
+            TypeKind::Enum(_enum_ty) => {
+                if self.is_const() {
+                    write!(writer, "const ")?;
+                }
+
+                let name = item.canonical_name(ctx);
+                write!(writer, "enum {}", name)?;
+            }
             ty => {
                 return Err(CodegenError::Serialize {
                     msg: format!("Cannot serialize type kind {:?}", ty),


### PR DESCRIPTION
This PR adds support for enums with the wrapped static functions feature.

I ran the experimental feature on a fairly large C project and got a crash with "Cannot serialize type kind enum"... so I fixed it and test it. Works as expected.