### PR TITLE
avoid implicit Cargo features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -190,6 +190,12 @@
   feature when depending on `bindgen` as a library.
 * Items are now parsed in the order they appear in source files. This may result in
   auto-generated `_bindgen_*` names having a different index.
+* Remove redundant Cargo features, which were all implicit:
+  - bindgen-cli: `env_logger` and `log` removed in favor of `logging`
+  - bindgen (lib):
+    + `log` removed in favor of `logging`
+    + `which` removed in favor of `which-logging`
+    + `annotate-snippets` removed in favor of `experimental`
 
 ## Removed
 

--- a/bindgen-cli/Cargo.toml
+++ b/bindgen-cli/Cargo.toml
@@ -29,7 +29,7 @@ log = { version = "0.4", optional = true }
 
 [features]
 default = ["logging", "runtime", "which-rustfmt"]
-logging = ["bindgen/logging", "env_logger", "log"]
+logging = ["bindgen/logging", "dep:env_logger", "dep:log"]
 static = ["bindgen/static"]
 runtime = ["bindgen/runtime"]
 # Dynamically discover a `rustfmt` binary using the `which` crate

--- a/bindgen-cli/Cargo.toml
+++ b/bindgen-cli/Cargo.toml
@@ -21,11 +21,11 @@ name = "bindgen"
 
 [dependencies]
 bindgen = { path = "../bindgen", version = "=0.65.1", features = ["__cli", "experimental"] }
-shlex = "1"
 clap = { version = "4", features = ["derive"] }
 clap_complete = "4"
 env_logger = { version = "0.10.0", optional = true }
 log = { version = "0.4", optional = true }
+shlex = "1"
 
 [features]
 default = ["logging", "runtime", "which-rustfmt"]

--- a/bindgen-tests/Cargo.toml
+++ b/bindgen-tests/Cargo.toml
@@ -6,10 +6,10 @@ publish = false
 
 [dev-dependencies]
 bindgen = { path = "../bindgen", features = ["__cli", "experimental"] }
-diff = "0.1"
-shlex = "1"
 clap = { version = "4", features = ["derive"] }
 clap_complete = "4"
+diff = "0.1"
+shlex = "1"
 prettyplease = { version = "0.2.0" }
 syn = { version = "2.0" }
 tempfile = "3"

--- a/bindgen-tests/tests/expectations/Cargo.toml
+++ b/bindgen-tests/tests/expectations/Cargo.toml
@@ -10,6 +10,6 @@ authors = [
 edition = "2018"
 
 [dependencies]
-objc = "0.2"
 block = "0.1"
 libloading = "0.7"
+objc = "0.2"

--- a/bindgen/Cargo.toml
+++ b/bindgen/Cargo.toml
@@ -44,12 +44,12 @@ log = { version = "0.4", optional = true }
 
 [features]
 default = ["logging", "prettyplease", "runtime", "which-rustfmt"]
-logging = ["log"]
+logging = ["dep:log"]
 static = ["clang-sys/static"]
 runtime = ["clang-sys/runtime"]
 # Dynamically discover a `rustfmt` binary using the `which` crate
-which-rustfmt = ["which"]
-experimental = ["annotate-snippets"]
+which-rustfmt = ["dep:which"]
+experimental = ["dep:annotate-snippets"]
 
 ## The following features are for internal use and they shouldn't be used if
 ## you're not hacking on bindgen

--- a/bindgen/Cargo.toml
+++ b/bindgen/Cargo.toml
@@ -25,22 +25,22 @@ name = "bindgen"
 path = "lib.rs"
 
 [dependencies]
+annotate-snippets = { version = "0.9.1", features = ["color"], optional = true }
 bitflags = "2.2.1"
 cexpr = "0.6"
 clang-sys = { version = "1", features = ["clang_6_0"] }
-lazycell = "1"
 lazy_static = "1"
-peeking_take_while = "0.1.2"
-quote = { version = "1", default-features = false }
-syn = { version = "2.0", features = ["full", "extra-traits", "visit-mut"]}
-regex = { version = "1.5", default-features = false , features = ["std", "unicode"] }
-which = { version = "4.2.1", optional = true, default-features = false }
-prettyplease = { version = "0.2.0", optional = true }
-annotate-snippets = { version = "0.9.1", features = ["color"], optional = true }
-shlex = "1"
-rustc-hash = "1.0.1"
-proc-macro2 = { version = "1", default-features = false }
+lazycell = "1"
 log = { version = "0.4", optional = true }
+peeking_take_while = "0.1.2"
+prettyplease = { version = "0.2.0", optional = true }
+proc-macro2 = { version = "1", default-features = false }
+quote = { version = "1", default-features = false }
+regex = { version = "1.5", default-features = false, features = ["std", "unicode"] }
+rustc-hash = "1.0.1"
+shlex = "1"
+syn = { version = "2.0", features = ["full", "extra-traits", "visit-mut"] }
+which = { version = "4.2.1", optional = true, default-features = false }
 
 [features]
 default = ["logging", "prettyplease", "runtime", "which-rustfmt"]


### PR DESCRIPTION
This breaks CLI that people may depend on, so maybe should be part of a new release.