### PR TITLE
Parse code by source order.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -188,6 +188,8 @@
 * Updated `bitflags` dependency to 2.2.1. This changes the API of `CodegenConfig`.
 * Prettyplease formatting is gated by an optional, enabled by default Cargo
   feature when depending on `bindgen` as a library.
+* Items are now parsed in the order they appear in source files. This may result in
+  auto-generated `_bindgen_*` names having a different index.
 
 ## Removed
 

--- a/bindgen-tests/tests/expectations/tests/allowlist-file.rs
+++ b/bindgen-tests/tests/expectations/tests/allowlist-file.rs
@@ -1,5 +1,4 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
-pub const SOME_DEFUN: u32 = 123;
 extern "C" {
     #[link_name = "\u{1}_Z12SomeFunctionv"]
     pub fn SomeFunction();
@@ -7,6 +6,7 @@ extern "C" {
 extern "C" {
     pub static mut someVar: ::std::os::raw::c_int;
 }
+pub const SOME_DEFUN: u32 = 123;
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct someClass {

--- a/bindgen-tests/tests/expectations/tests/jsval_layout_opaque.rs
+++ b/bindgen-tests/tests/expectations/tests/jsval_layout_opaque.rs
@@ -84,8 +84,6 @@ where
     }
 }
 pub const JSVAL_TAG_SHIFT: u32 = 47;
-pub const JSVAL_PAYLOAD_MASK: u64 = 140737488355327;
-pub const JSVAL_TAG_MASK: i64 = -140737488355328;
 #[repr(u8)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum JSValueType {
@@ -127,6 +125,8 @@ pub enum JSValueShiftedTag {
     JSVAL_SHIFTED_TAG_NULL = 18445477436314353664,
     JSVAL_SHIFTED_TAG_OBJECT = 18445618173802708992,
 }
+pub const JSVAL_PAYLOAD_MASK: u64 = 140737488355327;
+pub const JSVAL_TAG_MASK: i64 = -140737488355328;
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum JSWhyMagic {

--- a/bindgen-tests/tests/expectations/tests/jsval_layout_opaque_1_0.rs
+++ b/bindgen-tests/tests/expectations/tests/jsval_layout_opaque_1_0.rs
@@ -127,8 +127,6 @@ impl<T> ::std::cmp::PartialEq for __BindgenUnionField<T> {
 }
 impl<T> ::std::cmp::Eq for __BindgenUnionField<T> {}
 pub const JSVAL_TAG_SHIFT: u32 = 47;
-pub const JSVAL_PAYLOAD_MASK: u64 = 140737488355327;
-pub const JSVAL_TAG_MASK: i64 = -140737488355328;
 #[repr(u8)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum JSValueType {
@@ -170,6 +168,8 @@ pub enum JSValueShiftedTag {
     JSVAL_SHIFTED_TAG_NULL = 18445477436314353664,
     JSVAL_SHIFTED_TAG_OBJECT = 18445618173802708992,
 }
+pub const JSVAL_PAYLOAD_MASK: u64 = 140737488355327;
+pub const JSVAL_TAG_MASK: i64 = -140737488355328;
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum JSWhyMagic {

--- a/bindgen-tests/tests/expectations/tests/layout_arp.rs
+++ b/bindgen-tests/tests/expectations/tests/layout_arp.rs
@@ -1,12 +1,5 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 pub const ETHER_ADDR_LEN: u32 = 6;
-pub const ARP_HRD_ETHER: u32 = 1;
-pub const ARP_OP_REQUEST: u32 = 1;
-pub const ARP_OP_REPLY: u32 = 2;
-pub const ARP_OP_REVREQUEST: u32 = 3;
-pub const ARP_OP_REVREPLY: u32 = 4;
-pub const ARP_OP_INVREQUEST: u32 = 8;
-pub const ARP_OP_INVREPLY: u32 = 9;
 /** Ethernet address:
  A universally administered address is uniquely assigned to a device by its
  manufacturer. The first three octets (in transmission order) contain the
@@ -133,3 +126,10 @@ fn bindgen_test_layout_arp_hdr() {
         stringify!(arp_data))
     );
 }
+pub const ARP_HRD_ETHER: u32 = 1;
+pub const ARP_OP_REQUEST: u32 = 1;
+pub const ARP_OP_REPLY: u32 = 2;
+pub const ARP_OP_REVREQUEST: u32 = 3;
+pub const ARP_OP_REVREPLY: u32 = 4;
+pub const ARP_OP_INVREQUEST: u32 = 8;
+pub const ARP_OP_INVREPLY: u32 = 9;

--- a/bindgen-tests/tests/expectations/tests/layout_array.rs
+++ b/bindgen-tests/tests/expectations/tests/layout_array.rs
@@ -1,13 +1,6 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 pub const RTE_CACHE_LINE_SIZE: u32 = 64;
 pub const RTE_MEMPOOL_OPS_NAMESIZE: u32 = 32;
-pub const RTE_MEMPOOL_MAX_OPS_IDX: u32 = 16;
-pub const RTE_HEAP_NUM_FREELISTS: u32 = 13;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct rte_mempool {
-    _unused: [u8; 0],
-}
 /** Prototype for implementation specific data provisioning function.
 
  The function should provide the implementation specific memory for
@@ -19,6 +12,11 @@ pub struct rte_mempool {
 pub type rte_mempool_alloc_t = ::std::option::Option<
     unsafe extern "C" fn(mp: *mut rte_mempool) -> ::std::os::raw::c_int,
 >;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct rte_mempool {
+    _unused: [u8; 0],
+}
 /// Free the opaque private data pointed to by mp->pool_data pointer.
 pub type rte_mempool_free_t = ::std::option::Option<
     unsafe extern "C" fn(mp: *mut rte_mempool),
@@ -118,6 +116,7 @@ impl ::std::cmp::PartialEq for rte_mempool_ops {
             && self.get_count == other.get_count
     }
 }
+pub const RTE_MEMPOOL_MAX_OPS_IDX: u32 = 16;
 /// The rte_spinlock_t type.
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
@@ -199,6 +198,7 @@ impl Default for rte_mempool_ops_table {
         }
     }
 }
+pub const RTE_HEAP_NUM_FREELISTS: u32 = 13;
 /// Structure to hold malloc heap
 #[repr(C)]
 #[repr(align(64))]

--- a/bindgen-tests/tests/expectations/tests/layout_eth_conf.rs
+++ b/bindgen-tests/tests/expectations/tests/layout_eth_conf.rs
@@ -90,31 +90,6 @@ pub const ETH_VMDQ_MAX_VLAN_FILTERS: u32 = 64;
 pub const ETH_DCB_NUM_USER_PRIORITIES: u32 = 8;
 pub const ETH_VMDQ_DCB_NUM_QUEUES: u32 = 128;
 pub const ETH_DCB_NUM_QUEUES: u32 = 128;
-pub const RTE_ETH_FDIR_MAX_FLEXLEN: u32 = 16;
-pub const RTE_ETH_INSET_SIZE_MAX: u32 = 128;
-pub const RTE_ETH_FLOW_UNKNOWN: u32 = 0;
-pub const RTE_ETH_FLOW_RAW: u32 = 1;
-pub const RTE_ETH_FLOW_IPV4: u32 = 2;
-pub const RTE_ETH_FLOW_FRAG_IPV4: u32 = 3;
-pub const RTE_ETH_FLOW_NONFRAG_IPV4_TCP: u32 = 4;
-pub const RTE_ETH_FLOW_NONFRAG_IPV4_UDP: u32 = 5;
-pub const RTE_ETH_FLOW_NONFRAG_IPV4_SCTP: u32 = 6;
-pub const RTE_ETH_FLOW_NONFRAG_IPV4_OTHER: u32 = 7;
-pub const RTE_ETH_FLOW_IPV6: u32 = 8;
-pub const RTE_ETH_FLOW_FRAG_IPV6: u32 = 9;
-pub const RTE_ETH_FLOW_NONFRAG_IPV6_TCP: u32 = 10;
-pub const RTE_ETH_FLOW_NONFRAG_IPV6_UDP: u32 = 11;
-pub const RTE_ETH_FLOW_NONFRAG_IPV6_SCTP: u32 = 12;
-pub const RTE_ETH_FLOW_NONFRAG_IPV6_OTHER: u32 = 13;
-pub const RTE_ETH_FLOW_L2_PAYLOAD: u32 = 14;
-pub const RTE_ETH_FLOW_IPV6_EX: u32 = 15;
-pub const RTE_ETH_FLOW_IPV6_TCP_EX: u32 = 16;
-pub const RTE_ETH_FLOW_IPV6_UDP_EX: u32 = 17;
-pub const RTE_ETH_FLOW_PORT: u32 = 18;
-pub const RTE_ETH_FLOW_VXLAN: u32 = 19;
-pub const RTE_ETH_FLOW_GENEVE: u32 = 20;
-pub const RTE_ETH_FLOW_NVGRE: u32 = 21;
-pub const RTE_ETH_FLOW_MAX: u32 = 22;
 #[repr(u32)]
 /**  A set of values to identify what method is to be used to route
   packets to multiple queues.*/
@@ -1214,6 +1189,8 @@ pub enum rte_eth_payload_type {
     RTE_ETH_L4_PAYLOAD = 4,
     RTE_ETH_PAYLOAD_MAX = 8,
 }
+pub const RTE_ETH_FDIR_MAX_FLEXLEN: u32 = 16;
+pub const RTE_ETH_INSET_SIZE_MAX: u32 = 128;
 /** A structure used to select bytes extracted from the protocol layers to
  flexible payload for filter*/
 #[repr(C)]
@@ -1286,6 +1263,29 @@ fn bindgen_test_layout_rte_eth_fdir_flex_mask() {
         stringify!(mask))
     );
 }
+pub const RTE_ETH_FLOW_UNKNOWN: u32 = 0;
+pub const RTE_ETH_FLOW_RAW: u32 = 1;
+pub const RTE_ETH_FLOW_IPV4: u32 = 2;
+pub const RTE_ETH_FLOW_FRAG_IPV4: u32 = 3;
+pub const RTE_ETH_FLOW_NONFRAG_IPV4_TCP: u32 = 4;
+pub const RTE_ETH_FLOW_NONFRAG_IPV4_UDP: u32 = 5;
+pub const RTE_ETH_FLOW_NONFRAG_IPV4_SCTP: u32 = 6;
+pub const RTE_ETH_FLOW_NONFRAG_IPV4_OTHER: u32 = 7;
+pub const RTE_ETH_FLOW_IPV6: u32 = 8;
+pub const RTE_ETH_FLOW_FRAG_IPV6: u32 = 9;
+pub const RTE_ETH_FLOW_NONFRAG_IPV6_TCP: u32 = 10;
+pub const RTE_ETH_FLOW_NONFRAG_IPV6_UDP: u32 = 11;
+pub const RTE_ETH_FLOW_NONFRAG_IPV6_SCTP: u32 = 12;
+pub const RTE_ETH_FLOW_NONFRAG_IPV6_OTHER: u32 = 13;
+pub const RTE_ETH_FLOW_L2_PAYLOAD: u32 = 14;
+pub const RTE_ETH_FLOW_IPV6_EX: u32 = 15;
+pub const RTE_ETH_FLOW_IPV6_TCP_EX: u32 = 16;
+pub const RTE_ETH_FLOW_IPV6_UDP_EX: u32 = 17;
+pub const RTE_ETH_FLOW_PORT: u32 = 18;
+pub const RTE_ETH_FLOW_VXLAN: u32 = 19;
+pub const RTE_ETH_FLOW_GENEVE: u32 = 20;
+pub const RTE_ETH_FLOW_NVGRE: u32 = 21;
+pub const RTE_ETH_FLOW_MAX: u32 = 22;
 /** A structure used to define all flexible payload related setting
  include flex payload and flex mask*/
 #[repr(C)]

--- a/bindgen-tests/tests/expectations/tests/layout_eth_conf_1_0.rs
+++ b/bindgen-tests/tests/expectations/tests/layout_eth_conf_1_0.rs
@@ -133,31 +133,6 @@ pub const ETH_VMDQ_MAX_VLAN_FILTERS: u32 = 64;
 pub const ETH_DCB_NUM_USER_PRIORITIES: u32 = 8;
 pub const ETH_VMDQ_DCB_NUM_QUEUES: u32 = 128;
 pub const ETH_DCB_NUM_QUEUES: u32 = 128;
-pub const RTE_ETH_FDIR_MAX_FLEXLEN: u32 = 16;
-pub const RTE_ETH_INSET_SIZE_MAX: u32 = 128;
-pub const RTE_ETH_FLOW_UNKNOWN: u32 = 0;
-pub const RTE_ETH_FLOW_RAW: u32 = 1;
-pub const RTE_ETH_FLOW_IPV4: u32 = 2;
-pub const RTE_ETH_FLOW_FRAG_IPV4: u32 = 3;
-pub const RTE_ETH_FLOW_NONFRAG_IPV4_TCP: u32 = 4;
-pub const RTE_ETH_FLOW_NONFRAG_IPV4_UDP: u32 = 5;
-pub const RTE_ETH_FLOW_NONFRAG_IPV4_SCTP: u32 = 6;
-pub const RTE_ETH_FLOW_NONFRAG_IPV4_OTHER: u32 = 7;
-pub const RTE_ETH_FLOW_IPV6: u32 = 8;
-pub const RTE_ETH_FLOW_FRAG_IPV6: u32 = 9;
-pub const RTE_ETH_FLOW_NONFRAG_IPV6_TCP: u32 = 10;
-pub const RTE_ETH_FLOW_NONFRAG_IPV6_UDP: u32 = 11;
-pub const RTE_ETH_FLOW_NONFRAG_IPV6_SCTP: u32 = 12;
-pub const RTE_ETH_FLOW_NONFRAG_IPV6_OTHER: u32 = 13;
-pub const RTE_ETH_FLOW_L2_PAYLOAD: u32 = 14;
-pub const RTE_ETH_FLOW_IPV6_EX: u32 = 15;
-pub const RTE_ETH_FLOW_IPV6_TCP_EX: u32 = 16;
-pub const RTE_ETH_FLOW_IPV6_UDP_EX: u32 = 17;
-pub const RTE_ETH_FLOW_PORT: u32 = 18;
-pub const RTE_ETH_FLOW_VXLAN: u32 = 19;
-pub const RTE_ETH_FLOW_GENEVE: u32 = 20;
-pub const RTE_ETH_FLOW_NVGRE: u32 = 21;
-pub const RTE_ETH_FLOW_MAX: u32 = 22;
 #[repr(u32)]
 /**  A set of values to identify what method is to be used to route
   packets to multiple queues.*/
@@ -1327,6 +1302,8 @@ pub enum rte_eth_payload_type {
     RTE_ETH_L4_PAYLOAD = 4,
     RTE_ETH_PAYLOAD_MAX = 8,
 }
+pub const RTE_ETH_FDIR_MAX_FLEXLEN: u32 = 16;
+pub const RTE_ETH_INSET_SIZE_MAX: u32 = 128;
 /** A structure used to select bytes extracted from the protocol layers to
  flexible payload for filter*/
 #[repr(C)]
@@ -1409,6 +1386,29 @@ impl Clone for rte_eth_fdir_flex_mask {
         *self
     }
 }
