### PR TITLE
Make `prettyplease` non-optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -168,9 +168,7 @@
    `prettyplease` to select which tool will be used to format the bindings. The
    default value is `rustfmt`. 
  * Added the `Builder::formatter` method and the `Formatter` type to select
-   which tool will be used to format the bindings. The
-   `Formatter::Prettyplease`   variant is only available if the
-   `"prettyplease"` feature is enabled. 
+   which tool will be used to format the bindings.
  * Added the `Builder::emit_diagnostics` method and the  `--emit-diagnostics`
    flag to enable emission of diagnostic messages.
  * Added support for the `"efiapi"` calling convention.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -162,7 +162,7 @@
 # Unreleased
 
 ## Added
- * Added the `Bindgen::default_visibility` method and the
+ * Added the `Builder::default_visibility` method and the
    `--default-visibility` flag to set the default visibility of fields.
  * Added the `--formatter` CLI flag with the values `none`, `rustfmt` and
    `prettyplease` to select which tool will be used to format the bindings. The
@@ -170,7 +170,8 @@
  * Added the `Builder::formatter` method and the `Formatter` type to select
    which tool will be used to format the bindings.
  * Added the `Builder::emit_diagnostics` method and the  `--emit-diagnostics`
-   flag to enable emission of diagnostic messages.
+   flag to enable emission of diagnostic messages under the `experimental`
+   feature.
  * Added support for the `"efiapi"` calling convention.
  * Added the `ParseCallbacks::read_env_var` method which runs everytime
    `bindgen` reads and environment variable.
@@ -187,11 +188,12 @@
  * The documentation of the generated `type` aliases now matches the comments
    of their `typedef` counterparts instead of using the comments of the aliased
    types. 
+ * The `Builder::rustfmt_bindings` methods and the `--no-rustfmt-bindings` flag
+   are now deprecated in favor of the formatter API.
    
 ## Removed
  * The following deprecated flags were removed: `--use-msvc-mangling`,
    `--rustfmt-bindings` and `--size_t-is-usize`.
- * The `--no-rustfmt-bindings` flag was removed in favor of `--formatter=none`.
  * The `Bindings::emit_warnings` and `Bindings::warnings` methods were removed
    in favor of `--emit-diagnostics`.
  * Bindgen no longer generates C string constants that cannot be represented as

--- a/bindgen-cli/Cargo.toml
+++ b/bindgen-cli/Cargo.toml
@@ -28,10 +28,9 @@ env_logger = { version = "0.10.0", optional = true }
 log = { version = "0.4", optional = true }
 
 [features]
-default = ["logging", "runtime", "which-rustfmt", "prettyplease"]
+default = ["logging", "runtime", "which-rustfmt"]
 logging = ["bindgen/logging", "env_logger", "log"]
 static = ["bindgen/static"]
 runtime = ["bindgen/runtime"]
 # Dynamically discover a `rustfmt` binary using the `which` crate
 which-rustfmt = ["bindgen/which-rustfmt"]
-prettyplease = ["bindgen/prettyplease"]

--- a/bindgen-cli/options.rs
+++ b/bindgen-cli/options.rs
@@ -266,7 +266,8 @@ struct BindgenCommand {
     /// Do not bind size_t as usize (useful on platforms where those types are incompatible).
     #[arg(long = "no-size_t-is-usize")]
     no_size_t_is_usize: bool,
-    /// Do not format the generated bindings with rustfmt.
+    /// Do not format the generated bindings with rustfmt. This option is deprecated, please use
+    /// `--formatter=none` instead.
     #[arg(long)]
     no_rustfmt_bindings: bool,
     /// Which tool should be used to format the bindings
@@ -833,9 +834,8 @@ where
         builder = builder.size_t_is_usize(false);
     }
 
-    #[allow(deprecated)]
     if no_rustfmt_bindings {
-        builder = builder.rustfmt_bindings(false);
+        builder = builder.formatter(Formatter::None);
     }
 
     if let Some(formatter) = formatter {

--- a/bindgen/Cargo.toml
+++ b/bindgen/Cargo.toml
@@ -35,7 +35,7 @@ quote = { version = "1", default-features = false }
 syn = { version = "2.0", features = ["full", "extra-traits", "visit-mut"]}
 regex = { version = "1.5", default-features = false , features = ["std", "unicode"] }
 which = { version = "4.2.1", optional = true, default-features = false }
-prettyplease = { version = "0.2.0", optional = true }
+prettyplease = { version = "0.2.0" }
 annotate-snippets = { version = "0.9.1", features = ["color"], optional = true }
 shlex = "1"
 rustc-hash = "1.0.1"

--- a/bindgen/options/mod.rs
+++ b/bindgen/options/mod.rs
@@ -1574,13 +1574,13 @@ options! {
     /// The tool that should be used to format the generated bindings.
     formatter: Formatter {
         methods: {
-            #[cfg_attr(feature = "prettyplease", deprecated)]
             /// Set whether `rustfmt` should be used to format the generated bindings.
             ///
             /// `rustfmt` is used by default.
             ///
             /// This method overlaps in functionality with the more general [`Builder::formatter`].
             /// Thus, the latter should be preferred.
+            #[cfg(deprecated)]
             pub fn rustfmt_bindings(mut self, doit: bool) -> Self {
                 self.options.formatter = if doit {
                     Formatter::Rustfmt


### PR DESCRIPTION
This PR makes the `prettyplease` dependency on `bindgen` non-optional.
Meaning that the `Builder::no_rustfmt_bindings` method and its
equivalent flag are now deprecated.