### PR TITLE
Field visibility callback

### DIFF
--- a/bindgen-tests/tests/expectations/tests/default_visibility_private_respects_cxx_access_spec.rs
+++ b/bindgen-tests/tests/expectations/tests/default_visibility_private_respects_cxx_access_spec.rs
@@ -93,7 +93,7 @@ pub struct Point {
 #[derive(Debug, Default, Copy, Clone)]
 pub struct Color {
     _bitfield_align_1: [u8; 0],
-    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
+    _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
 }
 impl Color {
     #[inline]
@@ -130,7 +130,7 @@ impl Color {
         }
     }
     #[inline]
-    pub fn new_bitfield_1(
+    fn new_bitfield_1(
         r: ::std::os::raw::c_char,
         g: ::std::os::raw::c_char,
         b: ::std::os::raw::c_char,

--- a/bindgen-tests/tests/expectations/tests/field-visibility-callback.rs
+++ b/bindgen-tests/tests/expectations/tests/field-visibility-callback.rs
@@ -1,0 +1,166 @@
+#![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
+#[repr(C)]
+#[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct __BindgenBitfieldUnit<Storage> {
+    storage: Storage,
+}
+impl<Storage> __BindgenBitfieldUnit<Storage> {
+    #[inline]
+    pub const fn new(storage: Storage) -> Self {
+        Self { storage }
+    }
+}
+impl<Storage> __BindgenBitfieldUnit<Storage>
+where
+    Storage: AsRef<[u8]> + AsMut<[u8]>,
+{
+    #[inline]
+    pub fn get_bit(&self, index: usize) -> bool {
+        debug_assert!(index / 8 < self.storage.as_ref().len());
+        let byte_index = index / 8;
+        let byte = self.storage.as_ref()[byte_index];
+        let bit_index = if cfg!(target_endian = "big") {
+            7 - (index % 8)
+        } else {
+            index % 8
+        };
+        let mask = 1 << bit_index;
+        byte & mask == mask
+    }
+    #[inline]
+    pub fn set_bit(&mut self, index: usize, val: bool) {
+        debug_assert!(index / 8 < self.storage.as_ref().len());
+        let byte_index = index / 8;
+        let byte = &mut self.storage.as_mut()[byte_index];
+        let bit_index = if cfg!(target_endian = "big") {
+            7 - (index % 8)
+        } else {
+            index % 8
+        };
+        let mask = 1 << bit_index;
+        if val {
+            *byte |= mask;
+        } else {
+            *byte &= !mask;
+        }
+    }
+    #[inline]
+    pub fn get(&self, bit_offset: usize, bit_width: u8) -> u64 {
+        debug_assert!(bit_width <= 64);
+        debug_assert!(bit_offset / 8 < self.storage.as_ref().len());
+        debug_assert!(
+            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len()
+        );
+        let mut val = 0;
+        for i in 0..(bit_width as usize) {
+            if self.get_bit(i + bit_offset) {
+                let index = if cfg!(target_endian = "big") {
+                    bit_width as usize - 1 - i
+                } else {
+                    i
+                };
+                val |= 1 << index;
+            }
+        }
+        val
+    }
+    #[inline]
+    pub fn set(&mut self, bit_offset: usize, bit_width: u8, val: u64) {
+        debug_assert!(bit_width <= 64);
+        debug_assert!(bit_offset / 8 < self.storage.as_ref().len());
+        debug_assert!(
+            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len()
+        );
+        for i in 0..(bit_width as usize) {
+            let mask = 1 << i;
+            let val_bit_is_set = val & mask == mask;
+            let index = if cfg!(target_endian = "big") {
+                bit_width as usize - 1 - i
+            } else {
+                i
+            };
+            self.set_bit(index + bit_offset, val_bit_is_set);
+        }
+    }
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct my_struct {
+    pub a: ::std::os::raw::c_int,
+    private_b: ::std::os::raw::c_int,
+    _bitfield_align_1: [u8; 0],
+    _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
+    __bindgen_padding_0: [u8; 3usize],
+}
+#[test]
+fn bindgen_test_layout_my_struct() {
+    const UNINIT: ::std::mem::MaybeUninit<my_struct> = ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
+    assert_eq!(
+        ::std::mem::size_of:: < my_struct > (), 12usize, concat!("Size of: ",
+        stringify!(my_struct))
+    );
+    assert_eq!(
+        ::std::mem::align_of:: < my_struct > (), 4usize, concat!("Alignment of ",
+        stringify!(my_struct))
+    );
+    assert_eq!(
+        unsafe { ::std::ptr::addr_of!((* ptr).a) as usize - ptr as usize }, 0usize,
+        concat!("Offset of field: ", stringify!(my_struct), "::", stringify!(a))
+    );
+    assert_eq!(
+        unsafe { ::std::ptr::addr_of!((* ptr).private_b) as usize - ptr as usize },
+        4usize, concat!("Offset of field: ", stringify!(my_struct), "::",
+        stringify!(private_b))
+    );
+}
+impl my_struct {
+    #[inline]
+    pub fn c(&self) -> ::std::os::raw::c_int {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u32) }
+    }
+    #[inline]
+    pub fn set_c(&mut self, val: ::std::os::raw::c_int) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set(0usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    fn private_d(&self) -> ::std::os::raw::c_int {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u32) }
+    }
+    #[inline]
+    fn set_private_d(&mut self, val: ::std::os::raw::c_int) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set(1usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    fn new_bitfield_1(
+        c: ::std::os::raw::c_int,
+        private_d: ::std::os::raw::c_int,
+    ) -> __BindgenBitfieldUnit<[u8; 1usize]> {
+        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 1usize]> = Default::default();
+        __bindgen_bitfield_unit
+            .set(
+                0usize,
+                1u8,
+                {
+                    let c: u32 = unsafe { ::std::mem::transmute(c) };
+                    c as u64
+                },
+            );
+        __bindgen_bitfield_unit
+            .set(
+                1usize,
+                1u8,
+                {
+                    let private_d: u32 = unsafe { ::std::mem::transmute(private_d) };
+                    private_d as u64
+                },
+            );
+        __bindgen_bitfield_unit
+    }
+}

