### PR TITLE
Also de-duplicate functions with wrapped static functions feature

### DIFF
--- a/bindgen-tests/tests/headers/wrap-static-fns.h
+++ b/bindgen-tests/tests/headers/wrap-static-fns.h
@@ -3,6 +3,7 @@
 static inline int foo() {
     return 11;
 }
+static int bar();
 static int bar() {
     return 1;
 }

--- a/bindgen/codegen/mod.rs
+++ b/bindgen/codegen/mod.rs
@@ -4029,14 +4029,10 @@ impl CodeGenerator for Function {
 
         let is_internal = matches!(self.linkage(), Linkage::Internal);
 
-        if is_internal {
-            if ctx.options().wrap_static_fns {
-                result.items_to_serialize.push(item.id());
-            } else {
-                // We can't do anything with Internal functions if we are not wrapping them so just
-                // avoid generating anything for them.
-                return None;
-            }
+        if is_internal && !ctx.options().wrap_static_fns {
+            // We can't do anything with Internal functions if we are not wrapping them so just
+            // avoid generating anything for them.
+            return None;
         }
 
         // Pure virtual methods have no actual symbol, so we can't generate
@@ -4138,6 +4134,10 @@ impl CodeGenerator for Function {
             }
             abi => abi,
         };
+
+        if is_internal && ctx.options().wrap_static_fns {
+            result.items_to_serialize.push(item.id());
+        }
 
         // Handle overloaded functions by giving each overload its own unique
         // suffix.


### PR DESCRIPTION
This PR moves the logic for adding an item to be serialized after all the conditions which defines if a Rust extern function will be created are done. This is to make sure that functions are de-duplicated but also that we don't generate C wrapped that won't be used at all.