### PR TITLE
clang: Disable source order sorting for now.

### DIFF
--- a/bindgen-tests/tests/expectations/tests/allowlist-file.rs
+++ b/bindgen-tests/tests/expectations/tests/allowlist-file.rs
@@ -1,4 +1,5 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
+pub const SOME_DEFUN: u32 = 123;
 extern "C" {
     #[link_name = "\u{1}_Z12SomeFunctionv"]
     pub fn SomeFunction();
@@ -6,7 +7,6 @@ extern "C" {
 extern "C" {
     pub static mut someVar: ::std::os::raw::c_int;
 }
-pub const SOME_DEFUN: u32 = 123;
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct someClass {

--- a/bindgen-tests/tests/expectations/tests/issue-2556.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-2556.rs
@@ -1,0 +1,43 @@
+#![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
+#[allow(non_snake_case, non_camel_case_types, non_upper_case_globals)]
+pub mod root {
+    #[allow(unused_imports)]
+    use self::super::root;
+    #[repr(C)]
+    #[derive(Debug, Default, Copy, Clone)]
+    pub struct nsSize {
+        pub width: ::std::os::raw::c_int,
+        pub height: ::std::os::raw::c_int,
+    }
+    #[test]
+    fn bindgen_test_layout_nsSize() {
+        const UNINIT: ::std::mem::MaybeUninit<nsSize> = ::std::mem::MaybeUninit::uninit();
+        let ptr = UNINIT.as_ptr();
+        assert_eq!(
+            ::std::mem::size_of:: < nsSize > (), 8usize, concat!("Size of: ",
+            stringify!(nsSize))
+        );
+        assert_eq!(
+            ::std::mem::align_of:: < nsSize > (), 4usize, concat!("Alignment of ",
+            stringify!(nsSize))
+        );
+        assert_eq!(
+            unsafe { ::std::ptr::addr_of!((* ptr).width) as usize - ptr as usize },
+            0usize, concat!("Offset of field: ", stringify!(nsSize), "::",
+            stringify!(width))
+        );
+        assert_eq!(
+            unsafe { ::std::ptr::addr_of!((* ptr).height) as usize - ptr as usize },
+            4usize, concat!("Offset of field: ", stringify!(nsSize), "::",
+            stringify!(height))
+        );
+    }
+    pub mod foo {
+        #[allow(unused_imports)]
+        use self::super::super::root;
+        extern "C" {
+            #[link_name = "\u{1}_ZN3fooL22kFallbackIntrinsicSizeE"]
+            pub static kFallbackIntrinsicSize: root::nsSize;
+        }
+    }
+}

--- a/bindgen-tests/tests/expectations/tests/jsval_layout_opaque.rs
+++ b/bindgen-tests/tests/expectations/tests/jsval_layout_opaque.rs
@@ -84,6 +84,8 @@ where
     }
 }
 pub const JSVAL_TAG_SHIFT: u32 = 47;
+pub const JSVAL_PAYLOAD_MASK: u64 = 140737488355327;
+pub const JSVAL_TAG_MASK: i64 = -140737488355328;
 #[repr(u8)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum JSValueType {
@@ -125,8 +127,6 @@ pub enum JSValueShiftedTag {
     JSVAL_SHIFTED_TAG_NULL = 18445477436314353664,
     JSVAL_SHIFTED_TAG_OBJECT = 18445618173802708992,
 }
-pub const JSVAL_PAYLOAD_MASK: u64 = 140737488355327;
-pub const JSVAL_TAG_MASK: i64 = -140737488355328;
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum JSWhyMagic {

--- a/bindgen-tests/tests/expectations/tests/jsval_layout_opaque_1_0.rs
+++ b/bindgen-tests/tests/expectations/tests/jsval_layout_opaque_1_0.rs
@@ -127,6 +127,8 @@ impl<T> ::std::cmp::PartialEq for __BindgenUnionField<T> {
 }
 impl<T> ::std::cmp::Eq for __BindgenUnionField<T> {}
 pub const JSVAL_TAG_SHIFT: u32 = 47;
+pub const JSVAL_PAYLOAD_MASK: u64 = 140737488355327;
+pub const JSVAL_TAG_MASK: i64 = -140737488355328;
 #[repr(u8)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum JSValueType {
@@ -168,8 +170,6 @@ pub enum JSValueShiftedTag {
     JSVAL_SHIFTED_TAG_NULL = 18445477436314353664,
     JSVAL_SHIFTED_TAG_OBJECT = 18445618173802708992,
 }
-pub const JSVAL_PAYLOAD_MASK: u64 = 140737488355327;
-pub const JSVAL_TAG_MASK: i64 = -140737488355328;
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum JSWhyMagic {

--- a/bindgen-tests/tests/expectations/tests/layout_arp.rs
+++ b/bindgen-tests/tests/expectations/tests/layout_arp.rs
@@ -1,5 +1,12 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 pub const ETHER_ADDR_LEN: u32 = 6;
+pub const ARP_HRD_ETHER: u32 = 1;
+pub const ARP_OP_REQUEST: u32 = 1;
+pub const ARP_OP_REPLY: u32 = 2;
+pub const ARP_OP_REVREQUEST: u32 = 3;
+pub const ARP_OP_REVREPLY: u32 = 4;
+pub const ARP_OP_INVREQUEST: u32 = 8;
+pub const ARP_OP_INVREPLY: u32 = 9;
 /** Ethernet address:
  A universally administered address is uniquely assigned to a device by its
  manufacturer. The first three octets (in transmission order) contain the
@@ -126,10 +133,3 @@ fn bindgen_test_layout_arp_hdr() {
         stringify!(arp_data))
     );
 }
-pub const ARP_HRD_ETHER: u32 = 1;
-pub const ARP_OP_REQUEST: u32 = 1;
-pub const ARP_OP_REPLY: u32 = 2;
-pub const ARP_OP_REVREQUEST: u32 = 3;
-pub const ARP_OP_REVREPLY: u32 = 4;
-pub const ARP_OP_INVREQUEST: u32 = 8;
-pub const ARP_OP_INVREPLY: u32 = 9;

--- a/bindgen-tests/tests/expectations/tests/layout_array.rs
+++ b/bindgen-tests/tests/expectations/tests/layout_array.rs
@@ -1,6 +1,13 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 pub const RTE_CACHE_LINE_SIZE: u32 = 64;
 pub const RTE_MEMPOOL_OPS_NAMESIZE: u32 = 32;
+pub const RTE_MEMPOOL_MAX_OPS_IDX: u32 = 16;
+pub const RTE_HEAP_NUM_FREELISTS: u32 = 13;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct rte_mempool {
+    _unused: [u8; 0],
+}
 /** Prototype for implementation specific data provisioning function.
 
  The function should provide the implementation specific memory for
@@ -12,11 +19,6 @@ pub const RTE_MEMPOOL_OPS_NAMESIZE: u32 = 32;
 pub type rte_mempool_alloc_t = ::std::option::Option<
     unsafe extern "C" fn(mp: *mut rte_mempool) -> ::std::os::raw::c_int,
 >;
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct rte_mempool {
-    _unused: [u8; 0],
-}
 /// Free the opaque private data pointed to by mp->pool_data pointer.
 pub type rte_mempool_free_t = ::std::option::Option<
     unsafe extern "C" fn(mp: *mut rte_mempool),
@@ -116,7 +118,6 @@ impl ::std::cmp::PartialEq for rte_mempool_ops {
             && self.get_count == other.get_count
     }
 }
-pub const RTE_MEMPOOL_MAX_OPS_IDX: u32 = 16;
 /// The rte_spinlock_t type.
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
@@ -198,7 +199,6 @@ impl Default for rte_mempool_ops_table {
         }
     }
 }
-pub const RTE_HEAP_NUM_FREELISTS: u32 = 13;
 /// Structure to hold malloc heap
 #[repr(C)]
 #[repr(align(64))]

--- a/bindgen-tests/tests/expectations/tests/layout_eth_conf.rs
+++ b/bindgen-tests/tests/expectations/tests/layout_eth_conf.rs
@@ -90,6 +90,31 @@ pub const ETH_VMDQ_MAX_VLAN_FILTERS: u32 = 64;
 pub const ETH_DCB_NUM_USER_PRIORITIES: u32 = 8;
 pub const ETH_VMDQ_DCB_NUM_QUEUES: u32 = 128;
 pub const ETH_DCB_NUM_QUEUES: u32 = 128;
+pub const RTE_ETH_FDIR_MAX_FLEXLEN: u32 = 16;
+pub const RTE_ETH_INSET_SIZE_MAX: u32 = 128;
+pub const RTE_ETH_FLOW_UNKNOWN: u32 = 0;
+pub const RTE_ETH_FLOW_RAW: u32 = 1;
+pub const RTE_ETH_FLOW_IPV4: u32 = 2;
+pub const RTE_ETH_FLOW_FRAG_IPV4: u32 = 3;
+pub const RTE_ETH_FLOW_NONFRAG_IPV4_TCP: u32 = 4;
+pub const RTE_ETH_FLOW_NONFRAG_IPV4_UDP: u32 = 5;
+pub const RTE_ETH_FLOW_NONFRAG_IPV4_SCTP: u32 = 6;
+pub const RTE_ETH_FLOW_NONFRAG_IPV4_OTHER: u32 = 7;
+pub const RTE_ETH_FLOW_IPV6: u32 = 8;
+pub const RTE_ETH_FLOW_FRAG_IPV6: u32 = 9;
+pub const RTE_ETH_FLOW_NONFRAG_IPV6_TCP: u32 = 10;
+pub const RTE_ETH_FLOW_NONFRAG_IPV6_UDP: u32 = 11;
+pub const RTE_ETH_FLOW_NONFRAG_IPV6_SCTP: u32 = 12;
+pub const RTE_ETH_FLOW_NONFRAG_IPV6_OTHER: u32 = 13;
+pub const RTE_ETH_FLOW_L2_PAYLOAD: u32 = 14;
+pub const RTE_ETH_FLOW_IPV6_EX: u32 = 15;
+pub const RTE_ETH_FLOW_IPV6_TCP_EX: u32 = 16;
+pub const RTE_ETH_FLOW_IPV6_UDP_EX: u32 = 17;
+pub const RTE_ETH_FLOW_PORT: u32 = 18;
+pub const RTE_ETH_FLOW_VXLAN: u32 = 19;
+pub const RTE_ETH_FLOW_GENEVE: u32 = 20;
+pub const RTE_ETH_FLOW_NVGRE: u32 = 21;
+pub const RTE_ETH_FLOW_MAX: u32 = 22;
 #[repr(u32)]
 /**  A set of values to identify what method is to be used to route
   packets to multiple queues.*/
@@ -1189,8 +1214,6 @@ pub enum rte_eth_payload_type {
     RTE_ETH_L4_PAYLOAD = 4,
     RTE_ETH_PAYLOAD_MAX = 8,
 }
-pub const RTE_ETH_FDIR_MAX_FLEXLEN: u32 = 16;
-pub const RTE_ETH_INSET_SIZE_MAX: u32 = 128;
 /** A structure used to select bytes extracted from the protocol layers to
  flexible payload for filter*/
 #[repr(C)]
@@ -1263,29 +1286,6 @@ fn bindgen_test_layout_rte_eth_fdir_flex_mask() {
         stringify!(mask))
     );
 }
-pub const RTE_ETH_FLOW_UNKNOWN: u32 = 0;
-pub const RTE_ETH_FLOW_RAW: u32 = 1;
-pub const RTE_ETH_FLOW_IPV4: u32 = 2;
-pub const RTE_ETH_FLOW_FRAG_IPV4: u32 = 3;
-pub const RTE_ETH_FLOW_NONFRAG_IPV4_TCP: u32 = 4;
-pub const RTE_ETH_FLOW_NONFRAG_IPV4_UDP: u32 = 5;
-pub const RTE_ETH_FLOW_NONFRAG_IPV4_SCTP: u32 = 6;
-pub const RTE_ETH_FLOW_NONFRAG_IPV4_OTHER: u32 = 7;
-pub const RTE_ETH_FLOW_IPV6: u32 = 8;
-pub const RTE_ETH_FLOW_FRAG_IPV6: u32 = 9;
-pub const RTE_ETH_FLOW_NONFRAG_IPV6_TCP: u32 = 10;
-pub const RTE_ETH_FLOW_NONFRAG_IPV6_UDP: u32 = 11;
-pub const RTE_ETH_FLOW_NONFRAG_IPV6_SCTP: u32 = 12;
-pub const RTE_ETH_FLOW_NONFRAG_IPV6_OTHER: u32 = 13;
-pub const RTE_ETH_FLOW_L2_PAYLOAD: u32 = 14;
-pub const RTE_ETH_FLOW_IPV6_EX: u32 = 15;
-pub const RTE_ETH_FLOW_IPV6_TCP_EX: u32 = 16;
-pub const RTE_ETH_FLOW_IPV6_UDP_EX: u32 = 17;
-pub const RTE_ETH_FLOW_PORT: u32 = 18;
-pub const RTE_ETH_FLOW_VXLAN: u32 = 19;
-pub const RTE_ETH_FLOW_GENEVE: u32 = 20;
-pub const RTE_ETH_FLOW_NVGRE: u32 = 21;
-pub const RTE_ETH_FLOW_MAX: u32 = 22;
 /** A structure used to define all flexible payload related setting
  include flex payload and flex mask*/
 #[repr(C)]

--- a/bindgen-tests/tests/expectations/tests/layout_eth_conf_1_0.rs
+++ b/bindgen-tests/tests/expectations/tests/layout_eth_conf_1_0.rs
@@ -133,6 +133,31 @@ pub const ETH_VMDQ_MAX_VLAN_FILTERS: u32 = 64;
 pub const ETH_DCB_NUM_USER_PRIORITIES: u32 = 8;
 pub const ETH_VMDQ_DCB_NUM_QUEUES: u32 = 128;
 pub const ETH_DCB_NUM_QUEUES: u32 = 128;
+pub const RTE_ETH_FDIR_MAX_FLEXLEN: u32 = 16;
+pub const RTE_ETH_INSET_SIZE_MAX: u32 = 128;
+pub const RTE_ETH_FLOW_UNKNOWN: u32 = 0;
+pub const RTE_ETH_FLOW_RAW: u32 = 1;
+pub const RTE_ETH_FLOW_IPV4: u32 = 2;
+pub const RTE_ETH_FLOW_FRAG_IPV4: u32 = 3;
+pub const RTE_ETH_FLOW_NONFRAG_IPV4_TCP: u32 = 4;
+pub const RTE_ETH_FLOW_NONFRAG_IPV4_UDP: u32 = 5;
+pub const RTE_ETH_FLOW_NONFRAG_IPV4_SCTP: u32 = 6;
+pub const RTE_ETH_FLOW_NONFRAG_IPV4_OTHER: u32 = 7;
+pub const RTE_ETH_FLOW_IPV6: u32 = 8;
+pub const RTE_ETH_FLOW_FRAG_IPV6: u32 = 9;
+pub const RTE_ETH_FLOW_NONFRAG_IPV6_TCP: u32 = 10;
+pub const RTE_ETH_FLOW_NONFRAG_IPV6_UDP: u32 = 11;
+pub const RTE_ETH_FLOW_NONFRAG_IPV6_SCTP: u32 = 12;
+pub const RTE_ETH_FLOW_NONFRAG_IPV6_OTHER: u32 = 13;
+pub const RTE_ETH_FLOW_L2_PAYLOAD: u32 = 14;
+pub const RTE_ETH_FLOW_IPV6_EX: u32 = 15;
+pub const RTE_ETH_FLOW_IPV6_TCP_EX: u32 = 16;
+pub const RTE_ETH_FLOW_IPV6_UDP_EX: u32 = 17;
+pub const RTE_ETH_FLOW_PORT: u32 = 18;
+pub const RTE_ETH_FLOW_VXLAN: u32 = 19;
+pub const RTE_ETH_FLOW_GENEVE: u32 = 20;
+pub const RTE_ETH_FLOW_NVGRE: u32 = 21;
+pub const RTE_ETH_FLOW_MAX: u32 = 22;
 #[repr(u32)]
 /**  A set of values to identify what method is to be used to route
   packets to multiple queues.*/
@@ -1302,8 +1327,6 @@ pub enum rte_eth_payload_type {
     RTE_ETH_L4_PAYLOAD = 4,
     RTE_ETH_PAYLOAD_MAX = 8,
 }
-pub const RTE_ETH_FDIR_MAX_FLEXLEN: u32 = 16;
-pub const RTE_ETH_INSET_SIZE_MAX: u32 = 128;
 /** A structure used to select bytes extracted from the protocol layers to
  flexible payload for filter*/
 #[repr(C)]
@@ -1386,29 +1409,6 @@ impl Clone for rte_eth_fdir_flex_mask {
         *self
     }
 }