--- a/bindgen-tests/tests/expectations/tests/field-visibility.rs
+++ b/bindgen-tests/tests/expectations/tests/field-visibility.rs
@@ -1,0 +1,179 @@
+#![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
+#[repr(C)]
+#[derive(Copy, Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct __BindgenBitfieldUnit<Storage> {
+    storage: Storage,
+}
+impl<Storage> __BindgenBitfieldUnit<Storage> {
+    #[inline]
+    pub const fn new(storage: Storage) -> Self {
+        Self { storage }
+    }
+}
+impl<Storage> __BindgenBitfieldUnit<Storage>
+where
+    Storage: AsRef<[u8]> + AsMut<[u8]>,
+{
+    #[inline]
+    pub fn get_bit(&self, index: usize) -> bool {
+        debug_assert!(index / 8 < self.storage.as_ref().len());
+        let byte_index = index / 8;
+        let byte = self.storage.as_ref()[byte_index];
+        let bit_index = if cfg!(target_endian = "big") {
+            7 - (index % 8)
+        } else {
+            index % 8
+        };
+        let mask = 1 << bit_index;
+        byte & mask == mask
+    }
+    #[inline]
+    pub fn set_bit(&mut self, index: usize, val: bool) {
+        debug_assert!(index / 8 < self.storage.as_ref().len());
+        let byte_index = index / 8;
+        let byte = &mut self.storage.as_mut()[byte_index];
+        let bit_index = if cfg!(target_endian = "big") {
+            7 - (index % 8)
+        } else {
+            index % 8
+        };
+        let mask = 1 << bit_index;
+        if val {
+            *byte |= mask;
+        } else {
+            *byte &= !mask;
+        }
+    }
+    #[inline]
+    pub fn get(&self, bit_offset: usize, bit_width: u8) -> u64 {
+        debug_assert!(bit_width <= 64);
+        debug_assert!(bit_offset / 8 < self.storage.as_ref().len());
+        debug_assert!(
+            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len()
+        );
+        let mut val = 0;
+        for i in 0..(bit_width as usize) {
+            if self.get_bit(i + bit_offset) {
+                let index = if cfg!(target_endian = "big") {
+                    bit_width as usize - 1 - i
+                } else {
+                    i
+                };
+                val |= 1 << index;
+            }
+        }
+        val
+    }
+    #[inline]
+    pub fn set(&mut self, bit_offset: usize, bit_width: u8, val: u64) {
+        debug_assert!(bit_width <= 64);
+        debug_assert!(bit_offset / 8 < self.storage.as_ref().len());
+        debug_assert!(
+            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len()
+        );
+        for i in 0..(bit_width as usize) {
+            let mask = 1 << i;
+            let val_bit_is_set = val & mask == mask;
+            let index = if cfg!(target_endian = "big") {
+                bit_width as usize - 1 - i
+            } else {
+                i
+            };
+            self.set_bit(index + bit_offset, val_bit_is_set);
+        }
+    }
+}
+#[repr(C)]
+#[repr(align(4))]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct my_struct1 {
+    _bitfield_align_1: [u8; 0],
+    _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
+    __bindgen_padding_0: [u8; 3usize],
+}
+#[test]
+fn bindgen_test_layout_my_struct1() {
+    assert_eq!(
+        ::std::mem::size_of:: < my_struct1 > (), 4usize, concat!("Size of: ",
+        stringify!(my_struct1))
+    );
+    assert_eq!(
+        ::std::mem::align_of:: < my_struct1 > (), 4usize, concat!("Alignment of ",
+        stringify!(my_struct1))
+    );
+}
+impl my_struct1 {
+    #[inline]
+    fn a(&self) -> ::std::os::raw::c_int {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u32) }
+    }
+    #[inline]
+    fn set_a(&mut self, val: ::std::os::raw::c_int) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set(0usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    fn new_bitfield_1(a: ::std::os::raw::c_int) -> __BindgenBitfieldUnit<[u8; 1usize]> {
+        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 1usize]> = Default::default();
+        __bindgen_bitfield_unit
+            .set(
+                0usize,
+                1u8,
+                {
+                    let a: u32 = unsafe { ::std::mem::transmute(a) };
+                    a as u64
+                },
+            );
+        __bindgen_bitfield_unit
+    }
+}
+#[repr(C)]
+#[repr(align(4))]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct my_struct2 {
+    pub _bitfield_align_1: [u8; 0],
+    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
+    pub __bindgen_padding_0: [u8; 3usize],
+}
+#[test]
+fn bindgen_test_layout_my_struct2() {
+    assert_eq!(
+        ::std::mem::size_of:: < my_struct2 > (), 4usize, concat!("Size of: ",
+        stringify!(my_struct2))
+    );
+    assert_eq!(
+        ::std::mem::align_of:: < my_struct2 > (), 4usize, concat!("Alignment of ",
+        stringify!(my_struct2))
+    );
+}
+impl my_struct2 {
+    #[inline]
+    pub fn a(&self) -> ::std::os::raw::c_int {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u32) }
+    }
+    #[inline]
+    pub fn set_a(&mut self, val: ::std::os::raw::c_int) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set(0usize, 1u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn new_bitfield_1(
+        a: ::std::os::raw::c_int,
+    ) -> __BindgenBitfieldUnit<[u8; 1usize]> {
+        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 1usize]> = Default::default();
+        __bindgen_bitfield_unit
+            .set(
+                0usize,
+                1u8,
+                {
+                    let a: u32 = unsafe { ::std::mem::transmute(a) };
+                    a as u64
+                },
+            );
+        __bindgen_bitfield_unit
+    }
+}

