### PR TITLE
Wrap `va_list` function as variadic function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -170,6 +170,8 @@
   instead of `&[u8]`. (Requires Rust 1.59 or higher.)
 * Added the `--generate-shell-completions` CLI flag to generate completions for
   different shells.
+* The `--wrap-static-fns` option can now wrap `va_list` functions as variadic functions
+  with the experimental `wrap_as_variadic_fn` callback.
 
 ## Changed
 

--- a/bindgen-integration/src/lib.rs
+++ b/bindgen-integration/src/lib.rs
@@ -320,5 +320,13 @@ fn test_wrap_static_fns() {
         let tq =
             extern_bindings::takes_qualified(&(&5 as *const _) as *const _);
         assert_eq!(5, tq);
+
+        let wv1 = extern_bindings::wrap_as_variadic_fn1_wrapped(0);
+        assert_eq!(0, wv1);
+
+        let wv1 = extern_bindings::wrap_as_variadic_fn1_wrapped(2, 5, 3);
+        assert_eq!(8, wv1);
+
+        extern_bindings::wrap_as_variadic_fn2_wrapped(1, 2);
     }
 }

--- a/bindgen-tests/tests/expectations/tests/generated/wrap_static_fns.c
+++ b/bindgen-tests/tests/expectations/tests/generated/wrap_static_fns.c
@@ -11,3 +11,21 @@ int takes_alias__extern(func f) { return takes_alias(f); }
 int takes_qualified__extern(const int *const *arg) { return takes_qualified(arg); }
 enum foo takes_enum__extern(const enum foo f) { return takes_enum(f); }
 void nevermore__extern(void) { nevermore(); }
+void no_extra_argument__extern(__builtin_va_list va) { no_extra_argument(va); }
+int many_va_list__extern(int i, __builtin_va_list va1, __builtin_va_list va2) { return many_va_list(i, va1, va2); }
+int wrap_as_variadic_fn1__extern(int i, ...) {
+    int ret;
+    va_list ap;
+
+    va_start(ap, i);
+    ret = wrap_as_variadic_fn1(i, ap);
+    va_end(ap);
+    return ret;
+}
+void wrap_as_variadic_fn2__extern(int i, ...) {
+    va_list ap;
+
+    va_start(ap, i);
+    wrap_as_variadic_fn2(i, ap);
+    va_end(ap);
+}

--- a/bindgen-tests/tests/expectations/tests/wrap-static-fns.rs
+++ b/bindgen-tests/tests/expectations/tests/wrap-static-fns.rs
@@ -50,3 +50,36 @@ extern "C" {
     #[link_name = "nevermore__extern"]
     pub fn nevermore();
 }