-pub const RTE_ETH_FLOW_UNKNOWN: u32 = 0;
-pub const RTE_ETH_FLOW_RAW: u32 = 1;
-pub const RTE_ETH_FLOW_IPV4: u32 = 2;
-pub const RTE_ETH_FLOW_FRAG_IPV4: u32 = 3;
-pub const RTE_ETH_FLOW_NONFRAG_IPV4_TCP: u32 = 4;
-pub const RTE_ETH_FLOW_NONFRAG_IPV4_UDP: u32 = 5;
-pub const RTE_ETH_FLOW_NONFRAG_IPV4_SCTP: u32 = 6;
-pub const RTE_ETH_FLOW_NONFRAG_IPV4_OTHER: u32 = 7;
-pub const RTE_ETH_FLOW_IPV6: u32 = 8;
-pub const RTE_ETH_FLOW_FRAG_IPV6: u32 = 9;
-pub const RTE_ETH_FLOW_NONFRAG_IPV6_TCP: u32 = 10;
-pub const RTE_ETH_FLOW_NONFRAG_IPV6_UDP: u32 = 11;
-pub const RTE_ETH_FLOW_NONFRAG_IPV6_SCTP: u32 = 12;
-pub const RTE_ETH_FLOW_NONFRAG_IPV6_OTHER: u32 = 13;
-pub const RTE_ETH_FLOW_L2_PAYLOAD: u32 = 14;
-pub const RTE_ETH_FLOW_IPV6_EX: u32 = 15;
-pub const RTE_ETH_FLOW_IPV6_TCP_EX: u32 = 16;
-pub const RTE_ETH_FLOW_IPV6_UDP_EX: u32 = 17;
-pub const RTE_ETH_FLOW_PORT: u32 = 18;
-pub const RTE_ETH_FLOW_VXLAN: u32 = 19;
-pub const RTE_ETH_FLOW_GENEVE: u32 = 20;
-pub const RTE_ETH_FLOW_NVGRE: u32 = 21;
-pub const RTE_ETH_FLOW_MAX: u32 = 22;
 /** A structure used to define all flexible payload related setting
  include flex payload and flex mask*/
 #[repr(C)]