--- a/bindgen-tests/tests/expectations/tests/private_fields.rs
+++ b/bindgen-tests/tests/expectations/tests/private_fields.rs
@@ -490,7 +490,7 @@ pub struct Override {
     /// <div rustbindgen private></div>
     b: ::std::os::raw::c_uint,
     pub _bitfield_align_1: [u8; 0],
-    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
+    _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
     pub __bindgen_padding_0: [u8; 3usize],
 }
 #[test]
@@ -538,7 +538,7 @@ impl Override {
         }
     }
     #[inline]
-    pub fn new_bitfield_1(
+    fn new_bitfield_1(
         bf_a: ::std::os::raw::c_uint,
         bf_b: ::std::os::raw::c_uint,
     ) -> __BindgenBitfieldUnit<[u8; 1usize]> {

--- a/bindgen-tests/tests/expectations/tests/private_fields.rs
+++ b/bindgen-tests/tests/expectations/tests/private_fields.rs
@@ -489,16 +489,17 @@ pub struct Override {
     pub a: ::std::os::raw::c_uint,
     /// <div rustbindgen private></div>
     b: ::std::os::raw::c_uint,
+    private_c: ::std::os::raw::c_uint,
     pub _bitfield_align_1: [u8; 0],
-    _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
-    pub __bindgen_padding_0: [u8; 3usize],
+    _bitfield_1: __BindgenBitfieldUnit<[u8; 2usize]>,
+    pub __bindgen_padding_0: u16,
 }
 #[test]
 fn bindgen_test_layout_Override() {
     const UNINIT: ::std::mem::MaybeUninit<Override> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < Override > (), 12usize, concat!("Size of: ",
+        ::std::mem::size_of:: < Override > (), 16usize, concat!("Size of: ",
         stringify!(Override))
     );
     assert_eq!(
@@ -512,6 +513,11 @@ fn bindgen_test_layout_Override() {
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((* ptr).b) as usize - ptr as usize }, 4usize,
         concat!("Offset of field: ", stringify!(Override), "::", stringify!(b))
+    );
+    assert_eq!(
+        unsafe { ::std::ptr::addr_of!((* ptr).private_c) as usize - ptr as usize },
+        8usize, concat!("Offset of field: ", stringify!(Override), "::",
+        stringify!(private_c))
     );
 }
 impl Override {
@@ -538,11 +544,23 @@ impl Override {
         }
     }
     #[inline]
+    fn private_bf_c(&self) -> ::std::os::raw::c_uint {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(8usize, 4u8) as u32) }
+    }
+    #[inline]
+    fn set_private_bf_c(&mut self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set(8usize, 4u8, val as u64)
+        }
+    }
+    #[inline]
     fn new_bitfield_1(
         bf_a: ::std::os::raw::c_uint,
         bf_b: ::std::os::raw::c_uint,
-    ) -> __BindgenBitfieldUnit<[u8; 1usize]> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 1usize]> = Default::default();
+        private_bf_c: ::std::os::raw::c_uint,
+    ) -> __BindgenBitfieldUnit<[u8; 2usize]> {
+        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 2usize]> = Default::default();
         __bindgen_bitfield_unit
             .set(
                 0usize,
@@ -559,6 +577,17 @@ impl Override {
                 {
                     let bf_b: u32 = unsafe { ::std::mem::transmute(bf_b) };
                     bf_b as u64
+                },
+            );
+        __bindgen_bitfield_unit
+            .set(
+                8usize,
+                4u8,
+                {
+                    let private_bf_c: u32 = unsafe {
+                        ::std::mem::transmute(private_bf_c)
+                    };
+                    private_bf_c as u64
                 },
             );
         __bindgen_bitfield_unit

--- a/bindgen-tests/tests/expectations/tests/private_fields.rs
+++ b/bindgen-tests/tests/expectations/tests/private_fields.rs
@@ -483,3 +483,84 @@ impl Default for WithAnonUnion {
         }
     }
 }
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct Override {
+    pub a: ::std::os::raw::c_uint,
+    /// <div rustbindgen private></div>
+    b: ::std::os::raw::c_uint,
+    pub _bitfield_align_1: [u8; 0],
+    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
+    pub __bindgen_padding_0: [u8; 3usize],
+}
+#[test]
+fn bindgen_test_layout_Override() {
+    const UNINIT: ::std::mem::MaybeUninit<Override> = ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
+    assert_eq!(
+        ::std::mem::size_of:: < Override > (), 12usize, concat!("Size of: ",
+        stringify!(Override))
+    );
+    assert_eq!(
+        ::std::mem::align_of:: < Override > (), 4usize, concat!("Alignment of ",
+        stringify!(Override))
+    );
+    assert_eq!(
+        unsafe { ::std::ptr::addr_of!((* ptr).a) as usize - ptr as usize }, 0usize,
+        concat!("Offset of field: ", stringify!(Override), "::", stringify!(a))
+    );
+    assert_eq!(
+        unsafe { ::std::ptr::addr_of!((* ptr).b) as usize - ptr as usize }, 4usize,
+        concat!("Offset of field: ", stringify!(Override), "::", stringify!(b))
+    );
+}
+impl Override {
+    #[inline]
+    pub fn bf_a(&self) -> ::std::os::raw::c_uint {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(0usize, 4u8) as u32) }
+    }
+    #[inline]
+    pub fn set_bf_a(&mut self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set(0usize, 4u8, val as u64)
+        }
+    }
+    #[inline]
+    fn bf_b(&self) -> ::std::os::raw::c_uint {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(4usize, 4u8) as u32) }
+    }
+    #[inline]
+    fn set_bf_b(&mut self, val: ::std::os::raw::c_uint) {
+        unsafe {
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set(4usize, 4u8, val as u64)
+        }
+    }
+    #[inline]
+    pub fn new_bitfield_1(
+        bf_a: ::std::os::raw::c_uint,
+        bf_b: ::std::os::raw::c_uint,
+    ) -> __BindgenBitfieldUnit<[u8; 1usize]> {
+        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 1usize]> = Default::default();
+        __bindgen_bitfield_unit
+            .set(
+                0usize,
+                4u8,
+                {
+                    let bf_a: u32 = unsafe { ::std::mem::transmute(bf_a) };
+                    bf_a as u64
+                },
+            );
+        __bindgen_bitfield_unit
+            .set(
+                4usize,
+                4u8,
+                {
+                    let bf_b: u32 = unsafe { ::std::mem::transmute(bf_b) };
+                    bf_b as u64
+                },
+            );
+        __bindgen_bitfield_unit
+    }
+}

