### PR TITLE
Do not wrap static variadic functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -169,6 +169,8 @@
 ## Changed
 * Wrappers for static functions that return `void` no longer contain a `return`
   statement and only call the static function instead.
+* The `--wrap-static-fns` option no longer emits wrappers for static variadic
+  functions.
    
 ## Removed
 

--- a/bindgen-tests/tests/headers/wrap-static-fns.h
+++ b/bindgen-tests/tests/headers/wrap-static-fns.h
@@ -44,3 +44,7 @@ static inline enum foo takes_enum(const enum foo f) {
 static inline void nevermore() {
     while (1) { }
 }
+
+static inline int variadic(int x, ...) {
+    return x;
+}

--- a/bindgen/codegen/mod.rs
+++ b/bindgen/codegen/mod.rs
@@ -4151,16 +4151,16 @@ impl CodeGenerator for Function {
         };
 
         if is_internal {
-            if ctx.options().wrap_static_fns {
-                if signature.is_variadic() {
-                    // We cannot generate wrappers for variadic static functions so we avoid
-                    // generating any code for them.
-                    variadic_fn_diagnostic(self.name(), item.location(), ctx);
-                    return None;
-                }
-            } else {
-                // We cannott do anything with internal functions if we are not wrapping them so
+            if !ctx.options().wrap_static_fns {
+                // We cannot do anything with internal functions if we are not wrapping them so
                 // just avoid generating anything for them.
+                return None;
+            }
+            
+            if signature.is_variadic() {
+                // We cannot generate wrappers for variadic static functions so we avoid
+                // generating any code for them.
+                variadic_fn_diagnostic(self.name(), item.location(), ctx);
                 return None;
             }
         }

--- a/bindgen/codegen/mod.rs
+++ b/bindgen/codegen/mod.rs
@@ -4156,7 +4156,7 @@ impl CodeGenerator for Function {
                 // just avoid generating anything for them.
                 return None;
             }
-            
+
             if signature.is_variadic() {
                 // We cannot generate wrappers for variadic static functions so we avoid
                 // generating any code for them.

--- a/bindgen/codegen/serialize.rs
+++ b/bindgen/codegen/serialize.rs
@@ -77,6 +77,8 @@ impl<'a> CSerialize<'a> for Function {
             _ => unreachable!(),
         };
 
+        assert!(!signature.is_variadic());
+
         let name = self.name();
 
         // Function argoments stored as `(name, type_id)` tuples.


### PR DESCRIPTION
Currently there is no way to generate a wrapper for a static variadic function while using the `--wrap-static-fns` feature.

These changes modify `bindgen`'s behavior so such functions are skipped instead of generating invalid code for them. At the same time, a warning is emitted if the `--emit-diagnostics` feature is enabled.

Fixes #2498 