### PR TITLE
bindgen: enable prettyplease for library users

### DIFF
--- a/bindgen/Cargo.toml
+++ b/bindgen/Cargo.toml
@@ -46,6 +46,7 @@ default = ["logging", "runtime", "which-rustfmt"]
 logging = ["log"]
 static = ["clang-sys/static"]
 runtime = ["clang-sys/runtime"]
+prettyplease = ["dep:prettyplease"]
 # Dynamically discover a `rustfmt` binary using the `which` crate
 which-rustfmt = ["which"]
 __cli = []


### PR DESCRIPTION
`bindgen-cli` users can optionally enable `prettyplease` as their code formatter. Expose the same feature for library users.