### PR TITLE
Don't generate wrong strings.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -186,12 +186,15 @@
  * The documentation of the generated `type` aliases now matches the comments
    of their `typedef` counterparts instead of using the comments of the aliased
    types. 
+   
 ## Removed
  * The following deprecated flags were removed: `--use-msvc-mangling`,
    `--rustfmt-bindings` and `--size_t-is-usize`.
  * The `--no-rustfmt-bindings` flag was removed in favor of `--formatter=none`.
  * The `Bindings::emit_warnings` and `Bindings::warnings` methods were removed
    in favor of `--emit-diagnostics`.
+ * Bindgen no longer generates C string constants that cannot be represented as
+   byte slices.
 
 ## Fixed
 


### PR DESCRIPTION
A header with

```cpp
#include <stddef.h>

const char S1[] = "Hello";
const unsigned char S2[] = u8"Hello";
const char16_t S3[] = u"Hello";
const char32_t S4[] = U"Hello";
const wchar_t S5[] = L"Hello";
```

will wrongly generate (`-- -std=c++11`)


```rust
pub const S1: &[u8; 6usize] = b"Hello\0";
pub const S2: &[u8; 6usize] = b"Hello\0";
pub const S3: &[u8; 2usize] = b"H\0";
pub const S4: &[u8; 2usize] = b"H\0";
pub const S5: &[u8; 2usize] = b"H\0";
```

since `clang_EvalResult_getAsStr` only works for ordinary and UTF-8 strings. This seems like a `libclang` limitation since there isn't a similar function for other string literal types.

This disables generating code for unsupported string types.
