### PR TITLE
Fix `unused_code` warnings without `experimental`

### DIFF
--- a/bindgen/codegen/mod.rs
+++ b/bindgen/codegen/mod.rs
@@ -4338,9 +4338,9 @@ impl CodeGenerator for Function {
 
 fn unsupported_abi_diagnostic<const VARIADIC: bool>(
     fn_name: &str,
-    location: Option<&crate::clang::SourceLocation>,
+    _location: Option<&crate::clang::SourceLocation>,
     abi: &str,
-    ctx: &BindgenContext,
+    _ctx: &BindgenContext,
 ) {
     warn!(
         "Skipping {}function `{}` with the {} ABI that isn't supported by the configured Rust target",
@@ -4350,7 +4350,7 @@ fn unsupported_abi_diagnostic<const VARIADIC: bool>(
     );
 
     #[cfg(feature = "experimental")]
-    if ctx.options().emit_diagnostics {
+    if _ctx.options().emit_diagnostics {
         use crate::diagnostics::{get_line, Diagnostic, Level, Slice};
 
         let mut diag = Diagnostic::default();
@@ -4361,9 +4361,9 @@ fn unsupported_abi_diagnostic<const VARIADIC: bool>(
                 if VARIADIC { "variadic " } else { "" },
                 abi), Level::Warn)
             .add_annotation("No code will be generated for this function.", Level::Warn)
-            .add_annotation(format!("The configured Rust version is {}.", String::from(ctx.options().rust_target)), Level::Note);
+            .add_annotation(format!("The configured Rust version is {}.", String::from(_ctx.options().rust_target)), Level::Note);
 
-        if let Some(loc) = location {
+        if let Some(loc) = _location {
             let (file, line, col, _) = loc.location();
 
             if let Some(filename) = file.name() {

--- a/bindgen/ir/context.rs
+++ b/bindgen/ir/context.rs
@@ -2960,11 +2960,11 @@ impl TemplateParameters for PartialType {
     }
 }
 
-fn unused_regex_diagnostic(item: &str, name: &str, ctx: &BindgenContext) {
+fn unused_regex_diagnostic(item: &str, name: &str, _ctx: &BindgenContext) {
     warn!("unused option: {} {}", name, item);
 
     #[cfg(feature = "experimental")]
-    if ctx.options().emit_diagnostics {
+    if _ctx.options().emit_diagnostics {
         use crate::diagnostics::{Diagnostic, Level};
 
         Diagnostic::default()

--- a/bindgen/ir/var.rs
+++ b/bindgen/ir/var.rs
@@ -443,8 +443,8 @@ fn get_integer_literal_from_cursor(cursor: &clang::Cursor) -> Option<i64> {
 
 fn duplicated_macro_diagnostic(
     macro_name: &str,
-    location: crate::clang::SourceLocation,
-    ctx: &BindgenContext,
+    _location: crate::clang::SourceLocation,
+    _ctx: &BindgenContext,
 ) {
     warn!("Duplicated macro definition: {}", macro_name);
 
@@ -462,14 +462,14 @@ fn duplicated_macro_diagnostic(
     //
     // Will trigger this message even though there's nothing wrong with it.
     #[allow(clippy::overly_complex_bool_expr)]
-    if false && ctx.options().emit_diagnostics {
+    if false && _ctx.options().emit_diagnostics {
         use crate::diagnostics::{get_line, Diagnostic, Level, Slice};
         use std::borrow::Cow;
 
         let mut slice = Slice::default();
         let mut source = Cow::from(macro_name);
 
-        let (file, line, col, _) = location.location();
+        let (file, line, col, _) = _location.location();
         if let Some(filename) = file.name() {
             if let Ok(Some(code)) = get_line(&filename, line) {
                 source = code.into();

--- a/bindgen/lib.rs
+++ b/bindgen/lib.rs
@@ -407,7 +407,6 @@ impl Builder {
 impl BindgenOptions {
     fn build(&mut self) {
         const REGEX_SETS_LEN: usize = 27;
-        let sets_len = REGEX_SETS_LEN + self.abi_overrides.len();
 
         let regex_sets: [_; REGEX_SETS_LEN] = [
             &mut self.allowlisted_vars,
@@ -442,8 +441,9 @@ impl BindgenOptions {
         let record_matches = self.record_matches;
         #[cfg(feature = "experimental")]
         {
+            let sets_len = REGEX_SETS_LEN + self.abi_overrides.len();
             let names = if self.emit_diagnostics {
-                <[&str; 27]>::into_iter([
+                <[&str; REGEX_SETS_LEN]>::into_iter([
                     "--blocklist-type",
                     "--blocklist-function",
                     "--blocklist-item",
@@ -544,12 +544,12 @@ impl BindgenOptions {
     }
 }
 
-fn deprecated_target_diagnostic(target: RustTarget, options: &BindgenOptions) {
+fn deprecated_target_diagnostic(target: RustTarget, _options: &BindgenOptions) {
     let target = String::from(target);
     warn!("The {} Rust target is deprecated. If you have a good reason to use this target please report it at https://github.com/rust-lang/rust-bindgen/issues", target,);
 
     #[cfg(feature = "experimental")]
-    if options.emit_diagnostics {
+    if _options.emit_diagnostics {
         use crate::diagnostics::{Diagnostic, Level};
 
         let mut diagnostic = Diagnostic::default();
@@ -1013,11 +1013,11 @@ impl Bindings {
     }
 }
 
-fn rustfmt_non_fatal_error_diagnostic(msg: &str, options: &BindgenOptions) {
+fn rustfmt_non_fatal_error_diagnostic(msg: &str, _options: &BindgenOptions) {
     warn!("{}", msg);
 
     #[cfg(feature = "experimental")]
-    if options.emit_diagnostics {
+    if _options.emit_diagnostics {
         use crate::diagnostics::{Diagnostic, Level};
 
         Diagnostic::default()

--- a/bindgen/options/mod.rs
+++ b/bindgen/options/mod.rs
@@ -21,7 +21,9 @@ use crate::HashMap;
 use crate::DEFAULT_ANON_FIELDS_PREFIX;
 
 use std::env;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
+#[cfg(feature = "experimenal")]
+use std::path::Path;
 use std::rc::Rc;
 
 use as_args::AsArgs;
@@ -1195,10 +1197,10 @@ options! {
                 self
             }
         },
-        as_args: |parse_callbacks, args| {
+        as_args: |_callbacks, _args| {
             #[cfg(feature = "__cli")]
-            for callbacks in parse_callbacks {
-                args.extend(callbacks.cli_args());
+            for cb in _callbacks {
+                _args.extend(cb.cli_args());
             }
         },
     },

--- a/bindgen/options/mod.rs
+++ b/bindgen/options/mod.rs
@@ -21,9 +21,9 @@ use crate::HashMap;
 use crate::DEFAULT_ANON_FIELDS_PREFIX;
 
 use std::env;
-use std::path::PathBuf;
-#[cfg(feature = "experimenal")]
+#[cfg(feature = "experimental")]
 use std::path::Path;
+use std::path::PathBuf;
 use std::rc::Rc;
 
 use as_args::AsArgs;

--- a/bindgen/regex_set.rs
+++ b/bindgen/regex_set.rs
@@ -96,7 +96,7 @@ impl RegexSet {
     fn build_inner(
         &mut self,
         record_matches: bool,
-        name: Option<&'static str>,
+        _name: Option<&'static str>,
     ) {
         let items = self.items.iter().map(|item| format!("^({})$", item));
         self.record_matches = record_matches;
@@ -104,8 +104,8 @@ impl RegexSet {
             Ok(x) => Some(x),
             Err(e) => {
                 warn!("Invalid regex in {:?}: {:?}", self.items, e);
-                if let Some(name) = name {
-                    #[cfg(feature = "experimental")]
+                #[cfg(feature = "experimental")]
+                if let Some(name) = _name {
                     invalid_regex_warning(self, e, name);
                 }
                 None


### PR DESCRIPTION
This fixes the `unused_code` warnings that appear when compiling `bindgen` without the `experimental` and `__cli` features.