+pub const RTE_ETH_FLOW_UNKNOWN: u32 = 0;
+pub const RTE_ETH_FLOW_RAW: u32 = 1;
+pub const RTE_ETH_FLOW_IPV4: u32 = 2;
+pub const RTE_ETH_FLOW_FRAG_IPV4: u32 = 3;
+pub const RTE_ETH_FLOW_NONFRAG_IPV4_TCP: u32 = 4;
+pub const RTE_ETH_FLOW_NONFRAG_IPV4_UDP: u32 = 5;
+pub const RTE_ETH_FLOW_NONFRAG_IPV4_SCTP: u32 = 6;
+pub const RTE_ETH_FLOW_NONFRAG_IPV4_OTHER: u32 = 7;
+pub const RTE_ETH_FLOW_IPV6: u32 = 8;
+pub const RTE_ETH_FLOW_FRAG_IPV6: u32 = 9;
+pub const RTE_ETH_FLOW_NONFRAG_IPV6_TCP: u32 = 10;
+pub const RTE_ETH_FLOW_NONFRAG_IPV6_UDP: u32 = 11;
+pub const RTE_ETH_FLOW_NONFRAG_IPV6_SCTP: u32 = 12;
+pub const RTE_ETH_FLOW_NONFRAG_IPV6_OTHER: u32 = 13;
+pub const RTE_ETH_FLOW_L2_PAYLOAD: u32 = 14;
+pub const RTE_ETH_FLOW_IPV6_EX: u32 = 15;
+pub const RTE_ETH_FLOW_IPV6_TCP_EX: u32 = 16;
+pub const RTE_ETH_FLOW_IPV6_UDP_EX: u32 = 17;
+pub const RTE_ETH_FLOW_PORT: u32 = 18;
+pub const RTE_ETH_FLOW_VXLAN: u32 = 19;
+pub const RTE_ETH_FLOW_GENEVE: u32 = 20;
+pub const RTE_ETH_FLOW_NVGRE: u32 = 21;
+pub const RTE_ETH_FLOW_MAX: u32 = 22;
 /** A structure used to define all flexible payload related setting
  include flex payload and flex mask*/
 #[repr(C)]

