### PR TITLE
Rename `cli` feature to `__cli`

### DIFF
--- a/bindgen-cli/Cargo.toml
+++ b/bindgen-cli/Cargo.toml
@@ -21,7 +21,7 @@ path = "main.rs"
 name = "bindgen"
 
 [dependencies]
-bindgen = { path = "../bindgen", version = "=0.64.0", features = ["cli", "experimental"] }
+bindgen = { path = "../bindgen", version = "=0.64.0", features = ["__cli", "experimental"] }
 shlex = "1"
 clap = { version = "4", features = ["derive"] }
 env_logger = { version = "0.10.0", optional = true }

--- a/bindgen-tests/Cargo.toml
+++ b/bindgen-tests/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 publish = false
 
 [dev-dependencies]
-bindgen = { path = "../bindgen", features = ["cli", "experimental"] }
+bindgen = { path = "../bindgen", features = ["__cli", "experimental"] }
 diff = "0.1"
 shlex = "1"
 clap = { version = "4", features = ["derive"] }

--- a/bindgen/Cargo.toml
+++ b/bindgen/Cargo.toml
@@ -48,7 +48,7 @@ static = ["clang-sys/static"]
 runtime = ["clang-sys/runtime"]
 # Dynamically discover a `rustfmt` binary using the `which` crate
 which-rustfmt = ["which"]
-cli = []
+__cli = []
 experimental = []
 
 # These features only exist for CI testing -- don't use them if you're not hacking

--- a/bindgen/callbacks.rs
+++ b/bindgen/callbacks.rs
@@ -25,7 +25,7 @@ impl Default for MacroParsingBehavior {
 /// A trait to allow configuring different kinds of types in different
 /// situations.
 pub trait ParseCallbacks: fmt::Debug {
-    #[cfg(feature = "cli")]
+    #[cfg(feature = "__cli")]
     #[doc(hidden)]
     fn cli_args(&self) -> Vec<String> {
         vec![]

--- a/bindgen/lib.rs
+++ b/bindgen/lib.rs
@@ -357,10 +357,10 @@ impl Builder {
             input_headers,
             // These cannot be added from the CLI.
             input_header_contents: _,
-            #[cfg(feature = "cli")]
+            #[cfg(feature = "__cli")]
             parse_callbacks,
-            // ParseCallbacks cannot represent CLI flags if the `"cli"` feature is disabled.
-            #[cfg(not(feature = "cli"))]
+            // ParseCallbacks cannot represent CLI flags if the `"__cli"` feature is disabled.
+            #[cfg(not(feature = "__cli"))]
                 parse_callbacks: _,
             codegen_config,
             conservative_inline_namespaces,
@@ -794,7 +794,7 @@ impl Builder {
             output_vector.push("--wrap-unsafe-ops".into());
         }
 
-        #[cfg(feature = "cli")]
+        #[cfg(feature = "__cli")]
         for callbacks in parse_callbacks {
             output_vector.extend(callbacks.cli_args());
         }


### PR DESCRIPTION
This is done to prevent users from thinking this should be an user-facing feature