--- a/bindgen-tests/tests/expectations/tests/namespace.rs
+++ b/bindgen-tests/tests/expectations/tests/namespace.rs
@@ -17,7 +17,7 @@ pub mod root {
             pub fn in_whatever();
         }
     }
-    pub mod _bindgen_mod_id_13 {
+    pub mod _bindgen_mod_id_17 {
         #[allow(unused_imports)]
         use self::super::super::root;
         #[repr(C)]
@@ -46,7 +46,7 @@ pub mod root {
     #[repr(C)]
     #[derive(Debug)]
     pub struct C<T> {
-        pub _base: root::_bindgen_mod_id_13::A,
+        pub _base: root::_bindgen_mod_id_17::A,
         pub m_c: T,
         pub m_c_ptr: *mut T,
         pub m_c_arr: [T; 10usize],

--- a/bindgen-tests/tests/expectations/tests/template_instantiation_with_fn_local_type.rs
+++ b/bindgen-tests/tests/expectations/tests/template_instantiation_with_fn_local_type.rs
@@ -4,6 +4,10 @@
 pub struct Foo {
     pub _address: u8,
 }
+extern "C" {
+    #[link_name = "\u{1}_Z1fv"]
+    pub fn f();
+}
 #[test]
 fn __bindgen_test_layout_Foo_open0_Bar_close0_instantiation() {
     assert_eq!(
@@ -14,21 +18,6 @@ fn __bindgen_test_layout_Foo_open0_Bar_close0_instantiation() {
         ::std::mem::align_of:: < Foo > (), 1usize,
         concat!("Alignment of template specialization: ", stringify!(Foo))
     );
-}
-#[test]
-fn __bindgen_test_layout_Foo_open0_Boo_close0_instantiation() {
-    assert_eq!(
-        ::std::mem::size_of:: < Foo > (), 1usize,
-        concat!("Size of template specialization: ", stringify!(Foo))
-    );
-    assert_eq!(
-        ::std::mem::align_of:: < Foo > (), 1usize,
-        concat!("Alignment of template specialization: ", stringify!(Foo))
-    );
-}
-extern "C" {
-    #[link_name = "\u{1}_Z1fv"]
-    pub fn f();
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
@@ -43,6 +32,17 @@ fn bindgen_test_layout_Baz() {
     assert_eq!(
         ::std::mem::align_of:: < Baz > (), 1usize, concat!("Alignment of ",
         stringify!(Baz))
+    );
+}
+#[test]
+fn __bindgen_test_layout_Foo_open0_Boo_close0_instantiation() {
+    assert_eq!(
+        ::std::mem::size_of:: < Foo > (), 1usize,
+        concat!("Size of template specialization: ", stringify!(Foo))
+    );
+    assert_eq!(
+        ::std::mem::align_of:: < Foo > (), 1usize,
+        concat!("Alignment of template specialization: ", stringify!(Foo))
     );
 }
 #[repr(C)]

--- a/bindgen-tests/tests/headers/issue-2556.h
+++ b/bindgen-tests/tests/headers/issue-2556.h
@@ -1,0 +1,4 @@
+// bindgen-flags: --enable-cxx-namespaces -- -x c++ -Itests/headers -include tests/headers/issue-2556/nsStyleStruct.h -include tests/headers/issue-2556/LayoutConstants.h
+
+#include "issue-2556/nsSize.h"
+#include "issue-2556/nsStyleStruct.h"

--- a/bindgen-tests/tests/headers/issue-2556/LayoutConstants.h
+++ b/bindgen-tests/tests/headers/issue-2556/LayoutConstants.h
@@ -1,0 +1,7 @@
+#include "nsSize.h"
+
+namespace foo {
+
+static constexpr nsSize kFallbackIntrinsicSize(0, 0);
+
+}

--- a/bindgen-tests/tests/headers/issue-2556/nsSize.h
+++ b/bindgen-tests/tests/headers/issue-2556/nsSize.h
@@ -1,0 +1,6 @@
+#pragma once
+
+struct nsSize {
+  int width, height;
+  constexpr nsSize(int aWidth, int aHeight) : width(aWidth), height(aHeight) {}
+};

--- a/bindgen-tests/tests/headers/issue-2556/nsStyleStruct.h
+++ b/bindgen-tests/tests/headers/issue-2556/nsStyleStruct.h
@@ -1,0 +1,3 @@
+#pragma once
+
+#include "nsSize.h"

--- a/bindgen/clang.rs
+++ b/bindgen/clang.rs
@@ -508,6 +508,17 @@ impl Cursor {
     ) where
         Visitor: FnMut(&mut BindgenContext, Cursor),
     {
+        // FIXME(#2556): The current source order stuff doesn't account well for different levels
+        // of includes, or includes that show up at the same byte offset because they are passed in
+        // via CLI.
+        const SOURCE_ORDER_ENABLED: bool = false;
+        if !SOURCE_ORDER_ENABLED {
+            return self.visit(|c| {
+                visitor(ctx, c);
+                CXChildVisit_Continue
+            });
+        }
+
         let mut children = self.collect_children();
         for child in &children {
             if child.kind() == CXCursor_InclusionDirective {

--- a/bindgen/clang.rs
+++ b/bindgen/clang.rs
@@ -562,7 +562,7 @@ impl Cursor {
         };
 
         if file == other_file {
-            // Both items are in the same source file, compare by byte offset.file
+            // Both items are in the same source file, compare by byte offset.
             return offset.cmp(&other_offset);
         }
 

--- a/bindgen/clang.rs
+++ b/bindgen/clang.rs
@@ -562,7 +562,7 @@ impl Cursor {
         };
 
         if file == other_file {
-            // Both items are in the same source file, compare by byte offset.
+            // Both items are in the same source file, compare by byte offset.file
             return offset.cmp(&other_offset);
         }
 
@@ -584,7 +584,7 @@ impl Cursor {
                     cmp::Ordering::Equal
                 }
             }
-            (None, None) => cmp::Ordering::Equal,file
+            (None, None) => cmp::Ordering::Equal,
         }
     }
 

--- a/bindgen/lib.rs
+++ b/bindgen/lib.rs
@@ -1084,12 +1084,11 @@ fn parse_one(
     ctx: &mut BindgenContext,
     cursor: clang::Cursor,
     parent: Option<ItemId>,
-) -> clang_sys::CXChildVisitResult {
+) {
     if !filter_builtins(ctx, &cursor) {
-        return CXChildVisit_Continue;
+        return;
     }
 
-    use clang_sys::CXChildVisit_Continue;
     match Item::parse(cursor, parent, ctx) {
         Ok(..) => {}
         Err(ParseError::Continue) => {}
@@ -1098,7 +1097,6 @@ fn parse_one(
                 .visit_sorted(ctx, |ctx, child| parse_one(ctx, child, parent));
         }
     }
-    CXChildVisit_Continue
 }
 
 /// Parse the Clang AST into our `Item` internal representation.


### PR DESCRIPTION
This disables (hopefully temporarily, if this is eventually going to be needed)
source order sorting, for causing correctness regressions like #2556, for which
I added a test.