--- a/bindgen-tests/tests/expectations/tests/namespace.rs
+++ b/bindgen-tests/tests/expectations/tests/namespace.rs
@@ -17,7 +17,7 @@ pub mod root {
             pub fn in_whatever();
         }
     }
-    pub mod _bindgen_mod_id_17 {
+    pub mod _bindgen_mod_id_13 {
         #[allow(unused_imports)]
         use self::super::super::root;
         #[repr(C)]
@@ -46,7 +46,7 @@ pub mod root {
     #[repr(C)]
     #[derive(Debug)]
     pub struct C<T> {
-        pub _base: root::_bindgen_mod_id_17::A,
+        pub _base: root::_bindgen_mod_id_13::A,
         pub m_c: T,
         pub m_c_ptr: *mut T,
         pub m_c_arr: [T; 10usize],

--- a/bindgen-tests/tests/expectations/tests/template_instantiation_with_fn_local_type.rs
+++ b/bindgen-tests/tests/expectations/tests/template_instantiation_with_fn_local_type.rs
@@ -4,10 +4,6 @@
 pub struct Foo {
     pub _address: u8,
 }
-extern "C" {
-    #[link_name = "\u{1}_Z1fv"]
-    pub fn f();
-}
 #[test]
 fn __bindgen_test_layout_Foo_open0_Bar_close0_instantiation() {
     assert_eq!(
@@ -18,6 +14,21 @@ fn __bindgen_test_layout_Foo_open0_Bar_close0_instantiation() {
         ::std::mem::align_of:: < Foo > (), 1usize,
         concat!("Alignment of template specialization: ", stringify!(Foo))
     );
+}
+#[test]
+fn __bindgen_test_layout_Foo_open0_Boo_close0_instantiation() {
+    assert_eq!(
+        ::std::mem::size_of:: < Foo > (), 1usize,
+        concat!("Size of template specialization: ", stringify!(Foo))
+    );
+    assert_eq!(
+        ::std::mem::align_of:: < Foo > (), 1usize,
+        concat!("Alignment of template specialization: ", stringify!(Foo))
+    );
+}
+extern "C" {
+    #[link_name = "\u{1}_Z1fv"]
+    pub fn f();
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
@@ -32,17 +43,6 @@ fn bindgen_test_layout_Baz() {
     assert_eq!(
         ::std::mem::align_of:: < Baz > (), 1usize, concat!("Alignment of ",
         stringify!(Baz))
-    );
-}
-#[test]
-fn __bindgen_test_layout_Foo_open0_Boo_close0_instantiation() {
-    assert_eq!(
-        ::std::mem::size_of:: < Foo > (), 1usize,
-        concat!("Size of template specialization: ", stringify!(Foo))
-    );
-    assert_eq!(
-        ::std::mem::align_of:: < Foo > (), 1usize,
-        concat!("Alignment of template specialization: ", stringify!(Foo))
     );
 }
 #[repr(C)]

--- a/bindgen/deps.rs
+++ b/bindgen/deps.rs
@@ -9,7 +9,7 @@ pub(crate) struct DepfileSpec {
 
 impl DepfileSpec {
     pub fn write(&self, deps: &BTreeSet<String>) -> std::io::Result<()> {
-        std::fs::write(&self.depfile_path, &self.to_string(deps))
+        std::fs::write(&self.depfile_path, self.to_string(deps))
     }
 
     fn to_string(&self, deps: &BTreeSet<String>) -> String {

--- a/bindgen/ir/item.rs
+++ b/bindgen/ir/item.rs
@@ -1460,8 +1460,12 @@ impl Item {
                                 cursor
                             );
                         }
-                        Some(filename) => {
-                            ctx.include_file(filename);
+                        Some(included_file) => {
+                            for cb in &ctx.options().parse_callbacks {
+                                cb.include_file(&included_file);
+                            }
+
+                            ctx.add_dep(included_file);
                         }
                     }
                 }

--- a/bindgen/ir/module.rs
+++ b/bindgen/ir/module.rs
@@ -6,6 +6,7 @@ use super::item::ItemSet;
 use crate::clang;
 use crate::parse::{ClangSubItemParser, ParseError, ParseResult};
 use crate::parse_one;
+
 use std::io;
 
 /// Whether this module is inline or not.
@@ -82,8 +83,8 @@ impl ClangSubItemParser for Module {
             CXCursor_Namespace => {
                 let module_id = ctx.module(cursor);
                 ctx.with_module(module_id, |ctx| {
-                    cursor.visit(|cursor| {
-                        parse_one(ctx, cursor, Some(module_id.into()))
+                    cursor.visit_sorted(ctx, |ctx, child| {
+                        parse_one(ctx, child, Some(module_id.into()))
                     })
                 });
 

--- a/bindgen/lib.rs
+++ b/bindgen/lib.rs
@@ -1085,7 +1085,8 @@ fn parse_one(
         Ok(..) => {}
         Err(ParseError::Continue) => {}
         Err(ParseError::Recurse) => {
-            cursor.visit(|child| parse_one(ctx, child, parent));
+            cursor
+                .visit_sorted(ctx, |ctx, child| parse_one(ctx, child, parent));
         }
     }
     CXChildVisit_Continue
@@ -1126,8 +1127,8 @@ fn parse(context: &mut BindgenContext) -> Result<(), BindgenError> {
     }
 
     let root = context.root_module();
-    context.with_module(root, |context| {
-        cursor.visit(|cursor| parse_one(context, cursor, None))
+    context.with_module(root, |ctx| {
+        cursor.visit_sorted(ctx, |ctx, child| parse_one(ctx, child, None))
     });
 
     assert!(


### PR DESCRIPTION
Extracted from https://github.com/rust-lang/rust-bindgen/pull/2369.

In order to somewhat support `#undef`, code needs to be parsed in the correct order. Previously, all macros were parsed before all variables, making it impossible to reason about whether a variable was declared before or after a macro with the same name.