### PR TITLE
Add minimal workflow

### DIFF
--- a/.github/workflows/bindgen.yml
+++ b/.github/workflows/bindgen.yml
@@ -69,7 +69,7 @@ jobs:
           override: true
 
       - name: Check without default features 
-        run: cargo check -p bindgen --no-default-features 
+        run: cargo check -p bindgen --no-default-features --features=runtime 
 
   quickchecking:
     runs-on: ubuntu-latest

--- a/.github/workflows/bindgen.yml
+++ b/.github/workflows/bindgen.yml
@@ -54,6 +54,23 @@ jobs:
       - name: Build with msrv
         run: rm Cargo.lock && cargo +1.60.0 build --lib
 
+  minimal:
+    runs-on: ubuntu-latest
+    env:
+      RUSTFLAGS: -D warnings
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install stable
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+
+      - name: Check without default features 
+        run: cargo check -p bindgen --no-default-features 
+
   quickchecking:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This workflow runs `cargo check` for the `bindgen` crate without its default features and denies any warnings that occur. This would help us catch any build warnings that happen when building `bindgen` without the CLI and experimental features disabled.