### PR TITLE
Generate `CStr`s instead of byte arrays.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -166,7 +166,13 @@
 
 ## Added
 
+* Added the `--generate-cstr` CLI flag to generate string constants as `&CStr`
+  instead of `&[u8]`. (Requires Rust 1.59 or higher.)
+
 ## Changed
+
+* Non-UTF-8 string constants are now generated as references (`&[u8; SIZE]`)
+  instead of arrays (`[u8; SIZE]`) to match UTF-8 strings.
 * Wrappers for static functions that return `void` no longer contain a `return`
   statement and only call the static function instead.
    
@@ -252,7 +258,7 @@
  * The return type is now ommited in signatures of functions returning `void`.
  * Updated the `clap` dependency for `bindgen-cli` to 4.
  * Rewrote the `bindgen-cli` argument parser which could introduce unexpected
-   behavior changes. 
+   behavior changes.
  * The `ParseCallbacks::add_derives` method now receives `DeriveInfo<'_>` as
    argument instead of a `&str`. This type also includes the kind of target type.
 

--- a/bindgen-cli/options.rs
+++ b/bindgen-cli/options.rs
@@ -156,6 +156,9 @@ struct BindgenCommand {
     /// Generate block signatures instead of void pointers.
     #[arg(long)]
     generate_block: bool,
+    /// Generate string constants as `&CStr` instead of `&[u8]`.
+    #[arg(long)]
+    generate_cstr: bool,
     /// Use extern crate instead of use for block.
     #[arg(long)]
     block_extern_crate: bool,
@@ -430,6 +433,7 @@ where
         no_recursive_allowlist,
         objc_extern_crate,
         generate_block,
+        generate_cstr,
         block_extern_crate,
         distrust_clang_mangling,
         builtins,
@@ -753,6 +757,10 @@ where
 
     if generate_block {
         builder = builder.generate_block(true);
+    }
+
+    if generate_cstr {
+        builder = builder.generate_cstr(true);
     }
 
     if block_extern_crate {

--- a/bindgen-tests/tests/expectations/tests/libclang-5/constant-evaluate.rs
+++ b/bindgen-tests/tests/expectations/tests/libclang-5/constant-evaluate.rs
@@ -21,5 +21,5 @@ pub const BAZ: ::std::os::raw::c_longlong = 24;
 pub const fuzz: f64 = 51.0;
 pub const BAZZ: ::std::os::raw::c_char = 53;
 pub const WAT: ::std::os::raw::c_char = 0;
-pub const bytestring: &[u8; 4usize] = b"Foo\0";
-pub const NOT_UTF8: [u8; 5usize] = [240u8, 40u8, 140u8, 40u8, 0u8];
+pub const bytestring: &[u8; 4] = b"Foo\0";
+pub const NOT_UTF8: &[u8; 5] = b"\xF0(\x8C(\0";

--- a/bindgen-tests/tests/expectations/tests/libclang-9/constant-evaluate.rs
+++ b/bindgen-tests/tests/expectations/tests/libclang-9/constant-evaluate.rs
@@ -21,5 +21,5 @@ pub const BAZ: ::std::os::raw::c_longlong = 24;
 pub const fuzz: f64 = 51.0;
 pub const BAZZ: ::std::os::raw::c_char = 53;
 pub const WAT: ::std::os::raw::c_char = 0;
-pub const bytestring: &[u8; 4usize] = b"Foo\0";
-pub const NOT_UTF8: [u8; 5usize] = [240u8, 40u8, 140u8, 40u8, 0u8];
+pub const bytestring: &[u8; 4] = b"Foo\0";
+pub const NOT_UTF8: &[u8; 5] = b"\xF0(\x8C(\0";

--- a/bindgen-tests/tests/expectations/tests/macro_const.rs
+++ b/bindgen-tests/tests/expectations/tests/macro_const.rs
@@ -5,10 +5,10 @@
     non_upper_case_globals
 )]
 
-pub const foo: &[u8; 4usize] = b"bar\0";
+pub const foo: &[u8; 4] = b"bar\0";
 pub const CHAR: u8 = 98u8;
 pub const CHARR: u8 = 0u8;
 pub const FLOAT: f64 = 5.09;
 pub const FLOAT_EXPR: f64 = 0.005;
 pub const LONG: u32 = 3;
-pub const INVALID_UTF8: [u8; 5usize] = [240u8, 40u8, 140u8, 40u8, 0u8];
+pub const INVALID_UTF8: &[u8; 5] = b"\xF0(\x8C(\0";

--- a/bindgen-tests/tests/expectations/tests/macro_const_1_0.rs
+++ b/bindgen-tests/tests/expectations/tests/macro_const_1_0.rs
@@ -5,10 +5,10 @@
     non_upper_case_globals
 )]
 
-pub const foo: &'static [u8; 4usize] = b"bar\0";
+pub const foo: &'static [u8; 4] = b"bar\0";
 pub const CHAR: u8 = 98u8;
 pub const CHARR: u8 = 0u8;
 pub const FLOAT: f64 = 5.09;
 pub const FLOAT_EXPR: f64 = 0.005;
 pub const LONG: u32 = 3;
-pub const INVALID_UTF8: [u8; 5usize] = [240u8, 40u8, 140u8, 40u8, 0u8];
+pub const INVALID_UTF8: &'static [u8; 5] = b"\xF0(\x8C(\0";

