### PR TITLE
backticks are not pretty when not rendered

### DIFF
--- a/book/book.toml
+++ b/book/book.toml
@@ -1,4 +1,4 @@
 [book]
-title = "The `bindgen` User Guide"
+title = "The bindgen User Guide"
 author = "The Servo project developers"
 description = "`bindgen` automatically generates Rust FFI bindings to C and C++ libraries."


### PR DESCRIPTION
These ones are particularly uncomfortable due to being of large font, in addition to being visible on all pages of the book.