### PR TITLE
Update `tempfile` dependency to avoid vulnerability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -651,16 +651,15 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.3.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
+checksum = "af18f7ae1acd354b992402e9ec5864359d693cd8a79dcbef59f76891701c1e95"
 dependencies = [
  "cfg-if",
  "fastrand",
- "libc",
  "redox_syscall",
- "remove_dir_all",
- "winapi",
+ "rustix",
+ "windows-sys",
 ]
 
 [[package]]


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust-bindgen/security/dependabot/3