--- a/bindgen-tests/tests/expectations/tests/strings_array.rs
+++ b/bindgen-tests/tests/expectations/tests/strings_array.rs
@@ -1,0 +1,10 @@
+#![allow(
+    dead_code,
+    non_snake_case,
+    non_camel_case_types,
+    non_upper_case_globals
+)]
+
+pub const MY_STRING_UTF8: &'static [u8; 14] = b"Hello, world!\0";
+pub const MY_STRING_INTERIOR_NULL: &'static [u8; 7] = b"Hello,\0";
+pub const MY_STRING_NON_UTF8: &'static [u8; 7] = b"ABCDE\xFF\0";

--- a/bindgen-tests/tests/expectations/tests/strings_cstr.rs
+++ b/bindgen-tests/tests/expectations/tests/strings_cstr.rs
@@ -1,0 +1,17 @@
+#![allow(
+    dead_code,
+    non_snake_case,
+    non_camel_case_types,
+    non_upper_case_globals
+)]
+
+#[allow(unsafe_code)]
+pub const MY_STRING_UTF8: &::std::ffi::CStr = unsafe {
+    ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"Hello, world!\0")
+};
+#[allow(unsafe_code)]
+pub const MY_STRING_INTERIOR_NULL: &::std::ffi::CStr =
+    unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"Hello,\0") };
+#[allow(unsafe_code)]
+pub const MY_STRING_NON_UTF8: &::std::ffi::CStr =
+    unsafe { ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"ABCDE\xFF\0") };

--- a/bindgen-tests/tests/headers/strings_array.h
+++ b/bindgen-tests/tests/headers/strings_array.h
@@ -1,0 +1,5 @@
+// bindgen-flags: --rust-target=1.0
+
+const char* MY_STRING_UTF8 = "Hello, world!";
+const char* MY_STRING_INTERIOR_NULL = "Hello,\0World!";
+const char* MY_STRING_NON_UTF8 = "ABCDE\xFF";

--- a/bindgen-tests/tests/headers/strings_cstr.h
+++ b/bindgen-tests/tests/headers/strings_cstr.h
@@ -1,0 +1,5 @@
+// bindgen-flags: --rust-target=1.59 --generate-cstr
+
+const char* MY_STRING_UTF8 = "Hello, world!";
+const char* MY_STRING_INTERIOR_NULL = "Hello,\0World!";
+const char* MY_STRING_NON_UTF8 = "ABCDE\xFF";

--- a/bindgen/codegen/helpers.rs
+++ b/bindgen/codegen/helpers.rs
@@ -249,12 +249,6 @@ pub(crate) mod ast_ty {
         quote!(#val)
     }
 
-    pub(crate) fn byte_array_expr(bytes: &[u8]) -> TokenStream {
-        let mut bytes: Vec<_> = bytes.to_vec();
-        bytes.push(0);
-        quote! { [ #(#bytes),* ] }
-    }
-
     pub(crate) fn cstr_expr(mut string: String) -> TokenStream {
         string.push('\0');
         let b = proc_macro2::Literal::byte_string(string.as_bytes());

--- a/bindgen/features.rs
+++ b/bindgen/features.rs
@@ -128,6 +128,9 @@ macro_rules! rust_target_base {
             /// Rust stable 1.47
             /// * `larger_arrays` ([Tracking issue](https://github.com/rust-lang/rust/pull/74060))
             => Stable_1_47 => 1.47;
+            /// Rust stable 1.59
+            /// * `CStr::from_bytes_with_nul_unchecked` in `const` contexts ([PR](https://github.com/rust-lang/rust/pull/54745))
+            => Stable_1_59 => 1.59;
             /// Rust stable 1.64
             ///  * `core_ffi_c` ([Tracking issue](https://github.com/rust-lang/rust/issues/94501))
             => Stable_1_64 => 1.64;
@@ -240,6 +243,9 @@ rust_feature_def!(
     }
     Stable_1_47 {
         => larger_arrays;
+    }
+    Stable_1_59 {
+        => const_cstr;
     }
     Stable_1_64 {
         => core_ffi_c;

--- a/bindgen/options/mod.rs
+++ b/bindgen/options/mod.rs
@@ -1416,6 +1416,23 @@ options! {
         },
         as_args: "--generate-block",
     },
+    /// Whether to generate strings as `CStr`.
+    generate_cstr: bool {
+        methods: {
+            /// Set whether string constants should be generated as `&CStr` instead of `&[u8]`.
+            ///
+            /// A minimum Rust target of 1.59 is required for this to have any effect as support
+            /// for `CStr::from_bytes_with_nul_unchecked` in `const` contexts is needed.
+            ///
+            /// This option is disabled by default but will become enabled by default in a future
+            /// release, so enabling this is recommended.
+            pub fn generate_cstr(mut self, doit: bool) -> Self {
+                self.options.generate_cstr = doit;
+                self
+            }
+        },
+        as_args: "--generate-cstr",
+    },
     /// Whether to emit `#[macro_use] extern crate block;` instead of `use block;` in the prologue
     /// of the files generated from apple block files.
     block_extern_crate: bool {


### PR DESCRIPTION
~~The `bindgen` MSRV is 1.60.0, `CStr::from_bytes_with_nul` is `const`-stable since 1.59.0.~~

I see that the MSRV is only for compiling `bindgen`, so I added a new target for Rust 1.59 instead of always generating `CStr`s.

There is also a discussion regarding this in https://github.com/rust-lang/rust-bindgen/pull/2369#discussion_r1135967775.
