### PR TITLE
Fix expectation tests for clang 5

### DIFF
--- a/bindgen-tests/tests/expectations/tests/libclang-5/issue-2556.rs
+++ b/bindgen-tests/tests/expectations/tests/libclang-5/issue-2556.rs
@@ -1,0 +1,1 @@
+/* error generating bindings */


### PR DESCRIPTION
For some reason, the expectation test for issue #2556 fails due to clang 5 not being able to compile it.

r? @emilio