--- a/bindgen-tests/tests/headers/field-visibility-callback.h
+++ b/bindgen-tests/tests/headers/field-visibility-callback.h
@@ -1,0 +1,9 @@
+// bindgen-flags: --default-visibility private
+// bindgen-parse-callbacks: field-visibility-default-private
+
+struct my_struct {
+    int a;
+    int private_b;
+    int c: 1;
+    int private_d: 1;
+};

--- a/bindgen-tests/tests/headers/field-visibility.h
+++ b/bindgen-tests/tests/headers/field-visibility.h
@@ -1,0 +1,10 @@
+// bindgen-flags: --default-visibility private --no-doc-comments
+
+struct my_struct1 {
+    int a: 1;
+};
+
+/** <div rustbindgen private="false"></div> */
+struct my_struct2 {
+    int a: 1;
+};

--- a/bindgen-tests/tests/headers/private_fields.hpp
+++ b/bindgen-tests/tests/headers/private_fields.hpp
@@ -1,4 +1,5 @@
 // bindgen-flags: --respect-cxx-access-specs
+
 class PubPriv {
   public:
     int x;
@@ -41,4 +42,17 @@ class WithAnonStruct {
 
 class WithAnonUnion {
   union {};
+};
+
+class Override {
+ public:
+  unsigned int a;
+  // override with annotation
+  /** <div rustbindgen private></div> */
+  unsigned int b;
+
+  unsigned int bf_a : 4;
+  // override with annotation
+  /** <div rustbindgen private></div> */
+  unsigned int bf_b : 4;
 };

--- a/bindgen-tests/tests/headers/private_fields.hpp
+++ b/bindgen-tests/tests/headers/private_fields.hpp
@@ -1,4 +1,5 @@
 // bindgen-flags: --respect-cxx-access-specs
+// bindgen-parse-callbacks: field-visibility-default-public
 
 class PubPriv {
   public:
@@ -50,9 +51,13 @@ class Override {
   // override with annotation
   /** <div rustbindgen private></div> */
   unsigned int b;
+  // override with callback
+  unsigned int private_c;
 
   unsigned int bf_a : 4;
   // override with annotation
   /** <div rustbindgen private></div> */
   unsigned int bf_b : 4;
+  // override with callback
+  unsigned int private_bf_c : 4;
 };

--- a/bindgen/callbacks.rs
+++ b/bindgen/callbacks.rs
@@ -135,6 +135,17 @@ pub trait ParseCallbacks: fmt::Debug {
     fn process_comment(&self, _comment: &str) -> Option<String> {
         None
     }
+
+    /// Potentially override the visibility of a composite type field.
+    ///
+    /// Caution: This allows overriding standard C++ visibility inferred by
+    /// `respect_cxx_access_specs`.
+    fn field_visibility(
+        &self,
+        _info: FieldInfo<'_>,
+    ) -> Option<crate::FieldVisibilityKind> {
+        None
+    }
 }
 
 /// Relevant information about a type to which new derive attributes will be added using
@@ -175,4 +186,15 @@ pub enum ItemKind {
     Function,
     /// A Variable
     Var,
+}
+
+/// Relevant information about a field for which visibility can be determined using
+/// [`ParseCallbacks::field_visibility`].
+#[derive(Debug)]
+#[non_exhaustive]
+pub struct FieldInfo<'a> {
+    /// The name of the type.
+    pub type_name: &'a str,
+    /// The name of the field.
+    pub field_name: &'a str,
 }

--- a/bindgen/codegen/mod.rs
+++ b/bindgen/codegen/mod.rs
@@ -1933,8 +1933,17 @@ impl CodeGenerator for CompInfo {
         // the parent too.
         let is_opaque = item.is_opaque(ctx, &());
         let mut fields = vec![];
-        let mut struct_layout =
-            StructLayoutTracker::new(ctx, self, ty, &canonical_name);
+        let visibility = item
+            .annotations()
+            .visibility_kind()
+            .unwrap_or(ctx.options().default_visibility);
+        let mut struct_layout = StructLayoutTracker::new(
+            ctx,
+            self,
+            ty,
+            &canonical_name,
+            visibility,
+        );
 
         if !is_opaque {
             if item.has_vtable_ptr(ctx) {
@@ -1983,10 +1992,6 @@ impl CodeGenerator for CompInfo {
 
         let mut methods = vec![];
         if !is_opaque {
-            let visibility = item
-                .annotations()
-                .visibility_kind()
-                .unwrap_or(ctx.options().default_visibility);
             let struct_accessor_kind = item
                 .annotations()
                 .accessor_kind()

--- a/bindgen/ir/annotations.rs
+++ b/bindgen/ir/annotations.rs
@@ -9,7 +9,7 @@ use std::str::FromStr;
 use crate::clang;
 
 /// What kind of visibility modifer should be used for a struct or field?
-#[derive(Copy, PartialEq, Eq, Clone, Debug)]
+#[derive(Copy, PartialEq, Eq, PartialOrd, Ord, Clone, Debug)]
 pub enum FieldVisibilityKind {
     /// Fields are marked as private, i.e., struct Foo {bar: bool}
     Private,


### PR DESCRIPTION
Add a callback mechanism for determining field visibility. This PR includes 2 other related (breaking) behavior changes in the prior commits:

* *Use default visibility for padding fields* Previously, padding fields were always pub. Now, they follow the default visibility for the type they're in.
* *Compute visibility of bitfield unit based on actual field visibility* A bitfield unit field and its related functions now have their visibility determined based on the minimum of the default visibility and the actual visibility of the bitfields within the unit. private < pub(crate) < pub.