### PR TITLE
Add winget install bindgen setup docs

### DIFF
--- a/book/src/requirements.md
+++ b/book/src/requirements.md
@@ -13,12 +13,12 @@ It is required to use Clang 5.0 or greater.
 
 #### Windows
 
-Recent versions of Windows 10 or Windows 11:
-```
+If you use winget:
+```powershell
 winget install LLVM.LLVM
 ```
 
-Download and install the official pre-built binary from
+Alternatively, you can download and install the official pre-built binary from
 [LLVM download page](http://releases.llvm.org/download.html).
 
 You will also need to set `LIBCLANG_PATH` as an [environment

--- a/book/src/requirements.md
+++ b/book/src/requirements.md
@@ -13,6 +13,11 @@ It is required to use Clang 5.0 or greater.
 
 #### Windows
 
+Recent versions of Windows 10 or Windows 11:
+```
+winget install LLVM.LLVM
+```
+
 Download and install the official pre-built binary from
 [LLVM download page](http://releases.llvm.org/download.html).
 


### PR DESCRIPTION
Recent versions of Windows 10 and Windows 11 ship with the winget CLI tool, which can be used to install LLVM in a way similar to Linux. This PR adds this option to the requirements docs.