### PR TITLE
 Do not return when calling void functions 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -167,6 +167,8 @@
 ## Added
 
 ## Changed
+* Wrappers for static functions that return `void` no longer contain a `return`
+  statement and only call the static function instead.
    
 ## Removed
 

--- a/bindgen-tests/tests/expectations/tests/generated/wrap_static_fns.c
+++ b/bindgen-tests/tests/expectations/tests/generated/wrap_static_fns.c
@@ -10,3 +10,4 @@ int takes_fn__extern(int (f) (int)) { return takes_fn(f); }
 int takes_alias__extern(func f) { return takes_alias(f); }
 int takes_qualified__extern(const int *const *arg) { return takes_qualified(arg); }
 enum foo takes_enum__extern(const enum foo f) { return takes_enum(f); }
+void nevermore__extern(void) { nevermore(); }

--- a/bindgen-tests/tests/expectations/tests/wrap-static-fns.rs
+++ b/bindgen-tests/tests/expectations/tests/wrap-static-fns.rs
@@ -56,3 +56,7 @@ extern "C" {
     #[link_name = "takes_enum__extern"]
     pub fn takes_enum(f: foo) -> foo;
 }
+extern "C" {
+    #[link_name = "nevermore__extern"]
+    pub fn nevermore();
+}

--- a/bindgen-tests/tests/headers/wrap-static-fns.h
+++ b/bindgen-tests/tests/headers/wrap-static-fns.h
@@ -40,3 +40,7 @@ enum foo {
 static inline enum foo takes_enum(const enum foo f) {
     return f;
 }
+
+static inline void nevermore() {
+    while (1) { }
+}

--- a/bindgen/codegen/serialize.rs
+++ b/bindgen/codegen/serialize.rs
@@ -118,7 +118,7 @@ impl<'a> CSerialize<'a> for Function {
         // Write `wrap_name(args`.
         write!(writer, " {}(", wrap_name)?;
         serialize_args(&args, ctx, writer)?;
-        
+
         // Write `) { name(` if the function returns void and `) { return name(` if it does not.
         if ret_ty.is_void() {
             write!(writer, ") {{ {}(", name)?;

--- a/bindgen/ir/ty.rs
+++ b/bindgen/ir/ty.rs
@@ -124,6 +124,10 @@ impl Type {
         matches!(self.kind, TypeKind::Enum(..))
     }
 
+    /// Is this void?
+    pub(crate) fn is_void(&self) -> bool {
+        matches!(self.kind, TypeKind::Void)
+    }
     /// Is this either a builtin or named type?
     pub(crate) fn is_builtin_or_type_param(&self) -> bool {
         matches!(


### PR DESCRIPTION
Update the code generation for the `--wrap-static-fns` feature so the wrapper for a static function that returns `void` no longer contains a `return` statement and only calls the function instead.