### PR TITLE
Restore prettyplease feature gate to bindgen library crate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -184,7 +184,9 @@
   them. To make the escaping clear and consistent, backslashes are also
   escaped.
 * Updated `bitflags` dependency to 2.2.1. This changes the API of `CodegenConfig`.
-   
+* Prettyplease formatting is gated by an optional, enabled by default Cargo
+  feature when depending on `bindgen` as a library.
+
 ## Removed
 
 ## Fixed

--- a/bindgen/Cargo.toml
+++ b/bindgen/Cargo.toml
@@ -35,7 +35,7 @@ quote = { version = "1", default-features = false }
 syn = { version = "2.0", features = ["full", "extra-traits", "visit-mut"]}
 regex = { version = "1.5", default-features = false , features = ["std", "unicode"] }
 which = { version = "4.2.1", optional = true, default-features = false }
-prettyplease = { version = "0.2.0" }
+prettyplease = { version = "0.2.0", optional = true }
 annotate-snippets = { version = "0.9.1", features = ["color"], optional = true }
 shlex = "1"
 rustc-hash = "1.0.1"
@@ -43,7 +43,7 @@ proc-macro2 = { version = "1", default-features = false }
 log = { version = "0.4", optional = true }
 
 [features]
-default = ["logging", "runtime", "which-rustfmt"]
+default = ["logging", "prettyplease", "runtime", "which-rustfmt"]
 logging = ["log"]
 static = ["clang-sys/static"]
 runtime = ["clang-sys/runtime"]

--- a/bindgen/lib.rs
+++ b/bindgen/lib.rs
@@ -172,6 +172,7 @@ pub enum Formatter {
     None,
     /// Use `rustfmt` to format the bindings.
     Rustfmt,
+    #[cfg(feature = "prettyplease")]
     /// Use `prettyplease` to format the bindings.
     Prettyplease,
 }
@@ -189,6 +190,7 @@ impl FromStr for Formatter {
         match s {
             "none" => Ok(Self::None),
             "rustfmt" => Ok(Self::Rustfmt),
+            #[cfg(feature = "prettyplease")]
             "prettyplease" => Ok(Self::Prettyplease),
             _ => Err(format!("`{}` is not a valid formatter", s)),
         }
@@ -200,6 +202,7 @@ impl std::fmt::Display for Formatter {
         let s = match self {
             Self::None => "none",
             Self::Rustfmt => "rustfmt",
+            #[cfg(feature = "prettyplease")]
             Self::Prettyplease => "prettyplease",
         };
 
@@ -964,6 +967,7 @@ impl Bindings {
 
         match self.options.formatter {
             Formatter::None => return Ok(tokens.to_string()),
+            #[cfg(feature = "prettyplease")]
             Formatter::Prettyplease => {
                 return Ok(prettyplease::unparse(&syn::parse_quote!(#tokens)));
             }


### PR DESCRIPTION
This is a partial revert of these two PRs:

- https://github.com/rust-lang/rust-bindgen/pull/2491
- https://github.com/rust-lang/rust-bindgen/pull/2505

Allow formatting of generated bindings and the inclusion of the `prettyplease` dependency to be optional when depending on bindgen as a library.

`prettyplease` remains required and enabled by bindgen-cli.

In a project I maintain, `bindgen` is used in a build script to generate bindings for a native C library. Those bindings are written to `OUT_DIR` and are `include!`'d into the crate sources; these bindings don't need to be formatted.

See for additional context:

- https://github.com/rust-lang/rust-bindgen/pull/2491#issuecomment-1558266335
- https://github.com/rust-lang/rust-bindgen/pull/2491#issuecomment-1559699924
- https://github.com/rust-lang/rust-bindgen/pull/2491#issuecomment-1562248014

I tested all of the following locally:

```shell
cd bindgen
cargo check
cargo check --no-default-features
cargo check --no-default-features --features prettyplease
```

The CI steps added in rust-lang/rust-bindgen#2506 should be sufficient for maintaining the correctness of these conditional compilation features.

cc @pvdrz 