### PR TITLE
Add a callback to rename field names

### DIFF
--- a/bindgen/callbacks.rs
+++ b/bindgen/callbacks.rs
@@ -136,7 +136,7 @@ pub trait ParseCallbacks: fmt::Debug {
         None
     }
 
-    /// .
+    /// Allows renaming the name of a field, replacing `_name`.
     fn process_field_name(
         &self,
         _parent_name: &str,

--- a/bindgen/callbacks.rs
+++ b/bindgen/callbacks.rs
@@ -135,6 +135,15 @@ pub trait ParseCallbacks: fmt::Debug {
     fn process_comment(&self, _comment: &str) -> Option<String> {
         None
     }
+
+    /// .
+    fn process_field_name(
+        &self,
+        _parent_name: &str,
+        _name: &str,
+    ) -> Option<String> {
+        None
+    }
 }
 
 /// Relevant information about a type to which new derive attributes will be added using

--- a/bindgen/codegen/mod.rs
+++ b/bindgen/codegen/mod.rs
@@ -1813,7 +1813,7 @@ impl<'a> FieldCodegen<'a> for Bitfield {
         _fields: &mut F,
         methods: &mut M,
         (unit_field_name, bitfield_representable_as_int): (&'a str, &mut bool),
-        parent_name: &str,
+        _parent_name: &str,
     ) where
         F: Extend<proc_macro2::TokenStream>,
         M: Extend<proc_macro2::TokenStream>,

--- a/bindgen/lib.rs
+++ b/bindgen/lib.rs
@@ -562,6 +562,16 @@ impl BindgenOptions {
             .and_then(|cb| cb.process_comment(&comment))
             .unwrap_or(comment)
     }
+
+    fn process_field_name(
+        &self,
+        parent_name: &str,
+        name: &str,
+    ) -> Option<String> {
+        self.parse_callbacks
+            .last()
+            .and_then(|cb| cb.process_field_name(parent_name, name))
+    }
 }
 
 fn deprecated_target_diagnostic(target: RustTarget, _options: &BindgenOptions) {


### PR DESCRIPTION
I've been using this callback to rename anonymous fields:
```rust  
#[derive(Debug)]
struct BindgenCallbacks {
    item_replacements: HashMap<&'static str, &'static str>,
    field_name_replacements: HashMap<(&'static str, &'static str), &'static str>,
}

impl BindgenCallbacks {
    fn new() -> Self {
        let mut item_replacements = HashMap::new();
        item_replacements.insert("ResourceDescPacked__bindgen_ty_1", "ResourceBufferImageDescPacked");
        item_replacements.insert("ResourceDescPacked__bindgen_ty_1__bindgen_ty_1", "ResourceImageDescPacked");
        item_replacements.insert("ResourceDescPacked__bindgen_ty_1__bindgen_ty_2", "ResourceBufferDescPacked");
        item_replacements.insert("ResourceDescPacked__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1", "ResourceImageDepthArrayLayersDescPacked");
    
        let mut field_name_replacements = HashMap::new();
    
        field_name_replacements.insert(("ResourceDescPacked", "__bindgen_anon_1"), "buffer_image");
        field_name_replacements.insert(("ResourceImageDescPacked", "__bindgen_anon_1"), "depth_array_layers");

        Self {
            item_replacements, field_name_replacements
        }
    }
}

impl bindgen::callbacks::ParseCallbacks for BindgenCallbacks {
    fn process_field_name(&self, parent_name: &str, name: &str) -> Option<String> {
        if let Some(&replacement) = self.field_name_replacements.get(&(parent_name, name)) {
            Some(String::from(replacement))
        } else {
            None
        }
    }
    
    ...
}
```
Source struct (from https://github.com/GPUOpen-LibrariesAndSDKs/RenderPipelineShaders):
```cpp
struct ResourceDescPacked
    {
        RpsResourceType  type : 8;            ///< An enumeration indicating the type (and dimension) of the resource.
        uint32_t         temporalLayers : 8;  ///< The number of frames of temporal data.
        RpsResourceFlags flags : 16;          ///< A collection of <c><i>RpsResourceFlagBits</i></c> values.

        union
        {
            struct
            {
                uint32_t width;   ///< The width of an image, or low 32 bit of the byte size of a buffer.
                uint32_t height;  ///< The height of an image, or high 32 bit of the byte size of a buffer.
                union
                {
                    uint32_t depth;        ///< The depth of an 3D image.
                    uint32_t arrayLayers;  ///< The number of array layers for an non-3D image.
                };
                uint32_t  mipLevels : 8;    ///< The number of mipmap levels.
                RpsFormat format : 8;       ///< A platform independent format to be interepreted by the runtime.
                uint32_t  sampleCount : 8;  ///< The number of MSAA samples of an image.
            } image;
            struct
            {
                uint32_t sizeInBytesLo;
                uint32_t sizeInBytesHi;
            } buffer;
        };
}
```
I'm not sure whether this is implemented in the best way. Very happy to make changes.