+extern "C" {
+    #[link_name = "no_extra_argument__extern"]
+    pub fn no_extra_argument(va: *mut __va_list_tag);
+}
+extern "C" {
+    #[link_name = "many_va_list__extern"]
+    pub fn many_va_list(
+        i: ::std::os::raw::c_int,
+        va1: *mut __va_list_tag,
+        va2: *mut __va_list_tag,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    #[link_name = "wrap_as_variadic_fn1__extern"]
+    pub fn wrap_as_variadic_fn1_wrapped(
+        i: ::std::os::raw::c_int,
+        ...
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    #[link_name = "wrap_as_variadic_fn2__extern"]
+    pub fn wrap_as_variadic_fn2_wrapped(i: ::std::os::raw::c_int, ...);
+}
+pub type __builtin_va_list = [__va_list_tag; 1usize];
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct __va_list_tag {
+    pub gp_offset: ::std::os::raw::c_uint,
+    pub fp_offset: ::std::os::raw::c_uint,
+    pub overflow_arg_area: *mut ::std::os::raw::c_void,
+    pub reg_save_area: *mut ::std::os::raw::c_void,
+    _unused: [u8; 0],
+}

--- a/bindgen-tests/tests/headers/wrap-static-fns.h
+++ b/bindgen-tests/tests/headers/wrap-static-fns.h
@@ -1,4 +1,5 @@
 // bindgen-flags: --experimental --wrap-static-fns
+// bindgen-parse-callbacks: wrap-as-variadic-fn
 
 static inline int foo() {
     return 11;
@@ -48,3 +49,15 @@ static inline void nevermore() {
 static inline int variadic(int x, ...) {
     return x;
 }
+
+static inline void no_extra_argument(__builtin_va_list va) {}
+
+static inline int many_va_list(int i, __builtin_va_list va1, __builtin_va_list va2) {
+    return i;
+}
+
+static inline int wrap_as_variadic_fn1(int i, __builtin_va_list va) {
+    return i;
+}
+
+static inline void wrap_as_variadic_fn2(int i, __builtin_va_list va) {}

--- a/bindgen-tests/tests/headers/wrap-static-fns.h
+++ b/bindgen-tests/tests/headers/wrap-static-fns.h
@@ -1,6 +1,12 @@
 // bindgen-flags: --experimental --wrap-static-fns
 // bindgen-parse-callbacks: wrap-as-variadic-fn
 
+// to avoid poluting theexpectation tests we put the stdarg.h behind a conditional
+// variable only used in bindgen-integration
+#ifdef USE_VA_HEADER
+#include <stdarg.h>
+#endif
+
 static inline int foo() {
     return 11;
 }
@@ -56,8 +62,21 @@ static inline int many_va_list(int i, __builtin_va_list va1, __builtin_va_list v
     return i;
 }
 
+#ifndef USE_VA_HEADER
 static inline int wrap_as_variadic_fn1(int i, __builtin_va_list va) {
     return i;
 }
 
 static inline void wrap_as_variadic_fn2(int i, __builtin_va_list va) {}
+#else
+static inline int wrap_as_variadic_fn1(int i, va_list va) {
+    int res = 0;
+
+    for (int j = 0; j < i; j++)
+        res += (int) va_arg(va, int);
+
+    return res;
+}
+
+static inline void wrap_as_variadic_fn2(int i, va_list va) {}
+#endif

--- a/bindgen-tests/tests/parse_callbacks/mod.rs
+++ b/bindgen-tests/tests/parse_callbacks/mod.rs
@@ -113,6 +113,15 @@ impl ParseCallbacks for FieldVisibility {
     }
 }
 
+#[derive(Debug)]
+pub(super) struct WrapAsVariadicFn;
+
+impl ParseCallbacks for WrapAsVariadicFn {
+    fn wrap_as_variadic_fn(&self, name: &str) -> Option<String> {
+        Some(name.to_owned() + "_wrapped")
+    }
+}
+
 pub fn lookup(cb: &str) -> Box<dyn ParseCallbacks> {
     fn try_strip_prefix<'a>(s: &'a str, prefix: &str) -> Option<&'a str> {
         if s.starts_with(prefix) {
@@ -127,6 +136,7 @@ pub fn lookup(cb: &str) -> Box<dyn ParseCallbacks> {
         "blocklisted-type-implements-trait" => {
             Box::new(BlocklistedTypeImplementsTrait)
         }
+        "wrap-as-variadic-fn" => Box::new(WrapAsVariadicFn),
         call_back => {
             if let Some(prefix) =
                 try_strip_prefix(call_back, "remove-function-prefix-")

--- a/bindgen-tests/tests/tests.rs
+++ b/bindgen-tests/tests/tests.rs
@@ -618,6 +618,7 @@ fn test_wrap_static_fns() {
         .header("tests/headers/wrap-static-fns.h")
         .wrap_static_fns(true)
         .wrap_static_fns_path(generated_path.display().to_string())
+        .parse_callbacks(Box::new(parse_callbacks::WrapAsVariadicFn))
         .generate()
         .expect("Failed to generate bindings");
 

--- a/bindgen/callbacks.rs
+++ b/bindgen/callbacks.rs
@@ -146,6 +146,16 @@ pub trait ParseCallbacks: fmt::Debug {
     ) -> Option<crate::FieldVisibilityKind> {
         None
     }
+
+    /// Process a function name that as exactly one `va_list` argument
+    /// to be wrapped as a variadic function with the wrapped static function
+    /// feature.
+    ///
+    /// The returned string is new function name.
+    #[cfg(feature = "experimental")]
+    fn wrap_as_variadic_fn(&self, _name: &str) -> Option<String> {
+        None
+    }
 }
 
 /// Relevant information about a type to which new derive attributes will be added using

--- a/bindgen/codegen/mod.rs
+++ b/bindgen/codegen/mod.rs
@@ -221,6 +221,11 @@ impl From<DerivableTraits> for Vec<&'static str> {
     }
 }
 
+struct WrapAsVariadic {
+    new_name: String,
+    idx_of_va_list_arg: usize,
+}
+
 struct CodegenResult<'a> {
     items: Vec<proc_macro2::TokenStream>,
     dynamic_items: DynamicItems,
@@ -269,7 +274,9 @@ struct CodegenResult<'a> {
     /// that name. This lets us give each overload a unique suffix.
     overload_counters: HashMap<String, u32>,
 
-    items_to_serialize: Vec<ItemId>,
+    /// List of items to serialize. With optionally the argument for the wrap as
+    /// variadic transformation to be applied.
+    items_to_serialize: Vec<(ItemId, Option<WrapAsVariadic>)>,
 }
 
 impl<'a> CodegenResult<'a> {
@@ -4246,9 +4253,6 @@ impl CodeGenerator for Function {
             result.saw_function(seen_symbol_name);
         }
 
-        let args = utils::fnsig_arguments(ctx, signature);
-        let ret = utils::fnsig_return_ty(ctx, signature);
-
         let mut attributes = vec![];
 
         if ctx.options().rust_features().must_use_function {
@@ -4333,10 +4337,6 @@ impl CodeGenerator for Function {
             abi => abi,
         };
 
-        if is_internal && ctx.options().wrap_static_fns {
-            result.items_to_serialize.push(item.id());
-        }
-
         // Handle overloaded functions by giving each overload its own unique
         // suffix.
         let times_seen = result.overload_number(&canonical_name);
@@ -4370,12 +4370,49 @@ impl CodeGenerator for Function {
                 quote! { #[link(wasm_import_module = #name)] }
             });
 
-        if is_internal && ctx.options().wrap_static_fns && !has_link_name_attr {
+        let should_wrap =
+            is_internal && ctx.options().wrap_static_fns && !has_link_name_attr;
+
+        if should_wrap {
             let name = canonical_name.clone() + ctx.wrap_static_fns_suffix();
             attributes.push(attributes::link_name::<true>(&name));
         }
 
-        let ident = ctx.rust_ident(canonical_name);
+        let wrap_as_variadic = if should_wrap && !signature.is_variadic() {
+            utils::wrap_as_variadic_fn(ctx, signature, name)
+        } else {
+            None
+        };
+
+        let (ident, args) = if let Some(WrapAsVariadic {
+            idx_of_va_list_arg,
+            new_name,
+        }) = &wrap_as_variadic
+        {
+            (
+                new_name,
+                utils::fnsig_arguments_iter(
+                    ctx,
+                    // Prune argument at index (idx_of_va_list_arg)
+                    signature.argument_types().iter().enumerate().filter_map(
+                        |(idx, t)| {
+                            if idx == *idx_of_va_list_arg {
+                                None
+                            } else {
+                                Some(t)
+                            }
+                        },
+                    ),
+                    // and replace it by a `...` (variadic symbol and the end of the signature)
+                    true,
+                ),
+            )
+        } else {
+            (&canonical_name, utils::fnsig_arguments(ctx, signature))
+        };
+        let ret = utils::fnsig_return_ty(ctx, signature);
+
+        let ident = ctx.rust_ident(ident);
         let tokens = quote! {
             #wasm_link_attribute
             extern #abi {
@@ -4383,6 +4420,13 @@ impl CodeGenerator for Function {
                 pub fn #ident ( #( #args ),* ) #ret;
             }
         };
+
+        // Add the item to the serialization list if necessary
+        if should_wrap {
+            result
+                .items_to_serialize
+                .push((item.id(), wrap_as_variadic));
+        }
 
         // If we're doing dynamic binding generation, add to the dynamic items.
         if is_dynamic_function {
@@ -4886,14 +4930,70 @@ pub(crate) mod utils {
 
         writeln!(code, "// Static wrappers\n")?;
 
-        for &id in &result.items_to_serialize {
-            let item = context.resolve_item(id);
-            item.serialize(context, (), &mut vec![], &mut code)?;
+        for (id, wrap_as_variadic) in &result.items_to_serialize {
+            let item = context.resolve_item(*id);
+            item.serialize(context, wrap_as_variadic, &mut vec![], &mut code)?;
         }
 
         std::fs::write(source_path, code)?;
 
         Ok(())
+    }
+
+    pub(super) fn wrap_as_variadic_fn(
+        ctx: &BindgenContext,
+        signature: &FunctionSig,
+        name: &str,
+    ) -> Option<super::WrapAsVariadic> {
+        // Fast path, exclude because:
+        //  - with 0 args: no va_list possible, so no point searching for one
+        //  - with 1 args: cannot have a `va_list` and another arg (required by va_start)
+        if signature.argument_types().len() <= 1 {
+            return None;
+        }
+
+        let mut it = signature.argument_types().iter().enumerate().filter_map(
+            |(idx, (_name, mut type_id))| {
+                // Hand rolled visitor that checks for the presence of `va_list`
+                loop {
+                    let ty = ctx.resolve_type(type_id);
+                    if Some("__builtin_va_list") == ty.name() {
+                        return Some(idx);
+                    }
+                    match ty.kind() {
+                        TypeKind::Alias(type_id_alias) => {
+                            type_id = *type_id_alias
+                        }
+                        TypeKind::ResolvedTypeRef(type_id_typedef) => {
+                            type_id = *type_id_typedef
+                        }
+                        _ => break,
+                    }
+                }
+                None
+            },
+        );
+
+        // Return THE idx (by checking that there is no idx after)
+        // This is done since we cannot handle multiple `va_list`
+        it.next().filter(|_| it.next().is_none()).and_then(|idx| {
+            // Call the `wrap_as_variadic_fn` callback
+            #[cfg(feature = "experimental")]
+            {
+                ctx.options()
+                    .last_callback(|c| c.wrap_as_variadic_fn(name))
+                    .map(|new_name| super::WrapAsVariadic {
+                        new_name,
+                        idx_of_va_list_arg: idx,
+                    })
+            }
+            #[cfg(not(feature = "experimental"))]
+            {
+                let _ = name;
+                let _ = idx;
+                None
+            }
+        })
     }
 
     pub(crate) fn prepend_bitfield_unit_type(

--- a/ci/no-includes.sh
+++ b/ci/no-includes.sh
@@ -1,13 +1,17 @@
 #!/usr/bin/env bash
 
 # Don't allow any system include directives in tests.
+# 
+# We make an exception for stdarg.h which is used for
+# the wrapped va_list feature. stdarg.h is available since C89
+# therefor not having this header is a sign of a bigger issue.
 
 set -eu
 cd "$(dirname "$0")/.."
 
 echo "Checking for #include directives of system headers..."
 
-grep -rn '#include\s*<.*>' bindgen-tests/tests/headers || {
+grep -rn '#include\s*<(?!stdarg).*>' bindgen-tests/tests/headers || {
     echo "Found none; OK!"
     exit 0
 }


### PR DESCRIPTION
~~Opening a draft before doing more to get opinion on it.~~

This PR add a way to wrap `va_list` function as variadic function. See below for an example.

Input:
```c
#include <stdarg.h>

static inline int vfoo(int flags, va_list va) {
    // ...
    return flags;
}
```

Output:
```c
int vfoo__extern(int flags, ...) {
int ret;
va_list ap;

va_start(ap, flags);
ret = vfoo(flags, ap);
va_end(ap);
return ret;
}
```
```rust
extern "C" {
    #[link_name = "vfoo__extern"]
    pub fn vfoo(flags: ::std::os::raw::c_int, ...) -> ::std::os::raw::c_int;
}
```


Related to https://github.com/rust-lang/rust-bindgen/issues/2498

cc @pvdrz