### PR TITLE
Make harder to forget to update `Builder::command_line_flags`

### DIFF
--- a/bindgen/lib.rs
+++ b/bindgen/lib.rs
@@ -323,7 +323,11 @@ impl Builder {
             input_headers,
             // These cannot be added from the CLI.
             input_header_contents: _,
+            #[cfg(feature = "cli")]
             parse_callbacks,
+            // ParseCallbacks cannot represent CLI flags if the `"cli"` feature is disabled.
+            #[cfg(not(feature = "cli"))]
+            parse_callbacks: _,
             codegen_config,
             conservative_inline_namespaces,
             generate_comments,

--- a/bindgen/lib.rs
+++ b/bindgen/lib.rs
@@ -327,7 +327,7 @@ impl Builder {
             parse_callbacks,
             // ParseCallbacks cannot represent CLI flags if the `"cli"` feature is disabled.
             #[cfg(not(feature = "cli"))]
-            parse_callbacks: _,
+                parse_callbacks: _,
             codegen_config,
             conservative_inline_namespaces,
             generate_comments,


### PR DESCRIPTION
This PR destructures `BindgenOptions` inside `Builder::command_line_flags` so it is harder for contributors to forget emitting the CLI flags when adding new options and hopefully save some headaches due to the roundtrip tests failing.