### PR TITLE
Add target mappings for riscv32imc and riscv32imac

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -196,6 +196,7 @@
     + `log` removed in favor of `logging`
     + `which` removed in favor of `which-logging`
     + `annotate-snippets` removed in favor of `experimental`
+* Add target mappings for riscv32imc and riscv32imac.
 
 ## Removed
 

--- a/bindgen/lib.rs
+++ b/bindgen/lib.rs
@@ -692,7 +692,8 @@ fn rust_to_clang_target(rust_target: &str) -> String {
         return clang_target;
     } else if rust_target.starts_with("riscv32imac-") {
         let mut clang_target = "riscv32-".to_owned();
-        clang_target.push_str(rust_target.strip_prefix("riscv32imac-").unwrap());
+        clang_target
+            .push_str(rust_target.strip_prefix("riscv32imac-").unwrap());
         return clang_target;
     }
     rust_target.to_owned()

--- a/bindgen/lib.rs
+++ b/bindgen/lib.rs
@@ -686,6 +686,14 @@ fn rust_to_clang_target(rust_target: &str) -> String {
                 clang_target.strip_prefix("riscv32imc-").unwrap();
         }
         return clang_target;
+    } else if rust_target.starts_with("riscv32imc-") {
+        let mut clang_target = "riscv32-".to_owned();
+        clang_target.push_str(rust_target.strip_prefix("riscv32imc-").unwrap());
+        return clang_target;
+    } else if rust_target.starts_with("riscv32imac-") {
+        let mut clang_target = "riscv32-".to_owned();
+        clang_target.push_str(rust_target.strip_prefix("riscv32imac-").unwrap());
+        return clang_target;
     }
     rust_target.to_owned()
 }
@@ -1285,7 +1293,15 @@ fn test_rust_to_clang_target_riscv() {
     assert_eq!(
         rust_to_clang_target("riscv64gc-unknown-linux-gnu"),
         "riscv64-unknown-linux-gnu"
-    )
+    );
+    assert_eq!(
+        rust_to_clang_target("riscv32imc-unknown-none-elf"),
+        "riscv32-unknown-none-elf"
+    );
+    assert_eq!(
+        rust_to_clang_target("riscv32imac-unknown-none-elf"),
+        "riscv32-unknown-none-elf"
+    );
 }
 
 #[test]


### PR DESCRIPTION
Similar problem as the one mentioned in #2136, just continuing by adding the 32 bit risc tuple mappings. Tuples like riscv32imc- and riscv32imac- should map to the clang riscv32- tuple.

Fixed by adding mappings and tests for the mappings. Projects that now failed to build with the "riscv32imac-unknown-none-elf" target tuple now build without issue.