### PR TITLE
Update prettyplease to format macros better

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,7 +39,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.7",
+ "syn 2.0.18",
  "which",
 ]
 
@@ -73,7 +73,7 @@ dependencies = [
  "diff",
  "prettyplease",
  "shlex",
- "syn 2.0.7",
+ "syn 2.0.18",
  "tempfile",
 ]
 
@@ -410,12 +410,12 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "prettyplease"
-version = "0.2.0"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4508c0eff4d1e708551034de4bddd61bf8bda8c7b5ae72bd844cf68ea21117ac"
+checksum = "43ded2b5b204571f065ab8540367d738dfe1b3606ab9eb669dcfb5e7a3a07501"
 dependencies = [
  "proc-macro2",
- "syn 2.0.7",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -444,9 +444,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.52"
+version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d0e1ae9e836cc3beddd63db0df682593d7e2d3d891ae8c9083d2113e1744224"
+checksum = "dec2b086b7a862cf4de201096214fa870344cf922b2b30c167badb3af3195406"
 dependencies = [
  "unicode-ident",
 ]
@@ -474,9 +474,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.26"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
+checksum = "1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488"
 dependencies = [
  "proc-macro2",
 ]
@@ -570,9 +570,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.7"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a9a90d19f27bb60792270bb90225f96d97fc5705395134b2ca1dcbb3acc27f4"
+checksum = "32d41677bcbe24c20c52e7c70b0d8db04134c5d1066bf98662e2871ad200ea3e"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/bindgen-tests/Cargo.toml
+++ b/bindgen-tests/Cargo.toml
@@ -10,7 +10,7 @@ clap = { version = "4", features = ["derive"] }
 clap_complete = "4"
 diff = "0.1"
 shlex = "1"
-prettyplease = { version = "0.2.0" }
+prettyplease = { version = "0.2.7", features = ["verbatim"] }
 syn = { version = "2.0" }
 tempfile = "3"
 

--- a/bindgen-tests/tests/expectations/tests/16-byte-alignment.rs
+++ b/bindgen-tests/tests/expectations/tests/16-byte-alignment.rs
@@ -23,22 +23,34 @@ fn bindgen_test_layout_rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1 > (), 4usize,
-        concat!("Size of: ", stringify!(rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1))
+        ::std::mem::size_of::<rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1>(),
+        4usize,
+        concat!("Size of: ", stringify!(rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1 > (), 2usize,
-        concat!("Alignment of ", stringify!(rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1))
+        ::std::mem::align_of::<rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1>(),
+        2usize,
+        concat!("Alignment of ", stringify!(rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).dport) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ",
-        stringify!(rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1), "::", stringify!(dport))
+        unsafe { ::std::ptr::addr_of!((*ptr).dport) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1),
+            "::",
+            stringify!(dport),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).sport) as usize - ptr as usize }, 2usize,
-        concat!("Offset of field: ",
-        stringify!(rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1), "::", stringify!(sport))
+        unsafe { ::std::ptr::addr_of!((*ptr).sport) as usize - ptr as usize },
+        2usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1),
+            "::",
+            stringify!(sport),
+        ),
     );
 }
 #[test]
@@ -46,17 +58,24 @@ fn bindgen_test_layout_rte_ipv4_tuple__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<rte_ipv4_tuple__bindgen_ty_1> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < rte_ipv4_tuple__bindgen_ty_1 > (), 4usize,
-        concat!("Size of: ", stringify!(rte_ipv4_tuple__bindgen_ty_1))
+        ::std::mem::size_of::<rte_ipv4_tuple__bindgen_ty_1>(),
+        4usize,
+        concat!("Size of: ", stringify!(rte_ipv4_tuple__bindgen_ty_1)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < rte_ipv4_tuple__bindgen_ty_1 > (), 4usize,
-        concat!("Alignment of ", stringify!(rte_ipv4_tuple__bindgen_ty_1))
+        ::std::mem::align_of::<rte_ipv4_tuple__bindgen_ty_1>(),
+        4usize,
+        concat!("Alignment of ", stringify!(rte_ipv4_tuple__bindgen_ty_1)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).sctp_tag) as usize - ptr as usize },
-        0usize, concat!("Offset of field: ", stringify!(rte_ipv4_tuple__bindgen_ty_1),
-        "::", stringify!(sctp_tag))
+        unsafe { ::std::ptr::addr_of!((*ptr).sctp_tag) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_ipv4_tuple__bindgen_ty_1),
+            "::",
+            stringify!(sctp_tag),
+        ),
     );
 }
 impl Default for rte_ipv4_tuple__bindgen_ty_1 {
@@ -73,22 +92,34 @@ fn bindgen_test_layout_rte_ipv4_tuple() {
     const UNINIT: ::std::mem::MaybeUninit<rte_ipv4_tuple> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < rte_ipv4_tuple > (), 12usize, concat!("Size of: ",
-        stringify!(rte_ipv4_tuple))
+        ::std::mem::size_of::<rte_ipv4_tuple>(),
+        12usize,
+        concat!("Size of: ", stringify!(rte_ipv4_tuple)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < rte_ipv4_tuple > (), 4usize, concat!("Alignment of ",
-        stringify!(rte_ipv4_tuple))
+        ::std::mem::align_of::<rte_ipv4_tuple>(),
+        4usize,
+        concat!("Alignment of ", stringify!(rte_ipv4_tuple)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).src_addr) as usize - ptr as usize },
-        0usize, concat!("Offset of field: ", stringify!(rte_ipv4_tuple), "::",
-        stringify!(src_addr))
+        unsafe { ::std::ptr::addr_of!((*ptr).src_addr) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_ipv4_tuple),
+            "::",
+            stringify!(src_addr),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).dst_addr) as usize - ptr as usize },
-        4usize, concat!("Offset of field: ", stringify!(rte_ipv4_tuple), "::",
-        stringify!(dst_addr))
+        unsafe { ::std::ptr::addr_of!((*ptr).dst_addr) as usize - ptr as usize },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_ipv4_tuple),
+            "::",
+            stringify!(dst_addr),
+        ),
     );
 }
 impl Default for rte_ipv4_tuple {
@@ -124,22 +155,34 @@ fn bindgen_test_layout_rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1 > (), 4usize,
-        concat!("Size of: ", stringify!(rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1))
+        ::std::mem::size_of::<rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1>(),
+        4usize,
+        concat!("Size of: ", stringify!(rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1 > (), 2usize,
-        concat!("Alignment of ", stringify!(rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1))
+        ::std::mem::align_of::<rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1>(),
+        2usize,
+        concat!("Alignment of ", stringify!(rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).dport) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ",
-        stringify!(rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1), "::", stringify!(dport))
+        unsafe { ::std::ptr::addr_of!((*ptr).dport) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1),
+            "::",
+            stringify!(dport),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).sport) as usize - ptr as usize }, 2usize,
-        concat!("Offset of field: ",
-        stringify!(rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1), "::", stringify!(sport))
+        unsafe { ::std::ptr::addr_of!((*ptr).sport) as usize - ptr as usize },
+        2usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1),
+            "::",
+            stringify!(sport),
+        ),
     );
 }
 #[test]
@@ -147,17 +190,24 @@ fn bindgen_test_layout_rte_ipv6_tuple__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<rte_ipv6_tuple__bindgen_ty_1> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < rte_ipv6_tuple__bindgen_ty_1 > (), 4usize,
-        concat!("Size of: ", stringify!(rte_ipv6_tuple__bindgen_ty_1))
+        ::std::mem::size_of::<rte_ipv6_tuple__bindgen_ty_1>(),
+        4usize,
+        concat!("Size of: ", stringify!(rte_ipv6_tuple__bindgen_ty_1)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < rte_ipv6_tuple__bindgen_ty_1 > (), 4usize,
-        concat!("Alignment of ", stringify!(rte_ipv6_tuple__bindgen_ty_1))
+        ::std::mem::align_of::<rte_ipv6_tuple__bindgen_ty_1>(),
+        4usize,
+        concat!("Alignment of ", stringify!(rte_ipv6_tuple__bindgen_ty_1)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).sctp_tag) as usize - ptr as usize },
-        0usize, concat!("Offset of field: ", stringify!(rte_ipv6_tuple__bindgen_ty_1),
-        "::", stringify!(sctp_tag))
+        unsafe { ::std::ptr::addr_of!((*ptr).sctp_tag) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_ipv6_tuple__bindgen_ty_1),
+            "::",
+            stringify!(sctp_tag),
+        ),
     );
 }
 impl Default for rte_ipv6_tuple__bindgen_ty_1 {
@@ -174,22 +224,34 @@ fn bindgen_test_layout_rte_ipv6_tuple() {
     const UNINIT: ::std::mem::MaybeUninit<rte_ipv6_tuple> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < rte_ipv6_tuple > (), 36usize, concat!("Size of: ",
-        stringify!(rte_ipv6_tuple))
+        ::std::mem::size_of::<rte_ipv6_tuple>(),
+        36usize,
+        concat!("Size of: ", stringify!(rte_ipv6_tuple)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < rte_ipv6_tuple > (), 4usize, concat!("Alignment of ",
-        stringify!(rte_ipv6_tuple))
+        ::std::mem::align_of::<rte_ipv6_tuple>(),
+        4usize,
+        concat!("Alignment of ", stringify!(rte_ipv6_tuple)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).src_addr) as usize - ptr as usize },
-        0usize, concat!("Offset of field: ", stringify!(rte_ipv6_tuple), "::",
-        stringify!(src_addr))
+        unsafe { ::std::ptr::addr_of!((*ptr).src_addr) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_ipv6_tuple),
+            "::",
+            stringify!(src_addr),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).dst_addr) as usize - ptr as usize },
-        16usize, concat!("Offset of field: ", stringify!(rte_ipv6_tuple), "::",
-        stringify!(dst_addr))
+        unsafe { ::std::ptr::addr_of!((*ptr).dst_addr) as usize - ptr as usize },
+        16usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_ipv6_tuple),
+            "::",
+            stringify!(dst_addr),
+        ),
     );
 }
 impl Default for rte_ipv6_tuple {
@@ -213,20 +275,24 @@ fn bindgen_test_layout_rte_thash_tuple() {
     const UNINIT: ::std::mem::MaybeUninit<rte_thash_tuple> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < rte_thash_tuple > (), 48usize, concat!("Size of: ",
-        stringify!(rte_thash_tuple))
+        ::std::mem::size_of::<rte_thash_tuple>(),
+        48usize,
+        concat!("Size of: ", stringify!(rte_thash_tuple)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < rte_thash_tuple > (), 16usize, concat!("Alignment of ",
-        stringify!(rte_thash_tuple))
+        ::std::mem::align_of::<rte_thash_tuple>(),
+        16usize,
+        concat!("Alignment of ", stringify!(rte_thash_tuple)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).v4) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(rte_thash_tuple), "::", stringify!(v4))
+        unsafe { ::std::ptr::addr_of!((*ptr).v4) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(rte_thash_tuple), "::", stringify!(v4)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).v6) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(rte_thash_tuple), "::", stringify!(v6))
+        unsafe { ::std::ptr::addr_of!((*ptr).v6) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(rte_thash_tuple), "::", stringify!(v6)),
     );
 }
 impl Default for rte_thash_tuple {

--- a/bindgen-tests/tests/expectations/tests/16-byte-alignment_1_0.rs
+++ b/bindgen-tests/tests/expectations/tests/16-byte-alignment_1_0.rs
@@ -69,22 +69,34 @@ fn bindgen_test_layout_rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1 > (), 4usize,
-        concat!("Size of: ", stringify!(rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1))
+        ::std::mem::size_of::<rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1>(),
+        4usize,
+        concat!("Size of: ", stringify!(rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1 > (), 2usize,
-        concat!("Alignment of ", stringify!(rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1))
+        ::std::mem::align_of::<rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1>(),
+        2usize,
+        concat!("Alignment of ", stringify!(rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).dport) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ",
-        stringify!(rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1), "::", stringify!(dport))
+        unsafe { ::std::ptr::addr_of!((*ptr).dport) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1),
+            "::",
+            stringify!(dport),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).sport) as usize - ptr as usize }, 2usize,
-        concat!("Offset of field: ",
-        stringify!(rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1), "::", stringify!(sport))
+        unsafe { ::std::ptr::addr_of!((*ptr).sport) as usize - ptr as usize },
+        2usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1),
+            "::",
+            stringify!(sport),
+        ),
     );
 }
 impl Clone for rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1 {
@@ -97,17 +109,24 @@ fn bindgen_test_layout_rte_ipv4_tuple__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<rte_ipv4_tuple__bindgen_ty_1> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < rte_ipv4_tuple__bindgen_ty_1 > (), 4usize,
-        concat!("Size of: ", stringify!(rte_ipv4_tuple__bindgen_ty_1))
+        ::std::mem::size_of::<rte_ipv4_tuple__bindgen_ty_1>(),
+        4usize,
+        concat!("Size of: ", stringify!(rte_ipv4_tuple__bindgen_ty_1)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < rte_ipv4_tuple__bindgen_ty_1 > (), 4usize,
-        concat!("Alignment of ", stringify!(rte_ipv4_tuple__bindgen_ty_1))
+        ::std::mem::align_of::<rte_ipv4_tuple__bindgen_ty_1>(),
+        4usize,
+        concat!("Alignment of ", stringify!(rte_ipv4_tuple__bindgen_ty_1)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).sctp_tag) as usize - ptr as usize },
-        0usize, concat!("Offset of field: ", stringify!(rte_ipv4_tuple__bindgen_ty_1),
-        "::", stringify!(sctp_tag))
+        unsafe { ::std::ptr::addr_of!((*ptr).sctp_tag) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_ipv4_tuple__bindgen_ty_1),
+            "::",
+            stringify!(sctp_tag),
+        ),
     );
 }
 impl Clone for rte_ipv4_tuple__bindgen_ty_1 {
@@ -120,22 +139,34 @@ fn bindgen_test_layout_rte_ipv4_tuple() {
     const UNINIT: ::std::mem::MaybeUninit<rte_ipv4_tuple> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < rte_ipv4_tuple > (), 12usize, concat!("Size of: ",
-        stringify!(rte_ipv4_tuple))
+        ::std::mem::size_of::<rte_ipv4_tuple>(),
+        12usize,
+        concat!("Size of: ", stringify!(rte_ipv4_tuple)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < rte_ipv4_tuple > (), 4usize, concat!("Alignment of ",
-        stringify!(rte_ipv4_tuple))
+        ::std::mem::align_of::<rte_ipv4_tuple>(),
+        4usize,
+        concat!("Alignment of ", stringify!(rte_ipv4_tuple)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).src_addr) as usize - ptr as usize },
-        0usize, concat!("Offset of field: ", stringify!(rte_ipv4_tuple), "::",
-        stringify!(src_addr))
+        unsafe { ::std::ptr::addr_of!((*ptr).src_addr) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_ipv4_tuple),
+            "::",
+            stringify!(src_addr),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).dst_addr) as usize - ptr as usize },
-        4usize, concat!("Offset of field: ", stringify!(rte_ipv4_tuple), "::",
-        stringify!(dst_addr))
+        unsafe { ::std::ptr::addr_of!((*ptr).dst_addr) as usize - ptr as usize },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_ipv4_tuple),
+            "::",
+            stringify!(dst_addr),
+        ),
     );
 }
 impl Clone for rte_ipv4_tuple {
@@ -170,22 +201,34 @@ fn bindgen_test_layout_rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1 > (), 4usize,
-        concat!("Size of: ", stringify!(rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1))
+        ::std::mem::size_of::<rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1>(),
+        4usize,
+        concat!("Size of: ", stringify!(rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1 > (), 2usize,
-        concat!("Alignment of ", stringify!(rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1))
+        ::std::mem::align_of::<rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1>(),
+        2usize,
+        concat!("Alignment of ", stringify!(rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).dport) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ",
-        stringify!(rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1), "::", stringify!(dport))
+        unsafe { ::std::ptr::addr_of!((*ptr).dport) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1),
+            "::",
+            stringify!(dport),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).sport) as usize - ptr as usize }, 2usize,
-        concat!("Offset of field: ",
-        stringify!(rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1), "::", stringify!(sport))
+        unsafe { ::std::ptr::addr_of!((*ptr).sport) as usize - ptr as usize },
+        2usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1),
+            "::",
+            stringify!(sport),
+        ),
     );
 }
 impl Clone for rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1 {
@@ -198,17 +241,24 @@ fn bindgen_test_layout_rte_ipv6_tuple__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<rte_ipv6_tuple__bindgen_ty_1> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < rte_ipv6_tuple__bindgen_ty_1 > (), 4usize,
-        concat!("Size of: ", stringify!(rte_ipv6_tuple__bindgen_ty_1))
+        ::std::mem::size_of::<rte_ipv6_tuple__bindgen_ty_1>(),
+        4usize,
+        concat!("Size of: ", stringify!(rte_ipv6_tuple__bindgen_ty_1)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < rte_ipv6_tuple__bindgen_ty_1 > (), 4usize,
-        concat!("Alignment of ", stringify!(rte_ipv6_tuple__bindgen_ty_1))
+        ::std::mem::align_of::<rte_ipv6_tuple__bindgen_ty_1>(),
+        4usize,
+        concat!("Alignment of ", stringify!(rte_ipv6_tuple__bindgen_ty_1)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).sctp_tag) as usize - ptr as usize },
-        0usize, concat!("Offset of field: ", stringify!(rte_ipv6_tuple__bindgen_ty_1),
-        "::", stringify!(sctp_tag))
+        unsafe { ::std::ptr::addr_of!((*ptr).sctp_tag) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_ipv6_tuple__bindgen_ty_1),
+            "::",
+            stringify!(sctp_tag),
+        ),
     );
 }
 impl Clone for rte_ipv6_tuple__bindgen_ty_1 {
@@ -221,22 +271,34 @@ fn bindgen_test_layout_rte_ipv6_tuple() {
     const UNINIT: ::std::mem::MaybeUninit<rte_ipv6_tuple> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < rte_ipv6_tuple > (), 36usize, concat!("Size of: ",
-        stringify!(rte_ipv6_tuple))
+        ::std::mem::size_of::<rte_ipv6_tuple>(),
+        36usize,
+        concat!("Size of: ", stringify!(rte_ipv6_tuple)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < rte_ipv6_tuple > (), 4usize, concat!("Alignment of ",
-        stringify!(rte_ipv6_tuple))
+        ::std::mem::align_of::<rte_ipv6_tuple>(),
+        4usize,
+        concat!("Alignment of ", stringify!(rte_ipv6_tuple)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).src_addr) as usize - ptr as usize },
-        0usize, concat!("Offset of field: ", stringify!(rte_ipv6_tuple), "::",
-        stringify!(src_addr))
+        unsafe { ::std::ptr::addr_of!((*ptr).src_addr) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_ipv6_tuple),
+            "::",
+            stringify!(src_addr),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).dst_addr) as usize - ptr as usize },
-        16usize, concat!("Offset of field: ", stringify!(rte_ipv6_tuple), "::",
-        stringify!(dst_addr))
+        unsafe { ::std::ptr::addr_of!((*ptr).dst_addr) as usize - ptr as usize },
+        16usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_ipv6_tuple),
+            "::",
+            stringify!(dst_addr),
+        ),
     );
 }
 impl Clone for rte_ipv6_tuple {
@@ -256,16 +318,19 @@ fn bindgen_test_layout_rte_thash_tuple() {
     const UNINIT: ::std::mem::MaybeUninit<rte_thash_tuple> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < rte_thash_tuple > (), 48usize, concat!("Size of: ",
-        stringify!(rte_thash_tuple))
+        ::std::mem::size_of::<rte_thash_tuple>(),
+        48usize,
+        concat!("Size of: ", stringify!(rte_thash_tuple)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).v4) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(rte_thash_tuple), "::", stringify!(v4))
+        unsafe { ::std::ptr::addr_of!((*ptr).v4) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(rte_thash_tuple), "::", stringify!(v4)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).v6) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(rte_thash_tuple), "::", stringify!(v6))
+        unsafe { ::std::ptr::addr_of!((*ptr).v6) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(rte_thash_tuple), "::", stringify!(v6)),
     );
 }
 impl Clone for rte_thash_tuple {

--- a/bindgen-tests/tests/expectations/tests/accessors.rs
+++ b/bindgen-tests/tests/expectations/tests/accessors.rs
@@ -15,32 +15,56 @@ fn bindgen_test_layout_SomeAccessors() {
     const UNINIT: ::std::mem::MaybeUninit<SomeAccessors> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < SomeAccessors > (), 16usize, concat!("Size of: ",
-        stringify!(SomeAccessors))
+        ::std::mem::size_of::<SomeAccessors>(),
+        16usize,
+        concat!("Size of: ", stringify!(SomeAccessors)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < SomeAccessors > (), 4usize, concat!("Alignment of ",
-        stringify!(SomeAccessors))
+        ::std::mem::align_of::<SomeAccessors>(),
+        4usize,
+        concat!("Alignment of ", stringify!(SomeAccessors)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).mNoAccessor) as usize - ptr as usize },
-        0usize, concat!("Offset of field: ", stringify!(SomeAccessors), "::",
-        stringify!(mNoAccessor))
+        unsafe { ::std::ptr::addr_of!((*ptr).mNoAccessor) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(SomeAccessors),
+            "::",
+            stringify!(mNoAccessor),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).mBothAccessors) as usize - ptr as usize },
-        4usize, concat!("Offset of field: ", stringify!(SomeAccessors), "::",
-        stringify!(mBothAccessors))
+        unsafe { ::std::ptr::addr_of!((*ptr).mBothAccessors) as usize - ptr as usize },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(SomeAccessors),
+            "::",
+            stringify!(mBothAccessors),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).mUnsafeAccessors) as usize - ptr as usize
-        }, 8usize, concat!("Offset of field: ", stringify!(SomeAccessors), "::",
-        stringify!(mUnsafeAccessors))
+        unsafe { ::std::ptr::addr_of!((*ptr).mUnsafeAccessors) as usize - ptr as usize },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(SomeAccessors),
+            "::",
+            stringify!(mUnsafeAccessors),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).mImmutableAccessor) as usize - ptr as usize
-        }, 12usize, concat!("Offset of field: ", stringify!(SomeAccessors), "::",
-        stringify!(mImmutableAccessor))
+        unsafe {
+            ::std::ptr::addr_of!((*ptr).mImmutableAccessor) as usize - ptr as usize
+        },
+        12usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(SomeAccessors),
+            "::",
+            stringify!(mImmutableAccessor),
+        ),
     );
 }
 impl SomeAccessors {
@@ -77,22 +101,36 @@ fn bindgen_test_layout_AllAccessors() {
     const UNINIT: ::std::mem::MaybeUninit<AllAccessors> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < AllAccessors > (), 8usize, concat!("Size of: ",
-        stringify!(AllAccessors))
+        ::std::mem::size_of::<AllAccessors>(),
+        8usize,
+        concat!("Size of: ", stringify!(AllAccessors)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < AllAccessors > (), 4usize, concat!("Alignment of ",
-        stringify!(AllAccessors))
+        ::std::mem::align_of::<AllAccessors>(),
+        4usize,
+        concat!("Alignment of ", stringify!(AllAccessors)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).mBothAccessors) as usize - ptr as usize },
-        0usize, concat!("Offset of field: ", stringify!(AllAccessors), "::",
-        stringify!(mBothAccessors))
+        unsafe { ::std::ptr::addr_of!((*ptr).mBothAccessors) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(AllAccessors),
+            "::",
+            stringify!(mBothAccessors),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).mAlsoBothAccessors) as usize - ptr as usize
-        }, 4usize, concat!("Offset of field: ", stringify!(AllAccessors), "::",
-        stringify!(mAlsoBothAccessors))
+        unsafe {
+            ::std::ptr::addr_of!((*ptr).mAlsoBothAccessors) as usize - ptr as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(AllAccessors),
+            "::",
+            stringify!(mAlsoBothAccessors),
+        ),
     );
 }
 impl AllAccessors {
@@ -125,22 +163,36 @@ fn bindgen_test_layout_AllUnsafeAccessors() {
     const UNINIT: ::std::mem::MaybeUninit<AllUnsafeAccessors> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < AllUnsafeAccessors > (), 8usize, concat!("Size of: ",
-        stringify!(AllUnsafeAccessors))
+        ::std::mem::size_of::<AllUnsafeAccessors>(),
+        8usize,
+        concat!("Size of: ", stringify!(AllUnsafeAccessors)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < AllUnsafeAccessors > (), 4usize,
-        concat!("Alignment of ", stringify!(AllUnsafeAccessors))
+        ::std::mem::align_of::<AllUnsafeAccessors>(),
+        4usize,
+        concat!("Alignment of ", stringify!(AllUnsafeAccessors)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).mBothAccessors) as usize - ptr as usize },
-        0usize, concat!("Offset of field: ", stringify!(AllUnsafeAccessors), "::",
-        stringify!(mBothAccessors))
+        unsafe { ::std::ptr::addr_of!((*ptr).mBothAccessors) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(AllUnsafeAccessors),
+            "::",
+            stringify!(mBothAccessors),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).mAlsoBothAccessors) as usize - ptr as usize
-        }, 4usize, concat!("Offset of field: ", stringify!(AllUnsafeAccessors), "::",
-        stringify!(mAlsoBothAccessors))
+        unsafe {
+            ::std::ptr::addr_of!((*ptr).mAlsoBothAccessors) as usize - ptr as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(AllUnsafeAccessors),
+            "::",
+            stringify!(mAlsoBothAccessors),
+        ),
     );
 }
 impl AllUnsafeAccessors {
@@ -178,32 +230,56 @@ fn bindgen_test_layout_ContradictAccessors() {
     const UNINIT: ::std::mem::MaybeUninit<ContradictAccessors> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < ContradictAccessors > (), 16usize, concat!("Size of: ",
-        stringify!(ContradictAccessors))
+        ::std::mem::size_of::<ContradictAccessors>(),
+        16usize,
+        concat!("Size of: ", stringify!(ContradictAccessors)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < ContradictAccessors > (), 4usize,
-        concat!("Alignment of ", stringify!(ContradictAccessors))
+        ::std::mem::align_of::<ContradictAccessors>(),
+        4usize,
+        concat!("Alignment of ", stringify!(ContradictAccessors)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).mBothAccessors) as usize - ptr as usize },
-        0usize, concat!("Offset of field: ", stringify!(ContradictAccessors), "::",
-        stringify!(mBothAccessors))
+        unsafe { ::std::ptr::addr_of!((*ptr).mBothAccessors) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ContradictAccessors),
+            "::",
+            stringify!(mBothAccessors),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).mNoAccessors) as usize - ptr as usize },
-        4usize, concat!("Offset of field: ", stringify!(ContradictAccessors), "::",
-        stringify!(mNoAccessors))
+        unsafe { ::std::ptr::addr_of!((*ptr).mNoAccessors) as usize - ptr as usize },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ContradictAccessors),
+            "::",
+            stringify!(mNoAccessors),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).mUnsafeAccessors) as usize - ptr as usize
-        }, 8usize, concat!("Offset of field: ", stringify!(ContradictAccessors), "::",
-        stringify!(mUnsafeAccessors))
+        unsafe { ::std::ptr::addr_of!((*ptr).mUnsafeAccessors) as usize - ptr as usize },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ContradictAccessors),
+            "::",
+            stringify!(mUnsafeAccessors),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).mImmutableAccessor) as usize - ptr as usize
-        }, 12usize, concat!("Offset of field: ", stringify!(ContradictAccessors), "::",
-        stringify!(mImmutableAccessor))
+        unsafe {
+            ::std::ptr::addr_of!((*ptr).mImmutableAccessor) as usize - ptr as usize
+        },
+        12usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ContradictAccessors),
+            "::",
+            stringify!(mImmutableAccessor),
+        ),
     );
 }
 impl ContradictAccessors {
@@ -239,17 +315,19 @@ fn bindgen_test_layout_Replaced() {
     const UNINIT: ::std::mem::MaybeUninit<Replaced> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < Replaced > (), 4usize, concat!("Size of: ",
-        stringify!(Replaced))
+        ::std::mem::size_of::<Replaced>(),
+        4usize,
+        concat!("Size of: ", stringify!(Replaced)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Replaced > (), 4usize, concat!("Alignment of ",
-        stringify!(Replaced))
+        ::std::mem::align_of::<Replaced>(),
+        4usize,
+        concat!("Alignment of ", stringify!(Replaced)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).mAccessor) as usize - ptr as usize },
-        0usize, concat!("Offset of field: ", stringify!(Replaced), "::",
-        stringify!(mAccessor))
+        unsafe { ::std::ptr::addr_of!((*ptr).mAccessor) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(Replaced), "::", stringify!(mAccessor)),
     );
 }
 impl Replaced {
@@ -273,17 +351,19 @@ fn bindgen_test_layout_Wrapper() {
     const UNINIT: ::std::mem::MaybeUninit<Wrapper> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < Wrapper > (), 4usize, concat!("Size of: ",
-        stringify!(Wrapper))
+        ::std::mem::size_of::<Wrapper>(),
+        4usize,
+        concat!("Size of: ", stringify!(Wrapper)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Wrapper > (), 4usize, concat!("Alignment of ",
-        stringify!(Wrapper))
+        ::std::mem::align_of::<Wrapper>(),
+        4usize,
+        concat!("Alignment of ", stringify!(Wrapper)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).mReplaced) as usize - ptr as usize },
-        0usize, concat!("Offset of field: ", stringify!(Wrapper), "::",
-        stringify!(mReplaced))
+        unsafe { ::std::ptr::addr_of!((*ptr).mReplaced) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(Wrapper), "::", stringify!(mReplaced)),
     );
 }
 impl Wrapper {

--- a/bindgen-tests/tests/expectations/tests/allowlist-file.rs
+++ b/bindgen-tests/tests/expectations/tests/allowlist-file.rs
@@ -15,12 +15,14 @@ pub struct someClass {
 #[test]
 fn bindgen_test_layout_someClass() {
     assert_eq!(
-        ::std::mem::size_of:: < someClass > (), 1usize, concat!("Size of: ",
-        stringify!(someClass))
+        ::std::mem::size_of::<someClass>(),
+        1usize,
+        concat!("Size of: ", stringify!(someClass)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < someClass > (), 1usize, concat!("Alignment of ",
-        stringify!(someClass))
+        ::std::mem::align_of::<someClass>(),
+        1usize,
+        concat!("Alignment of ", stringify!(someClass)),
     );
 }
 extern "C" {
@@ -50,17 +52,24 @@ fn bindgen_test_layout_StructWithAllowlistedDefinition() {
     const UNINIT: ::std::mem::MaybeUninit<StructWithAllowlistedDefinition> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < StructWithAllowlistedDefinition > (), 8usize,
-        concat!("Size of: ", stringify!(StructWithAllowlistedDefinition))
+        ::std::mem::size_of::<StructWithAllowlistedDefinition>(),
+        8usize,
+        concat!("Size of: ", stringify!(StructWithAllowlistedDefinition)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < StructWithAllowlistedDefinition > (), 8usize,
-        concat!("Alignment of ", stringify!(StructWithAllowlistedDefinition))
+        ::std::mem::align_of::<StructWithAllowlistedDefinition>(),
+        8usize,
+        concat!("Alignment of ", stringify!(StructWithAllowlistedDefinition)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).other) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(StructWithAllowlistedDefinition), "::",
-        stringify!(other))
+        unsafe { ::std::ptr::addr_of!((*ptr).other) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(StructWithAllowlistedDefinition),
+            "::",
+            stringify!(other),
+        ),
     );
 }
 impl Default for StructWithAllowlistedDefinition {
@@ -82,17 +91,24 @@ fn bindgen_test_layout_StructWithAllowlistedFwdDecl() {
     const UNINIT: ::std::mem::MaybeUninit<StructWithAllowlistedFwdDecl> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < StructWithAllowlistedFwdDecl > (), 4usize,
-        concat!("Size of: ", stringify!(StructWithAllowlistedFwdDecl))
+        ::std::mem::size_of::<StructWithAllowlistedFwdDecl>(),
+        4usize,
+        concat!("Size of: ", stringify!(StructWithAllowlistedFwdDecl)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < StructWithAllowlistedFwdDecl > (), 4usize,
-        concat!("Alignment of ", stringify!(StructWithAllowlistedFwdDecl))
+        ::std::mem::align_of::<StructWithAllowlistedFwdDecl>(),
+        4usize,
+        concat!("Alignment of ", stringify!(StructWithAllowlistedFwdDecl)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).b) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(StructWithAllowlistedFwdDecl), "::",
-        stringify!(b))
+        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(StructWithAllowlistedFwdDecl),
+            "::",
+            stringify!(b),
+        ),
     );
 }
 #[repr(C)]
@@ -105,15 +121,18 @@ fn bindgen_test_layout_AllowlistMe() {
     const UNINIT: ::std::mem::MaybeUninit<AllowlistMe> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < AllowlistMe > (), 4usize, concat!("Size of: ",
-        stringify!(AllowlistMe))
+        ::std::mem::size_of::<AllowlistMe>(),
+        4usize,
+        concat!("Size of: ", stringify!(AllowlistMe)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < AllowlistMe > (), 4usize, concat!("Alignment of ",
-        stringify!(AllowlistMe))
+        ::std::mem::align_of::<AllowlistMe>(),
+        4usize,
+        concat!("Alignment of ", stringify!(AllowlistMe)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).foo) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(AllowlistMe), "::", stringify!(foo))
+        unsafe { ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(AllowlistMe), "::", stringify!(foo)),
     );
 }

--- a/bindgen-tests/tests/expectations/tests/allowlist-namespaces-basic.rs
+++ b/bindgen-tests/tests/expectations/tests/allowlist-namespaces-basic.rs
@@ -17,12 +17,14 @@ pub mod root {
             #[test]
             fn bindgen_test_layout_Helper() {
                 assert_eq!(
-                    ::std::mem::size_of:: < Helper > (), 1usize, concat!("Size of: ",
-                    stringify!(Helper))
+                    ::std::mem::size_of::<Helper>(),
+                    1usize,
+                    concat!("Size of: ", stringify!(Helper)),
                 );
                 assert_eq!(
-                    ::std::mem::align_of:: < Helper > (), 1usize,
-                    concat!("Alignment of ", stringify!(Helper))
+                    ::std::mem::align_of::<Helper>(),
+                    1usize,
+                    concat!("Alignment of ", stringify!(Helper)),
                 );
             }
         }

--- a/bindgen-tests/tests/expectations/tests/allowlist-namespaces.rs
+++ b/bindgen-tests/tests/expectations/tests/allowlist-namespaces.rs
@@ -17,12 +17,14 @@ pub mod root {
             #[test]
             fn bindgen_test_layout_Helper() {
                 assert_eq!(
-                    ::std::mem::size_of:: < Helper > (), 1usize, concat!("Size of: ",
-                    stringify!(Helper))
+                    ::std::mem::size_of::<Helper>(),
+                    1usize,
+                    concat!("Size of: ", stringify!(Helper)),
                 );
                 assert_eq!(
-                    ::std::mem::align_of:: < Helper > (), 1usize,
-                    concat!("Alignment of ", stringify!(Helper))
+                    ::std::mem::align_of::<Helper>(),
+                    1usize,
+                    concat!("Alignment of ", stringify!(Helper)),
                 );
             }
         }
@@ -36,17 +38,19 @@ pub mod root {
             const UNINIT: ::std::mem::MaybeUninit<Test> = ::std::mem::MaybeUninit::uninit();
             let ptr = UNINIT.as_ptr();
             assert_eq!(
-                ::std::mem::size_of:: < Test > (), 1usize, concat!("Size of: ",
-                stringify!(Test))
+                ::std::mem::size_of::<Test>(),
+                1usize,
+                concat!("Size of: ", stringify!(Test)),
             );
             assert_eq!(
-                ::std::mem::align_of:: < Test > (), 1usize, concat!("Alignment of ",
-                stringify!(Test))
+                ::std::mem::align_of::<Test>(),
+                1usize,
+                concat!("Alignment of ", stringify!(Test)),
             );
             assert_eq!(
-                unsafe { ::std::ptr::addr_of!((* ptr).helper) as usize - ptr as usize },
-                0usize, concat!("Offset of field: ", stringify!(Test), "::",
-                stringify!(helper))
+                unsafe { ::std::ptr::addr_of!((*ptr).helper) as usize - ptr as usize },
+                0usize,
+                concat!("Offset of field: ", stringify!(Test), "::", stringify!(helper)),
             );
         }
     }

--- a/bindgen-tests/tests/expectations/tests/allowlisted-item-references-no-hash.rs
+++ b/bindgen-tests/tests/expectations/tests/allowlisted-item-references-no-hash.rs
@@ -7,12 +7,14 @@ pub struct NoHash {
 #[test]
 fn bindgen_test_layout_NoHash() {
     assert_eq!(
-        ::std::mem::size_of:: < NoHash > (), 1usize, concat!("Size of: ",
-        stringify!(NoHash))
+        ::std::mem::size_of::<NoHash>(),
+        1usize,
+        concat!("Size of: ", stringify!(NoHash)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < NoHash > (), 1usize, concat!("Alignment of ",
-        stringify!(NoHash))
+        ::std::mem::align_of::<NoHash>(),
+        1usize,
+        concat!("Alignment of ", stringify!(NoHash)),
     );
 }
 #[repr(C)]
@@ -25,15 +27,18 @@ fn bindgen_test_layout_AllowlistMe() {
     const UNINIT: ::std::mem::MaybeUninit<AllowlistMe> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < AllowlistMe > (), 1usize, concat!("Size of: ",
-        stringify!(AllowlistMe))
+        ::std::mem::size_of::<AllowlistMe>(),
+        1usize,
+        concat!("Size of: ", stringify!(AllowlistMe)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < AllowlistMe > (), 1usize, concat!("Alignment of ",
-        stringify!(AllowlistMe))
+        ::std::mem::align_of::<AllowlistMe>(),
+        1usize,
+        concat!("Alignment of ", stringify!(AllowlistMe)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).a) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(AllowlistMe), "::", stringify!(a))
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(AllowlistMe), "::", stringify!(a)),
     );
 }

--- a/bindgen-tests/tests/expectations/tests/allowlisted-item-references-no-partialeq.rs
+++ b/bindgen-tests/tests/expectations/tests/allowlisted-item-references-no-partialeq.rs
@@ -7,12 +7,14 @@ pub struct NoPartialEq {
 #[test]
 fn bindgen_test_layout_NoPartialEq() {
     assert_eq!(
-        ::std::mem::size_of:: < NoPartialEq > (), 1usize, concat!("Size of: ",
-        stringify!(NoPartialEq))
+        ::std::mem::size_of::<NoPartialEq>(),
+        1usize,
+        concat!("Size of: ", stringify!(NoPartialEq)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < NoPartialEq > (), 1usize, concat!("Alignment of ",
-        stringify!(NoPartialEq))
+        ::std::mem::align_of::<NoPartialEq>(),
+        1usize,
+        concat!("Alignment of ", stringify!(NoPartialEq)),
     );
 }
 #[repr(C)]
@@ -25,15 +27,18 @@ fn bindgen_test_layout_AllowlistMe() {
     const UNINIT: ::std::mem::MaybeUninit<AllowlistMe> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < AllowlistMe > (), 1usize, concat!("Size of: ",
-        stringify!(AllowlistMe))
+        ::std::mem::size_of::<AllowlistMe>(),
+        1usize,
+        concat!("Size of: ", stringify!(AllowlistMe)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < AllowlistMe > (), 1usize, concat!("Alignment of ",
-        stringify!(AllowlistMe))
+        ::std::mem::align_of::<AllowlistMe>(),
+        1usize,
+        concat!("Alignment of ", stringify!(AllowlistMe)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).a) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(AllowlistMe), "::", stringify!(a))
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(AllowlistMe), "::", stringify!(a)),
     );
 }

--- a/bindgen-tests/tests/expectations/tests/allowlisted_item_references_no_copy.rs
+++ b/bindgen-tests/tests/expectations/tests/allowlisted_item_references_no_copy.rs
@@ -7,12 +7,14 @@ pub struct NoCopy {
 #[test]
 fn bindgen_test_layout_NoCopy() {
     assert_eq!(
-        ::std::mem::size_of:: < NoCopy > (), 1usize, concat!("Size of: ",
-        stringify!(NoCopy))
+        ::std::mem::size_of::<NoCopy>(),
+        1usize,
+        concat!("Size of: ", stringify!(NoCopy)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < NoCopy > (), 1usize, concat!("Alignment of ",
-        stringify!(NoCopy))
+        ::std::mem::align_of::<NoCopy>(),
+        1usize,
+        concat!("Alignment of ", stringify!(NoCopy)),
     );
 }
 #[repr(C)]
@@ -25,15 +27,18 @@ fn bindgen_test_layout_AllowlistMe() {
     const UNINIT: ::std::mem::MaybeUninit<AllowlistMe> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < AllowlistMe > (), 1usize, concat!("Size of: ",
-        stringify!(AllowlistMe))
+        ::std::mem::size_of::<AllowlistMe>(),
+        1usize,
+        concat!("Size of: ", stringify!(AllowlistMe)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < AllowlistMe > (), 1usize, concat!("Alignment of ",
-        stringify!(AllowlistMe))
+        ::std::mem::align_of::<AllowlistMe>(),
+        1usize,
+        concat!("Alignment of ", stringify!(AllowlistMe)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).a) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(AllowlistMe), "::", stringify!(a))
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(AllowlistMe), "::", stringify!(a)),
     );
 }

--- a/bindgen-tests/tests/expectations/tests/annotation_hide.rs
+++ b/bindgen-tests/tests/expectations/tests/annotation_hide.rs
@@ -8,11 +8,11 @@ pub struct D {
 }
 #[test]
 fn bindgen_test_layout_D() {
+    assert_eq!(::std::mem::size_of::<D>(), 4usize, concat!("Size of: ", stringify!(D)));
     assert_eq!(
-        ::std::mem::size_of:: < D > (), 4usize, concat!("Size of: ", stringify!(D))
-    );
-    assert_eq!(
-        ::std::mem::align_of:: < D > (), 4usize, concat!("Alignment of ", stringify!(D))
+        ::std::mem::align_of::<D>(),
+        4usize,
+        concat!("Alignment of ", stringify!(D)),
     );
 }
 #[repr(C)]
@@ -25,15 +25,18 @@ fn bindgen_test_layout_NotAnnotated() {
     const UNINIT: ::std::mem::MaybeUninit<NotAnnotated> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < NotAnnotated > (), 4usize, concat!("Size of: ",
-        stringify!(NotAnnotated))
+        ::std::mem::size_of::<NotAnnotated>(),
+        4usize,
+        concat!("Size of: ", stringify!(NotAnnotated)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < NotAnnotated > (), 4usize, concat!("Alignment of ",
-        stringify!(NotAnnotated))
+        ::std::mem::align_of::<NotAnnotated>(),
+        4usize,
+        concat!("Alignment of ", stringify!(NotAnnotated)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).f) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(NotAnnotated), "::", stringify!(f))
+        unsafe { ::std::ptr::addr_of!((*ptr).f) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(NotAnnotated), "::", stringify!(f)),
     );
 }

--- a/bindgen-tests/tests/expectations/tests/anon-fields-prefix.rs
+++ b/bindgen-tests/tests/expectations/tests/anon-fields-prefix.rs
@@ -18,27 +18,44 @@ fn bindgen_test_layout_color__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<color__bindgen_ty_1> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < color__bindgen_ty_1 > (), 3usize, concat!("Size of: ",
-        stringify!(color__bindgen_ty_1))
+        ::std::mem::size_of::<color__bindgen_ty_1>(),
+        3usize,
+        concat!("Size of: ", stringify!(color__bindgen_ty_1)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < color__bindgen_ty_1 > (), 1usize,
-        concat!("Alignment of ", stringify!(color__bindgen_ty_1))
+        ::std::mem::align_of::<color__bindgen_ty_1>(),
+        1usize,
+        concat!("Alignment of ", stringify!(color__bindgen_ty_1)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).r) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(color__bindgen_ty_1), "::",
-        stringify!(r))
+        unsafe { ::std::ptr::addr_of!((*ptr).r) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(color__bindgen_ty_1),
+            "::",
+            stringify!(r),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).g) as usize - ptr as usize }, 1usize,
-        concat!("Offset of field: ", stringify!(color__bindgen_ty_1), "::",
-        stringify!(g))
+        unsafe { ::std::ptr::addr_of!((*ptr).g) as usize - ptr as usize },
+        1usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(color__bindgen_ty_1),
+            "::",
+            stringify!(g),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).b) as usize - ptr as usize }, 2usize,
-        concat!("Offset of field: ", stringify!(color__bindgen_ty_1), "::",
-        stringify!(b))
+        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
+        2usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(color__bindgen_ty_1),
+            "::",
+            stringify!(b),
+        ),
     );
 }
 #[repr(C)]
@@ -53,27 +70,44 @@ fn bindgen_test_layout_color__bindgen_ty_2() {
     const UNINIT: ::std::mem::MaybeUninit<color__bindgen_ty_2> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < color__bindgen_ty_2 > (), 3usize, concat!("Size of: ",
-        stringify!(color__bindgen_ty_2))
+        ::std::mem::size_of::<color__bindgen_ty_2>(),
+        3usize,
+        concat!("Size of: ", stringify!(color__bindgen_ty_2)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < color__bindgen_ty_2 > (), 1usize,
-        concat!("Alignment of ", stringify!(color__bindgen_ty_2))
+        ::std::mem::align_of::<color__bindgen_ty_2>(),
+        1usize,
+        concat!("Alignment of ", stringify!(color__bindgen_ty_2)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).y) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(color__bindgen_ty_2), "::",
-        stringify!(y))
+        unsafe { ::std::ptr::addr_of!((*ptr).y) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(color__bindgen_ty_2),
+            "::",
+            stringify!(y),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).u) as usize - ptr as usize }, 1usize,
-        concat!("Offset of field: ", stringify!(color__bindgen_ty_2), "::",
-        stringify!(u))
+        unsafe { ::std::ptr::addr_of!((*ptr).u) as usize - ptr as usize },
+        1usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(color__bindgen_ty_2),
+            "::",
+            stringify!(u),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).v) as usize - ptr as usize }, 2usize,
-        concat!("Offset of field: ", stringify!(color__bindgen_ty_2), "::",
-        stringify!(v))
+        unsafe { ::std::ptr::addr_of!((*ptr).v) as usize - ptr as usize },
+        2usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(color__bindgen_ty_2),
+            "::",
+            stringify!(v),
+        ),
     );
 }
 #[test]
@@ -81,16 +115,19 @@ fn bindgen_test_layout_color() {
     const UNINIT: ::std::mem::MaybeUninit<color> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < color > (), 3usize, concat!("Size of: ",
-        stringify!(color))
+        ::std::mem::size_of::<color>(),
+        3usize,
+        concat!("Size of: ", stringify!(color)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < color > (), 1usize, concat!("Alignment of ",
-        stringify!(color))
+        ::std::mem::align_of::<color>(),
+        1usize,
+        concat!("Alignment of ", stringify!(color)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).v3) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(color), "::", stringify!(v3))
+        unsafe { ::std::ptr::addr_of!((*ptr).v3) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(color), "::", stringify!(v3)),
     );
 }
 impl Default for color {

--- a/bindgen-tests/tests/expectations/tests/anon_enum.rs
+++ b/bindgen-tests/tests/expectations/tests/anon_enum.rs
@@ -16,19 +16,24 @@ fn bindgen_test_layout_Test() {
     const UNINIT: ::std::mem::MaybeUninit<Test> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < Test > (), 8usize, concat!("Size of: ", stringify!(Test))
+        ::std::mem::size_of::<Test>(),
+        8usize,
+        concat!("Size of: ", stringify!(Test)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Test > (), 4usize, concat!("Alignment of ",
-        stringify!(Test))
+        ::std::mem::align_of::<Test>(),
+        4usize,
+        concat!("Alignment of ", stringify!(Test)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).foo) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(Test), "::", stringify!(foo))
+        unsafe { ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(Test), "::", stringify!(foo)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).bar) as usize - ptr as usize }, 4usize,
-        concat!("Offset of field: ", stringify!(Test), "::", stringify!(bar))
+        unsafe { ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize },
+        4usize,
+        concat!("Offset of field: ", stringify!(Test), "::", stringify!(bar)),
     );
 }
 #[repr(u32)]

--- a/bindgen-tests/tests/expectations/tests/anon_enum_trait.rs
+++ b/bindgen-tests/tests/expectations/tests/anon_enum_trait.rs
@@ -33,10 +33,13 @@ pub enum Foo__bindgen_ty_1 {
 #[test]
 fn bindgen_test_layout_Foo() {
     assert_eq!(
-        ::std::mem::size_of:: < Foo > (), 1usize, concat!("Size of: ", stringify!(Foo))
+        ::std::mem::size_of::<Foo>(),
+        1usize,
+        concat!("Size of: ", stringify!(Foo)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Foo > (), 1usize, concat!("Alignment of ",
-        stringify!(Foo))
+        ::std::mem::align_of::<Foo>(),
+        1usize,
+        concat!("Alignment of ", stringify!(Foo)),
     );
 }

--- a/bindgen-tests/tests/expectations/tests/anon_struct_in_union.rs
+++ b/bindgen-tests/tests/expectations/tests/anon_struct_in_union.rs
@@ -19,17 +19,24 @@ fn bindgen_test_layout_s__bindgen_ty_1_inner() {
     const UNINIT: ::std::mem::MaybeUninit<s__bindgen_ty_1_inner> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < s__bindgen_ty_1_inner > (), 4usize, concat!("Size of: ",
-        stringify!(s__bindgen_ty_1_inner))
+        ::std::mem::size_of::<s__bindgen_ty_1_inner>(),
+        4usize,
+        concat!("Size of: ", stringify!(s__bindgen_ty_1_inner)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < s__bindgen_ty_1_inner > (), 4usize,
-        concat!("Alignment of ", stringify!(s__bindgen_ty_1_inner))
+        ::std::mem::align_of::<s__bindgen_ty_1_inner>(),
+        4usize,
+        concat!("Alignment of ", stringify!(s__bindgen_ty_1_inner)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).b) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(s__bindgen_ty_1_inner), "::",
-        stringify!(b))
+        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(s__bindgen_ty_1_inner),
+            "::",
+            stringify!(b),
+        ),
     );
 }
 #[test]
@@ -37,17 +44,24 @@ fn bindgen_test_layout_s__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<s__bindgen_ty_1> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < s__bindgen_ty_1 > (), 4usize, concat!("Size of: ",
-        stringify!(s__bindgen_ty_1))
+        ::std::mem::size_of::<s__bindgen_ty_1>(),
+        4usize,
+        concat!("Size of: ", stringify!(s__bindgen_ty_1)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < s__bindgen_ty_1 > (), 4usize, concat!("Alignment of ",
-        stringify!(s__bindgen_ty_1))
+        ::std::mem::align_of::<s__bindgen_ty_1>(),
+        4usize,
+        concat!("Alignment of ", stringify!(s__bindgen_ty_1)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).field) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(s__bindgen_ty_1), "::",
-        stringify!(field))
+        unsafe { ::std::ptr::addr_of!((*ptr).field) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(s__bindgen_ty_1),
+            "::",
+            stringify!(field),
+        ),
     );
 }
 impl Default for s__bindgen_ty_1 {
@@ -63,15 +77,16 @@ impl Default for s__bindgen_ty_1 {
 fn bindgen_test_layout_s() {
     const UNINIT: ::std::mem::MaybeUninit<s> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
+    assert_eq!(::std::mem::size_of::<s>(), 4usize, concat!("Size of: ", stringify!(s)));
     assert_eq!(
-        ::std::mem::size_of:: < s > (), 4usize, concat!("Size of: ", stringify!(s))
+        ::std::mem::align_of::<s>(),
+        4usize,
+        concat!("Alignment of ", stringify!(s)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < s > (), 4usize, concat!("Alignment of ", stringify!(s))
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).u) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(s), "::", stringify!(u))
+        unsafe { ::std::ptr::addr_of!((*ptr).u) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(s), "::", stringify!(u)),
     );
 }
 impl Default for s {

--- a/bindgen-tests/tests/expectations/tests/anon_struct_in_union_1_0.rs
+++ b/bindgen-tests/tests/expectations/tests/anon_struct_in_union_1_0.rs
@@ -63,17 +63,24 @@ fn bindgen_test_layout_s__bindgen_ty_1_inner() {
     const UNINIT: ::std::mem::MaybeUninit<s__bindgen_ty_1_inner> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < s__bindgen_ty_1_inner > (), 4usize, concat!("Size of: ",
-        stringify!(s__bindgen_ty_1_inner))
+        ::std::mem::size_of::<s__bindgen_ty_1_inner>(),
+        4usize,
+        concat!("Size of: ", stringify!(s__bindgen_ty_1_inner)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < s__bindgen_ty_1_inner > (), 4usize,
-        concat!("Alignment of ", stringify!(s__bindgen_ty_1_inner))
+        ::std::mem::align_of::<s__bindgen_ty_1_inner>(),
+        4usize,
+        concat!("Alignment of ", stringify!(s__bindgen_ty_1_inner)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).b) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(s__bindgen_ty_1_inner), "::",
-        stringify!(b))
+        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(s__bindgen_ty_1_inner),
+            "::",
+            stringify!(b),
+        ),
     );
 }
 impl Clone for s__bindgen_ty_1_inner {
@@ -86,17 +93,24 @@ fn bindgen_test_layout_s__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<s__bindgen_ty_1> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < s__bindgen_ty_1 > (), 4usize, concat!("Size of: ",
-        stringify!(s__bindgen_ty_1))
+        ::std::mem::size_of::<s__bindgen_ty_1>(),
+        4usize,
+        concat!("Size of: ", stringify!(s__bindgen_ty_1)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < s__bindgen_ty_1 > (), 4usize, concat!("Alignment of ",
-        stringify!(s__bindgen_ty_1))
+        ::std::mem::align_of::<s__bindgen_ty_1>(),
+        4usize,
+        concat!("Alignment of ", stringify!(s__bindgen_ty_1)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).field) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(s__bindgen_ty_1), "::",
-        stringify!(field))
+        unsafe { ::std::ptr::addr_of!((*ptr).field) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(s__bindgen_ty_1),
+            "::",
+            stringify!(field),
+        ),
     );
 }
 impl Clone for s__bindgen_ty_1 {
@@ -108,15 +122,16 @@ impl Clone for s__bindgen_ty_1 {
 fn bindgen_test_layout_s() {
     const UNINIT: ::std::mem::MaybeUninit<s> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
+    assert_eq!(::std::mem::size_of::<s>(), 4usize, concat!("Size of: ", stringify!(s)));
     assert_eq!(
-        ::std::mem::size_of:: < s > (), 4usize, concat!("Size of: ", stringify!(s))
+        ::std::mem::align_of::<s>(),
+        4usize,
+        concat!("Alignment of ", stringify!(s)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < s > (), 4usize, concat!("Alignment of ", stringify!(s))
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).u) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(s), "::", stringify!(u))
+        unsafe { ::std::ptr::addr_of!((*ptr).u) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(s), "::", stringify!(u)),
     );
 }
 impl Clone for s {

--- a/bindgen-tests/tests/expectations/tests/anon_union.rs
+++ b/bindgen-tests/tests/expectations/tests/anon_union.rs
@@ -54,12 +54,14 @@ pub struct ErrorResult {
 #[test]
 fn bindgen_test_layout_ErrorResult() {
     assert_eq!(
-        ::std::mem::size_of:: < ErrorResult > (), 24usize, concat!("Size of: ",
-        stringify!(ErrorResult))
+        ::std::mem::size_of::<ErrorResult>(),
+        24usize,
+        concat!("Size of: ", stringify!(ErrorResult)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < ErrorResult > (), 8usize, concat!("Alignment of ",
-        stringify!(ErrorResult))
+        ::std::mem::align_of::<ErrorResult>(),
+        8usize,
+        concat!("Alignment of ", stringify!(ErrorResult)),
     );
 }
 impl Default for ErrorResult {
@@ -74,11 +76,13 @@ impl Default for ErrorResult {
 #[test]
 fn __bindgen_test_layout_TErrorResult_open0_int_close0_instantiation() {
     assert_eq!(
-        ::std::mem::size_of:: < TErrorResult > (), 24usize,
-        concat!("Size of template specialization: ", stringify!(TErrorResult))
+        ::std::mem::size_of::<TErrorResult>(),
+        24usize,
+        concat!("Size of template specialization: ", stringify!(TErrorResult)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < TErrorResult > (), 8usize,
-        concat!("Alignment of template specialization: ", stringify!(TErrorResult))
+        ::std::mem::align_of::<TErrorResult>(),
+        8usize,
+        concat!("Alignment of template specialization: ", stringify!(TErrorResult)),
     );
 }

--- a/bindgen-tests/tests/expectations/tests/anon_union_1_0.rs
+++ b/bindgen-tests/tests/expectations/tests/anon_union_1_0.rs
@@ -90,12 +90,14 @@ pub struct ErrorResult {
 #[test]
 fn bindgen_test_layout_ErrorResult() {
     assert_eq!(
-        ::std::mem::size_of:: < ErrorResult > (), 24usize, concat!("Size of: ",
-        stringify!(ErrorResult))
+        ::std::mem::size_of::<ErrorResult>(),
+        24usize,
+        concat!("Size of: ", stringify!(ErrorResult)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < ErrorResult > (), 8usize, concat!("Alignment of ",
-        stringify!(ErrorResult))
+        ::std::mem::align_of::<ErrorResult>(),
+        8usize,
+        concat!("Alignment of ", stringify!(ErrorResult)),
     );
 }
 impl Clone for ErrorResult {
@@ -115,11 +117,13 @@ impl Default for ErrorResult {
 #[test]
 fn __bindgen_test_layout_TErrorResult_open0_int_close0_instantiation() {
     assert_eq!(
-        ::std::mem::size_of:: < TErrorResult > (), 24usize,
-        concat!("Size of template specialization: ", stringify!(TErrorResult))
+        ::std::mem::size_of::<TErrorResult>(),
+        24usize,
+        concat!("Size of template specialization: ", stringify!(TErrorResult)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < TErrorResult > (), 8usize,
-        concat!("Alignment of template specialization: ", stringify!(TErrorResult))
+        ::std::mem::align_of::<TErrorResult>(),
+        8usize,
+        concat!("Alignment of template specialization: ", stringify!(TErrorResult)),
     );
 }

--- a/bindgen-tests/tests/expectations/tests/array-of-zero-sized-types.rs
+++ b/bindgen-tests/tests/expectations/tests/array-of-zero-sized-types.rs
@@ -8,12 +8,14 @@ pub struct Empty {
 #[test]
 fn bindgen_test_layout_Empty() {
     assert_eq!(
-        ::std::mem::size_of:: < Empty > (), 1usize, concat!("Size of: ",
-        stringify!(Empty))
+        ::std::mem::size_of::<Empty>(),
+        1usize,
+        concat!("Size of: ", stringify!(Empty)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Empty > (), 1usize, concat!("Alignment of ",
-        stringify!(Empty))
+        ::std::mem::align_of::<Empty>(),
+        1usize,
+        concat!("Alignment of ", stringify!(Empty)),
     );
 }
 /** This should not get an `_address` byte, since each `Empty` gets one, meaning
@@ -28,16 +30,23 @@ fn bindgen_test_layout_HasArrayOfEmpty() {
     const UNINIT: ::std::mem::MaybeUninit<HasArrayOfEmpty> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < HasArrayOfEmpty > (), 10usize, concat!("Size of: ",
-        stringify!(HasArrayOfEmpty))
+        ::std::mem::size_of::<HasArrayOfEmpty>(),
+        10usize,
+        concat!("Size of: ", stringify!(HasArrayOfEmpty)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < HasArrayOfEmpty > (), 1usize, concat!("Alignment of ",
-        stringify!(HasArrayOfEmpty))
+        ::std::mem::align_of::<HasArrayOfEmpty>(),
+        1usize,
+        concat!("Alignment of ", stringify!(HasArrayOfEmpty)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).empties) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(HasArrayOfEmpty), "::",
-        stringify!(empties))
+        unsafe { ::std::ptr::addr_of!((*ptr).empties) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(HasArrayOfEmpty),
+            "::",
+            stringify!(empties),
+        ),
     );
 }

--- a/bindgen-tests/tests/expectations/tests/attribute_warn_unused_result.rs
+++ b/bindgen-tests/tests/expectations/tests/attribute_warn_unused_result.rs
@@ -7,11 +7,14 @@ pub struct Foo {
 #[test]
 fn bindgen_test_layout_Foo() {
     assert_eq!(
-        ::std::mem::size_of:: < Foo > (), 1usize, concat!("Size of: ", stringify!(Foo))
+        ::std::mem::size_of::<Foo>(),
+        1usize,
+        concat!("Size of: ", stringify!(Foo)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Foo > (), 1usize, concat!("Alignment of ",
-        stringify!(Foo))
+        ::std::mem::align_of::<Foo>(),
+        1usize,
+        concat!("Alignment of ", stringify!(Foo)),
     );
 }
 extern "C" {

--- a/bindgen-tests/tests/expectations/tests/attribute_warn_unused_result_no_attribute_detection.rs
+++ b/bindgen-tests/tests/expectations/tests/attribute_warn_unused_result_no_attribute_detection.rs
@@ -7,11 +7,14 @@ pub struct Foo {
 #[test]
 fn bindgen_test_layout_Foo() {
     assert_eq!(
-        ::std::mem::size_of:: < Foo > (), 1usize, concat!("Size of: ", stringify!(Foo))
+        ::std::mem::size_of::<Foo>(),
+        1usize,
+        concat!("Size of: ", stringify!(Foo)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Foo > (), 1usize, concat!("Alignment of ",
-        stringify!(Foo))
+        ::std::mem::align_of::<Foo>(),
+        1usize,
+        concat!("Alignment of ", stringify!(Foo)),
     );
 }
 extern "C" {

--- a/bindgen-tests/tests/expectations/tests/attribute_warn_unused_result_pre_1_27.rs
+++ b/bindgen-tests/tests/expectations/tests/attribute_warn_unused_result_pre_1_27.rs
@@ -7,11 +7,14 @@ pub struct Foo {
 #[test]
 fn bindgen_test_layout_Foo() {
     assert_eq!(
-        ::std::mem::size_of:: < Foo > (), 1usize, concat!("Size of: ", stringify!(Foo))
+        ::std::mem::size_of::<Foo>(),
+        1usize,
+        concat!("Size of: ", stringify!(Foo)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Foo > (), 1usize, concat!("Alignment of ",
-        stringify!(Foo))
+        ::std::mem::align_of::<Foo>(),
+        1usize,
+        concat!("Alignment of ", stringify!(Foo)),
     );
 }
 extern "C" {

--- a/bindgen-tests/tests/expectations/tests/base-to-derived.rs
+++ b/bindgen-tests/tests/expectations/tests/base-to-derived.rs
@@ -7,11 +7,13 @@ pub struct false_type {
 #[test]
 fn bindgen_test_layout_false_type() {
     assert_eq!(
-        ::std::mem::size_of:: < false_type > (), 1usize, concat!("Size of: ",
-        stringify!(false_type))
+        ::std::mem::size_of::<false_type>(),
+        1usize,
+        concat!("Size of: ", stringify!(false_type)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < false_type > (), 1usize, concat!("Alignment of ",
-        stringify!(false_type))
+        ::std::mem::align_of::<false_type>(),
+        1usize,
+        concat!("Alignment of ", stringify!(false_type)),
     );
 }

--- a/bindgen-tests/tests/expectations/tests/bindgen-union-inside-namespace.rs
+++ b/bindgen-tests/tests/expectations/tests/bindgen-union-inside-namespace.rs
@@ -61,22 +61,24 @@ pub mod root {
             const UNINIT: ::std::mem::MaybeUninit<Bar> = ::std::mem::MaybeUninit::uninit();
             let ptr = UNINIT.as_ptr();
             assert_eq!(
-                ::std::mem::size_of:: < Bar > (), 4usize, concat!("Size of: ",
-                stringify!(Bar))
+                ::std::mem::size_of::<Bar>(),
+                4usize,
+                concat!("Size of: ", stringify!(Bar)),
             );
             assert_eq!(
-                ::std::mem::align_of:: < Bar > (), 4usize, concat!("Alignment of ",
-                stringify!(Bar))
+                ::std::mem::align_of::<Bar>(),
+                4usize,
+                concat!("Alignment of ", stringify!(Bar)),
             );
             assert_eq!(
-                unsafe { ::std::ptr::addr_of!((* ptr).foo) as usize - ptr as usize },
-                0usize, concat!("Offset of field: ", stringify!(Bar), "::",
-                stringify!(foo))
+                unsafe { ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize },
+                0usize,
+                concat!("Offset of field: ", stringify!(Bar), "::", stringify!(foo)),
             );
             assert_eq!(
-                unsafe { ::std::ptr::addr_of!((* ptr).bar) as usize - ptr as usize },
-                0usize, concat!("Offset of field: ", stringify!(Bar), "::",
-                stringify!(bar))
+                unsafe { ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize },
+                0usize,
+                concat!("Offset of field: ", stringify!(Bar), "::", stringify!(bar)),
             );
         }
         impl Clone for Bar {

--- a/bindgen-tests/tests/expectations/tests/bitfield-32bit-overflow.rs
+++ b/bindgen-tests/tests/expectations/tests/bitfield-32bit-overflow.rs
@@ -49,7 +49,7 @@ where
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < self.storage.as_ref().len());
         debug_assert!(
-            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len()
+            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len(),
         );
         let mut val = 0;
         for i in 0..(bit_width as usize) {
@@ -69,7 +69,7 @@ where
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < self.storage.as_ref().len());
         debug_assert!(
-            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len()
+            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len(),
         );
         for i in 0..(bit_width as usize) {
             let mask = 1 << i;
@@ -92,12 +92,14 @@ pub struct MuchBitfield {
 #[test]
 fn bindgen_test_layout_MuchBitfield() {
     assert_eq!(
-        ::std::mem::size_of:: < MuchBitfield > (), 5usize, concat!("Size of: ",
-        stringify!(MuchBitfield))
+        ::std::mem::size_of::<MuchBitfield>(),
+        5usize,
+        concat!("Size of: ", stringify!(MuchBitfield)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < MuchBitfield > (), 1usize, concat!("Alignment of ",
-        stringify!(MuchBitfield))
+        ::std::mem::align_of::<MuchBitfield>(),
+        1usize,
+        concat!("Alignment of ", stringify!(MuchBitfield)),
     );
 }
 impl MuchBitfield {

--- a/bindgen-tests/tests/expectations/tests/bitfield-enum-basic.rs
+++ b/bindgen-tests/tests/expectations/tests/bitfield-enum-basic.rs
@@ -151,11 +151,13 @@ pub struct Dummy__bindgen_ty_1(pub ::std::os::raw::c_uint);
 #[test]
 fn bindgen_test_layout_Dummy() {
     assert_eq!(
-        ::std::mem::size_of:: < Dummy > (), 1usize, concat!("Size of: ",
-        stringify!(Dummy))
+        ::std::mem::size_of::<Dummy>(),
+        1usize,
+        concat!("Size of: ", stringify!(Dummy)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Dummy > (), 1usize, concat!("Alignment of ",
-        stringify!(Dummy))
+        ::std::mem::align_of::<Dummy>(),
+        1usize,
+        concat!("Alignment of ", stringify!(Dummy)),
     );
 }

--- a/bindgen-tests/tests/expectations/tests/bitfield-large.rs
+++ b/bindgen-tests/tests/expectations/tests/bitfield-large.rs
@@ -49,7 +49,7 @@ where
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < self.storage.as_ref().len());
         debug_assert!(
-            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len()
+            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len(),
         );
         let mut val = 0;
         for i in 0..(bit_width as usize) {
@@ -69,7 +69,7 @@ where
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < self.storage.as_ref().len());
         debug_assert!(
-            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len()
+            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len(),
         );
         for i in 0..(bit_width as usize) {
             let mask = 1 << i;
@@ -93,12 +93,14 @@ pub struct HasBigBitfield {
 #[test]
 fn bindgen_test_layout_HasBigBitfield() {
     assert_eq!(
-        ::std::mem::size_of:: < HasBigBitfield > (), 16usize, concat!("Size of: ",
-        stringify!(HasBigBitfield))
+        ::std::mem::size_of::<HasBigBitfield>(),
+        16usize,
+        concat!("Size of: ", stringify!(HasBigBitfield)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < HasBigBitfield > (), 16usize, concat!("Alignment of ",
-        stringify!(HasBigBitfield))
+        ::std::mem::align_of::<HasBigBitfield>(),
+        16usize,
+        concat!("Alignment of ", stringify!(HasBigBitfield)),
     );
 }
 impl HasBigBitfield {
@@ -138,12 +140,14 @@ pub struct HasTwoBigBitfields {
 #[test]
 fn bindgen_test_layout_HasTwoBigBitfields() {
     assert_eq!(
-        ::std::mem::size_of:: < HasTwoBigBitfields > (), 16usize, concat!("Size of: ",
-        stringify!(HasTwoBigBitfields))
+        ::std::mem::size_of::<HasTwoBigBitfields>(),
+        16usize,
+        concat!("Size of: ", stringify!(HasTwoBigBitfields)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < HasTwoBigBitfields > (), 16usize,
-        concat!("Alignment of ", stringify!(HasTwoBigBitfields))
+        ::std::mem::align_of::<HasTwoBigBitfields>(),
+        16usize,
+        concat!("Alignment of ", stringify!(HasTwoBigBitfields)),
     );
 }
 impl HasTwoBigBitfields {

--- a/bindgen-tests/tests/expectations/tests/bitfield-linux-32.rs
+++ b/bindgen-tests/tests/expectations/tests/bitfield-linux-32.rs
@@ -49,7 +49,7 @@ where
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < self.storage.as_ref().len());
         debug_assert!(
-            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len()
+            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len(),
         );
         let mut val = 0;
         for i in 0..(bit_width as usize) {
@@ -69,7 +69,7 @@ where
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < self.storage.as_ref().len());
         debug_assert!(
-            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len()
+            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len(),
         );
         for i in 0..(bit_width as usize) {
             let mask = 1 << i;
@@ -95,16 +95,19 @@ fn bindgen_test_layout_Test() {
     const UNINIT: ::std::mem::MaybeUninit<Test> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < Test > (), 16usize, concat!("Size of: ",
-        stringify!(Test))
+        ::std::mem::size_of::<Test>(),
+        16usize,
+        concat!("Size of: ", stringify!(Test)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Test > (), 4usize, concat!("Alignment of ",
-        stringify!(Test))
+        ::std::mem::align_of::<Test>(),
+        4usize,
+        concat!("Alignment of ", stringify!(Test)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).foo) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(Test), "::", stringify!(foo))
+        unsafe { ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(Test), "::", stringify!(foo)),
     );
 }
 impl Test {

--- a/bindgen-tests/tests/expectations/tests/bitfield-method-same-name.rs
+++ b/bindgen-tests/tests/expectations/tests/bitfield-method-same-name.rs
@@ -49,7 +49,7 @@ where
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < self.storage.as_ref().len());
         debug_assert!(
-            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len()
+            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len(),
         );
         let mut val = 0;
         for i in 0..(bit_width as usize) {
@@ -69,7 +69,7 @@ where
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < self.storage.as_ref().len());
         debug_assert!(
-            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len()
+            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len(),
         );
         for i in 0..(bit_width as usize) {
             let mask = 1 << i;
@@ -92,11 +92,14 @@ pub struct Foo {
 #[test]
 fn bindgen_test_layout_Foo() {
     assert_eq!(
-        ::std::mem::size_of:: < Foo > (), 1usize, concat!("Size of: ", stringify!(Foo))
+        ::std::mem::size_of::<Foo>(),
+        1usize,
+        concat!("Size of: ", stringify!(Foo)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Foo > (), 1usize, concat!("Alignment of ",
-        stringify!(Foo))
+        ::std::mem::align_of::<Foo>(),
+        1usize,
+        concat!("Alignment of ", stringify!(Foo)),
     );
 }
 extern "C" {

--- a/bindgen-tests/tests/expectations/tests/bitfield_align.rs
+++ b/bindgen-tests/tests/expectations/tests/bitfield_align.rs
@@ -49,7 +49,7 @@ where
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < self.storage.as_ref().len());
         debug_assert!(
-            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len()
+            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len(),
         );
         let mut val = 0;
         for i in 0..(bit_width as usize) {
@@ -69,7 +69,7 @@ where
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < self.storage.as_ref().len());
         debug_assert!(
-            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len()
+            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len(),
         );
         for i in 0..(bit_width as usize) {
             let mask = 1 << i;
@@ -96,19 +96,21 @@ pub struct A {
 fn bindgen_test_layout_A() {
     const UNINIT: ::std::mem::MaybeUninit<A> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
+    assert_eq!(::std::mem::size_of::<A>(), 4usize, concat!("Size of: ", stringify!(A)));
     assert_eq!(
-        ::std::mem::size_of:: < A > (), 4usize, concat!("Size of: ", stringify!(A))
+        ::std::mem::align_of::<A>(),
+        4usize,
+        concat!("Alignment of ", stringify!(A)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < A > (), 4usize, concat!("Alignment of ", stringify!(A))
+        unsafe { ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(A), "::", stringify!(x)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).x) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(A), "::", stringify!(x))
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).y) as usize - ptr as usize }, 3usize,
-        concat!("Offset of field: ", stringify!(A), "::", stringify!(y))
+        unsafe { ::std::ptr::addr_of!((*ptr).y) as usize - ptr as usize },
+        3usize,
+        concat!("Offset of field: ", stringify!(A), "::", stringify!(y)),
     );
 }
 impl A {
@@ -338,11 +340,11 @@ pub struct B {
 }
 #[test]
 fn bindgen_test_layout_B() {
+    assert_eq!(::std::mem::size_of::<B>(), 4usize, concat!("Size of: ", stringify!(B)));
     assert_eq!(
-        ::std::mem::size_of:: < B > (), 4usize, concat!("Size of: ", stringify!(B))
-    );
-    assert_eq!(
-        ::std::mem::align_of:: < B > (), 4usize, concat!("Alignment of ", stringify!(B))
+        ::std::mem::align_of::<B>(),
+        4usize,
+        concat!("Alignment of ", stringify!(B)),
     );
 }
 impl B {
@@ -407,19 +409,21 @@ pub struct C {
 fn bindgen_test_layout_C() {
     const UNINIT: ::std::mem::MaybeUninit<C> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
+    assert_eq!(::std::mem::size_of::<C>(), 8usize, concat!("Size of: ", stringify!(C)));
     assert_eq!(
-        ::std::mem::size_of:: < C > (), 8usize, concat!("Size of: ", stringify!(C))
+        ::std::mem::align_of::<C>(),
+        4usize,
+        concat!("Alignment of ", stringify!(C)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < C > (), 4usize, concat!("Alignment of ", stringify!(C))
+        unsafe { ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(C), "::", stringify!(x)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).x) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(C), "::", stringify!(x))
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).baz) as usize - ptr as usize }, 4usize,
-        concat!("Offset of field: ", stringify!(C), "::", stringify!(baz))
+        unsafe { ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize },
+        4usize,
+        concat!("Offset of field: ", stringify!(C), "::", stringify!(baz)),
     );
 }
 impl C {
@@ -483,12 +487,14 @@ pub struct Date1 {
 #[test]
 fn bindgen_test_layout_Date1() {
     assert_eq!(
-        ::std::mem::size_of:: < Date1 > (), 4usize, concat!("Size of: ",
-        stringify!(Date1))
+        ::std::mem::size_of::<Date1>(),
+        4usize,
+        concat!("Size of: ", stringify!(Date1)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Date1 > (), 2usize, concat!("Alignment of ",
-        stringify!(Date1))
+        ::std::mem::align_of::<Date1>(),
+        2usize,
+        concat!("Alignment of ", stringify!(Date1)),
     );
 }
 impl Date1 {
@@ -593,12 +599,14 @@ pub struct Date2 {
 #[test]
 fn bindgen_test_layout_Date2() {
     assert_eq!(
-        ::std::mem::size_of:: < Date2 > (), 4usize, concat!("Size of: ",
-        stringify!(Date2))
+        ::std::mem::size_of::<Date2>(),
+        4usize,
+        concat!("Size of: ", stringify!(Date2)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Date2 > (), 2usize, concat!("Alignment of ",
-        stringify!(Date2))
+        ::std::mem::align_of::<Date2>(),
+        2usize,
+        concat!("Alignment of ", stringify!(Date2)),
     );
 }
 impl Date2 {
@@ -727,16 +735,19 @@ fn bindgen_test_layout_Date3() {
     const UNINIT: ::std::mem::MaybeUninit<Date3> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < Date3 > (), 4usize, concat!("Size of: ",
-        stringify!(Date3))
+        ::std::mem::size_of::<Date3>(),
+        4usize,
+        concat!("Size of: ", stringify!(Date3)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Date3 > (), 2usize, concat!("Alignment of ",
-        stringify!(Date3))
+        ::std::mem::align_of::<Date3>(),
+        2usize,
+        concat!("Alignment of ", stringify!(Date3)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).byte) as usize - ptr as usize }, 3usize,
-        concat!("Offset of field: ", stringify!(Date3), "::", stringify!(byte))
+        unsafe { ::std::ptr::addr_of!((*ptr).byte) as usize - ptr as usize },
+        3usize,
+        concat!("Offset of field: ", stringify!(Date3), "::", stringify!(byte)),
     );
 }
 impl Date3 {

--- a/bindgen-tests/tests/expectations/tests/bitfield_align_2.rs
+++ b/bindgen-tests/tests/expectations/tests/bitfield_align_2.rs
@@ -50,7 +50,7 @@ where
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < self.storage.as_ref().len());
         debug_assert!(
-            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len()
+            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len(),
         );
         let mut val = 0;
         for i in 0..(bit_width as usize) {
@@ -70,7 +70,7 @@ where
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < self.storage.as_ref().len());
         debug_assert!(
-            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len()
+            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len(),
         );
         for i in 0..(bit_width as usize) {
             let mask = 1 << i;
@@ -102,12 +102,14 @@ pub struct TaggedPtr {
 #[test]
 fn bindgen_test_layout_TaggedPtr() {
     assert_eq!(
-        ::std::mem::size_of:: < TaggedPtr > (), 8usize, concat!("Size of: ",
-        stringify!(TaggedPtr))
+        ::std::mem::size_of::<TaggedPtr>(),
+        8usize,
+        concat!("Size of: ", stringify!(TaggedPtr)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < TaggedPtr > (), 8usize, concat!("Alignment of ",
-        stringify!(TaggedPtr))
+        ::std::mem::align_of::<TaggedPtr>(),
+        8usize,
+        concat!("Alignment of ", stringify!(TaggedPtr)),
     );
 }
 impl Default for TaggedPtr {

--- a/bindgen-tests/tests/expectations/tests/bitfield_large_overflow.rs
+++ b/bindgen-tests/tests/expectations/tests/bitfield_large_overflow.rs
@@ -8,12 +8,14 @@ pub struct _bindgen_ty_1 {
 #[test]
 fn bindgen_test_layout__bindgen_ty_1() {
     assert_eq!(
-        ::std::mem::size_of:: < _bindgen_ty_1 > (), 80usize, concat!("Size of: ",
-        stringify!(_bindgen_ty_1))
+        ::std::mem::size_of::<_bindgen_ty_1>(),
+        80usize,
+        concat!("Size of: ", stringify!(_bindgen_ty_1)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < _bindgen_ty_1 > (), 8usize, concat!("Alignment of ",
-        stringify!(_bindgen_ty_1))
+        ::std::mem::align_of::<_bindgen_ty_1>(),
+        8usize,
+        concat!("Alignment of ", stringify!(_bindgen_ty_1)),
     );
 }
 extern "C" {

--- a/bindgen-tests/tests/expectations/tests/bitfield_method_mangling.rs
+++ b/bindgen-tests/tests/expectations/tests/bitfield_method_mangling.rs
@@ -49,7 +49,7 @@ where
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < self.storage.as_ref().len());
         debug_assert!(
-            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len()
+            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len(),
         );
         let mut val = 0;
         for i in 0..(bit_width as usize) {
@@ -69,7 +69,7 @@ where
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < self.storage.as_ref().len());
         debug_assert!(
-            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len()
+            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len(),
         );
         for i in 0..(bit_width as usize) {
             let mask = 1 << i;
@@ -93,12 +93,14 @@ pub struct mach_msg_type_descriptor_t {
 #[test]
 fn bindgen_test_layout_mach_msg_type_descriptor_t() {
     assert_eq!(
-        ::std::mem::size_of:: < mach_msg_type_descriptor_t > (), 4usize,
-        concat!("Size of: ", stringify!(mach_msg_type_descriptor_t))
+        ::std::mem::size_of::<mach_msg_type_descriptor_t>(),
+        4usize,
+        concat!("Size of: ", stringify!(mach_msg_type_descriptor_t)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < mach_msg_type_descriptor_t > (), 4usize,
-        concat!("Alignment of ", stringify!(mach_msg_type_descriptor_t))
+        ::std::mem::align_of::<mach_msg_type_descriptor_t>(),
+        4usize,
+        concat!("Alignment of ", stringify!(mach_msg_type_descriptor_t)),
     );
 }
 impl mach_msg_type_descriptor_t {

--- a/bindgen-tests/tests/expectations/tests/bitfield_pragma_packed.rs
+++ b/bindgen-tests/tests/expectations/tests/bitfield_pragma_packed.rs
@@ -49,7 +49,7 @@ where
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < self.storage.as_ref().len());
         debug_assert!(
-            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len()
+            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len(),
         );
         let mut val = 0;
         for i in 0..(bit_width as usize) {
@@ -69,7 +69,7 @@ where
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < self.storage.as_ref().len());
         debug_assert!(
-            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len()
+            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len(),
         );
         for i in 0..(bit_width as usize) {
             let mask = 1 << i;
@@ -92,12 +92,14 @@ pub struct Struct {
 #[test]
 fn bindgen_test_layout_Struct() {
     assert_eq!(
-        ::std::mem::size_of:: < Struct > (), 4usize, concat!("Size of: ",
-        stringify!(Struct))
+        ::std::mem::size_of::<Struct>(),
+        4usize,
+        concat!("Size of: ", stringify!(Struct)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Struct > (), 1usize, concat!("Alignment of ",
-        stringify!(Struct))
+        ::std::mem::align_of::<Struct>(),
+        1usize,
+        concat!("Alignment of ", stringify!(Struct)),
     );
 }
 impl Struct {

--- a/bindgen-tests/tests/expectations/tests/blocklist-and-impl-debug.rs
+++ b/bindgen-tests/tests/expectations/tests/blocklist-and-impl-debug.rs
@@ -10,17 +10,24 @@ fn bindgen_test_layout_ShouldManuallyImplDebug() {
     const UNINIT: ::std::mem::MaybeUninit<ShouldManuallyImplDebug> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < ShouldManuallyImplDebug > (), 1usize,
-        concat!("Size of: ", stringify!(ShouldManuallyImplDebug))
+        ::std::mem::size_of::<ShouldManuallyImplDebug>(),
+        1usize,
+        concat!("Size of: ", stringify!(ShouldManuallyImplDebug)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < ShouldManuallyImplDebug > (), 1usize,
-        concat!("Alignment of ", stringify!(ShouldManuallyImplDebug))
+        ::std::mem::align_of::<ShouldManuallyImplDebug>(),
+        1usize,
+        concat!("Alignment of ", stringify!(ShouldManuallyImplDebug)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).a) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(ShouldManuallyImplDebug), "::",
-        stringify!(a))
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ShouldManuallyImplDebug),
+            "::",
+            stringify!(a),
+        ),
     );
 }
 impl Default for ShouldManuallyImplDebug {

--- a/bindgen-tests/tests/expectations/tests/blocklist-file.rs
+++ b/bindgen-tests/tests/expectations/tests/blocklist-file.rs
@@ -11,24 +11,29 @@ fn bindgen_test_layout_SizedIntegers() {
     const UNINIT: ::std::mem::MaybeUninit<SizedIntegers> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < SizedIntegers > (), 8usize, concat!("Size of: ",
-        stringify!(SizedIntegers))
+        ::std::mem::size_of::<SizedIntegers>(),
+        8usize,
+        concat!("Size of: ", stringify!(SizedIntegers)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < SizedIntegers > (), 4usize, concat!("Alignment of ",
-        stringify!(SizedIntegers))
+        ::std::mem::align_of::<SizedIntegers>(),
+        4usize,
+        concat!("Alignment of ", stringify!(SizedIntegers)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).x) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(SizedIntegers), "::", stringify!(x))
+        unsafe { ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(SizedIntegers), "::", stringify!(x)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).y) as usize - ptr as usize }, 2usize,
-        concat!("Offset of field: ", stringify!(SizedIntegers), "::", stringify!(y))
+        unsafe { ::std::ptr::addr_of!((*ptr).y) as usize - ptr as usize },
+        2usize,
+        concat!("Offset of field: ", stringify!(SizedIntegers), "::", stringify!(y)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).z) as usize - ptr as usize }, 4usize,
-        concat!("Offset of field: ", stringify!(SizedIntegers), "::", stringify!(z))
+        unsafe { ::std::ptr::addr_of!((*ptr).z) as usize - ptr as usize },
+        4usize,
+        concat!("Offset of field: ", stringify!(SizedIntegers), "::", stringify!(z)),
     );
 }
 #[repr(C)]
@@ -41,16 +46,23 @@ fn bindgen_test_layout_StructWithBlocklistedFwdDecl() {
     const UNINIT: ::std::mem::MaybeUninit<StructWithBlocklistedFwdDecl> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < StructWithBlocklistedFwdDecl > (), 1usize,
-        concat!("Size of: ", stringify!(StructWithBlocklistedFwdDecl))
+        ::std::mem::size_of::<StructWithBlocklistedFwdDecl>(),
+        1usize,
+        concat!("Size of: ", stringify!(StructWithBlocklistedFwdDecl)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < StructWithBlocklistedFwdDecl > (), 1usize,
-        concat!("Alignment of ", stringify!(StructWithBlocklistedFwdDecl))
+        ::std::mem::align_of::<StructWithBlocklistedFwdDecl>(),
+        1usize,
+        concat!("Alignment of ", stringify!(StructWithBlocklistedFwdDecl)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).b) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(StructWithBlocklistedFwdDecl), "::",
-        stringify!(b))
+        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(StructWithBlocklistedFwdDecl),
+            "::",
+            stringify!(b),
+        ),
     );
 }

--- a/bindgen-tests/tests/expectations/tests/blocklist-function.rs
+++ b/bindgen-tests/tests/expectations/tests/blocklist-function.rs
@@ -23,11 +23,14 @@ pub mod root {
     #[test]
     fn bindgen_test_layout_C() {
         assert_eq!(
-            ::std::mem::size_of:: < C > (), 1usize, concat!("Size of: ", stringify!(C))
+            ::std::mem::size_of::<C>(),
+            1usize,
+            concat!("Size of: ", stringify!(C)),
         );
         assert_eq!(
-            ::std::mem::align_of:: < C > (), 1usize, concat!("Alignment of ",
-            stringify!(C))
+            ::std::mem::align_of::<C>(),
+            1usize,
+            concat!("Alignment of ", stringify!(C)),
         );
     }
 }

--- a/bindgen-tests/tests/expectations/tests/blocklist-methods.rs
+++ b/bindgen-tests/tests/expectations/tests/blocklist-methods.rs
@@ -7,11 +7,14 @@ pub struct Foo {
 #[test]
 fn bindgen_test_layout_Foo() {
     assert_eq!(
-        ::std::mem::size_of:: < Foo > (), 1usize, concat!("Size of: ", stringify!(Foo))
+        ::std::mem::size_of::<Foo>(),
+        1usize,
+        concat!("Size of: ", stringify!(Foo)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Foo > (), 1usize, concat!("Alignment of ",
-        stringify!(Foo))
+        ::std::mem::align_of::<Foo>(),
+        1usize,
+        concat!("Alignment of ", stringify!(Foo)),
     );
 }
 extern "C" {

--- a/bindgen-tests/tests/expectations/tests/blocks-signature.rs
+++ b/bindgen-tests/tests/expectations/tests/blocks-signature.rs
@@ -33,22 +33,34 @@ fn bindgen_test_layout_contains_block_pointers() {
     const UNINIT: ::std::mem::MaybeUninit<contains_block_pointers> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < contains_block_pointers > (), 16usize,
-        concat!("Size of: ", stringify!(contains_block_pointers))
+        ::std::mem::size_of::<contains_block_pointers>(),
+        16usize,
+        concat!("Size of: ", stringify!(contains_block_pointers)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < contains_block_pointers > (), 8usize,
-        concat!("Alignment of ", stringify!(contains_block_pointers))
+        ::std::mem::align_of::<contains_block_pointers>(),
+        8usize,
+        concat!("Alignment of ", stringify!(contains_block_pointers)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).val) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(contains_block_pointers), "::",
-        stringify!(val))
+        unsafe { ::std::ptr::addr_of!((*ptr).val) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(contains_block_pointers),
+            "::",
+            stringify!(val),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).ptr_val) as usize - ptr as usize }, 8usize,
-        concat!("Offset of field: ", stringify!(contains_block_pointers), "::",
-        stringify!(ptr_val))
+        unsafe { ::std::ptr::addr_of!((*ptr).ptr_val) as usize - ptr as usize },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(contains_block_pointers),
+            "::",
+            stringify!(ptr_val),
+        ),
     );
 }
 impl Default for contains_block_pointers {

--- a/bindgen-tests/tests/expectations/tests/blocks.rs
+++ b/bindgen-tests/tests/expectations/tests/blocks.rs
@@ -32,22 +32,34 @@ fn bindgen_test_layout_contains_block_pointers() {
     const UNINIT: ::std::mem::MaybeUninit<contains_block_pointers> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < contains_block_pointers > (), 16usize,
-        concat!("Size of: ", stringify!(contains_block_pointers))
+        ::std::mem::size_of::<contains_block_pointers>(),
+        16usize,
+        concat!("Size of: ", stringify!(contains_block_pointers)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < contains_block_pointers > (), 8usize,
-        concat!("Alignment of ", stringify!(contains_block_pointers))
+        ::std::mem::align_of::<contains_block_pointers>(),
+        8usize,
+        concat!("Alignment of ", stringify!(contains_block_pointers)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).val) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(contains_block_pointers), "::",
-        stringify!(val))
+        unsafe { ::std::ptr::addr_of!((*ptr).val) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(contains_block_pointers),
+            "::",
+            stringify!(val),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).ptr_val) as usize - ptr as usize }, 8usize,
-        concat!("Offset of field: ", stringify!(contains_block_pointers), "::",
-        stringify!(ptr_val))
+        unsafe { ::std::ptr::addr_of!((*ptr).ptr_val) as usize - ptr as usize },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(contains_block_pointers),
+            "::",
+            stringify!(ptr_val),
+        ),
     );
 }
 impl Default for contains_block_pointers {

--- a/bindgen-tests/tests/expectations/tests/bug-1529681.rs
+++ b/bindgen-tests/tests/expectations/tests/bug-1529681.rs
@@ -7,11 +7,13 @@ pub struct BrowsingContext {
 #[test]
 fn bindgen_test_layout_BrowsingContext() {
     assert_eq!(
-        ::std::mem::size_of:: < BrowsingContext > (), 1usize, concat!("Size of: ",
-        stringify!(BrowsingContext))
+        ::std::mem::size_of::<BrowsingContext>(),
+        1usize,
+        concat!("Size of: ", stringify!(BrowsingContext)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < BrowsingContext > (), 1usize, concat!("Alignment of ",
-        stringify!(BrowsingContext))
+        ::std::mem::align_of::<BrowsingContext>(),
+        1usize,
+        concat!("Alignment of ", stringify!(BrowsingContext)),
     );
 }

--- a/bindgen-tests/tests/expectations/tests/c-empty-layout.rs
+++ b/bindgen-tests/tests/expectations/tests/c-empty-layout.rs
@@ -5,10 +5,13 @@ pub struct Foo {}
 #[test]
 fn bindgen_test_layout_Foo() {
     assert_eq!(
-        ::std::mem::size_of:: < Foo > (), 0usize, concat!("Size of: ", stringify!(Foo))
+        ::std::mem::size_of::<Foo>(),
+        0usize,
+        concat!("Size of: ", stringify!(Foo)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Foo > (), 1usize, concat!("Alignment of ",
-        stringify!(Foo))
+        ::std::mem::align_of::<Foo>(),
+        1usize,
+        concat!("Alignment of ", stringify!(Foo)),
     );
 }

--- a/bindgen-tests/tests/expectations/tests/c_naming.rs
+++ b/bindgen-tests/tests/expectations/tests/c_naming.rs
@@ -9,16 +9,19 @@ fn bindgen_test_layout_struct_a() {
     const UNINIT: ::std::mem::MaybeUninit<struct_a> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < struct_a > (), 4usize, concat!("Size of: ",
-        stringify!(struct_a))
+        ::std::mem::size_of::<struct_a>(),
+        4usize,
+        concat!("Size of: ", stringify!(struct_a)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < struct_a > (), 4usize, concat!("Alignment of ",
-        stringify!(struct_a))
+        ::std::mem::align_of::<struct_a>(),
+        4usize,
+        concat!("Alignment of ", stringify!(struct_a)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).a) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(struct_a), "::", stringify!(a))
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(struct_a), "::", stringify!(a)),
     );
 }
 pub type a = *const struct_a;
@@ -33,20 +36,24 @@ fn bindgen_test_layout_union_b() {
     const UNINIT: ::std::mem::MaybeUninit<union_b> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < union_b > (), 4usize, concat!("Size of: ",
-        stringify!(union_b))
+        ::std::mem::size_of::<union_b>(),
+        4usize,
+        concat!("Size of: ", stringify!(union_b)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < union_b > (), 4usize, concat!("Alignment of ",
-        stringify!(union_b))
+        ::std::mem::align_of::<union_b>(),
+        4usize,
+        concat!("Alignment of ", stringify!(union_b)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).a) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(union_b), "::", stringify!(a))
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(union_b), "::", stringify!(a)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).b) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(union_b), "::", stringify!(b))
+        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(union_b), "::", stringify!(b)),
     );
 }
 impl Default for union_b {

--- a/bindgen-tests/tests/expectations/tests/canonical-types.rs
+++ b/bindgen-tests/tests/expectations/tests/canonical-types.rs
@@ -79,12 +79,14 @@ pub struct ClassD {
 #[test]
 fn bindgen_test_layout_ClassD() {
     assert_eq!(
-        ::std::mem::size_of:: < ClassD > (), 1usize, concat!("Size of: ",
-        stringify!(ClassD))
+        ::std::mem::size_of::<ClassD>(),
+        1usize,
+        concat!("Size of: ", stringify!(ClassD)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < ClassD > (), 1usize, concat!("Alignment of ",
-        stringify!(ClassD))
+        ::std::mem::align_of::<ClassD>(),
+        1usize,
+        concat!("Alignment of ", stringify!(ClassD)),
     );
 }
 impl Default for ClassD {
@@ -99,12 +101,14 @@ impl Default for ClassD {
 #[test]
 fn __bindgen_test_layout_ClassB_open0_ClassD_ClassCInnerCRTP_close0_instantiation() {
     assert_eq!(
-        ::std::mem::size_of:: < ClassB > (), 1usize,
-        concat!("Size of template specialization: ", stringify!(ClassB))
+        ::std::mem::size_of::<ClassB>(),
+        1usize,
+        concat!("Size of template specialization: ", stringify!(ClassB)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < ClassB > (), 1usize,
-        concat!("Alignment of template specialization: ", stringify!(ClassB))
+        ::std::mem::align_of::<ClassB>(),
+        1usize,
+        concat!("Alignment of template specialization: ", stringify!(ClassB)),
     );
 }
 #[repr(C)]
@@ -115,12 +119,14 @@ pub struct ClassCInnerCRTP {
 #[test]
 fn bindgen_test_layout_ClassCInnerCRTP() {
     assert_eq!(
-        ::std::mem::size_of:: < ClassCInnerCRTP > (), 1usize, concat!("Size of: ",
-        stringify!(ClassCInnerCRTP))
+        ::std::mem::size_of::<ClassCInnerCRTP>(),
+        1usize,
+        concat!("Size of: ", stringify!(ClassCInnerCRTP)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < ClassCInnerCRTP > (), 1usize, concat!("Alignment of ",
-        stringify!(ClassCInnerCRTP))
+        ::std::mem::align_of::<ClassCInnerCRTP>(),
+        1usize,
+        concat!("Alignment of ", stringify!(ClassCInnerCRTP)),
     );
 }
 impl Default for ClassCInnerCRTP {
@@ -135,12 +141,14 @@ impl Default for ClassCInnerCRTP {
 #[test]
 fn __bindgen_test_layout_ClassB_open0_ClassCInnerCRTP_ClassAInner_close0_instantiation() {
     assert_eq!(
-        ::std::mem::size_of:: < ClassB > (), 1usize,
-        concat!("Size of template specialization: ", stringify!(ClassB))
+        ::std::mem::size_of::<ClassB>(),
+        1usize,
+        concat!("Size of template specialization: ", stringify!(ClassB)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < ClassB > (), 1usize,
-        concat!("Alignment of template specialization: ", stringify!(ClassB))
+        ::std::mem::align_of::<ClassB>(),
+        1usize,
+        concat!("Alignment of template specialization: ", stringify!(ClassB)),
     );
 }
 #[repr(C)]
@@ -153,16 +161,19 @@ fn bindgen_test_layout_ClassAInner() {
     const UNINIT: ::std::mem::MaybeUninit<ClassAInner> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < ClassAInner > (), 8usize, concat!("Size of: ",
-        stringify!(ClassAInner))
+        ::std::mem::size_of::<ClassAInner>(),
+        8usize,
+        concat!("Size of: ", stringify!(ClassAInner)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < ClassAInner > (), 8usize, concat!("Alignment of ",
-        stringify!(ClassAInner))
+        ::std::mem::align_of::<ClassAInner>(),
+        8usize,
+        concat!("Alignment of ", stringify!(ClassAInner)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).x) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(ClassAInner), "::", stringify!(x))
+        unsafe { ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(ClassAInner), "::", stringify!(x)),
     );
 }
 impl Default for ClassAInner {
@@ -184,16 +195,19 @@ fn bindgen_test_layout_ClassCInnerA() {
     const UNINIT: ::std::mem::MaybeUninit<ClassCInnerA> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < ClassCInnerA > (), 8usize, concat!("Size of: ",
-        stringify!(ClassCInnerA))
+        ::std::mem::size_of::<ClassCInnerA>(),
+        8usize,
+        concat!("Size of: ", stringify!(ClassCInnerA)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < ClassCInnerA > (), 8usize, concat!("Alignment of ",
-        stringify!(ClassCInnerA))
+        ::std::mem::align_of::<ClassCInnerA>(),
+        8usize,
+        concat!("Alignment of ", stringify!(ClassCInnerA)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).member) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(ClassCInnerA), "::", stringify!(member))
+        unsafe { ::std::ptr::addr_of!((*ptr).member) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(ClassCInnerA), "::", stringify!(member)),
     );
 }
 impl Default for ClassCInnerA {
@@ -215,16 +229,19 @@ fn bindgen_test_layout_ClassCInnerB() {
     const UNINIT: ::std::mem::MaybeUninit<ClassCInnerB> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < ClassCInnerB > (), 8usize, concat!("Size of: ",
-        stringify!(ClassCInnerB))
+        ::std::mem::size_of::<ClassCInnerB>(),
+        8usize,
+        concat!("Size of: ", stringify!(ClassCInnerB)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < ClassCInnerB > (), 8usize, concat!("Alignment of ",
-        stringify!(ClassCInnerB))
+        ::std::mem::align_of::<ClassCInnerB>(),
+        8usize,
+        concat!("Alignment of ", stringify!(ClassCInnerB)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).cache) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(ClassCInnerB), "::", stringify!(cache))
+        unsafe { ::std::ptr::addr_of!((*ptr).cache) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(ClassCInnerB), "::", stringify!(cache)),
     );
 }
 impl Default for ClassCInnerB {

--- a/bindgen-tests/tests/expectations/tests/canonical_path_without_namespacing.rs
+++ b/bindgen-tests/tests/expectations/tests/canonical_path_without_namespacing.rs
@@ -7,11 +7,14 @@ pub struct Bar {
 #[test]
 fn bindgen_test_layout_Bar() {
     assert_eq!(
-        ::std::mem::size_of:: < Bar > (), 1usize, concat!("Size of: ", stringify!(Bar))
+        ::std::mem::size_of::<Bar>(),
+        1usize,
+        concat!("Size of: ", stringify!(Bar)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Bar > (), 1usize, concat!("Alignment of ",
-        stringify!(Bar))
+        ::std::mem::align_of::<Bar>(),
+        1usize,
+        concat!("Alignment of ", stringify!(Bar)),
     );
 }
 extern "C" {

--- a/bindgen-tests/tests/expectations/tests/char.rs
+++ b/bindgen-tests/tests/expectations/tests/char.rs
@@ -23,59 +23,73 @@ fn bindgen_test_layout_Test() {
     const UNINIT: ::std::mem::MaybeUninit<Test> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < Test > (), 12usize, concat!("Size of: ",
-        stringify!(Test))
+        ::std::mem::size_of::<Test>(),
+        12usize,
+        concat!("Size of: ", stringify!(Test)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Test > (), 1usize, concat!("Alignment of ",
-        stringify!(Test))
+        ::std::mem::align_of::<Test>(),
+        1usize,
+        concat!("Alignment of ", stringify!(Test)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).ch) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(Test), "::", stringify!(ch))
+        unsafe { ::std::ptr::addr_of!((*ptr).ch) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(Test), "::", stringify!(ch)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).u) as usize - ptr as usize }, 1usize,
-        concat!("Offset of field: ", stringify!(Test), "::", stringify!(u))
+        unsafe { ::std::ptr::addr_of!((*ptr).u) as usize - ptr as usize },
+        1usize,
+        concat!("Offset of field: ", stringify!(Test), "::", stringify!(u)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).d) as usize - ptr as usize }, 2usize,
-        concat!("Offset of field: ", stringify!(Test), "::", stringify!(d))
+        unsafe { ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize },
+        2usize,
+        concat!("Offset of field: ", stringify!(Test), "::", stringify!(d)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).cch) as usize - ptr as usize }, 3usize,
-        concat!("Offset of field: ", stringify!(Test), "::", stringify!(cch))
+        unsafe { ::std::ptr::addr_of!((*ptr).cch) as usize - ptr as usize },
+        3usize,
+        concat!("Offset of field: ", stringify!(Test), "::", stringify!(cch)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).cu) as usize - ptr as usize }, 4usize,
-        concat!("Offset of field: ", stringify!(Test), "::", stringify!(cu))
+        unsafe { ::std::ptr::addr_of!((*ptr).cu) as usize - ptr as usize },
+        4usize,
+        concat!("Offset of field: ", stringify!(Test), "::", stringify!(cu)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).cd) as usize - ptr as usize }, 5usize,
-        concat!("Offset of field: ", stringify!(Test), "::", stringify!(cd))
+        unsafe { ::std::ptr::addr_of!((*ptr).cd) as usize - ptr as usize },
+        5usize,
+        concat!("Offset of field: ", stringify!(Test), "::", stringify!(cd)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).Cch) as usize - ptr as usize }, 6usize,
-        concat!("Offset of field: ", stringify!(Test), "::", stringify!(Cch))
+        unsafe { ::std::ptr::addr_of!((*ptr).Cch) as usize - ptr as usize },
+        6usize,
+        concat!("Offset of field: ", stringify!(Test), "::", stringify!(Cch)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).Cu) as usize - ptr as usize }, 7usize,
-        concat!("Offset of field: ", stringify!(Test), "::", stringify!(Cu))
+        unsafe { ::std::ptr::addr_of!((*ptr).Cu) as usize - ptr as usize },
+        7usize,
+        concat!("Offset of field: ", stringify!(Test), "::", stringify!(Cu)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).Cd) as usize - ptr as usize }, 8usize,
-        concat!("Offset of field: ", stringify!(Test), "::", stringify!(Cd))
+        unsafe { ::std::ptr::addr_of!((*ptr).Cd) as usize - ptr as usize },
+        8usize,
+        concat!("Offset of field: ", stringify!(Test), "::", stringify!(Cd)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).Ccch) as usize - ptr as usize }, 9usize,
-        concat!("Offset of field: ", stringify!(Test), "::", stringify!(Ccch))
+        unsafe { ::std::ptr::addr_of!((*ptr).Ccch) as usize - ptr as usize },
+        9usize,
+        concat!("Offset of field: ", stringify!(Test), "::", stringify!(Ccch)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).Ccu) as usize - ptr as usize }, 10usize,
-        concat!("Offset of field: ", stringify!(Test), "::", stringify!(Ccu))
+        unsafe { ::std::ptr::addr_of!((*ptr).Ccu) as usize - ptr as usize },
+        10usize,
+        concat!("Offset of field: ", stringify!(Test), "::", stringify!(Ccu)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).Ccd) as usize - ptr as usize }, 11usize,
-        concat!("Offset of field: ", stringify!(Test), "::", stringify!(Ccd))
+        unsafe { ::std::ptr::addr_of!((*ptr).Ccd) as usize - ptr as usize },
+        11usize,
+        concat!("Offset of field: ", stringify!(Test), "::", stringify!(Ccd)),
     );
 }

--- a/bindgen-tests/tests/expectations/tests/class.rs
+++ b/bindgen-tests/tests/expectations/tests/class.rs
@@ -39,19 +39,21 @@ pub struct C {
 fn bindgen_test_layout_C() {
     const UNINIT: ::std::mem::MaybeUninit<C> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
+    assert_eq!(::std::mem::size_of::<C>(), 40usize, concat!("Size of: ", stringify!(C)));
     assert_eq!(
-        ::std::mem::size_of:: < C > (), 40usize, concat!("Size of: ", stringify!(C))
+        ::std::mem::align_of::<C>(),
+        4usize,
+        concat!("Alignment of ", stringify!(C)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < C > (), 4usize, concat!("Alignment of ", stringify!(C))
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(C), "::", stringify!(a)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).a) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(C), "::", stringify!(a))
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).big_array) as usize - ptr as usize },
-        4usize, concat!("Offset of field: ", stringify!(C), "::", stringify!(big_array))
+        unsafe { ::std::ptr::addr_of!((*ptr).big_array) as usize - ptr as usize },
+        4usize,
+        concat!("Offset of field: ", stringify!(C), "::", stringify!(big_array)),
     );
 }
 impl Default for C {
@@ -74,27 +76,46 @@ fn bindgen_test_layout_C_with_zero_length_array() {
     const UNINIT: ::std::mem::MaybeUninit<C_with_zero_length_array> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < C_with_zero_length_array > (), 40usize,
-        concat!("Size of: ", stringify!(C_with_zero_length_array))
+        ::std::mem::size_of::<C_with_zero_length_array>(),
+        40usize,
+        concat!("Size of: ", stringify!(C_with_zero_length_array)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < C_with_zero_length_array > (), 4usize,
-        concat!("Alignment of ", stringify!(C_with_zero_length_array))
+        ::std::mem::align_of::<C_with_zero_length_array>(),
+        4usize,
+        concat!("Alignment of ", stringify!(C_with_zero_length_array)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).a) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(C_with_zero_length_array), "::",
-        stringify!(a))
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C_with_zero_length_array),
+            "::",
+            stringify!(a),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).big_array) as usize - ptr as usize },
-        4usize, concat!("Offset of field: ", stringify!(C_with_zero_length_array), "::",
-        stringify!(big_array))
+        unsafe { ::std::ptr::addr_of!((*ptr).big_array) as usize - ptr as usize },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C_with_zero_length_array),
+            "::",
+            stringify!(big_array),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).zero_length_array) as usize - ptr as usize
-        }, 37usize, concat!("Offset of field: ", stringify!(C_with_zero_length_array),
-        "::", stringify!(zero_length_array))
+        unsafe {
+            ::std::ptr::addr_of!((*ptr).zero_length_array) as usize - ptr as usize
+        },
+        37usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C_with_zero_length_array),
+            "::",
+            stringify!(zero_length_array),
+        ),
     );
 }
 impl Default for C_with_zero_length_array {
@@ -117,22 +138,36 @@ fn bindgen_test_layout_C_with_zero_length_array_2() {
     const UNINIT: ::std::mem::MaybeUninit<C_with_zero_length_array_2> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < C_with_zero_length_array_2 > (), 4usize,
-        concat!("Size of: ", stringify!(C_with_zero_length_array_2))
+        ::std::mem::size_of::<C_with_zero_length_array_2>(),
+        4usize,
+        concat!("Size of: ", stringify!(C_with_zero_length_array_2)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < C_with_zero_length_array_2 > (), 4usize,
-        concat!("Alignment of ", stringify!(C_with_zero_length_array_2))
+        ::std::mem::align_of::<C_with_zero_length_array_2>(),
+        4usize,
+        concat!("Alignment of ", stringify!(C_with_zero_length_array_2)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).a) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(C_with_zero_length_array_2), "::",
-        stringify!(a))
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C_with_zero_length_array_2),
+            "::",
+            stringify!(a),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).zero_length_array) as usize - ptr as usize
-        }, 4usize, concat!("Offset of field: ", stringify!(C_with_zero_length_array_2),
-        "::", stringify!(zero_length_array))
+        unsafe {
+            ::std::ptr::addr_of!((*ptr).zero_length_array) as usize - ptr as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C_with_zero_length_array_2),
+            "::",
+            stringify!(zero_length_array),
+        ),
     );
 }
 #[repr(C)]
@@ -144,12 +179,14 @@ pub struct C_with_incomplete_array {
 #[test]
 fn bindgen_test_layout_C_with_incomplete_array() {
     assert_eq!(
-        ::std::mem::size_of:: < C_with_incomplete_array > (), 40usize,
-        concat!("Size of: ", stringify!(C_with_incomplete_array))
+        ::std::mem::size_of::<C_with_incomplete_array>(),
+        40usize,
+        concat!("Size of: ", stringify!(C_with_incomplete_array)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < C_with_incomplete_array > (), 4usize,
-        concat!("Alignment of ", stringify!(C_with_incomplete_array))
+        ::std::mem::align_of::<C_with_incomplete_array>(),
+        4usize,
+        concat!("Alignment of ", stringify!(C_with_incomplete_array)),
     );
 }
 impl Default for C_with_incomplete_array {
@@ -170,12 +207,14 @@ pub struct C_with_incomplete_array_2 {
 #[test]
 fn bindgen_test_layout_C_with_incomplete_array_2() {
     assert_eq!(
-        ::std::mem::size_of:: < C_with_incomplete_array_2 > (), 4usize,
-        concat!("Size of: ", stringify!(C_with_incomplete_array_2))
+        ::std::mem::size_of::<C_with_incomplete_array_2>(),
+        4usize,
+        concat!("Size of: ", stringify!(C_with_incomplete_array_2)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < C_with_incomplete_array_2 > (), 4usize,
-        concat!("Alignment of ", stringify!(C_with_incomplete_array_2))
+        ::std::mem::align_of::<C_with_incomplete_array_2>(),
+        4usize,
+        concat!("Alignment of ", stringify!(C_with_incomplete_array_2)),
     );
 }
 #[repr(C)]
@@ -188,14 +227,17 @@ pub struct C_with_zero_length_array_and_incomplete_array {
 #[test]
 fn bindgen_test_layout_C_with_zero_length_array_and_incomplete_array() {
     assert_eq!(
-        ::std::mem::size_of:: < C_with_zero_length_array_and_incomplete_array > (),
-        40usize, concat!("Size of: ",
-        stringify!(C_with_zero_length_array_and_incomplete_array))
+        ::std::mem::size_of::<C_with_zero_length_array_and_incomplete_array>(),
+        40usize,
+        concat!("Size of: ", stringify!(C_with_zero_length_array_and_incomplete_array)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < C_with_zero_length_array_and_incomplete_array > (),
-        4usize, concat!("Alignment of ",
-        stringify!(C_with_zero_length_array_and_incomplete_array))
+        ::std::mem::align_of::<C_with_zero_length_array_and_incomplete_array>(),
+        4usize,
+        concat!(
+            "Alignment of ",
+            stringify!(C_with_zero_length_array_and_incomplete_array),
+        ),
     );
 }
 impl Default for C_with_zero_length_array_and_incomplete_array {
@@ -217,14 +259,17 @@ pub struct C_with_zero_length_array_and_incomplete_array_2 {
 #[test]
 fn bindgen_test_layout_C_with_zero_length_array_and_incomplete_array_2() {
     assert_eq!(
-        ::std::mem::size_of:: < C_with_zero_length_array_and_incomplete_array_2 > (),
-        4usize, concat!("Size of: ",
-        stringify!(C_with_zero_length_array_and_incomplete_array_2))
+        ::std::mem::size_of::<C_with_zero_length_array_and_incomplete_array_2>(),
+        4usize,
+        concat!("Size of: ", stringify!(C_with_zero_length_array_and_incomplete_array_2)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < C_with_zero_length_array_and_incomplete_array_2 > (),
-        4usize, concat!("Alignment of ",
-        stringify!(C_with_zero_length_array_and_incomplete_array_2))
+        ::std::mem::align_of::<C_with_zero_length_array_and_incomplete_array_2>(),
+        4usize,
+        concat!(
+            "Alignment of ",
+            stringify!(C_with_zero_length_array_and_incomplete_array_2),
+        ),
     );
 }
 #[repr(C)]
@@ -237,16 +282,19 @@ fn bindgen_test_layout_WithDtor() {
     const UNINIT: ::std::mem::MaybeUninit<WithDtor> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < WithDtor > (), 4usize, concat!("Size of: ",
-        stringify!(WithDtor))
+        ::std::mem::size_of::<WithDtor>(),
+        4usize,
+        concat!("Size of: ", stringify!(WithDtor)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < WithDtor > (), 4usize, concat!("Alignment of ",
-        stringify!(WithDtor))
+        ::std::mem::align_of::<WithDtor>(),
+        4usize,
+        concat!("Alignment of ", stringify!(WithDtor)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).b) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(WithDtor), "::", stringify!(b))
+        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(WithDtor), "::", stringify!(b)),
     );
 }
 #[repr(C)]
@@ -257,12 +305,14 @@ pub struct IncompleteArrayNonCopiable {
 #[test]
 fn bindgen_test_layout_IncompleteArrayNonCopiable() {
     assert_eq!(
-        ::std::mem::size_of:: < IncompleteArrayNonCopiable > (), 8usize,
-        concat!("Size of: ", stringify!(IncompleteArrayNonCopiable))
+        ::std::mem::size_of::<IncompleteArrayNonCopiable>(),
+        8usize,
+        concat!("Size of: ", stringify!(IncompleteArrayNonCopiable)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < IncompleteArrayNonCopiable > (), 8usize,
-        concat!("Alignment of ", stringify!(IncompleteArrayNonCopiable))
+        ::std::mem::align_of::<IncompleteArrayNonCopiable>(),
+        8usize,
+        concat!("Alignment of ", stringify!(IncompleteArrayNonCopiable)),
     );
 }
 impl Default for IncompleteArrayNonCopiable {
@@ -285,20 +335,24 @@ fn bindgen_test_layout_Union() {
     const UNINIT: ::std::mem::MaybeUninit<Union> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < Union > (), 4usize, concat!("Size of: ",
-        stringify!(Union))
+        ::std::mem::size_of::<Union>(),
+        4usize,
+        concat!("Size of: ", stringify!(Union)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Union > (), 4usize, concat!("Alignment of ",
-        stringify!(Union))
+        ::std::mem::align_of::<Union>(),
+        4usize,
+        concat!("Alignment of ", stringify!(Union)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).d) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(Union), "::", stringify!(d))
+        unsafe { ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(Union), "::", stringify!(d)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).i) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(Union), "::", stringify!(i))
+        unsafe { ::std::ptr::addr_of!((*ptr).i) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(Union), "::", stringify!(i)),
     );
 }
 impl Default for Union {
@@ -320,16 +374,19 @@ fn bindgen_test_layout_WithUnion() {
     const UNINIT: ::std::mem::MaybeUninit<WithUnion> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < WithUnion > (), 4usize, concat!("Size of: ",
-        stringify!(WithUnion))
+        ::std::mem::size_of::<WithUnion>(),
+        4usize,
+        concat!("Size of: ", stringify!(WithUnion)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < WithUnion > (), 4usize, concat!("Alignment of ",
-        stringify!(WithUnion))
+        ::std::mem::align_of::<WithUnion>(),
+        4usize,
+        concat!("Alignment of ", stringify!(WithUnion)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).data) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(WithUnion), "::", stringify!(data))
+        unsafe { ::std::ptr::addr_of!((*ptr).data) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(WithUnion), "::", stringify!(data)),
     );
 }
 impl Default for WithUnion {
@@ -349,12 +406,14 @@ pub struct RealAbstractionWithTonsOfMethods {
 #[test]
 fn bindgen_test_layout_RealAbstractionWithTonsOfMethods() {
     assert_eq!(
-        ::std::mem::size_of:: < RealAbstractionWithTonsOfMethods > (), 1usize,
-        concat!("Size of: ", stringify!(RealAbstractionWithTonsOfMethods))
+        ::std::mem::size_of::<RealAbstractionWithTonsOfMethods>(),
+        1usize,
+        concat!("Size of: ", stringify!(RealAbstractionWithTonsOfMethods)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < RealAbstractionWithTonsOfMethods > (), 1usize,
-        concat!("Alignment of ", stringify!(RealAbstractionWithTonsOfMethods))
+        ::std::mem::align_of::<RealAbstractionWithTonsOfMethods>(),
+        1usize,
+        concat!("Alignment of ", stringify!(RealAbstractionWithTonsOfMethods)),
     );
 }
 extern "C" {

--- a/bindgen-tests/tests/expectations/tests/class_1_0.rs
+++ b/bindgen-tests/tests/expectations/tests/class_1_0.rs
@@ -82,19 +82,21 @@ pub struct C {
 fn bindgen_test_layout_C() {
     const UNINIT: ::std::mem::MaybeUninit<C> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
+    assert_eq!(::std::mem::size_of::<C>(), 40usize, concat!("Size of: ", stringify!(C)));
     assert_eq!(
-        ::std::mem::size_of:: < C > (), 40usize, concat!("Size of: ", stringify!(C))
+        ::std::mem::align_of::<C>(),
+        4usize,
+        concat!("Alignment of ", stringify!(C)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < C > (), 4usize, concat!("Alignment of ", stringify!(C))
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(C), "::", stringify!(a)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).a) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(C), "::", stringify!(a))
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).big_array) as usize - ptr as usize },
-        4usize, concat!("Offset of field: ", stringify!(C), "::", stringify!(big_array))
+        unsafe { ::std::ptr::addr_of!((*ptr).big_array) as usize - ptr as usize },
+        4usize,
+        concat!("Offset of field: ", stringify!(C), "::", stringify!(big_array)),
     );
 }
 impl Clone for C {
@@ -127,27 +129,46 @@ fn bindgen_test_layout_C_with_zero_length_array() {
     const UNINIT: ::std::mem::MaybeUninit<C_with_zero_length_array> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < C_with_zero_length_array > (), 40usize,
-        concat!("Size of: ", stringify!(C_with_zero_length_array))
+        ::std::mem::size_of::<C_with_zero_length_array>(),
+        40usize,
+        concat!("Size of: ", stringify!(C_with_zero_length_array)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < C_with_zero_length_array > (), 4usize,
-        concat!("Alignment of ", stringify!(C_with_zero_length_array))
+        ::std::mem::align_of::<C_with_zero_length_array>(),
+        4usize,
+        concat!("Alignment of ", stringify!(C_with_zero_length_array)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).a) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(C_with_zero_length_array), "::",
-        stringify!(a))
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C_with_zero_length_array),
+            "::",
+            stringify!(a),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).big_array) as usize - ptr as usize },
-        4usize, concat!("Offset of field: ", stringify!(C_with_zero_length_array), "::",
-        stringify!(big_array))
+        unsafe { ::std::ptr::addr_of!((*ptr).big_array) as usize - ptr as usize },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C_with_zero_length_array),
+            "::",
+            stringify!(big_array),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).zero_length_array) as usize - ptr as usize
-        }, 37usize, concat!("Offset of field: ", stringify!(C_with_zero_length_array),
-        "::", stringify!(zero_length_array))
+        unsafe {
+            ::std::ptr::addr_of!((*ptr).zero_length_array) as usize - ptr as usize
+        },
+        37usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C_with_zero_length_array),
+            "::",
+            stringify!(zero_length_array),
+        ),
     );
 }
 impl Default for C_with_zero_length_array {
@@ -170,22 +191,36 @@ fn bindgen_test_layout_C_with_zero_length_array_2() {
     const UNINIT: ::std::mem::MaybeUninit<C_with_zero_length_array_2> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < C_with_zero_length_array_2 > (), 4usize,
-        concat!("Size of: ", stringify!(C_with_zero_length_array_2))
+        ::std::mem::size_of::<C_with_zero_length_array_2>(),
+        4usize,
+        concat!("Size of: ", stringify!(C_with_zero_length_array_2)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < C_with_zero_length_array_2 > (), 4usize,
-        concat!("Alignment of ", stringify!(C_with_zero_length_array_2))
+        ::std::mem::align_of::<C_with_zero_length_array_2>(),
+        4usize,
+        concat!("Alignment of ", stringify!(C_with_zero_length_array_2)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).a) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(C_with_zero_length_array_2), "::",
-        stringify!(a))
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C_with_zero_length_array_2),
+            "::",
+            stringify!(a),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).zero_length_array) as usize - ptr as usize
-        }, 4usize, concat!("Offset of field: ", stringify!(C_with_zero_length_array_2),
-        "::", stringify!(zero_length_array))
+        unsafe {
+            ::std::ptr::addr_of!((*ptr).zero_length_array) as usize - ptr as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C_with_zero_length_array_2),
+            "::",
+            stringify!(zero_length_array),
+        ),
     );
 }
 #[repr(C)]
@@ -197,12 +232,14 @@ pub struct C_with_incomplete_array {
 #[test]
 fn bindgen_test_layout_C_with_incomplete_array() {
     assert_eq!(
-        ::std::mem::size_of:: < C_with_incomplete_array > (), 40usize,
-        concat!("Size of: ", stringify!(C_with_incomplete_array))
+        ::std::mem::size_of::<C_with_incomplete_array>(),
+        40usize,
+        concat!("Size of: ", stringify!(C_with_incomplete_array)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < C_with_incomplete_array > (), 4usize,
-        concat!("Alignment of ", stringify!(C_with_incomplete_array))
+        ::std::mem::align_of::<C_with_incomplete_array>(),
+        4usize,
+        concat!("Alignment of ", stringify!(C_with_incomplete_array)),
     );
 }
 impl Default for C_with_incomplete_array {
@@ -223,12 +260,14 @@ pub struct C_with_incomplete_array_2 {
 #[test]
 fn bindgen_test_layout_C_with_incomplete_array_2() {
     assert_eq!(
-        ::std::mem::size_of:: < C_with_incomplete_array_2 > (), 4usize,
-        concat!("Size of: ", stringify!(C_with_incomplete_array_2))
+        ::std::mem::size_of::<C_with_incomplete_array_2>(),
+        4usize,
+        concat!("Size of: ", stringify!(C_with_incomplete_array_2)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < C_with_incomplete_array_2 > (), 4usize,
-        concat!("Alignment of ", stringify!(C_with_incomplete_array_2))
+        ::std::mem::align_of::<C_with_incomplete_array_2>(),
+        4usize,
+        concat!("Alignment of ", stringify!(C_with_incomplete_array_2)),
     );
 }
 #[repr(C)]
@@ -241,14 +280,17 @@ pub struct C_with_zero_length_array_and_incomplete_array {
 #[test]
 fn bindgen_test_layout_C_with_zero_length_array_and_incomplete_array() {
     assert_eq!(
-        ::std::mem::size_of:: < C_with_zero_length_array_and_incomplete_array > (),
-        40usize, concat!("Size of: ",
-        stringify!(C_with_zero_length_array_and_incomplete_array))
+        ::std::mem::size_of::<C_with_zero_length_array_and_incomplete_array>(),
+        40usize,
+        concat!("Size of: ", stringify!(C_with_zero_length_array_and_incomplete_array)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < C_with_zero_length_array_and_incomplete_array > (),
-        4usize, concat!("Alignment of ",
-        stringify!(C_with_zero_length_array_and_incomplete_array))
+        ::std::mem::align_of::<C_with_zero_length_array_and_incomplete_array>(),
+        4usize,
+        concat!(
+            "Alignment of ",
+            stringify!(C_with_zero_length_array_and_incomplete_array),
+        ),
     );
 }
 impl Default for C_with_zero_length_array_and_incomplete_array {
@@ -270,14 +312,17 @@ pub struct C_with_zero_length_array_and_incomplete_array_2 {
 #[test]
 fn bindgen_test_layout_C_with_zero_length_array_and_incomplete_array_2() {
     assert_eq!(
-        ::std::mem::size_of:: < C_with_zero_length_array_and_incomplete_array_2 > (),
-        4usize, concat!("Size of: ",
-        stringify!(C_with_zero_length_array_and_incomplete_array_2))
+        ::std::mem::size_of::<C_with_zero_length_array_and_incomplete_array_2>(),
+        4usize,
+        concat!("Size of: ", stringify!(C_with_zero_length_array_and_incomplete_array_2)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < C_with_zero_length_array_and_incomplete_array_2 > (),
-        4usize, concat!("Alignment of ",
-        stringify!(C_with_zero_length_array_and_incomplete_array_2))
+        ::std::mem::align_of::<C_with_zero_length_array_and_incomplete_array_2>(),
+        4usize,
+        concat!(
+            "Alignment of ",
+            stringify!(C_with_zero_length_array_and_incomplete_array_2),
+        ),
     );
 }
 #[repr(C)]
@@ -290,16 +335,19 @@ fn bindgen_test_layout_WithDtor() {
     const UNINIT: ::std::mem::MaybeUninit<WithDtor> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < WithDtor > (), 4usize, concat!("Size of: ",
-        stringify!(WithDtor))
+        ::std::mem::size_of::<WithDtor>(),
+        4usize,
+        concat!("Size of: ", stringify!(WithDtor)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < WithDtor > (), 4usize, concat!("Alignment of ",
-        stringify!(WithDtor))
+        ::std::mem::align_of::<WithDtor>(),
+        4usize,
+        concat!("Alignment of ", stringify!(WithDtor)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).b) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(WithDtor), "::", stringify!(b))
+        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(WithDtor), "::", stringify!(b)),
     );
 }
 #[repr(C)]
@@ -310,12 +358,14 @@ pub struct IncompleteArrayNonCopiable {
 #[test]
 fn bindgen_test_layout_IncompleteArrayNonCopiable() {
     assert_eq!(
-        ::std::mem::size_of:: < IncompleteArrayNonCopiable > (), 8usize,
-        concat!("Size of: ", stringify!(IncompleteArrayNonCopiable))
+        ::std::mem::size_of::<IncompleteArrayNonCopiable>(),
+        8usize,
+        concat!("Size of: ", stringify!(IncompleteArrayNonCopiable)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < IncompleteArrayNonCopiable > (), 8usize,
-        concat!("Alignment of ", stringify!(IncompleteArrayNonCopiable))
+        ::std::mem::align_of::<IncompleteArrayNonCopiable>(),
+        8usize,
+        concat!("Alignment of ", stringify!(IncompleteArrayNonCopiable)),
     );
 }
 impl Default for IncompleteArrayNonCopiable {
@@ -339,20 +389,24 @@ fn bindgen_test_layout_Union() {
     const UNINIT: ::std::mem::MaybeUninit<Union> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < Union > (), 4usize, concat!("Size of: ",
-        stringify!(Union))
+        ::std::mem::size_of::<Union>(),
+        4usize,
+        concat!("Size of: ", stringify!(Union)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Union > (), 4usize, concat!("Alignment of ",
-        stringify!(Union))
+        ::std::mem::align_of::<Union>(),
+        4usize,
+        concat!("Alignment of ", stringify!(Union)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).d) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(Union), "::", stringify!(d))
+        unsafe { ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(Union), "::", stringify!(d)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).i) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(Union), "::", stringify!(i))
+        unsafe { ::std::ptr::addr_of!((*ptr).i) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(Union), "::", stringify!(i)),
     );
 }
 impl Clone for Union {
@@ -370,16 +424,19 @@ fn bindgen_test_layout_WithUnion() {
     const UNINIT: ::std::mem::MaybeUninit<WithUnion> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < WithUnion > (), 4usize, concat!("Size of: ",
-        stringify!(WithUnion))
+        ::std::mem::size_of::<WithUnion>(),
+        4usize,
+        concat!("Size of: ", stringify!(WithUnion)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < WithUnion > (), 4usize, concat!("Alignment of ",
-        stringify!(WithUnion))
+        ::std::mem::align_of::<WithUnion>(),
+        4usize,
+        concat!("Alignment of ", stringify!(WithUnion)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).data) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(WithUnion), "::", stringify!(data))
+        unsafe { ::std::ptr::addr_of!((*ptr).data) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(WithUnion), "::", stringify!(data)),
     );
 }
 impl Clone for WithUnion {
@@ -395,12 +452,14 @@ pub struct RealAbstractionWithTonsOfMethods {
 #[test]
 fn bindgen_test_layout_RealAbstractionWithTonsOfMethods() {
     assert_eq!(
-        ::std::mem::size_of:: < RealAbstractionWithTonsOfMethods > (), 1usize,
-        concat!("Size of: ", stringify!(RealAbstractionWithTonsOfMethods))
+        ::std::mem::size_of::<RealAbstractionWithTonsOfMethods>(),
+        1usize,
+        concat!("Size of: ", stringify!(RealAbstractionWithTonsOfMethods)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < RealAbstractionWithTonsOfMethods > (), 1usize,
-        concat!("Alignment of ", stringify!(RealAbstractionWithTonsOfMethods))
+        ::std::mem::align_of::<RealAbstractionWithTonsOfMethods>(),
+        1usize,
+        concat!("Alignment of ", stringify!(RealAbstractionWithTonsOfMethods)),
     );
 }
 extern "C" {

--- a/bindgen-tests/tests/expectations/tests/class_nested.rs
+++ b/bindgen-tests/tests/expectations/tests/class_nested.rs
@@ -14,15 +14,19 @@ fn bindgen_test_layout_A_B() {
     const UNINIT: ::std::mem::MaybeUninit<A_B> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < A_B > (), 4usize, concat!("Size of: ", stringify!(A_B))
+        ::std::mem::size_of::<A_B>(),
+        4usize,
+        concat!("Size of: ", stringify!(A_B)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < A_B > (), 4usize, concat!("Alignment of ",
-        stringify!(A_B))
+        ::std::mem::align_of::<A_B>(),
+        4usize,
+        concat!("Alignment of ", stringify!(A_B)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).member_b) as usize - ptr as usize },
-        0usize, concat!("Offset of field: ", stringify!(A_B), "::", stringify!(member_b))
+        unsafe { ::std::ptr::addr_of!((*ptr).member_b) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(A_B), "::", stringify!(member_b)),
     );
 }
 #[repr(C)]
@@ -44,15 +48,16 @@ impl<T> Default for A_D<T> {
 fn bindgen_test_layout_A() {
     const UNINIT: ::std::mem::MaybeUninit<A> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
+    assert_eq!(::std::mem::size_of::<A>(), 4usize, concat!("Size of: ", stringify!(A)));
     assert_eq!(
-        ::std::mem::size_of:: < A > (), 4usize, concat!("Size of: ", stringify!(A))
+        ::std::mem::align_of::<A>(),
+        4usize,
+        concat!("Alignment of ", stringify!(A)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < A > (), 4usize, concat!("Alignment of ", stringify!(A))
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).member_a) as usize - ptr as usize },
-        0usize, concat!("Offset of field: ", stringify!(A), "::", stringify!(member_a))
+        unsafe { ::std::ptr::addr_of!((*ptr).member_a) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(A), "::", stringify!(member_a)),
     );
 }
 #[repr(C)]
@@ -65,15 +70,19 @@ fn bindgen_test_layout_A_C() {
     const UNINIT: ::std::mem::MaybeUninit<A_C> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < A_C > (), 4usize, concat!("Size of: ", stringify!(A_C))
+        ::std::mem::size_of::<A_C>(),
+        4usize,
+        concat!("Size of: ", stringify!(A_C)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < A_C > (), 4usize, concat!("Alignment of ",
-        stringify!(A_C))
+        ::std::mem::align_of::<A_C>(),
+        4usize,
+        concat!("Alignment of ", stringify!(A_C)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).baz) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(A_C), "::", stringify!(baz))
+        unsafe { ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(A_C), "::", stringify!(baz)),
     );
 }
 extern "C" {
@@ -82,14 +91,20 @@ extern "C" {
 #[test]
 fn __bindgen_test_layout_A_D_open0_int_close0_instantiation() {
     assert_eq!(
-        ::std::mem::size_of:: < A_D < ::std::os::raw::c_int > > (), 4usize,
-        concat!("Size of template specialization: ", stringify!(A_D <
-        ::std::os::raw::c_int >))
+        ::std::mem::size_of::<A_D<::std::os::raw::c_int>>(),
+        4usize,
+        concat!(
+            "Size of template specialization: ",
+            stringify!(A_D < ::std::os::raw::c_int >),
+        ),
     );
     assert_eq!(
-        ::std::mem::align_of:: < A_D < ::std::os::raw::c_int > > (), 4usize,
-        concat!("Alignment of template specialization: ", stringify!(A_D <
-        ::std::os::raw::c_int >))
+        ::std::mem::align_of::<A_D<::std::os::raw::c_int>>(),
+        4usize,
+        concat!(
+            "Alignment of template specialization: ",
+            stringify!(A_D < ::std::os::raw::c_int >),
+        ),
     );
 }
 extern "C" {
@@ -104,15 +119,16 @@ pub struct D {
 fn bindgen_test_layout_D() {
     const UNINIT: ::std::mem::MaybeUninit<D> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
+    assert_eq!(::std::mem::size_of::<D>(), 4usize, concat!("Size of: ", stringify!(D)));
     assert_eq!(
-        ::std::mem::size_of:: < D > (), 4usize, concat!("Size of: ", stringify!(D))
+        ::std::mem::align_of::<D>(),
+        4usize,
+        concat!("Alignment of ", stringify!(D)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < D > (), 4usize, concat!("Alignment of ", stringify!(D))
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).member) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(D), "::", stringify!(member))
+        unsafe { ::std::ptr::addr_of!((*ptr).member) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(D), "::", stringify!(member)),
     );
 }
 #[repr(C)]

--- a/bindgen-tests/tests/expectations/tests/class_no_members.rs
+++ b/bindgen-tests/tests/expectations/tests/class_no_members.rs
@@ -7,12 +7,14 @@ pub struct whatever {
 #[test]
 fn bindgen_test_layout_whatever() {
     assert_eq!(
-        ::std::mem::size_of:: < whatever > (), 1usize, concat!("Size of: ",
-        stringify!(whatever))
+        ::std::mem::size_of::<whatever>(),
+        1usize,
+        concat!("Size of: ", stringify!(whatever)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < whatever > (), 1usize, concat!("Alignment of ",
-        stringify!(whatever))
+        ::std::mem::align_of::<whatever>(),
+        1usize,
+        concat!("Alignment of ", stringify!(whatever)),
     );
 }
 #[repr(C)]
@@ -23,12 +25,14 @@ pub struct whatever_child {
 #[test]
 fn bindgen_test_layout_whatever_child() {
     assert_eq!(
-        ::std::mem::size_of:: < whatever_child > (), 1usize, concat!("Size of: ",
-        stringify!(whatever_child))
+        ::std::mem::size_of::<whatever_child>(),
+        1usize,
+        concat!("Size of: ", stringify!(whatever_child)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < whatever_child > (), 1usize, concat!("Alignment of ",
-        stringify!(whatever_child))
+        ::std::mem::align_of::<whatever_child>(),
+        1usize,
+        concat!("Alignment of ", stringify!(whatever_child)),
     );
 }
 #[repr(C)]
@@ -41,16 +45,23 @@ fn bindgen_test_layout_whatever_child_with_member() {
     const UNINIT: ::std::mem::MaybeUninit<whatever_child_with_member> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < whatever_child_with_member > (), 4usize,
-        concat!("Size of: ", stringify!(whatever_child_with_member))
+        ::std::mem::size_of::<whatever_child_with_member>(),
+        4usize,
+        concat!("Size of: ", stringify!(whatever_child_with_member)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < whatever_child_with_member > (), 4usize,
-        concat!("Alignment of ", stringify!(whatever_child_with_member))
+        ::std::mem::align_of::<whatever_child_with_member>(),
+        4usize,
+        concat!("Alignment of ", stringify!(whatever_child_with_member)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).m_member) as usize - ptr as usize },
-        0usize, concat!("Offset of field: ", stringify!(whatever_child_with_member),
-        "::", stringify!(m_member))
+        unsafe { ::std::ptr::addr_of!((*ptr).m_member) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(whatever_child_with_member),
+            "::",
+            stringify!(m_member),
+        ),
     );
 }

--- a/bindgen-tests/tests/expectations/tests/class_static.rs
+++ b/bindgen-tests/tests/expectations/tests/class_static.rs
@@ -15,12 +15,14 @@ extern "C" {
 #[test]
 fn bindgen_test_layout_MyClass() {
     assert_eq!(
-        ::std::mem::size_of:: < MyClass > (), 1usize, concat!("Size of: ",
-        stringify!(MyClass))
+        ::std::mem::size_of::<MyClass>(),
+        1usize,
+        concat!("Size of: ", stringify!(MyClass)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < MyClass > (), 1usize, concat!("Alignment of ",
-        stringify!(MyClass))
+        ::std::mem::align_of::<MyClass>(),
+        1usize,
+        concat!("Alignment of ", stringify!(MyClass)),
     );
 }
 extern "C" {

--- a/bindgen-tests/tests/expectations/tests/class_static_const.rs
+++ b/bindgen-tests/tests/expectations/tests/class_static_const.rs
@@ -9,10 +9,10 @@ pub const A_b: i32 = 63;
 pub const A_c: u32 = 255;
 #[test]
 fn bindgen_test_layout_A() {
+    assert_eq!(::std::mem::size_of::<A>(), 1usize, concat!("Size of: ", stringify!(A)));
     assert_eq!(
-        ::std::mem::size_of:: < A > (), 1usize, concat!("Size of: ", stringify!(A))
-    );
-    assert_eq!(
-        ::std::mem::align_of:: < A > (), 1usize, concat!("Alignment of ", stringify!(A))
+        ::std::mem::align_of::<A>(),
+        1usize,
+        concat!("Alignment of ", stringify!(A)),
     );
 }

--- a/bindgen-tests/tests/expectations/tests/class_use_as.rs
+++ b/bindgen-tests/tests/expectations/tests/class_use_as.rs
@@ -10,17 +10,19 @@ fn bindgen_test_layout_whatever() {
     const UNINIT: ::std::mem::MaybeUninit<whatever> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < whatever > (), 4usize, concat!("Size of: ",
-        stringify!(whatever))
+        ::std::mem::size_of::<whatever>(),
+        4usize,
+        concat!("Size of: ", stringify!(whatever)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < whatever > (), 4usize, concat!("Alignment of ",
-        stringify!(whatever))
+        ::std::mem::align_of::<whatever>(),
+        4usize,
+        concat!("Alignment of ", stringify!(whatever)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).replacement) as usize - ptr as usize },
-        0usize, concat!("Offset of field: ", stringify!(whatever), "::",
-        stringify!(replacement))
+        unsafe { ::std::ptr::addr_of!((*ptr).replacement) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(whatever), "::", stringify!(replacement)),
     );
 }
 #[repr(C)]
@@ -33,15 +35,18 @@ fn bindgen_test_layout_container() {
     const UNINIT: ::std::mem::MaybeUninit<container> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < container > (), 4usize, concat!("Size of: ",
-        stringify!(container))
+        ::std::mem::size_of::<container>(),
+        4usize,
+        concat!("Size of: ", stringify!(container)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < container > (), 4usize, concat!("Alignment of ",
-        stringify!(container))
+        ::std::mem::align_of::<container>(),
+        4usize,
+        concat!("Alignment of ", stringify!(container)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).c) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(container), "::", stringify!(c))
+        unsafe { ::std::ptr::addr_of!((*ptr).c) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(container), "::", stringify!(c)),
     );
 }

--- a/bindgen-tests/tests/expectations/tests/class_with_dtor.rs
+++ b/bindgen-tests/tests/expectations/tests/class_with_dtor.rs
@@ -25,17 +25,24 @@ fn bindgen_test_layout_WithoutDtor() {
     const UNINIT: ::std::mem::MaybeUninit<WithoutDtor> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < WithoutDtor > (), 8usize, concat!("Size of: ",
-        stringify!(WithoutDtor))
+        ::std::mem::size_of::<WithoutDtor>(),
+        8usize,
+        concat!("Size of: ", stringify!(WithoutDtor)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < WithoutDtor > (), 8usize, concat!("Alignment of ",
-        stringify!(WithoutDtor))
+        ::std::mem::align_of::<WithoutDtor>(),
+        8usize,
+        concat!("Alignment of ", stringify!(WithoutDtor)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).shouldBeWithDtor) as usize - ptr as usize
-        }, 0usize, concat!("Offset of field: ", stringify!(WithoutDtor), "::",
-        stringify!(shouldBeWithDtor))
+        unsafe { ::std::ptr::addr_of!((*ptr).shouldBeWithDtor) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(WithoutDtor),
+            "::",
+            stringify!(shouldBeWithDtor),
+        ),
     );
 }
 impl Default for WithoutDtor {
@@ -50,13 +57,19 @@ impl Default for WithoutDtor {
 #[test]
 fn __bindgen_test_layout_HandleWithDtor_open0_int_close0_instantiation() {
     assert_eq!(
-        ::std::mem::size_of:: < HandleWithDtor < ::std::os::raw::c_int > > (), 8usize,
-        concat!("Size of template specialization: ", stringify!(HandleWithDtor <
-        ::std::os::raw::c_int >))
+        ::std::mem::size_of::<HandleWithDtor<::std::os::raw::c_int>>(),
+        8usize,
+        concat!(
+            "Size of template specialization: ",
+            stringify!(HandleWithDtor < ::std::os::raw::c_int >),
+        ),
     );
     assert_eq!(
-        ::std::mem::align_of:: < HandleWithDtor < ::std::os::raw::c_int > > (), 8usize,
-        concat!("Alignment of template specialization: ", stringify!(HandleWithDtor <
-        ::std::os::raw::c_int >))
+        ::std::mem::align_of::<HandleWithDtor<::std::os::raw::c_int>>(),
+        8usize,
+        concat!(
+            "Alignment of template specialization: ",
+            stringify!(HandleWithDtor < ::std::os::raw::c_int >),
+        ),
     );
 }

--- a/bindgen-tests/tests/expectations/tests/class_with_inner_struct.rs
+++ b/bindgen-tests/tests/expectations/tests/class_with_inner_struct.rs
@@ -17,20 +17,24 @@ fn bindgen_test_layout_A_Segment() {
     const UNINIT: ::std::mem::MaybeUninit<A_Segment> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < A_Segment > (), 8usize, concat!("Size of: ",
-        stringify!(A_Segment))
+        ::std::mem::size_of::<A_Segment>(),
+        8usize,
+        concat!("Size of: ", stringify!(A_Segment)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < A_Segment > (), 4usize, concat!("Alignment of ",
-        stringify!(A_Segment))
+        ::std::mem::align_of::<A_Segment>(),
+        4usize,
+        concat!("Alignment of ", stringify!(A_Segment)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).begin) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(A_Segment), "::", stringify!(begin))
+        unsafe { ::std::ptr::addr_of!((*ptr).begin) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(A_Segment), "::", stringify!(begin)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).end) as usize - ptr as usize }, 4usize,
-        concat!("Offset of field: ", stringify!(A_Segment), "::", stringify!(end))
+        unsafe { ::std::ptr::addr_of!((*ptr).end) as usize - ptr as usize },
+        4usize,
+        concat!("Offset of field: ", stringify!(A_Segment), "::", stringify!(end)),
     );
 }
 #[repr(C)]
@@ -43,16 +47,19 @@ fn bindgen_test_layout_A__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<A__bindgen_ty_1> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < A__bindgen_ty_1 > (), 4usize, concat!("Size of: ",
-        stringify!(A__bindgen_ty_1))
+        ::std::mem::size_of::<A__bindgen_ty_1>(),
+        4usize,
+        concat!("Size of: ", stringify!(A__bindgen_ty_1)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < A__bindgen_ty_1 > (), 4usize, concat!("Alignment of ",
-        stringify!(A__bindgen_ty_1))
+        ::std::mem::align_of::<A__bindgen_ty_1>(),
+        4usize,
+        concat!("Alignment of ", stringify!(A__bindgen_ty_1)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).f) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(A__bindgen_ty_1), "::", stringify!(f))
+        unsafe { ::std::ptr::addr_of!((*ptr).f) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(A__bindgen_ty_1), "::", stringify!(f)),
     );
 }
 impl Default for A__bindgen_ty_1 {
@@ -74,16 +81,19 @@ fn bindgen_test_layout_A__bindgen_ty_2() {
     const UNINIT: ::std::mem::MaybeUninit<A__bindgen_ty_2> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < A__bindgen_ty_2 > (), 4usize, concat!("Size of: ",
-        stringify!(A__bindgen_ty_2))
+        ::std::mem::size_of::<A__bindgen_ty_2>(),
+        4usize,
+        concat!("Size of: ", stringify!(A__bindgen_ty_2)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < A__bindgen_ty_2 > (), 4usize, concat!("Alignment of ",
-        stringify!(A__bindgen_ty_2))
+        ::std::mem::align_of::<A__bindgen_ty_2>(),
+        4usize,
+        concat!("Alignment of ", stringify!(A__bindgen_ty_2)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).d) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(A__bindgen_ty_2), "::", stringify!(d))
+        unsafe { ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(A__bindgen_ty_2), "::", stringify!(d)),
     );
 }
 impl Default for A__bindgen_ty_2 {
@@ -99,20 +109,21 @@ impl Default for A__bindgen_ty_2 {
 fn bindgen_test_layout_A() {
     const UNINIT: ::std::mem::MaybeUninit<A> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
+    assert_eq!(::std::mem::size_of::<A>(), 12usize, concat!("Size of: ", stringify!(A)));
     assert_eq!(
-        ::std::mem::size_of:: < A > (), 12usize, concat!("Size of: ", stringify!(A))
+        ::std::mem::align_of::<A>(),
+        4usize,
+        concat!("Alignment of ", stringify!(A)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < A > (), 4usize, concat!("Alignment of ", stringify!(A))
+        unsafe { ::std::ptr::addr_of!((*ptr).c) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(A), "::", stringify!(c)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).c) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(A), "::", stringify!(c))
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).named_union) as usize - ptr as usize },
-        4usize, concat!("Offset of field: ", stringify!(A), "::",
-        stringify!(named_union))
+        unsafe { ::std::ptr::addr_of!((*ptr).named_union) as usize - ptr as usize },
+        4usize,
+        concat!("Offset of field: ", stringify!(A), "::", stringify!(named_union)),
     );
 }
 impl Default for A {
@@ -140,35 +151,40 @@ fn bindgen_test_layout_B_Segment() {
     const UNINIT: ::std::mem::MaybeUninit<B_Segment> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < B_Segment > (), 8usize, concat!("Size of: ",
-        stringify!(B_Segment))
+        ::std::mem::size_of::<B_Segment>(),
+        8usize,
+        concat!("Size of: ", stringify!(B_Segment)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < B_Segment > (), 4usize, concat!("Alignment of ",
-        stringify!(B_Segment))
+        ::std::mem::align_of::<B_Segment>(),
+        4usize,
+        concat!("Alignment of ", stringify!(B_Segment)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).begin) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(B_Segment), "::", stringify!(begin))
+        unsafe { ::std::ptr::addr_of!((*ptr).begin) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(B_Segment), "::", stringify!(begin)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).end) as usize - ptr as usize }, 4usize,
-        concat!("Offset of field: ", stringify!(B_Segment), "::", stringify!(end))
+        unsafe { ::std::ptr::addr_of!((*ptr).end) as usize - ptr as usize },
+        4usize,
+        concat!("Offset of field: ", stringify!(B_Segment), "::", stringify!(end)),
     );
 }
 #[test]
 fn bindgen_test_layout_B() {
     const UNINIT: ::std::mem::MaybeUninit<B> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
+    assert_eq!(::std::mem::size_of::<B>(), 4usize, concat!("Size of: ", stringify!(B)));
     assert_eq!(
-        ::std::mem::size_of:: < B > (), 4usize, concat!("Size of: ", stringify!(B))
+        ::std::mem::align_of::<B>(),
+        4usize,
+        concat!("Alignment of ", stringify!(B)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < B > (), 4usize, concat!("Alignment of ", stringify!(B))
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).d) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(B), "::", stringify!(d))
+        unsafe { ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(B), "::", stringify!(d)),
     );
 }
 #[repr(i32)]
@@ -204,32 +220,54 @@ fn bindgen_test_layout_C__bindgen_ty_1__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<C__bindgen_ty_1__bindgen_ty_1> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < C__bindgen_ty_1__bindgen_ty_1 > (), 16usize,
-        concat!("Size of: ", stringify!(C__bindgen_ty_1__bindgen_ty_1))
+        ::std::mem::size_of::<C__bindgen_ty_1__bindgen_ty_1>(),
+        16usize,
+        concat!("Size of: ", stringify!(C__bindgen_ty_1__bindgen_ty_1)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < C__bindgen_ty_1__bindgen_ty_1 > (), 4usize,
-        concat!("Alignment of ", stringify!(C__bindgen_ty_1__bindgen_ty_1))
+        ::std::mem::align_of::<C__bindgen_ty_1__bindgen_ty_1>(),
+        4usize,
+        concat!("Alignment of ", stringify!(C__bindgen_ty_1__bindgen_ty_1)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).mX1) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(C__bindgen_ty_1__bindgen_ty_1), "::",
-        stringify!(mX1))
+        unsafe { ::std::ptr::addr_of!((*ptr).mX1) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C__bindgen_ty_1__bindgen_ty_1),
+            "::",
+            stringify!(mX1),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).mY1) as usize - ptr as usize }, 4usize,
-        concat!("Offset of field: ", stringify!(C__bindgen_ty_1__bindgen_ty_1), "::",
-        stringify!(mY1))
+        unsafe { ::std::ptr::addr_of!((*ptr).mY1) as usize - ptr as usize },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C__bindgen_ty_1__bindgen_ty_1),
+            "::",
+            stringify!(mY1),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).mX2) as usize - ptr as usize }, 8usize,
-        concat!("Offset of field: ", stringify!(C__bindgen_ty_1__bindgen_ty_1), "::",
-        stringify!(mX2))
+        unsafe { ::std::ptr::addr_of!((*ptr).mX2) as usize - ptr as usize },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C__bindgen_ty_1__bindgen_ty_1),
+            "::",
+            stringify!(mX2),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).mY2) as usize - ptr as usize }, 12usize,
-        concat!("Offset of field: ", stringify!(C__bindgen_ty_1__bindgen_ty_1), "::",
-        stringify!(mY2))
+        unsafe { ::std::ptr::addr_of!((*ptr).mY2) as usize - ptr as usize },
+        12usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C__bindgen_ty_1__bindgen_ty_1),
+            "::",
+            stringify!(mY2),
+        ),
     );
 }
 #[repr(C)]
@@ -243,22 +281,34 @@ fn bindgen_test_layout_C__bindgen_ty_1__bindgen_ty_2() {
     const UNINIT: ::std::mem::MaybeUninit<C__bindgen_ty_1__bindgen_ty_2> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < C__bindgen_ty_1__bindgen_ty_2 > (), 8usize,
-        concat!("Size of: ", stringify!(C__bindgen_ty_1__bindgen_ty_2))
+        ::std::mem::size_of::<C__bindgen_ty_1__bindgen_ty_2>(),
+        8usize,
+        concat!("Size of: ", stringify!(C__bindgen_ty_1__bindgen_ty_2)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < C__bindgen_ty_1__bindgen_ty_2 > (), 4usize,
-        concat!("Alignment of ", stringify!(C__bindgen_ty_1__bindgen_ty_2))
+        ::std::mem::align_of::<C__bindgen_ty_1__bindgen_ty_2>(),
+        4usize,
+        concat!("Alignment of ", stringify!(C__bindgen_ty_1__bindgen_ty_2)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).mStepSyntax) as usize - ptr as usize },
-        0usize, concat!("Offset of field: ", stringify!(C__bindgen_ty_1__bindgen_ty_2),
-        "::", stringify!(mStepSyntax))
+        unsafe { ::std::ptr::addr_of!((*ptr).mStepSyntax) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C__bindgen_ty_1__bindgen_ty_2),
+            "::",
+            stringify!(mStepSyntax),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).mSteps) as usize - ptr as usize }, 4usize,
-        concat!("Offset of field: ", stringify!(C__bindgen_ty_1__bindgen_ty_2), "::",
-        stringify!(mSteps))
+        unsafe { ::std::ptr::addr_of!((*ptr).mSteps) as usize - ptr as usize },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C__bindgen_ty_1__bindgen_ty_2),
+            "::",
+            stringify!(mSteps),
+        ),
     );
 }
 impl Default for C__bindgen_ty_1__bindgen_ty_2 {
@@ -275,17 +325,24 @@ fn bindgen_test_layout_C__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<C__bindgen_ty_1> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < C__bindgen_ty_1 > (), 16usize, concat!("Size of: ",
-        stringify!(C__bindgen_ty_1))
+        ::std::mem::size_of::<C__bindgen_ty_1>(),
+        16usize,
+        concat!("Size of: ", stringify!(C__bindgen_ty_1)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < C__bindgen_ty_1 > (), 4usize, concat!("Alignment of ",
-        stringify!(C__bindgen_ty_1))
+        ::std::mem::align_of::<C__bindgen_ty_1>(),
+        4usize,
+        concat!("Alignment of ", stringify!(C__bindgen_ty_1)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).mFunc) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(C__bindgen_ty_1), "::",
-        stringify!(mFunc))
+        unsafe { ::std::ptr::addr_of!((*ptr).mFunc) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C__bindgen_ty_1),
+            "::",
+            stringify!(mFunc),
+        ),
     );
 }
 impl Default for C__bindgen_ty_1 {
@@ -308,35 +365,40 @@ fn bindgen_test_layout_C_Segment() {
     const UNINIT: ::std::mem::MaybeUninit<C_Segment> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < C_Segment > (), 8usize, concat!("Size of: ",
-        stringify!(C_Segment))
+        ::std::mem::size_of::<C_Segment>(),
+        8usize,
+        concat!("Size of: ", stringify!(C_Segment)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < C_Segment > (), 4usize, concat!("Alignment of ",
-        stringify!(C_Segment))
+        ::std::mem::align_of::<C_Segment>(),
+        4usize,
+        concat!("Alignment of ", stringify!(C_Segment)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).begin) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(C_Segment), "::", stringify!(begin))
+        unsafe { ::std::ptr::addr_of!((*ptr).begin) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(C_Segment), "::", stringify!(begin)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).end) as usize - ptr as usize }, 4usize,
-        concat!("Offset of field: ", stringify!(C_Segment), "::", stringify!(end))
+        unsafe { ::std::ptr::addr_of!((*ptr).end) as usize - ptr as usize },
+        4usize,
+        concat!("Offset of field: ", stringify!(C_Segment), "::", stringify!(end)),
     );
 }
 #[test]
 fn bindgen_test_layout_C() {
     const UNINIT: ::std::mem::MaybeUninit<C> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
+    assert_eq!(::std::mem::size_of::<C>(), 20usize, concat!("Size of: ", stringify!(C)));
     assert_eq!(
-        ::std::mem::size_of:: < C > (), 20usize, concat!("Size of: ", stringify!(C))
+        ::std::mem::align_of::<C>(),
+        4usize,
+        concat!("Alignment of ", stringify!(C)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < C > (), 4usize, concat!("Alignment of ", stringify!(C))
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).d) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(C), "::", stringify!(d))
+        unsafe { ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(C), "::", stringify!(d)),
     );
 }
 impl Default for C {

--- a/bindgen-tests/tests/expectations/tests/class_with_inner_struct_1_0.rs
+++ b/bindgen-tests/tests/expectations/tests/class_with_inner_struct_1_0.rs
@@ -60,20 +60,24 @@ fn bindgen_test_layout_A_Segment() {
     const UNINIT: ::std::mem::MaybeUninit<A_Segment> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < A_Segment > (), 8usize, concat!("Size of: ",
-        stringify!(A_Segment))
+        ::std::mem::size_of::<A_Segment>(),
+        8usize,
+        concat!("Size of: ", stringify!(A_Segment)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < A_Segment > (), 4usize, concat!("Alignment of ",
-        stringify!(A_Segment))
+        ::std::mem::align_of::<A_Segment>(),
+        4usize,
+        concat!("Alignment of ", stringify!(A_Segment)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).begin) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(A_Segment), "::", stringify!(begin))
+        unsafe { ::std::ptr::addr_of!((*ptr).begin) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(A_Segment), "::", stringify!(begin)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).end) as usize - ptr as usize }, 4usize,
-        concat!("Offset of field: ", stringify!(A_Segment), "::", stringify!(end))
+        unsafe { ::std::ptr::addr_of!((*ptr).end) as usize - ptr as usize },
+        4usize,
+        concat!("Offset of field: ", stringify!(A_Segment), "::", stringify!(end)),
     );
 }
 impl Clone for A_Segment {
@@ -92,16 +96,19 @@ fn bindgen_test_layout_A__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<A__bindgen_ty_1> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < A__bindgen_ty_1 > (), 4usize, concat!("Size of: ",
-        stringify!(A__bindgen_ty_1))
+        ::std::mem::size_of::<A__bindgen_ty_1>(),
+        4usize,
+        concat!("Size of: ", stringify!(A__bindgen_ty_1)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < A__bindgen_ty_1 > (), 4usize, concat!("Alignment of ",
-        stringify!(A__bindgen_ty_1))
+        ::std::mem::align_of::<A__bindgen_ty_1>(),
+        4usize,
+        concat!("Alignment of ", stringify!(A__bindgen_ty_1)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).f) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(A__bindgen_ty_1), "::", stringify!(f))
+        unsafe { ::std::ptr::addr_of!((*ptr).f) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(A__bindgen_ty_1), "::", stringify!(f)),
     );
 }
 impl Clone for A__bindgen_ty_1 {
@@ -120,16 +127,19 @@ fn bindgen_test_layout_A__bindgen_ty_2() {
     const UNINIT: ::std::mem::MaybeUninit<A__bindgen_ty_2> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < A__bindgen_ty_2 > (), 4usize, concat!("Size of: ",
-        stringify!(A__bindgen_ty_2))
+        ::std::mem::size_of::<A__bindgen_ty_2>(),
+        4usize,
+        concat!("Size of: ", stringify!(A__bindgen_ty_2)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < A__bindgen_ty_2 > (), 4usize, concat!("Alignment of ",
-        stringify!(A__bindgen_ty_2))
+        ::std::mem::align_of::<A__bindgen_ty_2>(),
+        4usize,
+        concat!("Alignment of ", stringify!(A__bindgen_ty_2)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).d) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(A__bindgen_ty_2), "::", stringify!(d))
+        unsafe { ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(A__bindgen_ty_2), "::", stringify!(d)),
     );
 }
 impl Clone for A__bindgen_ty_2 {
@@ -141,20 +151,21 @@ impl Clone for A__bindgen_ty_2 {
 fn bindgen_test_layout_A() {
     const UNINIT: ::std::mem::MaybeUninit<A> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
+    assert_eq!(::std::mem::size_of::<A>(), 12usize, concat!("Size of: ", stringify!(A)));
     assert_eq!(
-        ::std::mem::size_of:: < A > (), 12usize, concat!("Size of: ", stringify!(A))
+        ::std::mem::align_of::<A>(),
+        4usize,
+        concat!("Alignment of ", stringify!(A)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < A > (), 4usize, concat!("Alignment of ", stringify!(A))
+        unsafe { ::std::ptr::addr_of!((*ptr).c) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(A), "::", stringify!(c)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).c) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(A), "::", stringify!(c))
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).named_union) as usize - ptr as usize },
-        4usize, concat!("Offset of field: ", stringify!(A), "::",
-        stringify!(named_union))
+        unsafe { ::std::ptr::addr_of!((*ptr).named_union) as usize - ptr as usize },
+        4usize,
+        concat!("Offset of field: ", stringify!(A), "::", stringify!(named_union)),
     );
 }
 impl Clone for A {
@@ -178,20 +189,24 @@ fn bindgen_test_layout_B_Segment() {
     const UNINIT: ::std::mem::MaybeUninit<B_Segment> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < B_Segment > (), 8usize, concat!("Size of: ",
-        stringify!(B_Segment))
+        ::std::mem::size_of::<B_Segment>(),
+        8usize,
+        concat!("Size of: ", stringify!(B_Segment)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < B_Segment > (), 4usize, concat!("Alignment of ",
-        stringify!(B_Segment))
+        ::std::mem::align_of::<B_Segment>(),
+        4usize,
+        concat!("Alignment of ", stringify!(B_Segment)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).begin) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(B_Segment), "::", stringify!(begin))
+        unsafe { ::std::ptr::addr_of!((*ptr).begin) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(B_Segment), "::", stringify!(begin)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).end) as usize - ptr as usize }, 4usize,
-        concat!("Offset of field: ", stringify!(B_Segment), "::", stringify!(end))
+        unsafe { ::std::ptr::addr_of!((*ptr).end) as usize - ptr as usize },
+        4usize,
+        concat!("Offset of field: ", stringify!(B_Segment), "::", stringify!(end)),
     );
 }
 impl Clone for B_Segment {
@@ -203,15 +218,16 @@ impl Clone for B_Segment {
 fn bindgen_test_layout_B() {
     const UNINIT: ::std::mem::MaybeUninit<B> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
+    assert_eq!(::std::mem::size_of::<B>(), 4usize, concat!("Size of: ", stringify!(B)));
     assert_eq!(
-        ::std::mem::size_of:: < B > (), 4usize, concat!("Size of: ", stringify!(B))
+        ::std::mem::align_of::<B>(),
+        4usize,
+        concat!("Alignment of ", stringify!(B)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < B > (), 4usize, concat!("Alignment of ", stringify!(B))
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).d) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(B), "::", stringify!(d))
+        unsafe { ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(B), "::", stringify!(d)),
     );
 }
 impl Clone for B {
@@ -253,32 +269,54 @@ fn bindgen_test_layout_C__bindgen_ty_1__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<C__bindgen_ty_1__bindgen_ty_1> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < C__bindgen_ty_1__bindgen_ty_1 > (), 16usize,
-        concat!("Size of: ", stringify!(C__bindgen_ty_1__bindgen_ty_1))
+        ::std::mem::size_of::<C__bindgen_ty_1__bindgen_ty_1>(),
+        16usize,
+        concat!("Size of: ", stringify!(C__bindgen_ty_1__bindgen_ty_1)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < C__bindgen_ty_1__bindgen_ty_1 > (), 4usize,
-        concat!("Alignment of ", stringify!(C__bindgen_ty_1__bindgen_ty_1))
+        ::std::mem::align_of::<C__bindgen_ty_1__bindgen_ty_1>(),
+        4usize,
+        concat!("Alignment of ", stringify!(C__bindgen_ty_1__bindgen_ty_1)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).mX1) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(C__bindgen_ty_1__bindgen_ty_1), "::",
-        stringify!(mX1))
+        unsafe { ::std::ptr::addr_of!((*ptr).mX1) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C__bindgen_ty_1__bindgen_ty_1),
+            "::",
+            stringify!(mX1),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).mY1) as usize - ptr as usize }, 4usize,
-        concat!("Offset of field: ", stringify!(C__bindgen_ty_1__bindgen_ty_1), "::",
-        stringify!(mY1))
+        unsafe { ::std::ptr::addr_of!((*ptr).mY1) as usize - ptr as usize },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C__bindgen_ty_1__bindgen_ty_1),
+            "::",
+            stringify!(mY1),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).mX2) as usize - ptr as usize }, 8usize,
-        concat!("Offset of field: ", stringify!(C__bindgen_ty_1__bindgen_ty_1), "::",
-        stringify!(mX2))
+        unsafe { ::std::ptr::addr_of!((*ptr).mX2) as usize - ptr as usize },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C__bindgen_ty_1__bindgen_ty_1),
+            "::",
+            stringify!(mX2),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).mY2) as usize - ptr as usize }, 12usize,
-        concat!("Offset of field: ", stringify!(C__bindgen_ty_1__bindgen_ty_1), "::",
-        stringify!(mY2))
+        unsafe { ::std::ptr::addr_of!((*ptr).mY2) as usize - ptr as usize },
+        12usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C__bindgen_ty_1__bindgen_ty_1),
+            "::",
+            stringify!(mY2),
+        ),
     );
 }
 impl Clone for C__bindgen_ty_1__bindgen_ty_1 {
@@ -297,22 +335,34 @@ fn bindgen_test_layout_C__bindgen_ty_1__bindgen_ty_2() {
     const UNINIT: ::std::mem::MaybeUninit<C__bindgen_ty_1__bindgen_ty_2> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < C__bindgen_ty_1__bindgen_ty_2 > (), 8usize,
-        concat!("Size of: ", stringify!(C__bindgen_ty_1__bindgen_ty_2))
+        ::std::mem::size_of::<C__bindgen_ty_1__bindgen_ty_2>(),
+        8usize,
+        concat!("Size of: ", stringify!(C__bindgen_ty_1__bindgen_ty_2)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < C__bindgen_ty_1__bindgen_ty_2 > (), 4usize,
-        concat!("Alignment of ", stringify!(C__bindgen_ty_1__bindgen_ty_2))
+        ::std::mem::align_of::<C__bindgen_ty_1__bindgen_ty_2>(),
+        4usize,
+        concat!("Alignment of ", stringify!(C__bindgen_ty_1__bindgen_ty_2)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).mStepSyntax) as usize - ptr as usize },
-        0usize, concat!("Offset of field: ", stringify!(C__bindgen_ty_1__bindgen_ty_2),
-        "::", stringify!(mStepSyntax))
+        unsafe { ::std::ptr::addr_of!((*ptr).mStepSyntax) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C__bindgen_ty_1__bindgen_ty_2),
+            "::",
+            stringify!(mStepSyntax),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).mSteps) as usize - ptr as usize }, 4usize,
-        concat!("Offset of field: ", stringify!(C__bindgen_ty_1__bindgen_ty_2), "::",
-        stringify!(mSteps))
+        unsafe { ::std::ptr::addr_of!((*ptr).mSteps) as usize - ptr as usize },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C__bindgen_ty_1__bindgen_ty_2),
+            "::",
+            stringify!(mSteps),
+        ),
     );
 }
 impl Clone for C__bindgen_ty_1__bindgen_ty_2 {
@@ -334,17 +384,24 @@ fn bindgen_test_layout_C__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<C__bindgen_ty_1> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < C__bindgen_ty_1 > (), 16usize, concat!("Size of: ",
-        stringify!(C__bindgen_ty_1))
+        ::std::mem::size_of::<C__bindgen_ty_1>(),
+        16usize,
+        concat!("Size of: ", stringify!(C__bindgen_ty_1)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < C__bindgen_ty_1 > (), 4usize, concat!("Alignment of ",
-        stringify!(C__bindgen_ty_1))
+        ::std::mem::align_of::<C__bindgen_ty_1>(),
+        4usize,
+        concat!("Alignment of ", stringify!(C__bindgen_ty_1)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).mFunc) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(C__bindgen_ty_1), "::",
-        stringify!(mFunc))
+        unsafe { ::std::ptr::addr_of!((*ptr).mFunc) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C__bindgen_ty_1),
+            "::",
+            stringify!(mFunc),
+        ),
     );
 }
 impl Clone for C__bindgen_ty_1 {
@@ -363,20 +420,24 @@ fn bindgen_test_layout_C_Segment() {
     const UNINIT: ::std::mem::MaybeUninit<C_Segment> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < C_Segment > (), 8usize, concat!("Size of: ",
-        stringify!(C_Segment))
+        ::std::mem::size_of::<C_Segment>(),
+        8usize,
+        concat!("Size of: ", stringify!(C_Segment)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < C_Segment > (), 4usize, concat!("Alignment of ",
-        stringify!(C_Segment))
+        ::std::mem::align_of::<C_Segment>(),
+        4usize,
+        concat!("Alignment of ", stringify!(C_Segment)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).begin) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(C_Segment), "::", stringify!(begin))
+        unsafe { ::std::ptr::addr_of!((*ptr).begin) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(C_Segment), "::", stringify!(begin)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).end) as usize - ptr as usize }, 4usize,
-        concat!("Offset of field: ", stringify!(C_Segment), "::", stringify!(end))
+        unsafe { ::std::ptr::addr_of!((*ptr).end) as usize - ptr as usize },
+        4usize,
+        concat!("Offset of field: ", stringify!(C_Segment), "::", stringify!(end)),
     );
 }
 impl Clone for C_Segment {
@@ -388,15 +449,16 @@ impl Clone for C_Segment {
 fn bindgen_test_layout_C() {
     const UNINIT: ::std::mem::MaybeUninit<C> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
+    assert_eq!(::std::mem::size_of::<C>(), 20usize, concat!("Size of: ", stringify!(C)));
     assert_eq!(
-        ::std::mem::size_of:: < C > (), 20usize, concat!("Size of: ", stringify!(C))
+        ::std::mem::align_of::<C>(),
+        4usize,
+        concat!("Alignment of ", stringify!(C)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < C > (), 4usize, concat!("Alignment of ", stringify!(C))
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).d) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(C), "::", stringify!(d))
+        unsafe { ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(C), "::", stringify!(d)),
     );
 }
 impl Clone for C {

--- a/bindgen-tests/tests/expectations/tests/class_with_typedef.rs
+++ b/bindgen-tests/tests/expectations/tests/class_with_typedef.rs
@@ -15,31 +15,36 @@ pub type C_Lookup = *const ::std::os::raw::c_char;
 fn bindgen_test_layout_C() {
     const UNINIT: ::std::mem::MaybeUninit<C> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
+    assert_eq!(::std::mem::size_of::<C>(), 72usize, concat!("Size of: ", stringify!(C)));
     assert_eq!(
-        ::std::mem::size_of:: < C > (), 72usize, concat!("Size of: ", stringify!(C))
+        ::std::mem::align_of::<C>(),
+        8usize,
+        concat!("Alignment of ", stringify!(C)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < C > (), 8usize, concat!("Alignment of ", stringify!(C))
+        unsafe { ::std::ptr::addr_of!((*ptr).c) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(C), "::", stringify!(c)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).c) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(C), "::", stringify!(c))
+        unsafe { ::std::ptr::addr_of!((*ptr).ptr) as usize - ptr as usize },
+        8usize,
+        concat!("Offset of field: ", stringify!(C), "::", stringify!(ptr)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).ptr) as usize - ptr as usize }, 8usize,
-        concat!("Offset of field: ", stringify!(C), "::", stringify!(ptr))
+        unsafe { ::std::ptr::addr_of!((*ptr).arr) as usize - ptr as usize },
+        16usize,
+        concat!("Offset of field: ", stringify!(C), "::", stringify!(arr)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).arr) as usize - ptr as usize }, 16usize,
-        concat!("Offset of field: ", stringify!(C), "::", stringify!(arr))
+        unsafe { ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize },
+        56usize,
+        concat!("Offset of field: ", stringify!(C), "::", stringify!(d)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).d) as usize - ptr as usize }, 56usize,
-        concat!("Offset of field: ", stringify!(C), "::", stringify!(d))
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).other_ptr) as usize - ptr as usize },
-        64usize, concat!("Offset of field: ", stringify!(C), "::", stringify!(other_ptr))
+        unsafe { ::std::ptr::addr_of!((*ptr).other_ptr) as usize - ptr as usize },
+        64usize,
+        concat!("Offset of field: ", stringify!(C), "::", stringify!(other_ptr)),
     );
 }
 extern "C" {
@@ -95,15 +100,16 @@ pub struct D {
 fn bindgen_test_layout_D() {
     const UNINIT: ::std::mem::MaybeUninit<D> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
+    assert_eq!(::std::mem::size_of::<D>(), 80usize, concat!("Size of: ", stringify!(D)));
     assert_eq!(
-        ::std::mem::size_of:: < D > (), 80usize, concat!("Size of: ", stringify!(D))
+        ::std::mem::align_of::<D>(),
+        8usize,
+        concat!("Alignment of ", stringify!(D)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < D > (), 8usize, concat!("Alignment of ", stringify!(D))
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).ptr) as usize - ptr as usize }, 72usize,
-        concat!("Offset of field: ", stringify!(D), "::", stringify!(ptr))
+        unsafe { ::std::ptr::addr_of!((*ptr).ptr) as usize - ptr as usize },
+        72usize,
+        concat!("Offset of field: ", stringify!(D), "::", stringify!(ptr)),
     );
 }
 impl Default for D {

--- a/bindgen-tests/tests/expectations/tests/comment-indent.rs
+++ b/bindgen-tests/tests/expectations/tests/comment-indent.rs
@@ -22,23 +22,27 @@ pub mod root {
     #[test]
     fn bindgen_test_layout_Foo_Bar() {
         assert_eq!(
-            ::std::mem::size_of:: < Foo_Bar > (), 1usize, concat!("Size of: ",
-            stringify!(Foo_Bar))
+            ::std::mem::size_of::<Foo_Bar>(),
+            1usize,
+            concat!("Size of: ", stringify!(Foo_Bar)),
         );
         assert_eq!(
-            ::std::mem::align_of:: < Foo_Bar > (), 1usize, concat!("Alignment of ",
-            stringify!(Foo_Bar))
+            ::std::mem::align_of::<Foo_Bar>(),
+            1usize,
+            concat!("Alignment of ", stringify!(Foo_Bar)),
         );
     }
     #[test]
     fn bindgen_test_layout_Foo() {
         assert_eq!(
-            ::std::mem::size_of:: < Foo > (), 1usize, concat!("Size of: ",
-            stringify!(Foo))
+            ::std::mem::size_of::<Foo>(),
+            1usize,
+            concat!("Size of: ", stringify!(Foo)),
         );
         assert_eq!(
-            ::std::mem::align_of:: < Foo > (), 1usize, concat!("Alignment of ",
-            stringify!(Foo))
+            ::std::mem::align_of::<Foo>(),
+            1usize,
+            concat!("Alignment of ", stringify!(Foo)),
         );
     }
     pub mod test {
@@ -63,17 +67,19 @@ pub mod root {
             const UNINIT: ::std::mem::MaybeUninit<Baz> = ::std::mem::MaybeUninit::uninit();
             let ptr = UNINIT.as_ptr();
             assert_eq!(
-                ::std::mem::size_of:: < Baz > (), 4usize, concat!("Size of: ",
-                stringify!(Baz))
+                ::std::mem::size_of::<Baz>(),
+                4usize,
+                concat!("Size of: ", stringify!(Baz)),
             );
             assert_eq!(
-                ::std::mem::align_of:: < Baz > (), 4usize, concat!("Alignment of ",
-                stringify!(Baz))
+                ::std::mem::align_of::<Baz>(),
+                4usize,
+                concat!("Alignment of ", stringify!(Baz)),
             );
             assert_eq!(
-                unsafe { ::std::ptr::addr_of!((* ptr).member) as usize - ptr as usize },
-                0usize, concat!("Offset of field: ", stringify!(Baz), "::",
-                stringify!(member))
+                unsafe { ::std::ptr::addr_of!((*ptr).member) as usize - ptr as usize },
+                0usize,
+                concat!("Offset of field: ", stringify!(Baz), "::", stringify!(member)),
             );
         }
         /** I'm in an inline namespace, and as such I shouldn't get generated inside
@@ -87,12 +93,14 @@ pub mod root {
         #[test]
         fn bindgen_test_layout_InInlineNS() {
             assert_eq!(
-                ::std::mem::size_of:: < InInlineNS > (), 1usize, concat!("Size of: ",
-                stringify!(InInlineNS))
+                ::std::mem::size_of::<InInlineNS>(),
+                1usize,
+                concat!("Size of: ", stringify!(InInlineNS)),
             );
             assert_eq!(
-                ::std::mem::align_of:: < InInlineNS > (), 1usize,
-                concat!("Alignment of ", stringify!(InInlineNS))
+                ::std::mem::align_of::<InInlineNS>(),
+                1usize,
+                concat!("Alignment of ", stringify!(InInlineNS)),
             );
         }
         #[repr(C)]
@@ -103,12 +111,14 @@ pub mod root {
         #[test]
         fn bindgen_test_layout_Bazz() {
             assert_eq!(
-                ::std::mem::size_of:: < Bazz > (), 1usize, concat!("Size of: ",
-                stringify!(Bazz))
+                ::std::mem::size_of::<Bazz>(),
+                1usize,
+                concat!("Size of: ", stringify!(Bazz)),
             );
             assert_eq!(
-                ::std::mem::align_of:: < Bazz > (), 1usize, concat!("Alignment of ",
-                stringify!(Bazz))
+                ::std::mem::align_of::<Bazz>(),
+                1usize,
+                concat!("Alignment of ", stringify!(Bazz)),
             );
         }
     }

--- a/bindgen-tests/tests/expectations/tests/complex.rs
+++ b/bindgen-tests/tests/expectations/tests/complex.rs
@@ -15,16 +15,19 @@ fn bindgen_test_layout_TestDouble() {
     const UNINIT: ::std::mem::MaybeUninit<TestDouble> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < TestDouble > (), 16usize, concat!("Size of: ",
-        stringify!(TestDouble))
+        ::std::mem::size_of::<TestDouble>(),
+        16usize,
+        concat!("Size of: ", stringify!(TestDouble)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < TestDouble > (), 8usize, concat!("Alignment of ",
-        stringify!(TestDouble))
+        ::std::mem::align_of::<TestDouble>(),
+        8usize,
+        concat!("Alignment of ", stringify!(TestDouble)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).mMember) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(TestDouble), "::", stringify!(mMember))
+        unsafe { ::std::ptr::addr_of!((*ptr).mMember) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(TestDouble), "::", stringify!(mMember)),
     );
 }
 #[repr(C)]
@@ -37,17 +40,24 @@ fn bindgen_test_layout_TestDoublePtr() {
     const UNINIT: ::std::mem::MaybeUninit<TestDoublePtr> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < TestDoublePtr > (), 8usize, concat!("Size of: ",
-        stringify!(TestDoublePtr))
+        ::std::mem::size_of::<TestDoublePtr>(),
+        8usize,
+        concat!("Size of: ", stringify!(TestDoublePtr)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < TestDoublePtr > (), 8usize, concat!("Alignment of ",
-        stringify!(TestDoublePtr))
+        ::std::mem::align_of::<TestDoublePtr>(),
+        8usize,
+        concat!("Alignment of ", stringify!(TestDoublePtr)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).mMember) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(TestDoublePtr), "::",
-        stringify!(mMember))
+        unsafe { ::std::ptr::addr_of!((*ptr).mMember) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(TestDoublePtr),
+            "::",
+            stringify!(mMember),
+        ),
     );
 }
 impl Default for TestDoublePtr {
@@ -69,16 +79,19 @@ fn bindgen_test_layout_TestFloat() {
     const UNINIT: ::std::mem::MaybeUninit<TestFloat> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < TestFloat > (), 8usize, concat!("Size of: ",
-        stringify!(TestFloat))
+        ::std::mem::size_of::<TestFloat>(),
+        8usize,
+        concat!("Size of: ", stringify!(TestFloat)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < TestFloat > (), 4usize, concat!("Alignment of ",
-        stringify!(TestFloat))
+        ::std::mem::align_of::<TestFloat>(),
+        4usize,
+        concat!("Alignment of ", stringify!(TestFloat)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).mMember) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(TestFloat), "::", stringify!(mMember))
+        unsafe { ::std::ptr::addr_of!((*ptr).mMember) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(TestFloat), "::", stringify!(mMember)),
     );
 }
 #[repr(C)]
@@ -91,16 +104,19 @@ fn bindgen_test_layout_TestFloatPtr() {
     const UNINIT: ::std::mem::MaybeUninit<TestFloatPtr> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < TestFloatPtr > (), 8usize, concat!("Size of: ",
-        stringify!(TestFloatPtr))
+        ::std::mem::size_of::<TestFloatPtr>(),
+        8usize,
+        concat!("Size of: ", stringify!(TestFloatPtr)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < TestFloatPtr > (), 8usize, concat!("Alignment of ",
-        stringify!(TestFloatPtr))
+        ::std::mem::align_of::<TestFloatPtr>(),
+        8usize,
+        concat!("Alignment of ", stringify!(TestFloatPtr)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).mMember) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(TestFloatPtr), "::", stringify!(mMember))
+        unsafe { ::std::ptr::addr_of!((*ptr).mMember) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(TestFloatPtr), "::", stringify!(mMember)),
     );
 }
 impl Default for TestFloatPtr {

--- a/bindgen-tests/tests/expectations/tests/const-const-mut-ptr.rs
+++ b/bindgen-tests/tests/expectations/tests/const-const-mut-ptr.rs
@@ -9,15 +9,19 @@ fn bindgen_test_layout_foo() {
     const UNINIT: ::std::mem::MaybeUninit<foo> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < foo > (), 8usize, concat!("Size of: ", stringify!(foo))
+        ::std::mem::size_of::<foo>(),
+        8usize,
+        concat!("Size of: ", stringify!(foo)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < foo > (), 8usize, concat!("Alignment of ",
-        stringify!(foo))
+        ::std::mem::align_of::<foo>(),
+        8usize,
+        concat!("Alignment of ", stringify!(foo)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).bar) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar))
+        unsafe { ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar)),
     );
 }
 impl Default for foo {

--- a/bindgen-tests/tests/expectations/tests/const_enum_unnamed.rs
+++ b/bindgen-tests/tests/expectations/tests/const_enum_unnamed.rs
@@ -21,10 +21,13 @@ pub enum Foo__bindgen_ty_1 {
 #[test]
 fn bindgen_test_layout_Foo() {
     assert_eq!(
-        ::std::mem::size_of:: < Foo > (), 1usize, concat!("Size of: ", stringify!(Foo))
+        ::std::mem::size_of::<Foo>(),
+        1usize,
+        concat!("Size of: ", stringify!(Foo)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Foo > (), 1usize, concat!("Alignment of ",
-        stringify!(Foo))
+        ::std::mem::align_of::<Foo>(),
+        1usize,
+        concat!("Alignment of ", stringify!(Foo)),
     );
 }

--- a/bindgen-tests/tests/expectations/tests/constified-enum-module-overflow.rs
+++ b/bindgen-tests/tests/expectations/tests/constified-enum-module-overflow.rs
@@ -19,25 +19,28 @@ pub struct A {
 fn bindgen_test_layout_A() {
     const UNINIT: ::std::mem::MaybeUninit<A> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
+    assert_eq!(::std::mem::size_of::<A>(), 1usize, concat!("Size of: ", stringify!(A)));
     assert_eq!(
-        ::std::mem::size_of:: < A > (), 1usize, concat!("Size of: ", stringify!(A))
+        ::std::mem::align_of::<A>(),
+        1usize,
+        concat!("Alignment of ", stringify!(A)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < A > (), 1usize, concat!("Alignment of ", stringify!(A))
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).u) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(A), "::", stringify!(u))
+        unsafe { ::std::ptr::addr_of!((*ptr).u) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(A), "::", stringify!(u)),
     );
 }
 #[test]
 fn __bindgen_test_layout_C_open0_A_close0_instantiation() {
     assert_eq!(
-        ::std::mem::size_of:: < C > (), 1usize,
-        concat!("Size of template specialization: ", stringify!(C))
+        ::std::mem::size_of::<C>(),
+        1usize,
+        concat!("Size of template specialization: ", stringify!(C)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < C > (), 1usize,
-        concat!("Alignment of template specialization: ", stringify!(C))
+        ::std::mem::align_of::<C>(),
+        1usize,
+        concat!("Alignment of template specialization: ", stringify!(C)),
     );
 }

--- a/bindgen-tests/tests/expectations/tests/constify-all-enums.rs
+++ b/bindgen-tests/tests/expectations/tests/constify-all-enums.rs
@@ -13,16 +13,19 @@ fn bindgen_test_layout_bar() {
     const UNINIT: ::std::mem::MaybeUninit<bar> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < bar > (), 4usize, concat!("Size of: ", stringify!(bar))
+        ::std::mem::size_of::<bar>(),
+        4usize,
+        concat!("Size of: ", stringify!(bar)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < bar > (), 4usize, concat!("Alignment of ",
-        stringify!(bar))
+        ::std::mem::align_of::<bar>(),
+        4usize,
+        concat!("Alignment of ", stringify!(bar)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).this_should_work) as usize - ptr as usize
-        }, 0usize, concat!("Offset of field: ", stringify!(bar), "::",
-        stringify!(this_should_work))
+        unsafe { ::std::ptr::addr_of!((*ptr).this_should_work) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(bar), "::", stringify!(this_should_work)),
     );
 }
 impl Default for bar {

--- a/bindgen-tests/tests/expectations/tests/constify-module-enums-basic.rs
+++ b/bindgen-tests/tests/expectations/tests/constify-module-enums-basic.rs
@@ -17,16 +17,19 @@ fn bindgen_test_layout_bar() {
     const UNINIT: ::std::mem::MaybeUninit<bar> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < bar > (), 4usize, concat!("Size of: ", stringify!(bar))
+        ::std::mem::size_of::<bar>(),
+        4usize,
+        concat!("Size of: ", stringify!(bar)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < bar > (), 4usize, concat!("Alignment of ",
-        stringify!(bar))
+        ::std::mem::align_of::<bar>(),
+        4usize,
+        concat!("Alignment of ", stringify!(bar)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).this_should_work) as usize - ptr as usize
-        }, 0usize, concat!("Offset of field: ", stringify!(bar), "::",
-        stringify!(this_should_work))
+        unsafe { ::std::ptr::addr_of!((*ptr).this_should_work) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(bar), "::", stringify!(this_should_work)),
     );
 }
 impl Default for bar {

--- a/bindgen-tests/tests/expectations/tests/constify-module-enums-namespace.rs
+++ b/bindgen-tests/tests/expectations/tests/constify-module-enums-namespace.rs
@@ -29,17 +29,27 @@ pub mod root {
                 const UNINIT: ::std::mem::MaybeUninit<bar> = ::std::mem::MaybeUninit::uninit();
                 let ptr = UNINIT.as_ptr();
                 assert_eq!(
-                    ::std::mem::size_of:: < bar > (), 4usize, concat!("Size of: ",
-                    stringify!(bar))
+                    ::std::mem::size_of::<bar>(),
+                    4usize,
+                    concat!("Size of: ", stringify!(bar)),
                 );
                 assert_eq!(
-                    ::std::mem::align_of:: < bar > (), 4usize, concat!("Alignment of ",
-                    stringify!(bar))
+                    ::std::mem::align_of::<bar>(),
+                    4usize,
+                    concat!("Alignment of ", stringify!(bar)),
                 );
                 assert_eq!(
-                    unsafe { ::std::ptr::addr_of!((* ptr).this_should_work) as usize -
-                    ptr as usize }, 0usize, concat!("Offset of field: ", stringify!(bar),
-                    "::", stringify!(this_should_work))
+                    unsafe {
+                        ::std::ptr::addr_of!((*ptr).this_should_work) as usize
+                            - ptr as usize
+                    },
+                    0usize,
+                    concat!(
+                        "Offset of field: ",
+                        stringify!(bar),
+                        "::",
+                        stringify!(this_should_work),
+                    ),
                 );
             }
             impl Default for bar {

--- a/bindgen-tests/tests/expectations/tests/constify-module-enums-shadow-name.rs
+++ b/bindgen-tests/tests/expectations/tests/constify-module-enums-shadow-name.rs
@@ -16,15 +16,19 @@ fn bindgen_test_layout_bar() {
     const UNINIT: ::std::mem::MaybeUninit<bar> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < bar > (), 4usize, concat!("Size of: ", stringify!(bar))
+        ::std::mem::size_of::<bar>(),
+        4usize,
+        concat!("Size of: ", stringify!(bar)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < bar > (), 4usize, concat!("Alignment of ",
-        stringify!(bar))
+        ::std::mem::align_of::<bar>(),
+        4usize,
+        concat!("Alignment of ", stringify!(bar)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).member) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(bar), "::", stringify!(member))
+        unsafe { ::std::ptr::addr_of!((*ptr).member) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(bar), "::", stringify!(member)),
     );
 }
 impl Default for bar {

--- a/bindgen-tests/tests/expectations/tests/constify-module-enums-simple-alias.rs
+++ b/bindgen-tests/tests/expectations/tests/constify-module-enums-simple-alias.rs
@@ -25,47 +25,54 @@ fn bindgen_test_layout_Bar() {
     const UNINIT: ::std::mem::MaybeUninit<Bar> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < Bar > (), 48usize, concat!("Size of: ", stringify!(Bar))
+        ::std::mem::size_of::<Bar>(),
+        48usize,
+        concat!("Size of: ", stringify!(Bar)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Bar > (), 8usize, concat!("Alignment of ",
-        stringify!(Bar))
+        ::std::mem::align_of::<Bar>(),
+        8usize,
+        concat!("Alignment of ", stringify!(Bar)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).baz1) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(Bar), "::", stringify!(baz1))
+        unsafe { ::std::ptr::addr_of!((*ptr).baz1) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(Bar), "::", stringify!(baz1)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).baz2) as usize - ptr as usize }, 4usize,
-        concat!("Offset of field: ", stringify!(Bar), "::", stringify!(baz2))
+        unsafe { ::std::ptr::addr_of!((*ptr).baz2) as usize - ptr as usize },
+        4usize,
+        concat!("Offset of field: ", stringify!(Bar), "::", stringify!(baz2)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).baz3) as usize - ptr as usize }, 8usize,
-        concat!("Offset of field: ", stringify!(Bar), "::", stringify!(baz3))
+        unsafe { ::std::ptr::addr_of!((*ptr).baz3) as usize - ptr as usize },
+        8usize,
+        concat!("Offset of field: ", stringify!(Bar), "::", stringify!(baz3)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).baz4) as usize - ptr as usize }, 12usize,
-        concat!("Offset of field: ", stringify!(Bar), "::", stringify!(baz4))
+        unsafe { ::std::ptr::addr_of!((*ptr).baz4) as usize - ptr as usize },
+        12usize,
+        concat!("Offset of field: ", stringify!(Bar), "::", stringify!(baz4)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).baz_ptr1) as usize - ptr as usize },
-        16usize, concat!("Offset of field: ", stringify!(Bar), "::",
-        stringify!(baz_ptr1))
+        unsafe { ::std::ptr::addr_of!((*ptr).baz_ptr1) as usize - ptr as usize },
+        16usize,
+        concat!("Offset of field: ", stringify!(Bar), "::", stringify!(baz_ptr1)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).baz_ptr2) as usize - ptr as usize },
-        24usize, concat!("Offset of field: ", stringify!(Bar), "::",
-        stringify!(baz_ptr2))
+        unsafe { ::std::ptr::addr_of!((*ptr).baz_ptr2) as usize - ptr as usize },
+        24usize,
+        concat!("Offset of field: ", stringify!(Bar), "::", stringify!(baz_ptr2)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).baz_ptr3) as usize - ptr as usize },
-        32usize, concat!("Offset of field: ", stringify!(Bar), "::",
-        stringify!(baz_ptr3))
+        unsafe { ::std::ptr::addr_of!((*ptr).baz_ptr3) as usize - ptr as usize },
+        32usize,
+        concat!("Offset of field: ", stringify!(Bar), "::", stringify!(baz_ptr3)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).baz_ptr4) as usize - ptr as usize },
-        40usize, concat!("Offset of field: ", stringify!(Bar), "::",
-        stringify!(baz_ptr4))
+        unsafe { ::std::ptr::addr_of!((*ptr).baz_ptr4) as usize - ptr as usize },
+        40usize,
+        concat!("Offset of field: ", stringify!(Bar), "::", stringify!(baz_ptr4)),
     );
 }
 impl Default for Bar {

--- a/bindgen-tests/tests/expectations/tests/constify-module-enums-simple-nonamespace.rs
+++ b/bindgen-tests/tests/expectations/tests/constify-module-enums-simple-nonamespace.rs
@@ -15,19 +15,24 @@ fn bindgen_test_layout_Bar() {
     const UNINIT: ::std::mem::MaybeUninit<Bar> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < Bar > (), 16usize, concat!("Size of: ", stringify!(Bar))
+        ::std::mem::size_of::<Bar>(),
+        16usize,
+        concat!("Size of: ", stringify!(Bar)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Bar > (), 8usize, concat!("Alignment of ",
-        stringify!(Bar))
+        ::std::mem::align_of::<Bar>(),
+        8usize,
+        concat!("Alignment of ", stringify!(Bar)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).baz1) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(Bar), "::", stringify!(baz1))
+        unsafe { ::std::ptr::addr_of!((*ptr).baz1) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(Bar), "::", stringify!(baz1)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).baz2) as usize - ptr as usize }, 8usize,
-        concat!("Offset of field: ", stringify!(Bar), "::", stringify!(baz2))
+        unsafe { ::std::ptr::addr_of!((*ptr).baz2) as usize - ptr as usize },
+        8usize,
+        concat!("Offset of field: ", stringify!(Bar), "::", stringify!(baz2)),
     );
 }
 impl Default for Bar {

--- a/bindgen-tests/tests/expectations/tests/constify-module-enums-types.rs
+++ b/bindgen-tests/tests/expectations/tests/constify-module-enums-types.rs
@@ -50,52 +50,64 @@ fn bindgen_test_layout_bar() {
     const UNINIT: ::std::mem::MaybeUninit<bar> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < bar > (), 48usize, concat!("Size of: ", stringify!(bar))
+        ::std::mem::size_of::<bar>(),
+        48usize,
+        concat!("Size of: ", stringify!(bar)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < bar > (), 8usize, concat!("Alignment of ",
-        stringify!(bar))
+        ::std::mem::align_of::<bar>(),
+        8usize,
+        concat!("Alignment of ", stringify!(bar)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).member1) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(bar), "::", stringify!(member1))
+        unsafe { ::std::ptr::addr_of!((*ptr).member1) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(bar), "::", stringify!(member1)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).member2) as usize - ptr as usize }, 4usize,
-        concat!("Offset of field: ", stringify!(bar), "::", stringify!(member2))
+        unsafe { ::std::ptr::addr_of!((*ptr).member2) as usize - ptr as usize },
+        4usize,
+        concat!("Offset of field: ", stringify!(bar), "::", stringify!(member2)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).member3) as usize - ptr as usize }, 8usize,
-        concat!("Offset of field: ", stringify!(bar), "::", stringify!(member3))
+        unsafe { ::std::ptr::addr_of!((*ptr).member3) as usize - ptr as usize },
+        8usize,
+        concat!("Offset of field: ", stringify!(bar), "::", stringify!(member3)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).member4) as usize - ptr as usize },
-        12usize, concat!("Offset of field: ", stringify!(bar), "::", stringify!(member4))
+        unsafe { ::std::ptr::addr_of!((*ptr).member4) as usize - ptr as usize },
+        12usize,
+        concat!("Offset of field: ", stringify!(bar), "::", stringify!(member4)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).member5) as usize - ptr as usize },
-        16usize, concat!("Offset of field: ", stringify!(bar), "::", stringify!(member5))
+        unsafe { ::std::ptr::addr_of!((*ptr).member5) as usize - ptr as usize },
+        16usize,
+        concat!("Offset of field: ", stringify!(bar), "::", stringify!(member5)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).member6) as usize - ptr as usize },
-        24usize, concat!("Offset of field: ", stringify!(bar), "::", stringify!(member6))
+        unsafe { ::std::ptr::addr_of!((*ptr).member6) as usize - ptr as usize },
+        24usize,
+        concat!("Offset of field: ", stringify!(bar), "::", stringify!(member6)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).member7) as usize - ptr as usize },
-        32usize, concat!("Offset of field: ", stringify!(bar), "::", stringify!(member7))
+        unsafe { ::std::ptr::addr_of!((*ptr).member7) as usize - ptr as usize },
+        32usize,
+        concat!("Offset of field: ", stringify!(bar), "::", stringify!(member7)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).member8) as usize - ptr as usize },
-        36usize, concat!("Offset of field: ", stringify!(bar), "::", stringify!(member8))
+        unsafe { ::std::ptr::addr_of!((*ptr).member8) as usize - ptr as usize },
+        36usize,
+        concat!("Offset of field: ", stringify!(bar), "::", stringify!(member8)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).member9) as usize - ptr as usize },
-        40usize, concat!("Offset of field: ", stringify!(bar), "::", stringify!(member9))
+        unsafe { ::std::ptr::addr_of!((*ptr).member9) as usize - ptr as usize },
+        40usize,
+        concat!("Offset of field: ", stringify!(bar), "::", stringify!(member9)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).member10) as usize - ptr as usize },
-        44usize, concat!("Offset of field: ", stringify!(bar), "::",
-        stringify!(member10))
+        unsafe { ::std::ptr::addr_of!((*ptr).member10) as usize - ptr as usize },
+        44usize,
+        concat!("Offset of field: ", stringify!(bar), "::", stringify!(member10)),
     );
 }
 impl Default for bar {
@@ -117,15 +129,19 @@ fn bindgen_test_layout_Baz() {
     const UNINIT: ::std::mem::MaybeUninit<Baz> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < Baz > (), 4usize, concat!("Size of: ", stringify!(Baz))
+        ::std::mem::size_of::<Baz>(),
+        4usize,
+        concat!("Size of: ", stringify!(Baz)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Baz > (), 4usize, concat!("Alignment of ",
-        stringify!(Baz))
+        ::std::mem::align_of::<Baz>(),
+        4usize,
+        concat!("Alignment of ", stringify!(Baz)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).member1) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(Baz), "::", stringify!(member1))
+        unsafe { ::std::ptr::addr_of!((*ptr).member1) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(Baz), "::", stringify!(member1)),
     );
 }
 impl Default for Baz {
@@ -152,15 +168,19 @@ fn bindgen_test_layout_Bar() {
     const UNINIT: ::std::mem::MaybeUninit<Bar> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < Bar > (), 8usize, concat!("Size of: ", stringify!(Bar))
+        ::std::mem::size_of::<Bar>(),
+        8usize,
+        concat!("Size of: ", stringify!(Bar)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Bar > (), 8usize, concat!("Alignment of ",
-        stringify!(Bar))
+        ::std::mem::align_of::<Bar>(),
+        8usize,
+        concat!("Alignment of ", stringify!(Bar)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).baz) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(Bar), "::", stringify!(baz))
+        unsafe { ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(Bar), "::", stringify!(baz)),
     );
 }
 impl Default for Bar {

--- a/bindgen-tests/tests/expectations/tests/constructor-tp.rs
+++ b/bindgen-tests/tests/expectations/tests/constructor-tp.rs
@@ -12,11 +12,14 @@ pub struct Bar {
 #[test]
 fn bindgen_test_layout_Bar() {
     assert_eq!(
-        ::std::mem::size_of:: < Bar > (), 1usize, concat!("Size of: ", stringify!(Bar))
+        ::std::mem::size_of::<Bar>(),
+        1usize,
+        concat!("Size of: ", stringify!(Bar)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Bar > (), 1usize, concat!("Alignment of ",
-        stringify!(Bar))
+        ::std::mem::align_of::<Bar>(),
+        1usize,
+        concat!("Alignment of ", stringify!(Bar)),
     );
 }
 extern "C" {

--- a/bindgen-tests/tests/expectations/tests/constructors.rs
+++ b/bindgen-tests/tests/expectations/tests/constructors.rs
@@ -7,12 +7,14 @@ pub struct TestOverload {
 #[test]
 fn bindgen_test_layout_TestOverload() {
     assert_eq!(
-        ::std::mem::size_of:: < TestOverload > (), 1usize, concat!("Size of: ",
-        stringify!(TestOverload))
+        ::std::mem::size_of::<TestOverload>(),
+        1usize,
+        concat!("Size of: ", stringify!(TestOverload)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < TestOverload > (), 1usize, concat!("Alignment of ",
-        stringify!(TestOverload))
+        ::std::mem::align_of::<TestOverload>(),
+        1usize,
+        concat!("Alignment of ", stringify!(TestOverload)),
     );
 }
 extern "C" {
@@ -48,12 +50,14 @@ pub struct TestPublicNoArgs {
 #[test]
 fn bindgen_test_layout_TestPublicNoArgs() {
     assert_eq!(
-        ::std::mem::size_of:: < TestPublicNoArgs > (), 1usize, concat!("Size of: ",
-        stringify!(TestPublicNoArgs))
+        ::std::mem::size_of::<TestPublicNoArgs>(),
+        1usize,
+        concat!("Size of: ", stringify!(TestPublicNoArgs)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < TestPublicNoArgs > (), 1usize, concat!("Alignment of ",
-        stringify!(TestPublicNoArgs))
+        ::std::mem::align_of::<TestPublicNoArgs>(),
+        1usize,
+        concat!("Alignment of ", stringify!(TestPublicNoArgs)),
     );
 }
 extern "C" {

--- a/bindgen-tests/tests/expectations/tests/constructors_1_33.rs
+++ b/bindgen-tests/tests/expectations/tests/constructors_1_33.rs
@@ -7,12 +7,14 @@ pub struct TestOverload {
 #[test]
 fn bindgen_test_layout_TestOverload() {
     assert_eq!(
-        ::std::mem::size_of:: < TestOverload > (), 1usize, concat!("Size of: ",
-        stringify!(TestOverload))
+        ::std::mem::size_of::<TestOverload>(),
+        1usize,
+        concat!("Size of: ", stringify!(TestOverload)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < TestOverload > (), 1usize, concat!("Alignment of ",
-        stringify!(TestOverload))
+        ::std::mem::align_of::<TestOverload>(),
+        1usize,
+        concat!("Alignment of ", stringify!(TestOverload)),
     );
 }
 extern "C" {
@@ -50,12 +52,14 @@ pub struct TestPublicNoArgs {
 #[test]
 fn bindgen_test_layout_TestPublicNoArgs() {
     assert_eq!(
-        ::std::mem::size_of:: < TestPublicNoArgs > (), 1usize, concat!("Size of: ",
-        stringify!(TestPublicNoArgs))
+        ::std::mem::size_of::<TestPublicNoArgs>(),
+        1usize,
+        concat!("Size of: ", stringify!(TestPublicNoArgs)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < TestPublicNoArgs > (), 1usize, concat!("Alignment of ",
-        stringify!(TestPublicNoArgs))
+        ::std::mem::align_of::<TestPublicNoArgs>(),
+        1usize,
+        concat!("Alignment of ", stringify!(TestPublicNoArgs)),
     );
 }
 extern "C" {

--- a/bindgen-tests/tests/expectations/tests/contains-vs-inherits-zero-sized.rs
+++ b/bindgen-tests/tests/expectations/tests/contains-vs-inherits-zero-sized.rs
@@ -8,12 +8,14 @@ pub struct Empty {
 #[test]
 fn bindgen_test_layout_Empty() {
     assert_eq!(
-        ::std::mem::size_of:: < Empty > (), 1usize, concat!("Size of: ",
-        stringify!(Empty))
+        ::std::mem::size_of::<Empty>(),
+        1usize,
+        concat!("Size of: ", stringify!(Empty)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Empty > (), 1usize, concat!("Alignment of ",
-        stringify!(Empty))
+        ::std::mem::align_of::<Empty>(),
+        1usize,
+        concat!("Alignment of ", stringify!(Empty)),
     );
 }
 /** This should not get an `_address` byte, so `sizeof(Inherits)` should be
@@ -28,16 +30,19 @@ fn bindgen_test_layout_Inherits() {
     const UNINIT: ::std::mem::MaybeUninit<Inherits> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < Inherits > (), 1usize, concat!("Size of: ",
-        stringify!(Inherits))
+        ::std::mem::size_of::<Inherits>(),
+        1usize,
+        concat!("Size of: ", stringify!(Inherits)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Inherits > (), 1usize, concat!("Alignment of ",
-        stringify!(Inherits))
+        ::std::mem::align_of::<Inherits>(),
+        1usize,
+        concat!("Alignment of ", stringify!(Inherits)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).b) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(Inherits), "::", stringify!(b))
+        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(Inherits), "::", stringify!(b)),
     );
 }
 /** This should not get an `_address` byte, but contains `Empty` which *does* get
@@ -53,19 +58,23 @@ fn bindgen_test_layout_Contains() {
     const UNINIT: ::std::mem::MaybeUninit<Contains> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < Contains > (), 2usize, concat!("Size of: ",
-        stringify!(Contains))
+        ::std::mem::size_of::<Contains>(),
+        2usize,
+        concat!("Size of: ", stringify!(Contains)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Contains > (), 1usize, concat!("Alignment of ",
-        stringify!(Contains))
+        ::std::mem::align_of::<Contains>(),
+        1usize,
+        concat!("Alignment of ", stringify!(Contains)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).empty) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(Contains), "::", stringify!(empty))
+        unsafe { ::std::ptr::addr_of!((*ptr).empty) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(Contains), "::", stringify!(empty)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).b) as usize - ptr as usize }, 1usize,
-        concat!("Offset of field: ", stringify!(Contains), "::", stringify!(b))
+        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
+        1usize,
+        concat!("Offset of field: ", stringify!(Contains), "::", stringify!(b)),
     );
 }

--- a/bindgen-tests/tests/expectations/tests/convert-floats.rs
+++ b/bindgen-tests/tests/expectations/tests/convert-floats.rs
@@ -20,37 +20,44 @@ fn bindgen_test_layout_foo() {
     const UNINIT: ::std::mem::MaybeUninit<foo> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < foo > (), 48usize, concat!("Size of: ", stringify!(foo))
+        ::std::mem::size_of::<foo>(),
+        48usize,
+        concat!("Size of: ", stringify!(foo)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < foo > (), 8usize, concat!("Alignment of ",
-        stringify!(foo))
+        ::std::mem::align_of::<foo>(),
+        8usize,
+        concat!("Alignment of ", stringify!(foo)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).bar) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar))
+        unsafe { ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).baz) as usize - ptr as usize }, 4usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(baz))
+        unsafe { ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize },
+        4usize,
+        concat!("Offset of field: ", stringify!(foo), "::", stringify!(baz)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).bazz) as usize - ptr as usize }, 8usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(bazz))
+        unsafe { ::std::ptr::addr_of!((*ptr).bazz) as usize - ptr as usize },
+        8usize,
+        concat!("Offset of field: ", stringify!(foo), "::", stringify!(bazz)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).bazzz) as usize - ptr as usize }, 16usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(bazzz))
+        unsafe { ::std::ptr::addr_of!((*ptr).bazzz) as usize - ptr as usize },
+        16usize,
+        concat!("Offset of field: ", stringify!(foo), "::", stringify!(bazzz)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).complexFloat) as usize - ptr as usize },
-        24usize, concat!("Offset of field: ", stringify!(foo), "::",
-        stringify!(complexFloat))
+        unsafe { ::std::ptr::addr_of!((*ptr).complexFloat) as usize - ptr as usize },
+        24usize,
+        concat!("Offset of field: ", stringify!(foo), "::", stringify!(complexFloat)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).complexDouble) as usize - ptr as usize },
-        32usize, concat!("Offset of field: ", stringify!(foo), "::",
-        stringify!(complexDouble))
+        unsafe { ::std::ptr::addr_of!((*ptr).complexDouble) as usize - ptr as usize },
+        32usize,
+        concat!("Offset of field: ", stringify!(foo), "::", stringify!(complexDouble)),
     );
 }
 impl Default for foo {

--- a/bindgen-tests/tests/expectations/tests/cpp-empty-layout.rs
+++ b/bindgen-tests/tests/expectations/tests/cpp-empty-layout.rs
@@ -7,10 +7,13 @@ pub struct Foo {
 #[test]
 fn bindgen_test_layout_Foo() {
     assert_eq!(
-        ::std::mem::size_of:: < Foo > (), 1usize, concat!("Size of: ", stringify!(Foo))
+        ::std::mem::size_of::<Foo>(),
+        1usize,
+        concat!("Size of: ", stringify!(Foo)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Foo > (), 1usize, concat!("Alignment of ",
-        stringify!(Foo))
+        ::std::mem::align_of::<Foo>(),
+        1usize,
+        concat!("Alignment of ", stringify!(Foo)),
     );
 }

--- a/bindgen-tests/tests/expectations/tests/crtp.rs
+++ b/bindgen-tests/tests/expectations/tests/crtp.rs
@@ -12,12 +12,14 @@ pub struct Derived {
 #[test]
 fn bindgen_test_layout_Derived() {
     assert_eq!(
-        ::std::mem::size_of:: < Derived > (), 1usize, concat!("Size of: ",
-        stringify!(Derived))
+        ::std::mem::size_of::<Derived>(),
+        1usize,
+        concat!("Size of: ", stringify!(Derived)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Derived > (), 1usize, concat!("Alignment of ",
-        stringify!(Derived))
+        ::std::mem::align_of::<Derived>(),
+        1usize,
+        concat!("Alignment of ", stringify!(Derived)),
     );
 }
 #[repr(C)]
@@ -33,33 +35,39 @@ pub struct DerivedFromBaseWithDestructor {
 #[test]
 fn bindgen_test_layout_DerivedFromBaseWithDestructor() {
     assert_eq!(
-        ::std::mem::size_of:: < DerivedFromBaseWithDestructor > (), 1usize,
-        concat!("Size of: ", stringify!(DerivedFromBaseWithDestructor))
+        ::std::mem::size_of::<DerivedFromBaseWithDestructor>(),
+        1usize,
+        concat!("Size of: ", stringify!(DerivedFromBaseWithDestructor)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < DerivedFromBaseWithDestructor > (), 1usize,
-        concat!("Alignment of ", stringify!(DerivedFromBaseWithDestructor))
+        ::std::mem::align_of::<DerivedFromBaseWithDestructor>(),
+        1usize,
+        concat!("Alignment of ", stringify!(DerivedFromBaseWithDestructor)),
     );
 }
 #[test]
 fn __bindgen_test_layout_Base_open0_Derived_close0_instantiation() {
     assert_eq!(
-        ::std::mem::size_of:: < Base > (), 1usize,
-        concat!("Size of template specialization: ", stringify!(Base))
+        ::std::mem::size_of::<Base>(),
+        1usize,
+        concat!("Size of template specialization: ", stringify!(Base)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Base > (), 1usize,
-        concat!("Alignment of template specialization: ", stringify!(Base))
+        ::std::mem::align_of::<Base>(),
+        1usize,
+        concat!("Alignment of template specialization: ", stringify!(Base)),
     );
 }
 #[test]
 fn __bindgen_test_layout_BaseWithDestructor_open0_DerivedFromBaseWithDestructor_close0_instantiation() {
     assert_eq!(
-        ::std::mem::size_of:: < BaseWithDestructor > (), 1usize,
-        concat!("Size of template specialization: ", stringify!(BaseWithDestructor))
+        ::std::mem::size_of::<BaseWithDestructor>(),
+        1usize,
+        concat!("Size of template specialization: ", stringify!(BaseWithDestructor)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < BaseWithDestructor > (), 1usize,
-        concat!("Alignment of template specialization: ", stringify!(BaseWithDestructor))
+        ::std::mem::align_of::<BaseWithDestructor>(),
+        1usize,
+        concat!("Alignment of template specialization: ", stringify!(BaseWithDestructor)),
     );
 }

--- a/bindgen-tests/tests/expectations/tests/ctypes-prefix-path.rs
+++ b/bindgen-tests/tests/expectations/tests/ctypes-prefix-path.rs
@@ -18,23 +18,29 @@ fn bindgen_test_layout_foo() {
     const UNINIT: ::core::mem::MaybeUninit<foo> = ::core::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::core::mem::size_of:: < foo > (), 16usize, concat!("Size of: ", stringify!(foo))
+        ::core::mem::size_of::<foo>(),
+        16usize,
+        concat!("Size of: ", stringify!(foo)),
     );
     assert_eq!(
-        ::core::mem::align_of:: < foo > (), 8usize, concat!("Alignment of ",
-        stringify!(foo))
+        ::core::mem::align_of::<foo>(),
+        8usize,
+        concat!("Alignment of ", stringify!(foo)),
     );
     assert_eq!(
-        unsafe { ::core::ptr::addr_of!((* ptr).a) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(a))
+        unsafe { ::core::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(foo), "::", stringify!(a)),
     );
     assert_eq!(
-        unsafe { ::core::ptr::addr_of!((* ptr).b) as usize - ptr as usize }, 4usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(b))
+        unsafe { ::core::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
+        4usize,
+        concat!("Offset of field: ", stringify!(foo), "::", stringify!(b)),
     );
     assert_eq!(
-        unsafe { ::core::ptr::addr_of!((* ptr).bar) as usize - ptr as usize }, 8usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar))
+        unsafe { ::core::ptr::addr_of!((*ptr).bar) as usize - ptr as usize },
+        8usize,
+        concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar)),
     );
 }
 impl Default for foo {

--- a/bindgen-tests/tests/expectations/tests/default-template-parameter.rs
+++ b/bindgen-tests/tests/expectations/tests/default-template-parameter.rs
@@ -19,14 +19,20 @@ impl<T, U> Default for Foo<T, U> {
 #[test]
 fn __bindgen_test_layout_Foo_open0_bool__int_close0_instantiation() {
     assert_eq!(
-        ::std::mem::size_of:: < Foo < bool, ::std::os::raw::c_int > > (), 8usize,
-        concat!("Size of template specialization: ", stringify!(Foo < bool,
-        ::std::os::raw::c_int >))
+        ::std::mem::size_of::<Foo<bool, ::std::os::raw::c_int>>(),
+        8usize,
+        concat!(
+            "Size of template specialization: ",
+            stringify!(Foo < bool, ::std::os::raw::c_int >),
+        ),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Foo < bool, ::std::os::raw::c_int > > (), 4usize,
-        concat!("Alignment of template specialization: ", stringify!(Foo < bool,
-        ::std::os::raw::c_int >))
+        ::std::mem::align_of::<Foo<bool, ::std::os::raw::c_int>>(),
+        4usize,
+        concat!(
+            "Alignment of template specialization: ",
+            stringify!(Foo < bool, ::std::os::raw::c_int >),
+        ),
     );
 }
 extern "C" {

--- a/bindgen-tests/tests/expectations/tests/default_visibility_crate.rs
+++ b/bindgen-tests/tests/expectations/tests/default_visibility_crate.rs
@@ -49,7 +49,7 @@ where
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < self.storage.as_ref().len());
         debug_assert!(
-            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len()
+            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len(),
         );
         let mut val = 0;
         for i in 0..(bit_width as usize) {
@@ -69,7 +69,7 @@ where
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < self.storage.as_ref().len());
         debug_assert!(
-            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len()
+            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len(),
         );
         for i in 0..(bit_width as usize) {
             let mask = 1 << i;

--- a/bindgen-tests/tests/expectations/tests/default_visibility_private.rs
+++ b/bindgen-tests/tests/expectations/tests/default_visibility_private.rs
@@ -49,7 +49,7 @@ where
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < self.storage.as_ref().len());
         debug_assert!(
-            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len()
+            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len(),
         );
         let mut val = 0;
         for i in 0..(bit_width as usize) {
@@ -69,7 +69,7 @@ where
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < self.storage.as_ref().len());
         debug_assert!(
-            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len()
+            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len(),
         );
         for i in 0..(bit_width as usize) {
             let mask = 1 << i;

--- a/bindgen-tests/tests/expectations/tests/default_visibility_private_respects_cxx_access_spec.rs
+++ b/bindgen-tests/tests/expectations/tests/default_visibility_private_respects_cxx_access_spec.rs
@@ -49,7 +49,7 @@ where
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < self.storage.as_ref().len());
         debug_assert!(
-            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len()
+            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len(),
         );
         let mut val = 0;
         for i in 0..(bit_width as usize) {
@@ -69,7 +69,7 @@ where
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < self.storage.as_ref().len());
         debug_assert!(
-            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len()
+            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len(),
         );
         for i in 0..(bit_width as usize) {
             let mask = 1 << i;

--- a/bindgen-tests/tests/expectations/tests/deleted-function.rs
+++ b/bindgen-tests/tests/expectations/tests/deleted-function.rs
@@ -6,11 +6,11 @@ pub struct A {
 }
 #[test]
 fn bindgen_test_layout_A() {
+    assert_eq!(::std::mem::size_of::<A>(), 1usize, concat!("Size of: ", stringify!(A)));
     assert_eq!(
-        ::std::mem::size_of:: < A > (), 1usize, concat!("Size of: ", stringify!(A))
-    );
-    assert_eq!(
-        ::std::mem::align_of:: < A > (), 1usize, concat!("Alignment of ", stringify!(A))
+        ::std::mem::align_of::<A>(),
+        1usize,
+        concat!("Alignment of ", stringify!(A)),
     );
 }
 extern "C" {
@@ -38,11 +38,11 @@ pub struct B {
 }
 #[test]
 fn bindgen_test_layout_B() {
+    assert_eq!(::std::mem::size_of::<B>(), 1usize, concat!("Size of: ", stringify!(B)));
     assert_eq!(
-        ::std::mem::size_of:: < B > (), 1usize, concat!("Size of: ", stringify!(B))
-    );
-    assert_eq!(
-        ::std::mem::align_of:: < B > (), 1usize, concat!("Alignment of ", stringify!(B))
+        ::std::mem::align_of::<B>(),
+        1usize,
+        concat!("Alignment of ", stringify!(B)),
     );
 }
 #[repr(C)]
@@ -52,11 +52,11 @@ pub struct C {
 }
 #[test]
 fn bindgen_test_layout_C() {
+    assert_eq!(::std::mem::size_of::<C>(), 1usize, concat!("Size of: ", stringify!(C)));
     assert_eq!(
-        ::std::mem::size_of:: < C > (), 1usize, concat!("Size of: ", stringify!(C))
-    );
-    assert_eq!(
-        ::std::mem::align_of:: < C > (), 1usize, concat!("Alignment of ", stringify!(C))
+        ::std::mem::align_of::<C>(),
+        1usize,
+        concat!("Alignment of ", stringify!(C)),
     );
 }
 extern "C" {

--- a/bindgen-tests/tests/expectations/tests/derive-bitfield-method-same-name.rs
+++ b/bindgen-tests/tests/expectations/tests/derive-bitfield-method-same-name.rs
@@ -49,7 +49,7 @@ where
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < self.storage.as_ref().len());
         debug_assert!(
-            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len()
+            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len(),
         );
         let mut val = 0;
         for i in 0..(bit_width as usize) {
@@ -69,7 +69,7 @@ where
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < self.storage.as_ref().len());
         debug_assert!(
-            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len()
+            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len(),
         );
         for i in 0..(bit_width as usize) {
             let mask = 1 << i;
@@ -99,15 +99,19 @@ fn bindgen_test_layout_Foo() {
     const UNINIT: ::std::mem::MaybeUninit<Foo> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < Foo > (), 136usize, concat!("Size of: ", stringify!(Foo))
+        ::std::mem::size_of::<Foo>(),
+        136usize,
+        concat!("Size of: ", stringify!(Foo)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Foo > (), 4usize, concat!("Alignment of ",
-        stringify!(Foo))
+        ::std::mem::align_of::<Foo>(),
+        4usize,
+        concat!("Alignment of ", stringify!(Foo)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).large) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(Foo), "::", stringify!(large))
+        unsafe { ::std::ptr::addr_of!((*ptr).large) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(Foo), "::", stringify!(large)),
     );
 }
 extern "C" {
@@ -134,9 +138,15 @@ impl Default for Foo {
 impl ::std::fmt::Debug for Foo {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         write!(
-            f, "Foo {{ large: [{}], type_ : {:?},  }}", self.large.iter().enumerate()
-            .map(| (i, v) | format!("{}{:?}", if i > 0 { ", " } else { "" }, v))
-            .collect:: < String > (), self.type__bindgen_bitfield()
+            f,
+            "Foo {{ large: [{}], type_ : {:?},  }}",
+            self
+                .large
+                .iter()
+                .enumerate()
+                .map(|(i, v)| format!("{}{:?}", if i > 0 { ", " } else { "" }, v))
+                .collect::<String>(),
+            self.type__bindgen_bitfield(),
         )
     }
 }

--- a/bindgen-tests/tests/expectations/tests/derive-clone.rs
+++ b/bindgen-tests/tests/expectations/tests/derive-clone.rs
@@ -10,17 +10,24 @@ fn bindgen_test_layout_ShouldDeriveClone() {
     const UNINIT: ::std::mem::MaybeUninit<ShouldDeriveClone> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < ShouldDeriveClone > (), 132usize, concat!("Size of: ",
-        stringify!(ShouldDeriveClone))
+        ::std::mem::size_of::<ShouldDeriveClone>(),
+        132usize,
+        concat!("Size of: ", stringify!(ShouldDeriveClone)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < ShouldDeriveClone > (), 4usize, concat!("Alignment of ",
-        stringify!(ShouldDeriveClone))
+        ::std::mem::align_of::<ShouldDeriveClone>(),
+        4usize,
+        concat!("Alignment of ", stringify!(ShouldDeriveClone)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).large) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(ShouldDeriveClone), "::",
-        stringify!(large))
+        unsafe { ::std::ptr::addr_of!((*ptr).large) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ShouldDeriveClone),
+            "::",
+            stringify!(large),
+        ),
     );
 }
 impl Default for ShouldDeriveClone {

--- a/bindgen-tests/tests/expectations/tests/derive-clone_1_0.rs
+++ b/bindgen-tests/tests/expectations/tests/derive-clone_1_0.rs
@@ -11,17 +11,24 @@ fn bindgen_test_layout_ShouldImplClone() {
     const UNINIT: ::std::mem::MaybeUninit<ShouldImplClone> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < ShouldImplClone > (), 132usize, concat!("Size of: ",
-        stringify!(ShouldImplClone))
+        ::std::mem::size_of::<ShouldImplClone>(),
+        132usize,
+        concat!("Size of: ", stringify!(ShouldImplClone)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < ShouldImplClone > (), 4usize, concat!("Alignment of ",
-        stringify!(ShouldImplClone))
+        ::std::mem::align_of::<ShouldImplClone>(),
+        4usize,
+        concat!("Alignment of ", stringify!(ShouldImplClone)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).large) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(ShouldImplClone), "::",
-        stringify!(large))
+        unsafe { ::std::ptr::addr_of!((*ptr).large) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ShouldImplClone),
+            "::",
+            stringify!(large),
+        ),
     );
 }
 impl Clone for ShouldImplClone {

--- a/bindgen-tests/tests/expectations/tests/derive-custom-cli.rs
+++ b/bindgen-tests/tests/expectations/tests/derive-custom-cli.rs
@@ -9,16 +9,19 @@ fn bindgen_test_layout_foo_struct() {
     const UNINIT: ::std::mem::MaybeUninit<foo_struct> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < foo_struct > (), 4usize, concat!("Size of: ",
-        stringify!(foo_struct))
+        ::std::mem::size_of::<foo_struct>(),
+        4usize,
+        concat!("Size of: ", stringify!(foo_struct)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < foo_struct > (), 4usize, concat!("Alignment of ",
-        stringify!(foo_struct))
+        ::std::mem::align_of::<foo_struct>(),
+        4usize,
+        concat!("Alignment of ", stringify!(foo_struct)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).inner) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(foo_struct), "::", stringify!(inner))
+        unsafe { ::std::ptr::addr_of!((*ptr).inner) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(foo_struct), "::", stringify!(inner)),
     );
 }
 #[repr(u32)]
@@ -37,20 +40,24 @@ fn bindgen_test_layout_foo_union() {
     const UNINIT: ::std::mem::MaybeUninit<foo_union> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < foo_union > (), 4usize, concat!("Size of: ",
-        stringify!(foo_union))
+        ::std::mem::size_of::<foo_union>(),
+        4usize,
+        concat!("Size of: ", stringify!(foo_union)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < foo_union > (), 4usize, concat!("Alignment of ",
-        stringify!(foo_union))
+        ::std::mem::align_of::<foo_union>(),
+        4usize,
+        concat!("Alignment of ", stringify!(foo_union)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).fst) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(foo_union), "::", stringify!(fst))
+        unsafe { ::std::ptr::addr_of!((*ptr).fst) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(foo_union), "::", stringify!(fst)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).snd) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(foo_union), "::", stringify!(snd))
+        unsafe { ::std::ptr::addr_of!((*ptr).snd) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(foo_union), "::", stringify!(snd)),
     );
 }
 #[repr(C)]
@@ -62,15 +69,18 @@ fn bindgen_test_layout_non_matching() {
     const UNINIT: ::std::mem::MaybeUninit<non_matching> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < non_matching > (), 4usize, concat!("Size of: ",
-        stringify!(non_matching))
+        ::std::mem::size_of::<non_matching>(),
+        4usize,
+        concat!("Size of: ", stringify!(non_matching)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < non_matching > (), 4usize, concat!("Alignment of ",
-        stringify!(non_matching))
+        ::std::mem::align_of::<non_matching>(),
+        4usize,
+        concat!("Alignment of ", stringify!(non_matching)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).inner) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(non_matching), "::", stringify!(inner))
+        unsafe { ::std::ptr::addr_of!((*ptr).inner) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(non_matching), "::", stringify!(inner)),
     );
 }

--- a/bindgen-tests/tests/expectations/tests/derive-debug-bitfield-core.rs
+++ b/bindgen-tests/tests/expectations/tests/derive-debug-bitfield-core.rs
@@ -50,7 +50,7 @@ where
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < self.storage.as_ref().len());
         debug_assert!(
-            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len()
+            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len(),
         );
         let mut val = 0;
         for i in 0..(bit_width as usize) {
@@ -70,7 +70,7 @@ where
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < self.storage.as_ref().len());
         debug_assert!(
-            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len()
+            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len(),
         );
         for i in 0..(bit_width as usize) {
             let mask = 1 << i;
@@ -96,15 +96,19 @@ fn bindgen_test_layout_C() {
     const UNINIT: ::core::mem::MaybeUninit<C> = ::core::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::core::mem::size_of:: < C > (), 204usize, concat!("Size of: ", stringify!(C))
+        ::core::mem::size_of::<C>(),
+        204usize,
+        concat!("Size of: ", stringify!(C)),
     );
     assert_eq!(
-        ::core::mem::align_of:: < C > (), 4usize, concat!("Alignment of ", stringify!(C))
+        ::core::mem::align_of::<C>(),
+        4usize,
+        concat!("Alignment of ", stringify!(C)),
     );
     assert_eq!(
-        unsafe { ::core::ptr::addr_of!((* ptr).large_array) as usize - ptr as usize },
-        4usize, concat!("Offset of field: ", stringify!(C), "::",
-        stringify!(large_array))
+        unsafe { ::core::ptr::addr_of!((*ptr).large_array) as usize - ptr as usize },
+        4usize,
+        concat!("Offset of field: ", stringify!(C), "::", stringify!(large_array)),
     );
 }
 impl Default for C {

--- a/bindgen-tests/tests/expectations/tests/derive-debug-bitfield.rs
+++ b/bindgen-tests/tests/expectations/tests/derive-debug-bitfield.rs
@@ -49,7 +49,7 @@ where
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < self.storage.as_ref().len());
         debug_assert!(
-            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len()
+            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len(),
         );
         let mut val = 0;
         for i in 0..(bit_width as usize) {
@@ -69,7 +69,7 @@ where
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < self.storage.as_ref().len());
         debug_assert!(
-            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len()
+            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len(),
         );
         for i in 0..(bit_width as usize) {
             let mask = 1 << i;
@@ -95,15 +95,19 @@ fn bindgen_test_layout_C() {
     const UNINIT: ::std::mem::MaybeUninit<C> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < C > (), 204usize, concat!("Size of: ", stringify!(C))
+        ::std::mem::size_of::<C>(),
+        204usize,
+        concat!("Size of: ", stringify!(C)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < C > (), 4usize, concat!("Alignment of ", stringify!(C))
+        ::std::mem::align_of::<C>(),
+        4usize,
+        concat!("Alignment of ", stringify!(C)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).large_array) as usize - ptr as usize },
-        4usize, concat!("Offset of field: ", stringify!(C), "::",
-        stringify!(large_array))
+        unsafe { ::std::ptr::addr_of!((*ptr).large_array) as usize - ptr as usize },
+        4usize,
+        concat!("Offset of field: ", stringify!(C), "::", stringify!(large_array)),
     );
 }
 impl Default for C {
@@ -118,9 +122,16 @@ impl Default for C {
 impl ::std::fmt::Debug for C {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         write!(
-            f, "C {{ a : {:?}, b : {:?}, large_array: [{}] }}", self.a(), self.b(), self
-            .large_array.iter().enumerate().map(| (i, v) | format!("{}{:?}", if i > 0 {
-            ", " } else { "" }, v)).collect:: < String > ()
+            f,
+            "C {{ a : {:?}, b : {:?}, large_array: [{}] }}",
+            self.a(),
+            self.b(),
+            self
+                .large_array
+                .iter()
+                .enumerate()
+                .map(|(i, v)| format!("{}{:?}", if i > 0 { ", " } else { "" }, v))
+                .collect::<String>(),
         )
     }
 }

--- a/bindgen-tests/tests/expectations/tests/derive-debug-function-pointer.rs
+++ b/bindgen-tests/tests/expectations/tests/derive-debug-function-pointer.rs
@@ -13,21 +13,24 @@ fn bindgen_test_layout_Nice() {
     const UNINIT: ::std::mem::MaybeUninit<Nice> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < Nice > (), 144usize, concat!("Size of: ",
-        stringify!(Nice))
+        ::std::mem::size_of::<Nice>(),
+        144usize,
+        concat!("Size of: ", stringify!(Nice)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Nice > (), 8usize, concat!("Alignment of ",
-        stringify!(Nice))
+        ::std::mem::align_of::<Nice>(),
+        8usize,
+        concat!("Alignment of ", stringify!(Nice)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).pointer) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(Nice), "::", stringify!(pointer))
+        unsafe { ::std::ptr::addr_of!((*ptr).pointer) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(Nice), "::", stringify!(pointer)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).large_array) as usize - ptr as usize },
-        8usize, concat!("Offset of field: ", stringify!(Nice), "::",
-        stringify!(large_array))
+        unsafe { ::std::ptr::addr_of!((*ptr).large_array) as usize - ptr as usize },
+        8usize,
+        concat!("Offset of field: ", stringify!(Nice), "::", stringify!(large_array)),
     );
 }
 impl Default for Nice {
@@ -42,9 +45,15 @@ impl Default for Nice {
 impl ::std::fmt::Debug for Nice {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         write!(
-            f, "Nice {{ pointer: {:?}, large_array: [{}] }}", self.pointer, self
-            .large_array.iter().enumerate().map(| (i, v) | format!("{}{:?}", if i > 0 {
-            ", " } else { "" }, v)).collect:: < String > ()
+            f,
+            "Nice {{ pointer: {:?}, large_array: [{}] }}",
+            self.pointer,
+            self
+                .large_array
+                .iter()
+                .enumerate()
+                .map(|(i, v)| format!("{}{:?}", if i > 0 { ", " } else { "" }, v))
+                .collect::<String>(),
         )
     }
 }

--- a/bindgen-tests/tests/expectations/tests/derive-debug-mangle-name.rs
+++ b/bindgen-tests/tests/expectations/tests/derive-debug-mangle-name.rs
@@ -17,22 +17,34 @@ fn bindgen_test_layout_perf_event_attr__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<perf_event_attr__bindgen_ty_1> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < perf_event_attr__bindgen_ty_1 > (), 4usize,
-        concat!("Size of: ", stringify!(perf_event_attr__bindgen_ty_1))
+        ::std::mem::size_of::<perf_event_attr__bindgen_ty_1>(),
+        4usize,
+        concat!("Size of: ", stringify!(perf_event_attr__bindgen_ty_1)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < perf_event_attr__bindgen_ty_1 > (), 4usize,
-        concat!("Alignment of ", stringify!(perf_event_attr__bindgen_ty_1))
+        ::std::mem::align_of::<perf_event_attr__bindgen_ty_1>(),
+        4usize,
+        concat!("Alignment of ", stringify!(perf_event_attr__bindgen_ty_1)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).b) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(perf_event_attr__bindgen_ty_1), "::",
-        stringify!(b))
+        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(perf_event_attr__bindgen_ty_1),
+            "::",
+            stringify!(b),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).c) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(perf_event_attr__bindgen_ty_1), "::",
-        stringify!(c))
+        unsafe { ::std::ptr::addr_of!((*ptr).c) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(perf_event_attr__bindgen_ty_1),
+            "::",
+            stringify!(c),
+        ),
     );
 }
 impl Default for perf_event_attr__bindgen_ty_1 {
@@ -54,21 +66,29 @@ fn bindgen_test_layout_perf_event_attr() {
     const UNINIT: ::std::mem::MaybeUninit<perf_event_attr> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < perf_event_attr > (), 12usize, concat!("Size of: ",
-        stringify!(perf_event_attr))
+        ::std::mem::size_of::<perf_event_attr>(),
+        12usize,
+        concat!("Size of: ", stringify!(perf_event_attr)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < perf_event_attr > (), 4usize, concat!("Alignment of ",
-        stringify!(perf_event_attr))
+        ::std::mem::align_of::<perf_event_attr>(),
+        4usize,
+        concat!("Alignment of ", stringify!(perf_event_attr)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).type_) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(perf_event_attr), "::",
-        stringify!(type_))
+        unsafe { ::std::ptr::addr_of!((*ptr).type_) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(perf_event_attr),
+            "::",
+            stringify!(type_),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).a) as usize - ptr as usize }, 4usize,
-        concat!("Offset of field: ", stringify!(perf_event_attr), "::", stringify!(a))
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
+        4usize,
+        concat!("Offset of field: ", stringify!(perf_event_attr), "::", stringify!(a)),
     );
 }
 impl Default for perf_event_attr {
@@ -83,8 +103,11 @@ impl Default for perf_event_attr {
 impl ::std::fmt::Debug for perf_event_attr {
     fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         write!(
-            f, "perf_event_attr {{ type: {:?}, a: {:?}, __bindgen_anon_1: {:?} }}", self
-            .type_, self.a, self.__bindgen_anon_1
+            f,
+            "perf_event_attr {{ type: {:?}, a: {:?}, __bindgen_anon_1: {:?} }}",
+            self.type_,
+            self.a,
+            self.__bindgen_anon_1,
         )
     }
 }

--- a/bindgen-tests/tests/expectations/tests/derive-debug-opaque-template-instantiation.rs
+++ b/bindgen-tests/tests/expectations/tests/derive-debug-opaque-template-instantiation.rs
@@ -8,16 +8,19 @@ fn bindgen_test_layout_Instance() {
     const UNINIT: ::std::mem::MaybeUninit<Instance> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < Instance > (), 200usize, concat!("Size of: ",
-        stringify!(Instance))
+        ::std::mem::size_of::<Instance>(),
+        200usize,
+        concat!("Size of: ", stringify!(Instance)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Instance > (), 4usize, concat!("Alignment of ",
-        stringify!(Instance))
+        ::std::mem::align_of::<Instance>(),
+        4usize,
+        concat!("Alignment of ", stringify!(Instance)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).val) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(Instance), "::", stringify!(val))
+        unsafe { ::std::ptr::addr_of!((*ptr).val) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(Instance), "::", stringify!(val)),
     );
 }
 impl Default for Instance {

--- a/bindgen-tests/tests/expectations/tests/derive-debug-opaque.rs
+++ b/bindgen-tests/tests/expectations/tests/derive-debug-opaque.rs
@@ -7,12 +7,14 @@ pub struct Opaque {
 #[test]
 fn bindgen_test_layout_Opaque() {
     assert_eq!(
-        ::std::mem::size_of:: < Opaque > (), 164usize, concat!("Size of: ",
-        stringify!(Opaque))
+        ::std::mem::size_of::<Opaque>(),
+        164usize,
+        concat!("Size of: ", stringify!(Opaque)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Opaque > (), 4usize, concat!("Alignment of ",
-        stringify!(Opaque))
+        ::std::mem::align_of::<Opaque>(),
+        4usize,
+        concat!("Alignment of ", stringify!(Opaque)),
     );
 }
 impl Default for Opaque {
@@ -38,16 +40,19 @@ fn bindgen_test_layout_OpaqueUser() {
     const UNINIT: ::std::mem::MaybeUninit<OpaqueUser> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < OpaqueUser > (), 164usize, concat!("Size of: ",
-        stringify!(OpaqueUser))
+        ::std::mem::size_of::<OpaqueUser>(),
+        164usize,
+        concat!("Size of: ", stringify!(OpaqueUser)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < OpaqueUser > (), 4usize, concat!("Alignment of ",
-        stringify!(OpaqueUser))
+        ::std::mem::align_of::<OpaqueUser>(),
+        4usize,
+        concat!("Alignment of ", stringify!(OpaqueUser)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).opaque) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(OpaqueUser), "::", stringify!(opaque))
+        unsafe { ::std::ptr::addr_of!((*ptr).opaque) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(OpaqueUser), "::", stringify!(opaque)),
     );
 }
 impl Default for OpaqueUser {

--- a/bindgen-tests/tests/expectations/tests/derive-default-and-blocklist.rs
+++ b/bindgen-tests/tests/expectations/tests/derive-default-and-blocklist.rs
@@ -11,17 +11,24 @@ fn bindgen_test_layout_ShouldNotDeriveDefault() {
     const UNINIT: ::std::mem::MaybeUninit<ShouldNotDeriveDefault> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < ShouldNotDeriveDefault > (), 1usize, concat!("Size of: ",
-        stringify!(ShouldNotDeriveDefault))
+        ::std::mem::size_of::<ShouldNotDeriveDefault>(),
+        1usize,
+        concat!("Size of: ", stringify!(ShouldNotDeriveDefault)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < ShouldNotDeriveDefault > (), 1usize,
-        concat!("Alignment of ", stringify!(ShouldNotDeriveDefault))
+        ::std::mem::align_of::<ShouldNotDeriveDefault>(),
+        1usize,
+        concat!("Alignment of ", stringify!(ShouldNotDeriveDefault)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).a) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(ShouldNotDeriveDefault), "::",
-        stringify!(a))
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ShouldNotDeriveDefault),
+            "::",
+            stringify!(a),
+        ),
     );
 }
 impl Default for ShouldNotDeriveDefault {

--- a/bindgen-tests/tests/expectations/tests/derive-fn-ptr.rs
+++ b/bindgen-tests/tests/expectations/tests/derive-fn-ptr.rs
@@ -29,15 +29,19 @@ fn bindgen_test_layout_Foo() {
     const UNINIT: ::std::mem::MaybeUninit<Foo> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < Foo > (), 8usize, concat!("Size of: ", stringify!(Foo))
+        ::std::mem::size_of::<Foo>(),
+        8usize,
+        concat!("Size of: ", stringify!(Foo)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Foo > (), 8usize, concat!("Alignment of ",
-        stringify!(Foo))
+        ::std::mem::align_of::<Foo>(),
+        8usize,
+        concat!("Alignment of ", stringify!(Foo)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).callback) as usize - ptr as usize },
-        0usize, concat!("Offset of field: ", stringify!(Foo), "::", stringify!(callback))
+        unsafe { ::std::ptr::addr_of!((*ptr).callback) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(Foo), "::", stringify!(callback)),
     );
 }
 pub type my_fun2_t = ::std::option::Option<
@@ -66,14 +70,18 @@ fn bindgen_test_layout_Bar() {
     const UNINIT: ::std::mem::MaybeUninit<Bar> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < Bar > (), 8usize, concat!("Size of: ", stringify!(Bar))
+        ::std::mem::size_of::<Bar>(),
+        8usize,
+        concat!("Size of: ", stringify!(Bar)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Bar > (), 8usize, concat!("Alignment of ",
-        stringify!(Bar))
+        ::std::mem::align_of::<Bar>(),
+        8usize,
+        concat!("Alignment of ", stringify!(Bar)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).callback) as usize - ptr as usize },
-        0usize, concat!("Offset of field: ", stringify!(Bar), "::", stringify!(callback))
+        unsafe { ::std::ptr::addr_of!((*ptr).callback) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(Bar), "::", stringify!(callback)),
     );
 }

--- a/bindgen-tests/tests/expectations/tests/derive-hash-and-blocklist.rs
+++ b/bindgen-tests/tests/expectations/tests/derive-hash-and-blocklist.rs
@@ -10,17 +10,24 @@ fn bindgen_test_layout_ShouldNotDeriveHash() {
     const UNINIT: ::std::mem::MaybeUninit<ShouldNotDeriveHash> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < ShouldNotDeriveHash > (), 1usize, concat!("Size of: ",
-        stringify!(ShouldNotDeriveHash))
+        ::std::mem::size_of::<ShouldNotDeriveHash>(),
+        1usize,
+        concat!("Size of: ", stringify!(ShouldNotDeriveHash)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < ShouldNotDeriveHash > (), 1usize,
-        concat!("Alignment of ", stringify!(ShouldNotDeriveHash))
+        ::std::mem::align_of::<ShouldNotDeriveHash>(),
+        1usize,
+        concat!("Alignment of ", stringify!(ShouldNotDeriveHash)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).a) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(ShouldNotDeriveHash), "::",
-        stringify!(a))
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ShouldNotDeriveHash),
+            "::",
+            stringify!(a),
+        ),
     );
 }
 impl Default for ShouldNotDeriveHash {

--- a/bindgen-tests/tests/expectations/tests/derive-hash-blocklisting.rs
+++ b/bindgen-tests/tests/expectations/tests/derive-hash-blocklisting.rs
@@ -16,16 +16,19 @@ fn bindgen_test_layout_AllowlistedOne() {
     const UNINIT: ::std::mem::MaybeUninit<AllowlistedOne> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < AllowlistedOne > (), 4usize, concat!("Size of: ",
-        stringify!(AllowlistedOne))
+        ::std::mem::size_of::<AllowlistedOne>(),
+        4usize,
+        concat!("Size of: ", stringify!(AllowlistedOne)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < AllowlistedOne > (), 4usize, concat!("Alignment of ",
-        stringify!(AllowlistedOne))
+        ::std::mem::align_of::<AllowlistedOne>(),
+        4usize,
+        concat!("Alignment of ", stringify!(AllowlistedOne)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).a) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(AllowlistedOne), "::", stringify!(a))
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(AllowlistedOne), "::", stringify!(a)),
     );
 }
 impl Default for AllowlistedOne {
@@ -47,16 +50,19 @@ fn bindgen_test_layout_AllowlistedTwo() {
     const UNINIT: ::std::mem::MaybeUninit<AllowlistedTwo> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < AllowlistedTwo > (), 4usize, concat!("Size of: ",
-        stringify!(AllowlistedTwo))
+        ::std::mem::size_of::<AllowlistedTwo>(),
+        4usize,
+        concat!("Size of: ", stringify!(AllowlistedTwo)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < AllowlistedTwo > (), 4usize, concat!("Alignment of ",
-        stringify!(AllowlistedTwo))
+        ::std::mem::align_of::<AllowlistedTwo>(),
+        4usize,
+        concat!("Alignment of ", stringify!(AllowlistedTwo)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).b) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(AllowlistedTwo), "::", stringify!(b))
+        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(AllowlistedTwo), "::", stringify!(b)),
     );
 }
 impl Default for AllowlistedTwo {

--- a/bindgen-tests/tests/expectations/tests/derive-hash-struct-with-anon-struct-float.rs
+++ b/bindgen-tests/tests/expectations/tests/derive-hash-struct-with-anon-struct-float.rs
@@ -16,20 +16,24 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<foo__bindgen_ty_1> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < foo__bindgen_ty_1 > (), 8usize, concat!("Size of: ",
-        stringify!(foo__bindgen_ty_1))
+        ::std::mem::size_of::<foo__bindgen_ty_1>(),
+        8usize,
+        concat!("Size of: ", stringify!(foo__bindgen_ty_1)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < foo__bindgen_ty_1 > (), 4usize, concat!("Alignment of ",
-        stringify!(foo__bindgen_ty_1))
+        ::std::mem::align_of::<foo__bindgen_ty_1>(),
+        4usize,
+        concat!("Alignment of ", stringify!(foo__bindgen_ty_1)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).a) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(foo__bindgen_ty_1), "::", stringify!(a))
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(foo__bindgen_ty_1), "::", stringify!(a)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).b) as usize - ptr as usize }, 4usize,
-        concat!("Offset of field: ", stringify!(foo__bindgen_ty_1), "::", stringify!(b))
+        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
+        4usize,
+        concat!("Offset of field: ", stringify!(foo__bindgen_ty_1), "::", stringify!(b)),
     );
 }
 #[test]
@@ -37,14 +41,18 @@ fn bindgen_test_layout_foo() {
     const UNINIT: ::std::mem::MaybeUninit<foo> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < foo > (), 8usize, concat!("Size of: ", stringify!(foo))
+        ::std::mem::size_of::<foo>(),
+        8usize,
+        concat!("Size of: ", stringify!(foo)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < foo > (), 4usize, concat!("Alignment of ",
-        stringify!(foo))
+        ::std::mem::align_of::<foo>(),
+        4usize,
+        concat!("Alignment of ", stringify!(foo)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).bar) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar))
+        unsafe { ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar)),
     );
 }

--- a/bindgen-tests/tests/expectations/tests/derive-hash-struct-with-float-array.rs
+++ b/bindgen-tests/tests/expectations/tests/derive-hash-struct-with-float-array.rs
@@ -10,14 +10,18 @@ fn bindgen_test_layout_foo() {
     const UNINIT: ::std::mem::MaybeUninit<foo> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < foo > (), 12usize, concat!("Size of: ", stringify!(foo))
+        ::std::mem::size_of::<foo>(),
+        12usize,
+        concat!("Size of: ", stringify!(foo)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < foo > (), 4usize, concat!("Alignment of ",
-        stringify!(foo))
+        ::std::mem::align_of::<foo>(),
+        4usize,
+        concat!("Alignment of ", stringify!(foo)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).bar) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar))
+        unsafe { ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar)),
     );
 }

--- a/bindgen-tests/tests/expectations/tests/derive-hash-struct-with-incomplete-array.rs
+++ b/bindgen-tests/tests/expectations/tests/derive-hash-struct-with-incomplete-array.rs
@@ -40,20 +40,31 @@ fn bindgen_test_layout_test() {
     const UNINIT: ::std::mem::MaybeUninit<test> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < test > (), 4usize, concat!("Size of: ", stringify!(test))
+        ::std::mem::size_of::<test>(),
+        4usize,
+        concat!("Size of: ", stringify!(test)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < test > (), 4usize, concat!("Alignment of ",
-        stringify!(test))
+        ::std::mem::align_of::<test>(),
+        4usize,
+        concat!("Alignment of ", stringify!(test)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).a) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(test), "::", stringify!(a))
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(test), "::", stringify!(a)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).zero_length_array) as usize - ptr as usize
-        }, 4usize, concat!("Offset of field: ", stringify!(test), "::",
-        stringify!(zero_length_array))
+        unsafe {
+            ::std::ptr::addr_of!((*ptr).zero_length_array) as usize - ptr as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(test),
+            "::",
+            stringify!(zero_length_array),
+        ),
     );
 }
 #[repr(C)]
@@ -65,12 +76,14 @@ pub struct test2 {
 #[test]
 fn bindgen_test_layout_test2() {
     assert_eq!(
-        ::std::mem::size_of:: < test2 > (), 4usize, concat!("Size of: ",
-        stringify!(test2))
+        ::std::mem::size_of::<test2>(),
+        4usize,
+        concat!("Size of: ", stringify!(test2)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < test2 > (), 4usize, concat!("Alignment of ",
-        stringify!(test2))
+        ::std::mem::align_of::<test2>(),
+        4usize,
+        concat!("Alignment of ", stringify!(test2)),
     );
 }
 #[repr(C)]
@@ -83,11 +96,13 @@ pub struct test3 {
 #[test]
 fn bindgen_test_layout_test3() {
     assert_eq!(
-        ::std::mem::size_of:: < test3 > (), 4usize, concat!("Size of: ",
-        stringify!(test3))
+        ::std::mem::size_of::<test3>(),
+        4usize,
+        concat!("Size of: ", stringify!(test3)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < test3 > (), 4usize, concat!("Alignment of ",
-        stringify!(test3))
+        ::std::mem::align_of::<test3>(),
+        4usize,
+        concat!("Alignment of ", stringify!(test3)),
     );
 }

--- a/bindgen-tests/tests/expectations/tests/derive-hash-struct-with-pointer.rs
+++ b/bindgen-tests/tests/expectations/tests/derive-hash-struct-with-pointer.rs
@@ -10,16 +10,19 @@ fn bindgen_test_layout_ConstPtrMutObj() {
     const UNINIT: ::std::mem::MaybeUninit<ConstPtrMutObj> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < ConstPtrMutObj > (), 8usize, concat!("Size of: ",
-        stringify!(ConstPtrMutObj))
+        ::std::mem::size_of::<ConstPtrMutObj>(),
+        8usize,
+        concat!("Size of: ", stringify!(ConstPtrMutObj)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < ConstPtrMutObj > (), 8usize, concat!("Alignment of ",
-        stringify!(ConstPtrMutObj))
+        ::std::mem::align_of::<ConstPtrMutObj>(),
+        8usize,
+        concat!("Alignment of ", stringify!(ConstPtrMutObj)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).bar) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(ConstPtrMutObj), "::", stringify!(bar))
+        unsafe { ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(ConstPtrMutObj), "::", stringify!(bar)),
     );
 }
 impl Default for ConstPtrMutObj {
@@ -41,16 +44,19 @@ fn bindgen_test_layout_MutPtrMutObj() {
     const UNINIT: ::std::mem::MaybeUninit<MutPtrMutObj> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < MutPtrMutObj > (), 8usize, concat!("Size of: ",
-        stringify!(MutPtrMutObj))
+        ::std::mem::size_of::<MutPtrMutObj>(),
+        8usize,
+        concat!("Size of: ", stringify!(MutPtrMutObj)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < MutPtrMutObj > (), 8usize, concat!("Alignment of ",
-        stringify!(MutPtrMutObj))
+        ::std::mem::align_of::<MutPtrMutObj>(),
+        8usize,
+        concat!("Alignment of ", stringify!(MutPtrMutObj)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).bar) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(MutPtrMutObj), "::", stringify!(bar))
+        unsafe { ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(MutPtrMutObj), "::", stringify!(bar)),
     );
 }
 impl Default for MutPtrMutObj {
@@ -72,16 +78,19 @@ fn bindgen_test_layout_MutPtrConstObj() {
     const UNINIT: ::std::mem::MaybeUninit<MutPtrConstObj> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < MutPtrConstObj > (), 8usize, concat!("Size of: ",
-        stringify!(MutPtrConstObj))
+        ::std::mem::size_of::<MutPtrConstObj>(),
+        8usize,
+        concat!("Size of: ", stringify!(MutPtrConstObj)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < MutPtrConstObj > (), 8usize, concat!("Alignment of ",
-        stringify!(MutPtrConstObj))
+        ::std::mem::align_of::<MutPtrConstObj>(),
+        8usize,
+        concat!("Alignment of ", stringify!(MutPtrConstObj)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).bar) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(MutPtrConstObj), "::", stringify!(bar))
+        unsafe { ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(MutPtrConstObj), "::", stringify!(bar)),
     );
 }
 impl Default for MutPtrConstObj {
@@ -103,16 +112,19 @@ fn bindgen_test_layout_ConstPtrConstObj() {
     const UNINIT: ::std::mem::MaybeUninit<ConstPtrConstObj> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < ConstPtrConstObj > (), 8usize, concat!("Size of: ",
-        stringify!(ConstPtrConstObj))
+        ::std::mem::size_of::<ConstPtrConstObj>(),
+        8usize,
+        concat!("Size of: ", stringify!(ConstPtrConstObj)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < ConstPtrConstObj > (), 8usize, concat!("Alignment of ",
-        stringify!(ConstPtrConstObj))
+        ::std::mem::align_of::<ConstPtrConstObj>(),
+        8usize,
+        concat!("Alignment of ", stringify!(ConstPtrConstObj)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).bar) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(ConstPtrConstObj), "::", stringify!(bar))
+        unsafe { ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(ConstPtrConstObj), "::", stringify!(bar)),
     );
 }
 impl Default for ConstPtrConstObj {

--- a/bindgen-tests/tests/expectations/tests/derive-hash-template-inst-float.rs
+++ b/bindgen-tests/tests/expectations/tests/derive-hash-template-inst-float.rs
@@ -26,16 +26,19 @@ fn bindgen_test_layout_IntStr() {
     const UNINIT: ::std::mem::MaybeUninit<IntStr> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < IntStr > (), 4usize, concat!("Size of: ",
-        stringify!(IntStr))
+        ::std::mem::size_of::<IntStr>(),
+        4usize,
+        concat!("Size of: ", stringify!(IntStr)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < IntStr > (), 4usize, concat!("Alignment of ",
-        stringify!(IntStr))
+        ::std::mem::align_of::<IntStr>(),
+        4usize,
+        concat!("Alignment of ", stringify!(IntStr)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).a) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(IntStr), "::", stringify!(a))
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(IntStr), "::", stringify!(a)),
     );
 }
 impl Default for IntStr {
@@ -58,16 +61,19 @@ fn bindgen_test_layout_FloatStr() {
     const UNINIT: ::std::mem::MaybeUninit<FloatStr> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < FloatStr > (), 4usize, concat!("Size of: ",
-        stringify!(FloatStr))
+        ::std::mem::size_of::<FloatStr>(),
+        4usize,
+        concat!("Size of: ", stringify!(FloatStr)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < FloatStr > (), 4usize, concat!("Alignment of ",
-        stringify!(FloatStr))
+        ::std::mem::align_of::<FloatStr>(),
+        4usize,
+        concat!("Alignment of ", stringify!(FloatStr)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).a) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(FloatStr), "::", stringify!(a))
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(FloatStr), "::", stringify!(a)),
     );
 }
 impl Default for FloatStr {
@@ -82,24 +88,32 @@ impl Default for FloatStr {
 #[test]
 fn __bindgen_test_layout_foo_open0_int_close0_instantiation() {
     assert_eq!(
-        ::std::mem::size_of:: < foo < ::std::os::raw::c_int > > (), 4usize,
-        concat!("Size of template specialization: ", stringify!(foo <
-        ::std::os::raw::c_int >))
+        ::std::mem::size_of::<foo<::std::os::raw::c_int>>(),
+        4usize,
+        concat!(
+            "Size of template specialization: ",
+            stringify!(foo < ::std::os::raw::c_int >),
+        ),
     );
     assert_eq!(
-        ::std::mem::align_of:: < foo < ::std::os::raw::c_int > > (), 4usize,
-        concat!("Alignment of template specialization: ", stringify!(foo <
-        ::std::os::raw::c_int >))
+        ::std::mem::align_of::<foo<::std::os::raw::c_int>>(),
+        4usize,
+        concat!(
+            "Alignment of template specialization: ",
+            stringify!(foo < ::std::os::raw::c_int >),
+        ),
     );
 }
 #[test]
 fn __bindgen_test_layout_foo_open0_float_close0_instantiation() {
     assert_eq!(
-        ::std::mem::size_of:: < foo < f32 > > (), 4usize,
-        concat!("Size of template specialization: ", stringify!(foo < f32 >))
+        ::std::mem::size_of::<foo<f32>>(),
+        4usize,
+        concat!("Size of template specialization: ", stringify!(foo < f32 >)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < foo < f32 > > (), 4usize,
-        concat!("Alignment of template specialization: ", stringify!(foo < f32 >))
+        ::std::mem::align_of::<foo<f32>>(),
+        4usize,
+        concat!("Alignment of template specialization: ", stringify!(foo < f32 >)),
     );
 }

--- a/bindgen-tests/tests/expectations/tests/derive-partialeq-and-blocklist.rs
+++ b/bindgen-tests/tests/expectations/tests/derive-partialeq-and-blocklist.rs
@@ -11,17 +11,24 @@ fn bindgen_test_layout_ShouldNotDerivePartialEq() {
     const UNINIT: ::std::mem::MaybeUninit<ShouldNotDerivePartialEq> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < ShouldNotDerivePartialEq > (), 1usize,
-        concat!("Size of: ", stringify!(ShouldNotDerivePartialEq))
+        ::std::mem::size_of::<ShouldNotDerivePartialEq>(),
+        1usize,
+        concat!("Size of: ", stringify!(ShouldNotDerivePartialEq)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < ShouldNotDerivePartialEq > (), 1usize,
-        concat!("Alignment of ", stringify!(ShouldNotDerivePartialEq))
+        ::std::mem::align_of::<ShouldNotDerivePartialEq>(),
+        1usize,
+        concat!("Alignment of ", stringify!(ShouldNotDerivePartialEq)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).a) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(ShouldNotDerivePartialEq), "::",
-        stringify!(a))
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ShouldNotDerivePartialEq),
+            "::",
+            stringify!(a),
+        ),
     );
 }
 impl Default for ShouldNotDerivePartialEq {

--- a/bindgen-tests/tests/expectations/tests/derive-partialeq-anonfield.rs
+++ b/bindgen-tests/tests/expectations/tests/derive-partialeq-anonfield.rs
@@ -14,12 +14,14 @@ pub struct rte_mbuf__bindgen_ty_1 {
 #[test]
 fn bindgen_test_layout_rte_mbuf__bindgen_ty_1() {
     assert_eq!(
-        ::std::mem::size_of:: < rte_mbuf__bindgen_ty_1 > (), 0usize, concat!("Size of: ",
-        stringify!(rte_mbuf__bindgen_ty_1))
+        ::std::mem::size_of::<rte_mbuf__bindgen_ty_1>(),
+        0usize,
+        concat!("Size of: ", stringify!(rte_mbuf__bindgen_ty_1)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < rte_mbuf__bindgen_ty_1 > (), 1usize,
-        concat!("Alignment of ", stringify!(rte_mbuf__bindgen_ty_1))
+        ::std::mem::align_of::<rte_mbuf__bindgen_ty_1>(),
+        1usize,
+        concat!("Alignment of ", stringify!(rte_mbuf__bindgen_ty_1)),
     );
 }
 impl Default for rte_mbuf__bindgen_ty_1 {
@@ -34,12 +36,14 @@ impl Default for rte_mbuf__bindgen_ty_1 {
 #[test]
 fn bindgen_test_layout_rte_mbuf() {
     assert_eq!(
-        ::std::mem::size_of:: < rte_mbuf > (), 0usize, concat!("Size of: ",
-        stringify!(rte_mbuf))
+        ::std::mem::size_of::<rte_mbuf>(),
+        0usize,
+        concat!("Size of: ", stringify!(rte_mbuf)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < rte_mbuf > (), 64usize, concat!("Alignment of ",
-        stringify!(rte_mbuf))
+        ::std::mem::align_of::<rte_mbuf>(),
+        64usize,
+        concat!("Alignment of ", stringify!(rte_mbuf)),
     );
 }
 impl Default for rte_mbuf {

--- a/bindgen-tests/tests/expectations/tests/derive-partialeq-base.rs
+++ b/bindgen-tests/tests/expectations/tests/derive-partialeq-base.rs
@@ -9,16 +9,19 @@ fn bindgen_test_layout_Base() {
     const UNINIT: ::std::mem::MaybeUninit<Base> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < Base > (), 132usize, concat!("Size of: ",
-        stringify!(Base))
+        ::std::mem::size_of::<Base>(),
+        132usize,
+        concat!("Size of: ", stringify!(Base)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Base > (), 4usize, concat!("Alignment of ",
-        stringify!(Base))
+        ::std::mem::align_of::<Base>(),
+        4usize,
+        concat!("Alignment of ", stringify!(Base)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).large) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(Base), "::", stringify!(large))
+        unsafe { ::std::ptr::addr_of!((*ptr).large) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(Base), "::", stringify!(large)),
     );
 }
 impl Default for Base {
@@ -43,12 +46,14 @@ pub struct ShouldDerivePartialEq {
 #[test]
 fn bindgen_test_layout_ShouldDerivePartialEq() {
     assert_eq!(
-        ::std::mem::size_of:: < ShouldDerivePartialEq > (), 132usize,
-        concat!("Size of: ", stringify!(ShouldDerivePartialEq))
+        ::std::mem::size_of::<ShouldDerivePartialEq>(),
+        132usize,
+        concat!("Size of: ", stringify!(ShouldDerivePartialEq)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < ShouldDerivePartialEq > (), 4usize,
-        concat!("Alignment of ", stringify!(ShouldDerivePartialEq))
+        ::std::mem::align_of::<ShouldDerivePartialEq>(),
+        4usize,
+        concat!("Alignment of ", stringify!(ShouldDerivePartialEq)),
     );
 }
 impl Default for ShouldDerivePartialEq {

--- a/bindgen-tests/tests/expectations/tests/derive-partialeq-bitfield.rs
+++ b/bindgen-tests/tests/expectations/tests/derive-partialeq-bitfield.rs
@@ -49,7 +49,7 @@ where
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < self.storage.as_ref().len());
         debug_assert!(
-            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len()
+            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len(),
         );
         let mut val = 0;
         for i in 0..(bit_width as usize) {
@@ -69,7 +69,7 @@ where
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < self.storage.as_ref().len());
         debug_assert!(
-            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len()
+            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len(),
         );
         for i in 0..(bit_width as usize) {
             let mask = 1 << i;
@@ -95,15 +95,19 @@ fn bindgen_test_layout_C() {
     const UNINIT: ::std::mem::MaybeUninit<C> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < C > (), 204usize, concat!("Size of: ", stringify!(C))
+        ::std::mem::size_of::<C>(),
+        204usize,
+        concat!("Size of: ", stringify!(C)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < C > (), 4usize, concat!("Alignment of ", stringify!(C))
+        ::std::mem::align_of::<C>(),
+        4usize,
+        concat!("Alignment of ", stringify!(C)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).large_array) as usize - ptr as usize },
-        4usize, concat!("Offset of field: ", stringify!(C), "::",
-        stringify!(large_array))
+        unsafe { ::std::ptr::addr_of!((*ptr).large_array) as usize - ptr as usize },
+        4usize,
+        concat!("Offset of field: ", stringify!(C), "::", stringify!(large_array)),
     );
 }
 impl Default for C {

--- a/bindgen-tests/tests/expectations/tests/derive-partialeq-core.rs
+++ b/bindgen-tests/tests/expectations/tests/derive-partialeq-core.rs
@@ -10,15 +10,19 @@ fn bindgen_test_layout_C() {
     const UNINIT: ::core::mem::MaybeUninit<C> = ::core::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::core::mem::size_of:: < C > (), 1680usize, concat!("Size of: ", stringify!(C))
+        ::core::mem::size_of::<C>(),
+        1680usize,
+        concat!("Size of: ", stringify!(C)),
     );
     assert_eq!(
-        ::core::mem::align_of:: < C > (), 4usize, concat!("Alignment of ", stringify!(C))
+        ::core::mem::align_of::<C>(),
+        4usize,
+        concat!("Alignment of ", stringify!(C)),
     );
     assert_eq!(
-        unsafe { ::core::ptr::addr_of!((* ptr).large_array) as usize - ptr as usize },
-        0usize, concat!("Offset of field: ", stringify!(C), "::",
-        stringify!(large_array))
+        unsafe { ::core::ptr::addr_of!((*ptr).large_array) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(C), "::", stringify!(large_array)),
     );
 }
 impl Default for C {

--- a/bindgen-tests/tests/expectations/tests/derive-partialeq-pointer.rs
+++ b/bindgen-tests/tests/expectations/tests/derive-partialeq-pointer.rs
@@ -9,15 +9,19 @@ fn bindgen_test_layout_Bar() {
     const UNINIT: ::std::mem::MaybeUninit<Bar> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < Bar > (), 8usize, concat!("Size of: ", stringify!(Bar))
+        ::std::mem::size_of::<Bar>(),
+        8usize,
+        concat!("Size of: ", stringify!(Bar)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Bar > (), 8usize, concat!("Alignment of ",
-        stringify!(Bar))
+        ::std::mem::align_of::<Bar>(),
+        8usize,
+        concat!("Alignment of ", stringify!(Bar)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).b) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(Bar), "::", stringify!(b))
+        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(Bar), "::", stringify!(b)),
     );
 }
 impl Default for Bar {
@@ -42,12 +46,14 @@ pub union c__bindgen_ty_1 {
 #[test]
 fn bindgen_test_layout_c__bindgen_ty_1() {
     assert_eq!(
-        ::std::mem::size_of:: < c__bindgen_ty_1 > (), 1usize, concat!("Size of: ",
-        stringify!(c__bindgen_ty_1))
+        ::std::mem::size_of::<c__bindgen_ty_1>(),
+        1usize,
+        concat!("Size of: ", stringify!(c__bindgen_ty_1)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < c__bindgen_ty_1 > (), 1usize, concat!("Alignment of ",
-        stringify!(c__bindgen_ty_1))
+        ::std::mem::align_of::<c__bindgen_ty_1>(),
+        1usize,
+        concat!("Alignment of ", stringify!(c__bindgen_ty_1)),
     );
 }
 impl Default for c__bindgen_ty_1 {
@@ -61,11 +67,11 @@ impl Default for c__bindgen_ty_1 {
 }
 #[test]
 fn bindgen_test_layout_c() {
+    assert_eq!(::std::mem::size_of::<c>(), 1usize, concat!("Size of: ", stringify!(c)));
     assert_eq!(
-        ::std::mem::size_of:: < c > (), 1usize, concat!("Size of: ", stringify!(c))
-    );
-    assert_eq!(
-        ::std::mem::align_of:: < c > (), 1usize, concat!("Alignment of ", stringify!(c))
+        ::std::mem::align_of::<c>(),
+        1usize,
+        concat!("Alignment of ", stringify!(c)),
     );
 }
 impl Default for c {
@@ -86,15 +92,16 @@ pub struct a {
 fn bindgen_test_layout_a() {
     const UNINIT: ::std::mem::MaybeUninit<a> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
+    assert_eq!(::std::mem::size_of::<a>(), 1usize, concat!("Size of: ", stringify!(a)));
     assert_eq!(
-        ::std::mem::size_of:: < a > (), 1usize, concat!("Size of: ", stringify!(a))
+        ::std::mem::align_of::<a>(),
+        1usize,
+        concat!("Alignment of ", stringify!(a)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < a > (), 1usize, concat!("Alignment of ", stringify!(a))
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).d) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(a), "::", stringify!(d))
+        unsafe { ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(a), "::", stringify!(d)),
     );
 }
 impl Default for a {

--- a/bindgen-tests/tests/expectations/tests/derive-partialeq-union.rs
+++ b/bindgen-tests/tests/expectations/tests/derive-partialeq-union.rs
@@ -11,22 +11,34 @@ fn bindgen_test_layout_ShouldNotDerivePartialEq() {
     const UNINIT: ::std::mem::MaybeUninit<ShouldNotDerivePartialEq> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < ShouldNotDerivePartialEq > (), 4usize,
-        concat!("Size of: ", stringify!(ShouldNotDerivePartialEq))
+        ::std::mem::size_of::<ShouldNotDerivePartialEq>(),
+        4usize,
+        concat!("Size of: ", stringify!(ShouldNotDerivePartialEq)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < ShouldNotDerivePartialEq > (), 4usize,
-        concat!("Alignment of ", stringify!(ShouldNotDerivePartialEq))
+        ::std::mem::align_of::<ShouldNotDerivePartialEq>(),
+        4usize,
+        concat!("Alignment of ", stringify!(ShouldNotDerivePartialEq)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).a) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(ShouldNotDerivePartialEq), "::",
-        stringify!(a))
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ShouldNotDerivePartialEq),
+            "::",
+            stringify!(a),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).b) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(ShouldNotDerivePartialEq), "::",
-        stringify!(b))
+        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ShouldNotDerivePartialEq),
+            "::",
+            stringify!(b),
+        ),
     );
 }
 impl Default for ShouldNotDerivePartialEq {

--- a/bindgen-tests/tests/expectations/tests/derive-partialeq-union_1_0.rs
+++ b/bindgen-tests/tests/expectations/tests/derive-partialeq-union_1_0.rs
@@ -55,22 +55,34 @@ fn bindgen_test_layout_ShouldDerivePartialEq() {
     const UNINIT: ::std::mem::MaybeUninit<ShouldDerivePartialEq> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < ShouldDerivePartialEq > (), 152usize,
-        concat!("Size of: ", stringify!(ShouldDerivePartialEq))
+        ::std::mem::size_of::<ShouldDerivePartialEq>(),
+        152usize,
+        concat!("Size of: ", stringify!(ShouldDerivePartialEq)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < ShouldDerivePartialEq > (), 4usize,
-        concat!("Alignment of ", stringify!(ShouldDerivePartialEq))
+        ::std::mem::align_of::<ShouldDerivePartialEq>(),
+        4usize,
+        concat!("Alignment of ", stringify!(ShouldDerivePartialEq)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).a) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(ShouldDerivePartialEq), "::",
-        stringify!(a))
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ShouldDerivePartialEq),
+            "::",
+            stringify!(a),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).b) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(ShouldDerivePartialEq), "::",
-        stringify!(b))
+        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ShouldDerivePartialEq),
+            "::",
+            stringify!(b),
+        ),
     );
 }
 impl Clone for ShouldDerivePartialEq {

--- a/bindgen-tests/tests/expectations/tests/disable-nested-struct-naming.rs
+++ b/bindgen-tests/tests/expectations/tests/disable-nested-struct-naming.rs
@@ -32,15 +32,19 @@ fn bindgen_test_layout_bar4() {
     const UNINIT: ::std::mem::MaybeUninit<bar4> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < bar4 > (), 4usize, concat!("Size of: ", stringify!(bar4))
+        ::std::mem::size_of::<bar4>(),
+        4usize,
+        concat!("Size of: ", stringify!(bar4)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < bar4 > (), 4usize, concat!("Alignment of ",
-        stringify!(bar4))
+        ::std::mem::align_of::<bar4>(),
+        4usize,
+        concat!("Alignment of ", stringify!(bar4)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).x4) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(bar4), "::", stringify!(x4))
+        unsafe { ::std::ptr::addr_of!((*ptr).x4) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(bar4), "::", stringify!(x4)),
     );
 }
 #[test]
@@ -48,22 +52,34 @@ fn bindgen_test_layout_bar1__bindgen_ty_1__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<bar1__bindgen_ty_1__bindgen_ty_1> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < bar1__bindgen_ty_1__bindgen_ty_1 > (), 8usize,
-        concat!("Size of: ", stringify!(bar1__bindgen_ty_1__bindgen_ty_1))
+        ::std::mem::size_of::<bar1__bindgen_ty_1__bindgen_ty_1>(),
+        8usize,
+        concat!("Size of: ", stringify!(bar1__bindgen_ty_1__bindgen_ty_1)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < bar1__bindgen_ty_1__bindgen_ty_1 > (), 4usize,
-        concat!("Alignment of ", stringify!(bar1__bindgen_ty_1__bindgen_ty_1))
+        ::std::mem::align_of::<bar1__bindgen_ty_1__bindgen_ty_1>(),
+        4usize,
+        concat!("Alignment of ", stringify!(bar1__bindgen_ty_1__bindgen_ty_1)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).x3) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(bar1__bindgen_ty_1__bindgen_ty_1), "::",
-        stringify!(x3))
+        unsafe { ::std::ptr::addr_of!((*ptr).x3) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bar1__bindgen_ty_1__bindgen_ty_1),
+            "::",
+            stringify!(x3),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).b4) as usize - ptr as usize }, 4usize,
-        concat!("Offset of field: ", stringify!(bar1__bindgen_ty_1__bindgen_ty_1), "::",
-        stringify!(b4))
+        unsafe { ::std::ptr::addr_of!((*ptr).b4) as usize - ptr as usize },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bar1__bindgen_ty_1__bindgen_ty_1),
+            "::",
+            stringify!(b4),
+        ),
     );
 }
 #[test]
@@ -71,22 +87,34 @@ fn bindgen_test_layout_bar1__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<bar1__bindgen_ty_1> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < bar1__bindgen_ty_1 > (), 12usize, concat!("Size of: ",
-        stringify!(bar1__bindgen_ty_1))
+        ::std::mem::size_of::<bar1__bindgen_ty_1>(),
+        12usize,
+        concat!("Size of: ", stringify!(bar1__bindgen_ty_1)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < bar1__bindgen_ty_1 > (), 4usize,
-        concat!("Alignment of ", stringify!(bar1__bindgen_ty_1))
+        ::std::mem::align_of::<bar1__bindgen_ty_1>(),
+        4usize,
+        concat!("Alignment of ", stringify!(bar1__bindgen_ty_1)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).x2) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(bar1__bindgen_ty_1), "::",
-        stringify!(x2))
+        unsafe { ::std::ptr::addr_of!((*ptr).x2) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bar1__bindgen_ty_1),
+            "::",
+            stringify!(x2),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).b3) as usize - ptr as usize }, 4usize,
-        concat!("Offset of field: ", stringify!(bar1__bindgen_ty_1), "::",
-        stringify!(b3))
+        unsafe { ::std::ptr::addr_of!((*ptr).b3) as usize - ptr as usize },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(bar1__bindgen_ty_1),
+            "::",
+            stringify!(b3),
+        ),
     );
 }
 #[test]
@@ -94,20 +122,24 @@ fn bindgen_test_layout_bar1() {
     const UNINIT: ::std::mem::MaybeUninit<bar1> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < bar1 > (), 16usize, concat!("Size of: ",
-        stringify!(bar1))
+        ::std::mem::size_of::<bar1>(),
+        16usize,
+        concat!("Size of: ", stringify!(bar1)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < bar1 > (), 4usize, concat!("Alignment of ",
-        stringify!(bar1))
+        ::std::mem::align_of::<bar1>(),
+        4usize,
+        concat!("Alignment of ", stringify!(bar1)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).x1) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(bar1), "::", stringify!(x1))
+        unsafe { ::std::ptr::addr_of!((*ptr).x1) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(bar1), "::", stringify!(x1)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).b2) as usize - ptr as usize }, 4usize,
-        concat!("Offset of field: ", stringify!(bar1), "::", stringify!(b2))
+        unsafe { ::std::ptr::addr_of!((*ptr).b2) as usize - ptr as usize },
+        4usize,
+        concat!("Offset of field: ", stringify!(bar1), "::", stringify!(b2)),
     );
 }
 #[test]
@@ -115,15 +147,19 @@ fn bindgen_test_layout_foo() {
     const UNINIT: ::std::mem::MaybeUninit<foo> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < foo > (), 16usize, concat!("Size of: ", stringify!(foo))
+        ::std::mem::size_of::<foo>(),
+        16usize,
+        concat!("Size of: ", stringify!(foo)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < foo > (), 4usize, concat!("Alignment of ",
-        stringify!(foo))
+        ::std::mem::align_of::<foo>(),
+        4usize,
+        concat!("Alignment of ", stringify!(foo)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).b1) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(b1))
+        unsafe { ::std::ptr::addr_of!((*ptr).b1) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(foo), "::", stringify!(b1)),
     );
 }
 #[repr(C)]
@@ -146,15 +182,19 @@ fn bindgen_test_layout_baz() {
     const UNINIT: ::std::mem::MaybeUninit<baz> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < baz > (), 4usize, concat!("Size of: ", stringify!(baz))
+        ::std::mem::size_of::<baz>(),
+        4usize,
+        concat!("Size of: ", stringify!(baz)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < baz > (), 4usize, concat!("Alignment of ",
-        stringify!(baz))
+        ::std::mem::align_of::<baz>(),
+        4usize,
+        concat!("Alignment of ", stringify!(baz)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).x) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(baz), "::", stringify!(x))
+        unsafe { ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(baz), "::", stringify!(x)),
     );
 }
 #[test]
@@ -162,17 +202,24 @@ fn bindgen_test_layout__bindgen_ty_1__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<_bindgen_ty_1__bindgen_ty_1> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < _bindgen_ty_1__bindgen_ty_1 > (), 4usize,
-        concat!("Size of: ", stringify!(_bindgen_ty_1__bindgen_ty_1))
+        ::std::mem::size_of::<_bindgen_ty_1__bindgen_ty_1>(),
+        4usize,
+        concat!("Size of: ", stringify!(_bindgen_ty_1__bindgen_ty_1)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < _bindgen_ty_1__bindgen_ty_1 > (), 4usize,
-        concat!("Alignment of ", stringify!(_bindgen_ty_1__bindgen_ty_1))
+        ::std::mem::align_of::<_bindgen_ty_1__bindgen_ty_1>(),
+        4usize,
+        concat!("Alignment of ", stringify!(_bindgen_ty_1__bindgen_ty_1)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).b) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(_bindgen_ty_1__bindgen_ty_1), "::",
-        stringify!(b))
+        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(_bindgen_ty_1__bindgen_ty_1),
+            "::",
+            stringify!(b),
+        ),
     );
 }
 #[test]
@@ -180,16 +227,19 @@ fn bindgen_test_layout__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<_bindgen_ty_1> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < _bindgen_ty_1 > (), 4usize, concat!("Size of: ",
-        stringify!(_bindgen_ty_1))
+        ::std::mem::size_of::<_bindgen_ty_1>(),
+        4usize,
+        concat!("Size of: ", stringify!(_bindgen_ty_1)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < _bindgen_ty_1 > (), 4usize, concat!("Alignment of ",
-        stringify!(_bindgen_ty_1))
+        ::std::mem::align_of::<_bindgen_ty_1>(),
+        4usize,
+        concat!("Alignment of ", stringify!(_bindgen_ty_1)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).anon2) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(_bindgen_ty_1), "::", stringify!(anon2))
+        unsafe { ::std::ptr::addr_of!((*ptr).anon2) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(_bindgen_ty_1), "::", stringify!(anon2)),
     );
 }
 extern "C" {

--- a/bindgen-tests/tests/expectations/tests/disable-untagged-union.rs
+++ b/bindgen-tests/tests/expectations/tests/disable-untagged-union.rs
@@ -54,18 +54,23 @@ fn bindgen_test_layout_Foo() {
     const UNINIT: ::std::mem::MaybeUninit<Foo> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < Foo > (), 4usize, concat!("Size of: ", stringify!(Foo))
+        ::std::mem::size_of::<Foo>(),
+        4usize,
+        concat!("Size of: ", stringify!(Foo)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Foo > (), 4usize, concat!("Alignment of ",
-        stringify!(Foo))
+        ::std::mem::align_of::<Foo>(),
+        4usize,
+        concat!("Alignment of ", stringify!(Foo)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).bar) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(Foo), "::", stringify!(bar))
+        unsafe { ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(Foo), "::", stringify!(bar)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).baz) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(Foo), "::", stringify!(baz))
+        unsafe { ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(Foo), "::", stringify!(baz)),
     );
 }

--- a/bindgen-tests/tests/expectations/tests/divide-by-zero-in-struct-layout.rs
+++ b/bindgen-tests/tests/expectations/tests/divide-by-zero-in-struct-layout.rs
@@ -49,7 +49,7 @@ where
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < self.storage.as_ref().len());
         debug_assert!(
-            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len()
+            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len(),
         );
         let mut val = 0;
         for i in 0..(bit_width as usize) {
@@ -69,7 +69,7 @@ where
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < self.storage.as_ref().len());
         debug_assert!(
-            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len()
+            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len(),
         );
         for i in 0..(bit_width as usize) {
             let mask = 1 << i;

--- a/bindgen-tests/tests/expectations/tests/do-not-derive-copy.rs
+++ b/bindgen-tests/tests/expectations/tests/do-not-derive-copy.rs
@@ -9,16 +9,23 @@ fn bindgen_test_layout_WouldBeCopyButWeAreNotDerivingCopy() {
     const UNINIT: ::std::mem::MaybeUninit<WouldBeCopyButWeAreNotDerivingCopy> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < WouldBeCopyButWeAreNotDerivingCopy > (), 4usize,
-        concat!("Size of: ", stringify!(WouldBeCopyButWeAreNotDerivingCopy))
+        ::std::mem::size_of::<WouldBeCopyButWeAreNotDerivingCopy>(),
+        4usize,
+        concat!("Size of: ", stringify!(WouldBeCopyButWeAreNotDerivingCopy)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < WouldBeCopyButWeAreNotDerivingCopy > (), 4usize,
-        concat!("Alignment of ", stringify!(WouldBeCopyButWeAreNotDerivingCopy))
+        ::std::mem::align_of::<WouldBeCopyButWeAreNotDerivingCopy>(),
+        4usize,
+        concat!("Alignment of ", stringify!(WouldBeCopyButWeAreNotDerivingCopy)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).x) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(WouldBeCopyButWeAreNotDerivingCopy),
-        "::", stringify!(x))
+        unsafe { ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(WouldBeCopyButWeAreNotDerivingCopy),
+            "::",
+            stringify!(x),
+        ),
     );
 }

--- a/bindgen-tests/tests/expectations/tests/doggo-or-null.rs
+++ b/bindgen-tests/tests/expectations/tests/doggo-or-null.rs
@@ -9,16 +9,19 @@ fn bindgen_test_layout_Doggo() {
     const UNINIT: ::std::mem::MaybeUninit<Doggo> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < Doggo > (), 4usize, concat!("Size of: ",
-        stringify!(Doggo))
+        ::std::mem::size_of::<Doggo>(),
+        4usize,
+        concat!("Size of: ", stringify!(Doggo)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Doggo > (), 4usize, concat!("Alignment of ",
-        stringify!(Doggo))
+        ::std::mem::align_of::<Doggo>(),
+        4usize,
+        concat!("Alignment of ", stringify!(Doggo)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).x) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(Doggo), "::", stringify!(x))
+        unsafe { ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(Doggo), "::", stringify!(x)),
     );
 }
 #[repr(C)]
@@ -29,11 +32,14 @@ pub struct Null {
 #[test]
 fn bindgen_test_layout_Null() {
     assert_eq!(
-        ::std::mem::size_of:: < Null > (), 1usize, concat!("Size of: ", stringify!(Null))
+        ::std::mem::size_of::<Null>(),
+        1usize,
+        concat!("Size of: ", stringify!(Null)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Null > (), 1usize, concat!("Alignment of ",
-        stringify!(Null))
+        ::std::mem::align_of::<Null>(),
+        1usize,
+        concat!("Alignment of ", stringify!(Null)),
     );
 }
 /** This type is an opaque union. Unions can't derive anything interesting like
@@ -51,12 +57,14 @@ pub union DoggoOrNull {
 #[test]
 fn bindgen_test_layout_DoggoOrNull() {
     assert_eq!(
-        ::std::mem::size_of:: < DoggoOrNull > (), 4usize, concat!("Size of: ",
-        stringify!(DoggoOrNull))
+        ::std::mem::size_of::<DoggoOrNull>(),
+        4usize,
+        concat!("Size of: ", stringify!(DoggoOrNull)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < DoggoOrNull > (), 4usize, concat!("Alignment of ",
-        stringify!(DoggoOrNull))
+        ::std::mem::align_of::<DoggoOrNull>(),
+        4usize,
+        concat!("Alignment of ", stringify!(DoggoOrNull)),
     );
 }
 impl Default for DoggoOrNull {

--- a/bindgen-tests/tests/expectations/tests/duplicated-definition-count.rs
+++ b/bindgen-tests/tests/expectations/tests/duplicated-definition-count.rs
@@ -7,12 +7,14 @@ pub struct BitStream {
 #[test]
 fn bindgen_test_layout_BitStream() {
     assert_eq!(
-        ::std::mem::size_of:: < BitStream > (), 1usize, concat!("Size of: ",
-        stringify!(BitStream))
+        ::std::mem::size_of::<BitStream>(),
+        1usize,
+        concat!("Size of: ", stringify!(BitStream)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < BitStream > (), 1usize, concat!("Alignment of ",
-        stringify!(BitStream))
+        ::std::mem::align_of::<BitStream>(),
+        1usize,
+        concat!("Alignment of ", stringify!(BitStream)),
     );
 }
 extern "C" {

--- a/bindgen-tests/tests/expectations/tests/duplicated-namespaces-definitions.rs
+++ b/bindgen-tests/tests/expectations/tests/duplicated-namespaces-definitions.rs
@@ -17,22 +17,24 @@ pub mod root {
             const UNINIT: ::std::mem::MaybeUninit<Bar> = ::std::mem::MaybeUninit::uninit();
             let ptr = UNINIT.as_ptr();
             assert_eq!(
-                ::std::mem::size_of:: < Bar > (), 8usize, concat!("Size of: ",
-                stringify!(Bar))
+                ::std::mem::size_of::<Bar>(),
+                8usize,
+                concat!("Size of: ", stringify!(Bar)),
             );
             assert_eq!(
-                ::std::mem::align_of:: < Bar > (), 4usize, concat!("Alignment of ",
-                stringify!(Bar))
+                ::std::mem::align_of::<Bar>(),
+                4usize,
+                concat!("Alignment of ", stringify!(Bar)),
             );
             assert_eq!(
-                unsafe { ::std::ptr::addr_of!((* ptr).foo) as usize - ptr as usize },
-                0usize, concat!("Offset of field: ", stringify!(Bar), "::",
-                stringify!(foo))
+                unsafe { ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize },
+                0usize,
+                concat!("Offset of field: ", stringify!(Bar), "::", stringify!(foo)),
             );
             assert_eq!(
-                unsafe { ::std::ptr::addr_of!((* ptr).baz) as usize - ptr as usize },
-                4usize, concat!("Offset of field: ", stringify!(Bar), "::",
-                stringify!(baz))
+                unsafe { ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize },
+                4usize,
+                concat!("Offset of field: ", stringify!(Bar), "::", stringify!(baz)),
             );
         }
     }
@@ -49,17 +51,19 @@ pub mod root {
             const UNINIT: ::std::mem::MaybeUninit<Foo> = ::std::mem::MaybeUninit::uninit();
             let ptr = UNINIT.as_ptr();
             assert_eq!(
-                ::std::mem::size_of:: < Foo > (), 8usize, concat!("Size of: ",
-                stringify!(Foo))
+                ::std::mem::size_of::<Foo>(),
+                8usize,
+                concat!("Size of: ", stringify!(Foo)),
             );
             assert_eq!(
-                ::std::mem::align_of:: < Foo > (), 8usize, concat!("Alignment of ",
-                stringify!(Foo))
+                ::std::mem::align_of::<Foo>(),
+                8usize,
+                concat!("Alignment of ", stringify!(Foo)),
             );
             assert_eq!(
-                unsafe { ::std::ptr::addr_of!((* ptr).ptr) as usize - ptr as usize },
-                0usize, concat!("Offset of field: ", stringify!(Foo), "::",
-                stringify!(ptr))
+                unsafe { ::std::ptr::addr_of!((*ptr).ptr) as usize - ptr as usize },
+                0usize,
+                concat!("Offset of field: ", stringify!(Foo), "::", stringify!(ptr)),
             );
         }
         impl Default for Foo {

--- a/bindgen-tests/tests/expectations/tests/dynamic_loading_with_blocklist.rs
+++ b/bindgen-tests/tests/expectations/tests/dynamic_loading_with_blocklist.rs
@@ -8,15 +8,16 @@ pub struct X {
 fn bindgen_test_layout_X() {
     const UNINIT: ::std::mem::MaybeUninit<X> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
+    assert_eq!(::std::mem::size_of::<X>(), 4usize, concat!("Size of: ", stringify!(X)));
     assert_eq!(
-        ::std::mem::size_of:: < X > (), 4usize, concat!("Size of: ", stringify!(X))
+        ::std::mem::align_of::<X>(),
+        4usize,
+        concat!("Alignment of ", stringify!(X)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < X > (), 4usize, concat!("Alignment of ", stringify!(X))
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr)._x) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(X), "::", stringify!(_x))
+        unsafe { ::std::ptr::addr_of!((*ptr)._x) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(X), "::", stringify!(_x)),
     );
 }
 extern "C" {

--- a/bindgen-tests/tests/expectations/tests/dynamic_loading_with_class.rs
+++ b/bindgen-tests/tests/expectations/tests/dynamic_loading_with_class.rs
@@ -8,15 +8,16 @@ pub struct A {
 fn bindgen_test_layout_A() {
     const UNINIT: ::std::mem::MaybeUninit<A> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
+    assert_eq!(::std::mem::size_of::<A>(), 4usize, concat!("Size of: ", stringify!(A)));
     assert_eq!(
-        ::std::mem::size_of:: < A > (), 4usize, concat!("Size of: ", stringify!(A))
+        ::std::mem::align_of::<A>(),
+        4usize,
+        concat!("Alignment of ", stringify!(A)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < A > (), 4usize, concat!("Alignment of ", stringify!(A))
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr)._x) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(A), "::", stringify!(_x))
+        unsafe { ::std::ptr::addr_of!((*ptr)._x) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(A), "::", stringify!(_x)),
     );
 }
 extern "C" {

--- a/bindgen-tests/tests/expectations/tests/enum-default-bitfield.rs
+++ b/bindgen-tests/tests/expectations/tests/enum-default-bitfield.rs
@@ -40,15 +40,19 @@ fn bindgen_test_layout_foo() {
     const UNINIT: ::std::mem::MaybeUninit<foo> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < foo > (), 4usize, concat!("Size of: ", stringify!(foo))
+        ::std::mem::size_of::<foo>(),
+        4usize,
+        concat!("Size of: ", stringify!(foo)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < foo > (), 4usize, concat!("Alignment of ",
-        stringify!(foo))
+        ::std::mem::align_of::<foo>(),
+        4usize,
+        concat!("Alignment of ", stringify!(foo)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).member) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(member))
+        unsafe { ::std::ptr::addr_of!((*ptr).member) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(foo), "::", stringify!(member)),
     );
 }
 impl Default for foo {

--- a/bindgen-tests/tests/expectations/tests/enum-default-consts.rs
+++ b/bindgen-tests/tests/expectations/tests/enum-default-consts.rs
@@ -12,15 +12,19 @@ fn bindgen_test_layout_foo() {
     const UNINIT: ::std::mem::MaybeUninit<foo> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < foo > (), 4usize, concat!("Size of: ", stringify!(foo))
+        ::std::mem::size_of::<foo>(),
+        4usize,
+        concat!("Size of: ", stringify!(foo)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < foo > (), 4usize, concat!("Alignment of ",
-        stringify!(foo))
+        ::std::mem::align_of::<foo>(),
+        4usize,
+        concat!("Alignment of ", stringify!(foo)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).member) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(member))
+        unsafe { ::std::ptr::addr_of!((*ptr).member) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(foo), "::", stringify!(member)),
     );
 }
 impl Default for foo {

--- a/bindgen-tests/tests/expectations/tests/enum-default-module.rs
+++ b/bindgen-tests/tests/expectations/tests/enum-default-module.rs
@@ -14,15 +14,19 @@ fn bindgen_test_layout_foo() {
     const UNINIT: ::std::mem::MaybeUninit<foo> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < foo > (), 4usize, concat!("Size of: ", stringify!(foo))
+        ::std::mem::size_of::<foo>(),
+        4usize,
+        concat!("Size of: ", stringify!(foo)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < foo > (), 4usize, concat!("Alignment of ",
-        stringify!(foo))
+        ::std::mem::align_of::<foo>(),
+        4usize,
+        concat!("Alignment of ", stringify!(foo)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).member) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(member))
+        unsafe { ::std::ptr::addr_of!((*ptr).member) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(foo), "::", stringify!(member)),
     );
 }
 impl Default for foo {

--- a/bindgen-tests/tests/expectations/tests/enum-default-rust.rs
+++ b/bindgen-tests/tests/expectations/tests/enum-default-rust.rs
@@ -17,15 +17,19 @@ fn bindgen_test_layout_foo() {
     const UNINIT: ::std::mem::MaybeUninit<foo> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < foo > (), 4usize, concat!("Size of: ", stringify!(foo))
+        ::std::mem::size_of::<foo>(),
+        4usize,
+        concat!("Size of: ", stringify!(foo)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < foo > (), 4usize, concat!("Alignment of ",
-        stringify!(foo))
+        ::std::mem::align_of::<foo>(),
+        4usize,
+        concat!("Alignment of ", stringify!(foo)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).member) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(member))
+        unsafe { ::std::ptr::addr_of!((*ptr).member) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(foo), "::", stringify!(member)),
     );
 }
 impl Default for foo {

--- a/bindgen-tests/tests/expectations/tests/enum-no-debug-rust.rs
+++ b/bindgen-tests/tests/expectations/tests/enum-no-debug-rust.rs
@@ -17,15 +17,19 @@ fn bindgen_test_layout_foo() {
     const UNINIT: ::std::mem::MaybeUninit<foo> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < foo > (), 4usize, concat!("Size of: ", stringify!(foo))
+        ::std::mem::size_of::<foo>(),
+        4usize,
+        concat!("Size of: ", stringify!(foo)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < foo > (), 4usize, concat!("Alignment of ",
-        stringify!(foo))
+        ::std::mem::align_of::<foo>(),
+        4usize,
+        concat!("Alignment of ", stringify!(foo)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).member) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(member))
+        unsafe { ::std::ptr::addr_of!((*ptr).member) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(foo), "::", stringify!(member)),
     );
 }
 impl Default for foo {

--- a/bindgen-tests/tests/expectations/tests/enum.rs
+++ b/bindgen-tests/tests/expectations/tests/enum.rs
@@ -12,15 +12,19 @@ fn bindgen_test_layout_foo() {
     const UNINIT: ::std::mem::MaybeUninit<foo> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < foo > (), 4usize, concat!("Size of: ", stringify!(foo))
+        ::std::mem::size_of::<foo>(),
+        4usize,
+        concat!("Size of: ", stringify!(foo)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < foo > (), 4usize, concat!("Alignment of ",
-        stringify!(foo))
+        ::std::mem::align_of::<foo>(),
+        4usize,
+        concat!("Alignment of ", stringify!(foo)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).member) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(member))
+        unsafe { ::std::ptr::addr_of!((*ptr).member) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(foo), "::", stringify!(member)),
     );
 }
 impl Default for foo {

--- a/bindgen-tests/tests/expectations/tests/enum_and_vtable_mangling.rs
+++ b/bindgen-tests/tests/expectations/tests/enum_and_vtable_mangling.rs
@@ -21,15 +21,16 @@ pub struct C {
 fn bindgen_test_layout_C() {
     const UNINIT: ::std::mem::MaybeUninit<C> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
+    assert_eq!(::std::mem::size_of::<C>(), 16usize, concat!("Size of: ", stringify!(C)));
     assert_eq!(
-        ::std::mem::size_of:: < C > (), 16usize, concat!("Size of: ", stringify!(C))
+        ::std::mem::align_of::<C>(),
+        8usize,
+        concat!("Alignment of ", stringify!(C)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < C > (), 8usize, concat!("Alignment of ", stringify!(C))
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).i) as usize - ptr as usize }, 8usize,
-        concat!("Offset of field: ", stringify!(C), "::", stringify!(i))
+        unsafe { ::std::ptr::addr_of!((*ptr).i) as usize - ptr as usize },
+        8usize,
+        concat!("Offset of field: ", stringify!(C), "::", stringify!(i)),
     );
 }
 impl Default for C {

--- a/bindgen-tests/tests/expectations/tests/explicit-padding.rs
+++ b/bindgen-tests/tests/expectations/tests/explicit-padding.rs
@@ -13,24 +13,29 @@ fn bindgen_test_layout_pad_me() {
     const UNINIT: ::std::mem::MaybeUninit<pad_me> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < pad_me > (), 12usize, concat!("Size of: ",
-        stringify!(pad_me))
+        ::std::mem::size_of::<pad_me>(),
+        12usize,
+        concat!("Size of: ", stringify!(pad_me)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < pad_me > (), 4usize, concat!("Alignment of ",
-        stringify!(pad_me))
+        ::std::mem::align_of::<pad_me>(),
+        4usize,
+        concat!("Alignment of ", stringify!(pad_me)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).first) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(pad_me), "::", stringify!(first))
+        unsafe { ::std::ptr::addr_of!((*ptr).first) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(pad_me), "::", stringify!(first)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).second) as usize - ptr as usize }, 4usize,
-        concat!("Offset of field: ", stringify!(pad_me), "::", stringify!(second))
+        unsafe { ::std::ptr::addr_of!((*ptr).second) as usize - ptr as usize },
+        4usize,
+        concat!("Offset of field: ", stringify!(pad_me), "::", stringify!(second)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).third) as usize - ptr as usize }, 8usize,
-        concat!("Offset of field: ", stringify!(pad_me), "::", stringify!(third))
+        unsafe { ::std::ptr::addr_of!((*ptr).third) as usize - ptr as usize },
+        8usize,
+        concat!("Offset of field: ", stringify!(pad_me), "::", stringify!(third)),
     );
 }
 #[repr(C)]
@@ -45,24 +50,29 @@ fn bindgen_test_layout_dont_pad_me() {
     const UNINIT: ::std::mem::MaybeUninit<dont_pad_me> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < dont_pad_me > (), 4usize, concat!("Size of: ",
-        stringify!(dont_pad_me))
+        ::std::mem::size_of::<dont_pad_me>(),
+        4usize,
+        concat!("Size of: ", stringify!(dont_pad_me)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < dont_pad_me > (), 4usize, concat!("Alignment of ",
-        stringify!(dont_pad_me))
+        ::std::mem::align_of::<dont_pad_me>(),
+        4usize,
+        concat!("Alignment of ", stringify!(dont_pad_me)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).first) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(dont_pad_me), "::", stringify!(first))
+        unsafe { ::std::ptr::addr_of!((*ptr).first) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(dont_pad_me), "::", stringify!(first)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).second) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(dont_pad_me), "::", stringify!(second))
+        unsafe { ::std::ptr::addr_of!((*ptr).second) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(dont_pad_me), "::", stringify!(second)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).third) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(dont_pad_me), "::", stringify!(third))
+        unsafe { ::std::ptr::addr_of!((*ptr).third) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(dont_pad_me), "::", stringify!(third)),
     );
 }
 impl Default for dont_pad_me {

--- a/bindgen-tests/tests/expectations/tests/extern-const-struct.rs
+++ b/bindgen-tests/tests/expectations/tests/extern-const-struct.rs
@@ -9,16 +9,19 @@ fn bindgen_test_layout_nsFoo() {
     const UNINIT: ::std::mem::MaybeUninit<nsFoo> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < nsFoo > (), 1600usize, concat!("Size of: ",
-        stringify!(nsFoo))
+        ::std::mem::size_of::<nsFoo>(),
+        1600usize,
+        concat!("Size of: ", stringify!(nsFoo)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < nsFoo > (), 4usize, concat!("Alignment of ",
-        stringify!(nsFoo))
+        ::std::mem::align_of::<nsFoo>(),
+        4usize,
+        concat!("Alignment of ", stringify!(nsFoo)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).details) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(nsFoo), "::", stringify!(details))
+        unsafe { ::std::ptr::addr_of!((*ptr).details) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(nsFoo), "::", stringify!(details)),
     );
 }
 impl Default for nsFoo {

--- a/bindgen-tests/tests/expectations/tests/field-visibility-callback.rs
+++ b/bindgen-tests/tests/expectations/tests/field-visibility-callback.rs
@@ -49,7 +49,7 @@ where
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < self.storage.as_ref().len());
         debug_assert!(
-            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len()
+            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len(),
         );
         let mut val = 0;
         for i in 0..(bit_width as usize) {
@@ -69,7 +69,7 @@ where
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < self.storage.as_ref().len());
         debug_assert!(
-            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len()
+            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len(),
         );
         for i in 0..(bit_width as usize) {
             let mask = 1 << i;
@@ -97,21 +97,24 @@ fn bindgen_test_layout_my_struct() {
     const UNINIT: ::std::mem::MaybeUninit<my_struct> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < my_struct > (), 12usize, concat!("Size of: ",
-        stringify!(my_struct))
+        ::std::mem::size_of::<my_struct>(),
+        12usize,
+        concat!("Size of: ", stringify!(my_struct)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < my_struct > (), 4usize, concat!("Alignment of ",
-        stringify!(my_struct))
+        ::std::mem::align_of::<my_struct>(),
+        4usize,
+        concat!("Alignment of ", stringify!(my_struct)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).a) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(my_struct), "::", stringify!(a))
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(my_struct), "::", stringify!(a)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).private_b) as usize - ptr as usize },
-        4usize, concat!("Offset of field: ", stringify!(my_struct), "::",
-        stringify!(private_b))
+        unsafe { ::std::ptr::addr_of!((*ptr).private_b) as usize - ptr as usize },
+        4usize,
+        concat!("Offset of field: ", stringify!(my_struct), "::", stringify!(private_b)),
     );
 }
 impl my_struct {

--- a/bindgen-tests/tests/expectations/tests/field-visibility.rs
+++ b/bindgen-tests/tests/expectations/tests/field-visibility.rs
@@ -49,7 +49,7 @@ where
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < self.storage.as_ref().len());
         debug_assert!(
-            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len()
+            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len(),
         );
         let mut val = 0;
         for i in 0..(bit_width as usize) {
@@ -69,7 +69,7 @@ where
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < self.storage.as_ref().len());
         debug_assert!(
-            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len()
+            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len(),
         );
         for i in 0..(bit_width as usize) {
             let mask = 1 << i;
@@ -94,12 +94,14 @@ pub struct my_struct1 {
 #[test]
 fn bindgen_test_layout_my_struct1() {
     assert_eq!(
-        ::std::mem::size_of:: < my_struct1 > (), 4usize, concat!("Size of: ",
-        stringify!(my_struct1))
+        ::std::mem::size_of::<my_struct1>(),
+        4usize,
+        concat!("Size of: ", stringify!(my_struct1)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < my_struct1 > (), 4usize, concat!("Alignment of ",
-        stringify!(my_struct1))
+        ::std::mem::align_of::<my_struct1>(),
+        4usize,
+        concat!("Alignment of ", stringify!(my_struct1)),
     );
 }
 impl my_struct1 {
@@ -140,12 +142,14 @@ pub struct my_struct2 {
 #[test]
 fn bindgen_test_layout_my_struct2() {
     assert_eq!(
-        ::std::mem::size_of:: < my_struct2 > (), 4usize, concat!("Size of: ",
-        stringify!(my_struct2))
+        ::std::mem::size_of::<my_struct2>(),
+        4usize,
+        concat!("Size of: ", stringify!(my_struct2)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < my_struct2 > (), 4usize, concat!("Alignment of ",
-        stringify!(my_struct2))
+        ::std::mem::align_of::<my_struct2>(),
+        4usize,
+        concat!("Alignment of ", stringify!(my_struct2)),
     );
 }
 impl my_struct2 {

--- a/bindgen-tests/tests/expectations/tests/forward-declaration-autoptr.rs
+++ b/bindgen-tests/tests/expectations/tests/forward-declaration-autoptr.rs
@@ -29,15 +29,19 @@ fn bindgen_test_layout_Bar() {
     const UNINIT: ::std::mem::MaybeUninit<Bar> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < Bar > (), 8usize, concat!("Size of: ", stringify!(Bar))
+        ::std::mem::size_of::<Bar>(),
+        8usize,
+        concat!("Size of: ", stringify!(Bar)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Bar > (), 8usize, concat!("Alignment of ",
-        stringify!(Bar))
+        ::std::mem::align_of::<Bar>(),
+        8usize,
+        concat!("Alignment of ", stringify!(Bar)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).m_member) as usize - ptr as usize },
-        0usize, concat!("Offset of field: ", stringify!(Bar), "::", stringify!(m_member))
+        unsafe { ::std::ptr::addr_of!((*ptr).m_member) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(Bar), "::", stringify!(m_member)),
     );
 }
 impl Default for Bar {
@@ -52,11 +56,13 @@ impl Default for Bar {
 #[test]
 fn __bindgen_test_layout_RefPtr_open0_Foo_close0_instantiation() {
     assert_eq!(
-        ::std::mem::size_of:: < RefPtr < Foo > > (), 8usize,
-        concat!("Size of template specialization: ", stringify!(RefPtr < Foo >))
+        ::std::mem::size_of::<RefPtr<Foo>>(),
+        8usize,
+        concat!("Size of template specialization: ", stringify!(RefPtr < Foo >)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < RefPtr < Foo > > (), 8usize,
-        concat!("Alignment of template specialization: ", stringify!(RefPtr < Foo >))
+        ::std::mem::align_of::<RefPtr<Foo>>(),
+        8usize,
+        concat!("Alignment of template specialization: ", stringify!(RefPtr < Foo >)),
     );
 }

--- a/bindgen-tests/tests/expectations/tests/forward_declared_complex_types.rs
+++ b/bindgen-tests/tests/expectations/tests/forward_declared_complex_types.rs
@@ -7,12 +7,14 @@ pub struct Foo_empty {
 #[test]
 fn bindgen_test_layout_Foo_empty() {
     assert_eq!(
-        ::std::mem::size_of:: < Foo_empty > (), 1usize, concat!("Size of: ",
-        stringify!(Foo_empty))
+        ::std::mem::size_of::<Foo_empty>(),
+        1usize,
+        concat!("Size of: ", stringify!(Foo_empty)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Foo_empty > (), 1usize, concat!("Alignment of ",
-        stringify!(Foo_empty))
+        ::std::mem::align_of::<Foo_empty>(),
+        1usize,
+        concat!("Alignment of ", stringify!(Foo_empty)),
     );
 }
 #[repr(C)]
@@ -30,15 +32,19 @@ fn bindgen_test_layout_Bar() {
     const UNINIT: ::std::mem::MaybeUninit<Bar> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < Bar > (), 8usize, concat!("Size of: ", stringify!(Bar))
+        ::std::mem::size_of::<Bar>(),
+        8usize,
+        concat!("Size of: ", stringify!(Bar)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Bar > (), 8usize, concat!("Alignment of ",
-        stringify!(Bar))
+        ::std::mem::align_of::<Bar>(),
+        8usize,
+        concat!("Alignment of ", stringify!(Bar)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).f) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(Bar), "::", stringify!(f))
+        unsafe { ::std::ptr::addr_of!((*ptr).f) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(Bar), "::", stringify!(f)),
     );
 }
 impl Default for Bar {

--- a/bindgen-tests/tests/expectations/tests/forward_declared_complex_types_1_0.rs
+++ b/bindgen-tests/tests/expectations/tests/forward_declared_complex_types_1_0.rs
@@ -7,12 +7,14 @@ pub struct Foo_empty {
 #[test]
 fn bindgen_test_layout_Foo_empty() {
     assert_eq!(
-        ::std::mem::size_of:: < Foo_empty > (), 1usize, concat!("Size of: ",
-        stringify!(Foo_empty))
+        ::std::mem::size_of::<Foo_empty>(),
+        1usize,
+        concat!("Size of: ", stringify!(Foo_empty)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Foo_empty > (), 1usize, concat!("Alignment of ",
-        stringify!(Foo_empty))
+        ::std::mem::align_of::<Foo_empty>(),
+        1usize,
+        concat!("Alignment of ", stringify!(Foo_empty)),
     );
 }
 impl Clone for Foo_empty {
@@ -40,15 +42,19 @@ fn bindgen_test_layout_Bar() {
     const UNINIT: ::std::mem::MaybeUninit<Bar> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < Bar > (), 8usize, concat!("Size of: ", stringify!(Bar))
+        ::std::mem::size_of::<Bar>(),
+        8usize,
+        concat!("Size of: ", stringify!(Bar)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Bar > (), 8usize, concat!("Alignment of ",
-        stringify!(Bar))
+        ::std::mem::align_of::<Bar>(),
+        8usize,
+        concat!("Alignment of ", stringify!(Bar)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).f) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(Bar), "::", stringify!(f))
+        unsafe { ::std::ptr::addr_of!((*ptr).f) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(Bar), "::", stringify!(f)),
     );
 }
 impl Clone for Bar {

--- a/bindgen-tests/tests/expectations/tests/forward_declared_struct.rs
+++ b/bindgen-tests/tests/expectations/tests/forward_declared_struct.rs
@@ -8,15 +8,16 @@ pub struct a {
 fn bindgen_test_layout_a() {
     const UNINIT: ::std::mem::MaybeUninit<a> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
+    assert_eq!(::std::mem::size_of::<a>(), 4usize, concat!("Size of: ", stringify!(a)));
     assert_eq!(
-        ::std::mem::size_of:: < a > (), 4usize, concat!("Size of: ", stringify!(a))
+        ::std::mem::align_of::<a>(),
+        4usize,
+        concat!("Alignment of ", stringify!(a)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < a > (), 4usize, concat!("Alignment of ", stringify!(a))
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).b) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(a), "::", stringify!(b))
+        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(a), "::", stringify!(b)),
     );
 }
 #[repr(C)]
@@ -28,14 +29,15 @@ pub struct c {
 fn bindgen_test_layout_c() {
     const UNINIT: ::std::mem::MaybeUninit<c> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
+    assert_eq!(::std::mem::size_of::<c>(), 4usize, concat!("Size of: ", stringify!(c)));
     assert_eq!(
-        ::std::mem::size_of:: < c > (), 4usize, concat!("Size of: ", stringify!(c))
+        ::std::mem::align_of::<c>(),
+        4usize,
+        concat!("Alignment of ", stringify!(c)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < c > (), 4usize, concat!("Alignment of ", stringify!(c))
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).d) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(c), "::", stringify!(d))
+        unsafe { ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(c), "::", stringify!(d)),
     );
 }

--- a/bindgen-tests/tests/expectations/tests/func_ptr_in_struct.rs
+++ b/bindgen-tests/tests/expectations/tests/func_ptr_in_struct.rs
@@ -16,14 +16,18 @@ fn bindgen_test_layout_Foo() {
     const UNINIT: ::std::mem::MaybeUninit<Foo> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < Foo > (), 8usize, concat!("Size of: ", stringify!(Foo))
+        ::std::mem::size_of::<Foo>(),
+        8usize,
+        concat!("Size of: ", stringify!(Foo)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Foo > (), 8usize, concat!("Alignment of ",
-        stringify!(Foo))
+        ::std::mem::align_of::<Foo>(),
+        8usize,
+        concat!("Alignment of ", stringify!(Foo)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).bar) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(Foo), "::", stringify!(bar))
+        unsafe { ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(Foo), "::", stringify!(bar)),
     );
 }

--- a/bindgen-tests/tests/expectations/tests/func_return_must_use.rs
+++ b/bindgen-tests/tests/expectations/tests/func_return_must_use.rs
@@ -31,12 +31,14 @@ pub struct AnnotatedStruct {}
 #[test]
 fn bindgen_test_layout_AnnotatedStruct() {
     assert_eq!(
-        ::std::mem::size_of:: < AnnotatedStruct > (), 0usize, concat!("Size of: ",
-        stringify!(AnnotatedStruct))
+        ::std::mem::size_of::<AnnotatedStruct>(),
+        0usize,
+        concat!("Size of: ", stringify!(AnnotatedStruct)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < AnnotatedStruct > (), 1usize, concat!("Alignment of ",
-        stringify!(AnnotatedStruct))
+        ::std::mem::align_of::<AnnotatedStruct>(),
+        1usize,
+        concat!("Alignment of ", stringify!(AnnotatedStruct)),
     );
 }
 extern "C" {
@@ -49,12 +51,14 @@ pub struct PlainStruct {}
 #[test]
 fn bindgen_test_layout_PlainStruct() {
     assert_eq!(
-        ::std::mem::size_of:: < PlainStruct > (), 0usize, concat!("Size of: ",
-        stringify!(PlainStruct))
+        ::std::mem::size_of::<PlainStruct>(),
+        0usize,
+        concat!("Size of: ", stringify!(PlainStruct)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < PlainStruct > (), 1usize, concat!("Alignment of ",
-        stringify!(PlainStruct))
+        ::std::mem::align_of::<PlainStruct>(),
+        1usize,
+        concat!("Alignment of ", stringify!(PlainStruct)),
     );
 }
 /// <div rustbindgen mustusetype></div>

--- a/bindgen-tests/tests/expectations/tests/gen-constructors-neg.rs
+++ b/bindgen-tests/tests/expectations/tests/gen-constructors-neg.rs
@@ -7,10 +7,13 @@ pub struct Foo {
 #[test]
 fn bindgen_test_layout_Foo() {
     assert_eq!(
-        ::std::mem::size_of:: < Foo > (), 1usize, concat!("Size of: ", stringify!(Foo))
+        ::std::mem::size_of::<Foo>(),
+        1usize,
+        concat!("Size of: ", stringify!(Foo)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Foo > (), 1usize, concat!("Alignment of ",
-        stringify!(Foo))
+        ::std::mem::align_of::<Foo>(),
+        1usize,
+        concat!("Alignment of ", stringify!(Foo)),
     );
 }

--- a/bindgen-tests/tests/expectations/tests/gen-constructors.rs
+++ b/bindgen-tests/tests/expectations/tests/gen-constructors.rs
@@ -7,11 +7,14 @@ pub struct Foo {
 #[test]
 fn bindgen_test_layout_Foo() {
     assert_eq!(
-        ::std::mem::size_of:: < Foo > (), 1usize, concat!("Size of: ", stringify!(Foo))
+        ::std::mem::size_of::<Foo>(),
+        1usize,
+        concat!("Size of: ", stringify!(Foo)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Foo > (), 1usize, concat!("Alignment of ",
-        stringify!(Foo))
+        ::std::mem::align_of::<Foo>(),
+        1usize,
+        concat!("Alignment of ", stringify!(Foo)),
     );
 }
 extern "C" {

--- a/bindgen-tests/tests/expectations/tests/gen-destructors-neg.rs
+++ b/bindgen-tests/tests/expectations/tests/gen-destructors-neg.rs
@@ -9,14 +9,18 @@ fn bindgen_test_layout_Foo() {
     const UNINIT: ::std::mem::MaybeUninit<Foo> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < Foo > (), 4usize, concat!("Size of: ", stringify!(Foo))
+        ::std::mem::size_of::<Foo>(),
+        4usize,
+        concat!("Size of: ", stringify!(Foo)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Foo > (), 4usize, concat!("Alignment of ",
-        stringify!(Foo))
+        ::std::mem::align_of::<Foo>(),
+        4usize,
+        concat!("Alignment of ", stringify!(Foo)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).bar) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(Foo), "::", stringify!(bar))
+        unsafe { ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(Foo), "::", stringify!(bar)),
     );
 }

--- a/bindgen-tests/tests/expectations/tests/gen-destructors.rs
+++ b/bindgen-tests/tests/expectations/tests/gen-destructors.rs
@@ -9,15 +9,19 @@ fn bindgen_test_layout_Foo() {
     const UNINIT: ::std::mem::MaybeUninit<Foo> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < Foo > (), 4usize, concat!("Size of: ", stringify!(Foo))
+        ::std::mem::size_of::<Foo>(),
+        4usize,
+        concat!("Size of: ", stringify!(Foo)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Foo > (), 4usize, concat!("Alignment of ",
-        stringify!(Foo))
+        ::std::mem::align_of::<Foo>(),
+        4usize,
+        concat!("Alignment of ", stringify!(Foo)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).bar) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(Foo), "::", stringify!(bar))
+        unsafe { ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(Foo), "::", stringify!(bar)),
     );
 }
 extern "C" {

--- a/bindgen-tests/tests/expectations/tests/generate-inline.rs
+++ b/bindgen-tests/tests/expectations/tests/generate-inline.rs
@@ -7,11 +7,14 @@ pub struct Foo {
 #[test]
 fn bindgen_test_layout_Foo() {
     assert_eq!(
-        ::std::mem::size_of:: < Foo > (), 1usize, concat!("Size of: ", stringify!(Foo))
+        ::std::mem::size_of::<Foo>(),
+        1usize,
+        concat!("Size of: ", stringify!(Foo)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Foo > (), 1usize, concat!("Alignment of ",
-        stringify!(Foo))
+        ::std::mem::align_of::<Foo>(),
+        1usize,
+        concat!("Alignment of ", stringify!(Foo)),
     );
 }
 extern "C" {

--- a/bindgen-tests/tests/expectations/tests/i128.rs
+++ b/bindgen-tests/tests/expectations/tests/i128.rs
@@ -11,20 +11,23 @@ fn bindgen_test_layout_foo() {
     const UNINIT: ::std::mem::MaybeUninit<foo> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < foo > (), 32usize, concat!("Size of: ", stringify!(foo))
+        ::std::mem::size_of::<foo>(),
+        32usize,
+        concat!("Size of: ", stringify!(foo)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < foo > (), 16usize, concat!("Alignment of ",
-        stringify!(foo))
+        ::std::mem::align_of::<foo>(),
+        16usize,
+        concat!("Alignment of ", stringify!(foo)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).my_signed) as usize - ptr as usize },
-        0usize, concat!("Offset of field: ", stringify!(foo), "::",
-        stringify!(my_signed))
+        unsafe { ::std::ptr::addr_of!((*ptr).my_signed) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(foo), "::", stringify!(my_signed)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).my_unsigned) as usize - ptr as usize },
-        16usize, concat!("Offset of field: ", stringify!(foo), "::",
-        stringify!(my_unsigned))
+        unsafe { ::std::ptr::addr_of!((*ptr).my_unsigned) as usize - ptr as usize },
+        16usize,
+        concat!("Offset of field: ", stringify!(foo), "::", stringify!(my_unsigned)),
     );
 }

--- a/bindgen-tests/tests/expectations/tests/incomplete-array-padding.rs
+++ b/bindgen-tests/tests/expectations/tests/incomplete-array-padding.rs
@@ -49,7 +49,7 @@ where
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < self.storage.as_ref().len());
         debug_assert!(
-            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len()
+            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len(),
         );
         let mut val = 0;
         for i in 0..(bit_width as usize) {
@@ -69,7 +69,7 @@ where
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < self.storage.as_ref().len());
         debug_assert!(
-            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len()
+            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len(),
         );
         for i in 0..(bit_width as usize) {
             let mask = 1 << i;
@@ -123,11 +123,14 @@ pub struct foo {
 #[test]
 fn bindgen_test_layout_foo() {
     assert_eq!(
-        ::std::mem::size_of:: < foo > (), 8usize, concat!("Size of: ", stringify!(foo))
+        ::std::mem::size_of::<foo>(),
+        8usize,
+        concat!("Size of: ", stringify!(foo)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < foo > (), 8usize, concat!("Alignment of ",
-        stringify!(foo))
+        ::std::mem::align_of::<foo>(),
+        8usize,
+        concat!("Alignment of ", stringify!(foo)),
     );
 }
 impl Default for foo {

--- a/bindgen-tests/tests/expectations/tests/inherit-from-template-instantiation-with-vtable.rs
+++ b/bindgen-tests/tests/expectations/tests/inherit-from-template-instantiation-with-vtable.rs
@@ -27,12 +27,14 @@ pub struct DerivedWithNoVirtualMethods {
 #[test]
 fn bindgen_test_layout_DerivedWithNoVirtualMethods() {
     assert_eq!(
-        ::std::mem::size_of:: < DerivedWithNoVirtualMethods > (), 16usize,
-        concat!("Size of: ", stringify!(DerivedWithNoVirtualMethods))
+        ::std::mem::size_of::<DerivedWithNoVirtualMethods>(),
+        16usize,
+        concat!("Size of: ", stringify!(DerivedWithNoVirtualMethods)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < DerivedWithNoVirtualMethods > (), 8usize,
-        concat!("Alignment of ", stringify!(DerivedWithNoVirtualMethods))
+        ::std::mem::align_of::<DerivedWithNoVirtualMethods>(),
+        8usize,
+        concat!("Alignment of ", stringify!(DerivedWithNoVirtualMethods)),
     );
 }
 impl Default for DerivedWithNoVirtualMethods {
@@ -53,12 +55,14 @@ pub struct DerivedWithVirtualMethods {
 #[test]
 fn bindgen_test_layout_DerivedWithVirtualMethods() {
     assert_eq!(
-        ::std::mem::size_of:: < DerivedWithVirtualMethods > (), 16usize,
-        concat!("Size of: ", stringify!(DerivedWithVirtualMethods))
+        ::std::mem::size_of::<DerivedWithVirtualMethods>(),
+        16usize,
+        concat!("Size of: ", stringify!(DerivedWithVirtualMethods)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < DerivedWithVirtualMethods > (), 8usize,
-        concat!("Alignment of ", stringify!(DerivedWithVirtualMethods))
+        ::std::mem::align_of::<DerivedWithVirtualMethods>(),
+        8usize,
+        concat!("Alignment of ", stringify!(DerivedWithVirtualMethods)),
     );
 }
 impl Default for DerivedWithVirtualMethods {
@@ -98,12 +102,14 @@ pub struct DerivedWithVtable {
 #[test]
 fn bindgen_test_layout_DerivedWithVtable() {
     assert_eq!(
-        ::std::mem::size_of:: < DerivedWithVtable > (), 16usize, concat!("Size of: ",
-        stringify!(DerivedWithVtable))
+        ::std::mem::size_of::<DerivedWithVtable>(),
+        16usize,
+        concat!("Size of: ", stringify!(DerivedWithVtable)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < DerivedWithVtable > (), 8usize, concat!("Alignment of ",
-        stringify!(DerivedWithVtable))
+        ::std::mem::align_of::<DerivedWithVtable>(),
+        8usize,
+        concat!("Alignment of ", stringify!(DerivedWithVtable)),
     );
 }
 impl Default for DerivedWithVtable {
@@ -124,12 +130,14 @@ pub struct DerivedWithoutVtable {
 #[test]
 fn bindgen_test_layout_DerivedWithoutVtable() {
     assert_eq!(
-        ::std::mem::size_of:: < DerivedWithoutVtable > (), 8usize, concat!("Size of: ",
-        stringify!(DerivedWithoutVtable))
+        ::std::mem::size_of::<DerivedWithoutVtable>(),
+        8usize,
+        concat!("Size of: ", stringify!(DerivedWithoutVtable)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < DerivedWithoutVtable > (), 8usize,
-        concat!("Alignment of ", stringify!(DerivedWithoutVtable))
+        ::std::mem::align_of::<DerivedWithoutVtable>(),
+        8usize,
+        concat!("Alignment of ", stringify!(DerivedWithoutVtable)),
     );
 }
 impl Default for DerivedWithoutVtable {
@@ -144,52 +152,76 @@ impl Default for DerivedWithoutVtable {
 #[test]
 fn __bindgen_test_layout_BaseWithVtable_open0_ptr_char_close0_instantiation() {
     assert_eq!(
-        ::std::mem::size_of:: < BaseWithVtable < * mut ::std::os::raw::c_char > > (),
-        16usize, concat!("Size of template specialization: ", stringify!(BaseWithVtable <
-        * mut ::std::os::raw::c_char >))
+        ::std::mem::size_of::<BaseWithVtable<*mut ::std::os::raw::c_char>>(),
+        16usize,
+        concat!(
+            "Size of template specialization: ",
+            stringify!(BaseWithVtable < * mut ::std::os::raw::c_char >),
+        ),
     );
     assert_eq!(
-        ::std::mem::align_of:: < BaseWithVtable < * mut ::std::os::raw::c_char > > (),
-        8usize, concat!("Alignment of template specialization: ",
-        stringify!(BaseWithVtable < * mut ::std::os::raw::c_char >))
+        ::std::mem::align_of::<BaseWithVtable<*mut ::std::os::raw::c_char>>(),
+        8usize,
+        concat!(
+            "Alignment of template specialization: ",
+            stringify!(BaseWithVtable < * mut ::std::os::raw::c_char >),
+        ),
     );
 }
 #[test]
 fn __bindgen_test_layout_BaseWithVtable_open0_ptr_char_close0_instantiation_1() {
     assert_eq!(
-        ::std::mem::size_of:: < BaseWithVtable < * mut ::std::os::raw::c_char > > (),
-        16usize, concat!("Size of template specialization: ", stringify!(BaseWithVtable <
-        * mut ::std::os::raw::c_char >))
+        ::std::mem::size_of::<BaseWithVtable<*mut ::std::os::raw::c_char>>(),
+        16usize,
+        concat!(
+            "Size of template specialization: ",
+            stringify!(BaseWithVtable < * mut ::std::os::raw::c_char >),
+        ),
     );
     assert_eq!(
-        ::std::mem::align_of:: < BaseWithVtable < * mut ::std::os::raw::c_char > > (),
-        8usize, concat!("Alignment of template specialization: ",
-        stringify!(BaseWithVtable < * mut ::std::os::raw::c_char >))
+        ::std::mem::align_of::<BaseWithVtable<*mut ::std::os::raw::c_char>>(),
+        8usize,
+        concat!(
+            "Alignment of template specialization: ",
+            stringify!(BaseWithVtable < * mut ::std::os::raw::c_char >),
+        ),
     );
 }
 #[test]
 fn __bindgen_test_layout_BaseWithoutVtable_open0_ptr_char_close0_instantiation() {
     assert_eq!(
-        ::std::mem::size_of:: < BaseWithoutVtable < * mut ::std::os::raw::c_char > > (),
-        8usize, concat!("Size of template specialization: ", stringify!(BaseWithoutVtable
-        < * mut ::std::os::raw::c_char >))
+        ::std::mem::size_of::<BaseWithoutVtable<*mut ::std::os::raw::c_char>>(),
+        8usize,
+        concat!(
+            "Size of template specialization: ",
+            stringify!(BaseWithoutVtable < * mut ::std::os::raw::c_char >),
+        ),
     );
     assert_eq!(
-        ::std::mem::align_of:: < BaseWithoutVtable < * mut ::std::os::raw::c_char > > (),
-        8usize, concat!("Alignment of template specialization: ",
-        stringify!(BaseWithoutVtable < * mut ::std::os::raw::c_char >))
+        ::std::mem::align_of::<BaseWithoutVtable<*mut ::std::os::raw::c_char>>(),
+        8usize,
+        concat!(
+            "Alignment of template specialization: ",
+            stringify!(BaseWithoutVtable < * mut ::std::os::raw::c_char >),
+        ),
     );
 }
 #[test]
 fn __bindgen_test_layout_BaseWithoutVtable_open0_ptr_char_close0_instantiation_1() {
     assert_eq!(
-        ::std::mem::size_of:: < BaseWithoutVtable < * mut ::std::os::raw::c_char > > (),
-        8usize, concat!("Size of template specialization: ", stringify!(BaseWithoutVtable
-        < * mut ::std::os::raw::c_char >))
+        ::std::mem::size_of::<BaseWithoutVtable<*mut ::std::os::raw::c_char>>(),
+        8usize,
+        concat!(
+            "Size of template specialization: ",
+            stringify!(BaseWithoutVtable < * mut ::std::os::raw::c_char >),
+        ),
     );
     assert_eq!(
-        ::std::mem::align_of:: < BaseWithoutVtable < * mut ::std::os::raw::c_char > > (),
-        8usize, concat!("Alignment of template specialization: ",
-        stringify!(BaseWithoutVtable < * mut ::std::os::raw::c_char >))
+        ::std::mem::align_of::<BaseWithoutVtable<*mut ::std::os::raw::c_char>>(),
+        8usize,
+        concat!(
+            "Alignment of template specialization: ",
+            stringify!(BaseWithoutVtable < * mut ::std::os::raw::c_char >),
+        ),
     );
 }

--- a/bindgen-tests/tests/expectations/tests/inherit_multiple_interfaces.rs
+++ b/bindgen-tests/tests/expectations/tests/inherit_multiple_interfaces.rs
@@ -11,15 +11,16 @@ pub struct A {
 fn bindgen_test_layout_A() {
     const UNINIT: ::std::mem::MaybeUninit<A> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
+    assert_eq!(::std::mem::size_of::<A>(), 16usize, concat!("Size of: ", stringify!(A)));
     assert_eq!(
-        ::std::mem::size_of:: < A > (), 16usize, concat!("Size of: ", stringify!(A))
+        ::std::mem::align_of::<A>(),
+        8usize,
+        concat!("Alignment of ", stringify!(A)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < A > (), 8usize, concat!("Alignment of ", stringify!(A))
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).member) as usize - ptr as usize }, 8usize,
-        concat!("Offset of field: ", stringify!(A), "::", stringify!(member))
+        unsafe { ::std::ptr::addr_of!((*ptr).member) as usize - ptr as usize },
+        8usize,
+        concat!("Offset of field: ", stringify!(A), "::", stringify!(member)),
     );
 }
 impl Default for A {
@@ -43,15 +44,16 @@ pub struct B {
 fn bindgen_test_layout_B() {
     const UNINIT: ::std::mem::MaybeUninit<B> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
+    assert_eq!(::std::mem::size_of::<B>(), 16usize, concat!("Size of: ", stringify!(B)));
     assert_eq!(
-        ::std::mem::size_of:: < B > (), 16usize, concat!("Size of: ", stringify!(B))
+        ::std::mem::align_of::<B>(),
+        8usize,
+        concat!("Alignment of ", stringify!(B)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < B > (), 8usize, concat!("Alignment of ", stringify!(B))
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).member2) as usize - ptr as usize }, 8usize,
-        concat!("Offset of field: ", stringify!(B), "::", stringify!(member2))
+        unsafe { ::std::ptr::addr_of!((*ptr).member2) as usize - ptr as usize },
+        8usize,
+        concat!("Offset of field: ", stringify!(B), "::", stringify!(member2)),
     );
 }
 impl Default for B {
@@ -74,15 +76,16 @@ pub struct C {
 fn bindgen_test_layout_C() {
     const UNINIT: ::std::mem::MaybeUninit<C> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
+    assert_eq!(::std::mem::size_of::<C>(), 40usize, concat!("Size of: ", stringify!(C)));
     assert_eq!(
-        ::std::mem::size_of:: < C > (), 40usize, concat!("Size of: ", stringify!(C))
+        ::std::mem::align_of::<C>(),
+        8usize,
+        concat!("Alignment of ", stringify!(C)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < C > (), 8usize, concat!("Alignment of ", stringify!(C))
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).member3) as usize - ptr as usize },
-        32usize, concat!("Offset of field: ", stringify!(C), "::", stringify!(member3))
+        unsafe { ::std::ptr::addr_of!((*ptr).member3) as usize - ptr as usize },
+        32usize,
+        concat!("Offset of field: ", stringify!(C), "::", stringify!(member3)),
     );
 }
 impl Default for C {

--- a/bindgen-tests/tests/expectations/tests/inherit_typedef.rs
+++ b/bindgen-tests/tests/expectations/tests/inherit_typedef.rs
@@ -7,11 +7,14 @@ pub struct Foo {
 #[test]
 fn bindgen_test_layout_Foo() {
     assert_eq!(
-        ::std::mem::size_of:: < Foo > (), 1usize, concat!("Size of: ", stringify!(Foo))
+        ::std::mem::size_of::<Foo>(),
+        1usize,
+        concat!("Size of: ", stringify!(Foo)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Foo > (), 1usize, concat!("Alignment of ",
-        stringify!(Foo))
+        ::std::mem::align_of::<Foo>(),
+        1usize,
+        concat!("Alignment of ", stringify!(Foo)),
     );
 }
 pub type TypedefedFoo = Foo;
@@ -23,10 +26,13 @@ pub struct Bar {
 #[test]
 fn bindgen_test_layout_Bar() {
     assert_eq!(
-        ::std::mem::size_of:: < Bar > (), 1usize, concat!("Size of: ", stringify!(Bar))
+        ::std::mem::size_of::<Bar>(),
+        1usize,
+        concat!("Size of: ", stringify!(Bar)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Bar > (), 1usize, concat!("Alignment of ",
-        stringify!(Bar))
+        ::std::mem::align_of::<Bar>(),
+        1usize,
+        concat!("Alignment of ", stringify!(Bar)),
     );
 }

--- a/bindgen-tests/tests/expectations/tests/inline_namespace.rs
+++ b/bindgen-tests/tests/expectations/tests/inline_namespace.rs
@@ -18,16 +18,19 @@ pub mod root {
         const UNINIT: ::std::mem::MaybeUninit<Bar> = ::std::mem::MaybeUninit::uninit();
         let ptr = UNINIT.as_ptr();
         assert_eq!(
-            ::std::mem::size_of:: < Bar > (), 4usize, concat!("Size of: ",
-            stringify!(Bar))
+            ::std::mem::size_of::<Bar>(),
+            4usize,
+            concat!("Size of: ", stringify!(Bar)),
         );
         assert_eq!(
-            ::std::mem::align_of:: < Bar > (), 4usize, concat!("Alignment of ",
-            stringify!(Bar))
+            ::std::mem::align_of::<Bar>(),
+            4usize,
+            concat!("Alignment of ", stringify!(Bar)),
         );
         assert_eq!(
-            unsafe { ::std::ptr::addr_of!((* ptr).baz) as usize - ptr as usize }, 0usize,
-            concat!("Offset of field: ", stringify!(Bar), "::", stringify!(baz))
+            unsafe { ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize },
+            0usize,
+            concat!("Offset of field: ", stringify!(Bar), "::", stringify!(baz)),
         );
     }
 }

--- a/bindgen-tests/tests/expectations/tests/inline_namespace_conservative.rs
+++ b/bindgen-tests/tests/expectations/tests/inline_namespace_conservative.rs
@@ -23,16 +23,19 @@ pub mod root {
         const UNINIT: ::std::mem::MaybeUninit<Bar> = ::std::mem::MaybeUninit::uninit();
         let ptr = UNINIT.as_ptr();
         assert_eq!(
-            ::std::mem::size_of:: < Bar > (), 4usize, concat!("Size of: ",
-            stringify!(Bar))
+            ::std::mem::size_of::<Bar>(),
+            4usize,
+            concat!("Size of: ", stringify!(Bar)),
         );
         assert_eq!(
-            ::std::mem::align_of:: < Bar > (), 4usize, concat!("Alignment of ",
-            stringify!(Bar))
+            ::std::mem::align_of::<Bar>(),
+            4usize,
+            concat!("Alignment of ", stringify!(Bar)),
         );
         assert_eq!(
-            unsafe { ::std::ptr::addr_of!((* ptr).baz) as usize - ptr as usize }, 0usize,
-            concat!("Offset of field: ", stringify!(Bar), "::", stringify!(baz))
+            unsafe { ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize },
+            0usize,
+            concat!("Offset of field: ", stringify!(Bar), "::", stringify!(baz)),
         );
     }
 }

--- a/bindgen-tests/tests/expectations/tests/inner_const.rs
+++ b/bindgen-tests/tests/expectations/tests/inner_const.rs
@@ -17,14 +17,18 @@ fn bindgen_test_layout_Foo() {
     const UNINIT: ::std::mem::MaybeUninit<Foo> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < Foo > (), 4usize, concat!("Size of: ", stringify!(Foo))
+        ::std::mem::size_of::<Foo>(),
+        4usize,
+        concat!("Size of: ", stringify!(Foo)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Foo > (), 4usize, concat!("Alignment of ",
-        stringify!(Foo))
+        ::std::mem::align_of::<Foo>(),
+        4usize,
+        concat!("Alignment of ", stringify!(Foo)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).bar) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(Foo), "::", stringify!(bar))
+        unsafe { ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(Foo), "::", stringify!(bar)),
     );
 }

--- a/bindgen-tests/tests/expectations/tests/inner_template_self.rs
+++ b/bindgen-tests/tests/expectations/tests/inner_template_self.rs
@@ -24,16 +24,19 @@ fn bindgen_test_layout_InstantiateIt() {
     const UNINIT: ::std::mem::MaybeUninit<InstantiateIt> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < InstantiateIt > (), 16usize, concat!("Size of: ",
-        stringify!(InstantiateIt))
+        ::std::mem::size_of::<InstantiateIt>(),
+        16usize,
+        concat!("Size of: ", stringify!(InstantiateIt)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < InstantiateIt > (), 8usize, concat!("Alignment of ",
-        stringify!(InstantiateIt))
+        ::std::mem::align_of::<InstantiateIt>(),
+        8usize,
+        concat!("Alignment of ", stringify!(InstantiateIt)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).m_list) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(InstantiateIt), "::", stringify!(m_list))
+        unsafe { ::std::ptr::addr_of!((*ptr).m_list) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(InstantiateIt), "::", stringify!(m_list)),
     );
 }
 impl Default for InstantiateIt {
@@ -48,11 +51,13 @@ impl Default for InstantiateIt {
 #[test]
 fn __bindgen_test_layout_LinkedList_open0_int_close0_instantiation() {
     assert_eq!(
-        ::std::mem::size_of:: < LinkedList > (), 16usize,
-        concat!("Size of template specialization: ", stringify!(LinkedList))
+        ::std::mem::size_of::<LinkedList>(),
+        16usize,
+        concat!("Size of template specialization: ", stringify!(LinkedList)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < LinkedList > (), 8usize,
-        concat!("Alignment of template specialization: ", stringify!(LinkedList))
+        ::std::mem::align_of::<LinkedList>(),
+        8usize,
+        concat!("Alignment of template specialization: ", stringify!(LinkedList)),
     );
 }

--- a/bindgen-tests/tests/expectations/tests/issue-1034.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-1034.rs
@@ -49,7 +49,7 @@ where
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < self.storage.as_ref().len());
         debug_assert!(
-            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len()
+            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len(),
         );
         let mut val = 0;
         for i in 0..(bit_width as usize) {
@@ -69,7 +69,7 @@ where
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < self.storage.as_ref().len());
         debug_assert!(
-            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len()
+            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len(),
         );
         for i in 0..(bit_width as usize) {
             let mask = 1 << i;
@@ -92,11 +92,14 @@ pub struct S2 {
 #[test]
 fn bindgen_test_layout_S2() {
     assert_eq!(
-        ::std::mem::size_of:: < S2 > (), 2usize, concat!("Size of: ", stringify!(S2))
+        ::std::mem::size_of::<S2>(),
+        2usize,
+        concat!("Size of: ", stringify!(S2)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < S2 > (), 1usize, concat!("Alignment of ",
-        stringify!(S2))
+        ::std::mem::align_of::<S2>(),
+        1usize,
+        concat!("Alignment of ", stringify!(S2)),
     );
 }
 impl S2 {

--- a/bindgen-tests/tests/expectations/tests/issue-1076-unnamed-bitfield-alignment.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-1076-unnamed-bitfield-alignment.rs
@@ -49,7 +49,7 @@ where
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < self.storage.as_ref().len());
         debug_assert!(
-            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len()
+            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len(),
         );
         let mut val = 0;
         for i in 0..(bit_width as usize) {
@@ -69,7 +69,7 @@ where
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < self.storage.as_ref().len());
         debug_assert!(
-            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len()
+            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len(),
         );
         for i in 0..(bit_width as usize) {
             let mask = 1 << i;
@@ -92,11 +92,14 @@ pub struct S1 {
 #[test]
 fn bindgen_test_layout_S1() {
     assert_eq!(
-        ::std::mem::size_of:: < S1 > (), 3usize, concat!("Size of: ", stringify!(S1))
+        ::std::mem::size_of::<S1>(),
+        3usize,
+        concat!("Size of: ", stringify!(S1)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < S1 > (), 1usize, concat!("Alignment of ",
-        stringify!(S1))
+        ::std::mem::align_of::<S1>(),
+        1usize,
+        concat!("Alignment of ", stringify!(S1)),
     );
 }
 impl S1 {

--- a/bindgen-tests/tests/expectations/tests/issue-1118-using-forward-decl.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-1118-using-forward-decl.rs
@@ -10,16 +10,19 @@ fn bindgen_test_layout_nsTArray_base() {
     const UNINIT: ::std::mem::MaybeUninit<nsTArray_base> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < nsTArray_base > (), 8usize, concat!("Size of: ",
-        stringify!(nsTArray_base))
+        ::std::mem::size_of::<nsTArray_base>(),
+        8usize,
+        concat!("Size of: ", stringify!(nsTArray_base)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < nsTArray_base > (), 8usize, concat!("Alignment of ",
-        stringify!(nsTArray_base))
+        ::std::mem::align_of::<nsTArray_base>(),
+        8usize,
+        concat!("Alignment of ", stringify!(nsTArray_base)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).d) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(nsTArray_base), "::", stringify!(d))
+        unsafe { ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(nsTArray_base), "::", stringify!(d)),
     );
 }
 impl Default for nsTArray_base {
@@ -55,16 +58,19 @@ fn bindgen_test_layout_nsIContent() {
     const UNINIT: ::std::mem::MaybeUninit<nsIContent> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < nsIContent > (), 8usize, concat!("Size of: ",
-        stringify!(nsIContent))
+        ::std::mem::size_of::<nsIContent>(),
+        8usize,
+        concat!("Size of: ", stringify!(nsIContent)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < nsIContent > (), 8usize, concat!("Alignment of ",
-        stringify!(nsIContent))
+        ::std::mem::align_of::<nsIContent>(),
+        8usize,
+        concat!("Alignment of ", stringify!(nsIContent)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).foo) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(nsIContent), "::", stringify!(foo))
+        unsafe { ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(nsIContent), "::", stringify!(foo)),
     );
 }
 impl Default for nsIContent {
@@ -83,22 +89,26 @@ extern "C" {
 #[test]
 fn __bindgen_test_layout_nsTArray_open0_ptr_nsIContent_close0_instantiation() {
     assert_eq!(
-        ::std::mem::size_of:: < nsTArray > (), 8usize,
-        concat!("Size of template specialization: ", stringify!(nsTArray))
+        ::std::mem::size_of::<nsTArray>(),
+        8usize,
+        concat!("Size of template specialization: ", stringify!(nsTArray)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < nsTArray > (), 8usize,
-        concat!("Alignment of template specialization: ", stringify!(nsTArray))
+        ::std::mem::align_of::<nsTArray>(),
+        8usize,
+        concat!("Alignment of template specialization: ", stringify!(nsTArray)),
     );
 }
 #[test]
 fn __bindgen_test_layout_nsTArray_open0_ptr_nsIContent_close0_instantiation_1() {
     assert_eq!(
-        ::std::mem::size_of:: < nsTArray > (), 8usize,
-        concat!("Size of template specialization: ", stringify!(nsTArray))
+        ::std::mem::size_of::<nsTArray>(),
+        8usize,
+        concat!("Size of template specialization: ", stringify!(nsTArray)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < nsTArray > (), 8usize,
-        concat!("Alignment of template specialization: ", stringify!(nsTArray))
+        ::std::mem::align_of::<nsTArray>(),
+        8usize,
+        concat!("Alignment of template specialization: ", stringify!(nsTArray)),
     );
 }

--- a/bindgen-tests/tests/expectations/tests/issue-1197-pure-virtual-stuff.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-1197-pure-virtual-stuff.rs
@@ -9,11 +9,14 @@ pub struct Foo {
 #[test]
 fn bindgen_test_layout_Foo() {
     assert_eq!(
-        ::std::mem::size_of:: < Foo > (), 8usize, concat!("Size of: ", stringify!(Foo))
+        ::std::mem::size_of::<Foo>(),
+        8usize,
+        concat!("Size of: ", stringify!(Foo)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Foo > (), 8usize, concat!("Alignment of ",
-        stringify!(Foo))
+        ::std::mem::align_of::<Foo>(),
+        8usize,
+        concat!("Alignment of ", stringify!(Foo)),
     );
 }
 impl Default for Foo {

--- a/bindgen-tests/tests/expectations/tests/issue-1216-variadic-member.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-1216-variadic-member.rs
@@ -19,14 +19,18 @@ fn bindgen_test_layout_Foo() {
     const UNINIT: ::std::mem::MaybeUninit<Foo> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < Foo > (), 8usize, concat!("Size of: ", stringify!(Foo))
+        ::std::mem::size_of::<Foo>(),
+        8usize,
+        concat!("Size of: ", stringify!(Foo)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Foo > (), 8usize, concat!("Alignment of ",
-        stringify!(Foo))
+        ::std::mem::align_of::<Foo>(),
+        8usize,
+        concat!("Alignment of ", stringify!(Foo)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).f) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(Foo), "::", stringify!(f))
+        unsafe { ::std::ptr::addr_of!((*ptr).f) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(Foo), "::", stringify!(f)),
     );
 }

--- a/bindgen-tests/tests/expectations/tests/issue-1281.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-1281.rs
@@ -14,15 +14,19 @@ fn bindgen_test_layout_foo() {
     const UNINIT: ::std::mem::MaybeUninit<foo> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < foo > (), 4usize, concat!("Size of: ", stringify!(foo))
+        ::std::mem::size_of::<foo>(),
+        4usize,
+        concat!("Size of: ", stringify!(foo)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < foo > (), 4usize, concat!("Alignment of ",
-        stringify!(foo))
+        ::std::mem::align_of::<foo>(),
+        4usize,
+        concat!("Alignment of ", stringify!(foo)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).foo) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(foo))
+        unsafe { ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(foo), "::", stringify!(foo)),
     );
 }
 #[test]
@@ -30,15 +34,19 @@ fn bindgen_test_layout_bar() {
     const UNINIT: ::std::mem::MaybeUninit<bar> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < bar > (), 4usize, concat!("Size of: ", stringify!(bar))
+        ::std::mem::size_of::<bar>(),
+        4usize,
+        concat!("Size of: ", stringify!(bar)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < bar > (), 4usize, concat!("Alignment of ",
-        stringify!(bar))
+        ::std::mem::align_of::<bar>(),
+        4usize,
+        concat!("Alignment of ", stringify!(bar)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).u) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(bar), "::", stringify!(u))
+        unsafe { ::std::ptr::addr_of!((*ptr).u) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(bar), "::", stringify!(u)),
     );
 }
 pub type bar_t = bar;
@@ -52,14 +60,18 @@ fn bindgen_test_layout_baz() {
     const UNINIT: ::std::mem::MaybeUninit<baz> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < baz > (), 4usize, concat!("Size of: ", stringify!(baz))
+        ::std::mem::size_of::<baz>(),
+        4usize,
+        concat!("Size of: ", stringify!(baz)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < baz > (), 4usize, concat!("Alignment of ",
-        stringify!(baz))
+        ::std::mem::align_of::<baz>(),
+        4usize,
+        concat!("Alignment of ", stringify!(baz)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).f) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(baz), "::", stringify!(f))
+        unsafe { ::std::ptr::addr_of!((*ptr).f) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(baz), "::", stringify!(f)),
     );
 }

--- a/bindgen-tests/tests/expectations/tests/issue-1285.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-1285.rs
@@ -15,20 +15,24 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<foo__bindgen_ty_1> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < foo__bindgen_ty_1 > (), 4usize, concat!("Size of: ",
-        stringify!(foo__bindgen_ty_1))
+        ::std::mem::size_of::<foo__bindgen_ty_1>(),
+        4usize,
+        concat!("Size of: ", stringify!(foo__bindgen_ty_1)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < foo__bindgen_ty_1 > (), 4usize, concat!("Alignment of ",
-        stringify!(foo__bindgen_ty_1))
+        ::std::mem::align_of::<foo__bindgen_ty_1>(),
+        4usize,
+        concat!("Alignment of ", stringify!(foo__bindgen_ty_1)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).a) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(foo__bindgen_ty_1), "::", stringify!(a))
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(foo__bindgen_ty_1), "::", stringify!(a)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).b) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(foo__bindgen_ty_1), "::", stringify!(b))
+        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(foo__bindgen_ty_1), "::", stringify!(b)),
     );
 }
 impl Default for foo__bindgen_ty_1 {
@@ -45,15 +49,19 @@ fn bindgen_test_layout_foo() {
     const UNINIT: ::std::mem::MaybeUninit<foo> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < foo > (), 4usize, concat!("Size of: ", stringify!(foo))
+        ::std::mem::size_of::<foo>(),
+        4usize,
+        concat!("Size of: ", stringify!(foo)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < foo > (), 4usize, concat!("Alignment of ",
-        stringify!(foo))
+        ::std::mem::align_of::<foo>(),
+        4usize,
+        concat!("Alignment of ", stringify!(foo)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).bar) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar))
+        unsafe { ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar)),
     );
 }
 impl Default for foo {

--- a/bindgen-tests/tests/expectations/tests/issue-1291.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-1291.rs
@@ -24,71 +24,88 @@ fn bindgen_test_layout_RTCRay() {
     const UNINIT: ::std::mem::MaybeUninit<RTCRay> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < RTCRay > (), 96usize, concat!("Size of: ",
-        stringify!(RTCRay))
+        ::std::mem::size_of::<RTCRay>(),
+        96usize,
+        concat!("Size of: ", stringify!(RTCRay)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < RTCRay > (), 16usize, concat!("Alignment of ",
-        stringify!(RTCRay))
+        ::std::mem::align_of::<RTCRay>(),
+        16usize,
+        concat!("Alignment of ", stringify!(RTCRay)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).org) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(RTCRay), "::", stringify!(org))
+        unsafe { ::std::ptr::addr_of!((*ptr).org) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(RTCRay), "::", stringify!(org)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).align0) as usize - ptr as usize }, 12usize,
-        concat!("Offset of field: ", stringify!(RTCRay), "::", stringify!(align0))
+        unsafe { ::std::ptr::addr_of!((*ptr).align0) as usize - ptr as usize },
+        12usize,
+        concat!("Offset of field: ", stringify!(RTCRay), "::", stringify!(align0)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).dir) as usize - ptr as usize }, 16usize,
-        concat!("Offset of field: ", stringify!(RTCRay), "::", stringify!(dir))
+        unsafe { ::std::ptr::addr_of!((*ptr).dir) as usize - ptr as usize },
+        16usize,
+        concat!("Offset of field: ", stringify!(RTCRay), "::", stringify!(dir)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).align1) as usize - ptr as usize }, 28usize,
-        concat!("Offset of field: ", stringify!(RTCRay), "::", stringify!(align1))
+        unsafe { ::std::ptr::addr_of!((*ptr).align1) as usize - ptr as usize },
+        28usize,
+        concat!("Offset of field: ", stringify!(RTCRay), "::", stringify!(align1)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).tnear) as usize - ptr as usize }, 32usize,
-        concat!("Offset of field: ", stringify!(RTCRay), "::", stringify!(tnear))
+        unsafe { ::std::ptr::addr_of!((*ptr).tnear) as usize - ptr as usize },
+        32usize,
+        concat!("Offset of field: ", stringify!(RTCRay), "::", stringify!(tnear)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).tfar) as usize - ptr as usize }, 36usize,
-        concat!("Offset of field: ", stringify!(RTCRay), "::", stringify!(tfar))
+        unsafe { ::std::ptr::addr_of!((*ptr).tfar) as usize - ptr as usize },
+        36usize,
+        concat!("Offset of field: ", stringify!(RTCRay), "::", stringify!(tfar)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).time) as usize - ptr as usize }, 40usize,
-        concat!("Offset of field: ", stringify!(RTCRay), "::", stringify!(time))
+        unsafe { ::std::ptr::addr_of!((*ptr).time) as usize - ptr as usize },
+        40usize,
+        concat!("Offset of field: ", stringify!(RTCRay), "::", stringify!(time)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).mask) as usize - ptr as usize }, 44usize,
-        concat!("Offset of field: ", stringify!(RTCRay), "::", stringify!(mask))
+        unsafe { ::std::ptr::addr_of!((*ptr).mask) as usize - ptr as usize },
+        44usize,
+        concat!("Offset of field: ", stringify!(RTCRay), "::", stringify!(mask)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).Ng) as usize - ptr as usize }, 48usize,
-        concat!("Offset of field: ", stringify!(RTCRay), "::", stringify!(Ng))
+        unsafe { ::std::ptr::addr_of!((*ptr).Ng) as usize - ptr as usize },
+        48usize,
+        concat!("Offset of field: ", stringify!(RTCRay), "::", stringify!(Ng)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).align2) as usize - ptr as usize }, 60usize,
-        concat!("Offset of field: ", stringify!(RTCRay), "::", stringify!(align2))
+        unsafe { ::std::ptr::addr_of!((*ptr).align2) as usize - ptr as usize },
+        60usize,
+        concat!("Offset of field: ", stringify!(RTCRay), "::", stringify!(align2)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).u) as usize - ptr as usize }, 64usize,
-        concat!("Offset of field: ", stringify!(RTCRay), "::", stringify!(u))
+        unsafe { ::std::ptr::addr_of!((*ptr).u) as usize - ptr as usize },
+        64usize,
+        concat!("Offset of field: ", stringify!(RTCRay), "::", stringify!(u)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).v) as usize - ptr as usize }, 68usize,
-        concat!("Offset of field: ", stringify!(RTCRay), "::", stringify!(v))
+        unsafe { ::std::ptr::addr_of!((*ptr).v) as usize - ptr as usize },
+        68usize,
+        concat!("Offset of field: ", stringify!(RTCRay), "::", stringify!(v)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).geomID) as usize - ptr as usize }, 72usize,
-        concat!("Offset of field: ", stringify!(RTCRay), "::", stringify!(geomID))
+        unsafe { ::std::ptr::addr_of!((*ptr).geomID) as usize - ptr as usize },
+        72usize,
+        concat!("Offset of field: ", stringify!(RTCRay), "::", stringify!(geomID)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).primID) as usize - ptr as usize }, 76usize,
-        concat!("Offset of field: ", stringify!(RTCRay), "::", stringify!(primID))
+        unsafe { ::std::ptr::addr_of!((*ptr).primID) as usize - ptr as usize },
+        76usize,
+        concat!("Offset of field: ", stringify!(RTCRay), "::", stringify!(primID)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).instID) as usize - ptr as usize }, 80usize,
-        concat!("Offset of field: ", stringify!(RTCRay), "::", stringify!(instID))
+        unsafe { ::std::ptr::addr_of!((*ptr).instID) as usize - ptr as usize },
+        80usize,
+        concat!("Offset of field: ", stringify!(RTCRay), "::", stringify!(instID)),
     );
 }

--- a/bindgen-tests/tests/expectations/tests/issue-1382-rust-primitive-types.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-1382-rust-primitive-types.rs
@@ -30,66 +30,83 @@ fn bindgen_test_layout_Foo() {
     const UNINIT: ::std::mem::MaybeUninit<Foo> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < Foo > (), 56usize, concat!("Size of: ", stringify!(Foo))
+        ::std::mem::size_of::<Foo>(),
+        56usize,
+        concat!("Size of: ", stringify!(Foo)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Foo > (), 4usize, concat!("Alignment of ",
-        stringify!(Foo))
+        ::std::mem::align_of::<Foo>(),
+        4usize,
+        concat!("Alignment of ", stringify!(Foo)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).i8_) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(Foo), "::", stringify!(i8_))
+        unsafe { ::std::ptr::addr_of!((*ptr).i8_) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(Foo), "::", stringify!(i8_)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).u8_) as usize - ptr as usize }, 4usize,
-        concat!("Offset of field: ", stringify!(Foo), "::", stringify!(u8_))
+        unsafe { ::std::ptr::addr_of!((*ptr).u8_) as usize - ptr as usize },
+        4usize,
+        concat!("Offset of field: ", stringify!(Foo), "::", stringify!(u8_)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).i16_) as usize - ptr as usize }, 8usize,
-        concat!("Offset of field: ", stringify!(Foo), "::", stringify!(i16_))
+        unsafe { ::std::ptr::addr_of!((*ptr).i16_) as usize - ptr as usize },
+        8usize,
+        concat!("Offset of field: ", stringify!(Foo), "::", stringify!(i16_)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).u16_) as usize - ptr as usize }, 12usize,
-        concat!("Offset of field: ", stringify!(Foo), "::", stringify!(u16_))
+        unsafe { ::std::ptr::addr_of!((*ptr).u16_) as usize - ptr as usize },
+        12usize,
+        concat!("Offset of field: ", stringify!(Foo), "::", stringify!(u16_)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).i32_) as usize - ptr as usize }, 16usize,
-        concat!("Offset of field: ", stringify!(Foo), "::", stringify!(i32_))
+        unsafe { ::std::ptr::addr_of!((*ptr).i32_) as usize - ptr as usize },
+        16usize,
+        concat!("Offset of field: ", stringify!(Foo), "::", stringify!(i32_)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).u32_) as usize - ptr as usize }, 20usize,
-        concat!("Offset of field: ", stringify!(Foo), "::", stringify!(u32_))
+        unsafe { ::std::ptr::addr_of!((*ptr).u32_) as usize - ptr as usize },
+        20usize,
+        concat!("Offset of field: ", stringify!(Foo), "::", stringify!(u32_)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).i64_) as usize - ptr as usize }, 24usize,
-        concat!("Offset of field: ", stringify!(Foo), "::", stringify!(i64_))
+        unsafe { ::std::ptr::addr_of!((*ptr).i64_) as usize - ptr as usize },
+        24usize,
+        concat!("Offset of field: ", stringify!(Foo), "::", stringify!(i64_)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).u64_) as usize - ptr as usize }, 28usize,
-        concat!("Offset of field: ", stringify!(Foo), "::", stringify!(u64_))
+        unsafe { ::std::ptr::addr_of!((*ptr).u64_) as usize - ptr as usize },
+        28usize,
+        concat!("Offset of field: ", stringify!(Foo), "::", stringify!(u64_)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).i128_) as usize - ptr as usize }, 32usize,
-        concat!("Offset of field: ", stringify!(Foo), "::", stringify!(i128_))
+        unsafe { ::std::ptr::addr_of!((*ptr).i128_) as usize - ptr as usize },
+        32usize,
+        concat!("Offset of field: ", stringify!(Foo), "::", stringify!(i128_)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).u128_) as usize - ptr as usize }, 36usize,
-        concat!("Offset of field: ", stringify!(Foo), "::", stringify!(u128_))
+        unsafe { ::std::ptr::addr_of!((*ptr).u128_) as usize - ptr as usize },
+        36usize,
+        concat!("Offset of field: ", stringify!(Foo), "::", stringify!(u128_)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).isize_) as usize - ptr as usize }, 40usize,
-        concat!("Offset of field: ", stringify!(Foo), "::", stringify!(isize_))
+        unsafe { ::std::ptr::addr_of!((*ptr).isize_) as usize - ptr as usize },
+        40usize,
+        concat!("Offset of field: ", stringify!(Foo), "::", stringify!(isize_)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).usize_) as usize - ptr as usize }, 44usize,
-        concat!("Offset of field: ", stringify!(Foo), "::", stringify!(usize_))
+        unsafe { ::std::ptr::addr_of!((*ptr).usize_) as usize - ptr as usize },
+        44usize,
+        concat!("Offset of field: ", stringify!(Foo), "::", stringify!(usize_)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).f32_) as usize - ptr as usize }, 48usize,
-        concat!("Offset of field: ", stringify!(Foo), "::", stringify!(f32_))
+        unsafe { ::std::ptr::addr_of!((*ptr).f32_) as usize - ptr as usize },
+        48usize,
+        concat!("Offset of field: ", stringify!(Foo), "::", stringify!(f32_)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).f64_) as usize - ptr as usize }, 52usize,
-        concat!("Offset of field: ", stringify!(Foo), "::", stringify!(f64_))
+        unsafe { ::std::ptr::addr_of!((*ptr).f64_) as usize - ptr as usize },
+        52usize,
+        concat!("Offset of field: ", stringify!(Foo), "::", stringify!(f64_)),
     );
 }

--- a/bindgen-tests/tests/expectations/tests/issue-1443.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-1443.rs
@@ -15,19 +15,24 @@ fn bindgen_test_layout_Bar() {
     const UNINIT: ::std::mem::MaybeUninit<Bar> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < Bar > (), 16usize, concat!("Size of: ", stringify!(Bar))
+        ::std::mem::size_of::<Bar>(),
+        16usize,
+        concat!("Size of: ", stringify!(Bar)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Bar > (), 8usize, concat!("Alignment of ",
-        stringify!(Bar))
+        ::std::mem::align_of::<Bar>(),
+        8usize,
+        concat!("Alignment of ", stringify!(Bar)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).f) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(Bar), "::", stringify!(f))
+        unsafe { ::std::ptr::addr_of!((*ptr).f) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(Bar), "::", stringify!(f)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).m) as usize - ptr as usize }, 8usize,
-        concat!("Offset of field: ", stringify!(Bar), "::", stringify!(m))
+        unsafe { ::std::ptr::addr_of!((*ptr).m) as usize - ptr as usize },
+        8usize,
+        concat!("Offset of field: ", stringify!(Bar), "::", stringify!(m)),
     );
 }
 impl Default for Bar {
@@ -50,19 +55,24 @@ fn bindgen_test_layout_Baz() {
     const UNINIT: ::std::mem::MaybeUninit<Baz> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < Baz > (), 16usize, concat!("Size of: ", stringify!(Baz))
+        ::std::mem::size_of::<Baz>(),
+        16usize,
+        concat!("Size of: ", stringify!(Baz)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Baz > (), 8usize, concat!("Alignment of ",
-        stringify!(Baz))
+        ::std::mem::align_of::<Baz>(),
+        8usize,
+        concat!("Alignment of ", stringify!(Baz)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).f) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(Baz), "::", stringify!(f))
+        unsafe { ::std::ptr::addr_of!((*ptr).f) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(Baz), "::", stringify!(f)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).m) as usize - ptr as usize }, 8usize,
-        concat!("Offset of field: ", stringify!(Baz), "::", stringify!(m))
+        unsafe { ::std::ptr::addr_of!((*ptr).m) as usize - ptr as usize },
+        8usize,
+        concat!("Offset of field: ", stringify!(Baz), "::", stringify!(m)),
     );
 }
 impl Default for Baz {
@@ -85,19 +95,24 @@ fn bindgen_test_layout_Tar() {
     const UNINIT: ::std::mem::MaybeUninit<Tar> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < Tar > (), 16usize, concat!("Size of: ", stringify!(Tar))
+        ::std::mem::size_of::<Tar>(),
+        16usize,
+        concat!("Size of: ", stringify!(Tar)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Tar > (), 8usize, concat!("Alignment of ",
-        stringify!(Tar))
+        ::std::mem::align_of::<Tar>(),
+        8usize,
+        concat!("Alignment of ", stringify!(Tar)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).f) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(Tar), "::", stringify!(f))
+        unsafe { ::std::ptr::addr_of!((*ptr).f) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(Tar), "::", stringify!(f)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).m) as usize - ptr as usize }, 8usize,
-        concat!("Offset of field: ", stringify!(Tar), "::", stringify!(m))
+        unsafe { ::std::ptr::addr_of!((*ptr).m) as usize - ptr as usize },
+        8usize,
+        concat!("Offset of field: ", stringify!(Tar), "::", stringify!(m)),
     );
 }
 impl Default for Tar {
@@ -120,19 +135,24 @@ fn bindgen_test_layout_Taz() {
     const UNINIT: ::std::mem::MaybeUninit<Taz> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < Taz > (), 16usize, concat!("Size of: ", stringify!(Taz))
+        ::std::mem::size_of::<Taz>(),
+        16usize,
+        concat!("Size of: ", stringify!(Taz)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Taz > (), 8usize, concat!("Alignment of ",
-        stringify!(Taz))
+        ::std::mem::align_of::<Taz>(),
+        8usize,
+        concat!("Alignment of ", stringify!(Taz)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).f) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(Taz), "::", stringify!(f))
+        unsafe { ::std::ptr::addr_of!((*ptr).f) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(Taz), "::", stringify!(f)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).m) as usize - ptr as usize }, 8usize,
-        concat!("Offset of field: ", stringify!(Taz), "::", stringify!(m))
+        unsafe { ::std::ptr::addr_of!((*ptr).m) as usize - ptr as usize },
+        8usize,
+        concat!("Offset of field: ", stringify!(Taz), "::", stringify!(m)),
     );
 }
 impl Default for Taz {

--- a/bindgen-tests/tests/expectations/tests/issue-1454.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-1454.rs
@@ -12,15 +12,18 @@ fn bindgen_test_layout_local_type() {
     const UNINIT: ::std::mem::MaybeUninit<local_type> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < local_type > (), 0usize, concat!("Size of: ",
-        stringify!(local_type))
+        ::std::mem::size_of::<local_type>(),
+        0usize,
+        concat!("Size of: ", stringify!(local_type)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < local_type > (), 1usize, concat!("Alignment of ",
-        stringify!(local_type))
+        ::std::mem::align_of::<local_type>(),
+        1usize,
+        concat!("Alignment of ", stringify!(local_type)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).inner) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(local_type), "::", stringify!(inner))
+        unsafe { ::std::ptr::addr_of!((*ptr).inner) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(local_type), "::", stringify!(inner)),
     );
 }

--- a/bindgen-tests/tests/expectations/tests/issue-1498.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-1498.rs
@@ -29,22 +29,34 @@ fn bindgen_test_layout_rte_memseg__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<rte_memseg__bindgen_ty_1> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < rte_memseg__bindgen_ty_1 > (), 8usize,
-        concat!("Size of: ", stringify!(rte_memseg__bindgen_ty_1))
+        ::std::mem::size_of::<rte_memseg__bindgen_ty_1>(),
+        8usize,
+        concat!("Size of: ", stringify!(rte_memseg__bindgen_ty_1)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < rte_memseg__bindgen_ty_1 > (), 8usize,
-        concat!("Alignment of ", stringify!(rte_memseg__bindgen_ty_1))
+        ::std::mem::align_of::<rte_memseg__bindgen_ty_1>(),
+        8usize,
+        concat!("Alignment of ", stringify!(rte_memseg__bindgen_ty_1)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).addr) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(rte_memseg__bindgen_ty_1), "::",
-        stringify!(addr))
+        unsafe { ::std::ptr::addr_of!((*ptr).addr) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_memseg__bindgen_ty_1),
+            "::",
+            stringify!(addr),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).addr_64) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(rte_memseg__bindgen_ty_1), "::",
-        stringify!(addr_64))
+        unsafe { ::std::ptr::addr_of!((*ptr).addr_64) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_memseg__bindgen_ty_1),
+            "::",
+            stringify!(addr_64),
+        ),
     );
 }
 impl Default for rte_memseg__bindgen_ty_1 {
@@ -61,40 +73,49 @@ fn bindgen_test_layout_rte_memseg() {
     const UNINIT: ::std::mem::MaybeUninit<rte_memseg> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < rte_memseg > (), 44usize, concat!("Size of: ",
-        stringify!(rte_memseg))
+        ::std::mem::size_of::<rte_memseg>(),
+        44usize,
+        concat!("Size of: ", stringify!(rte_memseg)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < rte_memseg > (), 1usize, concat!("Alignment of ",
-        stringify!(rte_memseg))
+        ::std::mem::align_of::<rte_memseg>(),
+        1usize,
+        concat!("Alignment of ", stringify!(rte_memseg)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).phys_addr) as usize - ptr as usize },
-        0usize, concat!("Offset of field: ", stringify!(rte_memseg), "::",
-        stringify!(phys_addr))
+        unsafe { ::std::ptr::addr_of!((*ptr).phys_addr) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(rte_memseg), "::", stringify!(phys_addr)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).len) as usize - ptr as usize }, 16usize,
-        concat!("Offset of field: ", stringify!(rte_memseg), "::", stringify!(len))
+        unsafe { ::std::ptr::addr_of!((*ptr).len) as usize - ptr as usize },
+        16usize,
+        concat!("Offset of field: ", stringify!(rte_memseg), "::", stringify!(len)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).hugepage_sz) as usize - ptr as usize },
-        24usize, concat!("Offset of field: ", stringify!(rte_memseg), "::",
-        stringify!(hugepage_sz))
+        unsafe { ::std::ptr::addr_of!((*ptr).hugepage_sz) as usize - ptr as usize },
+        24usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_memseg),
+            "::",
+            stringify!(hugepage_sz),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).socket_id) as usize - ptr as usize },
-        32usize, concat!("Offset of field: ", stringify!(rte_memseg), "::",
-        stringify!(socket_id))
+        unsafe { ::std::ptr::addr_of!((*ptr).socket_id) as usize - ptr as usize },
+        32usize,
+        concat!("Offset of field: ", stringify!(rte_memseg), "::", stringify!(socket_id)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).nchannel) as usize - ptr as usize },
-        36usize, concat!("Offset of field: ", stringify!(rte_memseg), "::",
-        stringify!(nchannel))
+        unsafe { ::std::ptr::addr_of!((*ptr).nchannel) as usize - ptr as usize },
+        36usize,
+        concat!("Offset of field: ", stringify!(rte_memseg), "::", stringify!(nchannel)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).nrank) as usize - ptr as usize }, 40usize,
-        concat!("Offset of field: ", stringify!(rte_memseg), "::", stringify!(nrank))
+        unsafe { ::std::ptr::addr_of!((*ptr).nrank) as usize - ptr as usize },
+        40usize,
+        concat!("Offset of field: ", stringify!(rte_memseg), "::", stringify!(nrank)),
     );
 }
 impl Default for rte_memseg {

--- a/bindgen-tests/tests/expectations/tests/issue-1947.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-1947.rs
@@ -49,7 +49,7 @@ where
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < self.storage.as_ref().len());
         debug_assert!(
-            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len()
+            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len(),
         );
         let mut val = 0;
         for i in 0..(bit_width as usize) {
@@ -69,7 +69,7 @@ where
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < self.storage.as_ref().len());
         debug_assert!(
-            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len()
+            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len(),
         );
         for i in 0..(bit_width as usize) {
             let mask = 1 << i;
@@ -102,24 +102,29 @@ fn bindgen_test_layout_V56AMDY() {
     const UNINIT: ::std::mem::MaybeUninit<V56AMDY> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < V56AMDY > (), 8usize, concat!("Size of: ",
-        stringify!(V56AMDY))
+        ::std::mem::size_of::<V56AMDY>(),
+        8usize,
+        concat!("Size of: ", stringify!(V56AMDY)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < V56AMDY > (), 2usize, concat!("Alignment of ",
-        stringify!(V56AMDY))
+        ::std::mem::align_of::<V56AMDY>(),
+        2usize,
+        concat!("Alignment of ", stringify!(V56AMDY)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).MADK) as usize - ptr as usize }, 2usize,
-        concat!("Offset of field: ", stringify!(V56AMDY), "::", stringify!(MADK))
+        unsafe { ::std::ptr::addr_of!((*ptr).MADK) as usize - ptr as usize },
+        2usize,
+        concat!("Offset of field: ", stringify!(V56AMDY), "::", stringify!(MADK)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).MABR) as usize - ptr as usize }, 3usize,
-        concat!("Offset of field: ", stringify!(V56AMDY), "::", stringify!(MABR))
+        unsafe { ::std::ptr::addr_of!((*ptr).MABR) as usize - ptr as usize },
+        3usize,
+        concat!("Offset of field: ", stringify!(V56AMDY), "::", stringify!(MABR)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr)._rB_) as usize - ptr as usize }, 7usize,
-        concat!("Offset of field: ", stringify!(V56AMDY), "::", stringify!(_rB_))
+        unsafe { ::std::ptr::addr_of!((*ptr)._rB_) as usize - ptr as usize },
+        7usize,
+        concat!("Offset of field: ", stringify!(V56AMDY), "::", stringify!(_rB_)),
     );
 }
 impl V56AMDY {

--- a/bindgen-tests/tests/expectations/tests/issue-1977-larger-arrays.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-1977-larger-arrays.rs
@@ -8,16 +8,16 @@ pub struct S {
 fn bindgen_test_layout_S() {
     const UNINIT: ::std::mem::MaybeUninit<S> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
+    assert_eq!(::std::mem::size_of::<S>(), 33usize, concat!("Size of: ", stringify!(S)));
     assert_eq!(
-        ::std::mem::size_of:: < S > (), 33usize, concat!("Size of: ", stringify!(S))
+        ::std::mem::align_of::<S>(),
+        1usize,
+        concat!("Alignment of ", stringify!(S)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < S > (), 1usize, concat!("Alignment of ", stringify!(S))
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).large_array) as usize - ptr as usize },
-        0usize, concat!("Offset of field: ", stringify!(S), "::",
-        stringify!(large_array))
+        unsafe { ::std::ptr::addr_of!((*ptr).large_array) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(S), "::", stringify!(large_array)),
     );
 }
 impl Default for S {

--- a/bindgen-tests/tests/expectations/tests/issue-1995.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-1995.rs
@@ -16,14 +16,18 @@ fn bindgen_test_layout_Bar() {
     const UNINIT: ::std::mem::MaybeUninit<Bar> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < Bar > (), 4usize, concat!("Size of: ", stringify!(Bar))
+        ::std::mem::size_of::<Bar>(),
+        4usize,
+        concat!("Size of: ", stringify!(Bar)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Bar > (), 4usize, concat!("Alignment of ",
-        stringify!(Bar))
+        ::std::mem::align_of::<Bar>(),
+        4usize,
+        concat!("Alignment of ", stringify!(Bar)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).baz) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(Bar), "::", stringify!(baz))
+        unsafe { ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(Bar), "::", stringify!(baz)),
     );
 }

--- a/bindgen-tests/tests/expectations/tests/issue-2019.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-2019.rs
@@ -8,15 +8,16 @@ pub struct A {
 fn bindgen_test_layout_A() {
     const UNINIT: ::std::mem::MaybeUninit<A> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
+    assert_eq!(::std::mem::size_of::<A>(), 4usize, concat!("Size of: ", stringify!(A)));
     assert_eq!(
-        ::std::mem::size_of:: < A > (), 4usize, concat!("Size of: ", stringify!(A))
+        ::std::mem::align_of::<A>(),
+        4usize,
+        concat!("Alignment of ", stringify!(A)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < A > (), 4usize, concat!("Alignment of ", stringify!(A))
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).a) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(A), "::", stringify!(a))
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(A), "::", stringify!(a)),
     );
 }
 extern "C" {
@@ -38,15 +39,16 @@ pub struct B {
 fn bindgen_test_layout_B() {
     const UNINIT: ::std::mem::MaybeUninit<B> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
+    assert_eq!(::std::mem::size_of::<B>(), 4usize, concat!("Size of: ", stringify!(B)));
     assert_eq!(
-        ::std::mem::size_of:: < B > (), 4usize, concat!("Size of: ", stringify!(B))
+        ::std::mem::align_of::<B>(),
+        4usize,
+        concat!("Alignment of ", stringify!(B)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < B > (), 4usize, concat!("Alignment of ", stringify!(B))
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).b) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(B), "::", stringify!(b))
+        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(B), "::", stringify!(b)),
     );
 }
 extern "C" {

--- a/bindgen-tests/tests/expectations/tests/issue-2556.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-2556.rs
@@ -14,22 +14,24 @@ pub mod root {
         const UNINIT: ::std::mem::MaybeUninit<nsSize> = ::std::mem::MaybeUninit::uninit();
         let ptr = UNINIT.as_ptr();
         assert_eq!(
-            ::std::mem::size_of:: < nsSize > (), 8usize, concat!("Size of: ",
-            stringify!(nsSize))
+            ::std::mem::size_of::<nsSize>(),
+            8usize,
+            concat!("Size of: ", stringify!(nsSize)),
         );
         assert_eq!(
-            ::std::mem::align_of:: < nsSize > (), 4usize, concat!("Alignment of ",
-            stringify!(nsSize))
+            ::std::mem::align_of::<nsSize>(),
+            4usize,
+            concat!("Alignment of ", stringify!(nsSize)),
         );
         assert_eq!(
-            unsafe { ::std::ptr::addr_of!((* ptr).width) as usize - ptr as usize },
-            0usize, concat!("Offset of field: ", stringify!(nsSize), "::",
-            stringify!(width))
+            unsafe { ::std::ptr::addr_of!((*ptr).width) as usize - ptr as usize },
+            0usize,
+            concat!("Offset of field: ", stringify!(nsSize), "::", stringify!(width)),
         );
         assert_eq!(
-            unsafe { ::std::ptr::addr_of!((* ptr).height) as usize - ptr as usize },
-            4usize, concat!("Offset of field: ", stringify!(nsSize), "::",
-            stringify!(height))
+            unsafe { ::std::ptr::addr_of!((*ptr).height) as usize - ptr as usize },
+            4usize,
+            concat!("Offset of field: ", stringify!(nsSize), "::", stringify!(height)),
         );
     }
     pub mod foo {

--- a/bindgen-tests/tests/expectations/tests/issue-372.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-372.rs
@@ -15,23 +15,29 @@ pub mod root {
         const UNINIT: ::std::mem::MaybeUninit<i> = ::std::mem::MaybeUninit::uninit();
         let ptr = UNINIT.as_ptr();
         assert_eq!(
-            ::std::mem::size_of:: < i > (), 24usize, concat!("Size of: ", stringify!(i))
+            ::std::mem::size_of::<i>(),
+            24usize,
+            concat!("Size of: ", stringify!(i)),
         );
         assert_eq!(
-            ::std::mem::align_of:: < i > (), 8usize, concat!("Alignment of ",
-            stringify!(i))
+            ::std::mem::align_of::<i>(),
+            8usize,
+            concat!("Alignment of ", stringify!(i)),
         );
         assert_eq!(
-            unsafe { ::std::ptr::addr_of!((* ptr).j) as usize - ptr as usize }, 0usize,
-            concat!("Offset of field: ", stringify!(i), "::", stringify!(j))
+            unsafe { ::std::ptr::addr_of!((*ptr).j) as usize - ptr as usize },
+            0usize,
+            concat!("Offset of field: ", stringify!(i), "::", stringify!(j)),
         );
         assert_eq!(
-            unsafe { ::std::ptr::addr_of!((* ptr).k) as usize - ptr as usize }, 8usize,
-            concat!("Offset of field: ", stringify!(i), "::", stringify!(k))
+            unsafe { ::std::ptr::addr_of!((*ptr).k) as usize - ptr as usize },
+            8usize,
+            concat!("Offset of field: ", stringify!(i), "::", stringify!(k)),
         );
         assert_eq!(
-            unsafe { ::std::ptr::addr_of!((* ptr).l) as usize - ptr as usize }, 16usize,
-            concat!("Offset of field: ", stringify!(i), "::", stringify!(l))
+            unsafe { ::std::ptr::addr_of!((*ptr).l) as usize - ptr as usize },
+            16usize,
+            concat!("Offset of field: ", stringify!(i), "::", stringify!(l)),
         );
     }
     impl Default for i {
@@ -53,15 +59,19 @@ pub mod root {
         const UNINIT: ::std::mem::MaybeUninit<d> = ::std::mem::MaybeUninit::uninit();
         let ptr = UNINIT.as_ptr();
         assert_eq!(
-            ::std::mem::size_of:: < d > (), 24usize, concat!("Size of: ", stringify!(d))
+            ::std::mem::size_of::<d>(),
+            24usize,
+            concat!("Size of: ", stringify!(d)),
         );
         assert_eq!(
-            ::std::mem::align_of:: < d > (), 8usize, concat!("Alignment of ",
-            stringify!(d))
+            ::std::mem::align_of::<d>(),
+            8usize,
+            concat!("Alignment of ", stringify!(d)),
         );
         assert_eq!(
-            unsafe { ::std::ptr::addr_of!((* ptr).m) as usize - ptr as usize }, 0usize,
-            concat!("Offset of field: ", stringify!(d), "::", stringify!(m))
+            unsafe { ::std::ptr::addr_of!((*ptr).m) as usize - ptr as usize },
+            0usize,
+            concat!("Offset of field: ", stringify!(d), "::", stringify!(m)),
         );
     }
     impl Default for d {
@@ -98,15 +108,19 @@ pub mod root {
         const UNINIT: ::std::mem::MaybeUninit<F> = ::std::mem::MaybeUninit::uninit();
         let ptr = UNINIT.as_ptr();
         assert_eq!(
-            ::std::mem::size_of:: < F > (), 264usize, concat!("Size of: ", stringify!(F))
+            ::std::mem::size_of::<F>(),
+            264usize,
+            concat!("Size of: ", stringify!(F)),
         );
         assert_eq!(
-            ::std::mem::align_of:: < F > (), 8usize, concat!("Alignment of ",
-            stringify!(F))
+            ::std::mem::align_of::<F>(),
+            8usize,
+            concat!("Alignment of ", stringify!(F)),
         );
         assert_eq!(
-            unsafe { ::std::ptr::addr_of!((* ptr).w) as usize - ptr as usize }, 0usize,
-            concat!("Offset of field: ", stringify!(F), "::", stringify!(w))
+            unsafe { ::std::ptr::addr_of!((*ptr).w) as usize - ptr as usize },
+            0usize,
+            concat!("Offset of field: ", stringify!(F), "::", stringify!(w)),
         );
     }
     impl Default for F {

--- a/bindgen-tests/tests/expectations/tests/issue-410.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-410.rs
@@ -14,12 +14,14 @@ pub mod root {
         #[test]
         fn bindgen_test_layout_Value() {
             assert_eq!(
-                ::std::mem::size_of:: < Value > (), 1usize, concat!("Size of: ",
-                stringify!(Value))
+                ::std::mem::size_of::<Value>(),
+                1usize,
+                concat!("Size of: ", stringify!(Value)),
             );
             assert_eq!(
-                ::std::mem::align_of:: < Value > (), 1usize, concat!("Alignment of ",
-                stringify!(Value))
+                ::std::mem::align_of::<Value>(),
+                1usize,
+                concat!("Alignment of ", stringify!(Value)),
             );
         }
         extern "C" {

--- a/bindgen-tests/tests/expectations/tests/issue-447.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-447.rs
@@ -17,12 +17,14 @@ pub mod root {
             #[test]
             fn bindgen_test_layout_GuardObjectNotifier() {
                 assert_eq!(
-                    ::std::mem::size_of:: < GuardObjectNotifier > (), 1usize,
-                    concat!("Size of: ", stringify!(GuardObjectNotifier))
+                    ::std::mem::size_of::<GuardObjectNotifier>(),
+                    1usize,
+                    concat!("Size of: ", stringify!(GuardObjectNotifier)),
                 );
                 assert_eq!(
-                    ::std::mem::align_of:: < GuardObjectNotifier > (), 1usize,
-                    concat!("Alignment of ", stringify!(GuardObjectNotifier))
+                    ::std::mem::align_of::<GuardObjectNotifier>(),
+                    1usize,
+                    concat!("Alignment of ", stringify!(GuardObjectNotifier)),
                 );
             }
         }
@@ -35,12 +37,14 @@ pub mod root {
     #[test]
     fn bindgen_test_layout_JSAutoCompartment() {
         assert_eq!(
-            ::std::mem::size_of:: < JSAutoCompartment > (), 1usize, concat!("Size of: ",
-            stringify!(JSAutoCompartment))
+            ::std::mem::size_of::<JSAutoCompartment>(),
+            1usize,
+            concat!("Size of: ", stringify!(JSAutoCompartment)),
         );
         assert_eq!(
-            ::std::mem::align_of:: < JSAutoCompartment > (), 1usize,
-            concat!("Alignment of ", stringify!(JSAutoCompartment))
+            ::std::mem::align_of::<JSAutoCompartment>(),
+            1usize,
+            concat!("Alignment of ", stringify!(JSAutoCompartment)),
         );
     }
     extern "C" {

--- a/bindgen-tests/tests/expectations/tests/issue-537-repr-packed-n.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-537-repr-packed-n.rs
@@ -12,16 +12,19 @@ fn bindgen_test_layout_AlignedToOne() {
     const UNINIT: ::std::mem::MaybeUninit<AlignedToOne> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < AlignedToOne > (), 4usize, concat!("Size of: ",
-        stringify!(AlignedToOne))
+        ::std::mem::size_of::<AlignedToOne>(),
+        4usize,
+        concat!("Size of: ", stringify!(AlignedToOne)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < AlignedToOne > (), 1usize, concat!("Alignment of ",
-        stringify!(AlignedToOne))
+        ::std::mem::align_of::<AlignedToOne>(),
+        1usize,
+        concat!("Alignment of ", stringify!(AlignedToOne)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).i) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(AlignedToOne), "::", stringify!(i))
+        unsafe { ::std::ptr::addr_of!((*ptr).i) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(AlignedToOne), "::", stringify!(i)),
     );
 }
 /// This should be be packed because Rust 1.33 has `#[repr(packed(N))]`.
@@ -35,16 +38,19 @@ fn bindgen_test_layout_AlignedToTwo() {
     const UNINIT: ::std::mem::MaybeUninit<AlignedToTwo> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < AlignedToTwo > (), 4usize, concat!("Size of: ",
-        stringify!(AlignedToTwo))
+        ::std::mem::size_of::<AlignedToTwo>(),
+        4usize,
+        concat!("Size of: ", stringify!(AlignedToTwo)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < AlignedToTwo > (), 2usize, concat!("Alignment of ",
-        stringify!(AlignedToTwo))
+        ::std::mem::align_of::<AlignedToTwo>(),
+        2usize,
+        concat!("Alignment of ", stringify!(AlignedToTwo)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).i) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(AlignedToTwo), "::", stringify!(i))
+        unsafe { ::std::ptr::addr_of!((*ptr).i) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(AlignedToTwo), "::", stringify!(i)),
     );
 }
 /** This should not be opaque because although `libclang` doesn't give us the
@@ -61,20 +67,24 @@ fn bindgen_test_layout_PackedToOne() {
     const UNINIT: ::std::mem::MaybeUninit<PackedToOne> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < PackedToOne > (), 8usize, concat!("Size of: ",
-        stringify!(PackedToOne))
+        ::std::mem::size_of::<PackedToOne>(),
+        8usize,
+        concat!("Size of: ", stringify!(PackedToOne)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < PackedToOne > (), 1usize, concat!("Alignment of ",
-        stringify!(PackedToOne))
+        ::std::mem::align_of::<PackedToOne>(),
+        1usize,
+        concat!("Alignment of ", stringify!(PackedToOne)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).x) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(PackedToOne), "::", stringify!(x))
+        unsafe { ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(PackedToOne), "::", stringify!(x)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).y) as usize - ptr as usize }, 4usize,
-        concat!("Offset of field: ", stringify!(PackedToOne), "::", stringify!(y))
+        unsafe { ::std::ptr::addr_of!((*ptr).y) as usize - ptr as usize },
+        4usize,
+        concat!("Offset of field: ", stringify!(PackedToOne), "::", stringify!(y)),
     );
 }
 /// This should be be packed because Rust 1.33 has `#[repr(packed(N))]`.
@@ -89,19 +99,23 @@ fn bindgen_test_layout_PackedToTwo() {
     const UNINIT: ::std::mem::MaybeUninit<PackedToTwo> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < PackedToTwo > (), 8usize, concat!("Size of: ",
-        stringify!(PackedToTwo))
+        ::std::mem::size_of::<PackedToTwo>(),
+        8usize,
+        concat!("Size of: ", stringify!(PackedToTwo)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < PackedToTwo > (), 2usize, concat!("Alignment of ",
-        stringify!(PackedToTwo))
+        ::std::mem::align_of::<PackedToTwo>(),
+        2usize,
+        concat!("Alignment of ", stringify!(PackedToTwo)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).x) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(PackedToTwo), "::", stringify!(x))
+        unsafe { ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(PackedToTwo), "::", stringify!(x)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).y) as usize - ptr as usize }, 4usize,
-        concat!("Offset of field: ", stringify!(PackedToTwo), "::", stringify!(y))
+        unsafe { ::std::ptr::addr_of!((*ptr).y) as usize - ptr as usize },
+        4usize,
+        concat!("Offset of field: ", stringify!(PackedToTwo), "::", stringify!(y)),
     );
 }

--- a/bindgen-tests/tests/expectations/tests/issue-537.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-537.rs
@@ -11,16 +11,19 @@ fn bindgen_test_layout_AlignedToOne() {
     const UNINIT: ::std::mem::MaybeUninit<AlignedToOne> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < AlignedToOne > (), 4usize, concat!("Size of: ",
-        stringify!(AlignedToOne))
+        ::std::mem::size_of::<AlignedToOne>(),
+        4usize,
+        concat!("Size of: ", stringify!(AlignedToOne)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < AlignedToOne > (), 1usize, concat!("Alignment of ",
-        stringify!(AlignedToOne))
+        ::std::mem::align_of::<AlignedToOne>(),
+        1usize,
+        concat!("Alignment of ", stringify!(AlignedToOne)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).i) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(AlignedToOne), "::", stringify!(i))
+        unsafe { ::std::ptr::addr_of!((*ptr).i) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(AlignedToOne), "::", stringify!(i)),
     );
 }
 /** This should be opaque because although we can see the attributes, Rust before
@@ -35,16 +38,19 @@ fn bindgen_test_layout_AlignedToTwo() {
     const UNINIT: ::std::mem::MaybeUninit<AlignedToTwo> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < AlignedToTwo > (), 4usize, concat!("Size of: ",
-        stringify!(AlignedToTwo))
+        ::std::mem::size_of::<AlignedToTwo>(),
+        4usize,
+        concat!("Size of: ", stringify!(AlignedToTwo)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < AlignedToTwo > (), 2usize, concat!("Alignment of ",
-        stringify!(AlignedToTwo))
+        ::std::mem::align_of::<AlignedToTwo>(),
+        2usize,
+        concat!("Alignment of ", stringify!(AlignedToTwo)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).i) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(AlignedToTwo), "::", stringify!(i))
+        unsafe { ::std::ptr::addr_of!((*ptr).i) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(AlignedToTwo), "::", stringify!(i)),
     );
 }
 /** This should not be opaque because although `libclang` doesn't give us the
@@ -61,20 +67,24 @@ fn bindgen_test_layout_PackedToOne() {
     const UNINIT: ::std::mem::MaybeUninit<PackedToOne> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < PackedToOne > (), 8usize, concat!("Size of: ",
-        stringify!(PackedToOne))
+        ::std::mem::size_of::<PackedToOne>(),
+        8usize,
+        concat!("Size of: ", stringify!(PackedToOne)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < PackedToOne > (), 1usize, concat!("Alignment of ",
-        stringify!(PackedToOne))
+        ::std::mem::align_of::<PackedToOne>(),
+        1usize,
+        concat!("Alignment of ", stringify!(PackedToOne)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).x) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(PackedToOne), "::", stringify!(x))
+        unsafe { ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(PackedToOne), "::", stringify!(x)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).y) as usize - ptr as usize }, 4usize,
-        concat!("Offset of field: ", stringify!(PackedToOne), "::", stringify!(y))
+        unsafe { ::std::ptr::addr_of!((*ptr).y) as usize - ptr as usize },
+        4usize,
+        concat!("Offset of field: ", stringify!(PackedToOne), "::", stringify!(y)),
     );
 }
 /** In this case, even if we can detect the weird alignment triggered by
@@ -91,19 +101,23 @@ fn bindgen_test_layout_PackedToTwo() {
     const UNINIT: ::std::mem::MaybeUninit<PackedToTwo> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < PackedToTwo > (), 8usize, concat!("Size of: ",
-        stringify!(PackedToTwo))
+        ::std::mem::size_of::<PackedToTwo>(),
+        8usize,
+        concat!("Size of: ", stringify!(PackedToTwo)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < PackedToTwo > (), 2usize, concat!("Alignment of ",
-        stringify!(PackedToTwo))
+        ::std::mem::align_of::<PackedToTwo>(),
+        2usize,
+        concat!("Alignment of ", stringify!(PackedToTwo)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).x) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(PackedToTwo), "::", stringify!(x))
+        unsafe { ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(PackedToTwo), "::", stringify!(x)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).y) as usize - ptr as usize }, 4usize,
-        concat!("Offset of field: ", stringify!(PackedToTwo), "::", stringify!(y))
+        unsafe { ::std::ptr::addr_of!((*ptr).y) as usize - ptr as usize },
+        4usize,
+        concat!("Offset of field: ", stringify!(PackedToTwo), "::", stringify!(y)),
     );
 }

--- a/bindgen-tests/tests/expectations/tests/issue-569-non-type-template-params-causing-layout-test-failures.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-569-non-type-template-params-causing-layout-test-failures.rs
@@ -30,12 +30,14 @@ pub struct JS_AutoIdVector {
 #[test]
 fn bindgen_test_layout_JS_AutoIdVector() {
     assert_eq!(
-        ::std::mem::size_of:: < JS_AutoIdVector > (), 1usize, concat!("Size of: ",
-        stringify!(JS_AutoIdVector))
+        ::std::mem::size_of::<JS_AutoIdVector>(),
+        1usize,
+        concat!("Size of: ", stringify!(JS_AutoIdVector)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < JS_AutoIdVector > (), 1usize, concat!("Alignment of ",
-        stringify!(JS_AutoIdVector))
+        ::std::mem::align_of::<JS_AutoIdVector>(),
+        1usize,
+        concat!("Alignment of ", stringify!(JS_AutoIdVector)),
     );
 }
 impl Default for JS_AutoIdVector {
@@ -50,11 +52,13 @@ impl Default for JS_AutoIdVector {
 #[test]
 fn __bindgen_test_layout_JS_Base_open0_int_close0_instantiation() {
     assert_eq!(
-        ::std::mem::size_of:: < JS_Base > (), 1usize,
-        concat!("Size of template specialization: ", stringify!(JS_Base))
+        ::std::mem::size_of::<JS_Base>(),
+        1usize,
+        concat!("Size of template specialization: ", stringify!(JS_Base)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < JS_Base > (), 1usize,
-        concat!("Alignment of template specialization: ", stringify!(JS_Base))
+        ::std::mem::align_of::<JS_Base>(),
+        1usize,
+        concat!("Alignment of template specialization: ", stringify!(JS_Base)),
     );
 }

--- a/bindgen-tests/tests/expectations/tests/issue-573-layout-test-failures.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-573-layout-test-failures.rs
@@ -14,26 +14,31 @@ fn bindgen_test_layout_AutoIdVector() {
     const UNINIT: ::std::mem::MaybeUninit<AutoIdVector> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < AutoIdVector > (), 1usize, concat!("Size of: ",
-        stringify!(AutoIdVector))
+        ::std::mem::size_of::<AutoIdVector>(),
+        1usize,
+        concat!("Size of: ", stringify!(AutoIdVector)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < AutoIdVector > (), 1usize, concat!("Alignment of ",
-        stringify!(AutoIdVector))
+        ::std::mem::align_of::<AutoIdVector>(),
+        1usize,
+        concat!("Alignment of ", stringify!(AutoIdVector)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).ar) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(AutoIdVector), "::", stringify!(ar))
+        unsafe { ::std::ptr::addr_of!((*ptr).ar) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(AutoIdVector), "::", stringify!(ar)),
     );
 }
 #[test]
 fn __bindgen_test_layout_Outer_open0_int_close0_instantiation() {
     assert_eq!(
-        ::std::mem::size_of:: < Outer > (), 1usize,
-        concat!("Size of template specialization: ", stringify!(Outer))
+        ::std::mem::size_of::<Outer>(),
+        1usize,
+        concat!("Size of template specialization: ", stringify!(Outer)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Outer > (), 1usize,
-        concat!("Alignment of template specialization: ", stringify!(Outer))
+        ::std::mem::align_of::<Outer>(),
+        1usize,
+        concat!("Alignment of template specialization: ", stringify!(Outer)),
     );
 }

--- a/bindgen-tests/tests/expectations/tests/issue-574-assertion-failure-in-codegen.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-574-assertion-failure-in-codegen.rs
@@ -14,16 +14,19 @@ fn bindgen_test_layout__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<_bindgen_ty_1> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < _bindgen_ty_1 > (), 1usize, concat!("Size of: ",
-        stringify!(_bindgen_ty_1))
+        ::std::mem::size_of::<_bindgen_ty_1>(),
+        1usize,
+        concat!("Size of: ", stringify!(_bindgen_ty_1)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < _bindgen_ty_1 > (), 1usize, concat!("Alignment of ",
-        stringify!(_bindgen_ty_1))
+        ::std::mem::align_of::<_bindgen_ty_1>(),
+        1usize,
+        concat!("Alignment of ", stringify!(_bindgen_ty_1)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).ar) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(_bindgen_ty_1), "::", stringify!(ar))
+        unsafe { ::std::ptr::addr_of!((*ptr).ar) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(_bindgen_ty_1), "::", stringify!(ar)),
     );
 }
 extern "C" {
@@ -32,11 +35,13 @@ extern "C" {
 #[test]
 fn __bindgen_test_layout_a_open0_int_close0_instantiation() {
     assert_eq!(
-        ::std::mem::size_of:: < a > (), 1usize,
-        concat!("Size of template specialization: ", stringify!(a))
+        ::std::mem::size_of::<a>(),
+        1usize,
+        concat!("Size of template specialization: ", stringify!(a)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < a > (), 1usize,
-        concat!("Alignment of template specialization: ", stringify!(a))
+        ::std::mem::align_of::<a>(),
+        1usize,
+        concat!("Alignment of template specialization: ", stringify!(a)),
     );
 }

--- a/bindgen-tests/tests/expectations/tests/issue-584-stylo-template-analysis-panic.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-584-stylo-template-analysis-panic.rs
@@ -8,11 +8,11 @@ pub struct A {
 pub type A_a = b;
 #[test]
 fn bindgen_test_layout_A() {
+    assert_eq!(::std::mem::size_of::<A>(), 1usize, concat!("Size of: ", stringify!(A)));
     assert_eq!(
-        ::std::mem::size_of:: < A > (), 1usize, concat!("Size of: ", stringify!(A))
-    );
-    assert_eq!(
-        ::std::mem::align_of:: < A > (), 1usize, concat!("Alignment of ", stringify!(A))
+        ::std::mem::align_of::<A>(),
+        1usize,
+        concat!("Alignment of ", stringify!(A)),
     );
 }
 #[repr(C)]
@@ -42,15 +42,16 @@ pub struct g {
 fn bindgen_test_layout_g() {
     const UNINIT: ::std::mem::MaybeUninit<g> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
+    assert_eq!(::std::mem::size_of::<g>(), 1usize, concat!("Size of: ", stringify!(g)));
     assert_eq!(
-        ::std::mem::size_of:: < g > (), 1usize, concat!("Size of: ", stringify!(g))
+        ::std::mem::align_of::<g>(),
+        1usize,
+        concat!("Alignment of ", stringify!(g)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < g > (), 1usize, concat!("Alignment of ", stringify!(g))
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).h) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(g), "::", stringify!(h))
+        unsafe { ::std::ptr::addr_of!((*ptr).h) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(g), "::", stringify!(h)),
     );
 }
 impl Default for g {
@@ -68,11 +69,11 @@ pub struct b {
 }
 #[test]
 fn bindgen_test_layout_b() {
+    assert_eq!(::std::mem::size_of::<b>(), 1usize, concat!("Size of: ", stringify!(b)));
     assert_eq!(
-        ::std::mem::size_of:: < b > (), 1usize, concat!("Size of: ", stringify!(b))
-    );
-    assert_eq!(
-        ::std::mem::align_of:: < b > (), 1usize, concat!("Alignment of ", stringify!(b))
+        ::std::mem::align_of::<b>(),
+        1usize,
+        concat!("Alignment of ", stringify!(b)),
     );
 }
 impl Default for b {
@@ -91,11 +92,13 @@ extern "C" {
 #[test]
 fn __bindgen_test_layout_f_open0_e_open1_int_close1_close0_instantiation() {
     assert_eq!(
-        ::std::mem::size_of:: < f > (), 1usize,
-        concat!("Size of template specialization: ", stringify!(f))
+        ::std::mem::size_of::<f>(),
+        1usize,
+        concat!("Size of template specialization: ", stringify!(f)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < f > (), 1usize,
-        concat!("Alignment of template specialization: ", stringify!(f))
+        ::std::mem::align_of::<f>(),
+        1usize,
+        concat!("Alignment of template specialization: ", stringify!(f)),
     );
 }

--- a/bindgen-tests/tests/expectations/tests/issue-639-typedef-anon-field.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-639-typedef-anon-field.rs
@@ -14,16 +14,19 @@ fn bindgen_test_layout_Foo_Bar() {
     const UNINIT: ::std::mem::MaybeUninit<Foo_Bar> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < Foo_Bar > (), 4usize, concat!("Size of: ",
-        stringify!(Foo_Bar))
+        ::std::mem::size_of::<Foo_Bar>(),
+        4usize,
+        concat!("Size of: ", stringify!(Foo_Bar)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Foo_Bar > (), 4usize, concat!("Alignment of ",
-        stringify!(Foo_Bar))
+        ::std::mem::align_of::<Foo_Bar>(),
+        4usize,
+        concat!("Alignment of ", stringify!(Foo_Bar)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).abc) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(Foo_Bar), "::", stringify!(abc))
+        unsafe { ::std::ptr::addr_of!((*ptr).abc) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(Foo_Bar), "::", stringify!(abc)),
     );
 }
 #[test]
@@ -31,15 +34,19 @@ fn bindgen_test_layout_Foo() {
     const UNINIT: ::std::mem::MaybeUninit<Foo> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < Foo > (), 4usize, concat!("Size of: ", stringify!(Foo))
+        ::std::mem::size_of::<Foo>(),
+        4usize,
+        concat!("Size of: ", stringify!(Foo)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Foo > (), 4usize, concat!("Alignment of ",
-        stringify!(Foo))
+        ::std::mem::align_of::<Foo>(),
+        4usize,
+        concat!("Alignment of ", stringify!(Foo)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).bar) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(Foo), "::", stringify!(bar))
+        unsafe { ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(Foo), "::", stringify!(bar)),
     );
 }
 #[repr(C)]
@@ -57,25 +64,31 @@ fn bindgen_test_layout_Baz_Bar() {
     const UNINIT: ::std::mem::MaybeUninit<Baz_Bar> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < Baz_Bar > (), 4usize, concat!("Size of: ",
-        stringify!(Baz_Bar))
+        ::std::mem::size_of::<Baz_Bar>(),
+        4usize,
+        concat!("Size of: ", stringify!(Baz_Bar)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Baz_Bar > (), 4usize, concat!("Alignment of ",
-        stringify!(Baz_Bar))
+        ::std::mem::align_of::<Baz_Bar>(),
+        4usize,
+        concat!("Alignment of ", stringify!(Baz_Bar)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).abc) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(Baz_Bar), "::", stringify!(abc))
+        unsafe { ::std::ptr::addr_of!((*ptr).abc) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(Baz_Bar), "::", stringify!(abc)),
     );
 }
 #[test]
 fn bindgen_test_layout_Baz() {
     assert_eq!(
-        ::std::mem::size_of:: < Baz > (), 1usize, concat!("Size of: ", stringify!(Baz))
+        ::std::mem::size_of::<Baz>(),
+        1usize,
+        concat!("Size of: ", stringify!(Baz)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Baz > (), 1usize, concat!("Alignment of ",
-        stringify!(Baz))
+        ::std::mem::align_of::<Baz>(),
+        1usize,
+        concat!("Alignment of ", stringify!(Baz)),
     );
 }

--- a/bindgen-tests/tests/expectations/tests/issue-643-inner-struct.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-643-inner-struct.rs
@@ -47,17 +47,24 @@ fn bindgen_test_layout_rte_ring_prod() {
     const UNINIT: ::std::mem::MaybeUninit<rte_ring_prod> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < rte_ring_prod > (), 4usize, concat!("Size of: ",
-        stringify!(rte_ring_prod))
+        ::std::mem::size_of::<rte_ring_prod>(),
+        4usize,
+        concat!("Size of: ", stringify!(rte_ring_prod)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < rte_ring_prod > (), 4usize, concat!("Alignment of ",
-        stringify!(rte_ring_prod))
+        ::std::mem::align_of::<rte_ring_prod>(),
+        4usize,
+        concat!("Alignment of ", stringify!(rte_ring_prod)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).watermark) as usize - ptr as usize },
-        0usize, concat!("Offset of field: ", stringify!(rte_ring_prod), "::",
-        stringify!(watermark))
+        unsafe { ::std::ptr::addr_of!((*ptr).watermark) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_ring_prod),
+            "::",
+            stringify!(watermark),
+        ),
     );
 }
 #[repr(C)]
@@ -70,28 +77,37 @@ fn bindgen_test_layout_rte_ring_cons() {
     const UNINIT: ::std::mem::MaybeUninit<rte_ring_cons> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < rte_ring_cons > (), 4usize, concat!("Size of: ",
-        stringify!(rte_ring_cons))
+        ::std::mem::size_of::<rte_ring_cons>(),
+        4usize,
+        concat!("Size of: ", stringify!(rte_ring_cons)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < rte_ring_cons > (), 4usize, concat!("Alignment of ",
-        stringify!(rte_ring_cons))
+        ::std::mem::align_of::<rte_ring_cons>(),
+        4usize,
+        concat!("Alignment of ", stringify!(rte_ring_cons)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).sc_dequeue) as usize - ptr as usize },
-        0usize, concat!("Offset of field: ", stringify!(rte_ring_cons), "::",
-        stringify!(sc_dequeue))
+        unsafe { ::std::ptr::addr_of!((*ptr).sc_dequeue) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_ring_cons),
+            "::",
+            stringify!(sc_dequeue),
+        ),
     );
 }
 #[test]
 fn bindgen_test_layout_rte_ring() {
     assert_eq!(
-        ::std::mem::size_of:: < rte_ring > (), 16usize, concat!("Size of: ",
-        stringify!(rte_ring))
+        ::std::mem::size_of::<rte_ring>(),
+        16usize,
+        concat!("Size of: ", stringify!(rte_ring)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < rte_ring > (), 8usize, concat!("Alignment of ",
-        stringify!(rte_ring))
+        ::std::mem::align_of::<rte_ring>(),
+        8usize,
+        concat!("Alignment of ", stringify!(rte_ring)),
     );
 }
 impl Default for rte_ring {

--- a/bindgen-tests/tests/expectations/tests/issue-648-derive-debug-with-padding.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-648-derive-debug-with-padding.rs
@@ -12,16 +12,19 @@ fn bindgen_test_layout_NoDebug() {
     const UNINIT: ::std::mem::MaybeUninit<NoDebug> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < NoDebug > (), 64usize, concat!("Size of: ",
-        stringify!(NoDebug))
+        ::std::mem::size_of::<NoDebug>(),
+        64usize,
+        concat!("Size of: ", stringify!(NoDebug)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < NoDebug > (), 64usize, concat!("Alignment of ",
-        stringify!(NoDebug))
+        ::std::mem::align_of::<NoDebug>(),
+        64usize,
+        concat!("Alignment of ", stringify!(NoDebug)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).c) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(NoDebug), "::", stringify!(c))
+        unsafe { ::std::ptr::addr_of!((*ptr).c) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(NoDebug), "::", stringify!(c)),
     );
 }
 impl Default for NoDebug {
@@ -54,22 +57,34 @@ fn bindgen_test_layout_ShouldDeriveDebugButDoesNot() {
     const UNINIT: ::std::mem::MaybeUninit<ShouldDeriveDebugButDoesNot> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < ShouldDeriveDebugButDoesNot > (), 64usize,
-        concat!("Size of: ", stringify!(ShouldDeriveDebugButDoesNot))
+        ::std::mem::size_of::<ShouldDeriveDebugButDoesNot>(),
+        64usize,
+        concat!("Size of: ", stringify!(ShouldDeriveDebugButDoesNot)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < ShouldDeriveDebugButDoesNot > (), 64usize,
-        concat!("Alignment of ", stringify!(ShouldDeriveDebugButDoesNot))
+        ::std::mem::align_of::<ShouldDeriveDebugButDoesNot>(),
+        64usize,
+        concat!("Alignment of ", stringify!(ShouldDeriveDebugButDoesNot)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).c) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(ShouldDeriveDebugButDoesNot), "::",
-        stringify!(c))
+        unsafe { ::std::ptr::addr_of!((*ptr).c) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ShouldDeriveDebugButDoesNot),
+            "::",
+            stringify!(c),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).d) as usize - ptr as usize }, 32usize,
-        concat!("Offset of field: ", stringify!(ShouldDeriveDebugButDoesNot), "::",
-        stringify!(d))
+        unsafe { ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize },
+        32usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ShouldDeriveDebugButDoesNot),
+            "::",
+            stringify!(d),
+        ),
     );
 }
 impl Default for ShouldDeriveDebugButDoesNot {

--- a/bindgen-tests/tests/expectations/tests/issue-674-1.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-674-1.rs
@@ -23,17 +23,24 @@ pub mod root {
         const UNINIT: ::std::mem::MaybeUninit<CapturingContentInfo> = ::std::mem::MaybeUninit::uninit();
         let ptr = UNINIT.as_ptr();
         assert_eq!(
-            ::std::mem::size_of:: < CapturingContentInfo > (), 1usize,
-            concat!("Size of: ", stringify!(CapturingContentInfo))
+            ::std::mem::size_of::<CapturingContentInfo>(),
+            1usize,
+            concat!("Size of: ", stringify!(CapturingContentInfo)),
         );
         assert_eq!(
-            ::std::mem::align_of:: < CapturingContentInfo > (), 1usize,
-            concat!("Alignment of ", stringify!(CapturingContentInfo))
+            ::std::mem::align_of::<CapturingContentInfo>(),
+            1usize,
+            concat!("Alignment of ", stringify!(CapturingContentInfo)),
         );
         assert_eq!(
-            unsafe { ::std::ptr::addr_of!((* ptr).a) as usize - ptr as usize }, 0usize,
-            concat!("Offset of field: ", stringify!(CapturingContentInfo), "::",
-            stringify!(a))
+            unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(CapturingContentInfo),
+                "::",
+                stringify!(a),
+            ),
         );
     }
 }

--- a/bindgen-tests/tests/expectations/tests/issue-674-2.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-674-2.rs
@@ -23,15 +23,19 @@ pub mod root {
         const UNINIT: ::std::mem::MaybeUninit<c> = ::std::mem::MaybeUninit::uninit();
         let ptr = UNINIT.as_ptr();
         assert_eq!(
-            ::std::mem::size_of:: < c > (), 1usize, concat!("Size of: ", stringify!(c))
+            ::std::mem::size_of::<c>(),
+            1usize,
+            concat!("Size of: ", stringify!(c)),
         );
         assert_eq!(
-            ::std::mem::align_of:: < c > (), 1usize, concat!("Alignment of ",
-            stringify!(c))
+            ::std::mem::align_of::<c>(),
+            1usize,
+            concat!("Alignment of ", stringify!(c)),
         );
         assert_eq!(
-            unsafe { ::std::ptr::addr_of!((* ptr).b) as usize - ptr as usize }, 0usize,
-            concat!("Offset of field: ", stringify!(c), "::", stringify!(b))
+            unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
+            0usize,
+            concat!("Offset of field: ", stringify!(c), "::", stringify!(b)),
         );
     }
     #[repr(C)]
@@ -44,15 +48,19 @@ pub mod root {
         const UNINIT: ::std::mem::MaybeUninit<B> = ::std::mem::MaybeUninit::uninit();
         let ptr = UNINIT.as_ptr();
         assert_eq!(
-            ::std::mem::size_of:: < B > (), 1usize, concat!("Size of: ", stringify!(B))
+            ::std::mem::size_of::<B>(),
+            1usize,
+            concat!("Size of: ", stringify!(B)),
         );
         assert_eq!(
-            ::std::mem::align_of:: < B > (), 1usize, concat!("Alignment of ",
-            stringify!(B))
+            ::std::mem::align_of::<B>(),
+            1usize,
+            concat!("Alignment of ", stringify!(B)),
         );
         assert_eq!(
-            unsafe { ::std::ptr::addr_of!((* ptr).a) as usize - ptr as usize }, 0usize,
-            concat!("Offset of field: ", stringify!(B), "::", stringify!(a))
+            unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
+            0usize,
+            concat!("Offset of field: ", stringify!(B), "::", stringify!(a)),
         );
     }
     #[repr(C)]
@@ -63,13 +71,17 @@ pub mod root {
     #[test]
     fn __bindgen_test_layout_StaticRefPtr_open0_B_close0_instantiation() {
         assert_eq!(
-            ::std::mem::size_of:: < root::StaticRefPtr > (), 1usize,
-            concat!("Size of template specialization: ", stringify!(root::StaticRefPtr))
+            ::std::mem::size_of::<root::StaticRefPtr>(),
+            1usize,
+            concat!("Size of template specialization: ", stringify!(root::StaticRefPtr)),
         );
         assert_eq!(
-            ::std::mem::align_of:: < root::StaticRefPtr > (), 1usize,
-            concat!("Alignment of template specialization: ",
-            stringify!(root::StaticRefPtr))
+            ::std::mem::align_of::<root::StaticRefPtr>(),
+            1usize,
+            concat!(
+                "Alignment of template specialization: ",
+                stringify!(root::StaticRefPtr),
+            ),
         );
     }
 }

--- a/bindgen-tests/tests/expectations/tests/issue-674-3.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-674-3.rs
@@ -19,15 +19,19 @@ pub mod root {
         const UNINIT: ::std::mem::MaybeUninit<a> = ::std::mem::MaybeUninit::uninit();
         let ptr = UNINIT.as_ptr();
         assert_eq!(
-            ::std::mem::size_of:: < a > (), 1usize, concat!("Size of: ", stringify!(a))
+            ::std::mem::size_of::<a>(),
+            1usize,
+            concat!("Size of: ", stringify!(a)),
         );
         assert_eq!(
-            ::std::mem::align_of:: < a > (), 1usize, concat!("Alignment of ",
-            stringify!(a))
+            ::std::mem::align_of::<a>(),
+            1usize,
+            concat!("Alignment of ", stringify!(a)),
         );
         assert_eq!(
-            unsafe { ::std::ptr::addr_of!((* ptr).b) as usize - ptr as usize }, 0usize,
-            concat!("Offset of field: ", stringify!(a), "::", stringify!(b))
+            unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
+            0usize,
+            concat!("Offset of field: ", stringify!(a), "::", stringify!(b)),
         );
     }
     #[repr(C)]
@@ -40,16 +44,19 @@ pub mod root {
         const UNINIT: ::std::mem::MaybeUninit<nsCSSValue> = ::std::mem::MaybeUninit::uninit();
         let ptr = UNINIT.as_ptr();
         assert_eq!(
-            ::std::mem::size_of:: < nsCSSValue > (), 1usize, concat!("Size of: ",
-            stringify!(nsCSSValue))
+            ::std::mem::size_of::<nsCSSValue>(),
+            1usize,
+            concat!("Size of: ", stringify!(nsCSSValue)),
         );
         assert_eq!(
-            ::std::mem::align_of:: < nsCSSValue > (), 1usize, concat!("Alignment of ",
-            stringify!(nsCSSValue))
+            ::std::mem::align_of::<nsCSSValue>(),
+            1usize,
+            concat!("Alignment of ", stringify!(nsCSSValue)),
         );
         assert_eq!(
-            unsafe { ::std::ptr::addr_of!((* ptr).c) as usize - ptr as usize }, 0usize,
-            concat!("Offset of field: ", stringify!(nsCSSValue), "::", stringify!(c))
+            unsafe { ::std::ptr::addr_of!((*ptr).c) as usize - ptr as usize },
+            0usize,
+            concat!("Offset of field: ", stringify!(nsCSSValue), "::", stringify!(c)),
         );
     }
 }

--- a/bindgen-tests/tests/expectations/tests/issue-691-template-parameter-virtual.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-691-template-parameter-virtual.rs
@@ -9,12 +9,14 @@ pub struct VirtualMethods {
 #[test]
 fn bindgen_test_layout_VirtualMethods() {
     assert_eq!(
-        ::std::mem::size_of:: < VirtualMethods > (), 8usize, concat!("Size of: ",
-        stringify!(VirtualMethods))
+        ::std::mem::size_of::<VirtualMethods>(),
+        8usize,
+        concat!("Size of: ", stringify!(VirtualMethods)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < VirtualMethods > (), 8usize, concat!("Alignment of ",
-        stringify!(VirtualMethods))
+        ::std::mem::align_of::<VirtualMethods>(),
+        8usize,
+        concat!("Alignment of ", stringify!(VirtualMethods)),
     );
 }
 impl Default for VirtualMethods {
@@ -39,12 +41,14 @@ pub struct ServoElementSnapshotTable {
 #[test]
 fn bindgen_test_layout_ServoElementSnapshotTable() {
     assert_eq!(
-        ::std::mem::size_of:: < ServoElementSnapshotTable > (), 4usize,
-        concat!("Size of: ", stringify!(ServoElementSnapshotTable))
+        ::std::mem::size_of::<ServoElementSnapshotTable>(),
+        4usize,
+        concat!("Size of: ", stringify!(ServoElementSnapshotTable)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < ServoElementSnapshotTable > (), 4usize,
-        concat!("Alignment of ", stringify!(ServoElementSnapshotTable))
+        ::std::mem::align_of::<ServoElementSnapshotTable>(),
+        4usize,
+        concat!("Alignment of ", stringify!(ServoElementSnapshotTable)),
     );
 }
 impl Default for ServoElementSnapshotTable {
@@ -59,11 +63,13 @@ impl Default for ServoElementSnapshotTable {
 #[test]
 fn __bindgen_test_layout_Set_open0_VirtualMethods_close0_instantiation() {
     assert_eq!(
-        ::std::mem::size_of:: < Set > (), 4usize,
-        concat!("Size of template specialization: ", stringify!(Set))
+        ::std::mem::size_of::<Set>(),
+        4usize,
+        concat!("Size of template specialization: ", stringify!(Set)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Set > (), 4usize,
-        concat!("Alignment of template specialization: ", stringify!(Set))
+        ::std::mem::align_of::<Set>(),
+        4usize,
+        concat!("Alignment of template specialization: ", stringify!(Set)),
     );
 }

--- a/bindgen-tests/tests/expectations/tests/issue-739-pointer-wide-bitfield.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-739-pointer-wide-bitfield.rs
@@ -50,7 +50,7 @@ where
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < self.storage.as_ref().len());
         debug_assert!(
-            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len()
+            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len(),
         );
         let mut val = 0;
         for i in 0..(bit_width as usize) {
@@ -70,7 +70,7 @@ where
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < self.storage.as_ref().len());
         debug_assert!(
-            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len()
+            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len(),
         );
         for i in 0..(bit_width as usize) {
             let mask = 1 << i;
@@ -94,11 +94,14 @@ pub struct Foo {
 #[test]
 fn bindgen_test_layout_Foo() {
     assert_eq!(
-        ::std::mem::size_of:: < Foo > (), 32usize, concat!("Size of: ", stringify!(Foo))
+        ::std::mem::size_of::<Foo>(),
+        32usize,
+        concat!("Size of: ", stringify!(Foo)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Foo > (), 8usize, concat!("Alignment of ",
-        stringify!(Foo))
+        ::std::mem::align_of::<Foo>(),
+        8usize,
+        concat!("Alignment of ", stringify!(Foo)),
     );
 }
 impl Foo {

--- a/bindgen-tests/tests/expectations/tests/issue-801-opaque-sloppiness.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-801-opaque-sloppiness.rs
@@ -12,11 +12,11 @@ pub struct B {
 }
 #[test]
 fn bindgen_test_layout_B() {
+    assert_eq!(::std::mem::size_of::<B>(), 1usize, concat!("Size of: ", stringify!(B)));
     assert_eq!(
-        ::std::mem::size_of:: < B > (), 1usize, concat!("Size of: ", stringify!(B))
-    );
-    assert_eq!(
-        ::std::mem::align_of:: < B > (), 1usize, concat!("Alignment of ", stringify!(B))
+        ::std::mem::align_of::<B>(),
+        1usize,
+        concat!("Alignment of ", stringify!(B)),
     );
 }
 extern "C" {
@@ -32,14 +32,15 @@ pub struct C {
 fn bindgen_test_layout_C() {
     const UNINIT: ::std::mem::MaybeUninit<C> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
+    assert_eq!(::std::mem::size_of::<C>(), 1usize, concat!("Size of: ", stringify!(C)));
     assert_eq!(
-        ::std::mem::size_of:: < C > (), 1usize, concat!("Size of: ", stringify!(C))
+        ::std::mem::align_of::<C>(),
+        1usize,
+        concat!("Alignment of ", stringify!(C)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < C > (), 1usize, concat!("Alignment of ", stringify!(C))
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).b) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(C), "::", stringify!(b))
+        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(C), "::", stringify!(b)),
     );
 }

--- a/bindgen-tests/tests/expectations/tests/issue-807-opaque-types-methods-being-generated.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-807-opaque-types-methods-being-generated.rs
@@ -7,12 +7,14 @@ pub struct Pupper {
 #[test]
 fn bindgen_test_layout_Pupper() {
     assert_eq!(
-        ::std::mem::size_of:: < Pupper > (), 1usize, concat!("Size of: ",
-        stringify!(Pupper))
+        ::std::mem::size_of::<Pupper>(),
+        1usize,
+        concat!("Size of: ", stringify!(Pupper)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Pupper > (), 1usize, concat!("Alignment of ",
-        stringify!(Pupper))
+        ::std::mem::align_of::<Pupper>(),
+        1usize,
+        concat!("Alignment of ", stringify!(Pupper)),
     );
 }
 #[repr(C)]
@@ -23,12 +25,14 @@ pub struct Doggo {
 #[test]
 fn bindgen_test_layout_Doggo() {
     assert_eq!(
-        ::std::mem::size_of:: < Doggo > (), 1usize, concat!("Size of: ",
-        stringify!(Doggo))
+        ::std::mem::size_of::<Doggo>(),
+        1usize,
+        concat!("Size of: ", stringify!(Doggo)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Doggo > (), 1usize, concat!("Alignment of ",
-        stringify!(Doggo))
+        ::std::mem::align_of::<Doggo>(),
+        1usize,
+        concat!("Alignment of ", stringify!(Doggo)),
     );
 }
 #[repr(C)]
@@ -39,12 +43,14 @@ pub struct SuchWow {
 #[test]
 fn bindgen_test_layout_SuchWow() {
     assert_eq!(
-        ::std::mem::size_of:: < SuchWow > (), 1usize, concat!("Size of: ",
-        stringify!(SuchWow))
+        ::std::mem::size_of::<SuchWow>(),
+        1usize,
+        concat!("Size of: ", stringify!(SuchWow)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < SuchWow > (), 1usize, concat!("Alignment of ",
-        stringify!(SuchWow))
+        ::std::mem::align_of::<SuchWow>(),
+        1usize,
+        concat!("Alignment of ", stringify!(SuchWow)),
     );
 }
 #[repr(C)]
@@ -56,12 +62,14 @@ pub struct Opaque {
 #[test]
 fn bindgen_test_layout_Opaque() {
     assert_eq!(
-        ::std::mem::size_of:: < Opaque > (), 1usize, concat!("Size of: ",
-        stringify!(Opaque))
+        ::std::mem::size_of::<Opaque>(),
+        1usize,
+        concat!("Size of: ", stringify!(Opaque)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Opaque > (), 1usize, concat!("Alignment of ",
-        stringify!(Opaque))
+        ::std::mem::align_of::<Opaque>(),
+        1usize,
+        concat!("Alignment of ", stringify!(Opaque)),
     );
 }
 extern "C" {
@@ -98,16 +106,23 @@ fn bindgen_test_layout_Allowlisted() {
     const UNINIT: ::std::mem::MaybeUninit<Allowlisted> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < Allowlisted > (), 1usize, concat!("Size of: ",
-        stringify!(Allowlisted))
+        ::std::mem::size_of::<Allowlisted>(),
+        1usize,
+        concat!("Size of: ", stringify!(Allowlisted)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Allowlisted > (), 1usize, concat!("Alignment of ",
-        stringify!(Allowlisted))
+        ::std::mem::align_of::<Allowlisted>(),
+        1usize,
+        concat!("Alignment of ", stringify!(Allowlisted)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).some_member) as usize - ptr as usize },
-        0usize, concat!("Offset of field: ", stringify!(Allowlisted), "::",
-        stringify!(some_member))
+        unsafe { ::std::ptr::addr_of!((*ptr).some_member) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(Allowlisted),
+            "::",
+            stringify!(some_member),
+        ),
     );
 }

--- a/bindgen-tests/tests/expectations/tests/issue-816.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-816.rs
@@ -49,7 +49,7 @@ where
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < self.storage.as_ref().len());
         debug_assert!(
-            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len()
+            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len(),
         );
         let mut val = 0;
         for i in 0..(bit_width as usize) {
@@ -69,7 +69,7 @@ where
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < self.storage.as_ref().len());
         debug_assert!(
-            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len()
+            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len(),
         );
         for i in 0..(bit_width as usize) {
             let mask = 1 << i;
@@ -93,12 +93,14 @@ pub struct capabilities {
 #[test]
 fn bindgen_test_layout_capabilities() {
     assert_eq!(
-        ::std::mem::size_of:: < capabilities > (), 16usize, concat!("Size of: ",
-        stringify!(capabilities))
+        ::std::mem::size_of::<capabilities>(),
+        16usize,
+        concat!("Size of: ", stringify!(capabilities)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < capabilities > (), 4usize, concat!("Alignment of ",
-        stringify!(capabilities))
+        ::std::mem::align_of::<capabilities>(),
+        4usize,
+        concat!("Alignment of ", stringify!(capabilities)),
     );
 }
 impl capabilities {

--- a/bindgen-tests/tests/expectations/tests/issue-826-generating-methods-when-asked-not-to.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-826-generating-methods-when-asked-not-to.rs
@@ -7,10 +7,13 @@ pub struct Foo {
 #[test]
 fn bindgen_test_layout_Foo() {
     assert_eq!(
-        ::std::mem::size_of:: < Foo > (), 1usize, concat!("Size of: ", stringify!(Foo))
+        ::std::mem::size_of::<Foo>(),
+        1usize,
+        concat!("Size of: ", stringify!(Foo)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Foo > (), 1usize, concat!("Alignment of ",
-        stringify!(Foo))
+        ::std::mem::align_of::<Foo>(),
+        1usize,
+        concat!("Alignment of ", stringify!(Foo)),
     );
 }

--- a/bindgen-tests/tests/expectations/tests/issue-834.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-834.rs
@@ -6,10 +6,10 @@ pub struct U {
 }
 #[test]
 fn bindgen_test_layout_U() {
+    assert_eq!(::std::mem::size_of::<U>(), 1usize, concat!("Size of: ", stringify!(U)));
     assert_eq!(
-        ::std::mem::size_of:: < U > (), 1usize, concat!("Size of: ", stringify!(U))
-    );
-    assert_eq!(
-        ::std::mem::align_of:: < U > (), 1usize, concat!("Alignment of ", stringify!(U))
+        ::std::mem::align_of::<U>(),
+        1usize,
+        concat!("Alignment of ", stringify!(U)),
     );
 }

--- a/bindgen-tests/tests/expectations/tests/issue-888-enum-var-decl-jump.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-888-enum-var-decl-jump.rs
@@ -18,12 +18,14 @@ pub mod root {
         #[test]
         fn bindgen_test_layout_Type() {
             assert_eq!(
-                ::std::mem::size_of:: < Type > (), 1usize, concat!("Size of: ",
-                stringify!(Type))
+                ::std::mem::size_of::<Type>(),
+                1usize,
+                concat!("Size of: ", stringify!(Type)),
             );
             assert_eq!(
-                ::std::mem::align_of:: < Type > (), 1usize, concat!("Alignment of ",
-                stringify!(Type))
+                ::std::mem::align_of::<Type>(),
+                1usize,
+                concat!("Alignment of ", stringify!(Type)),
             );
         }
     }

--- a/bindgen-tests/tests/expectations/tests/issue-944-derive-copy-and-blocklisting.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-944-derive-copy-and-blocklisting.rs
@@ -10,16 +10,19 @@ fn bindgen_test_layout_ShouldNotBeCopy() {
     const UNINIT: ::std::mem::MaybeUninit<ShouldNotBeCopy> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < ShouldNotBeCopy > (), 1usize, concat!("Size of: ",
-        stringify!(ShouldNotBeCopy))
+        ::std::mem::size_of::<ShouldNotBeCopy>(),
+        1usize,
+        concat!("Size of: ", stringify!(ShouldNotBeCopy)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < ShouldNotBeCopy > (), 1usize, concat!("Alignment of ",
-        stringify!(ShouldNotBeCopy))
+        ::std::mem::align_of::<ShouldNotBeCopy>(),
+        1usize,
+        concat!("Alignment of ", stringify!(ShouldNotBeCopy)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).a) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(ShouldNotBeCopy), "::", stringify!(a))
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(ShouldNotBeCopy), "::", stringify!(a)),
     );
 }
 impl Default for ShouldNotBeCopy {

--- a/bindgen-tests/tests/expectations/tests/issue-946.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-946.rs
@@ -5,11 +5,14 @@ pub struct foo {}
 #[test]
 fn bindgen_test_layout_foo() {
     assert_eq!(
-        ::std::mem::size_of:: < foo > (), 0usize, concat!("Size of: ", stringify!(foo))
+        ::std::mem::size_of::<foo>(),
+        0usize,
+        concat!("Size of: ", stringify!(foo)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < foo > (), 1usize, concat!("Alignment of ",
-        stringify!(foo))
+        ::std::mem::align_of::<foo>(),
+        1usize,
+        concat!("Alignment of ", stringify!(foo)),
     );
 }
 pub type bar = foo;

--- a/bindgen-tests/tests/expectations/tests/issue_311.rs
+++ b/bindgen-tests/tests/expectations/tests/issue_311.rs
@@ -16,23 +16,27 @@ pub mod root {
     #[test]
     fn bindgen_test_layout_jsval_layout__bindgen_ty_1() {
         assert_eq!(
-            ::std::mem::size_of:: < jsval_layout__bindgen_ty_1 > (), 1usize,
-            concat!("Size of: ", stringify!(jsval_layout__bindgen_ty_1))
+            ::std::mem::size_of::<jsval_layout__bindgen_ty_1>(),
+            1usize,
+            concat!("Size of: ", stringify!(jsval_layout__bindgen_ty_1)),
         );
         assert_eq!(
-            ::std::mem::align_of:: < jsval_layout__bindgen_ty_1 > (), 1usize,
-            concat!("Alignment of ", stringify!(jsval_layout__bindgen_ty_1))
+            ::std::mem::align_of::<jsval_layout__bindgen_ty_1>(),
+            1usize,
+            concat!("Alignment of ", stringify!(jsval_layout__bindgen_ty_1)),
         );
     }
     #[test]
     fn bindgen_test_layout_jsval_layout() {
         assert_eq!(
-            ::std::mem::size_of:: < jsval_layout > (), 1usize, concat!("Size of: ",
-            stringify!(jsval_layout))
+            ::std::mem::size_of::<jsval_layout>(),
+            1usize,
+            concat!("Size of: ", stringify!(jsval_layout)),
         );
         assert_eq!(
-            ::std::mem::align_of:: < jsval_layout > (), 1usize, concat!("Alignment of ",
-            stringify!(jsval_layout))
+            ::std::mem::align_of::<jsval_layout>(),
+            1usize,
+            concat!("Alignment of ", stringify!(jsval_layout)),
         );
     }
 }

--- a/bindgen-tests/tests/expectations/tests/jsval_layout_opaque.rs
+++ b/bindgen-tests/tests/expectations/tests/jsval_layout_opaque.rs
@@ -49,7 +49,7 @@ where
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < self.storage.as_ref().len());
         debug_assert!(
-            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len()
+            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len(),
         );
         let mut val = 0;
         for i in 0..(bit_width as usize) {
@@ -69,7 +69,7 @@ where
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < self.storage.as_ref().len());
         debug_assert!(
-            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len()
+            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len(),
         );
         for i in 0..(bit_width as usize) {
             let mask = 1 << i;
@@ -190,12 +190,14 @@ pub struct jsval_layout__bindgen_ty_1 {
 #[test]
 fn bindgen_test_layout_jsval_layout__bindgen_ty_1() {
     assert_eq!(
-        ::std::mem::size_of:: < jsval_layout__bindgen_ty_1 > (), 8usize,
-        concat!("Size of: ", stringify!(jsval_layout__bindgen_ty_1))
+        ::std::mem::size_of::<jsval_layout__bindgen_ty_1>(),
+        8usize,
+        concat!("Size of: ", stringify!(jsval_layout__bindgen_ty_1)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < jsval_layout__bindgen_ty_1 > (), 8usize,
-        concat!("Alignment of ", stringify!(jsval_layout__bindgen_ty_1))
+        ::std::mem::align_of::<jsval_layout__bindgen_ty_1>(),
+        8usize,
+        concat!("Alignment of ", stringify!(jsval_layout__bindgen_ty_1)),
     );
 }
 impl Default for jsval_layout__bindgen_ty_1 {
@@ -274,27 +276,44 @@ fn bindgen_test_layout_jsval_layout__bindgen_ty_2__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<jsval_layout__bindgen_ty_2__bindgen_ty_1> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < jsval_layout__bindgen_ty_2__bindgen_ty_1 > (), 4usize,
-        concat!("Size of: ", stringify!(jsval_layout__bindgen_ty_2__bindgen_ty_1))
+        ::std::mem::size_of::<jsval_layout__bindgen_ty_2__bindgen_ty_1>(),
+        4usize,
+        concat!("Size of: ", stringify!(jsval_layout__bindgen_ty_2__bindgen_ty_1)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < jsval_layout__bindgen_ty_2__bindgen_ty_1 > (), 4usize,
-        concat!("Alignment of ", stringify!(jsval_layout__bindgen_ty_2__bindgen_ty_1))
+        ::std::mem::align_of::<jsval_layout__bindgen_ty_2__bindgen_ty_1>(),
+        4usize,
+        concat!("Alignment of ", stringify!(jsval_layout__bindgen_ty_2__bindgen_ty_1)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).i32_) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ",
-        stringify!(jsval_layout__bindgen_ty_2__bindgen_ty_1), "::", stringify!(i32_))
+        unsafe { ::std::ptr::addr_of!((*ptr).i32_) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(jsval_layout__bindgen_ty_2__bindgen_ty_1),
+            "::",
+            stringify!(i32_),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).u32_) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ",
-        stringify!(jsval_layout__bindgen_ty_2__bindgen_ty_1), "::", stringify!(u32_))
+        unsafe { ::std::ptr::addr_of!((*ptr).u32_) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(jsval_layout__bindgen_ty_2__bindgen_ty_1),
+            "::",
+            stringify!(u32_),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).why) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ",
-        stringify!(jsval_layout__bindgen_ty_2__bindgen_ty_1), "::", stringify!(why))
+        unsafe { ::std::ptr::addr_of!((*ptr).why) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(jsval_layout__bindgen_ty_2__bindgen_ty_1),
+            "::",
+            stringify!(why),
+        ),
     );
 }
 impl Default for jsval_layout__bindgen_ty_2__bindgen_ty_1 {
@@ -311,17 +330,24 @@ fn bindgen_test_layout_jsval_layout__bindgen_ty_2() {
     const UNINIT: ::std::mem::MaybeUninit<jsval_layout__bindgen_ty_2> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < jsval_layout__bindgen_ty_2 > (), 4usize,
-        concat!("Size of: ", stringify!(jsval_layout__bindgen_ty_2))
+        ::std::mem::size_of::<jsval_layout__bindgen_ty_2>(),
+        4usize,
+        concat!("Size of: ", stringify!(jsval_layout__bindgen_ty_2)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < jsval_layout__bindgen_ty_2 > (), 4usize,
-        concat!("Alignment of ", stringify!(jsval_layout__bindgen_ty_2))
+        ::std::mem::align_of::<jsval_layout__bindgen_ty_2>(),
+        4usize,
+        concat!("Alignment of ", stringify!(jsval_layout__bindgen_ty_2)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).payload) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(jsval_layout__bindgen_ty_2), "::",
-        stringify!(payload))
+        unsafe { ::std::ptr::addr_of!((*ptr).payload) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(jsval_layout__bindgen_ty_2),
+            "::",
+            stringify!(payload),
+        ),
     );
 }
 impl Default for jsval_layout__bindgen_ty_2 {
@@ -338,43 +364,64 @@ fn bindgen_test_layout_jsval_layout() {
     const UNINIT: ::std::mem::MaybeUninit<jsval_layout> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < jsval_layout > (), 8usize, concat!("Size of: ",
-        stringify!(jsval_layout))
+        ::std::mem::size_of::<jsval_layout>(),
+        8usize,
+        concat!("Size of: ", stringify!(jsval_layout)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < jsval_layout > (), 8usize, concat!("Alignment of ",
-        stringify!(jsval_layout))
+        ::std::mem::align_of::<jsval_layout>(),
+        8usize,
+        concat!("Alignment of ", stringify!(jsval_layout)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).asBits) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(jsval_layout), "::", stringify!(asBits))
+        unsafe { ::std::ptr::addr_of!((*ptr).asBits) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(jsval_layout), "::", stringify!(asBits)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).debugView) as usize - ptr as usize },
-        0usize, concat!("Offset of field: ", stringify!(jsval_layout), "::",
-        stringify!(debugView))
+        unsafe { ::std::ptr::addr_of!((*ptr).debugView) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(jsval_layout),
+            "::",
+            stringify!(debugView),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).s) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(jsval_layout), "::", stringify!(s))
+        unsafe { ::std::ptr::addr_of!((*ptr).s) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(jsval_layout), "::", stringify!(s)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).asDouble) as usize - ptr as usize },
-        0usize, concat!("Offset of field: ", stringify!(jsval_layout), "::",
-        stringify!(asDouble))
+        unsafe { ::std::ptr::addr_of!((*ptr).asDouble) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(jsval_layout),
+            "::",
+            stringify!(asDouble),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).asPtr) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(jsval_layout), "::", stringify!(asPtr))
+        unsafe { ::std::ptr::addr_of!((*ptr).asPtr) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(jsval_layout), "::", stringify!(asPtr)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).asWord) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(jsval_layout), "::", stringify!(asWord))
+        unsafe { ::std::ptr::addr_of!((*ptr).asWord) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(jsval_layout), "::", stringify!(asWord)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).asUIntPtr) as usize - ptr as usize },
-        0usize, concat!("Offset of field: ", stringify!(jsval_layout), "::",
-        stringify!(asUIntPtr))
+        unsafe { ::std::ptr::addr_of!((*ptr).asUIntPtr) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(jsval_layout),
+            "::",
+            stringify!(asUIntPtr),
+        ),
     );
 }
 impl Default for jsval_layout {
@@ -396,16 +443,19 @@ fn bindgen_test_layout_Value() {
     const UNINIT: ::std::mem::MaybeUninit<Value> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < Value > (), 8usize, concat!("Size of: ",
-        stringify!(Value))
+        ::std::mem::size_of::<Value>(),
+        8usize,
+        concat!("Size of: ", stringify!(Value)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Value > (), 8usize, concat!("Alignment of ",
-        stringify!(Value))
+        ::std::mem::align_of::<Value>(),
+        8usize,
+        concat!("Alignment of ", stringify!(Value)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).data) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(Value), "::", stringify!(data))
+        unsafe { ::std::ptr::addr_of!((*ptr).data) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(Value), "::", stringify!(data)),
     );
 }
 impl Default for Value {

--- a/bindgen-tests/tests/expectations/tests/jsval_layout_opaque_1_0.rs
+++ b/bindgen-tests/tests/expectations/tests/jsval_layout_opaque_1_0.rs
@@ -49,7 +49,7 @@ where
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < self.storage.as_ref().len());
         debug_assert!(
-            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len()
+            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len(),
         );
         let mut val = 0;
         for i in 0..(bit_width as usize) {
@@ -69,7 +69,7 @@ where
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < self.storage.as_ref().len());
         debug_assert!(
-            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len()
+            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len(),
         );
         for i in 0..(bit_width as usize) {
             let mask = 1 << i;
@@ -234,12 +234,14 @@ pub struct jsval_layout__bindgen_ty_1 {
 #[test]
 fn bindgen_test_layout_jsval_layout__bindgen_ty_1() {
     assert_eq!(
-        ::std::mem::size_of:: < jsval_layout__bindgen_ty_1 > (), 8usize,
-        concat!("Size of: ", stringify!(jsval_layout__bindgen_ty_1))
+        ::std::mem::size_of::<jsval_layout__bindgen_ty_1>(),
+        8usize,
+        concat!("Size of: ", stringify!(jsval_layout__bindgen_ty_1)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < jsval_layout__bindgen_ty_1 > (), 8usize,
-        concat!("Alignment of ", stringify!(jsval_layout__bindgen_ty_1))
+        ::std::mem::align_of::<jsval_layout__bindgen_ty_1>(),
+        8usize,
+        concat!("Alignment of ", stringify!(jsval_layout__bindgen_ty_1)),
     );
 }
 impl Clone for jsval_layout__bindgen_ty_1 {
@@ -324,27 +326,44 @@ fn bindgen_test_layout_jsval_layout__bindgen_ty_2__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<jsval_layout__bindgen_ty_2__bindgen_ty_1> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < jsval_layout__bindgen_ty_2__bindgen_ty_1 > (), 4usize,
-        concat!("Size of: ", stringify!(jsval_layout__bindgen_ty_2__bindgen_ty_1))
+        ::std::mem::size_of::<jsval_layout__bindgen_ty_2__bindgen_ty_1>(),
+        4usize,
+        concat!("Size of: ", stringify!(jsval_layout__bindgen_ty_2__bindgen_ty_1)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < jsval_layout__bindgen_ty_2__bindgen_ty_1 > (), 4usize,
-        concat!("Alignment of ", stringify!(jsval_layout__bindgen_ty_2__bindgen_ty_1))
+        ::std::mem::align_of::<jsval_layout__bindgen_ty_2__bindgen_ty_1>(),
+        4usize,
+        concat!("Alignment of ", stringify!(jsval_layout__bindgen_ty_2__bindgen_ty_1)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).i32_) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ",
-        stringify!(jsval_layout__bindgen_ty_2__bindgen_ty_1), "::", stringify!(i32_))
+        unsafe { ::std::ptr::addr_of!((*ptr).i32_) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(jsval_layout__bindgen_ty_2__bindgen_ty_1),
+            "::",
+            stringify!(i32_),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).u32_) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ",
-        stringify!(jsval_layout__bindgen_ty_2__bindgen_ty_1), "::", stringify!(u32_))
+        unsafe { ::std::ptr::addr_of!((*ptr).u32_) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(jsval_layout__bindgen_ty_2__bindgen_ty_1),
+            "::",
+            stringify!(u32_),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).why) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ",
-        stringify!(jsval_layout__bindgen_ty_2__bindgen_ty_1), "::", stringify!(why))
+        unsafe { ::std::ptr::addr_of!((*ptr).why) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(jsval_layout__bindgen_ty_2__bindgen_ty_1),
+            "::",
+            stringify!(why),
+        ),
     );
 }
 impl Clone for jsval_layout__bindgen_ty_2__bindgen_ty_1 {
@@ -357,17 +376,24 @@ fn bindgen_test_layout_jsval_layout__bindgen_ty_2() {
     const UNINIT: ::std::mem::MaybeUninit<jsval_layout__bindgen_ty_2> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < jsval_layout__bindgen_ty_2 > (), 4usize,
-        concat!("Size of: ", stringify!(jsval_layout__bindgen_ty_2))
+        ::std::mem::size_of::<jsval_layout__bindgen_ty_2>(),
+        4usize,
+        concat!("Size of: ", stringify!(jsval_layout__bindgen_ty_2)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < jsval_layout__bindgen_ty_2 > (), 4usize,
-        concat!("Alignment of ", stringify!(jsval_layout__bindgen_ty_2))
+        ::std::mem::align_of::<jsval_layout__bindgen_ty_2>(),
+        4usize,
+        concat!("Alignment of ", stringify!(jsval_layout__bindgen_ty_2)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).payload) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(jsval_layout__bindgen_ty_2), "::",
-        stringify!(payload))
+        unsafe { ::std::ptr::addr_of!((*ptr).payload) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(jsval_layout__bindgen_ty_2),
+            "::",
+            stringify!(payload),
+        ),
     );
 }
 impl Clone for jsval_layout__bindgen_ty_2 {
@@ -380,43 +406,64 @@ fn bindgen_test_layout_jsval_layout() {
     const UNINIT: ::std::mem::MaybeUninit<jsval_layout> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < jsval_layout > (), 8usize, concat!("Size of: ",
-        stringify!(jsval_layout))
+        ::std::mem::size_of::<jsval_layout>(),
+        8usize,
+        concat!("Size of: ", stringify!(jsval_layout)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < jsval_layout > (), 8usize, concat!("Alignment of ",
-        stringify!(jsval_layout))
+        ::std::mem::align_of::<jsval_layout>(),
+        8usize,
+        concat!("Alignment of ", stringify!(jsval_layout)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).asBits) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(jsval_layout), "::", stringify!(asBits))
+        unsafe { ::std::ptr::addr_of!((*ptr).asBits) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(jsval_layout), "::", stringify!(asBits)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).debugView) as usize - ptr as usize },
-        0usize, concat!("Offset of field: ", stringify!(jsval_layout), "::",
-        stringify!(debugView))
+        unsafe { ::std::ptr::addr_of!((*ptr).debugView) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(jsval_layout),
+            "::",
+            stringify!(debugView),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).s) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(jsval_layout), "::", stringify!(s))
+        unsafe { ::std::ptr::addr_of!((*ptr).s) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(jsval_layout), "::", stringify!(s)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).asDouble) as usize - ptr as usize },
-        0usize, concat!("Offset of field: ", stringify!(jsval_layout), "::",
-        stringify!(asDouble))
+        unsafe { ::std::ptr::addr_of!((*ptr).asDouble) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(jsval_layout),
+            "::",
+            stringify!(asDouble),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).asPtr) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(jsval_layout), "::", stringify!(asPtr))
+        unsafe { ::std::ptr::addr_of!((*ptr).asPtr) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(jsval_layout), "::", stringify!(asPtr)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).asWord) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(jsval_layout), "::", stringify!(asWord))
+        unsafe { ::std::ptr::addr_of!((*ptr).asWord) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(jsval_layout), "::", stringify!(asWord)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).asUIntPtr) as usize - ptr as usize },
-        0usize, concat!("Offset of field: ", stringify!(jsval_layout), "::",
-        stringify!(asUIntPtr))
+        unsafe { ::std::ptr::addr_of!((*ptr).asUIntPtr) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(jsval_layout),
+            "::",
+            stringify!(asUIntPtr),
+        ),
     );
 }
 impl Clone for jsval_layout {
@@ -434,16 +481,19 @@ fn bindgen_test_layout_Value() {
     const UNINIT: ::std::mem::MaybeUninit<Value> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < Value > (), 8usize, concat!("Size of: ",
-        stringify!(Value))
+        ::std::mem::size_of::<Value>(),
+        8usize,
+        concat!("Size of: ", stringify!(Value)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Value > (), 8usize, concat!("Alignment of ",
-        stringify!(Value))
+        ::std::mem::align_of::<Value>(),
+        8usize,
+        concat!("Alignment of ", stringify!(Value)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).data) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(Value), "::", stringify!(data))
+        unsafe { ::std::ptr::addr_of!((*ptr).data) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(Value), "::", stringify!(data)),
     );
 }
 impl Clone for Value {

--- a/bindgen-tests/tests/expectations/tests/layout.rs
+++ b/bindgen-tests/tests/expectations/tests/layout.rs
@@ -6,8 +6,9 @@ pub struct header {
 #[test]
 fn bindgen_test_layout_header() {
     assert_eq!(
-        ::std::mem::size_of:: < header > (), 16usize, concat!("Size of: ",
-        stringify!(header))
+        ::std::mem::size_of::<header>(),
+        16usize,
+        concat!("Size of: ", stringify!(header)),
     );
 }
 impl Default for header {

--- a/bindgen-tests/tests/expectations/tests/layout_align.rs
+++ b/bindgen-tests/tests/expectations/tests/layout_align.rs
@@ -49,7 +49,7 @@ where
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < self.storage.as_ref().len());
         debug_assert!(
-            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len()
+            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len(),
         );
         let mut val = 0;
         for i in 0..(bit_width as usize) {
@@ -69,7 +69,7 @@ where
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < self.storage.as_ref().len());
         debug_assert!(
-            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len()
+            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len(),
         );
         for i in 0..(bit_width as usize) {
             let mask = 1 << i;
@@ -130,12 +130,14 @@ pub struct rte_kni_fifo {
 #[test]
 fn bindgen_test_layout_rte_kni_fifo() {
     assert_eq!(
-        ::std::mem::size_of:: < rte_kni_fifo > (), 16usize, concat!("Size of: ",
-        stringify!(rte_kni_fifo))
+        ::std::mem::size_of::<rte_kni_fifo>(),
+        16usize,
+        concat!("Size of: ", stringify!(rte_kni_fifo)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < rte_kni_fifo > (), 8usize, concat!("Alignment of ",
-        stringify!(rte_kni_fifo))
+        ::std::mem::align_of::<rte_kni_fifo>(),
+        8usize,
+        concat!("Alignment of ", stringify!(rte_kni_fifo)),
     );
 }
 impl Default for rte_kni_fifo {
@@ -162,17 +164,24 @@ fn bindgen_test_layout_rte_eth_link() {
     const UNINIT: ::std::mem::MaybeUninit<rte_eth_link> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < rte_eth_link > (), 8usize, concat!("Size of: ",
-        stringify!(rte_eth_link))
+        ::std::mem::size_of::<rte_eth_link>(),
+        8usize,
+        concat!("Size of: ", stringify!(rte_eth_link)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < rte_eth_link > (), 8usize, concat!("Alignment of ",
-        stringify!(rte_eth_link))
+        ::std::mem::align_of::<rte_eth_link>(),
+        8usize,
+        concat!("Alignment of ", stringify!(rte_eth_link)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).link_speed) as usize - ptr as usize },
-        0usize, concat!("Offset of field: ", stringify!(rte_eth_link), "::",
-        stringify!(link_speed))
+        unsafe { ::std::ptr::addr_of!((*ptr).link_speed) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_link),
+            "::",
+            stringify!(link_speed),
+        ),
     );
 }
 impl rte_eth_link {

--- a/bindgen-tests/tests/expectations/tests/layout_arp.rs
+++ b/bindgen-tests/tests/expectations/tests/layout_arp.rs
@@ -27,17 +27,24 @@ fn bindgen_test_layout_ether_addr() {
     const UNINIT: ::std::mem::MaybeUninit<ether_addr> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < ether_addr > (), 6usize, concat!("Size of: ",
-        stringify!(ether_addr))
+        ::std::mem::size_of::<ether_addr>(),
+        6usize,
+        concat!("Size of: ", stringify!(ether_addr)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < ether_addr > (), 1usize, concat!("Alignment of ",
-        stringify!(ether_addr))
+        ::std::mem::align_of::<ether_addr>(),
+        1usize,
+        concat!("Alignment of ", stringify!(ether_addr)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).addr_bytes) as usize - ptr as usize },
-        0usize, concat!("Offset of field: ", stringify!(ether_addr), "::",
-        stringify!(addr_bytes))
+        unsafe { ::std::ptr::addr_of!((*ptr).addr_bytes) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ether_addr),
+            "::",
+            stringify!(addr_bytes),
+        ),
     );
 }
 /// ARP header IPv4 payload.
@@ -58,30 +65,34 @@ fn bindgen_test_layout_arp_ipv4() {
     const UNINIT: ::std::mem::MaybeUninit<arp_ipv4> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < arp_ipv4 > (), 20usize, concat!("Size of: ",
-        stringify!(arp_ipv4))
+        ::std::mem::size_of::<arp_ipv4>(),
+        20usize,
+        concat!("Size of: ", stringify!(arp_ipv4)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < arp_ipv4 > (), 1usize, concat!("Alignment of ",
-        stringify!(arp_ipv4))
+        ::std::mem::align_of::<arp_ipv4>(),
+        1usize,
+        concat!("Alignment of ", stringify!(arp_ipv4)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).arp_sha) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(arp_ipv4), "::", stringify!(arp_sha))
+        unsafe { ::std::ptr::addr_of!((*ptr).arp_sha) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(arp_ipv4), "::", stringify!(arp_sha)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).arp_sip) as usize - ptr as usize }, 6usize,
-        concat!("Offset of field: ", stringify!(arp_ipv4), "::", stringify!(arp_sip))
+        unsafe { ::std::ptr::addr_of!((*ptr).arp_sip) as usize - ptr as usize },
+        6usize,
+        concat!("Offset of field: ", stringify!(arp_ipv4), "::", stringify!(arp_sip)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).arp_tha) as usize - ptr as usize },
-        10usize, concat!("Offset of field: ", stringify!(arp_ipv4), "::",
-        stringify!(arp_tha))
+        unsafe { ::std::ptr::addr_of!((*ptr).arp_tha) as usize - ptr as usize },
+        10usize,
+        concat!("Offset of field: ", stringify!(arp_ipv4), "::", stringify!(arp_tha)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).arp_tip) as usize - ptr as usize },
-        16usize, concat!("Offset of field: ", stringify!(arp_ipv4), "::",
-        stringify!(arp_tip))
+        unsafe { ::std::ptr::addr_of!((*ptr).arp_tip) as usize - ptr as usize },
+        16usize,
+        concat!("Offset of field: ", stringify!(arp_ipv4), "::", stringify!(arp_tip)),
     );
 }
 /// ARP header.
@@ -100,36 +111,43 @@ fn bindgen_test_layout_arp_hdr() {
     const UNINIT: ::std::mem::MaybeUninit<arp_hdr> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < arp_hdr > (), 28usize, concat!("Size of: ",
-        stringify!(arp_hdr))
+        ::std::mem::size_of::<arp_hdr>(),
+        28usize,
+        concat!("Size of: ", stringify!(arp_hdr)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < arp_hdr > (), 1usize, concat!("Alignment of ",
-        stringify!(arp_hdr))
+        ::std::mem::align_of::<arp_hdr>(),
+        1usize,
+        concat!("Alignment of ", stringify!(arp_hdr)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).arp_hrd) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(arp_hdr), "::", stringify!(arp_hrd))
+        unsafe { ::std::ptr::addr_of!((*ptr).arp_hrd) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(arp_hdr), "::", stringify!(arp_hrd)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).arp_pro) as usize - ptr as usize }, 2usize,
-        concat!("Offset of field: ", stringify!(arp_hdr), "::", stringify!(arp_pro))
+        unsafe { ::std::ptr::addr_of!((*ptr).arp_pro) as usize - ptr as usize },
+        2usize,
+        concat!("Offset of field: ", stringify!(arp_hdr), "::", stringify!(arp_pro)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).arp_hln) as usize - ptr as usize }, 4usize,
-        concat!("Offset of field: ", stringify!(arp_hdr), "::", stringify!(arp_hln))
+        unsafe { ::std::ptr::addr_of!((*ptr).arp_hln) as usize - ptr as usize },
+        4usize,
+        concat!("Offset of field: ", stringify!(arp_hdr), "::", stringify!(arp_hln)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).arp_pln) as usize - ptr as usize }, 5usize,
-        concat!("Offset of field: ", stringify!(arp_hdr), "::", stringify!(arp_pln))
+        unsafe { ::std::ptr::addr_of!((*ptr).arp_pln) as usize - ptr as usize },
+        5usize,
+        concat!("Offset of field: ", stringify!(arp_hdr), "::", stringify!(arp_pln)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).arp_op) as usize - ptr as usize }, 6usize,
-        concat!("Offset of field: ", stringify!(arp_hdr), "::", stringify!(arp_op))
+        unsafe { ::std::ptr::addr_of!((*ptr).arp_op) as usize - ptr as usize },
+        6usize,
+        concat!("Offset of field: ", stringify!(arp_hdr), "::", stringify!(arp_op)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).arp_data) as usize - ptr as usize },
-        8usize, concat!("Offset of field: ", stringify!(arp_hdr), "::",
-        stringify!(arp_data))
+        unsafe { ::std::ptr::addr_of!((*ptr).arp_data) as usize - ptr as usize },
+        8usize,
+        concat!("Offset of field: ", stringify!(arp_hdr), "::", stringify!(arp_data)),
     );
 }

--- a/bindgen-tests/tests/expectations/tests/layout_array.rs
+++ b/bindgen-tests/tests/expectations/tests/layout_array.rs
@@ -66,40 +66,64 @@ fn bindgen_test_layout_rte_mempool_ops() {
     const UNINIT: ::std::mem::MaybeUninit<rte_mempool_ops> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < rte_mempool_ops > (), 128usize, concat!("Size of: ",
-        stringify!(rte_mempool_ops))
+        ::std::mem::size_of::<rte_mempool_ops>(),
+        128usize,
+        concat!("Size of: ", stringify!(rte_mempool_ops)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < rte_mempool_ops > (), 64usize, concat!("Alignment of ",
-        stringify!(rte_mempool_ops))
+        ::std::mem::align_of::<rte_mempool_ops>(),
+        64usize,
+        concat!("Alignment of ", stringify!(rte_mempool_ops)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).name) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(rte_mempool_ops), "::", stringify!(name))
+        unsafe { ::std::ptr::addr_of!((*ptr).name) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(rte_mempool_ops), "::", stringify!(name)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).alloc) as usize - ptr as usize }, 32usize,
-        concat!("Offset of field: ", stringify!(rte_mempool_ops), "::",
-        stringify!(alloc))
+        unsafe { ::std::ptr::addr_of!((*ptr).alloc) as usize - ptr as usize },
+        32usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_mempool_ops),
+            "::",
+            stringify!(alloc),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).free) as usize - ptr as usize }, 40usize,
-        concat!("Offset of field: ", stringify!(rte_mempool_ops), "::", stringify!(free))
+        unsafe { ::std::ptr::addr_of!((*ptr).free) as usize - ptr as usize },
+        40usize,
+        concat!("Offset of field: ", stringify!(rte_mempool_ops), "::", stringify!(free)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).enqueue) as usize - ptr as usize },
-        48usize, concat!("Offset of field: ", stringify!(rte_mempool_ops), "::",
-        stringify!(enqueue))
+        unsafe { ::std::ptr::addr_of!((*ptr).enqueue) as usize - ptr as usize },
+        48usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_mempool_ops),
+            "::",
+            stringify!(enqueue),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).dequeue) as usize - ptr as usize },
-        56usize, concat!("Offset of field: ", stringify!(rte_mempool_ops), "::",
-        stringify!(dequeue))
+        unsafe { ::std::ptr::addr_of!((*ptr).dequeue) as usize - ptr as usize },
+        56usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_mempool_ops),
+            "::",
+            stringify!(dequeue),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).get_count) as usize - ptr as usize },
-        64usize, concat!("Offset of field: ", stringify!(rte_mempool_ops), "::",
-        stringify!(get_count))
+        unsafe { ::std::ptr::addr_of!((*ptr).get_count) as usize - ptr as usize },
+        64usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_mempool_ops),
+            "::",
+            stringify!(get_count),
+        ),
     );
 }
 impl Default for rte_mempool_ops {
@@ -130,17 +154,24 @@ fn bindgen_test_layout_rte_spinlock_t() {
     const UNINIT: ::std::mem::MaybeUninit<rte_spinlock_t> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < rte_spinlock_t > (), 4usize, concat!("Size of: ",
-        stringify!(rte_spinlock_t))
+        ::std::mem::size_of::<rte_spinlock_t>(),
+        4usize,
+        concat!("Size of: ", stringify!(rte_spinlock_t)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < rte_spinlock_t > (), 4usize, concat!("Alignment of ",
-        stringify!(rte_spinlock_t))
+        ::std::mem::align_of::<rte_spinlock_t>(),
+        4usize,
+        concat!("Alignment of ", stringify!(rte_spinlock_t)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).locked) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(rte_spinlock_t), "::",
-        stringify!(locked))
+        unsafe { ::std::ptr::addr_of!((*ptr).locked) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_spinlock_t),
+            "::",
+            stringify!(locked),
+        ),
     );
 }
 /** Structure storing the table of registered ops structs, each of which contain
@@ -167,27 +198,44 @@ fn bindgen_test_layout_rte_mempool_ops_table() {
     const UNINIT: ::std::mem::MaybeUninit<rte_mempool_ops_table> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < rte_mempool_ops_table > (), 2112usize,
-        concat!("Size of: ", stringify!(rte_mempool_ops_table))
+        ::std::mem::size_of::<rte_mempool_ops_table>(),
+        2112usize,
+        concat!("Size of: ", stringify!(rte_mempool_ops_table)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < rte_mempool_ops_table > (), 64usize,
-        concat!("Alignment of ", stringify!(rte_mempool_ops_table))
+        ::std::mem::align_of::<rte_mempool_ops_table>(),
+        64usize,
+        concat!("Alignment of ", stringify!(rte_mempool_ops_table)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).sl) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(rte_mempool_ops_table), "::",
-        stringify!(sl))
+        unsafe { ::std::ptr::addr_of!((*ptr).sl) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_mempool_ops_table),
+            "::",
+            stringify!(sl),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).num_ops) as usize - ptr as usize }, 4usize,
-        concat!("Offset of field: ", stringify!(rte_mempool_ops_table), "::",
-        stringify!(num_ops))
+        unsafe { ::std::ptr::addr_of!((*ptr).num_ops) as usize - ptr as usize },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_mempool_ops_table),
+            "::",
+            stringify!(num_ops),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).ops) as usize - ptr as usize }, 64usize,
-        concat!("Offset of field: ", stringify!(rte_mempool_ops_table), "::",
-        stringify!(ops))
+        unsafe { ::std::ptr::addr_of!((*ptr).ops) as usize - ptr as usize },
+        64usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_mempool_ops_table),
+            "::",
+            stringify!(ops),
+        ),
     );
 }
 impl Default for rte_mempool_ops_table {
@@ -219,17 +267,24 @@ fn bindgen_test_layout_malloc_heap__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<malloc_heap__bindgen_ty_1> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < malloc_heap__bindgen_ty_1 > (), 8usize,
-        concat!("Size of: ", stringify!(malloc_heap__bindgen_ty_1))
+        ::std::mem::size_of::<malloc_heap__bindgen_ty_1>(),
+        8usize,
+        concat!("Size of: ", stringify!(malloc_heap__bindgen_ty_1)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < malloc_heap__bindgen_ty_1 > (), 8usize,
-        concat!("Alignment of ", stringify!(malloc_heap__bindgen_ty_1))
+        ::std::mem::align_of::<malloc_heap__bindgen_ty_1>(),
+        8usize,
+        concat!("Alignment of ", stringify!(malloc_heap__bindgen_ty_1)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).lh_first) as usize - ptr as usize },
-        0usize, concat!("Offset of field: ", stringify!(malloc_heap__bindgen_ty_1), "::",
-        stringify!(lh_first))
+        unsafe { ::std::ptr::addr_of!((*ptr).lh_first) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(malloc_heap__bindgen_ty_1),
+            "::",
+            stringify!(lh_first),
+        ),
     );
 }
 impl Default for malloc_heap__bindgen_ty_1 {
@@ -246,31 +301,49 @@ fn bindgen_test_layout_malloc_heap() {
     const UNINIT: ::std::mem::MaybeUninit<malloc_heap> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < malloc_heap > (), 128usize, concat!("Size of: ",
-        stringify!(malloc_heap))
+        ::std::mem::size_of::<malloc_heap>(),
+        128usize,
+        concat!("Size of: ", stringify!(malloc_heap)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < malloc_heap > (), 64usize, concat!("Alignment of ",
-        stringify!(malloc_heap))
+        ::std::mem::align_of::<malloc_heap>(),
+        64usize,
+        concat!("Alignment of ", stringify!(malloc_heap)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).lock) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(malloc_heap), "::", stringify!(lock))
+        unsafe { ::std::ptr::addr_of!((*ptr).lock) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(malloc_heap), "::", stringify!(lock)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).free_head) as usize - ptr as usize },
-        8usize, concat!("Offset of field: ", stringify!(malloc_heap), "::",
-        stringify!(free_head))
+        unsafe { ::std::ptr::addr_of!((*ptr).free_head) as usize - ptr as usize },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(malloc_heap),
+            "::",
+            stringify!(free_head),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).alloc_count) as usize - ptr as usize },
-        112usize, concat!("Offset of field: ", stringify!(malloc_heap), "::",
-        stringify!(alloc_count))
+        unsafe { ::std::ptr::addr_of!((*ptr).alloc_count) as usize - ptr as usize },
+        112usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(malloc_heap),
+            "::",
+            stringify!(alloc_count),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).total_size) as usize - ptr as usize },
-        120usize, concat!("Offset of field: ", stringify!(malloc_heap), "::",
-        stringify!(total_size))
+        unsafe { ::std::ptr::addr_of!((*ptr).total_size) as usize - ptr as usize },
+        120usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(malloc_heap),
+            "::",
+            stringify!(total_size),
+        ),
     );
 }
 impl Default for malloc_heap {

--- a/bindgen-tests/tests/expectations/tests/layout_array_too_long.rs
+++ b/bindgen-tests/tests/expectations/tests/layout_array_too_long.rs
@@ -32,24 +32,29 @@ fn bindgen_test_layout_ip_frag() {
     const UNINIT: ::std::mem::MaybeUninit<ip_frag> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < ip_frag > (), 16usize, concat!("Size of: ",
-        stringify!(ip_frag))
+        ::std::mem::size_of::<ip_frag>(),
+        16usize,
+        concat!("Size of: ", stringify!(ip_frag)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < ip_frag > (), 8usize, concat!("Alignment of ",
-        stringify!(ip_frag))
+        ::std::mem::align_of::<ip_frag>(),
+        8usize,
+        concat!("Alignment of ", stringify!(ip_frag)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).ofs) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(ip_frag), "::", stringify!(ofs))
+        unsafe { ::std::ptr::addr_of!((*ptr).ofs) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(ip_frag), "::", stringify!(ofs)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).len) as usize - ptr as usize }, 2usize,
-        concat!("Offset of field: ", stringify!(ip_frag), "::", stringify!(len))
+        unsafe { ::std::ptr::addr_of!((*ptr).len) as usize - ptr as usize },
+        2usize,
+        concat!("Offset of field: ", stringify!(ip_frag), "::", stringify!(len)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).mb) as usize - ptr as usize }, 8usize,
-        concat!("Offset of field: ", stringify!(ip_frag), "::", stringify!(mb))
+        unsafe { ::std::ptr::addr_of!((*ptr).mb) as usize - ptr as usize },
+        8usize,
+        concat!("Offset of field: ", stringify!(ip_frag), "::", stringify!(mb)),
     );
 }
 impl Default for ip_frag {
@@ -77,25 +82,29 @@ fn bindgen_test_layout_ip_frag_key() {
     const UNINIT: ::std::mem::MaybeUninit<ip_frag_key> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < ip_frag_key > (), 40usize, concat!("Size of: ",
-        stringify!(ip_frag_key))
+        ::std::mem::size_of::<ip_frag_key>(),
+        40usize,
+        concat!("Size of: ", stringify!(ip_frag_key)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < ip_frag_key > (), 8usize, concat!("Alignment of ",
-        stringify!(ip_frag_key))
+        ::std::mem::align_of::<ip_frag_key>(),
+        8usize,
+        concat!("Alignment of ", stringify!(ip_frag_key)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).src_dst) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(ip_frag_key), "::", stringify!(src_dst))
+        unsafe { ::std::ptr::addr_of!((*ptr).src_dst) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(ip_frag_key), "::", stringify!(src_dst)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).id) as usize - ptr as usize }, 32usize,
-        concat!("Offset of field: ", stringify!(ip_frag_key), "::", stringify!(id))
+        unsafe { ::std::ptr::addr_of!((*ptr).id) as usize - ptr as usize },
+        32usize,
+        concat!("Offset of field: ", stringify!(ip_frag_key), "::", stringify!(id)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).key_len) as usize - ptr as usize },
-        36usize, concat!("Offset of field: ", stringify!(ip_frag_key), "::",
-        stringify!(key_len))
+        unsafe { ::std::ptr::addr_of!((*ptr).key_len) as usize - ptr as usize },
+        36usize,
+        concat!("Offset of field: ", stringify!(ip_frag_key), "::", stringify!(key_len)),
     );
 }
 /** @internal Fragmented packet to reassemble.
@@ -130,22 +139,34 @@ fn bindgen_test_layout_ip_frag_pkt__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<ip_frag_pkt__bindgen_ty_1> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < ip_frag_pkt__bindgen_ty_1 > (), 16usize,
-        concat!("Size of: ", stringify!(ip_frag_pkt__bindgen_ty_1))
+        ::std::mem::size_of::<ip_frag_pkt__bindgen_ty_1>(),
+        16usize,
+        concat!("Size of: ", stringify!(ip_frag_pkt__bindgen_ty_1)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < ip_frag_pkt__bindgen_ty_1 > (), 8usize,
-        concat!("Alignment of ", stringify!(ip_frag_pkt__bindgen_ty_1))
+        ::std::mem::align_of::<ip_frag_pkt__bindgen_ty_1>(),
+        8usize,
+        concat!("Alignment of ", stringify!(ip_frag_pkt__bindgen_ty_1)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).tqe_next) as usize - ptr as usize },
-        0usize, concat!("Offset of field: ", stringify!(ip_frag_pkt__bindgen_ty_1), "::",
-        stringify!(tqe_next))
+        unsafe { ::std::ptr::addr_of!((*ptr).tqe_next) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ip_frag_pkt__bindgen_ty_1),
+            "::",
+            stringify!(tqe_next),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).tqe_prev) as usize - ptr as usize },
-        8usize, concat!("Offset of field: ", stringify!(ip_frag_pkt__bindgen_ty_1), "::",
-        stringify!(tqe_prev))
+        unsafe { ::std::ptr::addr_of!((*ptr).tqe_prev) as usize - ptr as usize },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ip_frag_pkt__bindgen_ty_1),
+            "::",
+            stringify!(tqe_prev),
+        ),
     );
 }
 impl Default for ip_frag_pkt__bindgen_ty_1 {
@@ -162,43 +183,59 @@ fn bindgen_test_layout_ip_frag_pkt() {
     const UNINIT: ::std::mem::MaybeUninit<ip_frag_pkt> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < ip_frag_pkt > (), 192usize, concat!("Size of: ",
-        stringify!(ip_frag_pkt))
+        ::std::mem::size_of::<ip_frag_pkt>(),
+        192usize,
+        concat!("Size of: ", stringify!(ip_frag_pkt)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < ip_frag_pkt > (), 64usize, concat!("Alignment of ",
-        stringify!(ip_frag_pkt))
+        ::std::mem::align_of::<ip_frag_pkt>(),
+        64usize,
+        concat!("Alignment of ", stringify!(ip_frag_pkt)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).lru) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(ip_frag_pkt), "::", stringify!(lru))
+        unsafe { ::std::ptr::addr_of!((*ptr).lru) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(ip_frag_pkt), "::", stringify!(lru)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).key) as usize - ptr as usize }, 16usize,
-        concat!("Offset of field: ", stringify!(ip_frag_pkt), "::", stringify!(key))
+        unsafe { ::std::ptr::addr_of!((*ptr).key) as usize - ptr as usize },
+        16usize,
+        concat!("Offset of field: ", stringify!(ip_frag_pkt), "::", stringify!(key)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).start) as usize - ptr as usize }, 56usize,
-        concat!("Offset of field: ", stringify!(ip_frag_pkt), "::", stringify!(start))
+        unsafe { ::std::ptr::addr_of!((*ptr).start) as usize - ptr as usize },
+        56usize,
+        concat!("Offset of field: ", stringify!(ip_frag_pkt), "::", stringify!(start)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).total_size) as usize - ptr as usize },
-        64usize, concat!("Offset of field: ", stringify!(ip_frag_pkt), "::",
-        stringify!(total_size))
+        unsafe { ::std::ptr::addr_of!((*ptr).total_size) as usize - ptr as usize },
+        64usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ip_frag_pkt),
+            "::",
+            stringify!(total_size),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).frag_size) as usize - ptr as usize },
-        68usize, concat!("Offset of field: ", stringify!(ip_frag_pkt), "::",
-        stringify!(frag_size))
+        unsafe { ::std::ptr::addr_of!((*ptr).frag_size) as usize - ptr as usize },
+        68usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ip_frag_pkt),
+            "::",
+            stringify!(frag_size),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).last_idx) as usize - ptr as usize },
-        72usize, concat!("Offset of field: ", stringify!(ip_frag_pkt), "::",
-        stringify!(last_idx))
+        unsafe { ::std::ptr::addr_of!((*ptr).last_idx) as usize - ptr as usize },
+        72usize,
+        concat!("Offset of field: ", stringify!(ip_frag_pkt), "::", stringify!(last_idx)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).frags) as usize - ptr as usize }, 80usize,
-        concat!("Offset of field: ", stringify!(ip_frag_pkt), "::", stringify!(frags))
+        unsafe { ::std::ptr::addr_of!((*ptr).frags) as usize - ptr as usize },
+        80usize,
+        concat!("Offset of field: ", stringify!(ip_frag_pkt), "::", stringify!(frags)),
     );
 }
 impl Default for ip_frag_pkt {

--- a/bindgen-tests/tests/expectations/tests/layout_cmdline_token.rs
+++ b/bindgen-tests/tests/expectations/tests/layout_cmdline_token.rs
@@ -12,22 +12,34 @@ fn bindgen_test_layout_cmdline_token_hdr() {
     const UNINIT: ::std::mem::MaybeUninit<cmdline_token_hdr> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < cmdline_token_hdr > (), 16usize, concat!("Size of: ",
-        stringify!(cmdline_token_hdr))
+        ::std::mem::size_of::<cmdline_token_hdr>(),
+        16usize,
+        concat!("Size of: ", stringify!(cmdline_token_hdr)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < cmdline_token_hdr > (), 8usize, concat!("Alignment of ",
-        stringify!(cmdline_token_hdr))
+        ::std::mem::align_of::<cmdline_token_hdr>(),
+        8usize,
+        concat!("Alignment of ", stringify!(cmdline_token_hdr)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).ops) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(cmdline_token_hdr), "::",
-        stringify!(ops))
+        unsafe { ::std::ptr::addr_of!((*ptr).ops) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(cmdline_token_hdr),
+            "::",
+            stringify!(ops),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).offset) as usize - ptr as usize }, 8usize,
-        concat!("Offset of field: ", stringify!(cmdline_token_hdr), "::",
-        stringify!(offset))
+        unsafe { ::std::ptr::addr_of!((*ptr).offset) as usize - ptr as usize },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(cmdline_token_hdr),
+            "::",
+            stringify!(offset),
+        ),
     );
 }
 impl Default for cmdline_token_hdr {
@@ -100,32 +112,54 @@ fn bindgen_test_layout_cmdline_token_ops() {
     const UNINIT: ::std::mem::MaybeUninit<cmdline_token_ops> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < cmdline_token_ops > (), 32usize, concat!("Size of: ",
-        stringify!(cmdline_token_ops))
+        ::std::mem::size_of::<cmdline_token_ops>(),
+        32usize,
+        concat!("Size of: ", stringify!(cmdline_token_ops)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < cmdline_token_ops > (), 8usize, concat!("Alignment of ",
-        stringify!(cmdline_token_ops))
+        ::std::mem::align_of::<cmdline_token_ops>(),
+        8usize,
+        concat!("Alignment of ", stringify!(cmdline_token_ops)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).parse) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(cmdline_token_ops), "::",
-        stringify!(parse))
+        unsafe { ::std::ptr::addr_of!((*ptr).parse) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(cmdline_token_ops),
+            "::",
+            stringify!(parse),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).complete_get_nb) as usize - ptr as usize },
-        8usize, concat!("Offset of field: ", stringify!(cmdline_token_ops), "::",
-        stringify!(complete_get_nb))
+        unsafe { ::std::ptr::addr_of!((*ptr).complete_get_nb) as usize - ptr as usize },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(cmdline_token_ops),
+            "::",
+            stringify!(complete_get_nb),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).complete_get_elt) as usize - ptr as usize
-        }, 16usize, concat!("Offset of field: ", stringify!(cmdline_token_ops), "::",
-        stringify!(complete_get_elt))
+        unsafe { ::std::ptr::addr_of!((*ptr).complete_get_elt) as usize - ptr as usize },
+        16usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(cmdline_token_ops),
+            "::",
+            stringify!(complete_get_elt),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).get_help) as usize - ptr as usize },
-        24usize, concat!("Offset of field: ", stringify!(cmdline_token_ops), "::",
-        stringify!(get_help))
+        unsafe { ::std::ptr::addr_of!((*ptr).get_help) as usize - ptr as usize },
+        24usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(cmdline_token_ops),
+            "::",
+            stringify!(get_help),
+        ),
     );
 }
 #[repr(u32)]
@@ -150,17 +184,24 @@ fn bindgen_test_layout_cmdline_token_num_data() {
     const UNINIT: ::std::mem::MaybeUninit<cmdline_token_num_data> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < cmdline_token_num_data > (), 4usize, concat!("Size of: ",
-        stringify!(cmdline_token_num_data))
+        ::std::mem::size_of::<cmdline_token_num_data>(),
+        4usize,
+        concat!("Size of: ", stringify!(cmdline_token_num_data)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < cmdline_token_num_data > (), 4usize,
-        concat!("Alignment of ", stringify!(cmdline_token_num_data))
+        ::std::mem::align_of::<cmdline_token_num_data>(),
+        4usize,
+        concat!("Alignment of ", stringify!(cmdline_token_num_data)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).type_) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(cmdline_token_num_data), "::",
-        stringify!(type_))
+        unsafe { ::std::ptr::addr_of!((*ptr).type_) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(cmdline_token_num_data),
+            "::",
+            stringify!(type_),
+        ),
     );
 }
 impl Default for cmdline_token_num_data {
@@ -183,22 +224,34 @@ fn bindgen_test_layout_cmdline_token_num() {
     const UNINIT: ::std::mem::MaybeUninit<cmdline_token_num> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < cmdline_token_num > (), 24usize, concat!("Size of: ",
-        stringify!(cmdline_token_num))
+        ::std::mem::size_of::<cmdline_token_num>(),
+        24usize,
+        concat!("Size of: ", stringify!(cmdline_token_num)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < cmdline_token_num > (), 8usize, concat!("Alignment of ",
-        stringify!(cmdline_token_num))
+        ::std::mem::align_of::<cmdline_token_num>(),
+        8usize,
+        concat!("Alignment of ", stringify!(cmdline_token_num)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).hdr) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(cmdline_token_num), "::",
-        stringify!(hdr))
+        unsafe { ::std::ptr::addr_of!((*ptr).hdr) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(cmdline_token_num),
+            "::",
+            stringify!(hdr),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).num_data) as usize - ptr as usize },
-        16usize, concat!("Offset of field: ", stringify!(cmdline_token_num), "::",
-        stringify!(num_data))
+        unsafe { ::std::ptr::addr_of!((*ptr).num_data) as usize - ptr as usize },
+        16usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(cmdline_token_num),
+            "::",
+            stringify!(num_data),
+        ),
     );
 }
 impl Default for cmdline_token_num {

--- a/bindgen-tests/tests/expectations/tests/layout_eth_conf.rs
+++ b/bindgen-tests/tests/expectations/tests/layout_eth_conf.rs
@@ -49,7 +49,7 @@ where
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < self.storage.as_ref().len());
         debug_assert!(
-            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len()
+            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len(),
         );
         let mut val = 0;
         for i in 0..(bit_width as usize) {
@@ -69,7 +69,7 @@ where
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < self.storage.as_ref().len());
         debug_assert!(
-            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len()
+            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len(),
         );
         for i in 0..(bit_width as usize) {
             let mask = 1 << i;
@@ -155,27 +155,44 @@ fn bindgen_test_layout_rte_eth_rxmode() {
     const UNINIT: ::std::mem::MaybeUninit<rte_eth_rxmode> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < rte_eth_rxmode > (), 12usize, concat!("Size of: ",
-        stringify!(rte_eth_rxmode))
+        ::std::mem::size_of::<rte_eth_rxmode>(),
+        12usize,
+        concat!("Size of: ", stringify!(rte_eth_rxmode)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < rte_eth_rxmode > (), 4usize, concat!("Alignment of ",
-        stringify!(rte_eth_rxmode))
+        ::std::mem::align_of::<rte_eth_rxmode>(),
+        4usize,
+        concat!("Alignment of ", stringify!(rte_eth_rxmode)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).mq_mode) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(rte_eth_rxmode), "::",
-        stringify!(mq_mode))
+        unsafe { ::std::ptr::addr_of!((*ptr).mq_mode) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_rxmode),
+            "::",
+            stringify!(mq_mode),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).max_rx_pkt_len) as usize - ptr as usize },
-        4usize, concat!("Offset of field: ", stringify!(rte_eth_rxmode), "::",
-        stringify!(max_rx_pkt_len))
+        unsafe { ::std::ptr::addr_of!((*ptr).max_rx_pkt_len) as usize - ptr as usize },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_rxmode),
+            "::",
+            stringify!(max_rx_pkt_len),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).split_hdr_size) as usize - ptr as usize },
-        8usize, concat!("Offset of field: ", stringify!(rte_eth_rxmode), "::",
-        stringify!(split_hdr_size))
+        unsafe { ::std::ptr::addr_of!((*ptr).split_hdr_size) as usize - ptr as usize },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_rxmode),
+            "::",
+            stringify!(split_hdr_size),
+        ),
     );
 }
 impl Default for rte_eth_rxmode {
@@ -428,21 +445,29 @@ fn bindgen_test_layout_rte_eth_txmode() {
     const UNINIT: ::std::mem::MaybeUninit<rte_eth_txmode> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < rte_eth_txmode > (), 8usize, concat!("Size of: ",
-        stringify!(rte_eth_txmode))
+        ::std::mem::size_of::<rte_eth_txmode>(),
+        8usize,
+        concat!("Size of: ", stringify!(rte_eth_txmode)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < rte_eth_txmode > (), 4usize, concat!("Alignment of ",
-        stringify!(rte_eth_txmode))
+        ::std::mem::align_of::<rte_eth_txmode>(),
+        4usize,
+        concat!("Alignment of ", stringify!(rte_eth_txmode)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).mq_mode) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(rte_eth_txmode), "::",
-        stringify!(mq_mode))
+        unsafe { ::std::ptr::addr_of!((*ptr).mq_mode) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_txmode),
+            "::",
+            stringify!(mq_mode),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).pvid) as usize - ptr as usize }, 4usize,
-        concat!("Offset of field: ", stringify!(rte_eth_txmode), "::", stringify!(pvid))
+        unsafe { ::std::ptr::addr_of!((*ptr).pvid) as usize - ptr as usize },
+        4usize,
+        concat!("Offset of field: ", stringify!(rte_eth_txmode), "::", stringify!(pvid)),
     );
 }
 impl Default for rte_eth_txmode {
@@ -561,27 +586,44 @@ fn bindgen_test_layout_rte_eth_rss_conf() {
     const UNINIT: ::std::mem::MaybeUninit<rte_eth_rss_conf> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < rte_eth_rss_conf > (), 24usize, concat!("Size of: ",
-        stringify!(rte_eth_rss_conf))
+        ::std::mem::size_of::<rte_eth_rss_conf>(),
+        24usize,
+        concat!("Size of: ", stringify!(rte_eth_rss_conf)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < rte_eth_rss_conf > (), 8usize, concat!("Alignment of ",
-        stringify!(rte_eth_rss_conf))
+        ::std::mem::align_of::<rte_eth_rss_conf>(),
+        8usize,
+        concat!("Alignment of ", stringify!(rte_eth_rss_conf)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).rss_key) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(rte_eth_rss_conf), "::",
-        stringify!(rss_key))
+        unsafe { ::std::ptr::addr_of!((*ptr).rss_key) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_rss_conf),
+            "::",
+            stringify!(rss_key),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).rss_key_len) as usize - ptr as usize },
-        8usize, concat!("Offset of field: ", stringify!(rte_eth_rss_conf), "::",
-        stringify!(rss_key_len))
+        unsafe { ::std::ptr::addr_of!((*ptr).rss_key_len) as usize - ptr as usize },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_rss_conf),
+            "::",
+            stringify!(rss_key_len),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).rss_hf) as usize - ptr as usize }, 16usize,
-        concat!("Offset of field: ", stringify!(rte_eth_rss_conf), "::",
-        stringify!(rss_hf))
+        unsafe { ::std::ptr::addr_of!((*ptr).rss_hf) as usize - ptr as usize },
+        16usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_rss_conf),
+            "::",
+            stringify!(rss_hf),
+        ),
     );
 }
 impl Default for rte_eth_rss_conf {
@@ -654,22 +696,34 @@ fn bindgen_test_layout_rte_eth_vmdq_dcb_conf__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<rte_eth_vmdq_dcb_conf__bindgen_ty_1> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < rte_eth_vmdq_dcb_conf__bindgen_ty_1 > (), 16usize,
-        concat!("Size of: ", stringify!(rte_eth_vmdq_dcb_conf__bindgen_ty_1))
+        ::std::mem::size_of::<rte_eth_vmdq_dcb_conf__bindgen_ty_1>(),
+        16usize,
+        concat!("Size of: ", stringify!(rte_eth_vmdq_dcb_conf__bindgen_ty_1)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < rte_eth_vmdq_dcb_conf__bindgen_ty_1 > (), 8usize,
-        concat!("Alignment of ", stringify!(rte_eth_vmdq_dcb_conf__bindgen_ty_1))
+        ::std::mem::align_of::<rte_eth_vmdq_dcb_conf__bindgen_ty_1>(),
+        8usize,
+        concat!("Alignment of ", stringify!(rte_eth_vmdq_dcb_conf__bindgen_ty_1)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).vlan_id) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(rte_eth_vmdq_dcb_conf__bindgen_ty_1),
-        "::", stringify!(vlan_id))
+        unsafe { ::std::ptr::addr_of!((*ptr).vlan_id) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_vmdq_dcb_conf__bindgen_ty_1),
+            "::",
+            stringify!(vlan_id),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).pools) as usize - ptr as usize }, 8usize,
-        concat!("Offset of field: ", stringify!(rte_eth_vmdq_dcb_conf__bindgen_ty_1),
-        "::", stringify!(pools))
+        unsafe { ::std::ptr::addr_of!((*ptr).pools) as usize - ptr as usize },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_vmdq_dcb_conf__bindgen_ty_1),
+            "::",
+            stringify!(pools),
+        ),
     );
 }
 #[test]
@@ -677,42 +731,76 @@ fn bindgen_test_layout_rte_eth_vmdq_dcb_conf() {
     const UNINIT: ::std::mem::MaybeUninit<rte_eth_vmdq_dcb_conf> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < rte_eth_vmdq_dcb_conf > (), 1040usize,
-        concat!("Size of: ", stringify!(rte_eth_vmdq_dcb_conf))
+        ::std::mem::size_of::<rte_eth_vmdq_dcb_conf>(),
+        1040usize,
+        concat!("Size of: ", stringify!(rte_eth_vmdq_dcb_conf)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < rte_eth_vmdq_dcb_conf > (), 8usize,
-        concat!("Alignment of ", stringify!(rte_eth_vmdq_dcb_conf))
+        ::std::mem::align_of::<rte_eth_vmdq_dcb_conf>(),
+        8usize,
+        concat!("Alignment of ", stringify!(rte_eth_vmdq_dcb_conf)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).nb_queue_pools) as usize - ptr as usize },
-        0usize, concat!("Offset of field: ", stringify!(rte_eth_vmdq_dcb_conf), "::",
-        stringify!(nb_queue_pools))
+        unsafe { ::std::ptr::addr_of!((*ptr).nb_queue_pools) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_vmdq_dcb_conf),
+            "::",
+            stringify!(nb_queue_pools),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).enable_default_pool) as usize - ptr as
-        usize }, 4usize, concat!("Offset of field: ", stringify!(rte_eth_vmdq_dcb_conf),
-        "::", stringify!(enable_default_pool))
+        unsafe {
+            ::std::ptr::addr_of!((*ptr).enable_default_pool) as usize - ptr as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_vmdq_dcb_conf),
+            "::",
+            stringify!(enable_default_pool),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).default_pool) as usize - ptr as usize },
-        5usize, concat!("Offset of field: ", stringify!(rte_eth_vmdq_dcb_conf), "::",
-        stringify!(default_pool))
+        unsafe { ::std::ptr::addr_of!((*ptr).default_pool) as usize - ptr as usize },
+        5usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_vmdq_dcb_conf),
+            "::",
+            stringify!(default_pool),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).nb_pool_maps) as usize - ptr as usize },
-        6usize, concat!("Offset of field: ", stringify!(rte_eth_vmdq_dcb_conf), "::",
-        stringify!(nb_pool_maps))
+        unsafe { ::std::ptr::addr_of!((*ptr).nb_pool_maps) as usize - ptr as usize },
+        6usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_vmdq_dcb_conf),
+            "::",
+            stringify!(nb_pool_maps),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).pool_map) as usize - ptr as usize },
-        8usize, concat!("Offset of field: ", stringify!(rte_eth_vmdq_dcb_conf), "::",
-        stringify!(pool_map))
+        unsafe { ::std::ptr::addr_of!((*ptr).pool_map) as usize - ptr as usize },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_vmdq_dcb_conf),
+            "::",
+            stringify!(pool_map),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).dcb_tc) as usize - ptr as usize },
-        1032usize, concat!("Offset of field: ", stringify!(rte_eth_vmdq_dcb_conf), "::",
-        stringify!(dcb_tc))
+        unsafe { ::std::ptr::addr_of!((*ptr).dcb_tc) as usize - ptr as usize },
+        1032usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_vmdq_dcb_conf),
+            "::",
+            stringify!(dcb_tc),
+        ),
     );
 }
 impl Default for rte_eth_vmdq_dcb_conf {
@@ -737,22 +825,34 @@ fn bindgen_test_layout_rte_eth_dcb_rx_conf() {
     const UNINIT: ::std::mem::MaybeUninit<rte_eth_dcb_rx_conf> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < rte_eth_dcb_rx_conf > (), 12usize, concat!("Size of: ",
-        stringify!(rte_eth_dcb_rx_conf))
+        ::std::mem::size_of::<rte_eth_dcb_rx_conf>(),
+        12usize,
+        concat!("Size of: ", stringify!(rte_eth_dcb_rx_conf)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < rte_eth_dcb_rx_conf > (), 4usize,
-        concat!("Alignment of ", stringify!(rte_eth_dcb_rx_conf))
+        ::std::mem::align_of::<rte_eth_dcb_rx_conf>(),
+        4usize,
+        concat!("Alignment of ", stringify!(rte_eth_dcb_rx_conf)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).nb_tcs) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(rte_eth_dcb_rx_conf), "::",
-        stringify!(nb_tcs))
+        unsafe { ::std::ptr::addr_of!((*ptr).nb_tcs) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_dcb_rx_conf),
+            "::",
+            stringify!(nb_tcs),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).dcb_tc) as usize - ptr as usize }, 4usize,
-        concat!("Offset of field: ", stringify!(rte_eth_dcb_rx_conf), "::",
-        stringify!(dcb_tc))
+        unsafe { ::std::ptr::addr_of!((*ptr).dcb_tc) as usize - ptr as usize },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_dcb_rx_conf),
+            "::",
+            stringify!(dcb_tc),
+        ),
     );
 }
 impl Default for rte_eth_dcb_rx_conf {
@@ -777,22 +877,34 @@ fn bindgen_test_layout_rte_eth_vmdq_dcb_tx_conf() {
     const UNINIT: ::std::mem::MaybeUninit<rte_eth_vmdq_dcb_tx_conf> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < rte_eth_vmdq_dcb_tx_conf > (), 12usize,
-        concat!("Size of: ", stringify!(rte_eth_vmdq_dcb_tx_conf))
+        ::std::mem::size_of::<rte_eth_vmdq_dcb_tx_conf>(),
+        12usize,
+        concat!("Size of: ", stringify!(rte_eth_vmdq_dcb_tx_conf)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < rte_eth_vmdq_dcb_tx_conf > (), 4usize,
-        concat!("Alignment of ", stringify!(rte_eth_vmdq_dcb_tx_conf))
+        ::std::mem::align_of::<rte_eth_vmdq_dcb_tx_conf>(),
+        4usize,
+        concat!("Alignment of ", stringify!(rte_eth_vmdq_dcb_tx_conf)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).nb_queue_pools) as usize - ptr as usize },
-        0usize, concat!("Offset of field: ", stringify!(rte_eth_vmdq_dcb_tx_conf), "::",
-        stringify!(nb_queue_pools))
+        unsafe { ::std::ptr::addr_of!((*ptr).nb_queue_pools) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_vmdq_dcb_tx_conf),
+            "::",
+            stringify!(nb_queue_pools),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).dcb_tc) as usize - ptr as usize }, 4usize,
-        concat!("Offset of field: ", stringify!(rte_eth_vmdq_dcb_tx_conf), "::",
-        stringify!(dcb_tc))
+        unsafe { ::std::ptr::addr_of!((*ptr).dcb_tc) as usize - ptr as usize },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_vmdq_dcb_tx_conf),
+            "::",
+            stringify!(dcb_tc),
+        ),
     );
 }
 impl Default for rte_eth_vmdq_dcb_tx_conf {
@@ -817,22 +929,34 @@ fn bindgen_test_layout_rte_eth_dcb_tx_conf() {
     const UNINIT: ::std::mem::MaybeUninit<rte_eth_dcb_tx_conf> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < rte_eth_dcb_tx_conf > (), 12usize, concat!("Size of: ",
-        stringify!(rte_eth_dcb_tx_conf))
+        ::std::mem::size_of::<rte_eth_dcb_tx_conf>(),
+        12usize,
+        concat!("Size of: ", stringify!(rte_eth_dcb_tx_conf)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < rte_eth_dcb_tx_conf > (), 4usize,
-        concat!("Alignment of ", stringify!(rte_eth_dcb_tx_conf))
+        ::std::mem::align_of::<rte_eth_dcb_tx_conf>(),
+        4usize,
+        concat!("Alignment of ", stringify!(rte_eth_dcb_tx_conf)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).nb_tcs) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(rte_eth_dcb_tx_conf), "::",
-        stringify!(nb_tcs))
+        unsafe { ::std::ptr::addr_of!((*ptr).nb_tcs) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_dcb_tx_conf),
+            "::",
+            stringify!(nb_tcs),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).dcb_tc) as usize - ptr as usize }, 4usize,
-        concat!("Offset of field: ", stringify!(rte_eth_dcb_tx_conf), "::",
-        stringify!(dcb_tc))
+        unsafe { ::std::ptr::addr_of!((*ptr).dcb_tc) as usize - ptr as usize },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_dcb_tx_conf),
+            "::",
+            stringify!(dcb_tc),
+        ),
     );
 }
 impl Default for rte_eth_dcb_tx_conf {
@@ -855,17 +979,24 @@ fn bindgen_test_layout_rte_eth_vmdq_tx_conf() {
     const UNINIT: ::std::mem::MaybeUninit<rte_eth_vmdq_tx_conf> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < rte_eth_vmdq_tx_conf > (), 4usize, concat!("Size of: ",
-        stringify!(rte_eth_vmdq_tx_conf))
+        ::std::mem::size_of::<rte_eth_vmdq_tx_conf>(),
+        4usize,
+        concat!("Size of: ", stringify!(rte_eth_vmdq_tx_conf)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < rte_eth_vmdq_tx_conf > (), 4usize,
-        concat!("Alignment of ", stringify!(rte_eth_vmdq_tx_conf))
+        ::std::mem::align_of::<rte_eth_vmdq_tx_conf>(),
+        4usize,
+        concat!("Alignment of ", stringify!(rte_eth_vmdq_tx_conf)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).nb_queue_pools) as usize - ptr as usize },
-        0usize, concat!("Offset of field: ", stringify!(rte_eth_vmdq_tx_conf), "::",
-        stringify!(nb_queue_pools))
+        unsafe { ::std::ptr::addr_of!((*ptr).nb_queue_pools) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_vmdq_tx_conf),
+            "::",
+            stringify!(nb_queue_pools),
+        ),
     );
 }
 impl Default for rte_eth_vmdq_tx_conf {
@@ -908,22 +1039,34 @@ fn bindgen_test_layout_rte_eth_vmdq_rx_conf__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<rte_eth_vmdq_rx_conf__bindgen_ty_1> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < rte_eth_vmdq_rx_conf__bindgen_ty_1 > (), 16usize,
-        concat!("Size of: ", stringify!(rte_eth_vmdq_rx_conf__bindgen_ty_1))
+        ::std::mem::size_of::<rte_eth_vmdq_rx_conf__bindgen_ty_1>(),
+        16usize,
+        concat!("Size of: ", stringify!(rte_eth_vmdq_rx_conf__bindgen_ty_1)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < rte_eth_vmdq_rx_conf__bindgen_ty_1 > (), 8usize,
-        concat!("Alignment of ", stringify!(rte_eth_vmdq_rx_conf__bindgen_ty_1))
+        ::std::mem::align_of::<rte_eth_vmdq_rx_conf__bindgen_ty_1>(),
+        8usize,
+        concat!("Alignment of ", stringify!(rte_eth_vmdq_rx_conf__bindgen_ty_1)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).vlan_id) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(rte_eth_vmdq_rx_conf__bindgen_ty_1),
-        "::", stringify!(vlan_id))
+        unsafe { ::std::ptr::addr_of!((*ptr).vlan_id) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_vmdq_rx_conf__bindgen_ty_1),
+            "::",
+            stringify!(vlan_id),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).pools) as usize - ptr as usize }, 8usize,
-        concat!("Offset of field: ", stringify!(rte_eth_vmdq_rx_conf__bindgen_ty_1),
-        "::", stringify!(pools))
+        unsafe { ::std::ptr::addr_of!((*ptr).pools) as usize - ptr as usize },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_vmdq_rx_conf__bindgen_ty_1),
+            "::",
+            stringify!(pools),
+        ),
     );
 }
 #[test]
@@ -931,47 +1074,86 @@ fn bindgen_test_layout_rte_eth_vmdq_rx_conf() {
     const UNINIT: ::std::mem::MaybeUninit<rte_eth_vmdq_rx_conf> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < rte_eth_vmdq_rx_conf > (), 1040usize,
-        concat!("Size of: ", stringify!(rte_eth_vmdq_rx_conf))
+        ::std::mem::size_of::<rte_eth_vmdq_rx_conf>(),
+        1040usize,
+        concat!("Size of: ", stringify!(rte_eth_vmdq_rx_conf)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < rte_eth_vmdq_rx_conf > (), 8usize,
-        concat!("Alignment of ", stringify!(rte_eth_vmdq_rx_conf))
+        ::std::mem::align_of::<rte_eth_vmdq_rx_conf>(),
+        8usize,
+        concat!("Alignment of ", stringify!(rte_eth_vmdq_rx_conf)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).nb_queue_pools) as usize - ptr as usize },
-        0usize, concat!("Offset of field: ", stringify!(rte_eth_vmdq_rx_conf), "::",
-        stringify!(nb_queue_pools))
+        unsafe { ::std::ptr::addr_of!((*ptr).nb_queue_pools) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_vmdq_rx_conf),
+            "::",
+            stringify!(nb_queue_pools),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).enable_default_pool) as usize - ptr as
-        usize }, 4usize, concat!("Offset of field: ", stringify!(rte_eth_vmdq_rx_conf),
-        "::", stringify!(enable_default_pool))
+        unsafe {
+            ::std::ptr::addr_of!((*ptr).enable_default_pool) as usize - ptr as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_vmdq_rx_conf),
+            "::",
+            stringify!(enable_default_pool),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).default_pool) as usize - ptr as usize },
-        5usize, concat!("Offset of field: ", stringify!(rte_eth_vmdq_rx_conf), "::",
-        stringify!(default_pool))
+        unsafe { ::std::ptr::addr_of!((*ptr).default_pool) as usize - ptr as usize },
+        5usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_vmdq_rx_conf),
+            "::",
+            stringify!(default_pool),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).enable_loop_back) as usize - ptr as usize
-        }, 6usize, concat!("Offset of field: ", stringify!(rte_eth_vmdq_rx_conf), "::",
-        stringify!(enable_loop_back))
+        unsafe { ::std::ptr::addr_of!((*ptr).enable_loop_back) as usize - ptr as usize },
+        6usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_vmdq_rx_conf),
+            "::",
+            stringify!(enable_loop_back),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).nb_pool_maps) as usize - ptr as usize },
-        7usize, concat!("Offset of field: ", stringify!(rte_eth_vmdq_rx_conf), "::",
-        stringify!(nb_pool_maps))
+        unsafe { ::std::ptr::addr_of!((*ptr).nb_pool_maps) as usize - ptr as usize },
+        7usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_vmdq_rx_conf),
+            "::",
+            stringify!(nb_pool_maps),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).rx_mode) as usize - ptr as usize }, 8usize,
-        concat!("Offset of field: ", stringify!(rte_eth_vmdq_rx_conf), "::",
-        stringify!(rx_mode))
+        unsafe { ::std::ptr::addr_of!((*ptr).rx_mode) as usize - ptr as usize },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_vmdq_rx_conf),
+            "::",
+            stringify!(rx_mode),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).pool_map) as usize - ptr as usize },
-        16usize, concat!("Offset of field: ", stringify!(rte_eth_vmdq_rx_conf), "::",
-        stringify!(pool_map))
+        unsafe { ::std::ptr::addr_of!((*ptr).pool_map) as usize - ptr as usize },
+        16usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_vmdq_rx_conf),
+            "::",
+            stringify!(pool_map),
+        ),
     );
 }
 impl Default for rte_eth_vmdq_rx_conf {
@@ -1041,37 +1223,64 @@ fn bindgen_test_layout_rte_eth_ipv4_flow() {
     const UNINIT: ::std::mem::MaybeUninit<rte_eth_ipv4_flow> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < rte_eth_ipv4_flow > (), 12usize, concat!("Size of: ",
-        stringify!(rte_eth_ipv4_flow))
+        ::std::mem::size_of::<rte_eth_ipv4_flow>(),
+        12usize,
+        concat!("Size of: ", stringify!(rte_eth_ipv4_flow)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < rte_eth_ipv4_flow > (), 4usize, concat!("Alignment of ",
-        stringify!(rte_eth_ipv4_flow))
+        ::std::mem::align_of::<rte_eth_ipv4_flow>(),
+        4usize,
+        concat!("Alignment of ", stringify!(rte_eth_ipv4_flow)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).src_ip) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(rte_eth_ipv4_flow), "::",
-        stringify!(src_ip))
+        unsafe { ::std::ptr::addr_of!((*ptr).src_ip) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_ipv4_flow),
+            "::",
+            stringify!(src_ip),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).dst_ip) as usize - ptr as usize }, 4usize,
-        concat!("Offset of field: ", stringify!(rte_eth_ipv4_flow), "::",
-        stringify!(dst_ip))
+        unsafe { ::std::ptr::addr_of!((*ptr).dst_ip) as usize - ptr as usize },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_ipv4_flow),
+            "::",
+            stringify!(dst_ip),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).tos) as usize - ptr as usize }, 8usize,
-        concat!("Offset of field: ", stringify!(rte_eth_ipv4_flow), "::",
-        stringify!(tos))
+        unsafe { ::std::ptr::addr_of!((*ptr).tos) as usize - ptr as usize },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_ipv4_flow),
+            "::",
+            stringify!(tos),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).ttl) as usize - ptr as usize }, 9usize,
-        concat!("Offset of field: ", stringify!(rte_eth_ipv4_flow), "::",
-        stringify!(ttl))
+        unsafe { ::std::ptr::addr_of!((*ptr).ttl) as usize - ptr as usize },
+        9usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_ipv4_flow),
+            "::",
+            stringify!(ttl),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).proto) as usize - ptr as usize }, 10usize,
-        concat!("Offset of field: ", stringify!(rte_eth_ipv4_flow), "::",
-        stringify!(proto))
+        unsafe { ::std::ptr::addr_of!((*ptr).proto) as usize - ptr as usize },
+        10usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_ipv4_flow),
+            "::",
+            stringify!(proto),
+        ),
     );
 }
 /// A structure used to define the input for IPV6 flow
@@ -1094,36 +1303,59 @@ fn bindgen_test_layout_rte_eth_ipv6_flow() {
     const UNINIT: ::std::mem::MaybeUninit<rte_eth_ipv6_flow> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < rte_eth_ipv6_flow > (), 36usize, concat!("Size of: ",
-        stringify!(rte_eth_ipv6_flow))
+        ::std::mem::size_of::<rte_eth_ipv6_flow>(),
+        36usize,
+        concat!("Size of: ", stringify!(rte_eth_ipv6_flow)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < rte_eth_ipv6_flow > (), 4usize, concat!("Alignment of ",
-        stringify!(rte_eth_ipv6_flow))
+        ::std::mem::align_of::<rte_eth_ipv6_flow>(),
+        4usize,
+        concat!("Alignment of ", stringify!(rte_eth_ipv6_flow)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).src_ip) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(rte_eth_ipv6_flow), "::",
-        stringify!(src_ip))
+        unsafe { ::std::ptr::addr_of!((*ptr).src_ip) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_ipv6_flow),
+            "::",
+            stringify!(src_ip),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).dst_ip) as usize - ptr as usize }, 16usize,
-        concat!("Offset of field: ", stringify!(rte_eth_ipv6_flow), "::",
-        stringify!(dst_ip))
+        unsafe { ::std::ptr::addr_of!((*ptr).dst_ip) as usize - ptr as usize },
+        16usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_ipv6_flow),
+            "::",
+            stringify!(dst_ip),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).tc) as usize - ptr as usize }, 32usize,
-        concat!("Offset of field: ", stringify!(rte_eth_ipv6_flow), "::", stringify!(tc))
+        unsafe { ::std::ptr::addr_of!((*ptr).tc) as usize - ptr as usize },
+        32usize,
+        concat!("Offset of field: ", stringify!(rte_eth_ipv6_flow), "::", stringify!(tc)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).proto) as usize - ptr as usize }, 33usize,
-        concat!("Offset of field: ", stringify!(rte_eth_ipv6_flow), "::",
-        stringify!(proto))
+        unsafe { ::std::ptr::addr_of!((*ptr).proto) as usize - ptr as usize },
+        33usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_ipv6_flow),
+            "::",
+            stringify!(proto),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).hop_limits) as usize - ptr as usize },
-        34usize, concat!("Offset of field: ", stringify!(rte_eth_ipv6_flow), "::",
-        stringify!(hop_limits))
+        unsafe { ::std::ptr::addr_of!((*ptr).hop_limits) as usize - ptr as usize },
+        34usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_ipv6_flow),
+            "::",
+            stringify!(hop_limits),
+        ),
     );
 }
 /**  A structure used to configure FDIR masks that are used by the device
@@ -1155,52 +1387,96 @@ fn bindgen_test_layout_rte_eth_fdir_masks() {
     const UNINIT: ::std::mem::MaybeUninit<rte_eth_fdir_masks> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < rte_eth_fdir_masks > (), 68usize, concat!("Size of: ",
-        stringify!(rte_eth_fdir_masks))
+        ::std::mem::size_of::<rte_eth_fdir_masks>(),
+        68usize,
+        concat!("Size of: ", stringify!(rte_eth_fdir_masks)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < rte_eth_fdir_masks > (), 4usize,
-        concat!("Alignment of ", stringify!(rte_eth_fdir_masks))
+        ::std::mem::align_of::<rte_eth_fdir_masks>(),
+        4usize,
+        concat!("Alignment of ", stringify!(rte_eth_fdir_masks)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).vlan_tci_mask) as usize - ptr as usize },
-        0usize, concat!("Offset of field: ", stringify!(rte_eth_fdir_masks), "::",
-        stringify!(vlan_tci_mask))
+        unsafe { ::std::ptr::addr_of!((*ptr).vlan_tci_mask) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_fdir_masks),
+            "::",
+            stringify!(vlan_tci_mask),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).ipv4_mask) as usize - ptr as usize },
-        4usize, concat!("Offset of field: ", stringify!(rte_eth_fdir_masks), "::",
-        stringify!(ipv4_mask))
+        unsafe { ::std::ptr::addr_of!((*ptr).ipv4_mask) as usize - ptr as usize },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_fdir_masks),
+            "::",
+            stringify!(ipv4_mask),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).ipv6_mask) as usize - ptr as usize },
-        16usize, concat!("Offset of field: ", stringify!(rte_eth_fdir_masks), "::",
-        stringify!(ipv6_mask))
+        unsafe { ::std::ptr::addr_of!((*ptr).ipv6_mask) as usize - ptr as usize },
+        16usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_fdir_masks),
+            "::",
+            stringify!(ipv6_mask),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).src_port_mask) as usize - ptr as usize },
-        52usize, concat!("Offset of field: ", stringify!(rte_eth_fdir_masks), "::",
-        stringify!(src_port_mask))
+        unsafe { ::std::ptr::addr_of!((*ptr).src_port_mask) as usize - ptr as usize },
+        52usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_fdir_masks),
+            "::",
+            stringify!(src_port_mask),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).dst_port_mask) as usize - ptr as usize },
-        54usize, concat!("Offset of field: ", stringify!(rte_eth_fdir_masks), "::",
-        stringify!(dst_port_mask))
+        unsafe { ::std::ptr::addr_of!((*ptr).dst_port_mask) as usize - ptr as usize },
+        54usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_fdir_masks),
+            "::",
+            stringify!(dst_port_mask),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).mac_addr_byte_mask) as usize - ptr as usize
-        }, 56usize, concat!("Offset of field: ", stringify!(rte_eth_fdir_masks), "::",
-        stringify!(mac_addr_byte_mask))
+        unsafe {
+            ::std::ptr::addr_of!((*ptr).mac_addr_byte_mask) as usize - ptr as usize
+        },
+        56usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_fdir_masks),
+            "::",
+            stringify!(mac_addr_byte_mask),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).tunnel_id_mask) as usize - ptr as usize },
-        60usize, concat!("Offset of field: ", stringify!(rte_eth_fdir_masks), "::",
-        stringify!(tunnel_id_mask))
+        unsafe { ::std::ptr::addr_of!((*ptr).tunnel_id_mask) as usize - ptr as usize },
+        60usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_fdir_masks),
+            "::",
+            stringify!(tunnel_id_mask),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).tunnel_type_mask) as usize - ptr as usize
-        }, 64usize, concat!("Offset of field: ", stringify!(rte_eth_fdir_masks), "::",
-        stringify!(tunnel_type_mask))
+        unsafe { ::std::ptr::addr_of!((*ptr).tunnel_type_mask) as usize - ptr as usize },
+        64usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_fdir_masks),
+            "::",
+            stringify!(tunnel_type_mask),
+        ),
     );
 }
 #[repr(u32)]
@@ -1228,22 +1504,34 @@ fn bindgen_test_layout_rte_eth_flex_payload_cfg() {
     const UNINIT: ::std::mem::MaybeUninit<rte_eth_flex_payload_cfg> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < rte_eth_flex_payload_cfg > (), 36usize,
-        concat!("Size of: ", stringify!(rte_eth_flex_payload_cfg))
+        ::std::mem::size_of::<rte_eth_flex_payload_cfg>(),
+        36usize,
+        concat!("Size of: ", stringify!(rte_eth_flex_payload_cfg)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < rte_eth_flex_payload_cfg > (), 4usize,
-        concat!("Alignment of ", stringify!(rte_eth_flex_payload_cfg))
+        ::std::mem::align_of::<rte_eth_flex_payload_cfg>(),
+        4usize,
+        concat!("Alignment of ", stringify!(rte_eth_flex_payload_cfg)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).type_) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(rte_eth_flex_payload_cfg), "::",
-        stringify!(type_))
+        unsafe { ::std::ptr::addr_of!((*ptr).type_) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_flex_payload_cfg),
+            "::",
+            stringify!(type_),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).src_offset) as usize - ptr as usize },
-        4usize, concat!("Offset of field: ", stringify!(rte_eth_flex_payload_cfg), "::",
-        stringify!(src_offset))
+        unsafe { ::std::ptr::addr_of!((*ptr).src_offset) as usize - ptr as usize },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_flex_payload_cfg),
+            "::",
+            stringify!(src_offset),
+        ),
     );
 }
 impl Default for rte_eth_flex_payload_cfg {
@@ -1268,22 +1556,34 @@ fn bindgen_test_layout_rte_eth_fdir_flex_mask() {
     const UNINIT: ::std::mem::MaybeUninit<rte_eth_fdir_flex_mask> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < rte_eth_fdir_flex_mask > (), 18usize,
-        concat!("Size of: ", stringify!(rte_eth_fdir_flex_mask))
+        ::std::mem::size_of::<rte_eth_fdir_flex_mask>(),
+        18usize,
+        concat!("Size of: ", stringify!(rte_eth_fdir_flex_mask)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < rte_eth_fdir_flex_mask > (), 2usize,
-        concat!("Alignment of ", stringify!(rte_eth_fdir_flex_mask))
+        ::std::mem::align_of::<rte_eth_fdir_flex_mask>(),
+        2usize,
+        concat!("Alignment of ", stringify!(rte_eth_fdir_flex_mask)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).flow_type) as usize - ptr as usize },
-        0usize, concat!("Offset of field: ", stringify!(rte_eth_fdir_flex_mask), "::",
-        stringify!(flow_type))
+        unsafe { ::std::ptr::addr_of!((*ptr).flow_type) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_fdir_flex_mask),
+            "::",
+            stringify!(flow_type),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).mask) as usize - ptr as usize }, 2usize,
-        concat!("Offset of field: ", stringify!(rte_eth_fdir_flex_mask), "::",
-        stringify!(mask))
+        unsafe { ::std::ptr::addr_of!((*ptr).mask) as usize - ptr as usize },
+        2usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_fdir_flex_mask),
+            "::",
+            stringify!(mask),
+        ),
     );
 }
 /** A structure used to define all flexible payload related setting
@@ -1303,32 +1603,54 @@ fn bindgen_test_layout_rte_eth_fdir_flex_conf() {
     const UNINIT: ::std::mem::MaybeUninit<rte_eth_fdir_flex_conf> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < rte_eth_fdir_flex_conf > (), 688usize,
-        concat!("Size of: ", stringify!(rte_eth_fdir_flex_conf))
+        ::std::mem::size_of::<rte_eth_fdir_flex_conf>(),
+        688usize,
+        concat!("Size of: ", stringify!(rte_eth_fdir_flex_conf)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < rte_eth_fdir_flex_conf > (), 4usize,
-        concat!("Alignment of ", stringify!(rte_eth_fdir_flex_conf))
+        ::std::mem::align_of::<rte_eth_fdir_flex_conf>(),
+        4usize,
+        concat!("Alignment of ", stringify!(rte_eth_fdir_flex_conf)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).nb_payloads) as usize - ptr as usize },
-        0usize, concat!("Offset of field: ", stringify!(rte_eth_fdir_flex_conf), "::",
-        stringify!(nb_payloads))
+        unsafe { ::std::ptr::addr_of!((*ptr).nb_payloads) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_fdir_flex_conf),
+            "::",
+            stringify!(nb_payloads),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).nb_flexmasks) as usize - ptr as usize },
-        2usize, concat!("Offset of field: ", stringify!(rte_eth_fdir_flex_conf), "::",
-        stringify!(nb_flexmasks))
+        unsafe { ::std::ptr::addr_of!((*ptr).nb_flexmasks) as usize - ptr as usize },
+        2usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_fdir_flex_conf),
+            "::",
+            stringify!(nb_flexmasks),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).flex_set) as usize - ptr as usize },
-        4usize, concat!("Offset of field: ", stringify!(rte_eth_fdir_flex_conf), "::",
-        stringify!(flex_set))
+        unsafe { ::std::ptr::addr_of!((*ptr).flex_set) as usize - ptr as usize },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_fdir_flex_conf),
+            "::",
+            stringify!(flex_set),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).flex_mask) as usize - ptr as usize },
-        292usize, concat!("Offset of field: ", stringify!(rte_eth_fdir_flex_conf), "::",
-        stringify!(flex_mask))
+        unsafe { ::std::ptr::addr_of!((*ptr).flex_mask) as usize - ptr as usize },
+        292usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_fdir_flex_conf),
+            "::",
+            stringify!(flex_mask),
+        ),
     );
 }
 impl Default for rte_eth_fdir_flex_conf {
@@ -1363,39 +1685,59 @@ fn bindgen_test_layout_rte_fdir_conf() {
     const UNINIT: ::std::mem::MaybeUninit<rte_fdir_conf> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < rte_fdir_conf > (), 772usize, concat!("Size of: ",
-        stringify!(rte_fdir_conf))
+        ::std::mem::size_of::<rte_fdir_conf>(),
+        772usize,
+        concat!("Size of: ", stringify!(rte_fdir_conf)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < rte_fdir_conf > (), 4usize, concat!("Alignment of ",
-        stringify!(rte_fdir_conf))
+        ::std::mem::align_of::<rte_fdir_conf>(),
+        4usize,
+        concat!("Alignment of ", stringify!(rte_fdir_conf)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).mode) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(rte_fdir_conf), "::", stringify!(mode))
+        unsafe { ::std::ptr::addr_of!((*ptr).mode) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(rte_fdir_conf), "::", stringify!(mode)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).pballoc) as usize - ptr as usize }, 4usize,
-        concat!("Offset of field: ", stringify!(rte_fdir_conf), "::",
-        stringify!(pballoc))
+        unsafe { ::std::ptr::addr_of!((*ptr).pballoc) as usize - ptr as usize },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_fdir_conf),
+            "::",
+            stringify!(pballoc),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).status) as usize - ptr as usize }, 8usize,
-        concat!("Offset of field: ", stringify!(rte_fdir_conf), "::", stringify!(status))
+        unsafe { ::std::ptr::addr_of!((*ptr).status) as usize - ptr as usize },
+        8usize,
+        concat!("Offset of field: ", stringify!(rte_fdir_conf), "::", stringify!(status)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).drop_queue) as usize - ptr as usize },
-        12usize, concat!("Offset of field: ", stringify!(rte_fdir_conf), "::",
-        stringify!(drop_queue))
+        unsafe { ::std::ptr::addr_of!((*ptr).drop_queue) as usize - ptr as usize },
+        12usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_fdir_conf),
+            "::",
+            stringify!(drop_queue),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).mask) as usize - ptr as usize }, 16usize,
-        concat!("Offset of field: ", stringify!(rte_fdir_conf), "::", stringify!(mask))
+        unsafe { ::std::ptr::addr_of!((*ptr).mask) as usize - ptr as usize },
+        16usize,
+        concat!("Offset of field: ", stringify!(rte_fdir_conf), "::", stringify!(mask)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).flex_conf) as usize - ptr as usize },
-        84usize, concat!("Offset of field: ", stringify!(rte_fdir_conf), "::",
-        stringify!(flex_conf))
+        unsafe { ::std::ptr::addr_of!((*ptr).flex_conf) as usize - ptr as usize },
+        84usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_fdir_conf),
+            "::",
+            stringify!(flex_conf),
+        ),
     );
 }
 impl Default for rte_fdir_conf {
@@ -1421,20 +1763,24 @@ fn bindgen_test_layout_rte_intr_conf() {
     const UNINIT: ::std::mem::MaybeUninit<rte_intr_conf> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < rte_intr_conf > (), 4usize, concat!("Size of: ",
-        stringify!(rte_intr_conf))
+        ::std::mem::size_of::<rte_intr_conf>(),
+        4usize,
+        concat!("Size of: ", stringify!(rte_intr_conf)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < rte_intr_conf > (), 2usize, concat!("Alignment of ",
-        stringify!(rte_intr_conf))
+        ::std::mem::align_of::<rte_intr_conf>(),
+        2usize,
+        concat!("Alignment of ", stringify!(rte_intr_conf)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).lsc) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(rte_intr_conf), "::", stringify!(lsc))
+        unsafe { ::std::ptr::addr_of!((*ptr).lsc) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(rte_intr_conf), "::", stringify!(lsc)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).rxq) as usize - ptr as usize }, 2usize,
-        concat!("Offset of field: ", stringify!(rte_intr_conf), "::", stringify!(rxq))
+        unsafe { ::std::ptr::addr_of!((*ptr).rxq) as usize - ptr as usize },
+        2usize,
+        concat!("Offset of field: ", stringify!(rte_intr_conf), "::", stringify!(rxq)),
     );
 }
 /** A structure used to configure an Ethernet port.
@@ -1487,32 +1833,54 @@ fn bindgen_test_layout_rte_eth_conf__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<rte_eth_conf__bindgen_ty_1> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < rte_eth_conf__bindgen_ty_1 > (), 2120usize,
-        concat!("Size of: ", stringify!(rte_eth_conf__bindgen_ty_1))
+        ::std::mem::size_of::<rte_eth_conf__bindgen_ty_1>(),
+        2120usize,
+        concat!("Size of: ", stringify!(rte_eth_conf__bindgen_ty_1)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < rte_eth_conf__bindgen_ty_1 > (), 8usize,
-        concat!("Alignment of ", stringify!(rte_eth_conf__bindgen_ty_1))
+        ::std::mem::align_of::<rte_eth_conf__bindgen_ty_1>(),
+        8usize,
+        concat!("Alignment of ", stringify!(rte_eth_conf__bindgen_ty_1)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).rss_conf) as usize - ptr as usize },
-        0usize, concat!("Offset of field: ", stringify!(rte_eth_conf__bindgen_ty_1),
-        "::", stringify!(rss_conf))
+        unsafe { ::std::ptr::addr_of!((*ptr).rss_conf) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_conf__bindgen_ty_1),
+            "::",
+            stringify!(rss_conf),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).vmdq_dcb_conf) as usize - ptr as usize },
-        24usize, concat!("Offset of field: ", stringify!(rte_eth_conf__bindgen_ty_1),
-        "::", stringify!(vmdq_dcb_conf))
+        unsafe { ::std::ptr::addr_of!((*ptr).vmdq_dcb_conf) as usize - ptr as usize },
+        24usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_conf__bindgen_ty_1),
+            "::",
+            stringify!(vmdq_dcb_conf),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).dcb_rx_conf) as usize - ptr as usize },
-        1064usize, concat!("Offset of field: ", stringify!(rte_eth_conf__bindgen_ty_1),
-        "::", stringify!(dcb_rx_conf))
+        unsafe { ::std::ptr::addr_of!((*ptr).dcb_rx_conf) as usize - ptr as usize },
+        1064usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_conf__bindgen_ty_1),
+            "::",
+            stringify!(dcb_rx_conf),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).vmdq_rx_conf) as usize - ptr as usize },
-        1080usize, concat!("Offset of field: ", stringify!(rte_eth_conf__bindgen_ty_1),
-        "::", stringify!(vmdq_rx_conf))
+        unsafe { ::std::ptr::addr_of!((*ptr).vmdq_rx_conf) as usize - ptr as usize },
+        1080usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_conf__bindgen_ty_1),
+            "::",
+            stringify!(vmdq_rx_conf),
+        ),
     );
 }
 impl Default for rte_eth_conf__bindgen_ty_1 {
@@ -1536,27 +1904,44 @@ fn bindgen_test_layout_rte_eth_conf__bindgen_ty_2() {
     const UNINIT: ::std::mem::MaybeUninit<rte_eth_conf__bindgen_ty_2> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < rte_eth_conf__bindgen_ty_2 > (), 12usize,
-        concat!("Size of: ", stringify!(rte_eth_conf__bindgen_ty_2))
+        ::std::mem::size_of::<rte_eth_conf__bindgen_ty_2>(),
+        12usize,
+        concat!("Size of: ", stringify!(rte_eth_conf__bindgen_ty_2)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < rte_eth_conf__bindgen_ty_2 > (), 4usize,
-        concat!("Alignment of ", stringify!(rte_eth_conf__bindgen_ty_2))
+        ::std::mem::align_of::<rte_eth_conf__bindgen_ty_2>(),
+        4usize,
+        concat!("Alignment of ", stringify!(rte_eth_conf__bindgen_ty_2)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).vmdq_dcb_tx_conf) as usize - ptr as usize
-        }, 0usize, concat!("Offset of field: ", stringify!(rte_eth_conf__bindgen_ty_2),
-        "::", stringify!(vmdq_dcb_tx_conf))
+        unsafe { ::std::ptr::addr_of!((*ptr).vmdq_dcb_tx_conf) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_conf__bindgen_ty_2),
+            "::",
+            stringify!(vmdq_dcb_tx_conf),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).dcb_tx_conf) as usize - ptr as usize },
-        0usize, concat!("Offset of field: ", stringify!(rte_eth_conf__bindgen_ty_2),
-        "::", stringify!(dcb_tx_conf))
+        unsafe { ::std::ptr::addr_of!((*ptr).dcb_tx_conf) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_conf__bindgen_ty_2),
+            "::",
+            stringify!(dcb_tx_conf),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).vmdq_tx_conf) as usize - ptr as usize },
-        0usize, concat!("Offset of field: ", stringify!(rte_eth_conf__bindgen_ty_2),
-        "::", stringify!(vmdq_tx_conf))
+        unsafe { ::std::ptr::addr_of!((*ptr).vmdq_tx_conf) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_conf__bindgen_ty_2),
+            "::",
+            stringify!(vmdq_tx_conf),
+        ),
     );
 }
 impl Default for rte_eth_conf__bindgen_ty_2 {
@@ -1573,55 +1958,96 @@ fn bindgen_test_layout_rte_eth_conf() {
     const UNINIT: ::std::mem::MaybeUninit<rte_eth_conf> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < rte_eth_conf > (), 2944usize, concat!("Size of: ",
-        stringify!(rte_eth_conf))
+        ::std::mem::size_of::<rte_eth_conf>(),
+        2944usize,
+        concat!("Size of: ", stringify!(rte_eth_conf)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < rte_eth_conf > (), 8usize, concat!("Alignment of ",
-        stringify!(rte_eth_conf))
+        ::std::mem::align_of::<rte_eth_conf>(),
+        8usize,
+        concat!("Alignment of ", stringify!(rte_eth_conf)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).link_speeds) as usize - ptr as usize },
-        0usize, concat!("Offset of field: ", stringify!(rte_eth_conf), "::",
-        stringify!(link_speeds))
+        unsafe { ::std::ptr::addr_of!((*ptr).link_speeds) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_conf),
+            "::",
+            stringify!(link_speeds),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).rxmode) as usize - ptr as usize }, 4usize,
-        concat!("Offset of field: ", stringify!(rte_eth_conf), "::", stringify!(rxmode))
+        unsafe { ::std::ptr::addr_of!((*ptr).rxmode) as usize - ptr as usize },
+        4usize,
+        concat!("Offset of field: ", stringify!(rte_eth_conf), "::", stringify!(rxmode)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).txmode) as usize - ptr as usize }, 16usize,
-        concat!("Offset of field: ", stringify!(rte_eth_conf), "::", stringify!(txmode))
+        unsafe { ::std::ptr::addr_of!((*ptr).txmode) as usize - ptr as usize },
+        16usize,
+        concat!("Offset of field: ", stringify!(rte_eth_conf), "::", stringify!(txmode)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).lpbk_mode) as usize - ptr as usize },
-        24usize, concat!("Offset of field: ", stringify!(rte_eth_conf), "::",
-        stringify!(lpbk_mode))
+        unsafe { ::std::ptr::addr_of!((*ptr).lpbk_mode) as usize - ptr as usize },
+        24usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_conf),
+            "::",
+            stringify!(lpbk_mode),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).rx_adv_conf) as usize - ptr as usize },
-        32usize, concat!("Offset of field: ", stringify!(rte_eth_conf), "::",
-        stringify!(rx_adv_conf))
+        unsafe { ::std::ptr::addr_of!((*ptr).rx_adv_conf) as usize - ptr as usize },
+        32usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_conf),
+            "::",
+            stringify!(rx_adv_conf),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).tx_adv_conf) as usize - ptr as usize },
-        2152usize, concat!("Offset of field: ", stringify!(rte_eth_conf), "::",
-        stringify!(tx_adv_conf))
+        unsafe { ::std::ptr::addr_of!((*ptr).tx_adv_conf) as usize - ptr as usize },
+        2152usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_conf),
+            "::",
+            stringify!(tx_adv_conf),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).dcb_capability_en) as usize - ptr as usize
-        }, 2164usize, concat!("Offset of field: ", stringify!(rte_eth_conf), "::",
-        stringify!(dcb_capability_en))
+        unsafe {
+            ::std::ptr::addr_of!((*ptr).dcb_capability_en) as usize - ptr as usize
+        },
+        2164usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_conf),
+            "::",
+            stringify!(dcb_capability_en),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).fdir_conf) as usize - ptr as usize },
-        2168usize, concat!("Offset of field: ", stringify!(rte_eth_conf), "::",
-        stringify!(fdir_conf))
+        unsafe { ::std::ptr::addr_of!((*ptr).fdir_conf) as usize - ptr as usize },
+        2168usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_conf),
+            "::",
+            stringify!(fdir_conf),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).intr_conf) as usize - ptr as usize },
-        2940usize, concat!("Offset of field: ", stringify!(rte_eth_conf), "::",
-        stringify!(intr_conf))
+        unsafe { ::std::ptr::addr_of!((*ptr).intr_conf) as usize - ptr as usize },
+        2940usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_conf),
+            "::",
+            stringify!(intr_conf),
+        ),
     );
 }
 impl Default for rte_eth_conf {

--- a/bindgen-tests/tests/expectations/tests/layout_eth_conf_1_0.rs
+++ b/bindgen-tests/tests/expectations/tests/layout_eth_conf_1_0.rs
@@ -49,7 +49,7 @@ where
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < self.storage.as_ref().len());
         debug_assert!(
-            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len()
+            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len(),
         );
         let mut val = 0;
         for i in 0..(bit_width as usize) {
@@ -69,7 +69,7 @@ where
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < self.storage.as_ref().len());
         debug_assert!(
-            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len()
+            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len(),
         );
         for i in 0..(bit_width as usize) {
             let mask = 1 << i;
@@ -198,27 +198,44 @@ fn bindgen_test_layout_rte_eth_rxmode() {
     const UNINIT: ::std::mem::MaybeUninit<rte_eth_rxmode> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < rte_eth_rxmode > (), 12usize, concat!("Size of: ",
-        stringify!(rte_eth_rxmode))
+        ::std::mem::size_of::<rte_eth_rxmode>(),
+        12usize,
+        concat!("Size of: ", stringify!(rte_eth_rxmode)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < rte_eth_rxmode > (), 4usize, concat!("Alignment of ",
-        stringify!(rte_eth_rxmode))
+        ::std::mem::align_of::<rte_eth_rxmode>(),
+        4usize,
+        concat!("Alignment of ", stringify!(rte_eth_rxmode)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).mq_mode) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(rte_eth_rxmode), "::",
-        stringify!(mq_mode))
+        unsafe { ::std::ptr::addr_of!((*ptr).mq_mode) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_rxmode),
+            "::",
+            stringify!(mq_mode),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).max_rx_pkt_len) as usize - ptr as usize },
-        4usize, concat!("Offset of field: ", stringify!(rte_eth_rxmode), "::",
-        stringify!(max_rx_pkt_len))
+        unsafe { ::std::ptr::addr_of!((*ptr).max_rx_pkt_len) as usize - ptr as usize },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_rxmode),
+            "::",
+            stringify!(max_rx_pkt_len),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).split_hdr_size) as usize - ptr as usize },
-        8usize, concat!("Offset of field: ", stringify!(rte_eth_rxmode), "::",
-        stringify!(split_hdr_size))
+        unsafe { ::std::ptr::addr_of!((*ptr).split_hdr_size) as usize - ptr as usize },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_rxmode),
+            "::",
+            stringify!(split_hdr_size),
+        ),
     );
 }
 impl Clone for rte_eth_rxmode {
@@ -476,21 +493,29 @@ fn bindgen_test_layout_rte_eth_txmode() {
     const UNINIT: ::std::mem::MaybeUninit<rte_eth_txmode> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < rte_eth_txmode > (), 8usize, concat!("Size of: ",
-        stringify!(rte_eth_txmode))
+        ::std::mem::size_of::<rte_eth_txmode>(),
+        8usize,
+        concat!("Size of: ", stringify!(rte_eth_txmode)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < rte_eth_txmode > (), 4usize, concat!("Alignment of ",
-        stringify!(rte_eth_txmode))
+        ::std::mem::align_of::<rte_eth_txmode>(),
+        4usize,
+        concat!("Alignment of ", stringify!(rte_eth_txmode)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).mq_mode) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(rte_eth_txmode), "::",
-        stringify!(mq_mode))
+        unsafe { ::std::ptr::addr_of!((*ptr).mq_mode) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_txmode),
+            "::",
+            stringify!(mq_mode),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).pvid) as usize - ptr as usize }, 4usize,
-        concat!("Offset of field: ", stringify!(rte_eth_txmode), "::", stringify!(pvid))
+        unsafe { ::std::ptr::addr_of!((*ptr).pvid) as usize - ptr as usize },
+        4usize,
+        concat!("Offset of field: ", stringify!(rte_eth_txmode), "::", stringify!(pvid)),
     );
 }
 impl Clone for rte_eth_txmode {
@@ -614,27 +639,44 @@ fn bindgen_test_layout_rte_eth_rss_conf() {
     const UNINIT: ::std::mem::MaybeUninit<rte_eth_rss_conf> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < rte_eth_rss_conf > (), 24usize, concat!("Size of: ",
-        stringify!(rte_eth_rss_conf))
+        ::std::mem::size_of::<rte_eth_rss_conf>(),
+        24usize,
+        concat!("Size of: ", stringify!(rte_eth_rss_conf)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < rte_eth_rss_conf > (), 8usize, concat!("Alignment of ",
-        stringify!(rte_eth_rss_conf))
+        ::std::mem::align_of::<rte_eth_rss_conf>(),
+        8usize,
+        concat!("Alignment of ", stringify!(rte_eth_rss_conf)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).rss_key) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(rte_eth_rss_conf), "::",
-        stringify!(rss_key))
+        unsafe { ::std::ptr::addr_of!((*ptr).rss_key) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_rss_conf),
+            "::",
+            stringify!(rss_key),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).rss_key_len) as usize - ptr as usize },
-        8usize, concat!("Offset of field: ", stringify!(rte_eth_rss_conf), "::",
-        stringify!(rss_key_len))
+        unsafe { ::std::ptr::addr_of!((*ptr).rss_key_len) as usize - ptr as usize },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_rss_conf),
+            "::",
+            stringify!(rss_key_len),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).rss_hf) as usize - ptr as usize }, 16usize,
-        concat!("Offset of field: ", stringify!(rte_eth_rss_conf), "::",
-        stringify!(rss_hf))
+        unsafe { ::std::ptr::addr_of!((*ptr).rss_hf) as usize - ptr as usize },
+        16usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_rss_conf),
+            "::",
+            stringify!(rss_hf),
+        ),
     );
 }
 impl Clone for rte_eth_rss_conf {
@@ -712,22 +754,34 @@ fn bindgen_test_layout_rte_eth_vmdq_dcb_conf__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<rte_eth_vmdq_dcb_conf__bindgen_ty_1> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < rte_eth_vmdq_dcb_conf__bindgen_ty_1 > (), 16usize,
-        concat!("Size of: ", stringify!(rte_eth_vmdq_dcb_conf__bindgen_ty_1))
+        ::std::mem::size_of::<rte_eth_vmdq_dcb_conf__bindgen_ty_1>(),
+        16usize,
+        concat!("Size of: ", stringify!(rte_eth_vmdq_dcb_conf__bindgen_ty_1)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < rte_eth_vmdq_dcb_conf__bindgen_ty_1 > (), 8usize,
-        concat!("Alignment of ", stringify!(rte_eth_vmdq_dcb_conf__bindgen_ty_1))
+        ::std::mem::align_of::<rte_eth_vmdq_dcb_conf__bindgen_ty_1>(),
+        8usize,
+        concat!("Alignment of ", stringify!(rte_eth_vmdq_dcb_conf__bindgen_ty_1)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).vlan_id) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(rte_eth_vmdq_dcb_conf__bindgen_ty_1),
-        "::", stringify!(vlan_id))
+        unsafe { ::std::ptr::addr_of!((*ptr).vlan_id) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_vmdq_dcb_conf__bindgen_ty_1),
+            "::",
+            stringify!(vlan_id),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).pools) as usize - ptr as usize }, 8usize,
-        concat!("Offset of field: ", stringify!(rte_eth_vmdq_dcb_conf__bindgen_ty_1),
-        "::", stringify!(pools))
+        unsafe { ::std::ptr::addr_of!((*ptr).pools) as usize - ptr as usize },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_vmdq_dcb_conf__bindgen_ty_1),
+            "::",
+            stringify!(pools),
+        ),
     );
 }
 impl Clone for rte_eth_vmdq_dcb_conf__bindgen_ty_1 {
@@ -740,42 +794,76 @@ fn bindgen_test_layout_rte_eth_vmdq_dcb_conf() {
     const UNINIT: ::std::mem::MaybeUninit<rte_eth_vmdq_dcb_conf> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < rte_eth_vmdq_dcb_conf > (), 1040usize,
-        concat!("Size of: ", stringify!(rte_eth_vmdq_dcb_conf))
+        ::std::mem::size_of::<rte_eth_vmdq_dcb_conf>(),
+        1040usize,
+        concat!("Size of: ", stringify!(rte_eth_vmdq_dcb_conf)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < rte_eth_vmdq_dcb_conf > (), 8usize,
-        concat!("Alignment of ", stringify!(rte_eth_vmdq_dcb_conf))
+        ::std::mem::align_of::<rte_eth_vmdq_dcb_conf>(),
+        8usize,
+        concat!("Alignment of ", stringify!(rte_eth_vmdq_dcb_conf)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).nb_queue_pools) as usize - ptr as usize },
-        0usize, concat!("Offset of field: ", stringify!(rte_eth_vmdq_dcb_conf), "::",
-        stringify!(nb_queue_pools))
+        unsafe { ::std::ptr::addr_of!((*ptr).nb_queue_pools) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_vmdq_dcb_conf),
+            "::",
+            stringify!(nb_queue_pools),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).enable_default_pool) as usize - ptr as
-        usize }, 4usize, concat!("Offset of field: ", stringify!(rte_eth_vmdq_dcb_conf),
-        "::", stringify!(enable_default_pool))
+        unsafe {
+            ::std::ptr::addr_of!((*ptr).enable_default_pool) as usize - ptr as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_vmdq_dcb_conf),
+            "::",
+            stringify!(enable_default_pool),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).default_pool) as usize - ptr as usize },
-        5usize, concat!("Offset of field: ", stringify!(rte_eth_vmdq_dcb_conf), "::",
-        stringify!(default_pool))
+        unsafe { ::std::ptr::addr_of!((*ptr).default_pool) as usize - ptr as usize },
+        5usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_vmdq_dcb_conf),
+            "::",
+            stringify!(default_pool),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).nb_pool_maps) as usize - ptr as usize },
-        6usize, concat!("Offset of field: ", stringify!(rte_eth_vmdq_dcb_conf), "::",
-        stringify!(nb_pool_maps))
+        unsafe { ::std::ptr::addr_of!((*ptr).nb_pool_maps) as usize - ptr as usize },
+        6usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_vmdq_dcb_conf),
+            "::",
+            stringify!(nb_pool_maps),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).pool_map) as usize - ptr as usize },
-        8usize, concat!("Offset of field: ", stringify!(rte_eth_vmdq_dcb_conf), "::",
-        stringify!(pool_map))
+        unsafe { ::std::ptr::addr_of!((*ptr).pool_map) as usize - ptr as usize },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_vmdq_dcb_conf),
+            "::",
+            stringify!(pool_map),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).dcb_tc) as usize - ptr as usize },
-        1032usize, concat!("Offset of field: ", stringify!(rte_eth_vmdq_dcb_conf), "::",
-        stringify!(dcb_tc))
+        unsafe { ::std::ptr::addr_of!((*ptr).dcb_tc) as usize - ptr as usize },
+        1032usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_vmdq_dcb_conf),
+            "::",
+            stringify!(dcb_tc),
+        ),
     );
 }
 impl Clone for rte_eth_vmdq_dcb_conf {
@@ -805,22 +893,34 @@ fn bindgen_test_layout_rte_eth_dcb_rx_conf() {
     const UNINIT: ::std::mem::MaybeUninit<rte_eth_dcb_rx_conf> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < rte_eth_dcb_rx_conf > (), 12usize, concat!("Size of: ",
-        stringify!(rte_eth_dcb_rx_conf))
+        ::std::mem::size_of::<rte_eth_dcb_rx_conf>(),
+        12usize,
+        concat!("Size of: ", stringify!(rte_eth_dcb_rx_conf)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < rte_eth_dcb_rx_conf > (), 4usize,
-        concat!("Alignment of ", stringify!(rte_eth_dcb_rx_conf))
+        ::std::mem::align_of::<rte_eth_dcb_rx_conf>(),
+        4usize,
+        concat!("Alignment of ", stringify!(rte_eth_dcb_rx_conf)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).nb_tcs) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(rte_eth_dcb_rx_conf), "::",
-        stringify!(nb_tcs))
+        unsafe { ::std::ptr::addr_of!((*ptr).nb_tcs) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_dcb_rx_conf),
+            "::",
+            stringify!(nb_tcs),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).dcb_tc) as usize - ptr as usize }, 4usize,
-        concat!("Offset of field: ", stringify!(rte_eth_dcb_rx_conf), "::",
-        stringify!(dcb_tc))
+        unsafe { ::std::ptr::addr_of!((*ptr).dcb_tc) as usize - ptr as usize },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_dcb_rx_conf),
+            "::",
+            stringify!(dcb_tc),
+        ),
     );
 }
 impl Clone for rte_eth_dcb_rx_conf {
@@ -850,22 +950,34 @@ fn bindgen_test_layout_rte_eth_vmdq_dcb_tx_conf() {
     const UNINIT: ::std::mem::MaybeUninit<rte_eth_vmdq_dcb_tx_conf> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < rte_eth_vmdq_dcb_tx_conf > (), 12usize,
-        concat!("Size of: ", stringify!(rte_eth_vmdq_dcb_tx_conf))
+        ::std::mem::size_of::<rte_eth_vmdq_dcb_tx_conf>(),
+        12usize,
+        concat!("Size of: ", stringify!(rte_eth_vmdq_dcb_tx_conf)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < rte_eth_vmdq_dcb_tx_conf > (), 4usize,
-        concat!("Alignment of ", stringify!(rte_eth_vmdq_dcb_tx_conf))
+        ::std::mem::align_of::<rte_eth_vmdq_dcb_tx_conf>(),
+        4usize,
+        concat!("Alignment of ", stringify!(rte_eth_vmdq_dcb_tx_conf)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).nb_queue_pools) as usize - ptr as usize },
-        0usize, concat!("Offset of field: ", stringify!(rte_eth_vmdq_dcb_tx_conf), "::",
-        stringify!(nb_queue_pools))
+        unsafe { ::std::ptr::addr_of!((*ptr).nb_queue_pools) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_vmdq_dcb_tx_conf),
+            "::",
+            stringify!(nb_queue_pools),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).dcb_tc) as usize - ptr as usize }, 4usize,
-        concat!("Offset of field: ", stringify!(rte_eth_vmdq_dcb_tx_conf), "::",
-        stringify!(dcb_tc))
+        unsafe { ::std::ptr::addr_of!((*ptr).dcb_tc) as usize - ptr as usize },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_vmdq_dcb_tx_conf),
+            "::",
+            stringify!(dcb_tc),
+        ),
     );
 }
 impl Clone for rte_eth_vmdq_dcb_tx_conf {
@@ -895,22 +1007,34 @@ fn bindgen_test_layout_rte_eth_dcb_tx_conf() {
     const UNINIT: ::std::mem::MaybeUninit<rte_eth_dcb_tx_conf> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < rte_eth_dcb_tx_conf > (), 12usize, concat!("Size of: ",
-        stringify!(rte_eth_dcb_tx_conf))
+        ::std::mem::size_of::<rte_eth_dcb_tx_conf>(),
+        12usize,
+        concat!("Size of: ", stringify!(rte_eth_dcb_tx_conf)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < rte_eth_dcb_tx_conf > (), 4usize,
-        concat!("Alignment of ", stringify!(rte_eth_dcb_tx_conf))
+        ::std::mem::align_of::<rte_eth_dcb_tx_conf>(),
+        4usize,
+        concat!("Alignment of ", stringify!(rte_eth_dcb_tx_conf)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).nb_tcs) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(rte_eth_dcb_tx_conf), "::",
-        stringify!(nb_tcs))
+        unsafe { ::std::ptr::addr_of!((*ptr).nb_tcs) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_dcb_tx_conf),
+            "::",
+            stringify!(nb_tcs),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).dcb_tc) as usize - ptr as usize }, 4usize,
-        concat!("Offset of field: ", stringify!(rte_eth_dcb_tx_conf), "::",
-        stringify!(dcb_tc))
+        unsafe { ::std::ptr::addr_of!((*ptr).dcb_tc) as usize - ptr as usize },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_dcb_tx_conf),
+            "::",
+            stringify!(dcb_tc),
+        ),
     );
 }
 impl Clone for rte_eth_dcb_tx_conf {
@@ -938,17 +1062,24 @@ fn bindgen_test_layout_rte_eth_vmdq_tx_conf() {
     const UNINIT: ::std::mem::MaybeUninit<rte_eth_vmdq_tx_conf> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < rte_eth_vmdq_tx_conf > (), 4usize, concat!("Size of: ",
-        stringify!(rte_eth_vmdq_tx_conf))
+        ::std::mem::size_of::<rte_eth_vmdq_tx_conf>(),
+        4usize,
+        concat!("Size of: ", stringify!(rte_eth_vmdq_tx_conf)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < rte_eth_vmdq_tx_conf > (), 4usize,
-        concat!("Alignment of ", stringify!(rte_eth_vmdq_tx_conf))
+        ::std::mem::align_of::<rte_eth_vmdq_tx_conf>(),
+        4usize,
+        concat!("Alignment of ", stringify!(rte_eth_vmdq_tx_conf)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).nb_queue_pools) as usize - ptr as usize },
-        0usize, concat!("Offset of field: ", stringify!(rte_eth_vmdq_tx_conf), "::",
-        stringify!(nb_queue_pools))
+        unsafe { ::std::ptr::addr_of!((*ptr).nb_queue_pools) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_vmdq_tx_conf),
+            "::",
+            stringify!(nb_queue_pools),
+        ),
     );
 }
 impl Clone for rte_eth_vmdq_tx_conf {
@@ -996,22 +1127,34 @@ fn bindgen_test_layout_rte_eth_vmdq_rx_conf__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<rte_eth_vmdq_rx_conf__bindgen_ty_1> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < rte_eth_vmdq_rx_conf__bindgen_ty_1 > (), 16usize,
-        concat!("Size of: ", stringify!(rte_eth_vmdq_rx_conf__bindgen_ty_1))
+        ::std::mem::size_of::<rte_eth_vmdq_rx_conf__bindgen_ty_1>(),
+        16usize,
+        concat!("Size of: ", stringify!(rte_eth_vmdq_rx_conf__bindgen_ty_1)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < rte_eth_vmdq_rx_conf__bindgen_ty_1 > (), 8usize,
-        concat!("Alignment of ", stringify!(rte_eth_vmdq_rx_conf__bindgen_ty_1))
+        ::std::mem::align_of::<rte_eth_vmdq_rx_conf__bindgen_ty_1>(),
+        8usize,
+        concat!("Alignment of ", stringify!(rte_eth_vmdq_rx_conf__bindgen_ty_1)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).vlan_id) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(rte_eth_vmdq_rx_conf__bindgen_ty_1),
-        "::", stringify!(vlan_id))
+        unsafe { ::std::ptr::addr_of!((*ptr).vlan_id) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_vmdq_rx_conf__bindgen_ty_1),
+            "::",
+            stringify!(vlan_id),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).pools) as usize - ptr as usize }, 8usize,
-        concat!("Offset of field: ", stringify!(rte_eth_vmdq_rx_conf__bindgen_ty_1),
-        "::", stringify!(pools))
+        unsafe { ::std::ptr::addr_of!((*ptr).pools) as usize - ptr as usize },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_vmdq_rx_conf__bindgen_ty_1),
+            "::",
+            stringify!(pools),
+        ),
     );
 }
 impl Clone for rte_eth_vmdq_rx_conf__bindgen_ty_1 {
@@ -1024,47 +1167,86 @@ fn bindgen_test_layout_rte_eth_vmdq_rx_conf() {
     const UNINIT: ::std::mem::MaybeUninit<rte_eth_vmdq_rx_conf> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < rte_eth_vmdq_rx_conf > (), 1040usize,
-        concat!("Size of: ", stringify!(rte_eth_vmdq_rx_conf))
+        ::std::mem::size_of::<rte_eth_vmdq_rx_conf>(),
+        1040usize,
+        concat!("Size of: ", stringify!(rte_eth_vmdq_rx_conf)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < rte_eth_vmdq_rx_conf > (), 8usize,
-        concat!("Alignment of ", stringify!(rte_eth_vmdq_rx_conf))
+        ::std::mem::align_of::<rte_eth_vmdq_rx_conf>(),
+        8usize,
+        concat!("Alignment of ", stringify!(rte_eth_vmdq_rx_conf)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).nb_queue_pools) as usize - ptr as usize },
-        0usize, concat!("Offset of field: ", stringify!(rte_eth_vmdq_rx_conf), "::",
-        stringify!(nb_queue_pools))
+        unsafe { ::std::ptr::addr_of!((*ptr).nb_queue_pools) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_vmdq_rx_conf),
+            "::",
+            stringify!(nb_queue_pools),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).enable_default_pool) as usize - ptr as
-        usize }, 4usize, concat!("Offset of field: ", stringify!(rte_eth_vmdq_rx_conf),
-        "::", stringify!(enable_default_pool))
+        unsafe {
+            ::std::ptr::addr_of!((*ptr).enable_default_pool) as usize - ptr as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_vmdq_rx_conf),
+            "::",
+            stringify!(enable_default_pool),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).default_pool) as usize - ptr as usize },
-        5usize, concat!("Offset of field: ", stringify!(rte_eth_vmdq_rx_conf), "::",
-        stringify!(default_pool))
+        unsafe { ::std::ptr::addr_of!((*ptr).default_pool) as usize - ptr as usize },
+        5usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_vmdq_rx_conf),
+            "::",
+            stringify!(default_pool),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).enable_loop_back) as usize - ptr as usize
-        }, 6usize, concat!("Offset of field: ", stringify!(rte_eth_vmdq_rx_conf), "::",
-        stringify!(enable_loop_back))
+        unsafe { ::std::ptr::addr_of!((*ptr).enable_loop_back) as usize - ptr as usize },
+        6usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_vmdq_rx_conf),
+            "::",
+            stringify!(enable_loop_back),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).nb_pool_maps) as usize - ptr as usize },
-        7usize, concat!("Offset of field: ", stringify!(rte_eth_vmdq_rx_conf), "::",
-        stringify!(nb_pool_maps))
+        unsafe { ::std::ptr::addr_of!((*ptr).nb_pool_maps) as usize - ptr as usize },
+        7usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_vmdq_rx_conf),
+            "::",
+            stringify!(nb_pool_maps),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).rx_mode) as usize - ptr as usize }, 8usize,
-        concat!("Offset of field: ", stringify!(rte_eth_vmdq_rx_conf), "::",
-        stringify!(rx_mode))
+        unsafe { ::std::ptr::addr_of!((*ptr).rx_mode) as usize - ptr as usize },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_vmdq_rx_conf),
+            "::",
+            stringify!(rx_mode),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).pool_map) as usize - ptr as usize },
-        16usize, concat!("Offset of field: ", stringify!(rte_eth_vmdq_rx_conf), "::",
-        stringify!(pool_map))
+        unsafe { ::std::ptr::addr_of!((*ptr).pool_map) as usize - ptr as usize },
+        16usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_vmdq_rx_conf),
+            "::",
+            stringify!(pool_map),
+        ),
     );
 }
 impl Clone for rte_eth_vmdq_rx_conf {
@@ -1139,37 +1321,64 @@ fn bindgen_test_layout_rte_eth_ipv4_flow() {
     const UNINIT: ::std::mem::MaybeUninit<rte_eth_ipv4_flow> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < rte_eth_ipv4_flow > (), 12usize, concat!("Size of: ",
-        stringify!(rte_eth_ipv4_flow))
+        ::std::mem::size_of::<rte_eth_ipv4_flow>(),
+        12usize,
+        concat!("Size of: ", stringify!(rte_eth_ipv4_flow)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < rte_eth_ipv4_flow > (), 4usize, concat!("Alignment of ",
-        stringify!(rte_eth_ipv4_flow))
+        ::std::mem::align_of::<rte_eth_ipv4_flow>(),
+        4usize,
+        concat!("Alignment of ", stringify!(rte_eth_ipv4_flow)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).src_ip) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(rte_eth_ipv4_flow), "::",
-        stringify!(src_ip))
+        unsafe { ::std::ptr::addr_of!((*ptr).src_ip) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_ipv4_flow),
+            "::",
+            stringify!(src_ip),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).dst_ip) as usize - ptr as usize }, 4usize,
-        concat!("Offset of field: ", stringify!(rte_eth_ipv4_flow), "::",
-        stringify!(dst_ip))
+        unsafe { ::std::ptr::addr_of!((*ptr).dst_ip) as usize - ptr as usize },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_ipv4_flow),
+            "::",
+            stringify!(dst_ip),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).tos) as usize - ptr as usize }, 8usize,
-        concat!("Offset of field: ", stringify!(rte_eth_ipv4_flow), "::",
-        stringify!(tos))
+        unsafe { ::std::ptr::addr_of!((*ptr).tos) as usize - ptr as usize },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_ipv4_flow),
+            "::",
+            stringify!(tos),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).ttl) as usize - ptr as usize }, 9usize,
-        concat!("Offset of field: ", stringify!(rte_eth_ipv4_flow), "::",
-        stringify!(ttl))
+        unsafe { ::std::ptr::addr_of!((*ptr).ttl) as usize - ptr as usize },
+        9usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_ipv4_flow),
+            "::",
+            stringify!(ttl),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).proto) as usize - ptr as usize }, 10usize,
-        concat!("Offset of field: ", stringify!(rte_eth_ipv4_flow), "::",
-        stringify!(proto))
+        unsafe { ::std::ptr::addr_of!((*ptr).proto) as usize - ptr as usize },
+        10usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_ipv4_flow),
+            "::",
+            stringify!(proto),
+        ),
     );
 }
 impl Clone for rte_eth_ipv4_flow {
@@ -1197,36 +1406,59 @@ fn bindgen_test_layout_rte_eth_ipv6_flow() {
     const UNINIT: ::std::mem::MaybeUninit<rte_eth_ipv6_flow> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < rte_eth_ipv6_flow > (), 36usize, concat!("Size of: ",
-        stringify!(rte_eth_ipv6_flow))
+        ::std::mem::size_of::<rte_eth_ipv6_flow>(),
+        36usize,
+        concat!("Size of: ", stringify!(rte_eth_ipv6_flow)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < rte_eth_ipv6_flow > (), 4usize, concat!("Alignment of ",
-        stringify!(rte_eth_ipv6_flow))
+        ::std::mem::align_of::<rte_eth_ipv6_flow>(),
+        4usize,
+        concat!("Alignment of ", stringify!(rte_eth_ipv6_flow)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).src_ip) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(rte_eth_ipv6_flow), "::",
-        stringify!(src_ip))
+        unsafe { ::std::ptr::addr_of!((*ptr).src_ip) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_ipv6_flow),
+            "::",
+            stringify!(src_ip),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).dst_ip) as usize - ptr as usize }, 16usize,
-        concat!("Offset of field: ", stringify!(rte_eth_ipv6_flow), "::",
-        stringify!(dst_ip))
+        unsafe { ::std::ptr::addr_of!((*ptr).dst_ip) as usize - ptr as usize },
+        16usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_ipv6_flow),
+            "::",
+            stringify!(dst_ip),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).tc) as usize - ptr as usize }, 32usize,
-        concat!("Offset of field: ", stringify!(rte_eth_ipv6_flow), "::", stringify!(tc))
+        unsafe { ::std::ptr::addr_of!((*ptr).tc) as usize - ptr as usize },
+        32usize,
+        concat!("Offset of field: ", stringify!(rte_eth_ipv6_flow), "::", stringify!(tc)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).proto) as usize - ptr as usize }, 33usize,
-        concat!("Offset of field: ", stringify!(rte_eth_ipv6_flow), "::",
-        stringify!(proto))
+        unsafe { ::std::ptr::addr_of!((*ptr).proto) as usize - ptr as usize },
+        33usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_ipv6_flow),
+            "::",
+            stringify!(proto),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).hop_limits) as usize - ptr as usize },
-        34usize, concat!("Offset of field: ", stringify!(rte_eth_ipv6_flow), "::",
-        stringify!(hop_limits))
+        unsafe { ::std::ptr::addr_of!((*ptr).hop_limits) as usize - ptr as usize },
+        34usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_ipv6_flow),
+            "::",
+            stringify!(hop_limits),
+        ),
     );
 }
 impl Clone for rte_eth_ipv6_flow {
@@ -1263,52 +1495,96 @@ fn bindgen_test_layout_rte_eth_fdir_masks() {
     const UNINIT: ::std::mem::MaybeUninit<rte_eth_fdir_masks> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < rte_eth_fdir_masks > (), 68usize, concat!("Size of: ",
-        stringify!(rte_eth_fdir_masks))
+        ::std::mem::size_of::<rte_eth_fdir_masks>(),
+        68usize,
+        concat!("Size of: ", stringify!(rte_eth_fdir_masks)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < rte_eth_fdir_masks > (), 4usize,
-        concat!("Alignment of ", stringify!(rte_eth_fdir_masks))
+        ::std::mem::align_of::<rte_eth_fdir_masks>(),
+        4usize,
+        concat!("Alignment of ", stringify!(rte_eth_fdir_masks)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).vlan_tci_mask) as usize - ptr as usize },
-        0usize, concat!("Offset of field: ", stringify!(rte_eth_fdir_masks), "::",
-        stringify!(vlan_tci_mask))
+        unsafe { ::std::ptr::addr_of!((*ptr).vlan_tci_mask) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_fdir_masks),
+            "::",
+            stringify!(vlan_tci_mask),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).ipv4_mask) as usize - ptr as usize },
-        4usize, concat!("Offset of field: ", stringify!(rte_eth_fdir_masks), "::",
-        stringify!(ipv4_mask))
+        unsafe { ::std::ptr::addr_of!((*ptr).ipv4_mask) as usize - ptr as usize },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_fdir_masks),
+            "::",
+            stringify!(ipv4_mask),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).ipv6_mask) as usize - ptr as usize },
-        16usize, concat!("Offset of field: ", stringify!(rte_eth_fdir_masks), "::",
-        stringify!(ipv6_mask))
+        unsafe { ::std::ptr::addr_of!((*ptr).ipv6_mask) as usize - ptr as usize },
+        16usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_fdir_masks),
+            "::",
+            stringify!(ipv6_mask),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).src_port_mask) as usize - ptr as usize },
-        52usize, concat!("Offset of field: ", stringify!(rte_eth_fdir_masks), "::",
-        stringify!(src_port_mask))
+        unsafe { ::std::ptr::addr_of!((*ptr).src_port_mask) as usize - ptr as usize },
+        52usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_fdir_masks),
+            "::",
+            stringify!(src_port_mask),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).dst_port_mask) as usize - ptr as usize },
-        54usize, concat!("Offset of field: ", stringify!(rte_eth_fdir_masks), "::",
-        stringify!(dst_port_mask))
+        unsafe { ::std::ptr::addr_of!((*ptr).dst_port_mask) as usize - ptr as usize },
+        54usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_fdir_masks),
+            "::",
+            stringify!(dst_port_mask),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).mac_addr_byte_mask) as usize - ptr as usize
-        }, 56usize, concat!("Offset of field: ", stringify!(rte_eth_fdir_masks), "::",
-        stringify!(mac_addr_byte_mask))
+        unsafe {
+            ::std::ptr::addr_of!((*ptr).mac_addr_byte_mask) as usize - ptr as usize
+        },
+        56usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_fdir_masks),
+            "::",
+            stringify!(mac_addr_byte_mask),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).tunnel_id_mask) as usize - ptr as usize },
-        60usize, concat!("Offset of field: ", stringify!(rte_eth_fdir_masks), "::",
-        stringify!(tunnel_id_mask))
+        unsafe { ::std::ptr::addr_of!((*ptr).tunnel_id_mask) as usize - ptr as usize },
+        60usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_fdir_masks),
+            "::",
+            stringify!(tunnel_id_mask),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).tunnel_type_mask) as usize - ptr as usize
-        }, 64usize, concat!("Offset of field: ", stringify!(rte_eth_fdir_masks), "::",
-        stringify!(tunnel_type_mask))
+        unsafe { ::std::ptr::addr_of!((*ptr).tunnel_type_mask) as usize - ptr as usize },
+        64usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_fdir_masks),
+            "::",
+            stringify!(tunnel_type_mask),
+        ),
     );
 }
 impl Clone for rte_eth_fdir_masks {
@@ -1341,22 +1617,34 @@ fn bindgen_test_layout_rte_eth_flex_payload_cfg() {
     const UNINIT: ::std::mem::MaybeUninit<rte_eth_flex_payload_cfg> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < rte_eth_flex_payload_cfg > (), 36usize,
-        concat!("Size of: ", stringify!(rte_eth_flex_payload_cfg))
+        ::std::mem::size_of::<rte_eth_flex_payload_cfg>(),
+        36usize,
+        concat!("Size of: ", stringify!(rte_eth_flex_payload_cfg)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < rte_eth_flex_payload_cfg > (), 4usize,
-        concat!("Alignment of ", stringify!(rte_eth_flex_payload_cfg))
+        ::std::mem::align_of::<rte_eth_flex_payload_cfg>(),
+        4usize,
+        concat!("Alignment of ", stringify!(rte_eth_flex_payload_cfg)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).type_) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(rte_eth_flex_payload_cfg), "::",
-        stringify!(type_))
+        unsafe { ::std::ptr::addr_of!((*ptr).type_) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_flex_payload_cfg),
+            "::",
+            stringify!(type_),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).src_offset) as usize - ptr as usize },
-        4usize, concat!("Offset of field: ", stringify!(rte_eth_flex_payload_cfg), "::",
-        stringify!(src_offset))
+        unsafe { ::std::ptr::addr_of!((*ptr).src_offset) as usize - ptr as usize },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_flex_payload_cfg),
+            "::",
+            stringify!(src_offset),
+        ),
     );
 }
 impl Clone for rte_eth_flex_payload_cfg {
@@ -1386,22 +1674,34 @@ fn bindgen_test_layout_rte_eth_fdir_flex_mask() {
     const UNINIT: ::std::mem::MaybeUninit<rte_eth_fdir_flex_mask> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < rte_eth_fdir_flex_mask > (), 18usize,
-        concat!("Size of: ", stringify!(rte_eth_fdir_flex_mask))
+        ::std::mem::size_of::<rte_eth_fdir_flex_mask>(),
+        18usize,
+        concat!("Size of: ", stringify!(rte_eth_fdir_flex_mask)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < rte_eth_fdir_flex_mask > (), 2usize,
-        concat!("Alignment of ", stringify!(rte_eth_fdir_flex_mask))
+        ::std::mem::align_of::<rte_eth_fdir_flex_mask>(),
+        2usize,
+        concat!("Alignment of ", stringify!(rte_eth_fdir_flex_mask)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).flow_type) as usize - ptr as usize },
-        0usize, concat!("Offset of field: ", stringify!(rte_eth_fdir_flex_mask), "::",
-        stringify!(flow_type))
+        unsafe { ::std::ptr::addr_of!((*ptr).flow_type) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_fdir_flex_mask),
+            "::",
+            stringify!(flow_type),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).mask) as usize - ptr as usize }, 2usize,
-        concat!("Offset of field: ", stringify!(rte_eth_fdir_flex_mask), "::",
-        stringify!(mask))
+        unsafe { ::std::ptr::addr_of!((*ptr).mask) as usize - ptr as usize },
+        2usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_fdir_flex_mask),
+            "::",
+            stringify!(mask),
+        ),
     );
 }
 impl Clone for rte_eth_fdir_flex_mask {
@@ -1426,32 +1726,54 @@ fn bindgen_test_layout_rte_eth_fdir_flex_conf() {
     const UNINIT: ::std::mem::MaybeUninit<rte_eth_fdir_flex_conf> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < rte_eth_fdir_flex_conf > (), 688usize,
-        concat!("Size of: ", stringify!(rte_eth_fdir_flex_conf))
+        ::std::mem::size_of::<rte_eth_fdir_flex_conf>(),
+        688usize,
+        concat!("Size of: ", stringify!(rte_eth_fdir_flex_conf)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < rte_eth_fdir_flex_conf > (), 4usize,
-        concat!("Alignment of ", stringify!(rte_eth_fdir_flex_conf))
+        ::std::mem::align_of::<rte_eth_fdir_flex_conf>(),
+        4usize,
+        concat!("Alignment of ", stringify!(rte_eth_fdir_flex_conf)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).nb_payloads) as usize - ptr as usize },
-        0usize, concat!("Offset of field: ", stringify!(rte_eth_fdir_flex_conf), "::",
-        stringify!(nb_payloads))
+        unsafe { ::std::ptr::addr_of!((*ptr).nb_payloads) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_fdir_flex_conf),
+            "::",
+            stringify!(nb_payloads),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).nb_flexmasks) as usize - ptr as usize },
-        2usize, concat!("Offset of field: ", stringify!(rte_eth_fdir_flex_conf), "::",
-        stringify!(nb_flexmasks))
+        unsafe { ::std::ptr::addr_of!((*ptr).nb_flexmasks) as usize - ptr as usize },
+        2usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_fdir_flex_conf),
+            "::",
+            stringify!(nb_flexmasks),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).flex_set) as usize - ptr as usize },
-        4usize, concat!("Offset of field: ", stringify!(rte_eth_fdir_flex_conf), "::",
-        stringify!(flex_set))
+        unsafe { ::std::ptr::addr_of!((*ptr).flex_set) as usize - ptr as usize },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_fdir_flex_conf),
+            "::",
+            stringify!(flex_set),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).flex_mask) as usize - ptr as usize },
-        292usize, concat!("Offset of field: ", stringify!(rte_eth_fdir_flex_conf), "::",
-        stringify!(flex_mask))
+        unsafe { ::std::ptr::addr_of!((*ptr).flex_mask) as usize - ptr as usize },
+        292usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_fdir_flex_conf),
+            "::",
+            stringify!(flex_mask),
+        ),
     );
 }
 impl Clone for rte_eth_fdir_flex_conf {
@@ -1491,39 +1813,59 @@ fn bindgen_test_layout_rte_fdir_conf() {
     const UNINIT: ::std::mem::MaybeUninit<rte_fdir_conf> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < rte_fdir_conf > (), 772usize, concat!("Size of: ",
-        stringify!(rte_fdir_conf))
+        ::std::mem::size_of::<rte_fdir_conf>(),
+        772usize,
+        concat!("Size of: ", stringify!(rte_fdir_conf)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < rte_fdir_conf > (), 4usize, concat!("Alignment of ",
-        stringify!(rte_fdir_conf))
+        ::std::mem::align_of::<rte_fdir_conf>(),
+        4usize,
+        concat!("Alignment of ", stringify!(rte_fdir_conf)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).mode) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(rte_fdir_conf), "::", stringify!(mode))
+        unsafe { ::std::ptr::addr_of!((*ptr).mode) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(rte_fdir_conf), "::", stringify!(mode)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).pballoc) as usize - ptr as usize }, 4usize,
-        concat!("Offset of field: ", stringify!(rte_fdir_conf), "::",
-        stringify!(pballoc))
+        unsafe { ::std::ptr::addr_of!((*ptr).pballoc) as usize - ptr as usize },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_fdir_conf),
+            "::",
+            stringify!(pballoc),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).status) as usize - ptr as usize }, 8usize,
-        concat!("Offset of field: ", stringify!(rte_fdir_conf), "::", stringify!(status))
+        unsafe { ::std::ptr::addr_of!((*ptr).status) as usize - ptr as usize },
+        8usize,
+        concat!("Offset of field: ", stringify!(rte_fdir_conf), "::", stringify!(status)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).drop_queue) as usize - ptr as usize },
-        12usize, concat!("Offset of field: ", stringify!(rte_fdir_conf), "::",
-        stringify!(drop_queue))
+        unsafe { ::std::ptr::addr_of!((*ptr).drop_queue) as usize - ptr as usize },
+        12usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_fdir_conf),
+            "::",
+            stringify!(drop_queue),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).mask) as usize - ptr as usize }, 16usize,
-        concat!("Offset of field: ", stringify!(rte_fdir_conf), "::", stringify!(mask))
+        unsafe { ::std::ptr::addr_of!((*ptr).mask) as usize - ptr as usize },
+        16usize,
+        concat!("Offset of field: ", stringify!(rte_fdir_conf), "::", stringify!(mask)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).flex_conf) as usize - ptr as usize },
-        84usize, concat!("Offset of field: ", stringify!(rte_fdir_conf), "::",
-        stringify!(flex_conf))
+        unsafe { ::std::ptr::addr_of!((*ptr).flex_conf) as usize - ptr as usize },
+        84usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_fdir_conf),
+            "::",
+            stringify!(flex_conf),
+        ),
     );
 }
 impl Clone for rte_fdir_conf {
@@ -1554,20 +1896,24 @@ fn bindgen_test_layout_rte_intr_conf() {
     const UNINIT: ::std::mem::MaybeUninit<rte_intr_conf> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < rte_intr_conf > (), 4usize, concat!("Size of: ",
-        stringify!(rte_intr_conf))
+        ::std::mem::size_of::<rte_intr_conf>(),
+        4usize,
+        concat!("Size of: ", stringify!(rte_intr_conf)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < rte_intr_conf > (), 2usize, concat!("Alignment of ",
-        stringify!(rte_intr_conf))
+        ::std::mem::align_of::<rte_intr_conf>(),
+        2usize,
+        concat!("Alignment of ", stringify!(rte_intr_conf)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).lsc) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(rte_intr_conf), "::", stringify!(lsc))
+        unsafe { ::std::ptr::addr_of!((*ptr).lsc) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(rte_intr_conf), "::", stringify!(lsc)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).rxq) as usize - ptr as usize }, 2usize,
-        concat!("Offset of field: ", stringify!(rte_intr_conf), "::", stringify!(rxq))
+        unsafe { ::std::ptr::addr_of!((*ptr).rxq) as usize - ptr as usize },
+        2usize,
+        concat!("Offset of field: ", stringify!(rte_intr_conf), "::", stringify!(rxq)),
     );
 }
 impl Clone for rte_intr_conf {
@@ -1625,32 +1971,54 @@ fn bindgen_test_layout_rte_eth_conf__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<rte_eth_conf__bindgen_ty_1> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < rte_eth_conf__bindgen_ty_1 > (), 2120usize,
-        concat!("Size of: ", stringify!(rte_eth_conf__bindgen_ty_1))
+        ::std::mem::size_of::<rte_eth_conf__bindgen_ty_1>(),
+        2120usize,
+        concat!("Size of: ", stringify!(rte_eth_conf__bindgen_ty_1)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < rte_eth_conf__bindgen_ty_1 > (), 8usize,
-        concat!("Alignment of ", stringify!(rte_eth_conf__bindgen_ty_1))
+        ::std::mem::align_of::<rte_eth_conf__bindgen_ty_1>(),
+        8usize,
+        concat!("Alignment of ", stringify!(rte_eth_conf__bindgen_ty_1)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).rss_conf) as usize - ptr as usize },
-        0usize, concat!("Offset of field: ", stringify!(rte_eth_conf__bindgen_ty_1),
-        "::", stringify!(rss_conf))
+        unsafe { ::std::ptr::addr_of!((*ptr).rss_conf) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_conf__bindgen_ty_1),
+            "::",
+            stringify!(rss_conf),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).vmdq_dcb_conf) as usize - ptr as usize },
-        24usize, concat!("Offset of field: ", stringify!(rte_eth_conf__bindgen_ty_1),
-        "::", stringify!(vmdq_dcb_conf))
+        unsafe { ::std::ptr::addr_of!((*ptr).vmdq_dcb_conf) as usize - ptr as usize },
+        24usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_conf__bindgen_ty_1),
+            "::",
+            stringify!(vmdq_dcb_conf),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).dcb_rx_conf) as usize - ptr as usize },
-        1064usize, concat!("Offset of field: ", stringify!(rte_eth_conf__bindgen_ty_1),
-        "::", stringify!(dcb_rx_conf))
+        unsafe { ::std::ptr::addr_of!((*ptr).dcb_rx_conf) as usize - ptr as usize },
+        1064usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_conf__bindgen_ty_1),
+            "::",
+            stringify!(dcb_rx_conf),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).vmdq_rx_conf) as usize - ptr as usize },
-        1080usize, concat!("Offset of field: ", stringify!(rte_eth_conf__bindgen_ty_1),
-        "::", stringify!(vmdq_rx_conf))
+        unsafe { ::std::ptr::addr_of!((*ptr).vmdq_rx_conf) as usize - ptr as usize },
+        1080usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_conf__bindgen_ty_1),
+            "::",
+            stringify!(vmdq_rx_conf),
+        ),
     );
 }
 impl Clone for rte_eth_conf__bindgen_ty_1 {
@@ -1680,27 +2048,44 @@ fn bindgen_test_layout_rte_eth_conf__bindgen_ty_2() {
     const UNINIT: ::std::mem::MaybeUninit<rte_eth_conf__bindgen_ty_2> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < rte_eth_conf__bindgen_ty_2 > (), 12usize,
-        concat!("Size of: ", stringify!(rte_eth_conf__bindgen_ty_2))
+        ::std::mem::size_of::<rte_eth_conf__bindgen_ty_2>(),
+        12usize,
+        concat!("Size of: ", stringify!(rte_eth_conf__bindgen_ty_2)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < rte_eth_conf__bindgen_ty_2 > (), 4usize,
-        concat!("Alignment of ", stringify!(rte_eth_conf__bindgen_ty_2))
+        ::std::mem::align_of::<rte_eth_conf__bindgen_ty_2>(),
+        4usize,
+        concat!("Alignment of ", stringify!(rte_eth_conf__bindgen_ty_2)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).vmdq_dcb_tx_conf) as usize - ptr as usize
-        }, 0usize, concat!("Offset of field: ", stringify!(rte_eth_conf__bindgen_ty_2),
-        "::", stringify!(vmdq_dcb_tx_conf))
+        unsafe { ::std::ptr::addr_of!((*ptr).vmdq_dcb_tx_conf) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_conf__bindgen_ty_2),
+            "::",
+            stringify!(vmdq_dcb_tx_conf),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).dcb_tx_conf) as usize - ptr as usize },
-        0usize, concat!("Offset of field: ", stringify!(rte_eth_conf__bindgen_ty_2),
-        "::", stringify!(dcb_tx_conf))
+        unsafe { ::std::ptr::addr_of!((*ptr).dcb_tx_conf) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_conf__bindgen_ty_2),
+            "::",
+            stringify!(dcb_tx_conf),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).vmdq_tx_conf) as usize - ptr as usize },
-        0usize, concat!("Offset of field: ", stringify!(rte_eth_conf__bindgen_ty_2),
-        "::", stringify!(vmdq_tx_conf))
+        unsafe { ::std::ptr::addr_of!((*ptr).vmdq_tx_conf) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_conf__bindgen_ty_2),
+            "::",
+            stringify!(vmdq_tx_conf),
+        ),
     );
 }
 impl Clone for rte_eth_conf__bindgen_ty_2 {
@@ -1713,55 +2098,96 @@ fn bindgen_test_layout_rte_eth_conf() {
     const UNINIT: ::std::mem::MaybeUninit<rte_eth_conf> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < rte_eth_conf > (), 2944usize, concat!("Size of: ",
-        stringify!(rte_eth_conf))
+        ::std::mem::size_of::<rte_eth_conf>(),
+        2944usize,
+        concat!("Size of: ", stringify!(rte_eth_conf)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < rte_eth_conf > (), 8usize, concat!("Alignment of ",
-        stringify!(rte_eth_conf))
+        ::std::mem::align_of::<rte_eth_conf>(),
+        8usize,
+        concat!("Alignment of ", stringify!(rte_eth_conf)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).link_speeds) as usize - ptr as usize },
-        0usize, concat!("Offset of field: ", stringify!(rte_eth_conf), "::",
-        stringify!(link_speeds))
+        unsafe { ::std::ptr::addr_of!((*ptr).link_speeds) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_conf),
+            "::",
+            stringify!(link_speeds),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).rxmode) as usize - ptr as usize }, 4usize,
-        concat!("Offset of field: ", stringify!(rte_eth_conf), "::", stringify!(rxmode))
+        unsafe { ::std::ptr::addr_of!((*ptr).rxmode) as usize - ptr as usize },
+        4usize,
+        concat!("Offset of field: ", stringify!(rte_eth_conf), "::", stringify!(rxmode)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).txmode) as usize - ptr as usize }, 16usize,
-        concat!("Offset of field: ", stringify!(rte_eth_conf), "::", stringify!(txmode))
+        unsafe { ::std::ptr::addr_of!((*ptr).txmode) as usize - ptr as usize },
+        16usize,
+        concat!("Offset of field: ", stringify!(rte_eth_conf), "::", stringify!(txmode)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).lpbk_mode) as usize - ptr as usize },
-        24usize, concat!("Offset of field: ", stringify!(rte_eth_conf), "::",
-        stringify!(lpbk_mode))
+        unsafe { ::std::ptr::addr_of!((*ptr).lpbk_mode) as usize - ptr as usize },
+        24usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_conf),
+            "::",
+            stringify!(lpbk_mode),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).rx_adv_conf) as usize - ptr as usize },
-        32usize, concat!("Offset of field: ", stringify!(rte_eth_conf), "::",
-        stringify!(rx_adv_conf))
+        unsafe { ::std::ptr::addr_of!((*ptr).rx_adv_conf) as usize - ptr as usize },
+        32usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_conf),
+            "::",
+            stringify!(rx_adv_conf),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).tx_adv_conf) as usize - ptr as usize },
-        2152usize, concat!("Offset of field: ", stringify!(rte_eth_conf), "::",
-        stringify!(tx_adv_conf))
+        unsafe { ::std::ptr::addr_of!((*ptr).tx_adv_conf) as usize - ptr as usize },
+        2152usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_conf),
+            "::",
+            stringify!(tx_adv_conf),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).dcb_capability_en) as usize - ptr as usize
-        }, 2164usize, concat!("Offset of field: ", stringify!(rte_eth_conf), "::",
-        stringify!(dcb_capability_en))
+        unsafe {
+            ::std::ptr::addr_of!((*ptr).dcb_capability_en) as usize - ptr as usize
+        },
+        2164usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_conf),
+            "::",
+            stringify!(dcb_capability_en),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).fdir_conf) as usize - ptr as usize },
-        2168usize, concat!("Offset of field: ", stringify!(rte_eth_conf), "::",
-        stringify!(fdir_conf))
+        unsafe { ::std::ptr::addr_of!((*ptr).fdir_conf) as usize - ptr as usize },
+        2168usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_conf),
+            "::",
+            stringify!(fdir_conf),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).intr_conf) as usize - ptr as usize },
-        2940usize, concat!("Offset of field: ", stringify!(rte_eth_conf), "::",
-        stringify!(intr_conf))
+        unsafe { ::std::ptr::addr_of!((*ptr).intr_conf) as usize - ptr as usize },
+        2940usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_conf),
+            "::",
+            stringify!(intr_conf),
+        ),
     );
 }
 impl Clone for rte_eth_conf {

--- a/bindgen-tests/tests/expectations/tests/layout_kni_mbuf.rs
+++ b/bindgen-tests/tests/expectations/tests/layout_kni_mbuf.rs
@@ -31,75 +31,109 @@ fn bindgen_test_layout_rte_kni_mbuf() {
     const UNINIT: ::std::mem::MaybeUninit<rte_kni_mbuf> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < rte_kni_mbuf > (), 128usize, concat!("Size of: ",
-        stringify!(rte_kni_mbuf))
+        ::std::mem::size_of::<rte_kni_mbuf>(),
+        128usize,
+        concat!("Size of: ", stringify!(rte_kni_mbuf)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < rte_kni_mbuf > (), 64usize, concat!("Alignment of ",
-        stringify!(rte_kni_mbuf))
+        ::std::mem::align_of::<rte_kni_mbuf>(),
+        64usize,
+        concat!("Alignment of ", stringify!(rte_kni_mbuf)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).buf_addr) as usize - ptr as usize },
-        0usize, concat!("Offset of field: ", stringify!(rte_kni_mbuf), "::",
-        stringify!(buf_addr))
+        unsafe { ::std::ptr::addr_of!((*ptr).buf_addr) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_kni_mbuf),
+            "::",
+            stringify!(buf_addr),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).buf_physaddr) as usize - ptr as usize },
-        8usize, concat!("Offset of field: ", stringify!(rte_kni_mbuf), "::",
-        stringify!(buf_physaddr))
+        unsafe { ::std::ptr::addr_of!((*ptr).buf_physaddr) as usize - ptr as usize },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_kni_mbuf),
+            "::",
+            stringify!(buf_physaddr),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).pad0) as usize - ptr as usize }, 16usize,
-        concat!("Offset of field: ", stringify!(rte_kni_mbuf), "::", stringify!(pad0))
+        unsafe { ::std::ptr::addr_of!((*ptr).pad0) as usize - ptr as usize },
+        16usize,
+        concat!("Offset of field: ", stringify!(rte_kni_mbuf), "::", stringify!(pad0)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).data_off) as usize - ptr as usize },
-        18usize, concat!("Offset of field: ", stringify!(rte_kni_mbuf), "::",
-        stringify!(data_off))
+        unsafe { ::std::ptr::addr_of!((*ptr).data_off) as usize - ptr as usize },
+        18usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_kni_mbuf),
+            "::",
+            stringify!(data_off),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).pad1) as usize - ptr as usize }, 20usize,
-        concat!("Offset of field: ", stringify!(rte_kni_mbuf), "::", stringify!(pad1))
+        unsafe { ::std::ptr::addr_of!((*ptr).pad1) as usize - ptr as usize },
+        20usize,
+        concat!("Offset of field: ", stringify!(rte_kni_mbuf), "::", stringify!(pad1)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).nb_segs) as usize - ptr as usize },
-        22usize, concat!("Offset of field: ", stringify!(rte_kni_mbuf), "::",
-        stringify!(nb_segs))
+        unsafe { ::std::ptr::addr_of!((*ptr).nb_segs) as usize - ptr as usize },
+        22usize,
+        concat!("Offset of field: ", stringify!(rte_kni_mbuf), "::", stringify!(nb_segs)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).pad4) as usize - ptr as usize }, 23usize,
-        concat!("Offset of field: ", stringify!(rte_kni_mbuf), "::", stringify!(pad4))
+        unsafe { ::std::ptr::addr_of!((*ptr).pad4) as usize - ptr as usize },
+        23usize,
+        concat!("Offset of field: ", stringify!(rte_kni_mbuf), "::", stringify!(pad4)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).ol_flags) as usize - ptr as usize },
-        24usize, concat!("Offset of field: ", stringify!(rte_kni_mbuf), "::",
-        stringify!(ol_flags))
+        unsafe { ::std::ptr::addr_of!((*ptr).ol_flags) as usize - ptr as usize },
+        24usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_kni_mbuf),
+            "::",
+            stringify!(ol_flags),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).pad2) as usize - ptr as usize }, 32usize,
-        concat!("Offset of field: ", stringify!(rte_kni_mbuf), "::", stringify!(pad2))
+        unsafe { ::std::ptr::addr_of!((*ptr).pad2) as usize - ptr as usize },
+        32usize,
+        concat!("Offset of field: ", stringify!(rte_kni_mbuf), "::", stringify!(pad2)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).pkt_len) as usize - ptr as usize },
-        36usize, concat!("Offset of field: ", stringify!(rte_kni_mbuf), "::",
-        stringify!(pkt_len))
+        unsafe { ::std::ptr::addr_of!((*ptr).pkt_len) as usize - ptr as usize },
+        36usize,
+        concat!("Offset of field: ", stringify!(rte_kni_mbuf), "::", stringify!(pkt_len)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).data_len) as usize - ptr as usize },
-        40usize, concat!("Offset of field: ", stringify!(rte_kni_mbuf), "::",
-        stringify!(data_len))
+        unsafe { ::std::ptr::addr_of!((*ptr).data_len) as usize - ptr as usize },
+        40usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_kni_mbuf),
+            "::",
+            stringify!(data_len),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).pad3) as usize - ptr as usize }, 64usize,
-        concat!("Offset of field: ", stringify!(rte_kni_mbuf), "::", stringify!(pad3))
+        unsafe { ::std::ptr::addr_of!((*ptr).pad3) as usize - ptr as usize },
+        64usize,
+        concat!("Offset of field: ", stringify!(rte_kni_mbuf), "::", stringify!(pad3)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).pool) as usize - ptr as usize }, 72usize,
-        concat!("Offset of field: ", stringify!(rte_kni_mbuf), "::", stringify!(pool))
+        unsafe { ::std::ptr::addr_of!((*ptr).pool) as usize - ptr as usize },
+        72usize,
+        concat!("Offset of field: ", stringify!(rte_kni_mbuf), "::", stringify!(pool)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).next) as usize - ptr as usize }, 80usize,
-        concat!("Offset of field: ", stringify!(rte_kni_mbuf), "::", stringify!(next))
+        unsafe { ::std::ptr::addr_of!((*ptr).next) as usize - ptr as usize },
+        80usize,
+        concat!("Offset of field: ", stringify!(rte_kni_mbuf), "::", stringify!(next)),
     );
 }
 impl Default for rte_kni_mbuf {

--- a/bindgen-tests/tests/expectations/tests/layout_large_align_field.rs
+++ b/bindgen-tests/tests/expectations/tests/layout_large_align_field.rs
@@ -62,24 +62,29 @@ fn bindgen_test_layout_ip_frag() {
     const UNINIT: ::std::mem::MaybeUninit<ip_frag> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < ip_frag > (), 16usize, concat!("Size of: ",
-        stringify!(ip_frag))
+        ::std::mem::size_of::<ip_frag>(),
+        16usize,
+        concat!("Size of: ", stringify!(ip_frag)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < ip_frag > (), 8usize, concat!("Alignment of ",
-        stringify!(ip_frag))
+        ::std::mem::align_of::<ip_frag>(),
+        8usize,
+        concat!("Alignment of ", stringify!(ip_frag)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).ofs) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(ip_frag), "::", stringify!(ofs))
+        unsafe { ::std::ptr::addr_of!((*ptr).ofs) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(ip_frag), "::", stringify!(ofs)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).len) as usize - ptr as usize }, 2usize,
-        concat!("Offset of field: ", stringify!(ip_frag), "::", stringify!(len))
+        unsafe { ::std::ptr::addr_of!((*ptr).len) as usize - ptr as usize },
+        2usize,
+        concat!("Offset of field: ", stringify!(ip_frag), "::", stringify!(len)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).mb) as usize - ptr as usize }, 8usize,
-        concat!("Offset of field: ", stringify!(ip_frag), "::", stringify!(mb))
+        unsafe { ::std::ptr::addr_of!((*ptr).mb) as usize - ptr as usize },
+        8usize,
+        concat!("Offset of field: ", stringify!(ip_frag), "::", stringify!(mb)),
     );
 }
 impl Default for ip_frag {
@@ -107,25 +112,29 @@ fn bindgen_test_layout_ip_frag_key() {
     const UNINIT: ::std::mem::MaybeUninit<ip_frag_key> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < ip_frag_key > (), 40usize, concat!("Size of: ",
-        stringify!(ip_frag_key))
+        ::std::mem::size_of::<ip_frag_key>(),
+        40usize,
+        concat!("Size of: ", stringify!(ip_frag_key)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < ip_frag_key > (), 8usize, concat!("Alignment of ",
-        stringify!(ip_frag_key))
+        ::std::mem::align_of::<ip_frag_key>(),
+        8usize,
+        concat!("Alignment of ", stringify!(ip_frag_key)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).src_dst) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(ip_frag_key), "::", stringify!(src_dst))
+        unsafe { ::std::ptr::addr_of!((*ptr).src_dst) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(ip_frag_key), "::", stringify!(src_dst)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).id) as usize - ptr as usize }, 32usize,
-        concat!("Offset of field: ", stringify!(ip_frag_key), "::", stringify!(id))
+        unsafe { ::std::ptr::addr_of!((*ptr).id) as usize - ptr as usize },
+        32usize,
+        concat!("Offset of field: ", stringify!(ip_frag_key), "::", stringify!(id)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).key_len) as usize - ptr as usize },
-        36usize, concat!("Offset of field: ", stringify!(ip_frag_key), "::",
-        stringify!(key_len))
+        unsafe { ::std::ptr::addr_of!((*ptr).key_len) as usize - ptr as usize },
+        36usize,
+        concat!("Offset of field: ", stringify!(ip_frag_key), "::", stringify!(key_len)),
     );
 }
 /** @internal Fragmented packet to reassemble.
@@ -160,22 +169,34 @@ fn bindgen_test_layout_ip_frag_pkt__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<ip_frag_pkt__bindgen_ty_1> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < ip_frag_pkt__bindgen_ty_1 > (), 16usize,
-        concat!("Size of: ", stringify!(ip_frag_pkt__bindgen_ty_1))
+        ::std::mem::size_of::<ip_frag_pkt__bindgen_ty_1>(),
+        16usize,
+        concat!("Size of: ", stringify!(ip_frag_pkt__bindgen_ty_1)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < ip_frag_pkt__bindgen_ty_1 > (), 8usize,
-        concat!("Alignment of ", stringify!(ip_frag_pkt__bindgen_ty_1))
+        ::std::mem::align_of::<ip_frag_pkt__bindgen_ty_1>(),
+        8usize,
+        concat!("Alignment of ", stringify!(ip_frag_pkt__bindgen_ty_1)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).tqe_next) as usize - ptr as usize },
-        0usize, concat!("Offset of field: ", stringify!(ip_frag_pkt__bindgen_ty_1), "::",
-        stringify!(tqe_next))
+        unsafe { ::std::ptr::addr_of!((*ptr).tqe_next) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ip_frag_pkt__bindgen_ty_1),
+            "::",
+            stringify!(tqe_next),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).tqe_prev) as usize - ptr as usize },
-        8usize, concat!("Offset of field: ", stringify!(ip_frag_pkt__bindgen_ty_1), "::",
-        stringify!(tqe_prev))
+        unsafe { ::std::ptr::addr_of!((*ptr).tqe_prev) as usize - ptr as usize },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ip_frag_pkt__bindgen_ty_1),
+            "::",
+            stringify!(tqe_prev),
+        ),
     );
 }
 impl Default for ip_frag_pkt__bindgen_ty_1 {
@@ -192,43 +213,59 @@ fn bindgen_test_layout_ip_frag_pkt() {
     const UNINIT: ::std::mem::MaybeUninit<ip_frag_pkt> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < ip_frag_pkt > (), 192usize, concat!("Size of: ",
-        stringify!(ip_frag_pkt))
+        ::std::mem::size_of::<ip_frag_pkt>(),
+        192usize,
+        concat!("Size of: ", stringify!(ip_frag_pkt)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < ip_frag_pkt > (), 64usize, concat!("Alignment of ",
-        stringify!(ip_frag_pkt))
+        ::std::mem::align_of::<ip_frag_pkt>(),
+        64usize,
+        concat!("Alignment of ", stringify!(ip_frag_pkt)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).lru) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(ip_frag_pkt), "::", stringify!(lru))
+        unsafe { ::std::ptr::addr_of!((*ptr).lru) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(ip_frag_pkt), "::", stringify!(lru)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).key) as usize - ptr as usize }, 16usize,
-        concat!("Offset of field: ", stringify!(ip_frag_pkt), "::", stringify!(key))
+        unsafe { ::std::ptr::addr_of!((*ptr).key) as usize - ptr as usize },
+        16usize,
+        concat!("Offset of field: ", stringify!(ip_frag_pkt), "::", stringify!(key)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).start) as usize - ptr as usize }, 56usize,
-        concat!("Offset of field: ", stringify!(ip_frag_pkt), "::", stringify!(start))
+        unsafe { ::std::ptr::addr_of!((*ptr).start) as usize - ptr as usize },
+        56usize,
+        concat!("Offset of field: ", stringify!(ip_frag_pkt), "::", stringify!(start)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).total_size) as usize - ptr as usize },
-        64usize, concat!("Offset of field: ", stringify!(ip_frag_pkt), "::",
-        stringify!(total_size))
+        unsafe { ::std::ptr::addr_of!((*ptr).total_size) as usize - ptr as usize },
+        64usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ip_frag_pkt),
+            "::",
+            stringify!(total_size),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).frag_size) as usize - ptr as usize },
-        68usize, concat!("Offset of field: ", stringify!(ip_frag_pkt), "::",
-        stringify!(frag_size))
+        unsafe { ::std::ptr::addr_of!((*ptr).frag_size) as usize - ptr as usize },
+        68usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ip_frag_pkt),
+            "::",
+            stringify!(frag_size),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).last_idx) as usize - ptr as usize },
-        72usize, concat!("Offset of field: ", stringify!(ip_frag_pkt), "::",
-        stringify!(last_idx))
+        unsafe { ::std::ptr::addr_of!((*ptr).last_idx) as usize - ptr as usize },
+        72usize,
+        concat!("Offset of field: ", stringify!(ip_frag_pkt), "::", stringify!(last_idx)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).frags) as usize - ptr as usize }, 80usize,
-        concat!("Offset of field: ", stringify!(ip_frag_pkt), "::", stringify!(frags))
+        unsafe { ::std::ptr::addr_of!((*ptr).frags) as usize - ptr as usize },
+        80usize,
+        concat!("Offset of field: ", stringify!(ip_frag_pkt), "::", stringify!(frags)),
     );
 }
 impl Default for ip_frag_pkt {
@@ -251,22 +288,29 @@ fn bindgen_test_layout_ip_pkt_list() {
     const UNINIT: ::std::mem::MaybeUninit<ip_pkt_list> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < ip_pkt_list > (), 16usize, concat!("Size of: ",
-        stringify!(ip_pkt_list))
+        ::std::mem::size_of::<ip_pkt_list>(),
+        16usize,
+        concat!("Size of: ", stringify!(ip_pkt_list)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < ip_pkt_list > (), 8usize, concat!("Alignment of ",
-        stringify!(ip_pkt_list))
+        ::std::mem::align_of::<ip_pkt_list>(),
+        8usize,
+        concat!("Alignment of ", stringify!(ip_pkt_list)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).tqh_first) as usize - ptr as usize },
-        0usize, concat!("Offset of field: ", stringify!(ip_pkt_list), "::",
-        stringify!(tqh_first))
+        unsafe { ::std::ptr::addr_of!((*ptr).tqh_first) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ip_pkt_list),
+            "::",
+            stringify!(tqh_first),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).tqh_last) as usize - ptr as usize },
-        8usize, concat!("Offset of field: ", stringify!(ip_pkt_list), "::",
-        stringify!(tqh_last))
+        unsafe { ::std::ptr::addr_of!((*ptr).tqh_last) as usize - ptr as usize },
+        8usize,
+        concat!("Offset of field: ", stringify!(ip_pkt_list), "::", stringify!(tqh_last)),
     );
 }
 impl Default for ip_pkt_list {
@@ -301,42 +345,74 @@ fn bindgen_test_layout_ip_frag_tbl_stat() {
     const UNINIT: ::std::mem::MaybeUninit<ip_frag_tbl_stat> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < ip_frag_tbl_stat > (), 64usize, concat!("Size of: ",
-        stringify!(ip_frag_tbl_stat))
+        ::std::mem::size_of::<ip_frag_tbl_stat>(),
+        64usize,
+        concat!("Size of: ", stringify!(ip_frag_tbl_stat)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < ip_frag_tbl_stat > (), 64usize, concat!("Alignment of ",
-        stringify!(ip_frag_tbl_stat))
+        ::std::mem::align_of::<ip_frag_tbl_stat>(),
+        64usize,
+        concat!("Alignment of ", stringify!(ip_frag_tbl_stat)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).find_num) as usize - ptr as usize },
-        0usize, concat!("Offset of field: ", stringify!(ip_frag_tbl_stat), "::",
-        stringify!(find_num))
+        unsafe { ::std::ptr::addr_of!((*ptr).find_num) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ip_frag_tbl_stat),
+            "::",
+            stringify!(find_num),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).add_num) as usize - ptr as usize }, 8usize,
-        concat!("Offset of field: ", stringify!(ip_frag_tbl_stat), "::",
-        stringify!(add_num))
+        unsafe { ::std::ptr::addr_of!((*ptr).add_num) as usize - ptr as usize },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ip_frag_tbl_stat),
+            "::",
+            stringify!(add_num),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).del_num) as usize - ptr as usize },
-        16usize, concat!("Offset of field: ", stringify!(ip_frag_tbl_stat), "::",
-        stringify!(del_num))
+        unsafe { ::std::ptr::addr_of!((*ptr).del_num) as usize - ptr as usize },
+        16usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ip_frag_tbl_stat),
+            "::",
+            stringify!(del_num),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).reuse_num) as usize - ptr as usize },
-        24usize, concat!("Offset of field: ", stringify!(ip_frag_tbl_stat), "::",
-        stringify!(reuse_num))
+        unsafe { ::std::ptr::addr_of!((*ptr).reuse_num) as usize - ptr as usize },
+        24usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ip_frag_tbl_stat),
+            "::",
+            stringify!(reuse_num),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).fail_total) as usize - ptr as usize },
-        32usize, concat!("Offset of field: ", stringify!(ip_frag_tbl_stat), "::",
-        stringify!(fail_total))
+        unsafe { ::std::ptr::addr_of!((*ptr).fail_total) as usize - ptr as usize },
+        32usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ip_frag_tbl_stat),
+            "::",
+            stringify!(fail_total),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).fail_nospace) as usize - ptr as usize },
-        40usize, concat!("Offset of field: ", stringify!(ip_frag_tbl_stat), "::",
-        stringify!(fail_nospace))
+        unsafe { ::std::ptr::addr_of!((*ptr).fail_nospace) as usize - ptr as usize },
+        40usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ip_frag_tbl_stat),
+            "::",
+            stringify!(fail_nospace),
+        ),
     );
 }
 impl Default for ip_frag_tbl_stat {
@@ -381,63 +457,104 @@ fn bindgen_test_layout_rte_ip_frag_tbl() {
     const UNINIT: ::std::mem::MaybeUninit<rte_ip_frag_tbl> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < rte_ip_frag_tbl > (), 128usize, concat!("Size of: ",
-        stringify!(rte_ip_frag_tbl))
+        ::std::mem::size_of::<rte_ip_frag_tbl>(),
+        128usize,
+        concat!("Size of: ", stringify!(rte_ip_frag_tbl)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < rte_ip_frag_tbl > (), 64usize, concat!("Alignment of ",
-        stringify!(rte_ip_frag_tbl))
+        ::std::mem::align_of::<rte_ip_frag_tbl>(),
+        64usize,
+        concat!("Alignment of ", stringify!(rte_ip_frag_tbl)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).max_cycles) as usize - ptr as usize },
-        0usize, concat!("Offset of field: ", stringify!(rte_ip_frag_tbl), "::",
-        stringify!(max_cycles))
+        unsafe { ::std::ptr::addr_of!((*ptr).max_cycles) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_ip_frag_tbl),
+            "::",
+            stringify!(max_cycles),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).entry_mask) as usize - ptr as usize },
-        8usize, concat!("Offset of field: ", stringify!(rte_ip_frag_tbl), "::",
-        stringify!(entry_mask))
+        unsafe { ::std::ptr::addr_of!((*ptr).entry_mask) as usize - ptr as usize },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_ip_frag_tbl),
+            "::",
+            stringify!(entry_mask),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).max_entries) as usize - ptr as usize },
-        12usize, concat!("Offset of field: ", stringify!(rte_ip_frag_tbl), "::",
-        stringify!(max_entries))
+        unsafe { ::std::ptr::addr_of!((*ptr).max_entries) as usize - ptr as usize },
+        12usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_ip_frag_tbl),
+            "::",
+            stringify!(max_entries),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).use_entries) as usize - ptr as usize },
-        16usize, concat!("Offset of field: ", stringify!(rte_ip_frag_tbl), "::",
-        stringify!(use_entries))
+        unsafe { ::std::ptr::addr_of!((*ptr).use_entries) as usize - ptr as usize },
+        16usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_ip_frag_tbl),
+            "::",
+            stringify!(use_entries),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).bucket_entries) as usize - ptr as usize },
-        20usize, concat!("Offset of field: ", stringify!(rte_ip_frag_tbl), "::",
-        stringify!(bucket_entries))
+        unsafe { ::std::ptr::addr_of!((*ptr).bucket_entries) as usize - ptr as usize },
+        20usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_ip_frag_tbl),
+            "::",
+            stringify!(bucket_entries),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).nb_entries) as usize - ptr as usize },
-        24usize, concat!("Offset of field: ", stringify!(rte_ip_frag_tbl), "::",
-        stringify!(nb_entries))
+        unsafe { ::std::ptr::addr_of!((*ptr).nb_entries) as usize - ptr as usize },
+        24usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_ip_frag_tbl),
+            "::",
+            stringify!(nb_entries),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).nb_buckets) as usize - ptr as usize },
-        28usize, concat!("Offset of field: ", stringify!(rte_ip_frag_tbl), "::",
-        stringify!(nb_buckets))
+        unsafe { ::std::ptr::addr_of!((*ptr).nb_buckets) as usize - ptr as usize },
+        28usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_ip_frag_tbl),
+            "::",
+            stringify!(nb_buckets),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).last) as usize - ptr as usize }, 32usize,
-        concat!("Offset of field: ", stringify!(rte_ip_frag_tbl), "::", stringify!(last))
+        unsafe { ::std::ptr::addr_of!((*ptr).last) as usize - ptr as usize },
+        32usize,
+        concat!("Offset of field: ", stringify!(rte_ip_frag_tbl), "::", stringify!(last)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).lru) as usize - ptr as usize }, 40usize,
-        concat!("Offset of field: ", stringify!(rte_ip_frag_tbl), "::", stringify!(lru))
+        unsafe { ::std::ptr::addr_of!((*ptr).lru) as usize - ptr as usize },
+        40usize,
+        concat!("Offset of field: ", stringify!(rte_ip_frag_tbl), "::", stringify!(lru)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).stat) as usize - ptr as usize }, 64usize,
-        concat!("Offset of field: ", stringify!(rte_ip_frag_tbl), "::", stringify!(stat))
+        unsafe { ::std::ptr::addr_of!((*ptr).stat) as usize - ptr as usize },
+        64usize,
+        concat!("Offset of field: ", stringify!(rte_ip_frag_tbl), "::", stringify!(stat)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).pkt) as usize - ptr as usize }, 128usize,
-        concat!("Offset of field: ", stringify!(rte_ip_frag_tbl), "::", stringify!(pkt))
+        unsafe { ::std::ptr::addr_of!((*ptr).pkt) as usize - ptr as usize },
+        128usize,
+        concat!("Offset of field: ", stringify!(rte_ip_frag_tbl), "::", stringify!(pkt)),
     );
 }
 impl Default for rte_ip_frag_tbl {

--- a/bindgen-tests/tests/expectations/tests/layout_mbuf.rs
+++ b/bindgen-tests/tests/expectations/tests/layout_mbuf.rs
@@ -49,7 +49,7 @@ where
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < self.storage.as_ref().len());
         debug_assert!(
-            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len()
+            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len(),
         );
         let mut val = 0;
         for i in 0..(bit_width as usize) {
@@ -69,7 +69,7 @@ where
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < self.storage.as_ref().len());
         debug_assert!(
-            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len()
+            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len(),
         );
         for i in 0..(bit_width as usize) {
             let mask = 1 << i;
@@ -101,16 +101,19 @@ fn bindgen_test_layout_rte_atomic16_t() {
     const UNINIT: ::std::mem::MaybeUninit<rte_atomic16_t> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < rte_atomic16_t > (), 2usize, concat!("Size of: ",
-        stringify!(rte_atomic16_t))
+        ::std::mem::size_of::<rte_atomic16_t>(),
+        2usize,
+        concat!("Size of: ", stringify!(rte_atomic16_t)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < rte_atomic16_t > (), 2usize, concat!("Alignment of ",
-        stringify!(rte_atomic16_t))
+        ::std::mem::align_of::<rte_atomic16_t>(),
+        2usize,
+        concat!("Alignment of ", stringify!(rte_atomic16_t)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).cnt) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(rte_atomic16_t), "::", stringify!(cnt))
+        unsafe { ::std::ptr::addr_of!((*ptr).cnt) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(rte_atomic16_t), "::", stringify!(cnt)),
     );
 }
 /// The generic rte_mbuf, containing a packet mbuf.
@@ -179,22 +182,34 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<rte_mbuf__bindgen_ty_1> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < rte_mbuf__bindgen_ty_1 > (), 2usize, concat!("Size of: ",
-        stringify!(rte_mbuf__bindgen_ty_1))
+        ::std::mem::size_of::<rte_mbuf__bindgen_ty_1>(),
+        2usize,
+        concat!("Size of: ", stringify!(rte_mbuf__bindgen_ty_1)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < rte_mbuf__bindgen_ty_1 > (), 2usize,
-        concat!("Alignment of ", stringify!(rte_mbuf__bindgen_ty_1))
+        ::std::mem::align_of::<rte_mbuf__bindgen_ty_1>(),
+        2usize,
+        concat!("Alignment of ", stringify!(rte_mbuf__bindgen_ty_1)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).refcnt_atomic) as usize - ptr as usize },
-        0usize, concat!("Offset of field: ", stringify!(rte_mbuf__bindgen_ty_1), "::",
-        stringify!(refcnt_atomic))
+        unsafe { ::std::ptr::addr_of!((*ptr).refcnt_atomic) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_mbuf__bindgen_ty_1),
+            "::",
+            stringify!(refcnt_atomic),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).refcnt) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(rte_mbuf__bindgen_ty_1), "::",
-        stringify!(refcnt))
+        unsafe { ::std::ptr::addr_of!((*ptr).refcnt) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_mbuf__bindgen_ty_1),
+            "::",
+            stringify!(refcnt),
+        ),
     );
 }
 impl Default for rte_mbuf__bindgen_ty_1 {
@@ -223,12 +238,14 @@ pub struct rte_mbuf__bindgen_ty_2__bindgen_ty_1 {
 #[test]
 fn bindgen_test_layout_rte_mbuf__bindgen_ty_2__bindgen_ty_1() {
     assert_eq!(
-        ::std::mem::size_of:: < rte_mbuf__bindgen_ty_2__bindgen_ty_1 > (), 4usize,
-        concat!("Size of: ", stringify!(rte_mbuf__bindgen_ty_2__bindgen_ty_1))
+        ::std::mem::size_of::<rte_mbuf__bindgen_ty_2__bindgen_ty_1>(),
+        4usize,
+        concat!("Size of: ", stringify!(rte_mbuf__bindgen_ty_2__bindgen_ty_1)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < rte_mbuf__bindgen_ty_2__bindgen_ty_1 > (), 4usize,
-        concat!("Alignment of ", stringify!(rte_mbuf__bindgen_ty_2__bindgen_ty_1))
+        ::std::mem::align_of::<rte_mbuf__bindgen_ty_2__bindgen_ty_1>(),
+        4usize,
+        concat!("Alignment of ", stringify!(rte_mbuf__bindgen_ty_2__bindgen_ty_1)),
     );
 }
 impl rte_mbuf__bindgen_ty_2__bindgen_ty_1 {
@@ -397,17 +414,24 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_2() {
     const UNINIT: ::std::mem::MaybeUninit<rte_mbuf__bindgen_ty_2> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < rte_mbuf__bindgen_ty_2 > (), 4usize, concat!("Size of: ",
-        stringify!(rte_mbuf__bindgen_ty_2))
+        ::std::mem::size_of::<rte_mbuf__bindgen_ty_2>(),
+        4usize,
+        concat!("Size of: ", stringify!(rte_mbuf__bindgen_ty_2)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < rte_mbuf__bindgen_ty_2 > (), 4usize,
-        concat!("Alignment of ", stringify!(rte_mbuf__bindgen_ty_2))
+        ::std::mem::align_of::<rte_mbuf__bindgen_ty_2>(),
+        4usize,
+        concat!("Alignment of ", stringify!(rte_mbuf__bindgen_ty_2)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).packet_type) as usize - ptr as usize },
-        0usize, concat!("Offset of field: ", stringify!(rte_mbuf__bindgen_ty_2), "::",
-        stringify!(packet_type))
+        unsafe { ::std::ptr::addr_of!((*ptr).packet_type) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_mbuf__bindgen_ty_2),
+            "::",
+            stringify!(packet_type),
+        ),
     );
 }
 impl Default for rte_mbuf__bindgen_ty_2 {
@@ -456,28 +480,44 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindg
     > = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: <
-        rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1 > (), 4usize,
-        concat!("Size of: ",
-        stringify!(rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1))
+        ::std::mem::size_of::<
+            rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1,
+        >(),
+        4usize,
+        concat!(
+            "Size of: ",
+            stringify!(rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1),
+        ),
     );
     assert_eq!(
-        ::std::mem::align_of:: <
-        rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1 > (), 2usize,
-        concat!("Alignment of ",
-        stringify!(rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1))
+        ::std::mem::align_of::<
+            rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1,
+        >(),
+        2usize,
+        concat!(
+            "Alignment of ",
+            stringify!(rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).hash) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ",
-        stringify!(rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1),
-        "::", stringify!(hash))
+        unsafe { ::std::ptr::addr_of!((*ptr).hash) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1),
+            "::",
+            stringify!(hash),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).id) as usize - ptr as usize }, 2usize,
-        concat!("Offset of field: ",
-        stringify!(rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1),
-        "::", stringify!(id))
+        unsafe { ::std::ptr::addr_of!((*ptr).id) as usize - ptr as usize },
+        2usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1),
+            "::",
+            stringify!(id),
+        ),
     );
 }
 #[test]
@@ -487,20 +527,30 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1() {
     > = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1 > (),
-        4usize, concat!("Size of: ",
-        stringify!(rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1))
+        ::std::mem::size_of::<rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1>(),
+        4usize,
+        concat!(
+            "Size of: ",
+            stringify!(rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1),
+        ),
     );
     assert_eq!(
-        ::std::mem::align_of:: < rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1 > (),
-        4usize, concat!("Alignment of ",
-        stringify!(rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1))
+        ::std::mem::align_of::<rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1>(),
+        4usize,
+        concat!(
+            "Alignment of ",
+            stringify!(rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).lo) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ",
-        stringify!(rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1), "::",
-        stringify!(lo))
+        unsafe { ::std::ptr::addr_of!((*ptr).lo) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1),
+            "::",
+            stringify!(lo),
+        ),
     );
 }
 impl Default for rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1 {
@@ -517,17 +567,24 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_3__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<rte_mbuf__bindgen_ty_3__bindgen_ty_1> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < rte_mbuf__bindgen_ty_3__bindgen_ty_1 > (), 8usize,
-        concat!("Size of: ", stringify!(rte_mbuf__bindgen_ty_3__bindgen_ty_1))
+        ::std::mem::size_of::<rte_mbuf__bindgen_ty_3__bindgen_ty_1>(),
+        8usize,
+        concat!("Size of: ", stringify!(rte_mbuf__bindgen_ty_3__bindgen_ty_1)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < rte_mbuf__bindgen_ty_3__bindgen_ty_1 > (), 4usize,
-        concat!("Alignment of ", stringify!(rte_mbuf__bindgen_ty_3__bindgen_ty_1))
+        ::std::mem::align_of::<rte_mbuf__bindgen_ty_3__bindgen_ty_1>(),
+        4usize,
+        concat!("Alignment of ", stringify!(rte_mbuf__bindgen_ty_3__bindgen_ty_1)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).hi) as usize - ptr as usize }, 4usize,
-        concat!("Offset of field: ", stringify!(rte_mbuf__bindgen_ty_3__bindgen_ty_1),
-        "::", stringify!(hi))
+        unsafe { ::std::ptr::addr_of!((*ptr).hi) as usize - ptr as usize },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_mbuf__bindgen_ty_3__bindgen_ty_1),
+            "::",
+            stringify!(hi),
+        ),
     );
 }
 impl Default for rte_mbuf__bindgen_ty_3__bindgen_ty_1 {
@@ -550,22 +607,34 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_3__bindgen_ty_2() {
     const UNINIT: ::std::mem::MaybeUninit<rte_mbuf__bindgen_ty_3__bindgen_ty_2> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < rte_mbuf__bindgen_ty_3__bindgen_ty_2 > (), 8usize,
-        concat!("Size of: ", stringify!(rte_mbuf__bindgen_ty_3__bindgen_ty_2))
+        ::std::mem::size_of::<rte_mbuf__bindgen_ty_3__bindgen_ty_2>(),
+        8usize,
+        concat!("Size of: ", stringify!(rte_mbuf__bindgen_ty_3__bindgen_ty_2)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < rte_mbuf__bindgen_ty_3__bindgen_ty_2 > (), 4usize,
-        concat!("Alignment of ", stringify!(rte_mbuf__bindgen_ty_3__bindgen_ty_2))
+        ::std::mem::align_of::<rte_mbuf__bindgen_ty_3__bindgen_ty_2>(),
+        4usize,
+        concat!("Alignment of ", stringify!(rte_mbuf__bindgen_ty_3__bindgen_ty_2)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).lo) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(rte_mbuf__bindgen_ty_3__bindgen_ty_2),
-        "::", stringify!(lo))
+        unsafe { ::std::ptr::addr_of!((*ptr).lo) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_mbuf__bindgen_ty_3__bindgen_ty_2),
+            "::",
+            stringify!(lo),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).hi) as usize - ptr as usize }, 4usize,
-        concat!("Offset of field: ", stringify!(rte_mbuf__bindgen_ty_3__bindgen_ty_2),
-        "::", stringify!(hi))
+        unsafe { ::std::ptr::addr_of!((*ptr).hi) as usize - ptr as usize },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_mbuf__bindgen_ty_3__bindgen_ty_2),
+            "::",
+            stringify!(hi),
+        ),
     );
 }
 #[test]
@@ -573,32 +642,54 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_3() {
     const UNINIT: ::std::mem::MaybeUninit<rte_mbuf__bindgen_ty_3> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < rte_mbuf__bindgen_ty_3 > (), 8usize, concat!("Size of: ",
-        stringify!(rte_mbuf__bindgen_ty_3))
+        ::std::mem::size_of::<rte_mbuf__bindgen_ty_3>(),
+        8usize,
+        concat!("Size of: ", stringify!(rte_mbuf__bindgen_ty_3)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < rte_mbuf__bindgen_ty_3 > (), 4usize,
-        concat!("Alignment of ", stringify!(rte_mbuf__bindgen_ty_3))
+        ::std::mem::align_of::<rte_mbuf__bindgen_ty_3>(),
+        4usize,
+        concat!("Alignment of ", stringify!(rte_mbuf__bindgen_ty_3)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).rss) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(rte_mbuf__bindgen_ty_3), "::",
-        stringify!(rss))
+        unsafe { ::std::ptr::addr_of!((*ptr).rss) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_mbuf__bindgen_ty_3),
+            "::",
+            stringify!(rss),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).fdir) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(rte_mbuf__bindgen_ty_3), "::",
-        stringify!(fdir))
+        unsafe { ::std::ptr::addr_of!((*ptr).fdir) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_mbuf__bindgen_ty_3),
+            "::",
+            stringify!(fdir),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).sched) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(rte_mbuf__bindgen_ty_3), "::",
-        stringify!(sched))
+        unsafe { ::std::ptr::addr_of!((*ptr).sched) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_mbuf__bindgen_ty_3),
+            "::",
+            stringify!(sched),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).usr) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(rte_mbuf__bindgen_ty_3), "::",
-        stringify!(usr))
+        unsafe { ::std::ptr::addr_of!((*ptr).usr) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_mbuf__bindgen_ty_3),
+            "::",
+            stringify!(usr),
+        ),
     );
 }
 impl Default for rte_mbuf__bindgen_ty_3 {
@@ -623,22 +714,34 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_4() {
     const UNINIT: ::std::mem::MaybeUninit<rte_mbuf__bindgen_ty_4> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < rte_mbuf__bindgen_ty_4 > (), 8usize, concat!("Size of: ",
-        stringify!(rte_mbuf__bindgen_ty_4))
+        ::std::mem::size_of::<rte_mbuf__bindgen_ty_4>(),
+        8usize,
+        concat!("Size of: ", stringify!(rte_mbuf__bindgen_ty_4)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < rte_mbuf__bindgen_ty_4 > (), 8usize,
-        concat!("Alignment of ", stringify!(rte_mbuf__bindgen_ty_4))
+        ::std::mem::align_of::<rte_mbuf__bindgen_ty_4>(),
+        8usize,
+        concat!("Alignment of ", stringify!(rte_mbuf__bindgen_ty_4)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).userdata) as usize - ptr as usize },
-        0usize, concat!("Offset of field: ", stringify!(rte_mbuf__bindgen_ty_4), "::",
-        stringify!(userdata))
+        unsafe { ::std::ptr::addr_of!((*ptr).userdata) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_mbuf__bindgen_ty_4),
+            "::",
+            stringify!(userdata),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).udata64) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(rte_mbuf__bindgen_ty_4), "::",
-        stringify!(udata64))
+        unsafe { ::std::ptr::addr_of!((*ptr).udata64) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_mbuf__bindgen_ty_4),
+            "::",
+            stringify!(udata64),
+        ),
     );
 }
 impl Default for rte_mbuf__bindgen_ty_4 {
@@ -667,12 +770,14 @@ pub struct rte_mbuf__bindgen_ty_5__bindgen_ty_1 {
 #[test]
 fn bindgen_test_layout_rte_mbuf__bindgen_ty_5__bindgen_ty_1() {
     assert_eq!(
-        ::std::mem::size_of:: < rte_mbuf__bindgen_ty_5__bindgen_ty_1 > (), 8usize,
-        concat!("Size of: ", stringify!(rte_mbuf__bindgen_ty_5__bindgen_ty_1))
+        ::std::mem::size_of::<rte_mbuf__bindgen_ty_5__bindgen_ty_1>(),
+        8usize,
+        concat!("Size of: ", stringify!(rte_mbuf__bindgen_ty_5__bindgen_ty_1)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < rte_mbuf__bindgen_ty_5__bindgen_ty_1 > (), 8usize,
-        concat!("Alignment of ", stringify!(rte_mbuf__bindgen_ty_5__bindgen_ty_1))
+        ::std::mem::align_of::<rte_mbuf__bindgen_ty_5__bindgen_ty_1>(),
+        8usize,
+        concat!("Alignment of ", stringify!(rte_mbuf__bindgen_ty_5__bindgen_ty_1)),
     );
 }
 impl rte_mbuf__bindgen_ty_5__bindgen_ty_1 {
@@ -818,17 +923,24 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_5() {
     const UNINIT: ::std::mem::MaybeUninit<rte_mbuf__bindgen_ty_5> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < rte_mbuf__bindgen_ty_5 > (), 8usize, concat!("Size of: ",
-        stringify!(rte_mbuf__bindgen_ty_5))
+        ::std::mem::size_of::<rte_mbuf__bindgen_ty_5>(),
+        8usize,
+        concat!("Size of: ", stringify!(rte_mbuf__bindgen_ty_5)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < rte_mbuf__bindgen_ty_5 > (), 8usize,
-        concat!("Alignment of ", stringify!(rte_mbuf__bindgen_ty_5))
+        ::std::mem::align_of::<rte_mbuf__bindgen_ty_5>(),
+        8usize,
+        concat!("Alignment of ", stringify!(rte_mbuf__bindgen_ty_5)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).tx_offload) as usize - ptr as usize },
-        0usize, concat!("Offset of field: ", stringify!(rte_mbuf__bindgen_ty_5), "::",
-        stringify!(tx_offload))
+        unsafe { ::std::ptr::addr_of!((*ptr).tx_offload) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_mbuf__bindgen_ty_5),
+            "::",
+            stringify!(tx_offload),
+        ),
     );
 }
 impl Default for rte_mbuf__bindgen_ty_5 {
@@ -845,112 +957,136 @@ fn bindgen_test_layout_rte_mbuf() {
     const UNINIT: ::std::mem::MaybeUninit<rte_mbuf> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < rte_mbuf > (), 128usize, concat!("Size of: ",
-        stringify!(rte_mbuf))
+        ::std::mem::size_of::<rte_mbuf>(),
+        128usize,
+        concat!("Size of: ", stringify!(rte_mbuf)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < rte_mbuf > (), 64usize, concat!("Alignment of ",
-        stringify!(rte_mbuf))
+        ::std::mem::align_of::<rte_mbuf>(),
+        64usize,
+        concat!("Alignment of ", stringify!(rte_mbuf)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).cacheline0) as usize - ptr as usize },
-        0usize, concat!("Offset of field: ", stringify!(rte_mbuf), "::",
-        stringify!(cacheline0))
+        unsafe { ::std::ptr::addr_of!((*ptr).cacheline0) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(rte_mbuf), "::", stringify!(cacheline0)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).buf_addr) as usize - ptr as usize },
-        0usize, concat!("Offset of field: ", stringify!(rte_mbuf), "::",
-        stringify!(buf_addr))
+        unsafe { ::std::ptr::addr_of!((*ptr).buf_addr) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(rte_mbuf), "::", stringify!(buf_addr)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).buf_physaddr) as usize - ptr as usize },
-        8usize, concat!("Offset of field: ", stringify!(rte_mbuf), "::",
-        stringify!(buf_physaddr))
+        unsafe { ::std::ptr::addr_of!((*ptr).buf_physaddr) as usize - ptr as usize },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_mbuf),
+            "::",
+            stringify!(buf_physaddr),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).buf_len) as usize - ptr as usize },
-        16usize, concat!("Offset of field: ", stringify!(rte_mbuf), "::",
-        stringify!(buf_len))
+        unsafe { ::std::ptr::addr_of!((*ptr).buf_len) as usize - ptr as usize },
+        16usize,
+        concat!("Offset of field: ", stringify!(rte_mbuf), "::", stringify!(buf_len)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).rearm_data) as usize - ptr as usize },
-        18usize, concat!("Offset of field: ", stringify!(rte_mbuf), "::",
-        stringify!(rearm_data))
+        unsafe { ::std::ptr::addr_of!((*ptr).rearm_data) as usize - ptr as usize },
+        18usize,
+        concat!("Offset of field: ", stringify!(rte_mbuf), "::", stringify!(rearm_data)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).data_off) as usize - ptr as usize },
-        18usize, concat!("Offset of field: ", stringify!(rte_mbuf), "::",
-        stringify!(data_off))
+        unsafe { ::std::ptr::addr_of!((*ptr).data_off) as usize - ptr as usize },
+        18usize,
+        concat!("Offset of field: ", stringify!(rte_mbuf), "::", stringify!(data_off)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).nb_segs) as usize - ptr as usize },
-        22usize, concat!("Offset of field: ", stringify!(rte_mbuf), "::",
-        stringify!(nb_segs))
+        unsafe { ::std::ptr::addr_of!((*ptr).nb_segs) as usize - ptr as usize },
+        22usize,
+        concat!("Offset of field: ", stringify!(rte_mbuf), "::", stringify!(nb_segs)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).port) as usize - ptr as usize }, 23usize,
-        concat!("Offset of field: ", stringify!(rte_mbuf), "::", stringify!(port))
+        unsafe { ::std::ptr::addr_of!((*ptr).port) as usize - ptr as usize },
+        23usize,
+        concat!("Offset of field: ", stringify!(rte_mbuf), "::", stringify!(port)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).ol_flags) as usize - ptr as usize },
-        24usize, concat!("Offset of field: ", stringify!(rte_mbuf), "::",
-        stringify!(ol_flags))
+        unsafe { ::std::ptr::addr_of!((*ptr).ol_flags) as usize - ptr as usize },
+        24usize,
+        concat!("Offset of field: ", stringify!(rte_mbuf), "::", stringify!(ol_flags)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).rx_descriptor_fields1) as usize - ptr as
-        usize }, 32usize, concat!("Offset of field: ", stringify!(rte_mbuf), "::",
-        stringify!(rx_descriptor_fields1))
+        unsafe {
+            ::std::ptr::addr_of!((*ptr).rx_descriptor_fields1) as usize - ptr as usize
+        },
+        32usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_mbuf),
+            "::",
+            stringify!(rx_descriptor_fields1),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).pkt_len) as usize - ptr as usize },
-        36usize, concat!("Offset of field: ", stringify!(rte_mbuf), "::",
-        stringify!(pkt_len))
+        unsafe { ::std::ptr::addr_of!((*ptr).pkt_len) as usize - ptr as usize },
+        36usize,
+        concat!("Offset of field: ", stringify!(rte_mbuf), "::", stringify!(pkt_len)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).data_len) as usize - ptr as usize },
-        40usize, concat!("Offset of field: ", stringify!(rte_mbuf), "::",
-        stringify!(data_len))
+        unsafe { ::std::ptr::addr_of!((*ptr).data_len) as usize - ptr as usize },
+        40usize,
+        concat!("Offset of field: ", stringify!(rte_mbuf), "::", stringify!(data_len)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).vlan_tci) as usize - ptr as usize },
-        42usize, concat!("Offset of field: ", stringify!(rte_mbuf), "::",
-        stringify!(vlan_tci))
+        unsafe { ::std::ptr::addr_of!((*ptr).vlan_tci) as usize - ptr as usize },
+        42usize,
+        concat!("Offset of field: ", stringify!(rte_mbuf), "::", stringify!(vlan_tci)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).hash) as usize - ptr as usize }, 44usize,
-        concat!("Offset of field: ", stringify!(rte_mbuf), "::", stringify!(hash))
+        unsafe { ::std::ptr::addr_of!((*ptr).hash) as usize - ptr as usize },
+        44usize,
+        concat!("Offset of field: ", stringify!(rte_mbuf), "::", stringify!(hash)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).seqn) as usize - ptr as usize }, 52usize,
-        concat!("Offset of field: ", stringify!(rte_mbuf), "::", stringify!(seqn))
+        unsafe { ::std::ptr::addr_of!((*ptr).seqn) as usize - ptr as usize },
+        52usize,
+        concat!("Offset of field: ", stringify!(rte_mbuf), "::", stringify!(seqn)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).vlan_tci_outer) as usize - ptr as usize },
-        56usize, concat!("Offset of field: ", stringify!(rte_mbuf), "::",
-        stringify!(vlan_tci_outer))
+        unsafe { ::std::ptr::addr_of!((*ptr).vlan_tci_outer) as usize - ptr as usize },
+        56usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_mbuf),
+            "::",
+            stringify!(vlan_tci_outer),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).cacheline1) as usize - ptr as usize },
-        64usize, concat!("Offset of field: ", stringify!(rte_mbuf), "::",
-        stringify!(cacheline1))
+        unsafe { ::std::ptr::addr_of!((*ptr).cacheline1) as usize - ptr as usize },
+        64usize,
+        concat!("Offset of field: ", stringify!(rte_mbuf), "::", stringify!(cacheline1)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).pool) as usize - ptr as usize }, 72usize,
-        concat!("Offset of field: ", stringify!(rte_mbuf), "::", stringify!(pool))
+        unsafe { ::std::ptr::addr_of!((*ptr).pool) as usize - ptr as usize },
+        72usize,
+        concat!("Offset of field: ", stringify!(rte_mbuf), "::", stringify!(pool)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).next) as usize - ptr as usize }, 80usize,
-        concat!("Offset of field: ", stringify!(rte_mbuf), "::", stringify!(next))
+        unsafe { ::std::ptr::addr_of!((*ptr).next) as usize - ptr as usize },
+        80usize,
+        concat!("Offset of field: ", stringify!(rte_mbuf), "::", stringify!(next)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).priv_size) as usize - ptr as usize },
-        96usize, concat!("Offset of field: ", stringify!(rte_mbuf), "::",
-        stringify!(priv_size))
+        unsafe { ::std::ptr::addr_of!((*ptr).priv_size) as usize - ptr as usize },
+        96usize,
+        concat!("Offset of field: ", stringify!(rte_mbuf), "::", stringify!(priv_size)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).timesync) as usize - ptr as usize },
-        98usize, concat!("Offset of field: ", stringify!(rte_mbuf), "::",
-        stringify!(timesync))
+        unsafe { ::std::ptr::addr_of!((*ptr).timesync) as usize - ptr as usize },
+        98usize,
+        concat!("Offset of field: ", stringify!(rte_mbuf), "::", stringify!(timesync)),
     );
 }
 impl Default for rte_mbuf {

--- a/bindgen-tests/tests/expectations/tests/layout_mbuf_1_0.rs
+++ b/bindgen-tests/tests/expectations/tests/layout_mbuf_1_0.rs
@@ -49,7 +49,7 @@ where
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < self.storage.as_ref().len());
         debug_assert!(
-            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len()
+            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len(),
         );
         let mut val = 0;
         for i in 0..(bit_width as usize) {
@@ -69,7 +69,7 @@ where
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < self.storage.as_ref().len());
         debug_assert!(
-            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len()
+            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len(),
         );
         for i in 0..(bit_width as usize) {
             let mask = 1 << i;
@@ -144,16 +144,19 @@ fn bindgen_test_layout_rte_atomic16_t() {
     const UNINIT: ::std::mem::MaybeUninit<rte_atomic16_t> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < rte_atomic16_t > (), 2usize, concat!("Size of: ",
-        stringify!(rte_atomic16_t))
+        ::std::mem::size_of::<rte_atomic16_t>(),
+        2usize,
+        concat!("Size of: ", stringify!(rte_atomic16_t)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < rte_atomic16_t > (), 2usize, concat!("Alignment of ",
-        stringify!(rte_atomic16_t))
+        ::std::mem::align_of::<rte_atomic16_t>(),
+        2usize,
+        concat!("Alignment of ", stringify!(rte_atomic16_t)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).cnt) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(rte_atomic16_t), "::", stringify!(cnt))
+        unsafe { ::std::ptr::addr_of!((*ptr).cnt) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(rte_atomic16_t), "::", stringify!(cnt)),
     );
 }
 impl Clone for rte_atomic16_t {
@@ -228,22 +231,34 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<rte_mbuf__bindgen_ty_1> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < rte_mbuf__bindgen_ty_1 > (), 2usize, concat!("Size of: ",
-        stringify!(rte_mbuf__bindgen_ty_1))
+        ::std::mem::size_of::<rte_mbuf__bindgen_ty_1>(),
+        2usize,
+        concat!("Size of: ", stringify!(rte_mbuf__bindgen_ty_1)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < rte_mbuf__bindgen_ty_1 > (), 2usize,
-        concat!("Alignment of ", stringify!(rte_mbuf__bindgen_ty_1))
+        ::std::mem::align_of::<rte_mbuf__bindgen_ty_1>(),
+        2usize,
+        concat!("Alignment of ", stringify!(rte_mbuf__bindgen_ty_1)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).refcnt_atomic) as usize - ptr as usize },
-        0usize, concat!("Offset of field: ", stringify!(rte_mbuf__bindgen_ty_1), "::",
-        stringify!(refcnt_atomic))
+        unsafe { ::std::ptr::addr_of!((*ptr).refcnt_atomic) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_mbuf__bindgen_ty_1),
+            "::",
+            stringify!(refcnt_atomic),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).refcnt) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(rte_mbuf__bindgen_ty_1), "::",
-        stringify!(refcnt))
+        unsafe { ::std::ptr::addr_of!((*ptr).refcnt) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_mbuf__bindgen_ty_1),
+            "::",
+            stringify!(refcnt),
+        ),
     );
 }
 impl Clone for rte_mbuf__bindgen_ty_1 {
@@ -269,12 +284,14 @@ pub struct rte_mbuf__bindgen_ty_2__bindgen_ty_1 {
 #[test]
 fn bindgen_test_layout_rte_mbuf__bindgen_ty_2__bindgen_ty_1() {
     assert_eq!(
-        ::std::mem::size_of:: < rte_mbuf__bindgen_ty_2__bindgen_ty_1 > (), 4usize,
-        concat!("Size of: ", stringify!(rte_mbuf__bindgen_ty_2__bindgen_ty_1))
+        ::std::mem::size_of::<rte_mbuf__bindgen_ty_2__bindgen_ty_1>(),
+        4usize,
+        concat!("Size of: ", stringify!(rte_mbuf__bindgen_ty_2__bindgen_ty_1)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < rte_mbuf__bindgen_ty_2__bindgen_ty_1 > (), 4usize,
-        concat!("Alignment of ", stringify!(rte_mbuf__bindgen_ty_2__bindgen_ty_1))
+        ::std::mem::align_of::<rte_mbuf__bindgen_ty_2__bindgen_ty_1>(),
+        4usize,
+        concat!("Alignment of ", stringify!(rte_mbuf__bindgen_ty_2__bindgen_ty_1)),
     );
 }
 impl Clone for rte_mbuf__bindgen_ty_2__bindgen_ty_1 {
@@ -448,17 +465,24 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_2() {
     const UNINIT: ::std::mem::MaybeUninit<rte_mbuf__bindgen_ty_2> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < rte_mbuf__bindgen_ty_2 > (), 4usize, concat!("Size of: ",
-        stringify!(rte_mbuf__bindgen_ty_2))
+        ::std::mem::size_of::<rte_mbuf__bindgen_ty_2>(),
+        4usize,
+        concat!("Size of: ", stringify!(rte_mbuf__bindgen_ty_2)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < rte_mbuf__bindgen_ty_2 > (), 4usize,
-        concat!("Alignment of ", stringify!(rte_mbuf__bindgen_ty_2))
+        ::std::mem::align_of::<rte_mbuf__bindgen_ty_2>(),
+        4usize,
+        concat!("Alignment of ", stringify!(rte_mbuf__bindgen_ty_2)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).packet_type) as usize - ptr as usize },
-        0usize, concat!("Offset of field: ", stringify!(rte_mbuf__bindgen_ty_2), "::",
-        stringify!(packet_type))
+        unsafe { ::std::ptr::addr_of!((*ptr).packet_type) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_mbuf__bindgen_ty_2),
+            "::",
+            stringify!(packet_type),
+        ),
     );
 }
 impl Clone for rte_mbuf__bindgen_ty_2 {
@@ -507,28 +531,44 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindg
     > = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: <
-        rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1 > (), 4usize,
-        concat!("Size of: ",
-        stringify!(rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1))
+        ::std::mem::size_of::<
+            rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1,
+        >(),
+        4usize,
+        concat!(
+            "Size of: ",
+            stringify!(rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1),
+        ),
     );
     assert_eq!(
-        ::std::mem::align_of:: <
-        rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1 > (), 2usize,
-        concat!("Alignment of ",
-        stringify!(rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1))
+        ::std::mem::align_of::<
+            rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1,
+        >(),
+        2usize,
+        concat!(
+            "Alignment of ",
+            stringify!(rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).hash) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ",
-        stringify!(rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1),
-        "::", stringify!(hash))
+        unsafe { ::std::ptr::addr_of!((*ptr).hash) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1),
+            "::",
+            stringify!(hash),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).id) as usize - ptr as usize }, 2usize,
-        concat!("Offset of field: ",
-        stringify!(rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1),
-        "::", stringify!(id))
+        unsafe { ::std::ptr::addr_of!((*ptr).id) as usize - ptr as usize },
+        2usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1),
+            "::",
+            stringify!(id),
+        ),
     );
 }
 impl Clone for rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1 {
@@ -543,20 +583,30 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1() {
     > = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1 > (),
-        4usize, concat!("Size of: ",
-        stringify!(rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1))
+        ::std::mem::size_of::<rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1>(),
+        4usize,
+        concat!(
+            "Size of: ",
+            stringify!(rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1),
+        ),
     );
     assert_eq!(
-        ::std::mem::align_of:: < rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1 > (),
-        4usize, concat!("Alignment of ",
-        stringify!(rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1))
+        ::std::mem::align_of::<rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1>(),
+        4usize,
+        concat!(
+            "Alignment of ",
+            stringify!(rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).lo) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ",
-        stringify!(rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1), "::",
-        stringify!(lo))
+        unsafe { ::std::ptr::addr_of!((*ptr).lo) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1),
+            "::",
+            stringify!(lo),
+        ),
     );
 }
 impl Clone for rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1 {
@@ -569,17 +619,24 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_3__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<rte_mbuf__bindgen_ty_3__bindgen_ty_1> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < rte_mbuf__bindgen_ty_3__bindgen_ty_1 > (), 8usize,
-        concat!("Size of: ", stringify!(rte_mbuf__bindgen_ty_3__bindgen_ty_1))
+        ::std::mem::size_of::<rte_mbuf__bindgen_ty_3__bindgen_ty_1>(),
+        8usize,
+        concat!("Size of: ", stringify!(rte_mbuf__bindgen_ty_3__bindgen_ty_1)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < rte_mbuf__bindgen_ty_3__bindgen_ty_1 > (), 4usize,
-        concat!("Alignment of ", stringify!(rte_mbuf__bindgen_ty_3__bindgen_ty_1))
+        ::std::mem::align_of::<rte_mbuf__bindgen_ty_3__bindgen_ty_1>(),
+        4usize,
+        concat!("Alignment of ", stringify!(rte_mbuf__bindgen_ty_3__bindgen_ty_1)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).hi) as usize - ptr as usize }, 4usize,
-        concat!("Offset of field: ", stringify!(rte_mbuf__bindgen_ty_3__bindgen_ty_1),
-        "::", stringify!(hi))
+        unsafe { ::std::ptr::addr_of!((*ptr).hi) as usize - ptr as usize },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_mbuf__bindgen_ty_3__bindgen_ty_1),
+            "::",
+            stringify!(hi),
+        ),
     );
 }
 impl Clone for rte_mbuf__bindgen_ty_3__bindgen_ty_1 {
@@ -598,22 +655,34 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_3__bindgen_ty_2() {
     const UNINIT: ::std::mem::MaybeUninit<rte_mbuf__bindgen_ty_3__bindgen_ty_2> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < rte_mbuf__bindgen_ty_3__bindgen_ty_2 > (), 8usize,
-        concat!("Size of: ", stringify!(rte_mbuf__bindgen_ty_3__bindgen_ty_2))
+        ::std::mem::size_of::<rte_mbuf__bindgen_ty_3__bindgen_ty_2>(),
+        8usize,
+        concat!("Size of: ", stringify!(rte_mbuf__bindgen_ty_3__bindgen_ty_2)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < rte_mbuf__bindgen_ty_3__bindgen_ty_2 > (), 4usize,
-        concat!("Alignment of ", stringify!(rte_mbuf__bindgen_ty_3__bindgen_ty_2))
+        ::std::mem::align_of::<rte_mbuf__bindgen_ty_3__bindgen_ty_2>(),
+        4usize,
+        concat!("Alignment of ", stringify!(rte_mbuf__bindgen_ty_3__bindgen_ty_2)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).lo) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(rte_mbuf__bindgen_ty_3__bindgen_ty_2),
-        "::", stringify!(lo))
+        unsafe { ::std::ptr::addr_of!((*ptr).lo) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_mbuf__bindgen_ty_3__bindgen_ty_2),
+            "::",
+            stringify!(lo),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).hi) as usize - ptr as usize }, 4usize,
-        concat!("Offset of field: ", stringify!(rte_mbuf__bindgen_ty_3__bindgen_ty_2),
-        "::", stringify!(hi))
+        unsafe { ::std::ptr::addr_of!((*ptr).hi) as usize - ptr as usize },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_mbuf__bindgen_ty_3__bindgen_ty_2),
+            "::",
+            stringify!(hi),
+        ),
     );
 }
 impl Clone for rte_mbuf__bindgen_ty_3__bindgen_ty_2 {
@@ -626,32 +695,54 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_3() {
     const UNINIT: ::std::mem::MaybeUninit<rte_mbuf__bindgen_ty_3> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < rte_mbuf__bindgen_ty_3 > (), 8usize, concat!("Size of: ",
-        stringify!(rte_mbuf__bindgen_ty_3))
+        ::std::mem::size_of::<rte_mbuf__bindgen_ty_3>(),
+        8usize,
+        concat!("Size of: ", stringify!(rte_mbuf__bindgen_ty_3)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < rte_mbuf__bindgen_ty_3 > (), 4usize,
-        concat!("Alignment of ", stringify!(rte_mbuf__bindgen_ty_3))
+        ::std::mem::align_of::<rte_mbuf__bindgen_ty_3>(),
+        4usize,
+        concat!("Alignment of ", stringify!(rte_mbuf__bindgen_ty_3)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).rss) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(rte_mbuf__bindgen_ty_3), "::",
-        stringify!(rss))
+        unsafe { ::std::ptr::addr_of!((*ptr).rss) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_mbuf__bindgen_ty_3),
+            "::",
+            stringify!(rss),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).fdir) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(rte_mbuf__bindgen_ty_3), "::",
-        stringify!(fdir))
+        unsafe { ::std::ptr::addr_of!((*ptr).fdir) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_mbuf__bindgen_ty_3),
+            "::",
+            stringify!(fdir),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).sched) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(rte_mbuf__bindgen_ty_3), "::",
-        stringify!(sched))
+        unsafe { ::std::ptr::addr_of!((*ptr).sched) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_mbuf__bindgen_ty_3),
+            "::",
+            stringify!(sched),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).usr) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(rte_mbuf__bindgen_ty_3), "::",
-        stringify!(usr))
+        unsafe { ::std::ptr::addr_of!((*ptr).usr) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_mbuf__bindgen_ty_3),
+            "::",
+            stringify!(usr),
+        ),
     );
 }
 impl Clone for rte_mbuf__bindgen_ty_3 {
@@ -673,22 +764,34 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_4() {
     const UNINIT: ::std::mem::MaybeUninit<rte_mbuf__bindgen_ty_4> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < rte_mbuf__bindgen_ty_4 > (), 8usize, concat!("Size of: ",
-        stringify!(rte_mbuf__bindgen_ty_4))
+        ::std::mem::size_of::<rte_mbuf__bindgen_ty_4>(),
+        8usize,
+        concat!("Size of: ", stringify!(rte_mbuf__bindgen_ty_4)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < rte_mbuf__bindgen_ty_4 > (), 8usize,
-        concat!("Alignment of ", stringify!(rte_mbuf__bindgen_ty_4))
+        ::std::mem::align_of::<rte_mbuf__bindgen_ty_4>(),
+        8usize,
+        concat!("Alignment of ", stringify!(rte_mbuf__bindgen_ty_4)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).userdata) as usize - ptr as usize },
-        0usize, concat!("Offset of field: ", stringify!(rte_mbuf__bindgen_ty_4), "::",
-        stringify!(userdata))
+        unsafe { ::std::ptr::addr_of!((*ptr).userdata) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_mbuf__bindgen_ty_4),
+            "::",
+            stringify!(userdata),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).udata64) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(rte_mbuf__bindgen_ty_4), "::",
-        stringify!(udata64))
+        unsafe { ::std::ptr::addr_of!((*ptr).udata64) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_mbuf__bindgen_ty_4),
+            "::",
+            stringify!(udata64),
+        ),
     );
 }
 impl Clone for rte_mbuf__bindgen_ty_4 {
@@ -714,12 +817,14 @@ pub struct rte_mbuf__bindgen_ty_5__bindgen_ty_1 {
 #[test]
 fn bindgen_test_layout_rte_mbuf__bindgen_ty_5__bindgen_ty_1() {
     assert_eq!(
-        ::std::mem::size_of:: < rte_mbuf__bindgen_ty_5__bindgen_ty_1 > (), 8usize,
-        concat!("Size of: ", stringify!(rte_mbuf__bindgen_ty_5__bindgen_ty_1))
+        ::std::mem::size_of::<rte_mbuf__bindgen_ty_5__bindgen_ty_1>(),
+        8usize,
+        concat!("Size of: ", stringify!(rte_mbuf__bindgen_ty_5__bindgen_ty_1)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < rte_mbuf__bindgen_ty_5__bindgen_ty_1 > (), 8usize,
-        concat!("Alignment of ", stringify!(rte_mbuf__bindgen_ty_5__bindgen_ty_1))
+        ::std::mem::align_of::<rte_mbuf__bindgen_ty_5__bindgen_ty_1>(),
+        8usize,
+        concat!("Alignment of ", stringify!(rte_mbuf__bindgen_ty_5__bindgen_ty_1)),
     );
 }
 impl Clone for rte_mbuf__bindgen_ty_5__bindgen_ty_1 {
@@ -870,17 +975,24 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_5() {
     const UNINIT: ::std::mem::MaybeUninit<rte_mbuf__bindgen_ty_5> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < rte_mbuf__bindgen_ty_5 > (), 8usize, concat!("Size of: ",
-        stringify!(rte_mbuf__bindgen_ty_5))
+        ::std::mem::size_of::<rte_mbuf__bindgen_ty_5>(),
+        8usize,
+        concat!("Size of: ", stringify!(rte_mbuf__bindgen_ty_5)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < rte_mbuf__bindgen_ty_5 > (), 8usize,
-        concat!("Alignment of ", stringify!(rte_mbuf__bindgen_ty_5))
+        ::std::mem::align_of::<rte_mbuf__bindgen_ty_5>(),
+        8usize,
+        concat!("Alignment of ", stringify!(rte_mbuf__bindgen_ty_5)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).tx_offload) as usize - ptr as usize },
-        0usize, concat!("Offset of field: ", stringify!(rte_mbuf__bindgen_ty_5), "::",
-        stringify!(tx_offload))
+        unsafe { ::std::ptr::addr_of!((*ptr).tx_offload) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_mbuf__bindgen_ty_5),
+            "::",
+            stringify!(tx_offload),
+        ),
     );
 }
 impl Clone for rte_mbuf__bindgen_ty_5 {
@@ -893,108 +1005,131 @@ fn bindgen_test_layout_rte_mbuf() {
     const UNINIT: ::std::mem::MaybeUninit<rte_mbuf> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < rte_mbuf > (), 128usize, concat!("Size of: ",
-        stringify!(rte_mbuf))
+        ::std::mem::size_of::<rte_mbuf>(),
+        128usize,
+        concat!("Size of: ", stringify!(rte_mbuf)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).cacheline0) as usize - ptr as usize },
-        0usize, concat!("Offset of field: ", stringify!(rte_mbuf), "::",
-        stringify!(cacheline0))
+        unsafe { ::std::ptr::addr_of!((*ptr).cacheline0) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(rte_mbuf), "::", stringify!(cacheline0)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).buf_addr) as usize - ptr as usize },
-        0usize, concat!("Offset of field: ", stringify!(rte_mbuf), "::",
-        stringify!(buf_addr))
+        unsafe { ::std::ptr::addr_of!((*ptr).buf_addr) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(rte_mbuf), "::", stringify!(buf_addr)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).buf_physaddr) as usize - ptr as usize },
-        8usize, concat!("Offset of field: ", stringify!(rte_mbuf), "::",
-        stringify!(buf_physaddr))
+        unsafe { ::std::ptr::addr_of!((*ptr).buf_physaddr) as usize - ptr as usize },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_mbuf),
+            "::",
+            stringify!(buf_physaddr),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).buf_len) as usize - ptr as usize },
-        16usize, concat!("Offset of field: ", stringify!(rte_mbuf), "::",
-        stringify!(buf_len))
+        unsafe { ::std::ptr::addr_of!((*ptr).buf_len) as usize - ptr as usize },
+        16usize,
+        concat!("Offset of field: ", stringify!(rte_mbuf), "::", stringify!(buf_len)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).rearm_data) as usize - ptr as usize },
-        18usize, concat!("Offset of field: ", stringify!(rte_mbuf), "::",
-        stringify!(rearm_data))
+        unsafe { ::std::ptr::addr_of!((*ptr).rearm_data) as usize - ptr as usize },
+        18usize,
+        concat!("Offset of field: ", stringify!(rte_mbuf), "::", stringify!(rearm_data)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).data_off) as usize - ptr as usize },
-        18usize, concat!("Offset of field: ", stringify!(rte_mbuf), "::",
-        stringify!(data_off))
+        unsafe { ::std::ptr::addr_of!((*ptr).data_off) as usize - ptr as usize },
+        18usize,
+        concat!("Offset of field: ", stringify!(rte_mbuf), "::", stringify!(data_off)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).nb_segs) as usize - ptr as usize },
-        22usize, concat!("Offset of field: ", stringify!(rte_mbuf), "::",
-        stringify!(nb_segs))
+        unsafe { ::std::ptr::addr_of!((*ptr).nb_segs) as usize - ptr as usize },
+        22usize,
+        concat!("Offset of field: ", stringify!(rte_mbuf), "::", stringify!(nb_segs)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).port) as usize - ptr as usize }, 23usize,
-        concat!("Offset of field: ", stringify!(rte_mbuf), "::", stringify!(port))
+        unsafe { ::std::ptr::addr_of!((*ptr).port) as usize - ptr as usize },
+        23usize,
+        concat!("Offset of field: ", stringify!(rte_mbuf), "::", stringify!(port)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).ol_flags) as usize - ptr as usize },
-        24usize, concat!("Offset of field: ", stringify!(rte_mbuf), "::",
-        stringify!(ol_flags))
+        unsafe { ::std::ptr::addr_of!((*ptr).ol_flags) as usize - ptr as usize },
+        24usize,
+        concat!("Offset of field: ", stringify!(rte_mbuf), "::", stringify!(ol_flags)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).rx_descriptor_fields1) as usize - ptr as
-        usize }, 32usize, concat!("Offset of field: ", stringify!(rte_mbuf), "::",
-        stringify!(rx_descriptor_fields1))
+        unsafe {
+            ::std::ptr::addr_of!((*ptr).rx_descriptor_fields1) as usize - ptr as usize
+        },
+        32usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_mbuf),
+            "::",
+            stringify!(rx_descriptor_fields1),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).pkt_len) as usize - ptr as usize },
-        36usize, concat!("Offset of field: ", stringify!(rte_mbuf), "::",
-        stringify!(pkt_len))
+        unsafe { ::std::ptr::addr_of!((*ptr).pkt_len) as usize - ptr as usize },
+        36usize,
+        concat!("Offset of field: ", stringify!(rte_mbuf), "::", stringify!(pkt_len)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).data_len) as usize - ptr as usize },
-        40usize, concat!("Offset of field: ", stringify!(rte_mbuf), "::",
-        stringify!(data_len))
+        unsafe { ::std::ptr::addr_of!((*ptr).data_len) as usize - ptr as usize },
+        40usize,
+        concat!("Offset of field: ", stringify!(rte_mbuf), "::", stringify!(data_len)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).vlan_tci) as usize - ptr as usize },
-        42usize, concat!("Offset of field: ", stringify!(rte_mbuf), "::",
-        stringify!(vlan_tci))
+        unsafe { ::std::ptr::addr_of!((*ptr).vlan_tci) as usize - ptr as usize },
+        42usize,
+        concat!("Offset of field: ", stringify!(rte_mbuf), "::", stringify!(vlan_tci)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).hash) as usize - ptr as usize }, 44usize,
-        concat!("Offset of field: ", stringify!(rte_mbuf), "::", stringify!(hash))
+        unsafe { ::std::ptr::addr_of!((*ptr).hash) as usize - ptr as usize },
+        44usize,
+        concat!("Offset of field: ", stringify!(rte_mbuf), "::", stringify!(hash)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).seqn) as usize - ptr as usize }, 52usize,
-        concat!("Offset of field: ", stringify!(rte_mbuf), "::", stringify!(seqn))
+        unsafe { ::std::ptr::addr_of!((*ptr).seqn) as usize - ptr as usize },
+        52usize,
+        concat!("Offset of field: ", stringify!(rte_mbuf), "::", stringify!(seqn)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).vlan_tci_outer) as usize - ptr as usize },
-        56usize, concat!("Offset of field: ", stringify!(rte_mbuf), "::",
-        stringify!(vlan_tci_outer))
+        unsafe { ::std::ptr::addr_of!((*ptr).vlan_tci_outer) as usize - ptr as usize },
+        56usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_mbuf),
+            "::",
+            stringify!(vlan_tci_outer),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).cacheline1) as usize - ptr as usize },
-        64usize, concat!("Offset of field: ", stringify!(rte_mbuf), "::",
-        stringify!(cacheline1))
+        unsafe { ::std::ptr::addr_of!((*ptr).cacheline1) as usize - ptr as usize },
+        64usize,
+        concat!("Offset of field: ", stringify!(rte_mbuf), "::", stringify!(cacheline1)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).pool) as usize - ptr as usize }, 72usize,
-        concat!("Offset of field: ", stringify!(rte_mbuf), "::", stringify!(pool))
+        unsafe { ::std::ptr::addr_of!((*ptr).pool) as usize - ptr as usize },
+        72usize,
+        concat!("Offset of field: ", stringify!(rte_mbuf), "::", stringify!(pool)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).next) as usize - ptr as usize }, 80usize,
-        concat!("Offset of field: ", stringify!(rte_mbuf), "::", stringify!(next))
+        unsafe { ::std::ptr::addr_of!((*ptr).next) as usize - ptr as usize },
+        80usize,
+        concat!("Offset of field: ", stringify!(rte_mbuf), "::", stringify!(next)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).priv_size) as usize - ptr as usize },
-        96usize, concat!("Offset of field: ", stringify!(rte_mbuf), "::",
-        stringify!(priv_size))
+        unsafe { ::std::ptr::addr_of!((*ptr).priv_size) as usize - ptr as usize },
+        96usize,
+        concat!("Offset of field: ", stringify!(rte_mbuf), "::", stringify!(priv_size)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).timesync) as usize - ptr as usize },
-        98usize, concat!("Offset of field: ", stringify!(rte_mbuf), "::",
-        stringify!(timesync))
+        unsafe { ::std::ptr::addr_of!((*ptr).timesync) as usize - ptr as usize },
+        98usize,
+        concat!("Offset of field: ", stringify!(rte_mbuf), "::", stringify!(timesync)),
     );
 }
 impl Default for rte_mbuf {

--- a/bindgen-tests/tests/expectations/tests/libclang-5/auto.rs
+++ b/bindgen-tests/tests/expectations/tests/libclang-5/auto.rs
@@ -8,11 +8,14 @@ pub const Foo_kFoo: bool = true;
 #[test]
 fn bindgen_test_layout_Foo() {
     assert_eq!(
-        ::std::mem::size_of:: < Foo > (), 1usize, concat!("Size of: ", stringify!(Foo))
+        ::std::mem::size_of::<Foo>(),
+        1usize,
+        concat!("Size of: ", stringify!(Foo)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Foo > (), 1usize, concat!("Alignment of ",
-        stringify!(Foo))
+        ::std::mem::align_of::<Foo>(),
+        1usize,
+        concat!("Alignment of ", stringify!(Foo)),
     );
 }
 #[repr(C)]

--- a/bindgen-tests/tests/expectations/tests/libclang-5/call-conv-field.rs
+++ b/bindgen-tests/tests/expectations/tests/libclang-5/call-conv-field.rs
@@ -15,22 +15,34 @@ fn bindgen_test_layout_JNINativeInterface_() {
     const UNINIT: ::std::mem::MaybeUninit<JNINativeInterface_> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < JNINativeInterface_ > (), 16usize, concat!("Size of: ",
-        stringify!(JNINativeInterface_))
+        ::std::mem::size_of::<JNINativeInterface_>(),
+        16usize,
+        concat!("Size of: ", stringify!(JNINativeInterface_)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < JNINativeInterface_ > (), 8usize,
-        concat!("Alignment of ", stringify!(JNINativeInterface_))
+        ::std::mem::align_of::<JNINativeInterface_>(),
+        8usize,
+        concat!("Alignment of ", stringify!(JNINativeInterface_)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).GetVersion) as usize - ptr as usize },
-        0usize, concat!("Offset of field: ", stringify!(JNINativeInterface_), "::",
-        stringify!(GetVersion))
+        unsafe { ::std::ptr::addr_of!((*ptr).GetVersion) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(JNINativeInterface_),
+            "::",
+            stringify!(GetVersion),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).__hack) as usize - ptr as usize }, 8usize,
-        concat!("Offset of field: ", stringify!(JNINativeInterface_), "::",
-        stringify!(__hack))
+        unsafe { ::std::ptr::addr_of!((*ptr).__hack) as usize - ptr as usize },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(JNINativeInterface_),
+            "::",
+            stringify!(__hack),
+        ),
     );
 }
 extern "stdcall" {

--- a/bindgen-tests/tests/expectations/tests/libclang-5/const_bool.rs
+++ b/bindgen-tests/tests/expectations/tests/libclang-5/const_bool.rs
@@ -8,11 +8,11 @@ pub struct A {
 pub const A_k: bool = false;
 #[test]
 fn bindgen_test_layout_A() {
+    assert_eq!(::std::mem::size_of::<A>(), 1usize, concat!("Size of: ", stringify!(A)));
     assert_eq!(
-        ::std::mem::size_of:: < A > (), 1usize, concat!("Size of: ", stringify!(A))
-    );
-    assert_eq!(
-        ::std::mem::align_of:: < A > (), 1usize, concat!("Alignment of ", stringify!(A))
+        ::std::mem::align_of::<A>(),
+        1usize,
+        concat!("Alignment of ", stringify!(A)),
     );
 }
 pub type foo = bool;

--- a/bindgen-tests/tests/expectations/tests/libclang-5/issue-769-bad-instantiation-test.rs
+++ b/bindgen-tests/tests/expectations/tests/libclang-5/issue-769-bad-instantiation-test.rs
@@ -22,27 +22,39 @@ pub mod root {
     #[test]
     fn __bindgen_test_layout_Rooted_open0_int_close0_instantiation() {
         assert_eq!(
-            ::std::mem::size_of:: < root::Rooted < ::std::os::raw::c_int > > (), 4usize,
-            concat!("Size of template specialization: ", stringify!(root::Rooted <
-            ::std::os::raw::c_int >))
+            ::std::mem::size_of::<root::Rooted<::std::os::raw::c_int>>(),
+            4usize,
+            concat!(
+                "Size of template specialization: ",
+                stringify!(root::Rooted < ::std::os::raw::c_int >),
+            ),
         );
         assert_eq!(
-            ::std::mem::align_of:: < root::Rooted < ::std::os::raw::c_int > > (), 4usize,
-            concat!("Alignment of template specialization: ", stringify!(root::Rooted <
-            ::std::os::raw::c_int >))
+            ::std::mem::align_of::<root::Rooted<::std::os::raw::c_int>>(),
+            4usize,
+            concat!(
+                "Alignment of template specialization: ",
+                stringify!(root::Rooted < ::std::os::raw::c_int >),
+            ),
         );
     }
     #[test]
     fn __bindgen_test_layout_Rooted_open0_AutoValueVector_Alias_close0_instantiation() {
         assert_eq!(
-            ::std::mem::size_of:: < root::Rooted < root::AutoValueVector_Alias > > (),
-            4usize, concat!("Size of template specialization: ", stringify!(root::Rooted
-            < root::AutoValueVector_Alias >))
+            ::std::mem::size_of::<root::Rooted<root::AutoValueVector_Alias>>(),
+            4usize,
+            concat!(
+                "Size of template specialization: ",
+                stringify!(root::Rooted < root::AutoValueVector_Alias >),
+            ),
         );
         assert_eq!(
-            ::std::mem::align_of:: < root::Rooted < root::AutoValueVector_Alias > > (),
-            4usize, concat!("Alignment of template specialization: ",
-            stringify!(root::Rooted < root::AutoValueVector_Alias >))
+            ::std::mem::align_of::<root::Rooted<root::AutoValueVector_Alias>>(),
+            4usize,
+            concat!(
+                "Alignment of template specialization: ",
+                stringify!(root::Rooted < root::AutoValueVector_Alias >),
+            ),
         );
     }
 }

--- a/bindgen-tests/tests/expectations/tests/libclang-5/mangling-win32.rs
+++ b/bindgen-tests/tests/expectations/tests/libclang-5/mangling-win32.rs
@@ -14,11 +14,14 @@ extern "C" {
 #[test]
 fn bindgen_test_layout_Foo() {
     assert_eq!(
-        ::std::mem::size_of:: < Foo > (), 1usize, concat!("Size of: ", stringify!(Foo))
+        ::std::mem::size_of::<Foo>(),
+        1usize,
+        concat!("Size of: ", stringify!(Foo)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Foo > (), 1usize, concat!("Alignment of ",
-        stringify!(Foo))
+        ::std::mem::align_of::<Foo>(),
+        1usize,
+        concat!("Alignment of ", stringify!(Foo)),
     );
 }
 extern "fastcall" {

--- a/bindgen-tests/tests/expectations/tests/libclang-5/partial-specialization-and-inheritance.rs
+++ b/bindgen-tests/tests/expectations/tests/libclang-5/partial-specialization-and-inheritance.rs
@@ -21,11 +21,13 @@ extern "C" {
 #[test]
 fn bindgen_test_layout_Usage() {
     assert_eq!(
-        ::std::mem::size_of:: < Usage > (), 1usize, concat!("Size of: ",
-        stringify!(Usage))
+        ::std::mem::size_of::<Usage>(),
+        1usize,
+        concat!("Size of: ", stringify!(Usage)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Usage > (), 1usize, concat!("Alignment of ",
-        stringify!(Usage))
+        ::std::mem::align_of::<Usage>(),
+        1usize,
+        concat!("Alignment of ", stringify!(Usage)),
     );
 }

--- a/bindgen-tests/tests/expectations/tests/libclang-5/type_alias_template_specialized.rs
+++ b/bindgen-tests/tests/expectations/tests/libclang-5/type_alias_template_specialized.rs
@@ -9,16 +9,19 @@ fn bindgen_test_layout_Rooted() {
     const UNINIT: ::std::mem::MaybeUninit<Rooted> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < Rooted > (), 4usize, concat!("Size of: ",
-        stringify!(Rooted))
+        ::std::mem::size_of::<Rooted>(),
+        4usize,
+        concat!("Size of: ", stringify!(Rooted)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Rooted > (), 4usize, concat!("Alignment of ",
-        stringify!(Rooted))
+        ::std::mem::align_of::<Rooted>(),
+        4usize,
+        concat!("Alignment of ", stringify!(Rooted)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).ptr) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(Rooted), "::", stringify!(ptr))
+        unsafe { ::std::ptr::addr_of!((*ptr).ptr) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(Rooted), "::", stringify!(ptr)),
     );
 }
 impl Default for Rooted {
@@ -35,13 +38,19 @@ pub type MaybeWrapped<a> = a;
 #[test]
 fn __bindgen_test_layout_MaybeWrapped_open0_int_close0_instantiation() {
     assert_eq!(
-        ::std::mem::size_of:: < MaybeWrapped < ::std::os::raw::c_int > > (), 4usize,
-        concat!("Size of template specialization: ", stringify!(MaybeWrapped <
-        ::std::os::raw::c_int >))
+        ::std::mem::size_of::<MaybeWrapped<::std::os::raw::c_int>>(),
+        4usize,
+        concat!(
+            "Size of template specialization: ",
+            stringify!(MaybeWrapped < ::std::os::raw::c_int >),
+        ),
     );
     assert_eq!(
-        ::std::mem::align_of:: < MaybeWrapped < ::std::os::raw::c_int > > (), 4usize,
-        concat!("Alignment of template specialization: ", stringify!(MaybeWrapped <
-        ::std::os::raw::c_int >))
+        ::std::mem::align_of::<MaybeWrapped<::std::os::raw::c_int>>(),
+        4usize,
+        concat!(
+            "Alignment of template specialization: ",
+            stringify!(MaybeWrapped < ::std::os::raw::c_int >),
+        ),
     );
 }

--- a/bindgen-tests/tests/expectations/tests/libclang-9/auto.rs
+++ b/bindgen-tests/tests/expectations/tests/libclang-9/auto.rs
@@ -8,11 +8,14 @@ pub const Foo_kFoo: bool = true;
 #[test]
 fn bindgen_test_layout_Foo() {
     assert_eq!(
-        ::std::mem::size_of:: < Foo > (), 1usize, concat!("Size of: ", stringify!(Foo))
+        ::std::mem::size_of::<Foo>(),
+        1usize,
+        concat!("Size of: ", stringify!(Foo)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Foo > (), 1usize, concat!("Alignment of ",
-        stringify!(Foo))
+        ::std::mem::align_of::<Foo>(),
+        1usize,
+        concat!("Alignment of ", stringify!(Foo)),
     );
 }
 #[repr(C)]

--- a/bindgen-tests/tests/expectations/tests/libclang-9/call-conv-field.rs
+++ b/bindgen-tests/tests/expectations/tests/libclang-9/call-conv-field.rs
@@ -15,22 +15,34 @@ fn bindgen_test_layout_JNINativeInterface_() {
     const UNINIT: ::std::mem::MaybeUninit<JNINativeInterface_> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < JNINativeInterface_ > (), 16usize, concat!("Size of: ",
-        stringify!(JNINativeInterface_))
+        ::std::mem::size_of::<JNINativeInterface_>(),
+        16usize,
+        concat!("Size of: ", stringify!(JNINativeInterface_)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < JNINativeInterface_ > (), 8usize,
-        concat!("Alignment of ", stringify!(JNINativeInterface_))
+        ::std::mem::align_of::<JNINativeInterface_>(),
+        8usize,
+        concat!("Alignment of ", stringify!(JNINativeInterface_)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).GetVersion) as usize - ptr as usize },
-        0usize, concat!("Offset of field: ", stringify!(JNINativeInterface_), "::",
-        stringify!(GetVersion))
+        unsafe { ::std::ptr::addr_of!((*ptr).GetVersion) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(JNINativeInterface_),
+            "::",
+            stringify!(GetVersion),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).__hack) as usize - ptr as usize }, 8usize,
-        concat!("Offset of field: ", stringify!(JNINativeInterface_), "::",
-        stringify!(__hack))
+        unsafe { ::std::ptr::addr_of!((*ptr).__hack) as usize - ptr as usize },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(JNINativeInterface_),
+            "::",
+            stringify!(__hack),
+        ),
     );
 }
 extern "stdcall" {

--- a/bindgen-tests/tests/expectations/tests/libclang-9/class.rs
+++ b/bindgen-tests/tests/expectations/tests/libclang-9/class.rs
@@ -39,19 +39,21 @@ pub struct C {
 fn bindgen_test_layout_C() {
     const UNINIT: ::std::mem::MaybeUninit<C> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
+    assert_eq!(::std::mem::size_of::<C>(), 40usize, concat!("Size of: ", stringify!(C)));
     assert_eq!(
-        ::std::mem::size_of:: < C > (), 40usize, concat!("Size of: ", stringify!(C))
+        ::std::mem::align_of::<C>(),
+        4usize,
+        concat!("Alignment of ", stringify!(C)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < C > (), 4usize, concat!("Alignment of ", stringify!(C))
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(C), "::", stringify!(a)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).a) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(C), "::", stringify!(a))
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).big_array) as usize - ptr as usize },
-        4usize, concat!("Offset of field: ", stringify!(C), "::", stringify!(big_array))
+        unsafe { ::std::ptr::addr_of!((*ptr).big_array) as usize - ptr as usize },
+        4usize,
+        concat!("Offset of field: ", stringify!(C), "::", stringify!(big_array)),
     );
 }
 impl Default for C {
@@ -74,27 +76,46 @@ fn bindgen_test_layout_C_with_zero_length_array() {
     const UNINIT: ::std::mem::MaybeUninit<C_with_zero_length_array> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < C_with_zero_length_array > (), 40usize,
-        concat!("Size of: ", stringify!(C_with_zero_length_array))
+        ::std::mem::size_of::<C_with_zero_length_array>(),
+        40usize,
+        concat!("Size of: ", stringify!(C_with_zero_length_array)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < C_with_zero_length_array > (), 4usize,
-        concat!("Alignment of ", stringify!(C_with_zero_length_array))
+        ::std::mem::align_of::<C_with_zero_length_array>(),
+        4usize,
+        concat!("Alignment of ", stringify!(C_with_zero_length_array)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).a) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(C_with_zero_length_array), "::",
-        stringify!(a))
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C_with_zero_length_array),
+            "::",
+            stringify!(a),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).big_array) as usize - ptr as usize },
-        4usize, concat!("Offset of field: ", stringify!(C_with_zero_length_array), "::",
-        stringify!(big_array))
+        unsafe { ::std::ptr::addr_of!((*ptr).big_array) as usize - ptr as usize },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C_with_zero_length_array),
+            "::",
+            stringify!(big_array),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).zero_length_array) as usize - ptr as usize
-        }, 37usize, concat!("Offset of field: ", stringify!(C_with_zero_length_array),
-        "::", stringify!(zero_length_array))
+        unsafe {
+            ::std::ptr::addr_of!((*ptr).zero_length_array) as usize - ptr as usize
+        },
+        37usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C_with_zero_length_array),
+            "::",
+            stringify!(zero_length_array),
+        ),
     );
 }
 impl Default for C_with_zero_length_array {
@@ -117,22 +138,36 @@ fn bindgen_test_layout_C_with_zero_length_array_2() {
     const UNINIT: ::std::mem::MaybeUninit<C_with_zero_length_array_2> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < C_with_zero_length_array_2 > (), 4usize,
-        concat!("Size of: ", stringify!(C_with_zero_length_array_2))
+        ::std::mem::size_of::<C_with_zero_length_array_2>(),
+        4usize,
+        concat!("Size of: ", stringify!(C_with_zero_length_array_2)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < C_with_zero_length_array_2 > (), 4usize,
-        concat!("Alignment of ", stringify!(C_with_zero_length_array_2))
+        ::std::mem::align_of::<C_with_zero_length_array_2>(),
+        4usize,
+        concat!("Alignment of ", stringify!(C_with_zero_length_array_2)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).a) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(C_with_zero_length_array_2), "::",
-        stringify!(a))
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C_with_zero_length_array_2),
+            "::",
+            stringify!(a),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).zero_length_array) as usize - ptr as usize
-        }, 4usize, concat!("Offset of field: ", stringify!(C_with_zero_length_array_2),
-        "::", stringify!(zero_length_array))
+        unsafe {
+            ::std::ptr::addr_of!((*ptr).zero_length_array) as usize - ptr as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C_with_zero_length_array_2),
+            "::",
+            stringify!(zero_length_array),
+        ),
     );
 }
 #[repr(C)]
@@ -146,27 +181,44 @@ fn bindgen_test_layout_C_with_incomplete_array() {
     const UNINIT: ::std::mem::MaybeUninit<C_with_incomplete_array> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < C_with_incomplete_array > (), 40usize,
-        concat!("Size of: ", stringify!(C_with_incomplete_array))
+        ::std::mem::size_of::<C_with_incomplete_array>(),
+        40usize,
+        concat!("Size of: ", stringify!(C_with_incomplete_array)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < C_with_incomplete_array > (), 4usize,
-        concat!("Alignment of ", stringify!(C_with_incomplete_array))
+        ::std::mem::align_of::<C_with_incomplete_array>(),
+        4usize,
+        concat!("Alignment of ", stringify!(C_with_incomplete_array)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).a) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(C_with_incomplete_array), "::",
-        stringify!(a))
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C_with_incomplete_array),
+            "::",
+            stringify!(a),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).big_array) as usize - ptr as usize },
-        4usize, concat!("Offset of field: ", stringify!(C_with_incomplete_array), "::",
-        stringify!(big_array))
+        unsafe { ::std::ptr::addr_of!((*ptr).big_array) as usize - ptr as usize },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C_with_incomplete_array),
+            "::",
+            stringify!(big_array),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).incomplete_array) as usize - ptr as usize
-        }, 37usize, concat!("Offset of field: ", stringify!(C_with_incomplete_array),
-        "::", stringify!(incomplete_array))
+        unsafe { ::std::ptr::addr_of!((*ptr).incomplete_array) as usize - ptr as usize },
+        37usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C_with_incomplete_array),
+            "::",
+            stringify!(incomplete_array),
+        ),
     );
 }
 impl Default for C_with_incomplete_array {
@@ -189,22 +241,34 @@ fn bindgen_test_layout_C_with_incomplete_array_2() {
     const UNINIT: ::std::mem::MaybeUninit<C_with_incomplete_array_2> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < C_with_incomplete_array_2 > (), 4usize,
-        concat!("Size of: ", stringify!(C_with_incomplete_array_2))
+        ::std::mem::size_of::<C_with_incomplete_array_2>(),
+        4usize,
+        concat!("Size of: ", stringify!(C_with_incomplete_array_2)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < C_with_incomplete_array_2 > (), 4usize,
-        concat!("Alignment of ", stringify!(C_with_incomplete_array_2))
+        ::std::mem::align_of::<C_with_incomplete_array_2>(),
+        4usize,
+        concat!("Alignment of ", stringify!(C_with_incomplete_array_2)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).a) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(C_with_incomplete_array_2), "::",
-        stringify!(a))
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C_with_incomplete_array_2),
+            "::",
+            stringify!(a),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).incomplete_array) as usize - ptr as usize
-        }, 4usize, concat!("Offset of field: ", stringify!(C_with_incomplete_array_2),
-        "::", stringify!(incomplete_array))
+        unsafe { ::std::ptr::addr_of!((*ptr).incomplete_array) as usize - ptr as usize },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C_with_incomplete_array_2),
+            "::",
+            stringify!(incomplete_array),
+        ),
     );
 }
 #[repr(C)]
@@ -221,37 +285,59 @@ fn bindgen_test_layout_C_with_zero_length_array_and_incomplete_array() {
     > = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < C_with_zero_length_array_and_incomplete_array > (),
-        40usize, concat!("Size of: ",
-        stringify!(C_with_zero_length_array_and_incomplete_array))
+        ::std::mem::size_of::<C_with_zero_length_array_and_incomplete_array>(),
+        40usize,
+        concat!("Size of: ", stringify!(C_with_zero_length_array_and_incomplete_array)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < C_with_zero_length_array_and_incomplete_array > (),
-        4usize, concat!("Alignment of ",
-        stringify!(C_with_zero_length_array_and_incomplete_array))
+        ::std::mem::align_of::<C_with_zero_length_array_and_incomplete_array>(),
+        4usize,
+        concat!(
+            "Alignment of ",
+            stringify!(C_with_zero_length_array_and_incomplete_array),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).a) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ",
-        stringify!(C_with_zero_length_array_and_incomplete_array), "::", stringify!(a))
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C_with_zero_length_array_and_incomplete_array),
+            "::",
+            stringify!(a),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).big_array) as usize - ptr as usize },
-        4usize, concat!("Offset of field: ",
-        stringify!(C_with_zero_length_array_and_incomplete_array), "::",
-        stringify!(big_array))
+        unsafe { ::std::ptr::addr_of!((*ptr).big_array) as usize - ptr as usize },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C_with_zero_length_array_and_incomplete_array),
+            "::",
+            stringify!(big_array),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).zero_length_array) as usize - ptr as usize
-        }, 37usize, concat!("Offset of field: ",
-        stringify!(C_with_zero_length_array_and_incomplete_array), "::",
-        stringify!(zero_length_array))
+        unsafe {
+            ::std::ptr::addr_of!((*ptr).zero_length_array) as usize - ptr as usize
+        },
+        37usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C_with_zero_length_array_and_incomplete_array),
+            "::",
+            stringify!(zero_length_array),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).incomplete_array) as usize - ptr as usize
-        }, 37usize, concat!("Offset of field: ",
-        stringify!(C_with_zero_length_array_and_incomplete_array), "::",
-        stringify!(incomplete_array))
+        unsafe { ::std::ptr::addr_of!((*ptr).incomplete_array) as usize - ptr as usize },
+        37usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C_with_zero_length_array_and_incomplete_array),
+            "::",
+            stringify!(incomplete_array),
+        ),
     );
 }
 impl Default for C_with_zero_length_array_and_incomplete_array {
@@ -277,31 +363,49 @@ fn bindgen_test_layout_C_with_zero_length_array_and_incomplete_array_2() {
     > = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < C_with_zero_length_array_and_incomplete_array_2 > (),
-        4usize, concat!("Size of: ",
-        stringify!(C_with_zero_length_array_and_incomplete_array_2))
+        ::std::mem::size_of::<C_with_zero_length_array_and_incomplete_array_2>(),
+        4usize,
+        concat!("Size of: ", stringify!(C_with_zero_length_array_and_incomplete_array_2)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < C_with_zero_length_array_and_incomplete_array_2 > (),
-        4usize, concat!("Alignment of ",
-        stringify!(C_with_zero_length_array_and_incomplete_array_2))
+        ::std::mem::align_of::<C_with_zero_length_array_and_incomplete_array_2>(),
+        4usize,
+        concat!(
+            "Alignment of ",
+            stringify!(C_with_zero_length_array_and_incomplete_array_2),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).a) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ",
-        stringify!(C_with_zero_length_array_and_incomplete_array_2), "::", stringify!(a))
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C_with_zero_length_array_and_incomplete_array_2),
+            "::",
+            stringify!(a),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).zero_length_array) as usize - ptr as usize
-        }, 4usize, concat!("Offset of field: ",
-        stringify!(C_with_zero_length_array_and_incomplete_array_2), "::",
-        stringify!(zero_length_array))
+        unsafe {
+            ::std::ptr::addr_of!((*ptr).zero_length_array) as usize - ptr as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C_with_zero_length_array_and_incomplete_array_2),
+            "::",
+            stringify!(zero_length_array),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).incomplete_array) as usize - ptr as usize
-        }, 4usize, concat!("Offset of field: ",
-        stringify!(C_with_zero_length_array_and_incomplete_array_2), "::",
-        stringify!(incomplete_array))
+        unsafe { ::std::ptr::addr_of!((*ptr).incomplete_array) as usize - ptr as usize },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C_with_zero_length_array_and_incomplete_array_2),
+            "::",
+            stringify!(incomplete_array),
+        ),
     );
 }
 #[repr(C)]
@@ -314,16 +418,19 @@ fn bindgen_test_layout_WithDtor() {
     const UNINIT: ::std::mem::MaybeUninit<WithDtor> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < WithDtor > (), 4usize, concat!("Size of: ",
-        stringify!(WithDtor))
+        ::std::mem::size_of::<WithDtor>(),
+        4usize,
+        concat!("Size of: ", stringify!(WithDtor)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < WithDtor > (), 4usize, concat!("Alignment of ",
-        stringify!(WithDtor))
+        ::std::mem::align_of::<WithDtor>(),
+        4usize,
+        concat!("Alignment of ", stringify!(WithDtor)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).b) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(WithDtor), "::", stringify!(b))
+        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(WithDtor), "::", stringify!(b)),
     );
 }
 #[repr(C)]
@@ -336,22 +443,34 @@ fn bindgen_test_layout_IncompleteArrayNonCopiable() {
     const UNINIT: ::std::mem::MaybeUninit<IncompleteArrayNonCopiable> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < IncompleteArrayNonCopiable > (), 8usize,
-        concat!("Size of: ", stringify!(IncompleteArrayNonCopiable))
+        ::std::mem::size_of::<IncompleteArrayNonCopiable>(),
+        8usize,
+        concat!("Size of: ", stringify!(IncompleteArrayNonCopiable)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < IncompleteArrayNonCopiable > (), 8usize,
-        concat!("Alignment of ", stringify!(IncompleteArrayNonCopiable))
+        ::std::mem::align_of::<IncompleteArrayNonCopiable>(),
+        8usize,
+        concat!("Alignment of ", stringify!(IncompleteArrayNonCopiable)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).whatever) as usize - ptr as usize },
-        0usize, concat!("Offset of field: ", stringify!(IncompleteArrayNonCopiable),
-        "::", stringify!(whatever))
+        unsafe { ::std::ptr::addr_of!((*ptr).whatever) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(IncompleteArrayNonCopiable),
+            "::",
+            stringify!(whatever),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).incomplete_array) as usize - ptr as usize
-        }, 8usize, concat!("Offset of field: ", stringify!(IncompleteArrayNonCopiable),
-        "::", stringify!(incomplete_array))
+        unsafe { ::std::ptr::addr_of!((*ptr).incomplete_array) as usize - ptr as usize },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(IncompleteArrayNonCopiable),
+            "::",
+            stringify!(incomplete_array),
+        ),
     );
 }
 impl Default for IncompleteArrayNonCopiable {
@@ -374,20 +493,24 @@ fn bindgen_test_layout_Union() {
     const UNINIT: ::std::mem::MaybeUninit<Union> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < Union > (), 4usize, concat!("Size of: ",
-        stringify!(Union))
+        ::std::mem::size_of::<Union>(),
+        4usize,
+        concat!("Size of: ", stringify!(Union)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Union > (), 4usize, concat!("Alignment of ",
-        stringify!(Union))
+        ::std::mem::align_of::<Union>(),
+        4usize,
+        concat!("Alignment of ", stringify!(Union)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).d) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(Union), "::", stringify!(d))
+        unsafe { ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(Union), "::", stringify!(d)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).i) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(Union), "::", stringify!(i))
+        unsafe { ::std::ptr::addr_of!((*ptr).i) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(Union), "::", stringify!(i)),
     );
 }
 impl Default for Union {
@@ -409,16 +532,19 @@ fn bindgen_test_layout_WithUnion() {
     const UNINIT: ::std::mem::MaybeUninit<WithUnion> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < WithUnion > (), 4usize, concat!("Size of: ",
-        stringify!(WithUnion))
+        ::std::mem::size_of::<WithUnion>(),
+        4usize,
+        concat!("Size of: ", stringify!(WithUnion)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < WithUnion > (), 4usize, concat!("Alignment of ",
-        stringify!(WithUnion))
+        ::std::mem::align_of::<WithUnion>(),
+        4usize,
+        concat!("Alignment of ", stringify!(WithUnion)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).data) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(WithUnion), "::", stringify!(data))
+        unsafe { ::std::ptr::addr_of!((*ptr).data) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(WithUnion), "::", stringify!(data)),
     );
 }
 impl Default for WithUnion {
@@ -438,12 +564,14 @@ pub struct RealAbstractionWithTonsOfMethods {
 #[test]
 fn bindgen_test_layout_RealAbstractionWithTonsOfMethods() {
     assert_eq!(
-        ::std::mem::size_of:: < RealAbstractionWithTonsOfMethods > (), 1usize,
-        concat!("Size of: ", stringify!(RealAbstractionWithTonsOfMethods))
+        ::std::mem::size_of::<RealAbstractionWithTonsOfMethods>(),
+        1usize,
+        concat!("Size of: ", stringify!(RealAbstractionWithTonsOfMethods)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < RealAbstractionWithTonsOfMethods > (), 1usize,
-        concat!("Alignment of ", stringify!(RealAbstractionWithTonsOfMethods))
+        ::std::mem::align_of::<RealAbstractionWithTonsOfMethods>(),
+        1usize,
+        concat!("Alignment of ", stringify!(RealAbstractionWithTonsOfMethods)),
     );
 }
 extern "C" {

--- a/bindgen-tests/tests/expectations/tests/libclang-9/class_1_0.rs
+++ b/bindgen-tests/tests/expectations/tests/libclang-9/class_1_0.rs
@@ -82,19 +82,21 @@ pub struct C {
 fn bindgen_test_layout_C() {
     const UNINIT: ::std::mem::MaybeUninit<C> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
+    assert_eq!(::std::mem::size_of::<C>(), 40usize, concat!("Size of: ", stringify!(C)));
     assert_eq!(
-        ::std::mem::size_of:: < C > (), 40usize, concat!("Size of: ", stringify!(C))
+        ::std::mem::align_of::<C>(),
+        4usize,
+        concat!("Alignment of ", stringify!(C)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < C > (), 4usize, concat!("Alignment of ", stringify!(C))
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(C), "::", stringify!(a)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).a) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(C), "::", stringify!(a))
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).big_array) as usize - ptr as usize },
-        4usize, concat!("Offset of field: ", stringify!(C), "::", stringify!(big_array))
+        unsafe { ::std::ptr::addr_of!((*ptr).big_array) as usize - ptr as usize },
+        4usize,
+        concat!("Offset of field: ", stringify!(C), "::", stringify!(big_array)),
     );
 }
 impl Clone for C {
@@ -127,27 +129,46 @@ fn bindgen_test_layout_C_with_zero_length_array() {
     const UNINIT: ::std::mem::MaybeUninit<C_with_zero_length_array> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < C_with_zero_length_array > (), 40usize,
-        concat!("Size of: ", stringify!(C_with_zero_length_array))
+        ::std::mem::size_of::<C_with_zero_length_array>(),
+        40usize,
+        concat!("Size of: ", stringify!(C_with_zero_length_array)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < C_with_zero_length_array > (), 4usize,
-        concat!("Alignment of ", stringify!(C_with_zero_length_array))
+        ::std::mem::align_of::<C_with_zero_length_array>(),
+        4usize,
+        concat!("Alignment of ", stringify!(C_with_zero_length_array)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).a) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(C_with_zero_length_array), "::",
-        stringify!(a))
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C_with_zero_length_array),
+            "::",
+            stringify!(a),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).big_array) as usize - ptr as usize },
-        4usize, concat!("Offset of field: ", stringify!(C_with_zero_length_array), "::",
-        stringify!(big_array))
+        unsafe { ::std::ptr::addr_of!((*ptr).big_array) as usize - ptr as usize },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C_with_zero_length_array),
+            "::",
+            stringify!(big_array),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).zero_length_array) as usize - ptr as usize
-        }, 37usize, concat!("Offset of field: ", stringify!(C_with_zero_length_array),
-        "::", stringify!(zero_length_array))
+        unsafe {
+            ::std::ptr::addr_of!((*ptr).zero_length_array) as usize - ptr as usize
+        },
+        37usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C_with_zero_length_array),
+            "::",
+            stringify!(zero_length_array),
+        ),
     );
 }
 impl Default for C_with_zero_length_array {
@@ -170,22 +191,36 @@ fn bindgen_test_layout_C_with_zero_length_array_2() {
     const UNINIT: ::std::mem::MaybeUninit<C_with_zero_length_array_2> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < C_with_zero_length_array_2 > (), 4usize,
-        concat!("Size of: ", stringify!(C_with_zero_length_array_2))
+        ::std::mem::size_of::<C_with_zero_length_array_2>(),
+        4usize,
+        concat!("Size of: ", stringify!(C_with_zero_length_array_2)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < C_with_zero_length_array_2 > (), 4usize,
-        concat!("Alignment of ", stringify!(C_with_zero_length_array_2))
+        ::std::mem::align_of::<C_with_zero_length_array_2>(),
+        4usize,
+        concat!("Alignment of ", stringify!(C_with_zero_length_array_2)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).a) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(C_with_zero_length_array_2), "::",
-        stringify!(a))
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C_with_zero_length_array_2),
+            "::",
+            stringify!(a),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).zero_length_array) as usize - ptr as usize
-        }, 4usize, concat!("Offset of field: ", stringify!(C_with_zero_length_array_2),
-        "::", stringify!(zero_length_array))
+        unsafe {
+            ::std::ptr::addr_of!((*ptr).zero_length_array) as usize - ptr as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C_with_zero_length_array_2),
+            "::",
+            stringify!(zero_length_array),
+        ),
     );
 }
 #[repr(C)]
@@ -199,27 +234,44 @@ fn bindgen_test_layout_C_with_incomplete_array() {
     const UNINIT: ::std::mem::MaybeUninit<C_with_incomplete_array> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < C_with_incomplete_array > (), 40usize,
-        concat!("Size of: ", stringify!(C_with_incomplete_array))
+        ::std::mem::size_of::<C_with_incomplete_array>(),
+        40usize,
+        concat!("Size of: ", stringify!(C_with_incomplete_array)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < C_with_incomplete_array > (), 4usize,
-        concat!("Alignment of ", stringify!(C_with_incomplete_array))
+        ::std::mem::align_of::<C_with_incomplete_array>(),
+        4usize,
+        concat!("Alignment of ", stringify!(C_with_incomplete_array)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).a) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(C_with_incomplete_array), "::",
-        stringify!(a))
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C_with_incomplete_array),
+            "::",
+            stringify!(a),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).big_array) as usize - ptr as usize },
-        4usize, concat!("Offset of field: ", stringify!(C_with_incomplete_array), "::",
-        stringify!(big_array))
+        unsafe { ::std::ptr::addr_of!((*ptr).big_array) as usize - ptr as usize },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C_with_incomplete_array),
+            "::",
+            stringify!(big_array),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).incomplete_array) as usize - ptr as usize
-        }, 37usize, concat!("Offset of field: ", stringify!(C_with_incomplete_array),
-        "::", stringify!(incomplete_array))
+        unsafe { ::std::ptr::addr_of!((*ptr).incomplete_array) as usize - ptr as usize },
+        37usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C_with_incomplete_array),
+            "::",
+            stringify!(incomplete_array),
+        ),
     );
 }
 impl Default for C_with_incomplete_array {
@@ -242,22 +294,34 @@ fn bindgen_test_layout_C_with_incomplete_array_2() {
     const UNINIT: ::std::mem::MaybeUninit<C_with_incomplete_array_2> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < C_with_incomplete_array_2 > (), 4usize,
-        concat!("Size of: ", stringify!(C_with_incomplete_array_2))
+        ::std::mem::size_of::<C_with_incomplete_array_2>(),
+        4usize,
+        concat!("Size of: ", stringify!(C_with_incomplete_array_2)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < C_with_incomplete_array_2 > (), 4usize,
-        concat!("Alignment of ", stringify!(C_with_incomplete_array_2))
+        ::std::mem::align_of::<C_with_incomplete_array_2>(),
+        4usize,
+        concat!("Alignment of ", stringify!(C_with_incomplete_array_2)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).a) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(C_with_incomplete_array_2), "::",
-        stringify!(a))
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C_with_incomplete_array_2),
+            "::",
+            stringify!(a),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).incomplete_array) as usize - ptr as usize
-        }, 4usize, concat!("Offset of field: ", stringify!(C_with_incomplete_array_2),
-        "::", stringify!(incomplete_array))
+        unsafe { ::std::ptr::addr_of!((*ptr).incomplete_array) as usize - ptr as usize },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C_with_incomplete_array_2),
+            "::",
+            stringify!(incomplete_array),
+        ),
     );
 }
 #[repr(C)]
@@ -274,37 +338,59 @@ fn bindgen_test_layout_C_with_zero_length_array_and_incomplete_array() {
     > = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < C_with_zero_length_array_and_incomplete_array > (),
-        40usize, concat!("Size of: ",
-        stringify!(C_with_zero_length_array_and_incomplete_array))
+        ::std::mem::size_of::<C_with_zero_length_array_and_incomplete_array>(),
+        40usize,
+        concat!("Size of: ", stringify!(C_with_zero_length_array_and_incomplete_array)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < C_with_zero_length_array_and_incomplete_array > (),
-        4usize, concat!("Alignment of ",
-        stringify!(C_with_zero_length_array_and_incomplete_array))
+        ::std::mem::align_of::<C_with_zero_length_array_and_incomplete_array>(),
+        4usize,
+        concat!(
+            "Alignment of ",
+            stringify!(C_with_zero_length_array_and_incomplete_array),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).a) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ",
-        stringify!(C_with_zero_length_array_and_incomplete_array), "::", stringify!(a))
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C_with_zero_length_array_and_incomplete_array),
+            "::",
+            stringify!(a),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).big_array) as usize - ptr as usize },
-        4usize, concat!("Offset of field: ",
-        stringify!(C_with_zero_length_array_and_incomplete_array), "::",
-        stringify!(big_array))
+        unsafe { ::std::ptr::addr_of!((*ptr).big_array) as usize - ptr as usize },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C_with_zero_length_array_and_incomplete_array),
+            "::",
+            stringify!(big_array),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).zero_length_array) as usize - ptr as usize
-        }, 37usize, concat!("Offset of field: ",
-        stringify!(C_with_zero_length_array_and_incomplete_array), "::",
-        stringify!(zero_length_array))
+        unsafe {
+            ::std::ptr::addr_of!((*ptr).zero_length_array) as usize - ptr as usize
+        },
+        37usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C_with_zero_length_array_and_incomplete_array),
+            "::",
+            stringify!(zero_length_array),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).incomplete_array) as usize - ptr as usize
-        }, 37usize, concat!("Offset of field: ",
-        stringify!(C_with_zero_length_array_and_incomplete_array), "::",
-        stringify!(incomplete_array))
+        unsafe { ::std::ptr::addr_of!((*ptr).incomplete_array) as usize - ptr as usize },
+        37usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C_with_zero_length_array_and_incomplete_array),
+            "::",
+            stringify!(incomplete_array),
+        ),
     );
 }
 impl Default for C_with_zero_length_array_and_incomplete_array {
@@ -330,31 +416,49 @@ fn bindgen_test_layout_C_with_zero_length_array_and_incomplete_array_2() {
     > = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < C_with_zero_length_array_and_incomplete_array_2 > (),
-        4usize, concat!("Size of: ",
-        stringify!(C_with_zero_length_array_and_incomplete_array_2))
+        ::std::mem::size_of::<C_with_zero_length_array_and_incomplete_array_2>(),
+        4usize,
+        concat!("Size of: ", stringify!(C_with_zero_length_array_and_incomplete_array_2)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < C_with_zero_length_array_and_incomplete_array_2 > (),
-        4usize, concat!("Alignment of ",
-        stringify!(C_with_zero_length_array_and_incomplete_array_2))
+        ::std::mem::align_of::<C_with_zero_length_array_and_incomplete_array_2>(),
+        4usize,
+        concat!(
+            "Alignment of ",
+            stringify!(C_with_zero_length_array_and_incomplete_array_2),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).a) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ",
-        stringify!(C_with_zero_length_array_and_incomplete_array_2), "::", stringify!(a))
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C_with_zero_length_array_and_incomplete_array_2),
+            "::",
+            stringify!(a),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).zero_length_array) as usize - ptr as usize
-        }, 4usize, concat!("Offset of field: ",
-        stringify!(C_with_zero_length_array_and_incomplete_array_2), "::",
-        stringify!(zero_length_array))
+        unsafe {
+            ::std::ptr::addr_of!((*ptr).zero_length_array) as usize - ptr as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C_with_zero_length_array_and_incomplete_array_2),
+            "::",
+            stringify!(zero_length_array),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).incomplete_array) as usize - ptr as usize
-        }, 4usize, concat!("Offset of field: ",
-        stringify!(C_with_zero_length_array_and_incomplete_array_2), "::",
-        stringify!(incomplete_array))
+        unsafe { ::std::ptr::addr_of!((*ptr).incomplete_array) as usize - ptr as usize },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C_with_zero_length_array_and_incomplete_array_2),
+            "::",
+            stringify!(incomplete_array),
+        ),
     );
 }
 #[repr(C)]
@@ -367,16 +471,19 @@ fn bindgen_test_layout_WithDtor() {
     const UNINIT: ::std::mem::MaybeUninit<WithDtor> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < WithDtor > (), 4usize, concat!("Size of: ",
-        stringify!(WithDtor))
+        ::std::mem::size_of::<WithDtor>(),
+        4usize,
+        concat!("Size of: ", stringify!(WithDtor)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < WithDtor > (), 4usize, concat!("Alignment of ",
-        stringify!(WithDtor))
+        ::std::mem::align_of::<WithDtor>(),
+        4usize,
+        concat!("Alignment of ", stringify!(WithDtor)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).b) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(WithDtor), "::", stringify!(b))
+        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(WithDtor), "::", stringify!(b)),
     );
 }
 #[repr(C)]
@@ -389,22 +496,34 @@ fn bindgen_test_layout_IncompleteArrayNonCopiable() {
     const UNINIT: ::std::mem::MaybeUninit<IncompleteArrayNonCopiable> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < IncompleteArrayNonCopiable > (), 8usize,
-        concat!("Size of: ", stringify!(IncompleteArrayNonCopiable))
+        ::std::mem::size_of::<IncompleteArrayNonCopiable>(),
+        8usize,
+        concat!("Size of: ", stringify!(IncompleteArrayNonCopiable)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < IncompleteArrayNonCopiable > (), 8usize,
-        concat!("Alignment of ", stringify!(IncompleteArrayNonCopiable))
+        ::std::mem::align_of::<IncompleteArrayNonCopiable>(),
+        8usize,
+        concat!("Alignment of ", stringify!(IncompleteArrayNonCopiable)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).whatever) as usize - ptr as usize },
-        0usize, concat!("Offset of field: ", stringify!(IncompleteArrayNonCopiable),
-        "::", stringify!(whatever))
+        unsafe { ::std::ptr::addr_of!((*ptr).whatever) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(IncompleteArrayNonCopiable),
+            "::",
+            stringify!(whatever),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).incomplete_array) as usize - ptr as usize
-        }, 8usize, concat!("Offset of field: ", stringify!(IncompleteArrayNonCopiable),
-        "::", stringify!(incomplete_array))
+        unsafe { ::std::ptr::addr_of!((*ptr).incomplete_array) as usize - ptr as usize },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(IncompleteArrayNonCopiable),
+            "::",
+            stringify!(incomplete_array),
+        ),
     );
 }
 impl Default for IncompleteArrayNonCopiable {
@@ -428,20 +547,24 @@ fn bindgen_test_layout_Union() {
     const UNINIT: ::std::mem::MaybeUninit<Union> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < Union > (), 4usize, concat!("Size of: ",
-        stringify!(Union))
+        ::std::mem::size_of::<Union>(),
+        4usize,
+        concat!("Size of: ", stringify!(Union)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Union > (), 4usize, concat!("Alignment of ",
-        stringify!(Union))
+        ::std::mem::align_of::<Union>(),
+        4usize,
+        concat!("Alignment of ", stringify!(Union)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).d) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(Union), "::", stringify!(d))
+        unsafe { ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(Union), "::", stringify!(d)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).i) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(Union), "::", stringify!(i))
+        unsafe { ::std::ptr::addr_of!((*ptr).i) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(Union), "::", stringify!(i)),
     );
 }
 impl Clone for Union {
@@ -459,16 +582,19 @@ fn bindgen_test_layout_WithUnion() {
     const UNINIT: ::std::mem::MaybeUninit<WithUnion> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < WithUnion > (), 4usize, concat!("Size of: ",
-        stringify!(WithUnion))
+        ::std::mem::size_of::<WithUnion>(),
+        4usize,
+        concat!("Size of: ", stringify!(WithUnion)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < WithUnion > (), 4usize, concat!("Alignment of ",
-        stringify!(WithUnion))
+        ::std::mem::align_of::<WithUnion>(),
+        4usize,
+        concat!("Alignment of ", stringify!(WithUnion)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).data) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(WithUnion), "::", stringify!(data))
+        unsafe { ::std::ptr::addr_of!((*ptr).data) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(WithUnion), "::", stringify!(data)),
     );
 }
 impl Clone for WithUnion {
@@ -484,12 +610,14 @@ pub struct RealAbstractionWithTonsOfMethods {
 #[test]
 fn bindgen_test_layout_RealAbstractionWithTonsOfMethods() {
     assert_eq!(
-        ::std::mem::size_of:: < RealAbstractionWithTonsOfMethods > (), 1usize,
-        concat!("Size of: ", stringify!(RealAbstractionWithTonsOfMethods))
+        ::std::mem::size_of::<RealAbstractionWithTonsOfMethods>(),
+        1usize,
+        concat!("Size of: ", stringify!(RealAbstractionWithTonsOfMethods)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < RealAbstractionWithTonsOfMethods > (), 1usize,
-        concat!("Alignment of ", stringify!(RealAbstractionWithTonsOfMethods))
+        ::std::mem::align_of::<RealAbstractionWithTonsOfMethods>(),
+        1usize,
+        concat!("Alignment of ", stringify!(RealAbstractionWithTonsOfMethods)),
     );
 }
 extern "C" {

--- a/bindgen-tests/tests/expectations/tests/libclang-9/const_bool.rs
+++ b/bindgen-tests/tests/expectations/tests/libclang-9/const_bool.rs
@@ -8,11 +8,11 @@ pub struct A {
 pub const A_k: bool = false;
 #[test]
 fn bindgen_test_layout_A() {
+    assert_eq!(::std::mem::size_of::<A>(), 1usize, concat!("Size of: ", stringify!(A)));
     assert_eq!(
-        ::std::mem::size_of:: < A > (), 1usize, concat!("Size of: ", stringify!(A))
-    );
-    assert_eq!(
-        ::std::mem::align_of:: < A > (), 1usize, concat!("Alignment of ", stringify!(A))
+        ::std::mem::align_of::<A>(),
+        1usize,
+        concat!("Alignment of ", stringify!(A)),
     );
 }
 pub type foo = bool;

--- a/bindgen-tests/tests/expectations/tests/libclang-9/derive-hash-struct-with-incomplete-array.rs
+++ b/bindgen-tests/tests/expectations/tests/libclang-9/derive-hash-struct-with-incomplete-array.rs
@@ -40,20 +40,31 @@ fn bindgen_test_layout_test() {
     const UNINIT: ::std::mem::MaybeUninit<test> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < test > (), 4usize, concat!("Size of: ", stringify!(test))
+        ::std::mem::size_of::<test>(),
+        4usize,
+        concat!("Size of: ", stringify!(test)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < test > (), 4usize, concat!("Alignment of ",
-        stringify!(test))
+        ::std::mem::align_of::<test>(),
+        4usize,
+        concat!("Alignment of ", stringify!(test)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).a) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(test), "::", stringify!(a))
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(test), "::", stringify!(a)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).zero_length_array) as usize - ptr as usize
-        }, 4usize, concat!("Offset of field: ", stringify!(test), "::",
-        stringify!(zero_length_array))
+        unsafe {
+            ::std::ptr::addr_of!((*ptr).zero_length_array) as usize - ptr as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(test),
+            "::",
+            stringify!(zero_length_array),
+        ),
     );
 }
 #[repr(C)]
@@ -67,21 +78,29 @@ fn bindgen_test_layout_test2() {
     const UNINIT: ::std::mem::MaybeUninit<test2> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < test2 > (), 4usize, concat!("Size of: ",
-        stringify!(test2))
+        ::std::mem::size_of::<test2>(),
+        4usize,
+        concat!("Size of: ", stringify!(test2)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < test2 > (), 4usize, concat!("Alignment of ",
-        stringify!(test2))
+        ::std::mem::align_of::<test2>(),
+        4usize,
+        concat!("Alignment of ", stringify!(test2)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).a) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(test2), "::", stringify!(a))
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(test2), "::", stringify!(a)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).incomplete_array) as usize - ptr as usize
-        }, 4usize, concat!("Offset of field: ", stringify!(test2), "::",
-        stringify!(incomplete_array))
+        unsafe { ::std::ptr::addr_of!((*ptr).incomplete_array) as usize - ptr as usize },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(test2),
+            "::",
+            stringify!(incomplete_array),
+        ),
     );
 }
 #[repr(C)]
@@ -96,25 +115,40 @@ fn bindgen_test_layout_test3() {
     const UNINIT: ::std::mem::MaybeUninit<test3> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < test3 > (), 4usize, concat!("Size of: ",
-        stringify!(test3))
+        ::std::mem::size_of::<test3>(),
+        4usize,
+        concat!("Size of: ", stringify!(test3)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < test3 > (), 4usize, concat!("Alignment of ",
-        stringify!(test3))
+        ::std::mem::align_of::<test3>(),
+        4usize,
+        concat!("Alignment of ", stringify!(test3)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).a) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(test3), "::", stringify!(a))
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(test3), "::", stringify!(a)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).zero_length_array) as usize - ptr as usize
-        }, 4usize, concat!("Offset of field: ", stringify!(test3), "::",
-        stringify!(zero_length_array))
+        unsafe {
+            ::std::ptr::addr_of!((*ptr).zero_length_array) as usize - ptr as usize
+        },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(test3),
+            "::",
+            stringify!(zero_length_array),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).incomplete_array) as usize - ptr as usize
-        }, 4usize, concat!("Offset of field: ", stringify!(test3), "::",
-        stringify!(incomplete_array))
+        unsafe { ::std::ptr::addr_of!((*ptr).incomplete_array) as usize - ptr as usize },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(test3),
+            "::",
+            stringify!(incomplete_array),
+        ),
     );
 }

--- a/bindgen-tests/tests/expectations/tests/libclang-9/incomplete-array-padding.rs
+++ b/bindgen-tests/tests/expectations/tests/libclang-9/incomplete-array-padding.rs
@@ -49,7 +49,7 @@ where
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < self.storage.as_ref().len());
         debug_assert!(
-            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len()
+            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len(),
         );
         let mut val = 0;
         for i in 0..(bit_width as usize) {
@@ -69,7 +69,7 @@ where
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < self.storage.as_ref().len());
         debug_assert!(
-            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len()
+            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len(),
         );
         for i in 0..(bit_width as usize) {
             let mask = 1 << i;
@@ -125,15 +125,19 @@ fn bindgen_test_layout_foo() {
     const UNINIT: ::std::mem::MaybeUninit<foo> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < foo > (), 8usize, concat!("Size of: ", stringify!(foo))
+        ::std::mem::size_of::<foo>(),
+        8usize,
+        concat!("Size of: ", stringify!(foo)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < foo > (), 8usize, concat!("Alignment of ",
-        stringify!(foo))
+        ::std::mem::align_of::<foo>(),
+        8usize,
+        concat!("Alignment of ", stringify!(foo)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).b) as usize - ptr as usize }, 8usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(b))
+        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
+        8usize,
+        concat!("Offset of field: ", stringify!(foo), "::", stringify!(b)),
     );
 }
 impl Default for foo {

--- a/bindgen-tests/tests/expectations/tests/libclang-9/issue-643-inner-struct.rs
+++ b/bindgen-tests/tests/expectations/tests/libclang-9/issue-643-inner-struct.rs
@@ -47,17 +47,24 @@ fn bindgen_test_layout_rte_ring_prod() {
     const UNINIT: ::std::mem::MaybeUninit<rte_ring_prod> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < rte_ring_prod > (), 4usize, concat!("Size of: ",
-        stringify!(rte_ring_prod))
+        ::std::mem::size_of::<rte_ring_prod>(),
+        4usize,
+        concat!("Size of: ", stringify!(rte_ring_prod)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < rte_ring_prod > (), 4usize, concat!("Alignment of ",
-        stringify!(rte_ring_prod))
+        ::std::mem::align_of::<rte_ring_prod>(),
+        4usize,
+        concat!("Alignment of ", stringify!(rte_ring_prod)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).watermark) as usize - ptr as usize },
-        0usize, concat!("Offset of field: ", stringify!(rte_ring_prod), "::",
-        stringify!(watermark))
+        unsafe { ::std::ptr::addr_of!((*ptr).watermark) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_ring_prod),
+            "::",
+            stringify!(watermark),
+        ),
     );
 }
 #[repr(C)]
@@ -70,17 +77,24 @@ fn bindgen_test_layout_rte_ring_cons() {
     const UNINIT: ::std::mem::MaybeUninit<rte_ring_cons> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < rte_ring_cons > (), 4usize, concat!("Size of: ",
-        stringify!(rte_ring_cons))
+        ::std::mem::size_of::<rte_ring_cons>(),
+        4usize,
+        concat!("Size of: ", stringify!(rte_ring_cons)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < rte_ring_cons > (), 4usize, concat!("Alignment of ",
-        stringify!(rte_ring_cons))
+        ::std::mem::align_of::<rte_ring_cons>(),
+        4usize,
+        concat!("Alignment of ", stringify!(rte_ring_cons)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).sc_dequeue) as usize - ptr as usize },
-        0usize, concat!("Offset of field: ", stringify!(rte_ring_cons), "::",
-        stringify!(sc_dequeue))
+        unsafe { ::std::ptr::addr_of!((*ptr).sc_dequeue) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_ring_cons),
+            "::",
+            stringify!(sc_dequeue),
+        ),
     );
 }
 #[test]
@@ -88,28 +102,34 @@ fn bindgen_test_layout_rte_ring() {
     const UNINIT: ::std::mem::MaybeUninit<rte_ring> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < rte_ring > (), 16usize, concat!("Size of: ",
-        stringify!(rte_ring))
+        ::std::mem::size_of::<rte_ring>(),
+        16usize,
+        concat!("Size of: ", stringify!(rte_ring)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < rte_ring > (), 8usize, concat!("Alignment of ",
-        stringify!(rte_ring))
+        ::std::mem::align_of::<rte_ring>(),
+        8usize,
+        concat!("Alignment of ", stringify!(rte_ring)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).memzone) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(rte_ring), "::", stringify!(memzone))
+        unsafe { ::std::ptr::addr_of!((*ptr).memzone) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(rte_ring), "::", stringify!(memzone)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).prod) as usize - ptr as usize }, 8usize,
-        concat!("Offset of field: ", stringify!(rte_ring), "::", stringify!(prod))
+        unsafe { ::std::ptr::addr_of!((*ptr).prod) as usize - ptr as usize },
+        8usize,
+        concat!("Offset of field: ", stringify!(rte_ring), "::", stringify!(prod)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).cons) as usize - ptr as usize }, 12usize,
-        concat!("Offset of field: ", stringify!(rte_ring), "::", stringify!(cons))
+        unsafe { ::std::ptr::addr_of!((*ptr).cons) as usize - ptr as usize },
+        12usize,
+        concat!("Offset of field: ", stringify!(rte_ring), "::", stringify!(cons)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).ring) as usize - ptr as usize }, 16usize,
-        concat!("Offset of field: ", stringify!(rte_ring), "::", stringify!(ring))
+        unsafe { ::std::ptr::addr_of!((*ptr).ring) as usize - ptr as usize },
+        16usize,
+        concat!("Offset of field: ", stringify!(rte_ring), "::", stringify!(ring)),
     );
 }
 impl Default for rte_ring {

--- a/bindgen-tests/tests/expectations/tests/libclang-9/issue-769-bad-instantiation-test.rs
+++ b/bindgen-tests/tests/expectations/tests/libclang-9/issue-769-bad-instantiation-test.rs
@@ -22,27 +22,39 @@ pub mod root {
     #[test]
     fn __bindgen_test_layout_Rooted_open0_int_close0_instantiation() {
         assert_eq!(
-            ::std::mem::size_of:: < root::Rooted < ::std::os::raw::c_int > > (), 4usize,
-            concat!("Size of template specialization: ", stringify!(root::Rooted <
-            ::std::os::raw::c_int >))
+            ::std::mem::size_of::<root::Rooted<::std::os::raw::c_int>>(),
+            4usize,
+            concat!(
+                "Size of template specialization: ",
+                stringify!(root::Rooted < ::std::os::raw::c_int >),
+            ),
         );
         assert_eq!(
-            ::std::mem::align_of:: < root::Rooted < ::std::os::raw::c_int > > (), 4usize,
-            concat!("Alignment of template specialization: ", stringify!(root::Rooted <
-            ::std::os::raw::c_int >))
+            ::std::mem::align_of::<root::Rooted<::std::os::raw::c_int>>(),
+            4usize,
+            concat!(
+                "Alignment of template specialization: ",
+                stringify!(root::Rooted < ::std::os::raw::c_int >),
+            ),
         );
     }
     #[test]
     fn __bindgen_test_layout_Rooted_open0_AutoValueVector_Alias_close0_instantiation() {
         assert_eq!(
-            ::std::mem::size_of:: < root::Rooted < root::AutoValueVector_Alias > > (),
-            4usize, concat!("Size of template specialization: ", stringify!(root::Rooted
-            < root::AutoValueVector_Alias >))
+            ::std::mem::size_of::<root::Rooted<root::AutoValueVector_Alias>>(),
+            4usize,
+            concat!(
+                "Size of template specialization: ",
+                stringify!(root::Rooted < root::AutoValueVector_Alias >),
+            ),
         );
         assert_eq!(
-            ::std::mem::align_of:: < root::Rooted < root::AutoValueVector_Alias > > (),
-            4usize, concat!("Alignment of template specialization: ",
-            stringify!(root::Rooted < root::AutoValueVector_Alias >))
+            ::std::mem::align_of::<root::Rooted<root::AutoValueVector_Alias>>(),
+            4usize,
+            concat!(
+                "Alignment of template specialization: ",
+                stringify!(root::Rooted < root::AutoValueVector_Alias >),
+            ),
         );
     }
 }

--- a/bindgen-tests/tests/expectations/tests/libclang-9/layout_align.rs
+++ b/bindgen-tests/tests/expectations/tests/libclang-9/layout_align.rs
@@ -49,7 +49,7 @@ where
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < self.storage.as_ref().len());
         debug_assert!(
-            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len()
+            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len(),
         );
         let mut val = 0;
         for i in 0..(bit_width as usize) {
@@ -69,7 +69,7 @@ where
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < self.storage.as_ref().len());
         debug_assert!(
-            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len()
+            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len(),
         );
         for i in 0..(bit_width as usize) {
             let mask = 1 << i;
@@ -132,33 +132,44 @@ fn bindgen_test_layout_rte_kni_fifo() {
     const UNINIT: ::std::mem::MaybeUninit<rte_kni_fifo> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < rte_kni_fifo > (), 16usize, concat!("Size of: ",
-        stringify!(rte_kni_fifo))
+        ::std::mem::size_of::<rte_kni_fifo>(),
+        16usize,
+        concat!("Size of: ", stringify!(rte_kni_fifo)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < rte_kni_fifo > (), 8usize, concat!("Alignment of ",
-        stringify!(rte_kni_fifo))
+        ::std::mem::align_of::<rte_kni_fifo>(),
+        8usize,
+        concat!("Alignment of ", stringify!(rte_kni_fifo)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).write) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(rte_kni_fifo), "::", stringify!(write))
+        unsafe { ::std::ptr::addr_of!((*ptr).write) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(rte_kni_fifo), "::", stringify!(write)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).read) as usize - ptr as usize }, 4usize,
-        concat!("Offset of field: ", stringify!(rte_kni_fifo), "::", stringify!(read))
+        unsafe { ::std::ptr::addr_of!((*ptr).read) as usize - ptr as usize },
+        4usize,
+        concat!("Offset of field: ", stringify!(rte_kni_fifo), "::", stringify!(read)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).len) as usize - ptr as usize }, 8usize,
-        concat!("Offset of field: ", stringify!(rte_kni_fifo), "::", stringify!(len))
+        unsafe { ::std::ptr::addr_of!((*ptr).len) as usize - ptr as usize },
+        8usize,
+        concat!("Offset of field: ", stringify!(rte_kni_fifo), "::", stringify!(len)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).elem_size) as usize - ptr as usize },
-        12usize, concat!("Offset of field: ", stringify!(rte_kni_fifo), "::",
-        stringify!(elem_size))
+        unsafe { ::std::ptr::addr_of!((*ptr).elem_size) as usize - ptr as usize },
+        12usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_kni_fifo),
+            "::",
+            stringify!(elem_size),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).buffer) as usize - ptr as usize }, 16usize,
-        concat!("Offset of field: ", stringify!(rte_kni_fifo), "::", stringify!(buffer))
+        unsafe { ::std::ptr::addr_of!((*ptr).buffer) as usize - ptr as usize },
+        16usize,
+        concat!("Offset of field: ", stringify!(rte_kni_fifo), "::", stringify!(buffer)),
     );
 }
 impl Default for rte_kni_fifo {
@@ -185,17 +196,24 @@ fn bindgen_test_layout_rte_eth_link() {
     const UNINIT: ::std::mem::MaybeUninit<rte_eth_link> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < rte_eth_link > (), 8usize, concat!("Size of: ",
-        stringify!(rte_eth_link))
+        ::std::mem::size_of::<rte_eth_link>(),
+        8usize,
+        concat!("Size of: ", stringify!(rte_eth_link)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < rte_eth_link > (), 8usize, concat!("Alignment of ",
-        stringify!(rte_eth_link))
+        ::std::mem::align_of::<rte_eth_link>(),
+        8usize,
+        concat!("Alignment of ", stringify!(rte_eth_link)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).link_speed) as usize - ptr as usize },
-        0usize, concat!("Offset of field: ", stringify!(rte_eth_link), "::",
-        stringify!(link_speed))
+        unsafe { ::std::ptr::addr_of!((*ptr).link_speed) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(rte_eth_link),
+            "::",
+            stringify!(link_speed),
+        ),
     );
 }
 impl rte_eth_link {

--- a/bindgen-tests/tests/expectations/tests/libclang-9/mangling-win32.rs
+++ b/bindgen-tests/tests/expectations/tests/libclang-9/mangling-win32.rs
@@ -14,11 +14,14 @@ extern "C" {
 #[test]
 fn bindgen_test_layout_Foo() {
     assert_eq!(
-        ::std::mem::size_of:: < Foo > (), 1usize, concat!("Size of: ", stringify!(Foo))
+        ::std::mem::size_of::<Foo>(),
+        1usize,
+        concat!("Size of: ", stringify!(Foo)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Foo > (), 1usize, concat!("Alignment of ",
-        stringify!(Foo))
+        ::std::mem::align_of::<Foo>(),
+        1usize,
+        concat!("Alignment of ", stringify!(Foo)),
     );
 }
 extern "fastcall" {

--- a/bindgen-tests/tests/expectations/tests/libclang-9/partial-specialization-and-inheritance.rs
+++ b/bindgen-tests/tests/expectations/tests/libclang-9/partial-specialization-and-inheritance.rs
@@ -21,11 +21,13 @@ extern "C" {
 #[test]
 fn bindgen_test_layout_Usage() {
     assert_eq!(
-        ::std::mem::size_of:: < Usage > (), 1usize, concat!("Size of: ",
-        stringify!(Usage))
+        ::std::mem::size_of::<Usage>(),
+        1usize,
+        concat!("Size of: ", stringify!(Usage)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Usage > (), 1usize, concat!("Alignment of ",
-        stringify!(Usage))
+        ::std::mem::align_of::<Usage>(),
+        1usize,
+        concat!("Alignment of ", stringify!(Usage)),
     );
 }

--- a/bindgen-tests/tests/expectations/tests/libclang-9/type_alias_template_specialized.rs
+++ b/bindgen-tests/tests/expectations/tests/libclang-9/type_alias_template_specialized.rs
@@ -9,16 +9,19 @@ fn bindgen_test_layout_Rooted() {
     const UNINIT: ::std::mem::MaybeUninit<Rooted> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < Rooted > (), 4usize, concat!("Size of: ",
-        stringify!(Rooted))
+        ::std::mem::size_of::<Rooted>(),
+        4usize,
+        concat!("Size of: ", stringify!(Rooted)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Rooted > (), 4usize, concat!("Alignment of ",
-        stringify!(Rooted))
+        ::std::mem::align_of::<Rooted>(),
+        4usize,
+        concat!("Alignment of ", stringify!(Rooted)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).ptr) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(Rooted), "::", stringify!(ptr))
+        unsafe { ::std::ptr::addr_of!((*ptr).ptr) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(Rooted), "::", stringify!(ptr)),
     );
 }
 impl Default for Rooted {
@@ -35,13 +38,19 @@ pub type MaybeWrapped<a> = a;
 #[test]
 fn __bindgen_test_layout_MaybeWrapped_open0_int_close0_instantiation() {
     assert_eq!(
-        ::std::mem::size_of:: < MaybeWrapped < ::std::os::raw::c_int > > (), 4usize,
-        concat!("Size of template specialization: ", stringify!(MaybeWrapped <
-        ::std::os::raw::c_int >))
+        ::std::mem::size_of::<MaybeWrapped<::std::os::raw::c_int>>(),
+        4usize,
+        concat!(
+            "Size of template specialization: ",
+            stringify!(MaybeWrapped < ::std::os::raw::c_int >),
+        ),
     );
     assert_eq!(
-        ::std::mem::align_of:: < MaybeWrapped < ::std::os::raw::c_int > > (), 4usize,
-        concat!("Alignment of template specialization: ", stringify!(MaybeWrapped <
-        ::std::os::raw::c_int >))
+        ::std::mem::align_of::<MaybeWrapped<::std::os::raw::c_int>>(),
+        4usize,
+        concat!(
+            "Alignment of template specialization: ",
+            stringify!(MaybeWrapped < ::std::os::raw::c_int >),
+        ),
     );
 }

--- a/bindgen-tests/tests/expectations/tests/libclang-9/zero-sized-array.rs
+++ b/bindgen-tests/tests/expectations/tests/libclang-9/zero-sized-array.rs
@@ -40,16 +40,19 @@ fn bindgen_test_layout_ZeroSizedArray() {
     const UNINIT: ::std::mem::MaybeUninit<ZeroSizedArray> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < ZeroSizedArray > (), 0usize, concat!("Size of: ",
-        stringify!(ZeroSizedArray))
+        ::std::mem::size_of::<ZeroSizedArray>(),
+        0usize,
+        concat!("Size of: ", stringify!(ZeroSizedArray)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < ZeroSizedArray > (), 1usize, concat!("Alignment of ",
-        stringify!(ZeroSizedArray))
+        ::std::mem::align_of::<ZeroSizedArray>(),
+        1usize,
+        concat!("Alignment of ", stringify!(ZeroSizedArray)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).arr) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(ZeroSizedArray), "::", stringify!(arr))
+        unsafe { ::std::ptr::addr_of!((*ptr).arr) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(ZeroSizedArray), "::", stringify!(arr)),
     );
 }
 /// And nor should this get an `_address` field.
@@ -63,17 +66,24 @@ fn bindgen_test_layout_ContainsZeroSizedArray() {
     const UNINIT: ::std::mem::MaybeUninit<ContainsZeroSizedArray> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < ContainsZeroSizedArray > (), 0usize, concat!("Size of: ",
-        stringify!(ContainsZeroSizedArray))
+        ::std::mem::size_of::<ContainsZeroSizedArray>(),
+        0usize,
+        concat!("Size of: ", stringify!(ContainsZeroSizedArray)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < ContainsZeroSizedArray > (), 1usize,
-        concat!("Alignment of ", stringify!(ContainsZeroSizedArray))
+        ::std::mem::align_of::<ContainsZeroSizedArray>(),
+        1usize,
+        concat!("Alignment of ", stringify!(ContainsZeroSizedArray)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).zsa) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(ContainsZeroSizedArray), "::",
-        stringify!(zsa))
+        unsafe { ::std::ptr::addr_of!((*ptr).zsa) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ContainsZeroSizedArray),
+            "::",
+            stringify!(zsa),
+        ),
     );
 }
 /** Inheriting from ZeroSizedArray shouldn't cause an `_address` to be inserted
@@ -86,12 +96,14 @@ pub struct InheritsZeroSizedArray {
 #[test]
 fn bindgen_test_layout_InheritsZeroSizedArray() {
     assert_eq!(
-        ::std::mem::size_of:: < InheritsZeroSizedArray > (), 0usize, concat!("Size of: ",
-        stringify!(InheritsZeroSizedArray))
+        ::std::mem::size_of::<InheritsZeroSizedArray>(),
+        0usize,
+        concat!("Size of: ", stringify!(InheritsZeroSizedArray)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < InheritsZeroSizedArray > (), 1usize,
-        concat!("Alignment of ", stringify!(InheritsZeroSizedArray))
+        ::std::mem::align_of::<InheritsZeroSizedArray>(),
+        1usize,
+        concat!("Alignment of ", stringify!(InheritsZeroSizedArray)),
     );
 }
 /// And this should not get an `_address` field either.
@@ -105,17 +117,24 @@ fn bindgen_test_layout_DynamicallySizedArray() {
     const UNINIT: ::std::mem::MaybeUninit<DynamicallySizedArray> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < DynamicallySizedArray > (), 0usize, concat!("Size of: ",
-        stringify!(DynamicallySizedArray))
+        ::std::mem::size_of::<DynamicallySizedArray>(),
+        0usize,
+        concat!("Size of: ", stringify!(DynamicallySizedArray)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < DynamicallySizedArray > (), 1usize,
-        concat!("Alignment of ", stringify!(DynamicallySizedArray))
+        ::std::mem::align_of::<DynamicallySizedArray>(),
+        1usize,
+        concat!("Alignment of ", stringify!(DynamicallySizedArray)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).arr) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(DynamicallySizedArray), "::",
-        stringify!(arr))
+        unsafe { ::std::ptr::addr_of!((*ptr).arr) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(DynamicallySizedArray),
+            "::",
+            stringify!(arr),
+        ),
     );
 }
 /// No `_address` field here either.
@@ -129,16 +148,23 @@ fn bindgen_test_layout_ContainsDynamicallySizedArray() {
     const UNINIT: ::std::mem::MaybeUninit<ContainsDynamicallySizedArray> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < ContainsDynamicallySizedArray > (), 0usize,
-        concat!("Size of: ", stringify!(ContainsDynamicallySizedArray))
+        ::std::mem::size_of::<ContainsDynamicallySizedArray>(),
+        0usize,
+        concat!("Size of: ", stringify!(ContainsDynamicallySizedArray)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < ContainsDynamicallySizedArray > (), 1usize,
-        concat!("Alignment of ", stringify!(ContainsDynamicallySizedArray))
+        ::std::mem::align_of::<ContainsDynamicallySizedArray>(),
+        1usize,
+        concat!("Alignment of ", stringify!(ContainsDynamicallySizedArray)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).dsa) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(ContainsDynamicallySizedArray), "::",
-        stringify!(dsa))
+        unsafe { ::std::ptr::addr_of!((*ptr).dsa) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ContainsDynamicallySizedArray),
+            "::",
+            stringify!(dsa),
+        ),
     );
 }

--- a/bindgen-tests/tests/expectations/tests/long_double.rs
+++ b/bindgen-tests/tests/expectations/tests/long_double.rs
@@ -10,14 +10,18 @@ fn bindgen_test_layout_foo() {
     const UNINIT: ::std::mem::MaybeUninit<foo> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < foo > (), 16usize, concat!("Size of: ", stringify!(foo))
+        ::std::mem::size_of::<foo>(),
+        16usize,
+        concat!("Size of: ", stringify!(foo)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < foo > (), 16usize, concat!("Alignment of ",
-        stringify!(foo))
+        ::std::mem::align_of::<foo>(),
+        16usize,
+        concat!("Alignment of ", stringify!(foo)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).bar) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar))
+        unsafe { ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar)),
     );
 }

--- a/bindgen-tests/tests/expectations/tests/mangling-linux32.rs
+++ b/bindgen-tests/tests/expectations/tests/mangling-linux32.rs
@@ -14,10 +14,13 @@ extern "C" {
 #[test]
 fn bindgen_test_layout_Foo() {
     assert_eq!(
-        ::std::mem::size_of:: < Foo > (), 1usize, concat!("Size of: ", stringify!(Foo))
+        ::std::mem::size_of::<Foo>(),
+        1usize,
+        concat!("Size of: ", stringify!(Foo)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Foo > (), 1usize, concat!("Alignment of ",
-        stringify!(Foo))
+        ::std::mem::align_of::<Foo>(),
+        1usize,
+        concat!("Alignment of ", stringify!(Foo)),
     );
 }

--- a/bindgen-tests/tests/expectations/tests/mangling-linux64.rs
+++ b/bindgen-tests/tests/expectations/tests/mangling-linux64.rs
@@ -14,10 +14,13 @@ extern "C" {
 #[test]
 fn bindgen_test_layout_Foo() {
     assert_eq!(
-        ::std::mem::size_of:: < Foo > (), 1usize, concat!("Size of: ", stringify!(Foo))
+        ::std::mem::size_of::<Foo>(),
+        1usize,
+        concat!("Size of: ", stringify!(Foo)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Foo > (), 1usize, concat!("Alignment of ",
-        stringify!(Foo))
+        ::std::mem::align_of::<Foo>(),
+        1usize,
+        concat!("Alignment of ", stringify!(Foo)),
     );
 }

--- a/bindgen-tests/tests/expectations/tests/mangling-macos.rs
+++ b/bindgen-tests/tests/expectations/tests/mangling-macos.rs
@@ -14,10 +14,13 @@ extern "C" {
 #[test]
 fn bindgen_test_layout_Foo() {
     assert_eq!(
-        ::std::mem::size_of:: < Foo > (), 1usize, concat!("Size of: ", stringify!(Foo))
+        ::std::mem::size_of::<Foo>(),
+        1usize,
+        concat!("Size of: ", stringify!(Foo)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Foo > (), 1usize, concat!("Alignment of ",
-        stringify!(Foo))
+        ::std::mem::align_of::<Foo>(),
+        1usize,
+        concat!("Alignment of ", stringify!(Foo)),
     );
 }

--- a/bindgen-tests/tests/expectations/tests/mangling-win64.rs
+++ b/bindgen-tests/tests/expectations/tests/mangling-win64.rs
@@ -14,10 +14,13 @@ extern "C" {
 #[test]
 fn bindgen_test_layout_Foo() {
     assert_eq!(
-        ::std::mem::size_of:: < Foo > (), 1usize, concat!("Size of: ", stringify!(Foo))
+        ::std::mem::size_of::<Foo>(),
+        1usize,
+        concat!("Size of: ", stringify!(Foo)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Foo > (), 1usize, concat!("Alignment of ",
-        stringify!(Foo))
+        ::std::mem::align_of::<Foo>(),
+        1usize,
+        concat!("Alignment of ", stringify!(Foo)),
     );
 }

--- a/bindgen-tests/tests/expectations/tests/merge-extern-blocks.rs
+++ b/bindgen-tests/tests/expectations/tests/merge-extern-blocks.rs
@@ -13,16 +13,19 @@ pub mod root {
         const UNINIT: ::std::mem::MaybeUninit<Point> = ::std::mem::MaybeUninit::uninit();
         let ptr = UNINIT.as_ptr();
         assert_eq!(
-            ::std::mem::size_of:: < Point > (), 4usize, concat!("Size of: ",
-            stringify!(Point))
+            ::std::mem::size_of::<Point>(),
+            4usize,
+            concat!("Size of: ", stringify!(Point)),
         );
         assert_eq!(
-            ::std::mem::align_of:: < Point > (), 4usize, concat!("Alignment of ",
-            stringify!(Point))
+            ::std::mem::align_of::<Point>(),
+            4usize,
+            concat!("Alignment of ", stringify!(Point)),
         );
         assert_eq!(
-            unsafe { ::std::ptr::addr_of!((* ptr).x) as usize - ptr as usize }, 0usize,
-            concat!("Offset of field: ", stringify!(Point), "::", stringify!(x))
+            unsafe { ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize },
+            0usize,
+            concat!("Offset of field: ", stringify!(Point), "::", stringify!(x)),
         );
     }
     pub mod ns {
@@ -38,17 +41,19 @@ pub mod root {
             const UNINIT: ::std::mem::MaybeUninit<Point> = ::std::mem::MaybeUninit::uninit();
             let ptr = UNINIT.as_ptr();
             assert_eq!(
-                ::std::mem::size_of:: < Point > (), 4usize, concat!("Size of: ",
-                stringify!(Point))
+                ::std::mem::size_of::<Point>(),
+                4usize,
+                concat!("Size of: ", stringify!(Point)),
             );
             assert_eq!(
-                ::std::mem::align_of:: < Point > (), 4usize, concat!("Alignment of ",
-                stringify!(Point))
+                ::std::mem::align_of::<Point>(),
+                4usize,
+                concat!("Alignment of ", stringify!(Point)),
             );
             assert_eq!(
-                unsafe { ::std::ptr::addr_of!((* ptr).x) as usize - ptr as usize },
-                0usize, concat!("Offset of field: ", stringify!(Point), "::",
-                stringify!(x))
+                unsafe { ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize },
+                0usize,
+                concat!("Offset of field: ", stringify!(Point), "::", stringify!(x)),
             );
         }
         extern "C" {

--- a/bindgen-tests/tests/expectations/tests/method-mangling.rs
+++ b/bindgen-tests/tests/expectations/tests/method-mangling.rs
@@ -7,11 +7,14 @@ pub struct Foo {
 #[test]
 fn bindgen_test_layout_Foo() {
     assert_eq!(
-        ::std::mem::size_of:: < Foo > (), 1usize, concat!("Size of: ", stringify!(Foo))
+        ::std::mem::size_of::<Foo>(),
+        1usize,
+        concat!("Size of: ", stringify!(Foo)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Foo > (), 1usize, concat!("Alignment of ",
-        stringify!(Foo))
+        ::std::mem::align_of::<Foo>(),
+        1usize,
+        concat!("Alignment of ", stringify!(Foo)),
     );
 }
 extern "C" {

--- a/bindgen-tests/tests/expectations/tests/module-allowlisted.rs
+++ b/bindgen-tests/tests/expectations/tests/module-allowlisted.rs
@@ -11,12 +11,14 @@ pub mod root {
     #[test]
     fn bindgen_test_layout_Test() {
         assert_eq!(
-            ::std::mem::size_of:: < Test > (), 1usize, concat!("Size of: ",
-            stringify!(Test))
+            ::std::mem::size_of::<Test>(),
+            1usize,
+            concat!("Size of: ", stringify!(Test)),
         );
         assert_eq!(
-            ::std::mem::align_of:: < Test > (), 1usize, concat!("Alignment of ",
-            stringify!(Test))
+            ::std::mem::align_of::<Test>(),
+            1usize,
+            concat!("Alignment of ", stringify!(Test)),
         );
     }
 }

--- a/bindgen-tests/tests/expectations/tests/msvc-no-usr.rs
+++ b/bindgen-tests/tests/expectations/tests/msvc-no-usr.rs
@@ -8,14 +8,15 @@ pub struct A {
 fn bindgen_test_layout_A() {
     const UNINIT: ::std::mem::MaybeUninit<A> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
+    assert_eq!(::std::mem::size_of::<A>(), 8usize, concat!("Size of: ", stringify!(A)));
     assert_eq!(
-        ::std::mem::size_of:: < A > (), 8usize, concat!("Size of: ", stringify!(A))
+        ::std::mem::align_of::<A>(),
+        8usize,
+        concat!("Alignment of ", stringify!(A)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < A > (), 8usize, concat!("Alignment of ", stringify!(A))
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).foo) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(A), "::", stringify!(foo))
+        unsafe { ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(A), "::", stringify!(foo)),
     );
 }

--- a/bindgen-tests/tests/expectations/tests/multiple-inherit-empty-correct-layout.rs
+++ b/bindgen-tests/tests/expectations/tests/multiple-inherit-empty-correct-layout.rs
@@ -7,11 +7,14 @@ pub struct Foo {
 #[test]
 fn bindgen_test_layout_Foo() {
     assert_eq!(
-        ::std::mem::size_of:: < Foo > (), 1usize, concat!("Size of: ", stringify!(Foo))
+        ::std::mem::size_of::<Foo>(),
+        1usize,
+        concat!("Size of: ", stringify!(Foo)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Foo > (), 1usize, concat!("Alignment of ",
-        stringify!(Foo))
+        ::std::mem::align_of::<Foo>(),
+        1usize,
+        concat!("Alignment of ", stringify!(Foo)),
     );
 }
 #[repr(C)]
@@ -22,11 +25,14 @@ pub struct Bar {
 #[test]
 fn bindgen_test_layout_Bar() {
     assert_eq!(
-        ::std::mem::size_of:: < Bar > (), 1usize, concat!("Size of: ", stringify!(Bar))
+        ::std::mem::size_of::<Bar>(),
+        1usize,
+        concat!("Size of: ", stringify!(Bar)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Bar > (), 1usize, concat!("Alignment of ",
-        stringify!(Bar))
+        ::std::mem::align_of::<Bar>(),
+        1usize,
+        concat!("Alignment of ", stringify!(Bar)),
     );
 }
 #[repr(C)]
@@ -37,10 +43,13 @@ pub struct Baz {
 #[test]
 fn bindgen_test_layout_Baz() {
     assert_eq!(
-        ::std::mem::size_of:: < Baz > (), 1usize, concat!("Size of: ", stringify!(Baz))
+        ::std::mem::size_of::<Baz>(),
+        1usize,
+        concat!("Size of: ", stringify!(Baz)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Baz > (), 1usize, concat!("Alignment of ",
-        stringify!(Baz))
+        ::std::mem::align_of::<Baz>(),
+        1usize,
+        concat!("Alignment of ", stringify!(Baz)),
     );
 }

--- a/bindgen-tests/tests/expectations/tests/mutable.rs
+++ b/bindgen-tests/tests/expectations/tests/mutable.rs
@@ -9,19 +9,21 @@ pub struct C {
 fn bindgen_test_layout_C() {
     const UNINIT: ::std::mem::MaybeUninit<C> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
+    assert_eq!(::std::mem::size_of::<C>(), 8usize, concat!("Size of: ", stringify!(C)));
     assert_eq!(
-        ::std::mem::size_of:: < C > (), 8usize, concat!("Size of: ", stringify!(C))
+        ::std::mem::align_of::<C>(),
+        4usize,
+        concat!("Alignment of ", stringify!(C)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < C > (), 4usize, concat!("Alignment of ", stringify!(C))
+        unsafe { ::std::ptr::addr_of!((*ptr).m_member) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(C), "::", stringify!(m_member)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).m_member) as usize - ptr as usize },
-        0usize, concat!("Offset of field: ", stringify!(C), "::", stringify!(m_member))
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).m_other) as usize - ptr as usize }, 4usize,
-        concat!("Offset of field: ", stringify!(C), "::", stringify!(m_other))
+        unsafe { ::std::ptr::addr_of!((*ptr).m_other) as usize - ptr as usize },
+        4usize,
+        concat!("Offset of field: ", stringify!(C), "::", stringify!(m_other)),
     );
 }
 #[repr(C)]
@@ -34,17 +36,19 @@ fn bindgen_test_layout_NonCopiable() {
     const UNINIT: ::std::mem::MaybeUninit<NonCopiable> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < NonCopiable > (), 4usize, concat!("Size of: ",
-        stringify!(NonCopiable))
+        ::std::mem::size_of::<NonCopiable>(),
+        4usize,
+        concat!("Size of: ", stringify!(NonCopiable)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < NonCopiable > (), 4usize, concat!("Alignment of ",
-        stringify!(NonCopiable))
+        ::std::mem::align_of::<NonCopiable>(),
+        4usize,
+        concat!("Alignment of ", stringify!(NonCopiable)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).m_member) as usize - ptr as usize },
-        0usize, concat!("Offset of field: ", stringify!(NonCopiable), "::",
-        stringify!(m_member))
+        unsafe { ::std::ptr::addr_of!((*ptr).m_member) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(NonCopiable), "::", stringify!(m_member)),
     );
 }
 #[repr(C)]
@@ -57,16 +61,23 @@ fn bindgen_test_layout_NonCopiableWithNonCopiableMutableMember() {
     const UNINIT: ::std::mem::MaybeUninit<NonCopiableWithNonCopiableMutableMember> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < NonCopiableWithNonCopiableMutableMember > (), 4usize,
-        concat!("Size of: ", stringify!(NonCopiableWithNonCopiableMutableMember))
+        ::std::mem::size_of::<NonCopiableWithNonCopiableMutableMember>(),
+        4usize,
+        concat!("Size of: ", stringify!(NonCopiableWithNonCopiableMutableMember)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < NonCopiableWithNonCopiableMutableMember > (), 4usize,
-        concat!("Alignment of ", stringify!(NonCopiableWithNonCopiableMutableMember))
+        ::std::mem::align_of::<NonCopiableWithNonCopiableMutableMember>(),
+        4usize,
+        concat!("Alignment of ", stringify!(NonCopiableWithNonCopiableMutableMember)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).m_member) as usize - ptr as usize },
-        0usize, concat!("Offset of field: ",
-        stringify!(NonCopiableWithNonCopiableMutableMember), "::", stringify!(m_member))
+        unsafe { ::std::ptr::addr_of!((*ptr).m_member) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(NonCopiableWithNonCopiableMutableMember),
+            "::",
+            stringify!(m_member),
+        ),
     );
 }

--- a/bindgen-tests/tests/expectations/tests/namespace.rs
+++ b/bindgen-tests/tests/expectations/tests/namespace.rs
@@ -30,16 +30,19 @@ pub mod root {
             const UNINIT: ::std::mem::MaybeUninit<A> = ::std::mem::MaybeUninit::uninit();
             let ptr = UNINIT.as_ptr();
             assert_eq!(
-                ::std::mem::size_of:: < A > (), 4usize, concat!("Size of: ",
-                stringify!(A))
+                ::std::mem::size_of::<A>(),
+                4usize,
+                concat!("Size of: ", stringify!(A)),
             );
             assert_eq!(
-                ::std::mem::align_of:: < A > (), 4usize, concat!("Alignment of ",
-                stringify!(A))
+                ::std::mem::align_of::<A>(),
+                4usize,
+                concat!("Alignment of ", stringify!(A)),
             );
             assert_eq!(
-                unsafe { ::std::ptr::addr_of!((* ptr).b) as usize - ptr as usize },
-                0usize, concat!("Offset of field: ", stringify!(A), "::", stringify!(b))
+                unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
+                0usize,
+                concat!("Offset of field: ", stringify!(A), "::", stringify!(b)),
             );
         }
     }

--- a/bindgen-tests/tests/expectations/tests/nested.rs
+++ b/bindgen-tests/tests/expectations/tests/nested.rs
@@ -9,15 +9,19 @@ fn bindgen_test_layout_Calc() {
     const UNINIT: ::std::mem::MaybeUninit<Calc> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < Calc > (), 4usize, concat!("Size of: ", stringify!(Calc))
+        ::std::mem::size_of::<Calc>(),
+        4usize,
+        concat!("Size of: ", stringify!(Calc)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Calc > (), 4usize, concat!("Alignment of ",
-        stringify!(Calc))
+        ::std::mem::align_of::<Calc>(),
+        4usize,
+        concat!("Alignment of ", stringify!(Calc)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).w) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(Calc), "::", stringify!(w))
+        unsafe { ::std::ptr::addr_of!((*ptr).w) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(Calc), "::", stringify!(w)),
     );
 }
 #[repr(C)]
@@ -39,12 +43,14 @@ pub struct Test_Size_Dimension {
 #[test]
 fn bindgen_test_layout_Test_Size_Dimension() {
     assert_eq!(
-        ::std::mem::size_of:: < Test_Size_Dimension > (), 4usize, concat!("Size of: ",
-        stringify!(Test_Size_Dimension))
+        ::std::mem::size_of::<Test_Size_Dimension>(),
+        4usize,
+        concat!("Size of: ", stringify!(Test_Size_Dimension)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Test_Size_Dimension > (), 4usize,
-        concat!("Alignment of ", stringify!(Test_Size_Dimension))
+        ::std::mem::align_of::<Test_Size_Dimension>(),
+        4usize,
+        concat!("Alignment of ", stringify!(Test_Size_Dimension)),
     );
 }
 #[test]
@@ -52,29 +58,36 @@ fn bindgen_test_layout_Test_Size() {
     const UNINIT: ::std::mem::MaybeUninit<Test_Size> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < Test_Size > (), 8usize, concat!("Size of: ",
-        stringify!(Test_Size))
+        ::std::mem::size_of::<Test_Size>(),
+        8usize,
+        concat!("Size of: ", stringify!(Test_Size)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Test_Size > (), 4usize, concat!("Alignment of ",
-        stringify!(Test_Size))
+        ::std::mem::align_of::<Test_Size>(),
+        4usize,
+        concat!("Alignment of ", stringify!(Test_Size)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).mWidth) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(Test_Size), "::", stringify!(mWidth))
+        unsafe { ::std::ptr::addr_of!((*ptr).mWidth) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(Test_Size), "::", stringify!(mWidth)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).mHeight) as usize - ptr as usize }, 4usize,
-        concat!("Offset of field: ", stringify!(Test_Size), "::", stringify!(mHeight))
+        unsafe { ::std::ptr::addr_of!((*ptr).mHeight) as usize - ptr as usize },
+        4usize,
+        concat!("Offset of field: ", stringify!(Test_Size), "::", stringify!(mHeight)),
     );
 }
 #[test]
 fn bindgen_test_layout_Test() {
     assert_eq!(
-        ::std::mem::size_of:: < Test > (), 1usize, concat!("Size of: ", stringify!(Test))
+        ::std::mem::size_of::<Test>(),
+        1usize,
+        concat!("Size of: ", stringify!(Test)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Test > (), 1usize, concat!("Alignment of ",
-        stringify!(Test))
+        ::std::mem::align_of::<Test>(),
+        1usize,
+        concat!("Alignment of ", stringify!(Test)),
     );
 }

--- a/bindgen-tests/tests/expectations/tests/nested_vtable.rs
+++ b/bindgen-tests/tests/expectations/tests/nested_vtable.rs
@@ -13,12 +13,14 @@ pub struct nsISupports {
 #[test]
 fn bindgen_test_layout_nsISupports() {
     assert_eq!(
-        ::std::mem::size_of:: < nsISupports > (), 8usize, concat!("Size of: ",
-        stringify!(nsISupports))
+        ::std::mem::size_of::<nsISupports>(),
+        8usize,
+        concat!("Size of: ", stringify!(nsISupports)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < nsISupports > (), 8usize, concat!("Alignment of ",
-        stringify!(nsISupports))
+        ::std::mem::align_of::<nsISupports>(),
+        8usize,
+        concat!("Alignment of ", stringify!(nsISupports)),
     );
 }
 impl Default for nsISupports {
@@ -44,12 +46,14 @@ pub struct nsIRunnable {
 #[test]
 fn bindgen_test_layout_nsIRunnable() {
     assert_eq!(
-        ::std::mem::size_of:: < nsIRunnable > (), 8usize, concat!("Size of: ",
-        stringify!(nsIRunnable))
+        ::std::mem::size_of::<nsIRunnable>(),
+        8usize,
+        concat!("Size of: ", stringify!(nsIRunnable)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < nsIRunnable > (), 8usize, concat!("Alignment of ",
-        stringify!(nsIRunnable))
+        ::std::mem::align_of::<nsIRunnable>(),
+        8usize,
+        concat!("Alignment of ", stringify!(nsIRunnable)),
     );
 }
 impl Default for nsIRunnable {
@@ -69,12 +73,14 @@ pub struct Runnable {
 #[test]
 fn bindgen_test_layout_Runnable() {
     assert_eq!(
-        ::std::mem::size_of:: < Runnable > (), 8usize, concat!("Size of: ",
-        stringify!(Runnable))
+        ::std::mem::size_of::<Runnable>(),
+        8usize,
+        concat!("Size of: ", stringify!(Runnable)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Runnable > (), 8usize, concat!("Alignment of ",
-        stringify!(Runnable))
+        ::std::mem::align_of::<Runnable>(),
+        8usize,
+        concat!("Alignment of ", stringify!(Runnable)),
     );
 }
 impl Default for Runnable {

--- a/bindgen-tests/tests/expectations/tests/nested_within_namespace.rs
+++ b/bindgen-tests/tests/expectations/tests/nested_within_namespace.rs
@@ -21,17 +21,19 @@ pub mod root {
             const UNINIT: ::std::mem::MaybeUninit<Bar_Baz> = ::std::mem::MaybeUninit::uninit();
             let ptr = UNINIT.as_ptr();
             assert_eq!(
-                ::std::mem::size_of:: < Bar_Baz > (), 4usize, concat!("Size of: ",
-                stringify!(Bar_Baz))
+                ::std::mem::size_of::<Bar_Baz>(),
+                4usize,
+                concat!("Size of: ", stringify!(Bar_Baz)),
             );
             assert_eq!(
-                ::std::mem::align_of:: < Bar_Baz > (), 4usize, concat!("Alignment of ",
-                stringify!(Bar_Baz))
+                ::std::mem::align_of::<Bar_Baz>(),
+                4usize,
+                concat!("Alignment of ", stringify!(Bar_Baz)),
             );
             assert_eq!(
-                unsafe { ::std::ptr::addr_of!((* ptr).foo) as usize - ptr as usize },
-                0usize, concat!("Offset of field: ", stringify!(Bar_Baz), "::",
-                stringify!(foo))
+                unsafe { ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize },
+                0usize,
+                concat!("Offset of field: ", stringify!(Bar_Baz), "::", stringify!(foo)),
             );
         }
         #[test]
@@ -39,17 +41,19 @@ pub mod root {
             const UNINIT: ::std::mem::MaybeUninit<Bar> = ::std::mem::MaybeUninit::uninit();
             let ptr = UNINIT.as_ptr();
             assert_eq!(
-                ::std::mem::size_of:: < Bar > (), 4usize, concat!("Size of: ",
-                stringify!(Bar))
+                ::std::mem::size_of::<Bar>(),
+                4usize,
+                concat!("Size of: ", stringify!(Bar)),
             );
             assert_eq!(
-                ::std::mem::align_of:: < Bar > (), 4usize, concat!("Alignment of ",
-                stringify!(Bar))
+                ::std::mem::align_of::<Bar>(),
+                4usize,
+                concat!("Alignment of ", stringify!(Bar)),
             );
             assert_eq!(
-                unsafe { ::std::ptr::addr_of!((* ptr).foo) as usize - ptr as usize },
-                0usize, concat!("Offset of field: ", stringify!(Bar), "::",
-                stringify!(foo))
+                unsafe { ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize },
+                0usize,
+                concat!("Offset of field: ", stringify!(Bar), "::", stringify!(foo)),
             );
         }
         #[repr(C)]
@@ -62,17 +66,19 @@ pub mod root {
             const UNINIT: ::std::mem::MaybeUninit<Baz> = ::std::mem::MaybeUninit::uninit();
             let ptr = UNINIT.as_ptr();
             assert_eq!(
-                ::std::mem::size_of:: < Baz > (), 4usize, concat!("Size of: ",
-                stringify!(Baz))
+                ::std::mem::size_of::<Baz>(),
+                4usize,
+                concat!("Size of: ", stringify!(Baz)),
             );
             assert_eq!(
-                ::std::mem::align_of:: < Baz > (), 4usize, concat!("Alignment of ",
-                stringify!(Baz))
+                ::std::mem::align_of::<Baz>(),
+                4usize,
+                concat!("Alignment of ", stringify!(Baz)),
             );
             assert_eq!(
-                unsafe { ::std::ptr::addr_of!((* ptr).baz) as usize - ptr as usize },
-                0usize, concat!("Offset of field: ", stringify!(Baz), "::",
-                stringify!(baz))
+                unsafe { ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize },
+                0usize,
+                concat!("Offset of field: ", stringify!(Baz), "::", stringify!(baz)),
             );
         }
     }

--- a/bindgen-tests/tests/expectations/tests/no-comments.rs
+++ b/bindgen-tests/tests/expectations/tests/no-comments.rs
@@ -9,14 +9,18 @@ fn bindgen_test_layout_Foo() {
     const UNINIT: ::std::mem::MaybeUninit<Foo> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < Foo > (), 4usize, concat!("Size of: ", stringify!(Foo))
+        ::std::mem::size_of::<Foo>(),
+        4usize,
+        concat!("Size of: ", stringify!(Foo)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Foo > (), 4usize, concat!("Alignment of ",
-        stringify!(Foo))
+        ::std::mem::align_of::<Foo>(),
+        4usize,
+        concat!("Alignment of ", stringify!(Foo)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).s) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(Foo), "::", stringify!(s))
+        unsafe { ::std::ptr::addr_of!((*ptr).s) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(Foo), "::", stringify!(s)),
     );
 }

--- a/bindgen-tests/tests/expectations/tests/no-derive-debug.rs
+++ b/bindgen-tests/tests/expectations/tests/no-derive-debug.rs
@@ -17,19 +17,24 @@ fn bindgen_test_layout_bar() {
     const UNINIT: ::std::mem::MaybeUninit<bar> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < bar > (), 8usize, concat!("Size of: ", stringify!(bar))
+        ::std::mem::size_of::<bar>(),
+        8usize,
+        concat!("Size of: ", stringify!(bar)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < bar > (), 4usize, concat!("Alignment of ",
-        stringify!(bar))
+        ::std::mem::align_of::<bar>(),
+        4usize,
+        concat!("Alignment of ", stringify!(bar)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).foo) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(bar), "::", stringify!(foo))
+        unsafe { ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(bar), "::", stringify!(foo)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).baz) as usize - ptr as usize }, 4usize,
-        concat!("Offset of field: ", stringify!(bar), "::", stringify!(baz))
+        unsafe { ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize },
+        4usize,
+        concat!("Offset of field: ", stringify!(bar), "::", stringify!(baz)),
     );
 }
 impl Default for bar {

--- a/bindgen-tests/tests/expectations/tests/no-derive-default.rs
+++ b/bindgen-tests/tests/expectations/tests/no-derive-default.rs
@@ -17,18 +17,23 @@ fn bindgen_test_layout_bar() {
     const UNINIT: ::std::mem::MaybeUninit<bar> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < bar > (), 8usize, concat!("Size of: ", stringify!(bar))
+        ::std::mem::size_of::<bar>(),
+        8usize,
+        concat!("Size of: ", stringify!(bar)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < bar > (), 4usize, concat!("Alignment of ",
-        stringify!(bar))
+        ::std::mem::align_of::<bar>(),
+        4usize,
+        concat!("Alignment of ", stringify!(bar)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).foo) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(bar), "::", stringify!(foo))
+        unsafe { ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(bar), "::", stringify!(foo)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).baz) as usize - ptr as usize }, 4usize,
-        concat!("Offset of field: ", stringify!(bar), "::", stringify!(baz))
+        unsafe { ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize },
+        4usize,
+        concat!("Offset of field: ", stringify!(bar), "::", stringify!(baz)),
     );
 }

--- a/bindgen-tests/tests/expectations/tests/no-hash-allowlisted.rs
+++ b/bindgen-tests/tests/expectations/tests/no-hash-allowlisted.rs
@@ -9,15 +9,18 @@ fn bindgen_test_layout_NoHash() {
     const UNINIT: ::std::mem::MaybeUninit<NoHash> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < NoHash > (), 4usize, concat!("Size of: ",
-        stringify!(NoHash))
+        ::std::mem::size_of::<NoHash>(),
+        4usize,
+        concat!("Size of: ", stringify!(NoHash)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < NoHash > (), 4usize, concat!("Alignment of ",
-        stringify!(NoHash))
+        ::std::mem::align_of::<NoHash>(),
+        4usize,
+        concat!("Alignment of ", stringify!(NoHash)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).i) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(NoHash), "::", stringify!(i))
+        unsafe { ::std::ptr::addr_of!((*ptr).i) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(NoHash), "::", stringify!(i)),
     );
 }

--- a/bindgen-tests/tests/expectations/tests/no-hash-opaque.rs
+++ b/bindgen-tests/tests/expectations/tests/no-hash-opaque.rs
@@ -8,11 +8,13 @@ pub struct NoHash {
 #[test]
 fn bindgen_test_layout_NoHash() {
     assert_eq!(
-        ::std::mem::size_of:: < NoHash > (), 4usize, concat!("Size of: ",
-        stringify!(NoHash))
+        ::std::mem::size_of::<NoHash>(),
+        4usize,
+        concat!("Size of: ", stringify!(NoHash)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < NoHash > (), 4usize, concat!("Alignment of ",
-        stringify!(NoHash))
+        ::std::mem::align_of::<NoHash>(),
+        4usize,
+        concat!("Alignment of ", stringify!(NoHash)),
     );
 }

--- a/bindgen-tests/tests/expectations/tests/no-partialeq-allowlisted.rs
+++ b/bindgen-tests/tests/expectations/tests/no-partialeq-allowlisted.rs
@@ -9,15 +9,18 @@ fn bindgen_test_layout_NoPartialEq() {
     const UNINIT: ::std::mem::MaybeUninit<NoPartialEq> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < NoPartialEq > (), 4usize, concat!("Size of: ",
-        stringify!(NoPartialEq))
+        ::std::mem::size_of::<NoPartialEq>(),
+        4usize,
+        concat!("Size of: ", stringify!(NoPartialEq)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < NoPartialEq > (), 4usize, concat!("Alignment of ",
-        stringify!(NoPartialEq))
+        ::std::mem::align_of::<NoPartialEq>(),
+        4usize,
+        concat!("Alignment of ", stringify!(NoPartialEq)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).i) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(NoPartialEq), "::", stringify!(i))
+        unsafe { ::std::ptr::addr_of!((*ptr).i) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(NoPartialEq), "::", stringify!(i)),
     );
 }

--- a/bindgen-tests/tests/expectations/tests/no-partialeq-opaque.rs
+++ b/bindgen-tests/tests/expectations/tests/no-partialeq-opaque.rs
@@ -8,11 +8,13 @@ pub struct NoPartialEq {
 #[test]
 fn bindgen_test_layout_NoPartialEq() {
     assert_eq!(
-        ::std::mem::size_of:: < NoPartialEq > (), 4usize, concat!("Size of: ",
-        stringify!(NoPartialEq))
+        ::std::mem::size_of::<NoPartialEq>(),
+        4usize,
+        concat!("Size of: ", stringify!(NoPartialEq)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < NoPartialEq > (), 4usize, concat!("Alignment of ",
-        stringify!(NoPartialEq))
+        ::std::mem::align_of::<NoPartialEq>(),
+        4usize,
+        concat!("Alignment of ", stringify!(NoPartialEq)),
     );
 }

--- a/bindgen-tests/tests/expectations/tests/no-recursive-allowlisting.rs
+++ b/bindgen-tests/tests/expectations/tests/no-recursive-allowlisting.rs
@@ -10,15 +10,19 @@ fn bindgen_test_layout_Foo() {
     const UNINIT: ::std::mem::MaybeUninit<Foo> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < Foo > (), 8usize, concat!("Size of: ", stringify!(Foo))
+        ::std::mem::size_of::<Foo>(),
+        8usize,
+        concat!("Size of: ", stringify!(Foo)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Foo > (), 8usize, concat!("Alignment of ",
-        stringify!(Foo))
+        ::std::mem::align_of::<Foo>(),
+        8usize,
+        concat!("Alignment of ", stringify!(Foo)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).baz) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(Foo), "::", stringify!(baz))
+        unsafe { ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(Foo), "::", stringify!(baz)),
     );
 }
 impl Default for Foo {

--- a/bindgen-tests/tests/expectations/tests/no-std.rs
+++ b/bindgen-tests/tests/expectations/tests/no-std.rs
@@ -16,23 +16,29 @@ fn bindgen_test_layout_foo() {
     const UNINIT: ::core::mem::MaybeUninit<foo> = ::core::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::core::mem::size_of:: < foo > (), 16usize, concat!("Size of: ", stringify!(foo))
+        ::core::mem::size_of::<foo>(),
+        16usize,
+        concat!("Size of: ", stringify!(foo)),
     );
     assert_eq!(
-        ::core::mem::align_of:: < foo > (), 8usize, concat!("Alignment of ",
-        stringify!(foo))
+        ::core::mem::align_of::<foo>(),
+        8usize,
+        concat!("Alignment of ", stringify!(foo)),
     );
     assert_eq!(
-        unsafe { ::core::ptr::addr_of!((* ptr).a) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(a))
+        unsafe { ::core::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(foo), "::", stringify!(a)),
     );
     assert_eq!(
-        unsafe { ::core::ptr::addr_of!((* ptr).b) as usize - ptr as usize }, 4usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(b))
+        unsafe { ::core::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
+        4usize,
+        concat!("Offset of field: ", stringify!(foo), "::", stringify!(b)),
     );
     assert_eq!(
-        unsafe { ::core::ptr::addr_of!((* ptr).bar) as usize - ptr as usize }, 8usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar))
+        unsafe { ::core::ptr::addr_of!((*ptr).bar) as usize - ptr as usize },
+        8usize,
+        concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar)),
     );
 }
 impl Default for foo {

--- a/bindgen-tests/tests/expectations/tests/no_copy_allowlisted.rs
+++ b/bindgen-tests/tests/expectations/tests/no_copy_allowlisted.rs
@@ -9,15 +9,18 @@ fn bindgen_test_layout_NoCopy() {
     const UNINIT: ::std::mem::MaybeUninit<NoCopy> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < NoCopy > (), 4usize, concat!("Size of: ",
-        stringify!(NoCopy))
+        ::std::mem::size_of::<NoCopy>(),
+        4usize,
+        concat!("Size of: ", stringify!(NoCopy)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < NoCopy > (), 4usize, concat!("Alignment of ",
-        stringify!(NoCopy))
+        ::std::mem::align_of::<NoCopy>(),
+        4usize,
+        concat!("Alignment of ", stringify!(NoCopy)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).i) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(NoCopy), "::", stringify!(i))
+        unsafe { ::std::ptr::addr_of!((*ptr).i) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(NoCopy), "::", stringify!(i)),
     );
 }

--- a/bindgen-tests/tests/expectations/tests/no_copy_opaque.rs
+++ b/bindgen-tests/tests/expectations/tests/no_copy_opaque.rs
@@ -8,11 +8,13 @@ pub struct NoCopy {
 #[test]
 fn bindgen_test_layout_NoCopy() {
     assert_eq!(
-        ::std::mem::size_of:: < NoCopy > (), 4usize, concat!("Size of: ",
-        stringify!(NoCopy))
+        ::std::mem::size_of::<NoCopy>(),
+        4usize,
+        concat!("Size of: ", stringify!(NoCopy)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < NoCopy > (), 4usize, concat!("Alignment of ",
-        stringify!(NoCopy))
+        ::std::mem::align_of::<NoCopy>(),
+        4usize,
+        concat!("Alignment of ", stringify!(NoCopy)),
     );
 }

--- a/bindgen-tests/tests/expectations/tests/no_debug_allowlisted.rs
+++ b/bindgen-tests/tests/expectations/tests/no_debug_allowlisted.rs
@@ -9,15 +9,18 @@ fn bindgen_test_layout_NoDebug() {
     const UNINIT: ::std::mem::MaybeUninit<NoDebug> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < NoDebug > (), 4usize, concat!("Size of: ",
-        stringify!(NoDebug))
+        ::std::mem::size_of::<NoDebug>(),
+        4usize,
+        concat!("Size of: ", stringify!(NoDebug)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < NoDebug > (), 4usize, concat!("Alignment of ",
-        stringify!(NoDebug))
+        ::std::mem::align_of::<NoDebug>(),
+        4usize,
+        concat!("Alignment of ", stringify!(NoDebug)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).i) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(NoDebug), "::", stringify!(i))
+        unsafe { ::std::ptr::addr_of!((*ptr).i) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(NoDebug), "::", stringify!(i)),
     );
 }

--- a/bindgen-tests/tests/expectations/tests/no_debug_opaque.rs
+++ b/bindgen-tests/tests/expectations/tests/no_debug_opaque.rs
@@ -8,11 +8,13 @@ pub struct NoDebug {
 #[test]
 fn bindgen_test_layout_NoDebug() {
     assert_eq!(
-        ::std::mem::size_of:: < NoDebug > (), 4usize, concat!("Size of: ",
-        stringify!(NoDebug))
+        ::std::mem::size_of::<NoDebug>(),
+        4usize,
+        concat!("Size of: ", stringify!(NoDebug)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < NoDebug > (), 4usize, concat!("Alignment of ",
-        stringify!(NoDebug))
+        ::std::mem::align_of::<NoDebug>(),
+        4usize,
+        concat!("Alignment of ", stringify!(NoDebug)),
     );
 }

--- a/bindgen-tests/tests/expectations/tests/no_default_allowlisted.rs
+++ b/bindgen-tests/tests/expectations/tests/no_default_allowlisted.rs
@@ -9,15 +9,18 @@ fn bindgen_test_layout_NoDefault() {
     const UNINIT: ::std::mem::MaybeUninit<NoDefault> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < NoDefault > (), 4usize, concat!("Size of: ",
-        stringify!(NoDefault))
+        ::std::mem::size_of::<NoDefault>(),
+        4usize,
+        concat!("Size of: ", stringify!(NoDefault)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < NoDefault > (), 4usize, concat!("Alignment of ",
-        stringify!(NoDefault))
+        ::std::mem::align_of::<NoDefault>(),
+        4usize,
+        concat!("Alignment of ", stringify!(NoDefault)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).i) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(NoDefault), "::", stringify!(i))
+        unsafe { ::std::ptr::addr_of!((*ptr).i) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(NoDefault), "::", stringify!(i)),
     );
 }

--- a/bindgen-tests/tests/expectations/tests/no_default_opaque.rs
+++ b/bindgen-tests/tests/expectations/tests/no_default_opaque.rs
@@ -8,11 +8,13 @@ pub struct NoDefault {
 #[test]
 fn bindgen_test_layout_NoDefault() {
     assert_eq!(
-        ::std::mem::size_of:: < NoDefault > (), 4usize, concat!("Size of: ",
-        stringify!(NoDefault))
+        ::std::mem::size_of::<NoDefault>(),
+        4usize,
+        concat!("Size of: ", stringify!(NoDefault)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < NoDefault > (), 4usize, concat!("Alignment of ",
-        stringify!(NoDefault))
+        ::std::mem::align_of::<NoDefault>(),
+        4usize,
+        concat!("Alignment of ", stringify!(NoDefault)),
     );
 }

--- a/bindgen-tests/tests/expectations/tests/no_size_t_is_usize.rs
+++ b/bindgen-tests/tests/expectations/tests/no_size_t_is_usize.rs
@@ -12,23 +12,26 @@ pub struct A {
 fn bindgen_test_layout_A() {
     const UNINIT: ::std::mem::MaybeUninit<A> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
+    assert_eq!(::std::mem::size_of::<A>(), 24usize, concat!("Size of: ", stringify!(A)));
     assert_eq!(
-        ::std::mem::size_of:: < A > (), 24usize, concat!("Size of: ", stringify!(A))
+        ::std::mem::align_of::<A>(),
+        8usize,
+        concat!("Alignment of ", stringify!(A)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < A > (), 8usize, concat!("Alignment of ", stringify!(A))
+        unsafe { ::std::ptr::addr_of!((*ptr).len) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(A), "::", stringify!(len)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).len) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(A), "::", stringify!(len))
+        unsafe { ::std::ptr::addr_of!((*ptr).offset) as usize - ptr as usize },
+        8usize,
+        concat!("Offset of field: ", stringify!(A), "::", stringify!(offset)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).offset) as usize - ptr as usize }, 8usize,
-        concat!("Offset of field: ", stringify!(A), "::", stringify!(offset))
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).next) as usize - ptr as usize }, 16usize,
-        concat!("Offset of field: ", stringify!(A), "::", stringify!(next))
+        unsafe { ::std::ptr::addr_of!((*ptr).next) as usize - ptr as usize },
+        16usize,
+        concat!("Offset of field: ", stringify!(A), "::", stringify!(next)),
     );
 }
 impl Default for A {

--- a/bindgen-tests/tests/expectations/tests/non-type-params.rs
+++ b/bindgen-tests/tests/expectations/tests/non-type-params.rs
@@ -13,26 +13,43 @@ fn bindgen_test_layout_UsesArray() {
     const UNINIT: ::std::mem::MaybeUninit<UsesArray> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < UsesArray > (), 40usize, concat!("Size of: ",
-        stringify!(UsesArray))
+        ::std::mem::size_of::<UsesArray>(),
+        40usize,
+        concat!("Size of: ", stringify!(UsesArray)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < UsesArray > (), 4usize, concat!("Alignment of ",
-        stringify!(UsesArray))
+        ::std::mem::align_of::<UsesArray>(),
+        4usize,
+        concat!("Alignment of ", stringify!(UsesArray)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).array_char_16) as usize - ptr as usize },
-        0usize, concat!("Offset of field: ", stringify!(UsesArray), "::",
-        stringify!(array_char_16))
+        unsafe { ::std::ptr::addr_of!((*ptr).array_char_16) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(UsesArray),
+            "::",
+            stringify!(array_char_16),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).array_bool_8) as usize - ptr as usize },
-        16usize, concat!("Offset of field: ", stringify!(UsesArray), "::",
-        stringify!(array_bool_8))
+        unsafe { ::std::ptr::addr_of!((*ptr).array_bool_8) as usize - ptr as usize },
+        16usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(UsesArray),
+            "::",
+            stringify!(array_bool_8),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).array_int_4) as usize - ptr as usize },
-        24usize, concat!("Offset of field: ", stringify!(UsesArray), "::",
-        stringify!(array_int_4))
+        unsafe { ::std::ptr::addr_of!((*ptr).array_int_4) as usize - ptr as usize },
+        24usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(UsesArray),
+            "::",
+            stringify!(array_int_4),
+        ),
     );
 }

--- a/bindgen-tests/tests/expectations/tests/objc_interface_type.rs
+++ b/bindgen-tests/tests/expectations/tests/objc_interface_type.rs
@@ -30,16 +30,19 @@ fn bindgen_test_layout_FooStruct() {
     const UNINIT: ::std::mem::MaybeUninit<FooStruct> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < FooStruct > (), 8usize, concat!("Size of: ",
-        stringify!(FooStruct))
+        ::std::mem::size_of::<FooStruct>(),
+        8usize,
+        concat!("Size of: ", stringify!(FooStruct)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < FooStruct > (), 8usize, concat!("Alignment of ",
-        stringify!(FooStruct))
+        ::std::mem::align_of::<FooStruct>(),
+        8usize,
+        concat!("Alignment of ", stringify!(FooStruct)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).foo) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(FooStruct), "::", stringify!(foo))
+        unsafe { ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(FooStruct), "::", stringify!(foo)),
     );
 }
 impl Default for FooStruct {

--- a/bindgen-tests/tests/expectations/tests/only_bitfields.rs
+++ b/bindgen-tests/tests/expectations/tests/only_bitfields.rs
@@ -49,7 +49,7 @@ where
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < self.storage.as_ref().len());
         debug_assert!(
-            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len()
+            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len(),
         );
         let mut val = 0;
         for i in 0..(bit_width as usize) {
@@ -69,7 +69,7 @@ where
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < self.storage.as_ref().len());
         debug_assert!(
-            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len()
+            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len(),
         );
         for i in 0..(bit_width as usize) {
             let mask = 1 << i;
@@ -91,11 +91,11 @@ pub struct C {
 }
 #[test]
 fn bindgen_test_layout_C() {
+    assert_eq!(::std::mem::size_of::<C>(), 1usize, concat!("Size of: ", stringify!(C)));
     assert_eq!(
-        ::std::mem::size_of:: < C > (), 1usize, concat!("Size of: ", stringify!(C))
-    );
-    assert_eq!(
-        ::std::mem::align_of:: < C > (), 1usize, concat!("Alignment of ", stringify!(C))
+        ::std::mem::align_of::<C>(),
+        1usize,
+        concat!("Alignment of ", stringify!(C)),
     );
 }
 impl C {

--- a/bindgen-tests/tests/expectations/tests/opaque-template-inst-member-2.rs
+++ b/bindgen-tests/tests/expectations/tests/opaque-template-inst-member-2.rs
@@ -18,22 +18,34 @@ fn bindgen_test_layout_ContainsOpaqueTemplate() {
     const UNINIT: ::std::mem::MaybeUninit<ContainsOpaqueTemplate> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < ContainsOpaqueTemplate > (), 8usize, concat!("Size of: ",
-        stringify!(ContainsOpaqueTemplate))
+        ::std::mem::size_of::<ContainsOpaqueTemplate>(),
+        8usize,
+        concat!("Size of: ", stringify!(ContainsOpaqueTemplate)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < ContainsOpaqueTemplate > (), 4usize,
-        concat!("Alignment of ", stringify!(ContainsOpaqueTemplate))
+        ::std::mem::align_of::<ContainsOpaqueTemplate>(),
+        4usize,
+        concat!("Alignment of ", stringify!(ContainsOpaqueTemplate)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).mBlah) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(ContainsOpaqueTemplate), "::",
-        stringify!(mBlah))
+        unsafe { ::std::ptr::addr_of!((*ptr).mBlah) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ContainsOpaqueTemplate),
+            "::",
+            stringify!(mBlah),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).mBaz) as usize - ptr as usize }, 4usize,
-        concat!("Offset of field: ", stringify!(ContainsOpaqueTemplate), "::",
-        stringify!(mBaz))
+        unsafe { ::std::ptr::addr_of!((*ptr).mBaz) as usize - ptr as usize },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ContainsOpaqueTemplate),
+            "::",
+            stringify!(mBaz),
+        ),
     );
 }
 /// Should also derive Debug/Hash/PartialEq.
@@ -48,17 +60,24 @@ fn bindgen_test_layout_InheritsOpaqueTemplate() {
     const UNINIT: ::std::mem::MaybeUninit<InheritsOpaqueTemplate> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < InheritsOpaqueTemplate > (), 16usize,
-        concat!("Size of: ", stringify!(InheritsOpaqueTemplate))
+        ::std::mem::size_of::<InheritsOpaqueTemplate>(),
+        16usize,
+        concat!("Size of: ", stringify!(InheritsOpaqueTemplate)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < InheritsOpaqueTemplate > (), 8usize,
-        concat!("Alignment of ", stringify!(InheritsOpaqueTemplate))
+        ::std::mem::align_of::<InheritsOpaqueTemplate>(),
+        8usize,
+        concat!("Alignment of ", stringify!(InheritsOpaqueTemplate)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).wow) as usize - ptr as usize }, 8usize,
-        concat!("Offset of field: ", stringify!(InheritsOpaqueTemplate), "::",
-        stringify!(wow))
+        unsafe { ::std::ptr::addr_of!((*ptr).wow) as usize - ptr as usize },
+        8usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(InheritsOpaqueTemplate),
+            "::",
+            stringify!(wow),
+        ),
     );
 }
 impl Default for InheritsOpaqueTemplate {

--- a/bindgen-tests/tests/expectations/tests/opaque-template-inst-member.rs
+++ b/bindgen-tests/tests/expectations/tests/opaque-template-inst-member.rs
@@ -16,22 +16,34 @@ fn bindgen_test_layout_ContainsOpaqueTemplate() {
     const UNINIT: ::std::mem::MaybeUninit<ContainsOpaqueTemplate> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < ContainsOpaqueTemplate > (), 408usize,
-        concat!("Size of: ", stringify!(ContainsOpaqueTemplate))
+        ::std::mem::size_of::<ContainsOpaqueTemplate>(),
+        408usize,
+        concat!("Size of: ", stringify!(ContainsOpaqueTemplate)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < ContainsOpaqueTemplate > (), 4usize,
-        concat!("Alignment of ", stringify!(ContainsOpaqueTemplate))
+        ::std::mem::align_of::<ContainsOpaqueTemplate>(),
+        4usize,
+        concat!("Alignment of ", stringify!(ContainsOpaqueTemplate)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).mBlah) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(ContainsOpaqueTemplate), "::",
-        stringify!(mBlah))
+        unsafe { ::std::ptr::addr_of!((*ptr).mBlah) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ContainsOpaqueTemplate),
+            "::",
+            stringify!(mBlah),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).mBaz) as usize - ptr as usize }, 404usize,
-        concat!("Offset of field: ", stringify!(ContainsOpaqueTemplate), "::",
-        stringify!(mBaz))
+        unsafe { ::std::ptr::addr_of!((*ptr).mBaz) as usize - ptr as usize },
+        404usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ContainsOpaqueTemplate),
+            "::",
+            stringify!(mBaz),
+        ),
     );
 }
 impl Default for ContainsOpaqueTemplate {
@@ -60,17 +72,24 @@ fn bindgen_test_layout_InheritsOpaqueTemplate() {
     const UNINIT: ::std::mem::MaybeUninit<InheritsOpaqueTemplate> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < InheritsOpaqueTemplate > (), 416usize,
-        concat!("Size of: ", stringify!(InheritsOpaqueTemplate))
+        ::std::mem::size_of::<InheritsOpaqueTemplate>(),
+        416usize,
+        concat!("Size of: ", stringify!(InheritsOpaqueTemplate)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < InheritsOpaqueTemplate > (), 8usize,
-        concat!("Alignment of ", stringify!(InheritsOpaqueTemplate))
+        ::std::mem::align_of::<InheritsOpaqueTemplate>(),
+        8usize,
+        concat!("Alignment of ", stringify!(InheritsOpaqueTemplate)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).wow) as usize - ptr as usize }, 408usize,
-        concat!("Offset of field: ", stringify!(InheritsOpaqueTemplate), "::",
-        stringify!(wow))
+        unsafe { ::std::ptr::addr_of!((*ptr).wow) as usize - ptr as usize },
+        408usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(InheritsOpaqueTemplate),
+            "::",
+            stringify!(wow),
+        ),
     );
 }
 impl Default for InheritsOpaqueTemplate {

--- a/bindgen-tests/tests/expectations/tests/opaque-template-instantiation-namespaced.rs
+++ b/bindgen-tests/tests/expectations/tests/opaque-template-instantiation-namespaced.rs
@@ -31,17 +31,19 @@ pub mod root {
             const UNINIT: ::std::mem::MaybeUninit<Foo> = ::std::mem::MaybeUninit::uninit();
             let ptr = UNINIT.as_ptr();
             assert_eq!(
-                ::std::mem::size_of:: < Foo > (), 1usize, concat!("Size of: ",
-                stringify!(Foo))
+                ::std::mem::size_of::<Foo>(),
+                1usize,
+                concat!("Size of: ", stringify!(Foo)),
             );
             assert_eq!(
-                ::std::mem::align_of:: < Foo > (), 1usize, concat!("Alignment of ",
-                stringify!(Foo))
+                ::std::mem::align_of::<Foo>(),
+                1usize,
+                concat!("Alignment of ", stringify!(Foo)),
             );
             assert_eq!(
-                unsafe { ::std::ptr::addr_of!((* ptr).c) as usize - ptr as usize },
-                0usize, concat!("Offset of field: ", stringify!(Foo), "::",
-                stringify!(c))
+                unsafe { ::std::ptr::addr_of!((*ptr).c) as usize - ptr as usize },
+                0usize,
+                concat!("Offset of field: ", stringify!(Foo), "::", stringify!(c)),
             );
         }
         #[repr(C)]
@@ -54,17 +56,19 @@ pub mod root {
             const UNINIT: ::std::mem::MaybeUninit<Bar> = ::std::mem::MaybeUninit::uninit();
             let ptr = UNINIT.as_ptr();
             assert_eq!(
-                ::std::mem::size_of:: < Bar > (), 4usize, concat!("Size of: ",
-                stringify!(Bar))
+                ::std::mem::size_of::<Bar>(),
+                4usize,
+                concat!("Size of: ", stringify!(Bar)),
             );
             assert_eq!(
-                ::std::mem::align_of:: < Bar > (), 4usize, concat!("Alignment of ",
-                stringify!(Bar))
+                ::std::mem::align_of::<Bar>(),
+                4usize,
+                concat!("Alignment of ", stringify!(Bar)),
             );
             assert_eq!(
-                unsafe { ::std::ptr::addr_of!((* ptr).i) as usize - ptr as usize },
-                0usize, concat!("Offset of field: ", stringify!(Bar), "::",
-                stringify!(i))
+                unsafe { ::std::ptr::addr_of!((*ptr).i) as usize - ptr as usize },
+                0usize,
+                concat!("Offset of field: ", stringify!(Bar), "::", stringify!(i)),
             );
         }
         #[repr(C)]
@@ -77,17 +81,26 @@ pub mod root {
             const UNINIT: ::std::mem::MaybeUninit<ContainsInstantiation> = ::std::mem::MaybeUninit::uninit();
             let ptr = UNINIT.as_ptr();
             assert_eq!(
-                ::std::mem::size_of:: < ContainsInstantiation > (), 1usize,
-                concat!("Size of: ", stringify!(ContainsInstantiation))
+                ::std::mem::size_of::<ContainsInstantiation>(),
+                1usize,
+                concat!("Size of: ", stringify!(ContainsInstantiation)),
             );
             assert_eq!(
-                ::std::mem::align_of:: < ContainsInstantiation > (), 1usize,
-                concat!("Alignment of ", stringify!(ContainsInstantiation))
+                ::std::mem::align_of::<ContainsInstantiation>(),
+                1usize,
+                concat!("Alignment of ", stringify!(ContainsInstantiation)),
             );
             assert_eq!(
-                unsafe { ::std::ptr::addr_of!((* ptr).not_opaque) as usize - ptr as usize
-                }, 0usize, concat!("Offset of field: ",
-                stringify!(ContainsInstantiation), "::", stringify!(not_opaque))
+                unsafe {
+                    ::std::ptr::addr_of!((*ptr).not_opaque) as usize - ptr as usize
+                },
+                0usize,
+                concat!(
+                    "Offset of field: ",
+                    stringify!(ContainsInstantiation),
+                    "::",
+                    stringify!(not_opaque),
+                ),
             );
         }
         impl Default for ContainsInstantiation {
@@ -109,31 +122,44 @@ pub mod root {
             const UNINIT: ::std::mem::MaybeUninit<ContainsOpaqueInstantiation> = ::std::mem::MaybeUninit::uninit();
             let ptr = UNINIT.as_ptr();
             assert_eq!(
-                ::std::mem::size_of:: < ContainsOpaqueInstantiation > (), 4usize,
-                concat!("Size of: ", stringify!(ContainsOpaqueInstantiation))
+                ::std::mem::size_of::<ContainsOpaqueInstantiation>(),
+                4usize,
+                concat!("Size of: ", stringify!(ContainsOpaqueInstantiation)),
             );
             assert_eq!(
-                ::std::mem::align_of:: < ContainsOpaqueInstantiation > (), 4usize,
-                concat!("Alignment of ", stringify!(ContainsOpaqueInstantiation))
+                ::std::mem::align_of::<ContainsOpaqueInstantiation>(),
+                4usize,
+                concat!("Alignment of ", stringify!(ContainsOpaqueInstantiation)),
             );
             assert_eq!(
-                unsafe { ::std::ptr::addr_of!((* ptr).opaque) as usize - ptr as usize },
-                0usize, concat!("Offset of field: ",
-                stringify!(ContainsOpaqueInstantiation), "::", stringify!(opaque))
+                unsafe { ::std::ptr::addr_of!((*ptr).opaque) as usize - ptr as usize },
+                0usize,
+                concat!(
+                    "Offset of field: ",
+                    stringify!(ContainsOpaqueInstantiation),
+                    "::",
+                    stringify!(opaque),
+                ),
             );
         }
     }
     #[test]
     fn __bindgen_test_layout_Template_open0_Foo_close0_instantiation() {
         assert_eq!(
-            ::std::mem::size_of:: < root::zoidberg::Template < root::zoidberg::Foo > >
-            (), 1usize, concat!("Size of template specialization: ",
-            stringify!(root::zoidberg::Template < root::zoidberg::Foo >))
+            ::std::mem::size_of::<root::zoidberg::Template<root::zoidberg::Foo>>(),
+            1usize,
+            concat!(
+                "Size of template specialization: ",
+                stringify!(root::zoidberg::Template < root::zoidberg::Foo >),
+            ),
         );
         assert_eq!(
-            ::std::mem::align_of:: < root::zoidberg::Template < root::zoidberg::Foo > >
-            (), 1usize, concat!("Alignment of template specialization: ",
-            stringify!(root::zoidberg::Template < root::zoidberg::Foo >))
+            ::std::mem::align_of::<root::zoidberg::Template<root::zoidberg::Foo>>(),
+            1usize,
+            concat!(
+                "Alignment of template specialization: ",
+                stringify!(root::zoidberg::Template < root::zoidberg::Foo >),
+            ),
         );
     }
 }

--- a/bindgen-tests/tests/expectations/tests/opaque-template-instantiation.rs
+++ b/bindgen-tests/tests/expectations/tests/opaque-template-instantiation.rs
@@ -24,17 +24,24 @@ fn bindgen_test_layout_ContainsInstantiation() {
     const UNINIT: ::std::mem::MaybeUninit<ContainsInstantiation> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < ContainsInstantiation > (), 1usize, concat!("Size of: ",
-        stringify!(ContainsInstantiation))
+        ::std::mem::size_of::<ContainsInstantiation>(),
+        1usize,
+        concat!("Size of: ", stringify!(ContainsInstantiation)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < ContainsInstantiation > (), 1usize,
-        concat!("Alignment of ", stringify!(ContainsInstantiation))
+        ::std::mem::align_of::<ContainsInstantiation>(),
+        1usize,
+        concat!("Alignment of ", stringify!(ContainsInstantiation)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).not_opaque) as usize - ptr as usize },
-        0usize, concat!("Offset of field: ", stringify!(ContainsInstantiation), "::",
-        stringify!(not_opaque))
+        unsafe { ::std::ptr::addr_of!((*ptr).not_opaque) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ContainsInstantiation),
+            "::",
+            stringify!(not_opaque),
+        ),
     );
 }
 impl Default for ContainsInstantiation {
@@ -56,29 +63,42 @@ fn bindgen_test_layout_ContainsOpaqueInstantiation() {
     const UNINIT: ::std::mem::MaybeUninit<ContainsOpaqueInstantiation> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < ContainsOpaqueInstantiation > (), 4usize,
-        concat!("Size of: ", stringify!(ContainsOpaqueInstantiation))
+        ::std::mem::size_of::<ContainsOpaqueInstantiation>(),
+        4usize,
+        concat!("Size of: ", stringify!(ContainsOpaqueInstantiation)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < ContainsOpaqueInstantiation > (), 4usize,
-        concat!("Alignment of ", stringify!(ContainsOpaqueInstantiation))
+        ::std::mem::align_of::<ContainsOpaqueInstantiation>(),
+        4usize,
+        concat!("Alignment of ", stringify!(ContainsOpaqueInstantiation)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).opaque) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(ContainsOpaqueInstantiation), "::",
-        stringify!(opaque))
+        unsafe { ::std::ptr::addr_of!((*ptr).opaque) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ContainsOpaqueInstantiation),
+            "::",
+            stringify!(opaque),
+        ),
     );
 }
 #[test]
 fn __bindgen_test_layout_Template_open0_char_close0_instantiation() {
     assert_eq!(
-        ::std::mem::size_of:: < Template < ::std::os::raw::c_char > > (), 1usize,
-        concat!("Size of template specialization: ", stringify!(Template <
-        ::std::os::raw::c_char >))
+        ::std::mem::size_of::<Template<::std::os::raw::c_char>>(),
+        1usize,
+        concat!(
+            "Size of template specialization: ",
+            stringify!(Template < ::std::os::raw::c_char >),
+        ),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Template < ::std::os::raw::c_char > > (), 1usize,
-        concat!("Alignment of template specialization: ", stringify!(Template <
-        ::std::os::raw::c_char >))
+        ::std::mem::align_of::<Template<::std::os::raw::c_char>>(),
+        1usize,
+        concat!(
+            "Alignment of template specialization: ",
+            stringify!(Template < ::std::os::raw::c_char >),
+        ),
     );
 }

--- a/bindgen-tests/tests/expectations/tests/opaque-tracing.rs
+++ b/bindgen-tests/tests/expectations/tests/opaque-tracing.rs
@@ -12,11 +12,13 @@ pub struct Container {
 #[test]
 fn bindgen_test_layout_Container() {
     assert_eq!(
-        ::std::mem::size_of:: < Container > (), 8usize, concat!("Size of: ",
-        stringify!(Container))
+        ::std::mem::size_of::<Container>(),
+        8usize,
+        concat!("Size of: ", stringify!(Container)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Container > (), 4usize, concat!("Alignment of ",
-        stringify!(Container))
+        ::std::mem::align_of::<Container>(),
+        4usize,
+        concat!("Alignment of ", stringify!(Container)),
     );
 }

--- a/bindgen-tests/tests/expectations/tests/opaque_in_struct.rs
+++ b/bindgen-tests/tests/expectations/tests/opaque_in_struct.rs
@@ -9,12 +9,14 @@ pub struct opaque {
 #[test]
 fn bindgen_test_layout_opaque() {
     assert_eq!(
-        ::std::mem::size_of:: < opaque > (), 4usize, concat!("Size of: ",
-        stringify!(opaque))
+        ::std::mem::size_of::<opaque>(),
+        4usize,
+        concat!("Size of: ", stringify!(opaque)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < opaque > (), 4usize, concat!("Alignment of ",
-        stringify!(opaque))
+        ::std::mem::align_of::<opaque>(),
+        4usize,
+        concat!("Alignment of ", stringify!(opaque)),
     );
 }
 #[repr(C)]
@@ -27,16 +29,18 @@ fn bindgen_test_layout_container() {
     const UNINIT: ::std::mem::MaybeUninit<container> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < container > (), 4usize, concat!("Size of: ",
-        stringify!(container))
+        ::std::mem::size_of::<container>(),
+        4usize,
+        concat!("Size of: ", stringify!(container)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < container > (), 4usize, concat!("Alignment of ",
-        stringify!(container))
+        ::std::mem::align_of::<container>(),
+        4usize,
+        concat!("Alignment of ", stringify!(container)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).contained) as usize - ptr as usize },
-        0usize, concat!("Offset of field: ", stringify!(container), "::",
-        stringify!(contained))
+        unsafe { ::std::ptr::addr_of!((*ptr).contained) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(container), "::", stringify!(contained)),
     );
 }

--- a/bindgen-tests/tests/expectations/tests/opaque_pointer.rs
+++ b/bindgen-tests/tests/expectations/tests/opaque_pointer.rs
@@ -9,12 +9,14 @@ pub struct OtherOpaque {
 #[test]
 fn bindgen_test_layout_OtherOpaque() {
     assert_eq!(
-        ::std::mem::size_of:: < OtherOpaque > (), 4usize, concat!("Size of: ",
-        stringify!(OtherOpaque))
+        ::std::mem::size_of::<OtherOpaque>(),
+        4usize,
+        concat!("Size of: ", stringify!(OtherOpaque)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < OtherOpaque > (), 4usize, concat!("Alignment of ",
-        stringify!(OtherOpaque))
+        ::std::mem::align_of::<OtherOpaque>(),
+        4usize,
+        concat!("Alignment of ", stringify!(OtherOpaque)),
     );
 }
 /// <div rustbindgen opaque></div>
@@ -35,25 +37,34 @@ fn bindgen_test_layout_WithOpaquePtr() {
     const UNINIT: ::std::mem::MaybeUninit<WithOpaquePtr> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < WithOpaquePtr > (), 16usize, concat!("Size of: ",
-        stringify!(WithOpaquePtr))
+        ::std::mem::size_of::<WithOpaquePtr>(),
+        16usize,
+        concat!("Size of: ", stringify!(WithOpaquePtr)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < WithOpaquePtr > (), 8usize, concat!("Alignment of ",
-        stringify!(WithOpaquePtr))
+        ::std::mem::align_of::<WithOpaquePtr>(),
+        8usize,
+        concat!("Alignment of ", stringify!(WithOpaquePtr)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).whatever) as usize - ptr as usize },
-        0usize, concat!("Offset of field: ", stringify!(WithOpaquePtr), "::",
-        stringify!(whatever))
+        unsafe { ::std::ptr::addr_of!((*ptr).whatever) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(WithOpaquePtr),
+            "::",
+            stringify!(whatever),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).other) as usize - ptr as usize }, 8usize,
-        concat!("Offset of field: ", stringify!(WithOpaquePtr), "::", stringify!(other))
+        unsafe { ::std::ptr::addr_of!((*ptr).other) as usize - ptr as usize },
+        8usize,
+        concat!("Offset of field: ", stringify!(WithOpaquePtr), "::", stringify!(other)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).t) as usize - ptr as usize }, 12usize,
-        concat!("Offset of field: ", stringify!(WithOpaquePtr), "::", stringify!(t))
+        unsafe { ::std::ptr::addr_of!((*ptr).t) as usize - ptr as usize },
+        12usize,
+        concat!("Offset of field: ", stringify!(WithOpaquePtr), "::", stringify!(t)),
     );
 }
 impl Default for WithOpaquePtr {

--- a/bindgen-tests/tests/expectations/tests/packed-bitfield.rs
+++ b/bindgen-tests/tests/expectations/tests/packed-bitfield.rs
@@ -49,7 +49,7 @@ where
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < self.storage.as_ref().len());
         debug_assert!(
-            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len()
+            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len(),
         );
         let mut val = 0;
         for i in 0..(bit_width as usize) {
@@ -69,7 +69,7 @@ where
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < self.storage.as_ref().len());
         debug_assert!(
-            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len()
+            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len(),
         );
         for i in 0..(bit_width as usize) {
             let mask = 1 << i;
@@ -92,11 +92,14 @@ pub struct Date {
 #[test]
 fn bindgen_test_layout_Date() {
     assert_eq!(
-        ::std::mem::size_of:: < Date > (), 3usize, concat!("Size of: ", stringify!(Date))
+        ::std::mem::size_of::<Date>(),
+        3usize,
+        concat!("Size of: ", stringify!(Date)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Date > (), 1usize, concat!("Alignment of ",
-        stringify!(Date))
+        ::std::mem::align_of::<Date>(),
+        1usize,
+        concat!("Alignment of ", stringify!(Date)),
     );
 }
 impl Date {

--- a/bindgen-tests/tests/expectations/tests/packed-n-with-padding.rs
+++ b/bindgen-tests/tests/expectations/tests/packed-n-with-padding.rs
@@ -12,27 +12,33 @@ fn bindgen_test_layout_Packed() {
     const UNINIT: ::std::mem::MaybeUninit<Packed> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < Packed > (), 10usize, concat!("Size of: ",
-        stringify!(Packed))
+        ::std::mem::size_of::<Packed>(),
+        10usize,
+        concat!("Size of: ", stringify!(Packed)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Packed > (), 2usize, concat!("Alignment of ",
-        stringify!(Packed))
+        ::std::mem::align_of::<Packed>(),
+        2usize,
+        concat!("Alignment of ", stringify!(Packed)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).a) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(Packed), "::", stringify!(a))
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(Packed), "::", stringify!(a)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).b) as usize - ptr as usize }, 2usize,
-        concat!("Offset of field: ", stringify!(Packed), "::", stringify!(b))
+        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
+        2usize,
+        concat!("Offset of field: ", stringify!(Packed), "::", stringify!(b)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).c) as usize - ptr as usize }, 4usize,
-        concat!("Offset of field: ", stringify!(Packed), "::", stringify!(c))
+        unsafe { ::std::ptr::addr_of!((*ptr).c) as usize - ptr as usize },
+        4usize,
+        concat!("Offset of field: ", stringify!(Packed), "::", stringify!(c)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).d) as usize - ptr as usize }, 6usize,
-        concat!("Offset of field: ", stringify!(Packed), "::", stringify!(d))
+        unsafe { ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize },
+        6usize,
+        concat!("Offset of field: ", stringify!(Packed), "::", stringify!(d)),
     );
 }

--- a/bindgen-tests/tests/expectations/tests/packed-vtable.rs
+++ b/bindgen-tests/tests/expectations/tests/packed-vtable.rs
@@ -9,12 +9,14 @@ pub struct PackedVtable {
 #[test]
 fn bindgen_test_layout_PackedVtable() {
     assert_eq!(
-        ::std::mem::size_of:: < PackedVtable > (), 8usize, concat!("Size of: ",
-        stringify!(PackedVtable))
+        ::std::mem::size_of::<PackedVtable>(),
+        8usize,
+        concat!("Size of: ", stringify!(PackedVtable)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < PackedVtable > (), 1usize, concat!("Alignment of ",
-        stringify!(PackedVtable))
+        ::std::mem::align_of::<PackedVtable>(),
+        1usize,
+        concat!("Alignment of ", stringify!(PackedVtable)),
     );
 }
 impl Default for PackedVtable {

--- a/bindgen-tests/tests/expectations/tests/parm-union.rs
+++ b/bindgen-tests/tests/expectations/tests/parm-union.rs
@@ -7,12 +7,14 @@ pub struct Struct {
 #[test]
 fn bindgen_test_layout_Struct() {
     assert_eq!(
-        ::std::mem::size_of:: < Struct > (), 1usize, concat!("Size of: ",
-        stringify!(Struct))
+        ::std::mem::size_of::<Struct>(),
+        1usize,
+        concat!("Size of: ", stringify!(Struct)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Struct > (), 1usize, concat!("Alignment of ",
-        stringify!(Struct))
+        ::std::mem::align_of::<Struct>(),
+        1usize,
+        concat!("Alignment of ", stringify!(Struct)),
     );
 }
 extern "C" {

--- a/bindgen-tests/tests/expectations/tests/private.rs
+++ b/bindgen-tests/tests/expectations/tests/private.rs
@@ -11,22 +11,34 @@ fn bindgen_test_layout_HasPrivate() {
     const UNINIT: ::std::mem::MaybeUninit<HasPrivate> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < HasPrivate > (), 8usize, concat!("Size of: ",
-        stringify!(HasPrivate))
+        ::std::mem::size_of::<HasPrivate>(),
+        8usize,
+        concat!("Size of: ", stringify!(HasPrivate)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < HasPrivate > (), 4usize, concat!("Alignment of ",
-        stringify!(HasPrivate))
+        ::std::mem::align_of::<HasPrivate>(),
+        4usize,
+        concat!("Alignment of ", stringify!(HasPrivate)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).mNotPrivate) as usize - ptr as usize },
-        0usize, concat!("Offset of field: ", stringify!(HasPrivate), "::",
-        stringify!(mNotPrivate))
+        unsafe { ::std::ptr::addr_of!((*ptr).mNotPrivate) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(HasPrivate),
+            "::",
+            stringify!(mNotPrivate),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).mIsPrivate) as usize - ptr as usize },
-        4usize, concat!("Offset of field: ", stringify!(HasPrivate), "::",
-        stringify!(mIsPrivate))
+        unsafe { ::std::ptr::addr_of!((*ptr).mIsPrivate) as usize - ptr as usize },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(HasPrivate),
+            "::",
+            stringify!(mIsPrivate),
+        ),
     );
 }
 /// <div rustbindgen private></div>
@@ -41,22 +53,34 @@ fn bindgen_test_layout_VeryPrivate() {
     const UNINIT: ::std::mem::MaybeUninit<VeryPrivate> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < VeryPrivate > (), 8usize, concat!("Size of: ",
-        stringify!(VeryPrivate))
+        ::std::mem::size_of::<VeryPrivate>(),
+        8usize,
+        concat!("Size of: ", stringify!(VeryPrivate)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < VeryPrivate > (), 4usize, concat!("Alignment of ",
-        stringify!(VeryPrivate))
+        ::std::mem::align_of::<VeryPrivate>(),
+        4usize,
+        concat!("Alignment of ", stringify!(VeryPrivate)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).mIsPrivate) as usize - ptr as usize },
-        0usize, concat!("Offset of field: ", stringify!(VeryPrivate), "::",
-        stringify!(mIsPrivate))
+        unsafe { ::std::ptr::addr_of!((*ptr).mIsPrivate) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(VeryPrivate),
+            "::",
+            stringify!(mIsPrivate),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).mIsAlsoPrivate) as usize - ptr as usize },
-        4usize, concat!("Offset of field: ", stringify!(VeryPrivate), "::",
-        stringify!(mIsAlsoPrivate))
+        unsafe { ::std::ptr::addr_of!((*ptr).mIsAlsoPrivate) as usize - ptr as usize },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(VeryPrivate),
+            "::",
+            stringify!(mIsAlsoPrivate),
+        ),
     );
 }
 /// <div rustbindgen private></div>
@@ -72,21 +96,33 @@ fn bindgen_test_layout_ContradictPrivate() {
     const UNINIT: ::std::mem::MaybeUninit<ContradictPrivate> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < ContradictPrivate > (), 8usize, concat!("Size of: ",
-        stringify!(ContradictPrivate))
+        ::std::mem::size_of::<ContradictPrivate>(),
+        8usize,
+        concat!("Size of: ", stringify!(ContradictPrivate)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < ContradictPrivate > (), 4usize, concat!("Alignment of ",
-        stringify!(ContradictPrivate))
+        ::std::mem::align_of::<ContradictPrivate>(),
+        4usize,
+        concat!("Alignment of ", stringify!(ContradictPrivate)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).mNotPrivate) as usize - ptr as usize },
-        0usize, concat!("Offset of field: ", stringify!(ContradictPrivate), "::",
-        stringify!(mNotPrivate))
+        unsafe { ::std::ptr::addr_of!((*ptr).mNotPrivate) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ContradictPrivate),
+            "::",
+            stringify!(mNotPrivate),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).mIsPrivate) as usize - ptr as usize },
-        4usize, concat!("Offset of field: ", stringify!(ContradictPrivate), "::",
-        stringify!(mIsPrivate))
+        unsafe { ::std::ptr::addr_of!((*ptr).mIsPrivate) as usize - ptr as usize },
+        4usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ContradictPrivate),
+            "::",
+            stringify!(mIsPrivate),
+        ),
     );
 }

--- a/bindgen-tests/tests/expectations/tests/private_fields.rs
+++ b/bindgen-tests/tests/expectations/tests/private_fields.rs
@@ -49,7 +49,7 @@ where
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < self.storage.as_ref().len());
         debug_assert!(
-            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len()
+            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len(),
         );
         let mut val = 0;
         for i in 0..(bit_width as usize) {
@@ -69,7 +69,7 @@ where
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < self.storage.as_ref().len());
         debug_assert!(
-            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len()
+            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len(),
         );
         for i in 0..(bit_width as usize) {
             let mask = 1 << i;
@@ -94,20 +94,24 @@ fn bindgen_test_layout_PubPriv() {
     const UNINIT: ::std::mem::MaybeUninit<PubPriv> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < PubPriv > (), 8usize, concat!("Size of: ",
-        stringify!(PubPriv))
+        ::std::mem::size_of::<PubPriv>(),
+        8usize,
+        concat!("Size of: ", stringify!(PubPriv)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < PubPriv > (), 4usize, concat!("Alignment of ",
-        stringify!(PubPriv))
+        ::std::mem::align_of::<PubPriv>(),
+        4usize,
+        concat!("Alignment of ", stringify!(PubPriv)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).x) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(PubPriv), "::", stringify!(x))
+        unsafe { ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(PubPriv), "::", stringify!(x)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).y) as usize - ptr as usize }, 4usize,
-        concat!("Offset of field: ", stringify!(PubPriv), "::", stringify!(y))
+        unsafe { ::std::ptr::addr_of!((*ptr).y) as usize - ptr as usize },
+        4usize,
+        concat!("Offset of field: ", stringify!(PubPriv), "::", stringify!(y)),
     );
 }
 #[repr(C)]
@@ -121,12 +125,14 @@ pub struct PrivateBitFields {
 #[test]
 fn bindgen_test_layout_PrivateBitFields() {
     assert_eq!(
-        ::std::mem::size_of:: < PrivateBitFields > (), 4usize, concat!("Size of: ",
-        stringify!(PrivateBitFields))
+        ::std::mem::size_of::<PrivateBitFields>(),
+        4usize,
+        concat!("Size of: ", stringify!(PrivateBitFields)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < PrivateBitFields > (), 4usize, concat!("Alignment of ",
-        stringify!(PrivateBitFields))
+        ::std::mem::align_of::<PrivateBitFields>(),
+        4usize,
+        concat!("Alignment of ", stringify!(PrivateBitFields)),
     );
 }
 impl PrivateBitFields {
@@ -190,12 +196,14 @@ pub struct PublicBitFields {
 #[test]
 fn bindgen_test_layout_PublicBitFields() {
     assert_eq!(
-        ::std::mem::size_of:: < PublicBitFields > (), 4usize, concat!("Size of: ",
-        stringify!(PublicBitFields))
+        ::std::mem::size_of::<PublicBitFields>(),
+        4usize,
+        concat!("Size of: ", stringify!(PublicBitFields)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < PublicBitFields > (), 4usize, concat!("Alignment of ",
-        stringify!(PublicBitFields))
+        ::std::mem::align_of::<PublicBitFields>(),
+        4usize,
+        concat!("Alignment of ", stringify!(PublicBitFields)),
     );
 }
 impl PublicBitFields {
@@ -259,12 +267,14 @@ pub struct MixedBitFields {
 #[test]
 fn bindgen_test_layout_MixedBitFields() {
     assert_eq!(
-        ::std::mem::size_of:: < MixedBitFields > (), 4usize, concat!("Size of: ",
-        stringify!(MixedBitFields))
+        ::std::mem::size_of::<MixedBitFields>(),
+        4usize,
+        concat!("Size of: ", stringify!(MixedBitFields)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < MixedBitFields > (), 4usize, concat!("Alignment of ",
-        stringify!(MixedBitFields))
+        ::std::mem::align_of::<MixedBitFields>(),
+        4usize,
+        concat!("Alignment of ", stringify!(MixedBitFields)),
     );
 }
 impl MixedBitFields {
@@ -327,15 +337,19 @@ fn bindgen_test_layout_Base() {
     const UNINIT: ::std::mem::MaybeUninit<Base> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < Base > (), 4usize, concat!("Size of: ", stringify!(Base))
+        ::std::mem::size_of::<Base>(),
+        4usize,
+        concat!("Size of: ", stringify!(Base)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Base > (), 4usize, concat!("Alignment of ",
-        stringify!(Base))
+        ::std::mem::align_of::<Base>(),
+        4usize,
+        concat!("Alignment of ", stringify!(Base)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).member) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(Base), "::", stringify!(member))
+        unsafe { ::std::ptr::addr_of!((*ptr).member) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(Base), "::", stringify!(member)),
     );
 }
 #[repr(C)]
@@ -346,12 +360,14 @@ pub struct InheritsPrivately {
 #[test]
 fn bindgen_test_layout_InheritsPrivately() {
     assert_eq!(
-        ::std::mem::size_of:: < InheritsPrivately > (), 4usize, concat!("Size of: ",
-        stringify!(InheritsPrivately))
+        ::std::mem::size_of::<InheritsPrivately>(),
+        4usize,
+        concat!("Size of: ", stringify!(InheritsPrivately)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < InheritsPrivately > (), 4usize, concat!("Alignment of ",
-        stringify!(InheritsPrivately))
+        ::std::mem::align_of::<InheritsPrivately>(),
+        4usize,
+        concat!("Alignment of ", stringify!(InheritsPrivately)),
     );
 }
 #[repr(C)]
@@ -362,12 +378,14 @@ pub struct InheritsPublically {
 #[test]
 fn bindgen_test_layout_InheritsPublically() {
     assert_eq!(
-        ::std::mem::size_of:: < InheritsPublically > (), 4usize, concat!("Size of: ",
-        stringify!(InheritsPublically))
+        ::std::mem::size_of::<InheritsPublically>(),
+        4usize,
+        concat!("Size of: ", stringify!(InheritsPublically)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < InheritsPublically > (), 4usize,
-        concat!("Alignment of ", stringify!(InheritsPublically))
+        ::std::mem::align_of::<InheritsPublically>(),
+        4usize,
+        concat!("Alignment of ", stringify!(InheritsPublically)),
     );
 }
 #[repr(C)]
@@ -386,17 +404,24 @@ fn bindgen_test_layout_WithAnonStruct__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<WithAnonStruct__bindgen_ty_1> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < WithAnonStruct__bindgen_ty_1 > (), 4usize,
-        concat!("Size of: ", stringify!(WithAnonStruct__bindgen_ty_1))
+        ::std::mem::size_of::<WithAnonStruct__bindgen_ty_1>(),
+        4usize,
+        concat!("Size of: ", stringify!(WithAnonStruct__bindgen_ty_1)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < WithAnonStruct__bindgen_ty_1 > (), 4usize,
-        concat!("Alignment of ", stringify!(WithAnonStruct__bindgen_ty_1))
+        ::std::mem::align_of::<WithAnonStruct__bindgen_ty_1>(),
+        4usize,
+        concat!("Alignment of ", stringify!(WithAnonStruct__bindgen_ty_1)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).a) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(WithAnonStruct__bindgen_ty_1), "::",
-        stringify!(a))
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(WithAnonStruct__bindgen_ty_1),
+            "::",
+            stringify!(a),
+        ),
     );
 }
 #[repr(C)]
@@ -409,28 +434,37 @@ fn bindgen_test_layout_WithAnonStruct__bindgen_ty_2() {
     const UNINIT: ::std::mem::MaybeUninit<WithAnonStruct__bindgen_ty_2> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < WithAnonStruct__bindgen_ty_2 > (), 4usize,
-        concat!("Size of: ", stringify!(WithAnonStruct__bindgen_ty_2))
+        ::std::mem::size_of::<WithAnonStruct__bindgen_ty_2>(),
+        4usize,
+        concat!("Size of: ", stringify!(WithAnonStruct__bindgen_ty_2)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < WithAnonStruct__bindgen_ty_2 > (), 4usize,
-        concat!("Alignment of ", stringify!(WithAnonStruct__bindgen_ty_2))
+        ::std::mem::align_of::<WithAnonStruct__bindgen_ty_2>(),
+        4usize,
+        concat!("Alignment of ", stringify!(WithAnonStruct__bindgen_ty_2)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).b) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(WithAnonStruct__bindgen_ty_2), "::",
-        stringify!(b))
+        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(WithAnonStruct__bindgen_ty_2),
+            "::",
+            stringify!(b),
+        ),
     );
 }
 #[test]
 fn bindgen_test_layout_WithAnonStruct() {
     assert_eq!(
-        ::std::mem::size_of:: < WithAnonStruct > (), 8usize, concat!("Size of: ",
-        stringify!(WithAnonStruct))
+        ::std::mem::size_of::<WithAnonStruct>(),
+        8usize,
+        concat!("Size of: ", stringify!(WithAnonStruct)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < WithAnonStruct > (), 4usize, concat!("Alignment of ",
-        stringify!(WithAnonStruct))
+        ::std::mem::align_of::<WithAnonStruct>(),
+        4usize,
+        concat!("Alignment of ", stringify!(WithAnonStruct)),
     );
 }
 #[repr(C)]
@@ -446,12 +480,14 @@ pub union WithAnonUnion__bindgen_ty_1 {
 #[test]
 fn bindgen_test_layout_WithAnonUnion__bindgen_ty_1() {
     assert_eq!(
-        ::std::mem::size_of:: < WithAnonUnion__bindgen_ty_1 > (), 1usize,
-        concat!("Size of: ", stringify!(WithAnonUnion__bindgen_ty_1))
+        ::std::mem::size_of::<WithAnonUnion__bindgen_ty_1>(),
+        1usize,
+        concat!("Size of: ", stringify!(WithAnonUnion__bindgen_ty_1)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < WithAnonUnion__bindgen_ty_1 > (), 1usize,
-        concat!("Alignment of ", stringify!(WithAnonUnion__bindgen_ty_1))
+        ::std::mem::align_of::<WithAnonUnion__bindgen_ty_1>(),
+        1usize,
+        concat!("Alignment of ", stringify!(WithAnonUnion__bindgen_ty_1)),
     );
 }
 impl Default for WithAnonUnion__bindgen_ty_1 {
@@ -466,12 +502,14 @@ impl Default for WithAnonUnion__bindgen_ty_1 {
 #[test]
 fn bindgen_test_layout_WithAnonUnion() {
     assert_eq!(
-        ::std::mem::size_of:: < WithAnonUnion > (), 1usize, concat!("Size of: ",
-        stringify!(WithAnonUnion))
+        ::std::mem::size_of::<WithAnonUnion>(),
+        1usize,
+        concat!("Size of: ", stringify!(WithAnonUnion)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < WithAnonUnion > (), 1usize, concat!("Alignment of ",
-        stringify!(WithAnonUnion))
+        ::std::mem::align_of::<WithAnonUnion>(),
+        1usize,
+        concat!("Alignment of ", stringify!(WithAnonUnion)),
     );
 }
 impl Default for WithAnonUnion {
@@ -499,25 +537,29 @@ fn bindgen_test_layout_Override() {
     const UNINIT: ::std::mem::MaybeUninit<Override> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < Override > (), 16usize, concat!("Size of: ",
-        stringify!(Override))
+        ::std::mem::size_of::<Override>(),
+        16usize,
+        concat!("Size of: ", stringify!(Override)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Override > (), 4usize, concat!("Alignment of ",
-        stringify!(Override))
+        ::std::mem::align_of::<Override>(),
+        4usize,
+        concat!("Alignment of ", stringify!(Override)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).a) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(Override), "::", stringify!(a))
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(Override), "::", stringify!(a)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).b) as usize - ptr as usize }, 4usize,
-        concat!("Offset of field: ", stringify!(Override), "::", stringify!(b))
+        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
+        4usize,
+        concat!("Offset of field: ", stringify!(Override), "::", stringify!(b)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).private_c) as usize - ptr as usize },
-        8usize, concat!("Offset of field: ", stringify!(Override), "::",
-        stringify!(private_c))
+        unsafe { ::std::ptr::addr_of!((*ptr).private_c) as usize - ptr as usize },
+        8usize,
+        concat!("Offset of field: ", stringify!(Override), "::", stringify!(private_c)),
     );
 }
 impl Override {

--- a/bindgen-tests/tests/expectations/tests/public-dtor.rs
+++ b/bindgen-tests/tests/expectations/tests/public-dtor.rs
@@ -7,12 +7,14 @@ pub struct cv_Foo {
 #[test]
 fn bindgen_test_layout_cv_Foo() {
     assert_eq!(
-        ::std::mem::size_of:: < cv_Foo > (), 1usize, concat!("Size of: ",
-        stringify!(cv_Foo))
+        ::std::mem::size_of::<cv_Foo>(),
+        1usize,
+        concat!("Size of: ", stringify!(cv_Foo)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < cv_Foo > (), 1usize, concat!("Alignment of ",
-        stringify!(cv_Foo))
+        ::std::mem::align_of::<cv_Foo>(),
+        1usize,
+        concat!("Alignment of ", stringify!(cv_Foo)),
     );
 }
 extern "C" {
@@ -33,11 +35,13 @@ pub struct cv_Bar {
 #[test]
 fn bindgen_test_layout_cv_Bar() {
     assert_eq!(
-        ::std::mem::size_of:: < cv_Bar > (), 1usize, concat!("Size of: ",
-        stringify!(cv_Bar))
+        ::std::mem::size_of::<cv_Bar>(),
+        1usize,
+        concat!("Size of: ", stringify!(cv_Bar)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < cv_Bar > (), 1usize, concat!("Alignment of ",
-        stringify!(cv_Bar))
+        ::std::mem::align_of::<cv_Bar>(),
+        1usize,
+        concat!("Alignment of ", stringify!(cv_Bar)),
     );
 }

--- a/bindgen-tests/tests/expectations/tests/ref_argument_array.rs
+++ b/bindgen-tests/tests/expectations/tests/ref_argument_array.rs
@@ -15,11 +15,14 @@ pub struct nsID {
 #[test]
 fn bindgen_test_layout_nsID() {
     assert_eq!(
-        ::std::mem::size_of:: < nsID > (), 8usize, concat!("Size of: ", stringify!(nsID))
+        ::std::mem::size_of::<nsID>(),
+        8usize,
+        concat!("Size of: ", stringify!(nsID)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < nsID > (), 8usize, concat!("Alignment of ",
-        stringify!(nsID))
+        ::std::mem::align_of::<nsID>(),
+        8usize,
+        concat!("Alignment of ", stringify!(nsID)),
     );
 }
 impl Default for nsID {

--- a/bindgen-tests/tests/expectations/tests/reparented_replacement.rs
+++ b/bindgen-tests/tests/expectations/tests/reparented_replacement.rs
@@ -17,17 +17,19 @@ pub mod root {
             const UNINIT: ::std::mem::MaybeUninit<Bar> = ::std::mem::MaybeUninit::uninit();
             let ptr = UNINIT.as_ptr();
             assert_eq!(
-                ::std::mem::size_of:: < Bar > (), 4usize, concat!("Size of: ",
-                stringify!(Bar))
+                ::std::mem::size_of::<Bar>(),
+                4usize,
+                concat!("Size of: ", stringify!(Bar)),
             );
             assert_eq!(
-                ::std::mem::align_of:: < Bar > (), 4usize, concat!("Alignment of ",
-                stringify!(Bar))
+                ::std::mem::align_of::<Bar>(),
+                4usize,
+                concat!("Alignment of ", stringify!(Bar)),
             );
             assert_eq!(
-                unsafe { ::std::ptr::addr_of!((* ptr).bazz) as usize - ptr as usize },
-                0usize, concat!("Offset of field: ", stringify!(Bar), "::",
-                stringify!(bazz))
+                unsafe { ::std::ptr::addr_of!((*ptr).bazz) as usize - ptr as usize },
+                0usize,
+                concat!("Offset of field: ", stringify!(Bar), "::", stringify!(bazz)),
             );
         }
     }

--- a/bindgen-tests/tests/expectations/tests/replace_use.rs
+++ b/bindgen-tests/tests/expectations/tests/replace_use.rs
@@ -15,25 +15,31 @@ fn bindgen_test_layout_Test() {
     const UNINIT: ::std::mem::MaybeUninit<Test> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < Test > (), 4usize, concat!("Size of: ", stringify!(Test))
+        ::std::mem::size_of::<Test>(),
+        4usize,
+        concat!("Size of: ", stringify!(Test)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Test > (), 4usize, concat!("Alignment of ",
-        stringify!(Test))
+        ::std::mem::align_of::<Test>(),
+        4usize,
+        concat!("Alignment of ", stringify!(Test)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).a) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(Test), "::", stringify!(a))
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(Test), "::", stringify!(a)),
     );
 }
 #[test]
 fn __bindgen_test_layout_nsTArray_open0_long_close0_instantiation() {
     assert_eq!(
-        ::std::mem::size_of:: < nsTArray > (), 4usize,
-        concat!("Size of template specialization: ", stringify!(nsTArray))
+        ::std::mem::size_of::<nsTArray>(),
+        4usize,
+        concat!("Size of template specialization: ", stringify!(nsTArray)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < nsTArray > (), 4usize,
-        concat!("Alignment of template specialization: ", stringify!(nsTArray))
+        ::std::mem::align_of::<nsTArray>(),
+        4usize,
+        concat!("Alignment of template specialization: ", stringify!(nsTArray)),
     );
 }

--- a/bindgen-tests/tests/expectations/tests/repr-align.rs
+++ b/bindgen-tests/tests/expectations/tests/repr-align.rs
@@ -11,19 +11,21 @@ pub struct a {
 fn bindgen_test_layout_a() {
     const UNINIT: ::std::mem::MaybeUninit<a> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
+    assert_eq!(::std::mem::size_of::<a>(), 8usize, concat!("Size of: ", stringify!(a)));
     assert_eq!(
-        ::std::mem::size_of:: < a > (), 8usize, concat!("Size of: ", stringify!(a))
+        ::std::mem::align_of::<a>(),
+        8usize,
+        concat!("Alignment of ", stringify!(a)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < a > (), 8usize, concat!("Alignment of ", stringify!(a))
+        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(a), "::", stringify!(b)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).b) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(a), "::", stringify!(b))
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).c) as usize - ptr as usize }, 4usize,
-        concat!("Offset of field: ", stringify!(a), "::", stringify!(c))
+        unsafe { ::std::ptr::addr_of!((*ptr).c) as usize - ptr as usize },
+        4usize,
+        concat!("Offset of field: ", stringify!(a), "::", stringify!(c)),
     );
 }
 #[repr(C)]
@@ -37,18 +39,20 @@ pub struct b {
 fn bindgen_test_layout_b() {
     const UNINIT: ::std::mem::MaybeUninit<b> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
+    assert_eq!(::std::mem::size_of::<b>(), 8usize, concat!("Size of: ", stringify!(b)));
     assert_eq!(
-        ::std::mem::size_of:: < b > (), 8usize, concat!("Size of: ", stringify!(b))
+        ::std::mem::align_of::<b>(),
+        8usize,
+        concat!("Alignment of ", stringify!(b)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < b > (), 8usize, concat!("Alignment of ", stringify!(b))
+        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(b), "::", stringify!(b)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).b) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(b), "::", stringify!(b))
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).c) as usize - ptr as usize }, 4usize,
-        concat!("Offset of field: ", stringify!(b), "::", stringify!(c))
+        unsafe { ::std::ptr::addr_of!((*ptr).c) as usize - ptr as usize },
+        4usize,
+        concat!("Offset of field: ", stringify!(b), "::", stringify!(c)),
     );
 }

--- a/bindgen-tests/tests/expectations/tests/same_struct_name_in_different_namespaces.rs
+++ b/bindgen-tests/tests/expectations/tests/same_struct_name_in_different_namespaces.rs
@@ -15,19 +15,23 @@ fn bindgen_test_layout_JS_shadow_Zone() {
     const UNINIT: ::std::mem::MaybeUninit<JS_shadow_Zone> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < JS_shadow_Zone > (), 8usize, concat!("Size of: ",
-        stringify!(JS_shadow_Zone))
+        ::std::mem::size_of::<JS_shadow_Zone>(),
+        8usize,
+        concat!("Size of: ", stringify!(JS_shadow_Zone)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < JS_shadow_Zone > (), 4usize, concat!("Alignment of ",
-        stringify!(JS_shadow_Zone))
+        ::std::mem::align_of::<JS_shadow_Zone>(),
+        4usize,
+        concat!("Alignment of ", stringify!(JS_shadow_Zone)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).x) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(JS_shadow_Zone), "::", stringify!(x))
+        unsafe { ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(JS_shadow_Zone), "::", stringify!(x)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).y) as usize - ptr as usize }, 4usize,
-        concat!("Offset of field: ", stringify!(JS_shadow_Zone), "::", stringify!(y))
+        unsafe { ::std::ptr::addr_of!((*ptr).y) as usize - ptr as usize },
+        4usize,
+        concat!("Offset of field: ", stringify!(JS_shadow_Zone), "::", stringify!(y)),
     );
 }

--- a/bindgen-tests/tests/expectations/tests/sentry-defined-multiple-times.rs
+++ b/bindgen-tests/tests/expectations/tests/sentry-defined-multiple-times.rs
@@ -26,17 +26,27 @@ pub mod root {
             const UNINIT: ::std::mem::MaybeUninit<sentry> = ::std::mem::MaybeUninit::uninit();
             let ptr = UNINIT.as_ptr();
             assert_eq!(
-                ::std::mem::size_of:: < sentry > (), 1usize, concat!("Size of: ",
-                stringify!(sentry))
+                ::std::mem::size_of::<sentry>(),
+                1usize,
+                concat!("Size of: ", stringify!(sentry)),
             );
             assert_eq!(
-                ::std::mem::align_of:: < sentry > (), 1usize, concat!("Alignment of ",
-                stringify!(sentry))
+                ::std::mem::align_of::<sentry>(),
+                1usize,
+                concat!("Alignment of ", stringify!(sentry)),
             );
             assert_eq!(
-                unsafe { ::std::ptr::addr_of!((* ptr).i_am_plain_sentry) as usize - ptr
-                as usize }, 0usize, concat!("Offset of field: ", stringify!(sentry),
-                "::", stringify!(i_am_plain_sentry))
+                unsafe {
+                    ::std::ptr::addr_of!((*ptr).i_am_plain_sentry) as usize
+                        - ptr as usize
+                },
+                0usize,
+                concat!(
+                    "Offset of field: ",
+                    stringify!(sentry),
+                    "::",
+                    stringify!(i_am_plain_sentry),
+                ),
             );
         }
         #[repr(C)]
@@ -47,12 +57,14 @@ pub mod root {
         #[test]
         fn bindgen_test_layout_NotTemplateWrapper() {
             assert_eq!(
-                ::std::mem::size_of:: < NotTemplateWrapper > (), 1usize,
-                concat!("Size of: ", stringify!(NotTemplateWrapper))
+                ::std::mem::size_of::<NotTemplateWrapper>(),
+                1usize,
+                concat!("Size of: ", stringify!(NotTemplateWrapper)),
             );
             assert_eq!(
-                ::std::mem::align_of:: < NotTemplateWrapper > (), 1usize,
-                concat!("Alignment of ", stringify!(NotTemplateWrapper))
+                ::std::mem::align_of::<NotTemplateWrapper>(),
+                1usize,
+                concat!("Alignment of ", stringify!(NotTemplateWrapper)),
             );
         }
         #[repr(C)]
@@ -65,18 +77,27 @@ pub mod root {
             const UNINIT: ::std::mem::MaybeUninit<NotTemplateWrapper_sentry> = ::std::mem::MaybeUninit::uninit();
             let ptr = UNINIT.as_ptr();
             assert_eq!(
-                ::std::mem::size_of:: < NotTemplateWrapper_sentry > (), 1usize,
-                concat!("Size of: ", stringify!(NotTemplateWrapper_sentry))
+                ::std::mem::size_of::<NotTemplateWrapper_sentry>(),
+                1usize,
+                concat!("Size of: ", stringify!(NotTemplateWrapper_sentry)),
             );
             assert_eq!(
-                ::std::mem::align_of:: < NotTemplateWrapper_sentry > (), 1usize,
-                concat!("Alignment of ", stringify!(NotTemplateWrapper_sentry))
+                ::std::mem::align_of::<NotTemplateWrapper_sentry>(),
+                1usize,
+                concat!("Alignment of ", stringify!(NotTemplateWrapper_sentry)),
             );
             assert_eq!(
-                unsafe { ::std::ptr::addr_of!((* ptr).i_am_not_template_wrapper_sentry)
-                as usize - ptr as usize }, 0usize, concat!("Offset of field: ",
-                stringify!(NotTemplateWrapper_sentry), "::",
-                stringify!(i_am_not_template_wrapper_sentry))
+                unsafe {
+                    ::std::ptr::addr_of!((*ptr).i_am_not_template_wrapper_sentry)
+                        as usize - ptr as usize
+                },
+                0usize,
+                concat!(
+                    "Offset of field: ",
+                    stringify!(NotTemplateWrapper_sentry),
+                    "::",
+                    stringify!(i_am_not_template_wrapper_sentry),
+                ),
             );
         }
         #[repr(C)]
@@ -94,30 +115,40 @@ pub mod root {
             const UNINIT: ::std::mem::MaybeUninit<InlineNotTemplateWrapper_sentry> = ::std::mem::MaybeUninit::uninit();
             let ptr = UNINIT.as_ptr();
             assert_eq!(
-                ::std::mem::size_of:: < InlineNotTemplateWrapper_sentry > (), 1usize,
-                concat!("Size of: ", stringify!(InlineNotTemplateWrapper_sentry))
+                ::std::mem::size_of::<InlineNotTemplateWrapper_sentry>(),
+                1usize,
+                concat!("Size of: ", stringify!(InlineNotTemplateWrapper_sentry)),
             );
             assert_eq!(
-                ::std::mem::align_of:: < InlineNotTemplateWrapper_sentry > (), 1usize,
-                concat!("Alignment of ", stringify!(InlineNotTemplateWrapper_sentry))
+                ::std::mem::align_of::<InlineNotTemplateWrapper_sentry>(),
+                1usize,
+                concat!("Alignment of ", stringify!(InlineNotTemplateWrapper_sentry)),
             );
             assert_eq!(
-                unsafe { ::std::ptr::addr_of!((* ptr)
-                .i_am_inline_not_template_wrapper_sentry) as usize - ptr as usize },
-                0usize, concat!("Offset of field: ",
-                stringify!(InlineNotTemplateWrapper_sentry), "::",
-                stringify!(i_am_inline_not_template_wrapper_sentry))
+                unsafe {
+                    ::std::ptr::addr_of!((*ptr).i_am_inline_not_template_wrapper_sentry)
+                        as usize - ptr as usize
+                },
+                0usize,
+                concat!(
+                    "Offset of field: ",
+                    stringify!(InlineNotTemplateWrapper_sentry),
+                    "::",
+                    stringify!(i_am_inline_not_template_wrapper_sentry),
+                ),
             );
         }
         #[test]
         fn bindgen_test_layout_InlineNotTemplateWrapper() {
             assert_eq!(
-                ::std::mem::size_of:: < InlineNotTemplateWrapper > (), 1usize,
-                concat!("Size of: ", stringify!(InlineNotTemplateWrapper))
+                ::std::mem::size_of::<InlineNotTemplateWrapper>(),
+                1usize,
+                concat!("Size of: ", stringify!(InlineNotTemplateWrapper)),
             );
             assert_eq!(
-                ::std::mem::align_of:: < InlineNotTemplateWrapper > (), 1usize,
-                concat!("Alignment of ", stringify!(InlineNotTemplateWrapper))
+                ::std::mem::align_of::<InlineNotTemplateWrapper>(),
+                1usize,
+                concat!("Alignment of ", stringify!(InlineNotTemplateWrapper)),
             );
         }
         #[repr(C)]
@@ -143,25 +174,30 @@ pub mod root {
         #[test]
         fn bindgen_test_layout_OuterDoubleWrapper_InnerDoubleWrapper() {
             assert_eq!(
-                ::std::mem::size_of:: < OuterDoubleWrapper_InnerDoubleWrapper > (),
-                1usize, concat!("Size of: ",
-                stringify!(OuterDoubleWrapper_InnerDoubleWrapper))
+                ::std::mem::size_of::<OuterDoubleWrapper_InnerDoubleWrapper>(),
+                1usize,
+                concat!("Size of: ", stringify!(OuterDoubleWrapper_InnerDoubleWrapper)),
             );
             assert_eq!(
-                ::std::mem::align_of:: < OuterDoubleWrapper_InnerDoubleWrapper > (),
-                1usize, concat!("Alignment of ",
-                stringify!(OuterDoubleWrapper_InnerDoubleWrapper))
+                ::std::mem::align_of::<OuterDoubleWrapper_InnerDoubleWrapper>(),
+                1usize,
+                concat!(
+                    "Alignment of ",
+                    stringify!(OuterDoubleWrapper_InnerDoubleWrapper),
+                ),
             );
         }
         #[test]
         fn bindgen_test_layout_OuterDoubleWrapper() {
             assert_eq!(
-                ::std::mem::size_of:: < OuterDoubleWrapper > (), 1usize,
-                concat!("Size of: ", stringify!(OuterDoubleWrapper))
+                ::std::mem::size_of::<OuterDoubleWrapper>(),
+                1usize,
+                concat!("Size of: ", stringify!(OuterDoubleWrapper)),
             );
             assert_eq!(
-                ::std::mem::align_of:: < OuterDoubleWrapper > (), 1usize,
-                concat!("Alignment of ", stringify!(OuterDoubleWrapper))
+                ::std::mem::align_of::<OuterDoubleWrapper>(),
+                1usize,
+                concat!("Alignment of ", stringify!(OuterDoubleWrapper)),
             );
         }
         #[repr(C)]
@@ -176,20 +212,33 @@ pub mod root {
             > = ::std::mem::MaybeUninit::uninit();
             let ptr = UNINIT.as_ptr();
             assert_eq!(
-                ::std::mem::size_of:: < OuterDoubleWrapper_InnerDoubleWrapper_sentry >
-                (), 4usize, concat!("Size of: ",
-                stringify!(OuterDoubleWrapper_InnerDoubleWrapper_sentry))
+                ::std::mem::size_of::<OuterDoubleWrapper_InnerDoubleWrapper_sentry>(),
+                4usize,
+                concat!(
+                    "Size of: ",
+                    stringify!(OuterDoubleWrapper_InnerDoubleWrapper_sentry),
+                ),
             );
             assert_eq!(
-                ::std::mem::align_of:: < OuterDoubleWrapper_InnerDoubleWrapper_sentry >
-                (), 4usize, concat!("Alignment of ",
-                stringify!(OuterDoubleWrapper_InnerDoubleWrapper_sentry))
+                ::std::mem::align_of::<OuterDoubleWrapper_InnerDoubleWrapper_sentry>(),
+                4usize,
+                concat!(
+                    "Alignment of ",
+                    stringify!(OuterDoubleWrapper_InnerDoubleWrapper_sentry),
+                ),
             );
             assert_eq!(
-                unsafe { ::std::ptr::addr_of!((* ptr).i_am_double_wrapper_sentry) as
-                usize - ptr as usize }, 0usize, concat!("Offset of field: ",
-                stringify!(OuterDoubleWrapper_InnerDoubleWrapper_sentry), "::",
-                stringify!(i_am_double_wrapper_sentry))
+                unsafe {
+                    ::std::ptr::addr_of!((*ptr).i_am_double_wrapper_sentry) as usize
+                        - ptr as usize
+                },
+                0usize,
+                concat!(
+                    "Offset of field: ",
+                    stringify!(OuterDoubleWrapper_InnerDoubleWrapper_sentry),
+                    "::",
+                    stringify!(i_am_double_wrapper_sentry),
+                ),
             );
         }
         #[repr(C)]
@@ -214,47 +263,73 @@ pub mod root {
             > = ::std::mem::MaybeUninit::uninit();
             let ptr = UNINIT.as_ptr();
             assert_eq!(
-                ::std::mem::size_of:: <
-                OuterDoubleInlineWrapper_InnerDoubleInlineWrapper_sentry > (), 4usize,
-                concat!("Size of: ",
-                stringify!(OuterDoubleInlineWrapper_InnerDoubleInlineWrapper_sentry))
+                ::std::mem::size_of::<
+                    OuterDoubleInlineWrapper_InnerDoubleInlineWrapper_sentry,
+                >(),
+                4usize,
+                concat!(
+                    "Size of: ",
+                    stringify!(OuterDoubleInlineWrapper_InnerDoubleInlineWrapper_sentry),
+                ),
             );
             assert_eq!(
-                ::std::mem::align_of:: <
-                OuterDoubleInlineWrapper_InnerDoubleInlineWrapper_sentry > (), 4usize,
-                concat!("Alignment of ",
-                stringify!(OuterDoubleInlineWrapper_InnerDoubleInlineWrapper_sentry))
+                ::std::mem::align_of::<
+                    OuterDoubleInlineWrapper_InnerDoubleInlineWrapper_sentry,
+                >(),
+                4usize,
+                concat!(
+                    "Alignment of ",
+                    stringify!(OuterDoubleInlineWrapper_InnerDoubleInlineWrapper_sentry),
+                ),
             );
             assert_eq!(
-                unsafe { ::std::ptr::addr_of!((* ptr).i_am_double_wrapper_inline_sentry)
-                as usize - ptr as usize }, 0usize, concat!("Offset of field: ",
-                stringify!(OuterDoubleInlineWrapper_InnerDoubleInlineWrapper_sentry),
-                "::", stringify!(i_am_double_wrapper_inline_sentry))
+                unsafe {
+                    ::std::ptr::addr_of!((*ptr).i_am_double_wrapper_inline_sentry)
+                        as usize - ptr as usize
+                },
+                0usize,
+                concat!(
+                    "Offset of field: ",
+                    stringify!(OuterDoubleInlineWrapper_InnerDoubleInlineWrapper_sentry),
+                    "::",
+                    stringify!(i_am_double_wrapper_inline_sentry),
+                ),
             );
         }
         #[test]
         fn bindgen_test_layout_OuterDoubleInlineWrapper_InnerDoubleInlineWrapper() {
             assert_eq!(
-                ::std::mem::size_of:: < OuterDoubleInlineWrapper_InnerDoubleInlineWrapper
-                > (), 1usize, concat!("Size of: ",
-                stringify!(OuterDoubleInlineWrapper_InnerDoubleInlineWrapper))
+                ::std::mem::size_of::<
+                    OuterDoubleInlineWrapper_InnerDoubleInlineWrapper,
+                >(),
+                1usize,
+                concat!(
+                    "Size of: ",
+                    stringify!(OuterDoubleInlineWrapper_InnerDoubleInlineWrapper),
+                ),
             );
             assert_eq!(
-                ::std::mem::align_of:: <
-                OuterDoubleInlineWrapper_InnerDoubleInlineWrapper > (), 1usize,
-                concat!("Alignment of ",
-                stringify!(OuterDoubleInlineWrapper_InnerDoubleInlineWrapper))
+                ::std::mem::align_of::<
+                    OuterDoubleInlineWrapper_InnerDoubleInlineWrapper,
+                >(),
+                1usize,
+                concat!(
+                    "Alignment of ",
+                    stringify!(OuterDoubleInlineWrapper_InnerDoubleInlineWrapper),
+                ),
             );
         }
         #[test]
         fn bindgen_test_layout_OuterDoubleInlineWrapper() {
             assert_eq!(
-                ::std::mem::size_of:: < OuterDoubleInlineWrapper > (), 1usize,
-                concat!("Size of: ", stringify!(OuterDoubleInlineWrapper))
+                ::std::mem::size_of::<OuterDoubleInlineWrapper>(),
+                1usize,
+                concat!("Size of: ", stringify!(OuterDoubleInlineWrapper)),
             );
             assert_eq!(
-                ::std::mem::align_of:: < OuterDoubleInlineWrapper > (), 1usize,
-                concat!("Alignment of ", stringify!(OuterDoubleInlineWrapper))
+                ::std::mem::align_of::<OuterDoubleInlineWrapper>(),
+                1usize,
+                concat!("Alignment of ", stringify!(OuterDoubleInlineWrapper)),
             );
         }
     }
@@ -278,17 +353,27 @@ pub mod root {
         const UNINIT: ::std::mem::MaybeUninit<sentry> = ::std::mem::MaybeUninit::uninit();
         let ptr = UNINIT.as_ptr();
         assert_eq!(
-            ::std::mem::size_of:: < sentry > (), 4usize, concat!("Size of: ",
-            stringify!(sentry))
+            ::std::mem::size_of::<sentry>(),
+            4usize,
+            concat!("Size of: ", stringify!(sentry)),
         );
         assert_eq!(
-            ::std::mem::align_of:: < sentry > (), 4usize, concat!("Alignment of ",
-            stringify!(sentry))
+            ::std::mem::align_of::<sentry>(),
+            4usize,
+            concat!("Alignment of ", stringify!(sentry)),
         );
         assert_eq!(
-            unsafe { ::std::ptr::addr_of!((* ptr).i_am_outside_namespace_sentry) as usize
-            - ptr as usize }, 0usize, concat!("Offset of field: ", stringify!(sentry),
-            "::", stringify!(i_am_outside_namespace_sentry))
+            unsafe {
+                ::std::ptr::addr_of!((*ptr).i_am_outside_namespace_sentry) as usize
+                    - ptr as usize
+            },
+            0usize,
+            concat!(
+                "Offset of field: ",
+                stringify!(sentry),
+                "::",
+                stringify!(i_am_outside_namespace_sentry),
+            ),
         );
     }
 }

--- a/bindgen-tests/tests/expectations/tests/size_t_template.rs
+++ b/bindgen-tests/tests/expectations/tests/size_t_template.rs
@@ -8,14 +8,15 @@ pub struct C {
 fn bindgen_test_layout_C() {
     const UNINIT: ::std::mem::MaybeUninit<C> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
+    assert_eq!(::std::mem::size_of::<C>(), 12usize, concat!("Size of: ", stringify!(C)));
     assert_eq!(
-        ::std::mem::size_of:: < C > (), 12usize, concat!("Size of: ", stringify!(C))
+        ::std::mem::align_of::<C>(),
+        4usize,
+        concat!("Alignment of ", stringify!(C)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < C > (), 4usize, concat!("Alignment of ", stringify!(C))
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).arr) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(C), "::", stringify!(arr))
+        unsafe { ::std::ptr::addr_of!((*ptr).arr) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(C), "::", stringify!(arr)),
     );
 }

--- a/bindgen-tests/tests/expectations/tests/sorted_items.rs
+++ b/bindgen-tests/tests/expectations/tests/sorted_items.rs
@@ -20,20 +20,24 @@ pub mod root {
         const UNINIT: ::std::mem::MaybeUninit<Point> = ::std::mem::MaybeUninit::uninit();
         let ptr = UNINIT.as_ptr();
         assert_eq!(
-            ::std::mem::size_of:: < Point > (), 8usize, concat!("Size of: ",
-            stringify!(Point))
+            ::std::mem::size_of::<Point>(),
+            8usize,
+            concat!("Size of: ", stringify!(Point)),
         );
         assert_eq!(
-            ::std::mem::align_of:: < Point > (), 4usize, concat!("Alignment of ",
-            stringify!(Point))
+            ::std::mem::align_of::<Point>(),
+            4usize,
+            concat!("Alignment of ", stringify!(Point)),
         );
         assert_eq!(
-            unsafe { ::std::ptr::addr_of!((* ptr).x) as usize - ptr as usize }, 0usize,
-            concat!("Offset of field: ", stringify!(Point), "::", stringify!(x))
+            unsafe { ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize },
+            0usize,
+            concat!("Offset of field: ", stringify!(Point), "::", stringify!(x)),
         );
         assert_eq!(
-            unsafe { ::std::ptr::addr_of!((* ptr).y) as usize - ptr as usize }, 4usize,
-            concat!("Offset of field: ", stringify!(Point), "::", stringify!(y))
+            unsafe { ::std::ptr::addr_of!((*ptr).y) as usize - ptr as usize },
+            4usize,
+            concat!("Offset of field: ", stringify!(Point), "::", stringify!(y)),
         );
     }
     #[test]
@@ -41,20 +45,24 @@ pub mod root {
         const UNINIT: ::std::mem::MaybeUninit<Angle> = ::std::mem::MaybeUninit::uninit();
         let ptr = UNINIT.as_ptr();
         assert_eq!(
-            ::std::mem::size_of:: < Angle > (), 8usize, concat!("Size of: ",
-            stringify!(Angle))
+            ::std::mem::size_of::<Angle>(),
+            8usize,
+            concat!("Size of: ", stringify!(Angle)),
         );
         assert_eq!(
-            ::std::mem::align_of:: < Angle > (), 4usize, concat!("Alignment of ",
-            stringify!(Angle))
+            ::std::mem::align_of::<Angle>(),
+            4usize,
+            concat!("Alignment of ", stringify!(Angle)),
         );
         assert_eq!(
-            unsafe { ::std::ptr::addr_of!((* ptr).a) as usize - ptr as usize }, 0usize,
-            concat!("Offset of field: ", stringify!(Angle), "::", stringify!(a))
+            unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
+            0usize,
+            concat!("Offset of field: ", stringify!(Angle), "::", stringify!(a)),
         );
         assert_eq!(
-            unsafe { ::std::ptr::addr_of!((* ptr).b) as usize - ptr as usize }, 4usize,
-            concat!("Offset of field: ", stringify!(Angle), "::", stringify!(b))
+            unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
+            4usize,
+            concat!("Offset of field: ", stringify!(Angle), "::", stringify!(b)),
         );
     }
     pub mod ns {
@@ -77,22 +85,24 @@ pub mod root {
             const UNINIT: ::std::mem::MaybeUninit<Point> = ::std::mem::MaybeUninit::uninit();
             let ptr = UNINIT.as_ptr();
             assert_eq!(
-                ::std::mem::size_of:: < Point > (), 8usize, concat!("Size of: ",
-                stringify!(Point))
+                ::std::mem::size_of::<Point>(),
+                8usize,
+                concat!("Size of: ", stringify!(Point)),
             );
             assert_eq!(
-                ::std::mem::align_of:: < Point > (), 4usize, concat!("Alignment of ",
-                stringify!(Point))
+                ::std::mem::align_of::<Point>(),
+                4usize,
+                concat!("Alignment of ", stringify!(Point)),
             );
             assert_eq!(
-                unsafe { ::std::ptr::addr_of!((* ptr).x) as usize - ptr as usize },
-                0usize, concat!("Offset of field: ", stringify!(Point), "::",
-                stringify!(x))
+                unsafe { ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize },
+                0usize,
+                concat!("Offset of field: ", stringify!(Point), "::", stringify!(x)),
             );
             assert_eq!(
-                unsafe { ::std::ptr::addr_of!((* ptr).y) as usize - ptr as usize },
-                4usize, concat!("Offset of field: ", stringify!(Point), "::",
-                stringify!(y))
+                unsafe { ::std::ptr::addr_of!((*ptr).y) as usize - ptr as usize },
+                4usize,
+                concat!("Offset of field: ", stringify!(Point), "::", stringify!(y)),
             );
         }
         #[test]
@@ -100,22 +110,24 @@ pub mod root {
             const UNINIT: ::std::mem::MaybeUninit<Angle> = ::std::mem::MaybeUninit::uninit();
             let ptr = UNINIT.as_ptr();
             assert_eq!(
-                ::std::mem::size_of:: < Angle > (), 8usize, concat!("Size of: ",
-                stringify!(Angle))
+                ::std::mem::size_of::<Angle>(),
+                8usize,
+                concat!("Size of: ", stringify!(Angle)),
             );
             assert_eq!(
-                ::std::mem::align_of:: < Angle > (), 4usize, concat!("Alignment of ",
-                stringify!(Angle))
+                ::std::mem::align_of::<Angle>(),
+                4usize,
+                concat!("Alignment of ", stringify!(Angle)),
             );
             assert_eq!(
-                unsafe { ::std::ptr::addr_of!((* ptr).a) as usize - ptr as usize },
-                0usize, concat!("Offset of field: ", stringify!(Angle), "::",
-                stringify!(a))
+                unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
+                0usize,
+                concat!("Offset of field: ", stringify!(Angle), "::", stringify!(a)),
             );
             assert_eq!(
-                unsafe { ::std::ptr::addr_of!((* ptr).b) as usize - ptr as usize },
-                4usize, concat!("Offset of field: ", stringify!(Angle), "::",
-                stringify!(b))
+                unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
+                4usize,
+                concat!("Offset of field: ", stringify!(Angle), "::", stringify!(b)),
             );
         }
         #[allow(unused_imports)]

--- a/bindgen-tests/tests/expectations/tests/stdint_typedef.rs
+++ b/bindgen-tests/tests/expectations/tests/stdint_typedef.rs
@@ -12,15 +12,18 @@ fn bindgen_test_layout_Struct() {
     const UNINIT: ::std::mem::MaybeUninit<Struct> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < Struct > (), 8usize, concat!("Size of: ",
-        stringify!(Struct))
+        ::std::mem::size_of::<Struct>(),
+        8usize,
+        concat!("Size of: ", stringify!(Struct)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Struct > (), 8usize, concat!("Alignment of ",
-        stringify!(Struct))
+        ::std::mem::align_of::<Struct>(),
+        8usize,
+        concat!("Alignment of ", stringify!(Struct)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).field) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(Struct), "::", stringify!(field))
+        unsafe { ::std::ptr::addr_of!((*ptr).field) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(Struct), "::", stringify!(field)),
     );
 }

--- a/bindgen-tests/tests/expectations/tests/struct_containing_forward_declared_struct.rs
+++ b/bindgen-tests/tests/expectations/tests/struct_containing_forward_declared_struct.rs
@@ -8,15 +8,16 @@ pub struct a {
 fn bindgen_test_layout_a() {
     const UNINIT: ::std::mem::MaybeUninit<a> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
+    assert_eq!(::std::mem::size_of::<a>(), 8usize, concat!("Size of: ", stringify!(a)));
     assert_eq!(
-        ::std::mem::size_of:: < a > (), 8usize, concat!("Size of: ", stringify!(a))
+        ::std::mem::align_of::<a>(),
+        8usize,
+        concat!("Alignment of ", stringify!(a)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < a > (), 8usize, concat!("Alignment of ", stringify!(a))
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).val_a) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(a), "::", stringify!(val_a))
+        unsafe { ::std::ptr::addr_of!((*ptr).val_a) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(a), "::", stringify!(val_a)),
     );
 }
 impl Default for a {
@@ -37,14 +38,15 @@ pub struct b {
 fn bindgen_test_layout_b() {
     const UNINIT: ::std::mem::MaybeUninit<b> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
+    assert_eq!(::std::mem::size_of::<b>(), 4usize, concat!("Size of: ", stringify!(b)));
     assert_eq!(
-        ::std::mem::size_of:: < b > (), 4usize, concat!("Size of: ", stringify!(b))
+        ::std::mem::align_of::<b>(),
+        4usize,
+        concat!("Alignment of ", stringify!(b)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < b > (), 4usize, concat!("Alignment of ", stringify!(b))
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).val_b) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(b), "::", stringify!(val_b))
+        unsafe { ::std::ptr::addr_of!((*ptr).val_b) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(b), "::", stringify!(val_b)),
     );
 }

--- a/bindgen-tests/tests/expectations/tests/struct_typedef.rs
+++ b/bindgen-tests/tests/expectations/tests/struct_typedef.rs
@@ -9,17 +9,24 @@ fn bindgen_test_layout_typedef_named_struct() {
     const UNINIT: ::std::mem::MaybeUninit<typedef_named_struct> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < typedef_named_struct > (), 1usize, concat!("Size of: ",
-        stringify!(typedef_named_struct))
+        ::std::mem::size_of::<typedef_named_struct>(),
+        1usize,
+        concat!("Size of: ", stringify!(typedef_named_struct)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < typedef_named_struct > (), 1usize,
-        concat!("Alignment of ", stringify!(typedef_named_struct))
+        ::std::mem::align_of::<typedef_named_struct>(),
+        1usize,
+        concat!("Alignment of ", stringify!(typedef_named_struct)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).has_name) as usize - ptr as usize },
-        0usize, concat!("Offset of field: ", stringify!(typedef_named_struct), "::",
-        stringify!(has_name))
+        unsafe { ::std::ptr::addr_of!((*ptr).has_name) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(typedef_named_struct),
+            "::",
+            stringify!(has_name),
+        ),
     );
 }
 #[repr(C)]
@@ -32,17 +39,24 @@ fn bindgen_test_layout__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<_bindgen_ty_1> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < _bindgen_ty_1 > (), 8usize, concat!("Size of: ",
-        stringify!(_bindgen_ty_1))
+        ::std::mem::size_of::<_bindgen_ty_1>(),
+        8usize,
+        concat!("Size of: ", stringify!(_bindgen_ty_1)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < _bindgen_ty_1 > (), 8usize, concat!("Alignment of ",
-        stringify!(_bindgen_ty_1))
+        ::std::mem::align_of::<_bindgen_ty_1>(),
+        8usize,
+        concat!("Alignment of ", stringify!(_bindgen_ty_1)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).no_name) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(_bindgen_ty_1), "::",
-        stringify!(no_name))
+        unsafe { ::std::ptr::addr_of!((*ptr).no_name) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(_bindgen_ty_1),
+            "::",
+            stringify!(no_name),
+        ),
     );
 }
 impl Default for _bindgen_ty_1 {

--- a/bindgen-tests/tests/expectations/tests/struct_typedef_ns.rs
+++ b/bindgen-tests/tests/expectations/tests/struct_typedef_ns.rs
@@ -16,17 +16,24 @@ pub mod root {
             const UNINIT: ::std::mem::MaybeUninit<typedef_struct> = ::std::mem::MaybeUninit::uninit();
             let ptr = UNINIT.as_ptr();
             assert_eq!(
-                ::std::mem::size_of:: < typedef_struct > (), 4usize, concat!("Size of: ",
-                stringify!(typedef_struct))
+                ::std::mem::size_of::<typedef_struct>(),
+                4usize,
+                concat!("Size of: ", stringify!(typedef_struct)),
             );
             assert_eq!(
-                ::std::mem::align_of:: < typedef_struct > (), 4usize,
-                concat!("Alignment of ", stringify!(typedef_struct))
+                ::std::mem::align_of::<typedef_struct>(),
+                4usize,
+                concat!("Alignment of ", stringify!(typedef_struct)),
             );
             assert_eq!(
-                unsafe { ::std::ptr::addr_of!((* ptr).foo) as usize - ptr as usize },
-                0usize, concat!("Offset of field: ", stringify!(typedef_struct), "::",
-                stringify!(foo))
+                unsafe { ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize },
+                0usize,
+                concat!(
+                    "Offset of field: ",
+                    stringify!(typedef_struct),
+                    "::",
+                    stringify!(foo),
+                ),
             );
         }
         #[repr(u32)]
@@ -48,17 +55,24 @@ pub mod root {
             const UNINIT: ::std::mem::MaybeUninit<_bindgen_ty_1> = ::std::mem::MaybeUninit::uninit();
             let ptr = UNINIT.as_ptr();
             assert_eq!(
-                ::std::mem::size_of:: < _bindgen_ty_1 > (), 4usize, concat!("Size of: ",
-                stringify!(_bindgen_ty_1))
+                ::std::mem::size_of::<_bindgen_ty_1>(),
+                4usize,
+                concat!("Size of: ", stringify!(_bindgen_ty_1)),
             );
             assert_eq!(
-                ::std::mem::align_of:: < _bindgen_ty_1 > (), 4usize,
-                concat!("Alignment of ", stringify!(_bindgen_ty_1))
+                ::std::mem::align_of::<_bindgen_ty_1>(),
+                4usize,
+                concat!("Alignment of ", stringify!(_bindgen_ty_1)),
             );
             assert_eq!(
-                unsafe { ::std::ptr::addr_of!((* ptr).foo) as usize - ptr as usize },
-                0usize, concat!("Offset of field: ", stringify!(_bindgen_ty_1), "::",
-                stringify!(foo))
+                unsafe { ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize },
+                0usize,
+                concat!(
+                    "Offset of field: ",
+                    stringify!(_bindgen_ty_1),
+                    "::",
+                    stringify!(foo),
+                ),
             );
         }
         pub type typedef_struct = root::_bindgen_mod_id_12::_bindgen_ty_1;

--- a/bindgen-tests/tests/expectations/tests/struct_with_anon_struct.rs
+++ b/bindgen-tests/tests/expectations/tests/struct_with_anon_struct.rs
@@ -15,20 +15,24 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<foo__bindgen_ty_1> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < foo__bindgen_ty_1 > (), 8usize, concat!("Size of: ",
-        stringify!(foo__bindgen_ty_1))
+        ::std::mem::size_of::<foo__bindgen_ty_1>(),
+        8usize,
+        concat!("Size of: ", stringify!(foo__bindgen_ty_1)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < foo__bindgen_ty_1 > (), 4usize, concat!("Alignment of ",
-        stringify!(foo__bindgen_ty_1))
+        ::std::mem::align_of::<foo__bindgen_ty_1>(),
+        4usize,
+        concat!("Alignment of ", stringify!(foo__bindgen_ty_1)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).a) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(foo__bindgen_ty_1), "::", stringify!(a))
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(foo__bindgen_ty_1), "::", stringify!(a)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).b) as usize - ptr as usize }, 4usize,
-        concat!("Offset of field: ", stringify!(foo__bindgen_ty_1), "::", stringify!(b))
+        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
+        4usize,
+        concat!("Offset of field: ", stringify!(foo__bindgen_ty_1), "::", stringify!(b)),
     );
 }
 #[test]
@@ -36,14 +40,18 @@ fn bindgen_test_layout_foo() {
     const UNINIT: ::std::mem::MaybeUninit<foo> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < foo > (), 8usize, concat!("Size of: ", stringify!(foo))
+        ::std::mem::size_of::<foo>(),
+        8usize,
+        concat!("Size of: ", stringify!(foo)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < foo > (), 4usize, concat!("Alignment of ",
-        stringify!(foo))
+        ::std::mem::align_of::<foo>(),
+        4usize,
+        concat!("Alignment of ", stringify!(foo)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).bar) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar))
+        unsafe { ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar)),
     );
 }

--- a/bindgen-tests/tests/expectations/tests/struct_with_anon_struct_array.rs
+++ b/bindgen-tests/tests/expectations/tests/struct_with_anon_struct_array.rs
@@ -16,20 +16,24 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<foo__bindgen_ty_1> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < foo__bindgen_ty_1 > (), 8usize, concat!("Size of: ",
-        stringify!(foo__bindgen_ty_1))
+        ::std::mem::size_of::<foo__bindgen_ty_1>(),
+        8usize,
+        concat!("Size of: ", stringify!(foo__bindgen_ty_1)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < foo__bindgen_ty_1 > (), 4usize, concat!("Alignment of ",
-        stringify!(foo__bindgen_ty_1))
+        ::std::mem::align_of::<foo__bindgen_ty_1>(),
+        4usize,
+        concat!("Alignment of ", stringify!(foo__bindgen_ty_1)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).a) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(foo__bindgen_ty_1), "::", stringify!(a))
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(foo__bindgen_ty_1), "::", stringify!(a)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).b) as usize - ptr as usize }, 4usize,
-        concat!("Offset of field: ", stringify!(foo__bindgen_ty_1), "::", stringify!(b))
+        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
+        4usize,
+        concat!("Offset of field: ", stringify!(foo__bindgen_ty_1), "::", stringify!(b)),
     );
 }
 #[repr(C)]
@@ -43,20 +47,24 @@ fn bindgen_test_layout_foo__bindgen_ty_2() {
     const UNINIT: ::std::mem::MaybeUninit<foo__bindgen_ty_2> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < foo__bindgen_ty_2 > (), 8usize, concat!("Size of: ",
-        stringify!(foo__bindgen_ty_2))
+        ::std::mem::size_of::<foo__bindgen_ty_2>(),
+        8usize,
+        concat!("Size of: ", stringify!(foo__bindgen_ty_2)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < foo__bindgen_ty_2 > (), 4usize, concat!("Alignment of ",
-        stringify!(foo__bindgen_ty_2))
+        ::std::mem::align_of::<foo__bindgen_ty_2>(),
+        4usize,
+        concat!("Alignment of ", stringify!(foo__bindgen_ty_2)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).a) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(foo__bindgen_ty_2), "::", stringify!(a))
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(foo__bindgen_ty_2), "::", stringify!(a)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).b) as usize - ptr as usize }, 4usize,
-        concat!("Offset of field: ", stringify!(foo__bindgen_ty_2), "::", stringify!(b))
+        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
+        4usize,
+        concat!("Offset of field: ", stringify!(foo__bindgen_ty_2), "::", stringify!(b)),
     );
 }
 #[test]
@@ -64,18 +72,23 @@ fn bindgen_test_layout_foo() {
     const UNINIT: ::std::mem::MaybeUninit<foo> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < foo > (), 208usize, concat!("Size of: ", stringify!(foo))
+        ::std::mem::size_of::<foo>(),
+        208usize,
+        concat!("Size of: ", stringify!(foo)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < foo > (), 4usize, concat!("Alignment of ",
-        stringify!(foo))
+        ::std::mem::align_of::<foo>(),
+        4usize,
+        concat!("Alignment of ", stringify!(foo)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).bar) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar))
+        unsafe { ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).baz) as usize - ptr as usize }, 16usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(baz))
+        unsafe { ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize },
+        16usize,
+        concat!("Offset of field: ", stringify!(foo), "::", stringify!(baz)),
     );
 }

--- a/bindgen-tests/tests/expectations/tests/struct_with_anon_struct_pointer.rs
+++ b/bindgen-tests/tests/expectations/tests/struct_with_anon_struct_pointer.rs
@@ -15,20 +15,24 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<foo__bindgen_ty_1> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < foo__bindgen_ty_1 > (), 8usize, concat!("Size of: ",
-        stringify!(foo__bindgen_ty_1))
+        ::std::mem::size_of::<foo__bindgen_ty_1>(),
+        8usize,
+        concat!("Size of: ", stringify!(foo__bindgen_ty_1)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < foo__bindgen_ty_1 > (), 4usize, concat!("Alignment of ",
-        stringify!(foo__bindgen_ty_1))
+        ::std::mem::align_of::<foo__bindgen_ty_1>(),
+        4usize,
+        concat!("Alignment of ", stringify!(foo__bindgen_ty_1)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).a) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(foo__bindgen_ty_1), "::", stringify!(a))
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(foo__bindgen_ty_1), "::", stringify!(a)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).b) as usize - ptr as usize }, 4usize,
-        concat!("Offset of field: ", stringify!(foo__bindgen_ty_1), "::", stringify!(b))
+        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
+        4usize,
+        concat!("Offset of field: ", stringify!(foo__bindgen_ty_1), "::", stringify!(b)),
     );
 }
 #[test]
@@ -36,15 +40,19 @@ fn bindgen_test_layout_foo() {
     const UNINIT: ::std::mem::MaybeUninit<foo> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < foo > (), 8usize, concat!("Size of: ", stringify!(foo))
+        ::std::mem::size_of::<foo>(),
+        8usize,
+        concat!("Size of: ", stringify!(foo)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < foo > (), 8usize, concat!("Alignment of ",
-        stringify!(foo))
+        ::std::mem::align_of::<foo>(),
+        8usize,
+        concat!("Alignment of ", stringify!(foo)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).bar) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar))
+        unsafe { ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar)),
     );
 }
 impl Default for foo {

--- a/bindgen-tests/tests/expectations/tests/struct_with_anon_union.rs
+++ b/bindgen-tests/tests/expectations/tests/struct_with_anon_union.rs
@@ -15,20 +15,24 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<foo__bindgen_ty_1> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < foo__bindgen_ty_1 > (), 4usize, concat!("Size of: ",
-        stringify!(foo__bindgen_ty_1))
+        ::std::mem::size_of::<foo__bindgen_ty_1>(),
+        4usize,
+        concat!("Size of: ", stringify!(foo__bindgen_ty_1)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < foo__bindgen_ty_1 > (), 4usize, concat!("Alignment of ",
-        stringify!(foo__bindgen_ty_1))
+        ::std::mem::align_of::<foo__bindgen_ty_1>(),
+        4usize,
+        concat!("Alignment of ", stringify!(foo__bindgen_ty_1)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).a) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(foo__bindgen_ty_1), "::", stringify!(a))
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(foo__bindgen_ty_1), "::", stringify!(a)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).b) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(foo__bindgen_ty_1), "::", stringify!(b))
+        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(foo__bindgen_ty_1), "::", stringify!(b)),
     );
 }
 impl Default for foo__bindgen_ty_1 {
@@ -45,15 +49,19 @@ fn bindgen_test_layout_foo() {
     const UNINIT: ::std::mem::MaybeUninit<foo> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < foo > (), 4usize, concat!("Size of: ", stringify!(foo))
+        ::std::mem::size_of::<foo>(),
+        4usize,
+        concat!("Size of: ", stringify!(foo)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < foo > (), 4usize, concat!("Alignment of ",
-        stringify!(foo))
+        ::std::mem::align_of::<foo>(),
+        4usize,
+        concat!("Alignment of ", stringify!(foo)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).bar) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar))
+        unsafe { ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar)),
     );
 }
 impl Default for foo {

--- a/bindgen-tests/tests/expectations/tests/struct_with_anon_union_1_0.rs
+++ b/bindgen-tests/tests/expectations/tests/struct_with_anon_union_1_0.rs
@@ -59,20 +59,24 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<foo__bindgen_ty_1> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < foo__bindgen_ty_1 > (), 4usize, concat!("Size of: ",
-        stringify!(foo__bindgen_ty_1))
+        ::std::mem::size_of::<foo__bindgen_ty_1>(),
+        4usize,
+        concat!("Size of: ", stringify!(foo__bindgen_ty_1)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < foo__bindgen_ty_1 > (), 4usize, concat!("Alignment of ",
-        stringify!(foo__bindgen_ty_1))
+        ::std::mem::align_of::<foo__bindgen_ty_1>(),
+        4usize,
+        concat!("Alignment of ", stringify!(foo__bindgen_ty_1)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).a) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(foo__bindgen_ty_1), "::", stringify!(a))
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(foo__bindgen_ty_1), "::", stringify!(a)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).b) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(foo__bindgen_ty_1), "::", stringify!(b))
+        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(foo__bindgen_ty_1), "::", stringify!(b)),
     );
 }
 impl Clone for foo__bindgen_ty_1 {
@@ -85,15 +89,19 @@ fn bindgen_test_layout_foo() {
     const UNINIT: ::std::mem::MaybeUninit<foo> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < foo > (), 4usize, concat!("Size of: ", stringify!(foo))
+        ::std::mem::size_of::<foo>(),
+        4usize,
+        concat!("Size of: ", stringify!(foo)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < foo > (), 4usize, concat!("Alignment of ",
-        stringify!(foo))
+        ::std::mem::align_of::<foo>(),
+        4usize,
+        concat!("Alignment of ", stringify!(foo)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).bar) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar))
+        unsafe { ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar)),
     );
 }
 impl Clone for foo {

--- a/bindgen-tests/tests/expectations/tests/struct_with_anon_unnamed_struct.rs
+++ b/bindgen-tests/tests/expectations/tests/struct_with_anon_unnamed_struct.rs
@@ -15,29 +15,36 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<foo__bindgen_ty_1> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < foo__bindgen_ty_1 > (), 8usize, concat!("Size of: ",
-        stringify!(foo__bindgen_ty_1))
+        ::std::mem::size_of::<foo__bindgen_ty_1>(),
+        8usize,
+        concat!("Size of: ", stringify!(foo__bindgen_ty_1)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < foo__bindgen_ty_1 > (), 4usize, concat!("Alignment of ",
-        stringify!(foo__bindgen_ty_1))
+        ::std::mem::align_of::<foo__bindgen_ty_1>(),
+        4usize,
+        concat!("Alignment of ", stringify!(foo__bindgen_ty_1)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).a) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(foo__bindgen_ty_1), "::", stringify!(a))
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(foo__bindgen_ty_1), "::", stringify!(a)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).b) as usize - ptr as usize }, 4usize,
-        concat!("Offset of field: ", stringify!(foo__bindgen_ty_1), "::", stringify!(b))
+        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
+        4usize,
+        concat!("Offset of field: ", stringify!(foo__bindgen_ty_1), "::", stringify!(b)),
     );
 }
 #[test]
 fn bindgen_test_layout_foo() {
     assert_eq!(
-        ::std::mem::size_of:: < foo > (), 8usize, concat!("Size of: ", stringify!(foo))
+        ::std::mem::size_of::<foo>(),
+        8usize,
+        concat!("Size of: ", stringify!(foo)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < foo > (), 4usize, concat!("Alignment of ",
-        stringify!(foo))
+        ::std::mem::align_of::<foo>(),
+        4usize,
+        concat!("Alignment of ", stringify!(foo)),
     );
 }

--- a/bindgen-tests/tests/expectations/tests/struct_with_anon_unnamed_union.rs
+++ b/bindgen-tests/tests/expectations/tests/struct_with_anon_unnamed_union.rs
@@ -15,20 +15,24 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<foo__bindgen_ty_1> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < foo__bindgen_ty_1 > (), 4usize, concat!("Size of: ",
-        stringify!(foo__bindgen_ty_1))
+        ::std::mem::size_of::<foo__bindgen_ty_1>(),
+        4usize,
+        concat!("Size of: ", stringify!(foo__bindgen_ty_1)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < foo__bindgen_ty_1 > (), 4usize, concat!("Alignment of ",
-        stringify!(foo__bindgen_ty_1))
+        ::std::mem::align_of::<foo__bindgen_ty_1>(),
+        4usize,
+        concat!("Alignment of ", stringify!(foo__bindgen_ty_1)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).a) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(foo__bindgen_ty_1), "::", stringify!(a))
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(foo__bindgen_ty_1), "::", stringify!(a)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).b) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(foo__bindgen_ty_1), "::", stringify!(b))
+        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(foo__bindgen_ty_1), "::", stringify!(b)),
     );
 }
 impl Default for foo__bindgen_ty_1 {
@@ -43,11 +47,14 @@ impl Default for foo__bindgen_ty_1 {
 #[test]
 fn bindgen_test_layout_foo() {
     assert_eq!(
-        ::std::mem::size_of:: < foo > (), 4usize, concat!("Size of: ", stringify!(foo))
+        ::std::mem::size_of::<foo>(),
+        4usize,
+        concat!("Size of: ", stringify!(foo)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < foo > (), 4usize, concat!("Alignment of ",
-        stringify!(foo))
+        ::std::mem::align_of::<foo>(),
+        4usize,
+        concat!("Alignment of ", stringify!(foo)),
     );
 }
 impl Default for foo {

--- a/bindgen-tests/tests/expectations/tests/struct_with_anon_unnamed_union_1_0.rs
+++ b/bindgen-tests/tests/expectations/tests/struct_with_anon_unnamed_union_1_0.rs
@@ -59,20 +59,24 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<foo__bindgen_ty_1> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < foo__bindgen_ty_1 > (), 4usize, concat!("Size of: ",
-        stringify!(foo__bindgen_ty_1))
+        ::std::mem::size_of::<foo__bindgen_ty_1>(),
+        4usize,
+        concat!("Size of: ", stringify!(foo__bindgen_ty_1)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < foo__bindgen_ty_1 > (), 4usize, concat!("Alignment of ",
-        stringify!(foo__bindgen_ty_1))
+        ::std::mem::align_of::<foo__bindgen_ty_1>(),
+        4usize,
+        concat!("Alignment of ", stringify!(foo__bindgen_ty_1)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).a) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(foo__bindgen_ty_1), "::", stringify!(a))
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(foo__bindgen_ty_1), "::", stringify!(a)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).b) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(foo__bindgen_ty_1), "::", stringify!(b))
+        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(foo__bindgen_ty_1), "::", stringify!(b)),
     );
 }
 impl Clone for foo__bindgen_ty_1 {
@@ -83,11 +87,14 @@ impl Clone for foo__bindgen_ty_1 {
 #[test]
 fn bindgen_test_layout_foo() {
     assert_eq!(
-        ::std::mem::size_of:: < foo > (), 4usize, concat!("Size of: ", stringify!(foo))
+        ::std::mem::size_of::<foo>(),
+        4usize,
+        concat!("Size of: ", stringify!(foo)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < foo > (), 4usize, concat!("Alignment of ",
-        stringify!(foo))
+        ::std::mem::align_of::<foo>(),
+        4usize,
+        concat!("Alignment of ", stringify!(foo)),
     );
 }
 impl Clone for foo {

--- a/bindgen-tests/tests/expectations/tests/struct_with_bitfields.rs
+++ b/bindgen-tests/tests/expectations/tests/struct_with_bitfields.rs
@@ -49,7 +49,7 @@ where
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < self.storage.as_ref().len());
         debug_assert!(
-            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len()
+            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len(),
         );
         let mut val = 0;
         for i in 0..(bit_width as usize) {
@@ -69,7 +69,7 @@ where
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < self.storage.as_ref().len());
         debug_assert!(
-            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len()
+            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len(),
         );
         for i in 0..(bit_width as usize) {
             let mask = 1 << i;
@@ -97,16 +97,19 @@ fn bindgen_test_layout_bitfield() {
     const UNINIT: ::std::mem::MaybeUninit<bitfield> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < bitfield > (), 16usize, concat!("Size of: ",
-        stringify!(bitfield))
+        ::std::mem::size_of::<bitfield>(),
+        16usize,
+        concat!("Size of: ", stringify!(bitfield)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < bitfield > (), 4usize, concat!("Alignment of ",
-        stringify!(bitfield))
+        ::std::mem::align_of::<bitfield>(),
+        4usize,
+        concat!("Alignment of ", stringify!(bitfield)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).e) as usize - ptr as usize }, 4usize,
-        concat!("Offset of field: ", stringify!(bitfield), "::", stringify!(e))
+        unsafe { ::std::ptr::addr_of!((*ptr).e) as usize - ptr as usize },
+        4usize,
+        concat!("Offset of field: ", stringify!(bitfield), "::", stringify!(e)),
     );
 }
 impl bitfield {

--- a/bindgen-tests/tests/expectations/tests/struct_with_derive_debug.rs
+++ b/bindgen-tests/tests/expectations/tests/struct_with_derive_debug.rs
@@ -9,16 +9,19 @@ fn bindgen_test_layout_LittleArray() {
     const UNINIT: ::std::mem::MaybeUninit<LittleArray> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < LittleArray > (), 128usize, concat!("Size of: ",
-        stringify!(LittleArray))
+        ::std::mem::size_of::<LittleArray>(),
+        128usize,
+        concat!("Size of: ", stringify!(LittleArray)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < LittleArray > (), 4usize, concat!("Alignment of ",
-        stringify!(LittleArray))
+        ::std::mem::align_of::<LittleArray>(),
+        4usize,
+        concat!("Alignment of ", stringify!(LittleArray)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).a) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(LittleArray), "::", stringify!(a))
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(LittleArray), "::", stringify!(a)),
     );
 }
 #[repr(C)]
@@ -31,16 +34,19 @@ fn bindgen_test_layout_BigArray() {
     const UNINIT: ::std::mem::MaybeUninit<BigArray> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < BigArray > (), 132usize, concat!("Size of: ",
-        stringify!(BigArray))
+        ::std::mem::size_of::<BigArray>(),
+        132usize,
+        concat!("Size of: ", stringify!(BigArray)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < BigArray > (), 4usize, concat!("Alignment of ",
-        stringify!(BigArray))
+        ::std::mem::align_of::<BigArray>(),
+        4usize,
+        concat!("Alignment of ", stringify!(BigArray)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).a) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(BigArray), "::", stringify!(a))
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(BigArray), "::", stringify!(a)),
     );
 }
 impl Default for BigArray {
@@ -62,16 +68,19 @@ fn bindgen_test_layout_WithLittleArray() {
     const UNINIT: ::std::mem::MaybeUninit<WithLittleArray> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < WithLittleArray > (), 128usize, concat!("Size of: ",
-        stringify!(WithLittleArray))
+        ::std::mem::size_of::<WithLittleArray>(),
+        128usize,
+        concat!("Size of: ", stringify!(WithLittleArray)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < WithLittleArray > (), 4usize, concat!("Alignment of ",
-        stringify!(WithLittleArray))
+        ::std::mem::align_of::<WithLittleArray>(),
+        4usize,
+        concat!("Alignment of ", stringify!(WithLittleArray)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).a) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(WithLittleArray), "::", stringify!(a))
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(WithLittleArray), "::", stringify!(a)),
     );
 }
 #[repr(C)]
@@ -84,16 +93,19 @@ fn bindgen_test_layout_WithBigArray() {
     const UNINIT: ::std::mem::MaybeUninit<WithBigArray> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < WithBigArray > (), 132usize, concat!("Size of: ",
-        stringify!(WithBigArray))
+        ::std::mem::size_of::<WithBigArray>(),
+        132usize,
+        concat!("Size of: ", stringify!(WithBigArray)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < WithBigArray > (), 4usize, concat!("Alignment of ",
-        stringify!(WithBigArray))
+        ::std::mem::align_of::<WithBigArray>(),
+        4usize,
+        concat!("Alignment of ", stringify!(WithBigArray)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).a) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(WithBigArray), "::", stringify!(a))
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(WithBigArray), "::", stringify!(a)),
     );
 }
 impl Default for WithBigArray {

--- a/bindgen-tests/tests/expectations/tests/struct_with_large_array.rs
+++ b/bindgen-tests/tests/expectations/tests/struct_with_large_array.rs
@@ -8,16 +8,16 @@ pub struct S {
 fn bindgen_test_layout_S() {
     const UNINIT: ::std::mem::MaybeUninit<S> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
+    assert_eq!(::std::mem::size_of::<S>(), 33usize, concat!("Size of: ", stringify!(S)));
     assert_eq!(
-        ::std::mem::size_of:: < S > (), 33usize, concat!("Size of: ", stringify!(S))
+        ::std::mem::align_of::<S>(),
+        1usize,
+        concat!("Alignment of ", stringify!(S)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < S > (), 1usize, concat!("Alignment of ", stringify!(S))
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).large_array) as usize - ptr as usize },
-        0usize, concat!("Offset of field: ", stringify!(S), "::",
-        stringify!(large_array))
+        unsafe { ::std::ptr::addr_of!((*ptr).large_array) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(S), "::", stringify!(large_array)),
     );
 }
 impl Default for S {

--- a/bindgen-tests/tests/expectations/tests/struct_with_nesting.rs
+++ b/bindgen-tests/tests/expectations/tests/struct_with_nesting.rs
@@ -23,22 +23,34 @@ fn bindgen_test_layout_foo__bindgen_ty_1__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<foo__bindgen_ty_1__bindgen_ty_1> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < foo__bindgen_ty_1__bindgen_ty_1 > (), 4usize,
-        concat!("Size of: ", stringify!(foo__bindgen_ty_1__bindgen_ty_1))
+        ::std::mem::size_of::<foo__bindgen_ty_1__bindgen_ty_1>(),
+        4usize,
+        concat!("Size of: ", stringify!(foo__bindgen_ty_1__bindgen_ty_1)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < foo__bindgen_ty_1__bindgen_ty_1 > (), 2usize,
-        concat!("Alignment of ", stringify!(foo__bindgen_ty_1__bindgen_ty_1))
+        ::std::mem::align_of::<foo__bindgen_ty_1__bindgen_ty_1>(),
+        2usize,
+        concat!("Alignment of ", stringify!(foo__bindgen_ty_1__bindgen_ty_1)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).c1) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(foo__bindgen_ty_1__bindgen_ty_1), "::",
-        stringify!(c1))
+        unsafe { ::std::ptr::addr_of!((*ptr).c1) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(foo__bindgen_ty_1__bindgen_ty_1),
+            "::",
+            stringify!(c1),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).c2) as usize - ptr as usize }, 2usize,
-        concat!("Offset of field: ", stringify!(foo__bindgen_ty_1__bindgen_ty_1), "::",
-        stringify!(c2))
+        unsafe { ::std::ptr::addr_of!((*ptr).c2) as usize - ptr as usize },
+        2usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(foo__bindgen_ty_1__bindgen_ty_1),
+            "::",
+            stringify!(c2),
+        ),
     );
 }
 #[repr(C)]
@@ -54,32 +66,54 @@ fn bindgen_test_layout_foo__bindgen_ty_1__bindgen_ty_2() {
     const UNINIT: ::std::mem::MaybeUninit<foo__bindgen_ty_1__bindgen_ty_2> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < foo__bindgen_ty_1__bindgen_ty_2 > (), 4usize,
-        concat!("Size of: ", stringify!(foo__bindgen_ty_1__bindgen_ty_2))
+        ::std::mem::size_of::<foo__bindgen_ty_1__bindgen_ty_2>(),
+        4usize,
+        concat!("Size of: ", stringify!(foo__bindgen_ty_1__bindgen_ty_2)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < foo__bindgen_ty_1__bindgen_ty_2 > (), 1usize,
-        concat!("Alignment of ", stringify!(foo__bindgen_ty_1__bindgen_ty_2))
+        ::std::mem::align_of::<foo__bindgen_ty_1__bindgen_ty_2>(),
+        1usize,
+        concat!("Alignment of ", stringify!(foo__bindgen_ty_1__bindgen_ty_2)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).d1) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(foo__bindgen_ty_1__bindgen_ty_2), "::",
-        stringify!(d1))
+        unsafe { ::std::ptr::addr_of!((*ptr).d1) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(foo__bindgen_ty_1__bindgen_ty_2),
+            "::",
+            stringify!(d1),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).d2) as usize - ptr as usize }, 1usize,
-        concat!("Offset of field: ", stringify!(foo__bindgen_ty_1__bindgen_ty_2), "::",
-        stringify!(d2))
+        unsafe { ::std::ptr::addr_of!((*ptr).d2) as usize - ptr as usize },
+        1usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(foo__bindgen_ty_1__bindgen_ty_2),
+            "::",
+            stringify!(d2),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).d3) as usize - ptr as usize }, 2usize,
-        concat!("Offset of field: ", stringify!(foo__bindgen_ty_1__bindgen_ty_2), "::",
-        stringify!(d3))
+        unsafe { ::std::ptr::addr_of!((*ptr).d3) as usize - ptr as usize },
+        2usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(foo__bindgen_ty_1__bindgen_ty_2),
+            "::",
+            stringify!(d3),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).d4) as usize - ptr as usize }, 3usize,
-        concat!("Offset of field: ", stringify!(foo__bindgen_ty_1__bindgen_ty_2), "::",
-        stringify!(d4))
+        unsafe { ::std::ptr::addr_of!((*ptr).d4) as usize - ptr as usize },
+        3usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(foo__bindgen_ty_1__bindgen_ty_2),
+            "::",
+            stringify!(d4),
+        ),
     );
 }
 #[test]
@@ -87,16 +121,19 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<foo__bindgen_ty_1> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < foo__bindgen_ty_1 > (), 4usize, concat!("Size of: ",
-        stringify!(foo__bindgen_ty_1))
+        ::std::mem::size_of::<foo__bindgen_ty_1>(),
+        4usize,
+        concat!("Size of: ", stringify!(foo__bindgen_ty_1)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < foo__bindgen_ty_1 > (), 4usize, concat!("Alignment of ",
-        stringify!(foo__bindgen_ty_1))
+        ::std::mem::align_of::<foo__bindgen_ty_1>(),
+        4usize,
+        concat!("Alignment of ", stringify!(foo__bindgen_ty_1)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).b) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(foo__bindgen_ty_1), "::", stringify!(b))
+        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(foo__bindgen_ty_1), "::", stringify!(b)),
     );
 }
 impl Default for foo__bindgen_ty_1 {
@@ -113,15 +150,19 @@ fn bindgen_test_layout_foo() {
     const UNINIT: ::std::mem::MaybeUninit<foo> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < foo > (), 8usize, concat!("Size of: ", stringify!(foo))
+        ::std::mem::size_of::<foo>(),
+        8usize,
+        concat!("Size of: ", stringify!(foo)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < foo > (), 4usize, concat!("Alignment of ",
-        stringify!(foo))
+        ::std::mem::align_of::<foo>(),
+        4usize,
+        concat!("Alignment of ", stringify!(foo)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).a) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(a))
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(foo), "::", stringify!(a)),
     );
 }
 impl Default for foo {

--- a/bindgen-tests/tests/expectations/tests/struct_with_nesting_1_0.rs
+++ b/bindgen-tests/tests/expectations/tests/struct_with_nesting_1_0.rs
@@ -67,22 +67,34 @@ fn bindgen_test_layout_foo__bindgen_ty_1__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<foo__bindgen_ty_1__bindgen_ty_1> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < foo__bindgen_ty_1__bindgen_ty_1 > (), 4usize,
-        concat!("Size of: ", stringify!(foo__bindgen_ty_1__bindgen_ty_1))
+        ::std::mem::size_of::<foo__bindgen_ty_1__bindgen_ty_1>(),
+        4usize,
+        concat!("Size of: ", stringify!(foo__bindgen_ty_1__bindgen_ty_1)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < foo__bindgen_ty_1__bindgen_ty_1 > (), 2usize,
-        concat!("Alignment of ", stringify!(foo__bindgen_ty_1__bindgen_ty_1))
+        ::std::mem::align_of::<foo__bindgen_ty_1__bindgen_ty_1>(),
+        2usize,
+        concat!("Alignment of ", stringify!(foo__bindgen_ty_1__bindgen_ty_1)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).c1) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(foo__bindgen_ty_1__bindgen_ty_1), "::",
-        stringify!(c1))
+        unsafe { ::std::ptr::addr_of!((*ptr).c1) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(foo__bindgen_ty_1__bindgen_ty_1),
+            "::",
+            stringify!(c1),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).c2) as usize - ptr as usize }, 2usize,
-        concat!("Offset of field: ", stringify!(foo__bindgen_ty_1__bindgen_ty_1), "::",
-        stringify!(c2))
+        unsafe { ::std::ptr::addr_of!((*ptr).c2) as usize - ptr as usize },
+        2usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(foo__bindgen_ty_1__bindgen_ty_1),
+            "::",
+            stringify!(c2),
+        ),
     );
 }
 impl Clone for foo__bindgen_ty_1__bindgen_ty_1 {
@@ -103,32 +115,54 @@ fn bindgen_test_layout_foo__bindgen_ty_1__bindgen_ty_2() {
     const UNINIT: ::std::mem::MaybeUninit<foo__bindgen_ty_1__bindgen_ty_2> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < foo__bindgen_ty_1__bindgen_ty_2 > (), 4usize,
-        concat!("Size of: ", stringify!(foo__bindgen_ty_1__bindgen_ty_2))
+        ::std::mem::size_of::<foo__bindgen_ty_1__bindgen_ty_2>(),
+        4usize,
+        concat!("Size of: ", stringify!(foo__bindgen_ty_1__bindgen_ty_2)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < foo__bindgen_ty_1__bindgen_ty_2 > (), 1usize,
-        concat!("Alignment of ", stringify!(foo__bindgen_ty_1__bindgen_ty_2))
+        ::std::mem::align_of::<foo__bindgen_ty_1__bindgen_ty_2>(),
+        1usize,
+        concat!("Alignment of ", stringify!(foo__bindgen_ty_1__bindgen_ty_2)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).d1) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(foo__bindgen_ty_1__bindgen_ty_2), "::",
-        stringify!(d1))
+        unsafe { ::std::ptr::addr_of!((*ptr).d1) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(foo__bindgen_ty_1__bindgen_ty_2),
+            "::",
+            stringify!(d1),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).d2) as usize - ptr as usize }, 1usize,
-        concat!("Offset of field: ", stringify!(foo__bindgen_ty_1__bindgen_ty_2), "::",
-        stringify!(d2))
+        unsafe { ::std::ptr::addr_of!((*ptr).d2) as usize - ptr as usize },
+        1usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(foo__bindgen_ty_1__bindgen_ty_2),
+            "::",
+            stringify!(d2),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).d3) as usize - ptr as usize }, 2usize,
-        concat!("Offset of field: ", stringify!(foo__bindgen_ty_1__bindgen_ty_2), "::",
-        stringify!(d3))
+        unsafe { ::std::ptr::addr_of!((*ptr).d3) as usize - ptr as usize },
+        2usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(foo__bindgen_ty_1__bindgen_ty_2),
+            "::",
+            stringify!(d3),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).d4) as usize - ptr as usize }, 3usize,
-        concat!("Offset of field: ", stringify!(foo__bindgen_ty_1__bindgen_ty_2), "::",
-        stringify!(d4))
+        unsafe { ::std::ptr::addr_of!((*ptr).d4) as usize - ptr as usize },
+        3usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(foo__bindgen_ty_1__bindgen_ty_2),
+            "::",
+            stringify!(d4),
+        ),
     );
 }
 impl Clone for foo__bindgen_ty_1__bindgen_ty_2 {
@@ -141,16 +175,19 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<foo__bindgen_ty_1> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < foo__bindgen_ty_1 > (), 4usize, concat!("Size of: ",
-        stringify!(foo__bindgen_ty_1))
+        ::std::mem::size_of::<foo__bindgen_ty_1>(),
+        4usize,
+        concat!("Size of: ", stringify!(foo__bindgen_ty_1)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < foo__bindgen_ty_1 > (), 4usize, concat!("Alignment of ",
-        stringify!(foo__bindgen_ty_1))
+        ::std::mem::align_of::<foo__bindgen_ty_1>(),
+        4usize,
+        concat!("Alignment of ", stringify!(foo__bindgen_ty_1)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).b) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(foo__bindgen_ty_1), "::", stringify!(b))
+        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(foo__bindgen_ty_1), "::", stringify!(b)),
     );
 }
 impl Clone for foo__bindgen_ty_1 {
@@ -163,15 +200,19 @@ fn bindgen_test_layout_foo() {
     const UNINIT: ::std::mem::MaybeUninit<foo> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < foo > (), 8usize, concat!("Size of: ", stringify!(foo))
+        ::std::mem::size_of::<foo>(),
+        8usize,
+        concat!("Size of: ", stringify!(foo)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < foo > (), 4usize, concat!("Alignment of ",
-        stringify!(foo))
+        ::std::mem::align_of::<foo>(),
+        4usize,
+        concat!("Alignment of ", stringify!(foo)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).a) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(a))
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(foo), "::", stringify!(a)),
     );
 }
 impl Clone for foo {

--- a/bindgen-tests/tests/expectations/tests/struct_with_packing.rs
+++ b/bindgen-tests/tests/expectations/tests/struct_with_packing.rs
@@ -9,18 +9,20 @@ pub struct a {
 fn bindgen_test_layout_a() {
     const UNINIT: ::std::mem::MaybeUninit<a> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
+    assert_eq!(::std::mem::size_of::<a>(), 3usize, concat!("Size of: ", stringify!(a)));
     assert_eq!(
-        ::std::mem::size_of:: < a > (), 3usize, concat!("Size of: ", stringify!(a))
+        ::std::mem::align_of::<a>(),
+        1usize,
+        concat!("Alignment of ", stringify!(a)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < a > (), 1usize, concat!("Alignment of ", stringify!(a))
+        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(a), "::", stringify!(b)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).b) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(a), "::", stringify!(b))
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).c) as usize - ptr as usize }, 1usize,
-        concat!("Offset of field: ", stringify!(a), "::", stringify!(c))
+        unsafe { ::std::ptr::addr_of!((*ptr).c) as usize - ptr as usize },
+        1usize,
+        concat!("Offset of field: ", stringify!(a), "::", stringify!(c)),
     );
 }

--- a/bindgen-tests/tests/expectations/tests/struct_with_struct.rs
+++ b/bindgen-tests/tests/expectations/tests/struct_with_struct.rs
@@ -15,20 +15,24 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<foo__bindgen_ty_1> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < foo__bindgen_ty_1 > (), 8usize, concat!("Size of: ",
-        stringify!(foo__bindgen_ty_1))
+        ::std::mem::size_of::<foo__bindgen_ty_1>(),
+        8usize,
+        concat!("Size of: ", stringify!(foo__bindgen_ty_1)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < foo__bindgen_ty_1 > (), 4usize, concat!("Alignment of ",
-        stringify!(foo__bindgen_ty_1))
+        ::std::mem::align_of::<foo__bindgen_ty_1>(),
+        4usize,
+        concat!("Alignment of ", stringify!(foo__bindgen_ty_1)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).x) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(foo__bindgen_ty_1), "::", stringify!(x))
+        unsafe { ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(foo__bindgen_ty_1), "::", stringify!(x)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).y) as usize - ptr as usize }, 4usize,
-        concat!("Offset of field: ", stringify!(foo__bindgen_ty_1), "::", stringify!(y))
+        unsafe { ::std::ptr::addr_of!((*ptr).y) as usize - ptr as usize },
+        4usize,
+        concat!("Offset of field: ", stringify!(foo__bindgen_ty_1), "::", stringify!(y)),
     );
 }
 #[test]
@@ -36,14 +40,18 @@ fn bindgen_test_layout_foo() {
     const UNINIT: ::std::mem::MaybeUninit<foo> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < foo > (), 8usize, concat!("Size of: ", stringify!(foo))
+        ::std::mem::size_of::<foo>(),
+        8usize,
+        concat!("Size of: ", stringify!(foo)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < foo > (), 4usize, concat!("Alignment of ",
-        stringify!(foo))
+        ::std::mem::align_of::<foo>(),
+        4usize,
+        concat!("Alignment of ", stringify!(foo)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).bar) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar))
+        unsafe { ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar)),
     );
 }

--- a/bindgen-tests/tests/expectations/tests/template.rs
+++ b/bindgen-tests/tests/expectations/tests/template.rs
@@ -65,83 +65,101 @@ fn bindgen_test_layout_C() {
     const UNINIT: ::std::mem::MaybeUninit<C> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < C > (), 104usize, concat!("Size of: ", stringify!(C))
+        ::std::mem::size_of::<C>(),
+        104usize,
+        concat!("Size of: ", stringify!(C)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < C > (), 8usize, concat!("Alignment of ", stringify!(C))
+        ::std::mem::align_of::<C>(),
+        8usize,
+        concat!("Alignment of ", stringify!(C)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).mB) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(C), "::", stringify!(mB))
+        unsafe { ::std::ptr::addr_of!((*ptr).mB) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(C), "::", stringify!(mB)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).mBConstPtr) as usize - ptr as usize },
-        8usize, concat!("Offset of field: ", stringify!(C), "::", stringify!(mBConstPtr))
+        unsafe { ::std::ptr::addr_of!((*ptr).mBConstPtr) as usize - ptr as usize },
+        8usize,
+        concat!("Offset of field: ", stringify!(C), "::", stringify!(mBConstPtr)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).mBConstStructPtr) as usize - ptr as usize
-        }, 16usize, concat!("Offset of field: ", stringify!(C), "::",
-        stringify!(mBConstStructPtr))
+        unsafe { ::std::ptr::addr_of!((*ptr).mBConstStructPtr) as usize - ptr as usize },
+        16usize,
+        concat!("Offset of field: ", stringify!(C), "::", stringify!(mBConstStructPtr)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).mBConstStructPtrArray) as usize - ptr as
-        usize }, 24usize, concat!("Offset of field: ", stringify!(C), "::",
-        stringify!(mBConstStructPtrArray))
+        unsafe {
+            ::std::ptr::addr_of!((*ptr).mBConstStructPtrArray) as usize - ptr as usize
+        },
+        24usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(C),
+            "::",
+            stringify!(mBConstStructPtrArray),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).mBConst) as usize - ptr as usize },
-        32usize, concat!("Offset of field: ", stringify!(C), "::", stringify!(mBConst))
+        unsafe { ::std::ptr::addr_of!((*ptr).mBConst) as usize - ptr as usize },
+        32usize,
+        concat!("Offset of field: ", stringify!(C), "::", stringify!(mBConst)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).mBVolatile) as usize - ptr as usize },
-        36usize, concat!("Offset of field: ", stringify!(C), "::",
-        stringify!(mBVolatile))
+        unsafe { ::std::ptr::addr_of!((*ptr).mBVolatile) as usize - ptr as usize },
+        36usize,
+        concat!("Offset of field: ", stringify!(C), "::", stringify!(mBVolatile)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).mBConstBool) as usize - ptr as usize },
-        40usize, concat!("Offset of field: ", stringify!(C), "::",
-        stringify!(mBConstBool))
+        unsafe { ::std::ptr::addr_of!((*ptr).mBConstBool) as usize - ptr as usize },
+        40usize,
+        concat!("Offset of field: ", stringify!(C), "::", stringify!(mBConstBool)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).mBConstChar) as usize - ptr as usize },
-        42usize, concat!("Offset of field: ", stringify!(C), "::",
-        stringify!(mBConstChar))
+        unsafe { ::std::ptr::addr_of!((*ptr).mBConstChar) as usize - ptr as usize },
+        42usize,
+        concat!("Offset of field: ", stringify!(C), "::", stringify!(mBConstChar)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).mBArray) as usize - ptr as usize },
-        44usize, concat!("Offset of field: ", stringify!(C), "::", stringify!(mBArray))
+        unsafe { ::std::ptr::addr_of!((*ptr).mBArray) as usize - ptr as usize },
+        44usize,
+        concat!("Offset of field: ", stringify!(C), "::", stringify!(mBArray)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).mBPtrArray) as usize - ptr as usize },
-        48usize, concat!("Offset of field: ", stringify!(C), "::",
-        stringify!(mBPtrArray))
+        unsafe { ::std::ptr::addr_of!((*ptr).mBPtrArray) as usize - ptr as usize },
+        48usize,
+        concat!("Offset of field: ", stringify!(C), "::", stringify!(mBPtrArray)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).mBArrayPtr) as usize - ptr as usize },
-        56usize, concat!("Offset of field: ", stringify!(C), "::",
-        stringify!(mBArrayPtr))
+        unsafe { ::std::ptr::addr_of!((*ptr).mBArrayPtr) as usize - ptr as usize },
+        56usize,
+        concat!("Offset of field: ", stringify!(C), "::", stringify!(mBArrayPtr)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).mBRef) as usize - ptr as usize }, 64usize,
-        concat!("Offset of field: ", stringify!(C), "::", stringify!(mBRef))
+        unsafe { ::std::ptr::addr_of!((*ptr).mBRef) as usize - ptr as usize },
+        64usize,
+        concat!("Offset of field: ", stringify!(C), "::", stringify!(mBRef)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).mBConstRef) as usize - ptr as usize },
-        72usize, concat!("Offset of field: ", stringify!(C), "::",
-        stringify!(mBConstRef))
+        unsafe { ::std::ptr::addr_of!((*ptr).mBConstRef) as usize - ptr as usize },
+        72usize,
+        concat!("Offset of field: ", stringify!(C), "::", stringify!(mBConstRef)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).mPtrRef) as usize - ptr as usize },
-        80usize, concat!("Offset of field: ", stringify!(C), "::", stringify!(mPtrRef))
+        unsafe { ::std::ptr::addr_of!((*ptr).mPtrRef) as usize - ptr as usize },
+        80usize,
+        concat!("Offset of field: ", stringify!(C), "::", stringify!(mPtrRef)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).mArrayRef) as usize - ptr as usize },
-        88usize, concat!("Offset of field: ", stringify!(C), "::", stringify!(mArrayRef))
+        unsafe { ::std::ptr::addr_of!((*ptr).mArrayRef) as usize - ptr as usize },
+        88usize,
+        concat!("Offset of field: ", stringify!(C), "::", stringify!(mArrayRef)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).mBConstArray) as usize - ptr as usize },
-        96usize, concat!("Offset of field: ", stringify!(C), "::",
-        stringify!(mBConstArray))
+        unsafe { ::std::ptr::addr_of!((*ptr).mBConstArray) as usize - ptr as usize },
+        96usize,
+        concat!("Offset of field: ", stringify!(C), "::", stringify!(mBConstArray)),
     );
 }
 impl Default for C {
@@ -211,16 +229,19 @@ fn bindgen_test_layout_RootedContainer() {
     const UNINIT: ::std::mem::MaybeUninit<RootedContainer> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < RootedContainer > (), 24usize, concat!("Size of: ",
-        stringify!(RootedContainer))
+        ::std::mem::size_of::<RootedContainer>(),
+        24usize,
+        concat!("Size of: ", stringify!(RootedContainer)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < RootedContainer > (), 8usize, concat!("Alignment of ",
-        stringify!(RootedContainer))
+        ::std::mem::align_of::<RootedContainer>(),
+        8usize,
+        concat!("Alignment of ", stringify!(RootedContainer)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).root) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(RootedContainer), "::", stringify!(root))
+        unsafe { ::std::ptr::addr_of!((*ptr).root) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(RootedContainer), "::", stringify!(root)),
     );
 }
 impl Default for RootedContainer {
@@ -258,17 +279,24 @@ fn bindgen_test_layout_PODButContainsDtor() {
     const UNINIT: ::std::mem::MaybeUninit<PODButContainsDtor> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < PODButContainsDtor > (), 4usize, concat!("Size of: ",
-        stringify!(PODButContainsDtor))
+        ::std::mem::size_of::<PODButContainsDtor>(),
+        4usize,
+        concat!("Size of: ", stringify!(PODButContainsDtor)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < PODButContainsDtor > (), 4usize,
-        concat!("Alignment of ", stringify!(PODButContainsDtor))
+        ::std::mem::align_of::<PODButContainsDtor>(),
+        4usize,
+        concat!("Alignment of ", stringify!(PODButContainsDtor)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).member) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(PODButContainsDtor), "::",
-        stringify!(member))
+        unsafe { ::std::ptr::addr_of!((*ptr).member) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(PODButContainsDtor),
+            "::",
+            stringify!(member),
+        ),
     );
 }
 impl Default for PODButContainsDtor {
@@ -296,16 +324,19 @@ fn bindgen_test_layout_POD() {
     const UNINIT: ::std::mem::MaybeUninit<POD> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < POD > (), 4usize, concat!("Size of: ", stringify!(POD))
+        ::std::mem::size_of::<POD>(),
+        4usize,
+        concat!("Size of: ", stringify!(POD)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < POD > (), 4usize, concat!("Alignment of ",
-        stringify!(POD))
+        ::std::mem::align_of::<POD>(),
+        4usize,
+        concat!("Alignment of ", stringify!(POD)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).opaque_member) as usize - ptr as usize },
-        0usize, concat!("Offset of field: ", stringify!(POD), "::",
-        stringify!(opaque_member))
+        unsafe { ::std::ptr::addr_of!((*ptr).opaque_member) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(POD), "::", stringify!(opaque_member)),
     );
 }
 /// <div rustbindgen replaces="NestedReplaced"></div>
@@ -379,12 +410,14 @@ pub struct Untemplated {
 #[test]
 fn bindgen_test_layout_Untemplated() {
     assert_eq!(
-        ::std::mem::size_of:: < Untemplated > (), 1usize, concat!("Size of: ",
-        stringify!(Untemplated))
+        ::std::mem::size_of::<Untemplated>(),
+        1usize,
+        concat!("Size of: ", stringify!(Untemplated)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Untemplated > (), 1usize, concat!("Alignment of ",
-        stringify!(Untemplated))
+        ::std::mem::align_of::<Untemplated>(),
+        1usize,
+        concat!("Alignment of ", stringify!(Untemplated)),
     );
 }
 #[repr(C)]
@@ -463,269 +496,387 @@ impl<T> Default for ReplacedWithoutDestructorFwd<T> {
 #[test]
 fn __bindgen_test_layout_Foo_open0_int_int_close0_instantiation() {
     assert_eq!(
-        ::std::mem::size_of:: < Foo < ::std::os::raw::c_int > > (), 24usize,
-        concat!("Size of template specialization: ", stringify!(Foo <
-        ::std::os::raw::c_int >))
+        ::std::mem::size_of::<Foo<::std::os::raw::c_int>>(),
+        24usize,
+        concat!(
+            "Size of template specialization: ",
+            stringify!(Foo < ::std::os::raw::c_int >),
+        ),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Foo < ::std::os::raw::c_int > > (), 8usize,
-        concat!("Alignment of template specialization: ", stringify!(Foo <
-        ::std::os::raw::c_int >))
+        ::std::mem::align_of::<Foo<::std::os::raw::c_int>>(),
+        8usize,
+        concat!(
+            "Alignment of template specialization: ",
+            stringify!(Foo < ::std::os::raw::c_int >),
+        ),
     );
 }
 #[test]
 fn __bindgen_test_layout_B_open0_unsigned_int_close0_instantiation() {
     assert_eq!(
-        ::std::mem::size_of:: < B < ::std::os::raw::c_uint > > (), 4usize,
-        concat!("Size of template specialization: ", stringify!(B <
-        ::std::os::raw::c_uint >))
+        ::std::mem::size_of::<B<::std::os::raw::c_uint>>(),
+        4usize,
+        concat!(
+            "Size of template specialization: ",
+            stringify!(B < ::std::os::raw::c_uint >),
+        ),
     );
     assert_eq!(
-        ::std::mem::align_of:: < B < ::std::os::raw::c_uint > > (), 4usize,
-        concat!("Alignment of template specialization: ", stringify!(B <
-        ::std::os::raw::c_uint >))
+        ::std::mem::align_of::<B<::std::os::raw::c_uint>>(),
+        4usize,
+        concat!(
+            "Alignment of template specialization: ",
+            stringify!(B < ::std::os::raw::c_uint >),
+        ),
     );
 }
 #[test]
 fn __bindgen_test_layout_B_open0_ptr_const_int_close0_instantiation() {
     assert_eq!(
-        ::std::mem::size_of:: < B < * const ::std::os::raw::c_int > > (), 8usize,
-        concat!("Size of template specialization: ", stringify!(B < * const
-        ::std::os::raw::c_int >))
+        ::std::mem::size_of::<B<*const ::std::os::raw::c_int>>(),
+        8usize,
+        concat!(
+            "Size of template specialization: ",
+            stringify!(B < * const ::std::os::raw::c_int >),
+        ),
     );
     assert_eq!(
-        ::std::mem::align_of:: < B < * const ::std::os::raw::c_int > > (), 8usize,
-        concat!("Alignment of template specialization: ", stringify!(B < * const
-        ::std::os::raw::c_int >))
+        ::std::mem::align_of::<B<*const ::std::os::raw::c_int>>(),
+        8usize,
+        concat!(
+            "Alignment of template specialization: ",
+            stringify!(B < * const ::std::os::raw::c_int >),
+        ),
     );
 }
 #[test]
 fn __bindgen_test_layout_B_open0_ptr_const_mozilla__Foo_close0_instantiation() {
     assert_eq!(
-        ::std::mem::size_of:: < B < * const mozilla_Foo > > (), 8usize,
-        concat!("Size of template specialization: ", stringify!(B < * const mozilla_Foo
-        >))
+        ::std::mem::size_of::<B<*const mozilla_Foo>>(),
+        8usize,
+        concat!(
+            "Size of template specialization: ",
+            stringify!(B < * const mozilla_Foo >),
+        ),
     );
     assert_eq!(
-        ::std::mem::align_of:: < B < * const mozilla_Foo > > (), 8usize,
-        concat!("Alignment of template specialization: ", stringify!(B < * const
-        mozilla_Foo >))
+        ::std::mem::align_of::<B<*const mozilla_Foo>>(),
+        8usize,
+        concat!(
+            "Alignment of template specialization: ",
+            stringify!(B < * const mozilla_Foo >),
+        ),
     );
 }
 #[test]
 fn __bindgen_test_layout_B_open0_array1_ptr_const_mozilla__Foo_close0_instantiation() {
     assert_eq!(
-        ::std::mem::size_of:: < B < [* const mozilla_Foo; 1usize] > > (), 8usize,
-        concat!("Size of template specialization: ", stringify!(B < [* const mozilla_Foo;
-        1usize] >))
+        ::std::mem::size_of::<B<[*const mozilla_Foo; 1usize]>>(),
+        8usize,
+        concat!(
+            "Size of template specialization: ",
+            stringify!(B < [* const mozilla_Foo; 1usize] >),
+        ),
     );
     assert_eq!(
-        ::std::mem::align_of:: < B < [* const mozilla_Foo; 1usize] > > (), 8usize,
-        concat!("Alignment of template specialization: ", stringify!(B < [* const
-        mozilla_Foo; 1usize] >))
+        ::std::mem::align_of::<B<[*const mozilla_Foo; 1usize]>>(),
+        8usize,
+        concat!(
+            "Alignment of template specialization: ",
+            stringify!(B < [* const mozilla_Foo; 1usize] >),
+        ),
     );
 }
 #[test]
 fn __bindgen_test_layout_B_open0_const_int_close0_instantiation() {
     assert_eq!(
-        ::std::mem::size_of:: < B < ::std::os::raw::c_int > > (), 4usize,
-        concat!("Size of template specialization: ", stringify!(B < ::std::os::raw::c_int
-        >))
+        ::std::mem::size_of::<B<::std::os::raw::c_int>>(),
+        4usize,
+        concat!(
+            "Size of template specialization: ",
+            stringify!(B < ::std::os::raw::c_int >),
+        ),
     );
     assert_eq!(
-        ::std::mem::align_of:: < B < ::std::os::raw::c_int > > (), 4usize,
-        concat!("Alignment of template specialization: ", stringify!(B <
-        ::std::os::raw::c_int >))
+        ::std::mem::align_of::<B<::std::os::raw::c_int>>(),
+        4usize,
+        concat!(
+            "Alignment of template specialization: ",
+            stringify!(B < ::std::os::raw::c_int >),
+        ),
     );
 }
 #[test]
 fn __bindgen_test_layout_B_open0_volatile_int_close0_instantiation() {
     assert_eq!(
-        ::std::mem::size_of:: < B < ::std::os::raw::c_int > > (), 4usize,
-        concat!("Size of template specialization: ", stringify!(B < ::std::os::raw::c_int
-        >))
+        ::std::mem::size_of::<B<::std::os::raw::c_int>>(),
+        4usize,
+        concat!(
+            "Size of template specialization: ",
+            stringify!(B < ::std::os::raw::c_int >),
+        ),
     );
     assert_eq!(
-        ::std::mem::align_of:: < B < ::std::os::raw::c_int > > (), 4usize,
-        concat!("Alignment of template specialization: ", stringify!(B <
-        ::std::os::raw::c_int >))
+        ::std::mem::align_of::<B<::std::os::raw::c_int>>(),
+        4usize,
+        concat!(
+            "Alignment of template specialization: ",
+            stringify!(B < ::std::os::raw::c_int >),
+        ),
     );
 }
 #[test]
 fn __bindgen_test_layout_B_open0_const_bool_close0_instantiation() {
     assert_eq!(
-        ::std::mem::size_of:: < B < bool > > (), 1usize,
-        concat!("Size of template specialization: ", stringify!(B < bool >))
+        ::std::mem::size_of::<B<bool>>(),
+        1usize,
+        concat!("Size of template specialization: ", stringify!(B < bool >)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < B < bool > > (), 1usize,
-        concat!("Alignment of template specialization: ", stringify!(B < bool >))
+        ::std::mem::align_of::<B<bool>>(),
+        1usize,
+        concat!("Alignment of template specialization: ", stringify!(B < bool >)),
     );
 }
 #[test]
 fn __bindgen_test_layout_B_open0_const_char16_t_close0_instantiation() {
     assert_eq!(
-        ::std::mem::size_of:: < B < u16 > > (), 2usize,
-        concat!("Size of template specialization: ", stringify!(B < u16 >))
+        ::std::mem::size_of::<B<u16>>(),
+        2usize,
+        concat!("Size of template specialization: ", stringify!(B < u16 >)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < B < u16 > > (), 2usize,
-        concat!("Alignment of template specialization: ", stringify!(B < u16 >))
+        ::std::mem::align_of::<B<u16>>(),
+        2usize,
+        concat!("Alignment of template specialization: ", stringify!(B < u16 >)),
     );
 }
 #[test]
 fn __bindgen_test_layout_B_open0_array1_int_close0_instantiation() {
     assert_eq!(
-        ::std::mem::size_of:: < B < [::std::os::raw::c_int; 1usize] > > (), 4usize,
-        concat!("Size of template specialization: ", stringify!(B <
-        [::std::os::raw::c_int; 1usize] >))
+        ::std::mem::size_of::<B<[::std::os::raw::c_int; 1usize]>>(),
+        4usize,
+        concat!(
+            "Size of template specialization: ",
+            stringify!(B < [::std::os::raw::c_int; 1usize] >),
+        ),
     );
     assert_eq!(
-        ::std::mem::align_of:: < B < [::std::os::raw::c_int; 1usize] > > (), 4usize,
-        concat!("Alignment of template specialization: ", stringify!(B <
-        [::std::os::raw::c_int; 1usize] >))
+        ::std::mem::align_of::<B<[::std::os::raw::c_int; 1usize]>>(),
+        4usize,
+        concat!(
+            "Alignment of template specialization: ",
+            stringify!(B < [::std::os::raw::c_int; 1usize] >),
+        ),
     );
 }
 #[test]
 fn __bindgen_test_layout_B_open0_array1_ptr_int_close0_instantiation() {
     assert_eq!(
-        ::std::mem::size_of:: < B < [* mut ::std::os::raw::c_int; 1usize] > > (), 8usize,
-        concat!("Size of template specialization: ", stringify!(B < [* mut
-        ::std::os::raw::c_int; 1usize] >))
+        ::std::mem::size_of::<B<[*mut ::std::os::raw::c_int; 1usize]>>(),
+        8usize,
+        concat!(
+            "Size of template specialization: ",
+            stringify!(B < [* mut ::std::os::raw::c_int; 1usize] >),
+        ),
     );
     assert_eq!(
-        ::std::mem::align_of:: < B < [* mut ::std::os::raw::c_int; 1usize] > > (),
-        8usize, concat!("Alignment of template specialization: ", stringify!(B < [* mut
-        ::std::os::raw::c_int; 1usize] >))
+        ::std::mem::align_of::<B<[*mut ::std::os::raw::c_int; 1usize]>>(),
+        8usize,
+        concat!(
+            "Alignment of template specialization: ",
+            stringify!(B < [* mut ::std::os::raw::c_int; 1usize] >),
+        ),
     );
 }
 #[test]
 fn __bindgen_test_layout_B_open0_ptr_array1_int_close0_instantiation() {
     assert_eq!(
-        ::std::mem::size_of:: < B < * mut [::std::os::raw::c_int; 1usize] > > (), 8usize,
-        concat!("Size of template specialization: ", stringify!(B < * mut
-        [::std::os::raw::c_int; 1usize] >))
+        ::std::mem::size_of::<B<*mut [::std::os::raw::c_int; 1usize]>>(),
+        8usize,
+        concat!(
+            "Size of template specialization: ",
+            stringify!(B < * mut [::std::os::raw::c_int; 1usize] >),
+        ),
     );
     assert_eq!(
-        ::std::mem::align_of:: < B < * mut [::std::os::raw::c_int; 1usize] > > (),
-        8usize, concat!("Alignment of template specialization: ", stringify!(B < * mut
-        [::std::os::raw::c_int; 1usize] >))
+        ::std::mem::align_of::<B<*mut [::std::os::raw::c_int; 1usize]>>(),
+        8usize,
+        concat!(
+            "Alignment of template specialization: ",
+            stringify!(B < * mut [::std::os::raw::c_int; 1usize] >),
+        ),
     );
 }
 #[test]
 fn __bindgen_test_layout_B_open0_ref_int_close0_instantiation() {
     assert_eq!(
-        ::std::mem::size_of:: < B < * mut ::std::os::raw::c_int > > (), 8usize,
-        concat!("Size of template specialization: ", stringify!(B < * mut
-        ::std::os::raw::c_int >))
+        ::std::mem::size_of::<B<*mut ::std::os::raw::c_int>>(),
+        8usize,
+        concat!(
+            "Size of template specialization: ",
+            stringify!(B < * mut ::std::os::raw::c_int >),
+        ),
     );
     assert_eq!(
-        ::std::mem::align_of:: < B < * mut ::std::os::raw::c_int > > (), 8usize,
-        concat!("Alignment of template specialization: ", stringify!(B < * mut
-        ::std::os::raw::c_int >))
+        ::std::mem::align_of::<B<*mut ::std::os::raw::c_int>>(),
+        8usize,
+        concat!(
+            "Alignment of template specialization: ",
+            stringify!(B < * mut ::std::os::raw::c_int >),
+        ),
     );
 }
 #[test]
 fn __bindgen_test_layout_B_open0_ref_const_int_close0_instantiation() {
     assert_eq!(
-        ::std::mem::size_of:: < B < * const ::std::os::raw::c_int > > (), 8usize,
-        concat!("Size of template specialization: ", stringify!(B < * const
-        ::std::os::raw::c_int >))
+        ::std::mem::size_of::<B<*const ::std::os::raw::c_int>>(),
+        8usize,
+        concat!(
+            "Size of template specialization: ",
+            stringify!(B < * const ::std::os::raw::c_int >),
+        ),
     );
     assert_eq!(
-        ::std::mem::align_of:: < B < * const ::std::os::raw::c_int > > (), 8usize,
-        concat!("Alignment of template specialization: ", stringify!(B < * const
-        ::std::os::raw::c_int >))
+        ::std::mem::align_of::<B<*const ::std::os::raw::c_int>>(),
+        8usize,
+        concat!(
+            "Alignment of template specialization: ",
+            stringify!(B < * const ::std::os::raw::c_int >),
+        ),
     );
 }
 #[test]
 fn __bindgen_test_layout_B_open0_ref_ptr_int_close0_instantiation() {
     assert_eq!(
-        ::std::mem::size_of:: < B < * mut * mut ::std::os::raw::c_int > > (), 8usize,
-        concat!("Size of template specialization: ", stringify!(B < * mut * mut
-        ::std::os::raw::c_int >))
+        ::std::mem::size_of::<B<*mut *mut ::std::os::raw::c_int>>(),
+        8usize,
+        concat!(
+            "Size of template specialization: ",
+            stringify!(B < * mut * mut ::std::os::raw::c_int >),
+        ),
     );
     assert_eq!(
-        ::std::mem::align_of:: < B < * mut * mut ::std::os::raw::c_int > > (), 8usize,
-        concat!("Alignment of template specialization: ", stringify!(B < * mut * mut
-        ::std::os::raw::c_int >))
+        ::std::mem::align_of::<B<*mut *mut ::std::os::raw::c_int>>(),
+        8usize,
+        concat!(
+            "Alignment of template specialization: ",
+            stringify!(B < * mut * mut ::std::os::raw::c_int >),
+        ),
     );
 }
 #[test]
 fn __bindgen_test_layout_B_open0_ref_array1_int_close0_instantiation() {
     assert_eq!(
-        ::std::mem::size_of:: < B < * mut [::std::os::raw::c_int; 1usize] > > (), 8usize,
-        concat!("Size of template specialization: ", stringify!(B < * mut
-        [::std::os::raw::c_int; 1usize] >))
+        ::std::mem::size_of::<B<*mut [::std::os::raw::c_int; 1usize]>>(),
+        8usize,
+        concat!(
+            "Size of template specialization: ",
+            stringify!(B < * mut [::std::os::raw::c_int; 1usize] >),
+        ),
     );
     assert_eq!(
-        ::std::mem::align_of:: < B < * mut [::std::os::raw::c_int; 1usize] > > (),
-        8usize, concat!("Alignment of template specialization: ", stringify!(B < * mut
-        [::std::os::raw::c_int; 1usize] >))
+        ::std::mem::align_of::<B<*mut [::std::os::raw::c_int; 1usize]>>(),
+        8usize,
+        concat!(
+            "Alignment of template specialization: ",
+            stringify!(B < * mut [::std::os::raw::c_int; 1usize] >),
+        ),
     );
 }
 #[test]
 fn __bindgen_test_layout_B_open0_array1_const_int_close0_instantiation() {
     assert_eq!(
-        ::std::mem::size_of:: < B < [::std::os::raw::c_int; 1usize] > > (), 4usize,
-        concat!("Size of template specialization: ", stringify!(B <
-        [::std::os::raw::c_int; 1usize] >))
+        ::std::mem::size_of::<B<[::std::os::raw::c_int; 1usize]>>(),
+        4usize,
+        concat!(
+            "Size of template specialization: ",
+            stringify!(B < [::std::os::raw::c_int; 1usize] >),
+        ),
     );
     assert_eq!(
-        ::std::mem::align_of:: < B < [::std::os::raw::c_int; 1usize] > > (), 4usize,
-        concat!("Alignment of template specialization: ", stringify!(B <
-        [::std::os::raw::c_int; 1usize] >))
+        ::std::mem::align_of::<B<[::std::os::raw::c_int; 1usize]>>(),
+        4usize,
+        concat!(
+            "Alignment of template specialization: ",
+            stringify!(B < [::std::os::raw::c_int; 1usize] >),
+        ),
     );
 }
 #[test]
 fn __bindgen_test_layout_Foo_open0_int_int_close0_instantiation_1() {
     assert_eq!(
-        ::std::mem::size_of:: < Foo < ::std::os::raw::c_int > > (), 24usize,
-        concat!("Size of template specialization: ", stringify!(Foo <
-        ::std::os::raw::c_int >))
+        ::std::mem::size_of::<Foo<::std::os::raw::c_int>>(),
+        24usize,
+        concat!(
+            "Size of template specialization: ",
+            stringify!(Foo < ::std::os::raw::c_int >),
+        ),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Foo < ::std::os::raw::c_int > > (), 8usize,
-        concat!("Alignment of template specialization: ", stringify!(Foo <
-        ::std::os::raw::c_int >))
+        ::std::mem::align_of::<Foo<::std::os::raw::c_int>>(),
+        8usize,
+        concat!(
+            "Alignment of template specialization: ",
+            stringify!(Foo < ::std::os::raw::c_int >),
+        ),
     );
 }
 #[test]
 fn __bindgen_test_layout_Rooted_open0_ptr_void_close0_instantiation() {
     assert_eq!(
-        ::std::mem::size_of:: < Rooted < * mut ::std::os::raw::c_void > > (), 24usize,
-        concat!("Size of template specialization: ", stringify!(Rooted < * mut
-        ::std::os::raw::c_void >))
+        ::std::mem::size_of::<Rooted<*mut ::std::os::raw::c_void>>(),
+        24usize,
+        concat!(
+            "Size of template specialization: ",
+            stringify!(Rooted < * mut ::std::os::raw::c_void >),
+        ),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Rooted < * mut ::std::os::raw::c_void > > (), 8usize,
-        concat!("Alignment of template specialization: ", stringify!(Rooted < * mut
-        ::std::os::raw::c_void >))
+        ::std::mem::align_of::<Rooted<*mut ::std::os::raw::c_void>>(),
+        8usize,
+        concat!(
+            "Alignment of template specialization: ",
+            stringify!(Rooted < * mut ::std::os::raw::c_void >),
+        ),
     );
 }
 #[test]
 fn __bindgen_test_layout_Rooted_open0_ptr_void_close0_instantiation_1() {
     assert_eq!(
-        ::std::mem::size_of:: < Rooted < * mut ::std::os::raw::c_void > > (), 24usize,
-        concat!("Size of template specialization: ", stringify!(Rooted < * mut
-        ::std::os::raw::c_void >))
+        ::std::mem::size_of::<Rooted<*mut ::std::os::raw::c_void>>(),
+        24usize,
+        concat!(
+            "Size of template specialization: ",
+            stringify!(Rooted < * mut ::std::os::raw::c_void >),
+        ),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Rooted < * mut ::std::os::raw::c_void > > (), 8usize,
-        concat!("Alignment of template specialization: ", stringify!(Rooted < * mut
-        ::std::os::raw::c_void >))
+        ::std::mem::align_of::<Rooted<*mut ::std::os::raw::c_void>>(),
+        8usize,
+        concat!(
+            "Alignment of template specialization: ",
+            stringify!(Rooted < * mut ::std::os::raw::c_void >),
+        ),
     );
 }
 #[test]
 fn __bindgen_test_layout_WithDtor_open0_int_close0_instantiation() {
     assert_eq!(
-        ::std::mem::size_of:: < WithDtor < ::std::os::raw::c_int > > (), 4usize,
-        concat!("Size of template specialization: ", stringify!(WithDtor <
-        ::std::os::raw::c_int >))
+        ::std::mem::size_of::<WithDtor<::std::os::raw::c_int>>(),
+        4usize,
+        concat!(
+            "Size of template specialization: ",
+            stringify!(WithDtor < ::std::os::raw::c_int >),
+        ),
     );
     assert_eq!(
-        ::std::mem::align_of:: < WithDtor < ::std::os::raw::c_int > > (), 4usize,
-        concat!("Alignment of template specialization: ", stringify!(WithDtor <
-        ::std::os::raw::c_int >))
+        ::std::mem::align_of::<WithDtor<::std::os::raw::c_int>>(),
+        4usize,
+        concat!(
+            "Alignment of template specialization: ",
+            stringify!(WithDtor < ::std::os::raw::c_int >),
+        ),
     );
 }

--- a/bindgen-tests/tests/expectations/tests/template_instantiation_with_fn_local_type.rs
+++ b/bindgen-tests/tests/expectations/tests/template_instantiation_with_fn_local_type.rs
@@ -11,12 +11,14 @@ extern "C" {
 #[test]
 fn __bindgen_test_layout_Foo_open0_Bar_close0_instantiation() {
     assert_eq!(
-        ::std::mem::size_of:: < Foo > (), 1usize,
-        concat!("Size of template specialization: ", stringify!(Foo))
+        ::std::mem::size_of::<Foo>(),
+        1usize,
+        concat!("Size of template specialization: ", stringify!(Foo)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Foo > (), 1usize,
-        concat!("Alignment of template specialization: ", stringify!(Foo))
+        ::std::mem::align_of::<Foo>(),
+        1usize,
+        concat!("Alignment of template specialization: ", stringify!(Foo)),
     );
 }
 #[repr(C)]
@@ -27,22 +29,27 @@ pub struct Baz {
 #[test]
 fn bindgen_test_layout_Baz() {
     assert_eq!(
-        ::std::mem::size_of:: < Baz > (), 1usize, concat!("Size of: ", stringify!(Baz))
+        ::std::mem::size_of::<Baz>(),
+        1usize,
+        concat!("Size of: ", stringify!(Baz)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Baz > (), 1usize, concat!("Alignment of ",
-        stringify!(Baz))
+        ::std::mem::align_of::<Baz>(),
+        1usize,
+        concat!("Alignment of ", stringify!(Baz)),
     );
 }
 #[test]
 fn __bindgen_test_layout_Foo_open0_Boo_close0_instantiation() {
     assert_eq!(
-        ::std::mem::size_of:: < Foo > (), 1usize,
-        concat!("Size of template specialization: ", stringify!(Foo))
+        ::std::mem::size_of::<Foo>(),
+        1usize,
+        concat!("Size of template specialization: ", stringify!(Foo)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Foo > (), 1usize,
-        concat!("Alignment of template specialization: ", stringify!(Foo))
+        ::std::mem::align_of::<Foo>(),
+        1usize,
+        concat!("Alignment of template specialization: ", stringify!(Foo)),
     );
 }
 #[repr(C)]
@@ -53,11 +60,14 @@ pub struct Bar {
 #[test]
 fn bindgen_test_layout_Bar() {
     assert_eq!(
-        ::std::mem::size_of:: < Bar > (), 1usize, concat!("Size of: ", stringify!(Bar))
+        ::std::mem::size_of::<Bar>(),
+        1usize,
+        concat!("Size of: ", stringify!(Bar)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Bar > (), 1usize, concat!("Alignment of ",
-        stringify!(Bar))
+        ::std::mem::align_of::<Bar>(),
+        1usize,
+        concat!("Alignment of ", stringify!(Bar)),
     );
 }
 #[repr(C)]
@@ -68,10 +78,13 @@ pub struct Boo {
 #[test]
 fn bindgen_test_layout_Boo() {
     assert_eq!(
-        ::std::mem::size_of:: < Boo > (), 1usize, concat!("Size of: ", stringify!(Boo))
+        ::std::mem::size_of::<Boo>(),
+        1usize,
+        concat!("Size of: ", stringify!(Boo)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Boo > (), 1usize, concat!("Alignment of ",
-        stringify!(Boo))
+        ::std::mem::align_of::<Boo>(),
+        1usize,
+        concat!("Alignment of ", stringify!(Boo)),
     );
 }

--- a/bindgen-tests/tests/expectations/tests/timex.rs
+++ b/bindgen-tests/tests/expectations/tests/timex.rs
@@ -49,7 +49,7 @@ where
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < self.storage.as_ref().len());
         debug_assert!(
-            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len()
+            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len(),
         );
         let mut val = 0;
         for i in 0..(bit_width as usize) {
@@ -69,7 +69,7 @@ where
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < self.storage.as_ref().len());
         debug_assert!(
-            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len()
+            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len(),
         );
         for i in 0..(bit_width as usize) {
             let mask = 1 << i;
@@ -95,16 +95,19 @@ fn bindgen_test_layout_timex() {
     const UNINIT: ::std::mem::MaybeUninit<timex> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < timex > (), 48usize, concat!("Size of: ",
-        stringify!(timex))
+        ::std::mem::size_of::<timex>(),
+        48usize,
+        concat!("Size of: ", stringify!(timex)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < timex > (), 4usize, concat!("Alignment of ",
-        stringify!(timex))
+        ::std::mem::align_of::<timex>(),
+        4usize,
+        concat!("Alignment of ", stringify!(timex)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).tai) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(timex), "::", stringify!(tai))
+        unsafe { ::std::ptr::addr_of!((*ptr).tai) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(timex), "::", stringify!(tai)),
     );
 }
 impl Default for timex {
@@ -128,16 +131,19 @@ fn bindgen_test_layout_timex_named() {
     const UNINIT: ::std::mem::MaybeUninit<timex_named> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < timex_named > (), 48usize, concat!("Size of: ",
-        stringify!(timex_named))
+        ::std::mem::size_of::<timex_named>(),
+        48usize,
+        concat!("Size of: ", stringify!(timex_named)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < timex_named > (), 4usize, concat!("Alignment of ",
-        stringify!(timex_named))
+        ::std::mem::align_of::<timex_named>(),
+        4usize,
+        concat!("Alignment of ", stringify!(timex_named)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).tai) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(timex_named), "::", stringify!(tai))
+        unsafe { ::std::ptr::addr_of!((*ptr).tai) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(timex_named), "::", stringify!(tai)),
     );
 }
 impl Default for timex_named {

--- a/bindgen-tests/tests/expectations/tests/transform-op.rs
+++ b/bindgen-tests/tests/expectations/tests/transform-op.rs
@@ -217,22 +217,26 @@ impl<T> Default for StyleBar<T> {
 #[test]
 fn __bindgen_test_layout_StylePoint_open0_float_close0_instantiation() {
     assert_eq!(
-        ::std::mem::size_of:: < StylePoint < f32 > > (), 8usize,
-        concat!("Size of template specialization: ", stringify!(StylePoint < f32 >))
+        ::std::mem::size_of::<StylePoint<f32>>(),
+        8usize,
+        concat!("Size of template specialization: ", stringify!(StylePoint < f32 >)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < StylePoint < f32 > > (), 4usize,
-        concat!("Alignment of template specialization: ", stringify!(StylePoint < f32 >))
+        ::std::mem::align_of::<StylePoint<f32>>(),
+        4usize,
+        concat!("Alignment of template specialization: ", stringify!(StylePoint < f32 >)),
     );
 }
 #[test]
 fn __bindgen_test_layout_StylePoint_open0_float_close0_instantiation_1() {
     assert_eq!(
-        ::std::mem::size_of:: < StylePoint < f32 > > (), 8usize,
-        concat!("Size of template specialization: ", stringify!(StylePoint < f32 >))
+        ::std::mem::size_of::<StylePoint<f32>>(),
+        8usize,
+        concat!("Size of template specialization: ", stringify!(StylePoint < f32 >)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < StylePoint < f32 > > (), 4usize,
-        concat!("Alignment of template specialization: ", stringify!(StylePoint < f32 >))
+        ::std::mem::align_of::<StylePoint<f32>>(),
+        4usize,
+        concat!("Alignment of template specialization: ", stringify!(StylePoint < f32 >)),
     );
 }

--- a/bindgen-tests/tests/expectations/tests/type-referenced-by-allowlisted-function.rs
+++ b/bindgen-tests/tests/expectations/tests/type-referenced-by-allowlisted-function.rs
@@ -9,16 +9,19 @@ fn bindgen_test_layout_dl_phdr_info() {
     const UNINIT: ::std::mem::MaybeUninit<dl_phdr_info> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < dl_phdr_info > (), 4usize, concat!("Size of: ",
-        stringify!(dl_phdr_info))
+        ::std::mem::size_of::<dl_phdr_info>(),
+        4usize,
+        concat!("Size of: ", stringify!(dl_phdr_info)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < dl_phdr_info > (), 4usize, concat!("Alignment of ",
-        stringify!(dl_phdr_info))
+        ::std::mem::align_of::<dl_phdr_info>(),
+        4usize,
+        concat!("Alignment of ", stringify!(dl_phdr_info)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).x) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(dl_phdr_info), "::", stringify!(x))
+        unsafe { ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(dl_phdr_info), "::", stringify!(x)),
     );
 }
 extern "C" {

--- a/bindgen-tests/tests/expectations/tests/typedef-pointer-overlap.rs
+++ b/bindgen-tests/tests/expectations/tests/typedef-pointer-overlap.rs
@@ -9,15 +9,19 @@ fn bindgen_test_layout_foo() {
     const UNINIT: ::std::mem::MaybeUninit<foo> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < foo > (), 1usize, concat!("Size of: ", stringify!(foo))
+        ::std::mem::size_of::<foo>(),
+        1usize,
+        concat!("Size of: ", stringify!(foo)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < foo > (), 1usize, concat!("Alignment of ",
-        stringify!(foo))
+        ::std::mem::align_of::<foo>(),
+        1usize,
+        concat!("Alignment of ", stringify!(foo)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).inner) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(inner))
+        unsafe { ::std::ptr::addr_of!((*ptr).inner) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(foo), "::", stringify!(inner)),
     );
 }
 pub type foo_ptr = *const foo;
@@ -31,15 +35,19 @@ fn bindgen_test_layout_bar() {
     const UNINIT: ::std::mem::MaybeUninit<bar> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < bar > (), 1usize, concat!("Size of: ", stringify!(bar))
+        ::std::mem::size_of::<bar>(),
+        1usize,
+        concat!("Size of: ", stringify!(bar)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < bar > (), 1usize, concat!("Alignment of ",
-        stringify!(bar))
+        ::std::mem::align_of::<bar>(),
+        1usize,
+        concat!("Alignment of ", stringify!(bar)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).inner) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(bar), "::", stringify!(inner))
+        unsafe { ::std::ptr::addr_of!((*ptr).inner) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(bar), "::", stringify!(inner)),
     );
 }
 pub type bar_ptr = *mut bar;
@@ -59,16 +67,19 @@ fn bindgen_test_layout_cat() {
     const UNINIT: ::std::mem::MaybeUninit<cat> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < cat > (), 4usize, concat!("Size of: ", stringify!(cat))
+        ::std::mem::size_of::<cat>(),
+        4usize,
+        concat!("Size of: ", stringify!(cat)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < cat > (), 4usize, concat!("Alignment of ",
-        stringify!(cat))
+        ::std::mem::align_of::<cat>(),
+        4usize,
+        concat!("Alignment of ", stringify!(cat)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).standard_issue) as usize - ptr as usize },
-        0usize, concat!("Offset of field: ", stringify!(cat), "::",
-        stringify!(standard_issue))
+        unsafe { ::std::ptr::addr_of!((*ptr).standard_issue) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(cat), "::", stringify!(standard_issue)),
     );
 }
 impl Default for cat {

--- a/bindgen-tests/tests/expectations/tests/typeref.rs
+++ b/bindgen-tests/tests/expectations/tests/typeref.rs
@@ -9,17 +9,24 @@ fn bindgen_test_layout_mozilla_FragmentOrURL() {
     const UNINIT: ::std::mem::MaybeUninit<mozilla_FragmentOrURL> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < mozilla_FragmentOrURL > (), 1usize, concat!("Size of: ",
-        stringify!(mozilla_FragmentOrURL))
+        ::std::mem::size_of::<mozilla_FragmentOrURL>(),
+        1usize,
+        concat!("Size of: ", stringify!(mozilla_FragmentOrURL)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < mozilla_FragmentOrURL > (), 1usize,
-        concat!("Alignment of ", stringify!(mozilla_FragmentOrURL))
+        ::std::mem::align_of::<mozilla_FragmentOrURL>(),
+        1usize,
+        concat!("Alignment of ", stringify!(mozilla_FragmentOrURL)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).mIsLocalRef) as usize - ptr as usize },
-        0usize, concat!("Offset of field: ", stringify!(mozilla_FragmentOrURL), "::",
-        stringify!(mIsLocalRef))
+        unsafe { ::std::ptr::addr_of!((*ptr).mIsLocalRef) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(mozilla_FragmentOrURL),
+            "::",
+            stringify!(mIsLocalRef),
+        ),
     );
 }
 #[repr(C)]
@@ -30,12 +37,14 @@ pub struct mozilla_Position {
 #[test]
 fn bindgen_test_layout_mozilla_Position() {
     assert_eq!(
-        ::std::mem::size_of:: < mozilla_Position > (), 1usize, concat!("Size of: ",
-        stringify!(mozilla_Position))
+        ::std::mem::size_of::<mozilla_Position>(),
+        1usize,
+        concat!("Size of: ", stringify!(mozilla_Position)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < mozilla_Position > (), 1usize, concat!("Alignment of ",
-        stringify!(mozilla_Position))
+        ::std::mem::align_of::<mozilla_Position>(),
+        1usize,
+        concat!("Alignment of ", stringify!(mozilla_Position)),
     );
 }
 #[repr(C)]
@@ -75,15 +84,19 @@ fn bindgen_test_layout_Bar() {
     const UNINIT: ::std::mem::MaybeUninit<Bar> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < Bar > (), 8usize, concat!("Size of: ", stringify!(Bar))
+        ::std::mem::size_of::<Bar>(),
+        8usize,
+        concat!("Size of: ", stringify!(Bar)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Bar > (), 8usize, concat!("Alignment of ",
-        stringify!(Bar))
+        ::std::mem::align_of::<Bar>(),
+        8usize,
+        concat!("Alignment of ", stringify!(Bar)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).mFoo) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(Bar), "::", stringify!(mFoo))
+        unsafe { ::std::ptr::addr_of!((*ptr).mFoo) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(Bar), "::", stringify!(mFoo)),
     );
 }
 impl Default for Bar {
@@ -104,16 +117,19 @@ fn bindgen_test_layout_nsFoo() {
     const UNINIT: ::std::mem::MaybeUninit<nsFoo> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < nsFoo > (), 8usize, concat!("Size of: ",
-        stringify!(nsFoo))
+        ::std::mem::size_of::<nsFoo>(),
+        8usize,
+        concat!("Size of: ", stringify!(nsFoo)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < nsFoo > (), 8usize, concat!("Alignment of ",
-        stringify!(nsFoo))
+        ::std::mem::align_of::<nsFoo>(),
+        8usize,
+        concat!("Alignment of ", stringify!(nsFoo)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).mBar) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(nsFoo), "::", stringify!(mBar))
+        unsafe { ::std::ptr::addr_of!((*ptr).mBar) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(nsFoo), "::", stringify!(mBar)),
     );
 }
 impl Default for nsFoo {
@@ -128,13 +144,19 @@ impl Default for nsFoo {
 #[test]
 fn __bindgen_test_layout_mozilla_StyleShapeSource_open0_int_close0_instantiation() {
     assert_eq!(
-        ::std::mem::size_of:: < mozilla_StyleShapeSource > (), 8usize,
-        concat!("Size of template specialization: ",
-        stringify!(mozilla_StyleShapeSource))
+        ::std::mem::size_of::<mozilla_StyleShapeSource>(),
+        8usize,
+        concat!(
+            "Size of template specialization: ",
+            stringify!(mozilla_StyleShapeSource),
+        ),
     );
     assert_eq!(
-        ::std::mem::align_of:: < mozilla_StyleShapeSource > (), 8usize,
-        concat!("Alignment of template specialization: ",
-        stringify!(mozilla_StyleShapeSource))
+        ::std::mem::align_of::<mozilla_StyleShapeSource>(),
+        8usize,
+        concat!(
+            "Alignment of template specialization: ",
+            stringify!(mozilla_StyleShapeSource),
+        ),
     );
 }

--- a/bindgen-tests/tests/expectations/tests/typeref_1_0.rs
+++ b/bindgen-tests/tests/expectations/tests/typeref_1_0.rs
@@ -52,17 +52,24 @@ fn bindgen_test_layout_mozilla_FragmentOrURL() {
     const UNINIT: ::std::mem::MaybeUninit<mozilla_FragmentOrURL> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < mozilla_FragmentOrURL > (), 1usize, concat!("Size of: ",
-        stringify!(mozilla_FragmentOrURL))
+        ::std::mem::size_of::<mozilla_FragmentOrURL>(),
+        1usize,
+        concat!("Size of: ", stringify!(mozilla_FragmentOrURL)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < mozilla_FragmentOrURL > (), 1usize,
-        concat!("Alignment of ", stringify!(mozilla_FragmentOrURL))
+        ::std::mem::align_of::<mozilla_FragmentOrURL>(),
+        1usize,
+        concat!("Alignment of ", stringify!(mozilla_FragmentOrURL)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).mIsLocalRef) as usize - ptr as usize },
-        0usize, concat!("Offset of field: ", stringify!(mozilla_FragmentOrURL), "::",
-        stringify!(mIsLocalRef))
+        unsafe { ::std::ptr::addr_of!((*ptr).mIsLocalRef) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(mozilla_FragmentOrURL),
+            "::",
+            stringify!(mIsLocalRef),
+        ),
     );
 }
 impl Clone for mozilla_FragmentOrURL {
@@ -78,12 +85,14 @@ pub struct mozilla_Position {
 #[test]
 fn bindgen_test_layout_mozilla_Position() {
     assert_eq!(
-        ::std::mem::size_of:: < mozilla_Position > (), 1usize, concat!("Size of: ",
-        stringify!(mozilla_Position))
+        ::std::mem::size_of::<mozilla_Position>(),
+        1usize,
+        concat!("Size of: ", stringify!(mozilla_Position)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < mozilla_Position > (), 1usize, concat!("Alignment of ",
-        stringify!(mozilla_Position))
+        ::std::mem::align_of::<mozilla_Position>(),
+        1usize,
+        concat!("Alignment of ", stringify!(mozilla_Position)),
     );
 }
 impl Clone for mozilla_Position {
@@ -113,15 +122,19 @@ fn bindgen_test_layout_Bar() {
     const UNINIT: ::std::mem::MaybeUninit<Bar> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < Bar > (), 8usize, concat!("Size of: ", stringify!(Bar))
+        ::std::mem::size_of::<Bar>(),
+        8usize,
+        concat!("Size of: ", stringify!(Bar)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Bar > (), 8usize, concat!("Alignment of ",
-        stringify!(Bar))
+        ::std::mem::align_of::<Bar>(),
+        8usize,
+        concat!("Alignment of ", stringify!(Bar)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).mFoo) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(Bar), "::", stringify!(mFoo))
+        unsafe { ::std::ptr::addr_of!((*ptr).mFoo) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(Bar), "::", stringify!(mFoo)),
     );
 }
 impl Clone for Bar {
@@ -148,16 +161,19 @@ fn bindgen_test_layout_nsFoo() {
     const UNINIT: ::std::mem::MaybeUninit<nsFoo> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < nsFoo > (), 8usize, concat!("Size of: ",
-        stringify!(nsFoo))
+        ::std::mem::size_of::<nsFoo>(),
+        8usize,
+        concat!("Size of: ", stringify!(nsFoo)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < nsFoo > (), 8usize, concat!("Alignment of ",
-        stringify!(nsFoo))
+        ::std::mem::align_of::<nsFoo>(),
+        8usize,
+        concat!("Alignment of ", stringify!(nsFoo)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).mBar) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(nsFoo), "::", stringify!(mBar))
+        unsafe { ::std::ptr::addr_of!((*ptr).mBar) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(nsFoo), "::", stringify!(mBar)),
     );
 }
 impl Clone for nsFoo {
@@ -168,13 +184,19 @@ impl Clone for nsFoo {
 #[test]
 fn __bindgen_test_layout_mozilla_StyleShapeSource_open0_int_close0_instantiation() {
     assert_eq!(
-        ::std::mem::size_of:: < mozilla_StyleShapeSource > (), 8usize,
-        concat!("Size of template specialization: ",
-        stringify!(mozilla_StyleShapeSource))
+        ::std::mem::size_of::<mozilla_StyleShapeSource>(),
+        8usize,
+        concat!(
+            "Size of template specialization: ",
+            stringify!(mozilla_StyleShapeSource),
+        ),
     );
     assert_eq!(
-        ::std::mem::align_of:: < mozilla_StyleShapeSource > (), 8usize,
-        concat!("Alignment of template specialization: ",
-        stringify!(mozilla_StyleShapeSource))
+        ::std::mem::align_of::<mozilla_StyleShapeSource>(),
+        8usize,
+        concat!(
+            "Alignment of template specialization: ",
+            stringify!(mozilla_StyleShapeSource),
+        ),
     );
 }

--- a/bindgen-tests/tests/expectations/tests/underscore.rs
+++ b/bindgen-tests/tests/expectations/tests/underscore.rs
@@ -10,15 +10,18 @@ fn bindgen_test_layout_ptr_t() {
     const UNINIT: ::std::mem::MaybeUninit<ptr_t> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < ptr_t > (), 8usize, concat!("Size of: ",
-        stringify!(ptr_t))
+        ::std::mem::size_of::<ptr_t>(),
+        8usize,
+        concat!("Size of: ", stringify!(ptr_t)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < ptr_t > (), 1usize, concat!("Alignment of ",
-        stringify!(ptr_t))
+        ::std::mem::align_of::<ptr_t>(),
+        1usize,
+        concat!("Alignment of ", stringify!(ptr_t)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).__) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(ptr_t), "::", stringify!(__))
+        unsafe { ::std::ptr::addr_of!((*ptr).__) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(ptr_t), "::", stringify!(__)),
     );
 }

--- a/bindgen-tests/tests/expectations/tests/union-align.rs
+++ b/bindgen-tests/tests/expectations/tests/union-align.rs
@@ -10,15 +10,19 @@ fn bindgen_test_layout_Bar() {
     const UNINIT: ::std::mem::MaybeUninit<Bar> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < Bar > (), 16usize, concat!("Size of: ", stringify!(Bar))
+        ::std::mem::size_of::<Bar>(),
+        16usize,
+        concat!("Size of: ", stringify!(Bar)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Bar > (), 16usize, concat!("Alignment of ",
-        stringify!(Bar))
+        ::std::mem::align_of::<Bar>(),
+        16usize,
+        concat!("Alignment of ", stringify!(Bar)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).foo) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(Bar), "::", stringify!(foo))
+        unsafe { ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(Bar), "::", stringify!(foo)),
     );
 }
 impl Default for Bar {
@@ -41,15 +45,19 @@ fn bindgen_test_layout_Baz() {
     const UNINIT: ::std::mem::MaybeUninit<Baz> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < Baz > (), 16usize, concat!("Size of: ", stringify!(Baz))
+        ::std::mem::size_of::<Baz>(),
+        16usize,
+        concat!("Size of: ", stringify!(Baz)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Baz > (), 16usize, concat!("Alignment of ",
-        stringify!(Baz))
+        ::std::mem::align_of::<Baz>(),
+        16usize,
+        concat!("Alignment of ", stringify!(Baz)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).bar) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(Baz), "::", stringify!(bar))
+        unsafe { ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(Baz), "::", stringify!(bar)),
     );
 }
 impl Default for Baz {

--- a/bindgen-tests/tests/expectations/tests/union-in-ns.rs
+++ b/bindgen-tests/tests/expectations/tests/union-in-ns.rs
@@ -13,16 +13,19 @@ pub mod root {
         const UNINIT: ::std::mem::MaybeUninit<bar> = ::std::mem::MaybeUninit::uninit();
         let ptr = UNINIT.as_ptr();
         assert_eq!(
-            ::std::mem::size_of:: < bar > (), 4usize, concat!("Size of: ",
-            stringify!(bar))
+            ::std::mem::size_of::<bar>(),
+            4usize,
+            concat!("Size of: ", stringify!(bar)),
         );
         assert_eq!(
-            ::std::mem::align_of:: < bar > (), 4usize, concat!("Alignment of ",
-            stringify!(bar))
+            ::std::mem::align_of::<bar>(),
+            4usize,
+            concat!("Alignment of ", stringify!(bar)),
         );
         assert_eq!(
-            unsafe { ::std::ptr::addr_of!((* ptr).baz) as usize - ptr as usize }, 0usize,
-            concat!("Offset of field: ", stringify!(bar), "::", stringify!(baz))
+            unsafe { ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize },
+            0usize,
+            concat!("Offset of field: ", stringify!(bar), "::", stringify!(baz)),
         );
     }
     impl Default for bar {

--- a/bindgen-tests/tests/expectations/tests/union-in-ns_1_0.rs
+++ b/bindgen-tests/tests/expectations/tests/union-in-ns_1_0.rs
@@ -57,16 +57,19 @@ pub mod root {
         const UNINIT: ::std::mem::MaybeUninit<bar> = ::std::mem::MaybeUninit::uninit();
         let ptr = UNINIT.as_ptr();
         assert_eq!(
-            ::std::mem::size_of:: < bar > (), 4usize, concat!("Size of: ",
-            stringify!(bar))
+            ::std::mem::size_of::<bar>(),
+            4usize,
+            concat!("Size of: ", stringify!(bar)),
         );
         assert_eq!(
-            ::std::mem::align_of:: < bar > (), 4usize, concat!("Alignment of ",
-            stringify!(bar))
+            ::std::mem::align_of::<bar>(),
+            4usize,
+            concat!("Alignment of ", stringify!(bar)),
         );
         assert_eq!(
-            unsafe { ::std::ptr::addr_of!((* ptr).baz) as usize - ptr as usize }, 0usize,
-            concat!("Offset of field: ", stringify!(bar), "::", stringify!(baz))
+            unsafe { ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize },
+            0usize,
+            concat!("Offset of field: ", stringify!(bar), "::", stringify!(baz)),
         );
     }
     impl Clone for bar {

--- a/bindgen-tests/tests/expectations/tests/union_bitfield.rs
+++ b/bindgen-tests/tests/expectations/tests/union_bitfield.rs
@@ -49,7 +49,7 @@ where
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < self.storage.as_ref().len());
         debug_assert!(
-            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len()
+            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len(),
         );
         let mut val = 0;
         for i in 0..(bit_width as usize) {
@@ -69,7 +69,7 @@ where
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < self.storage.as_ref().len());
         debug_assert!(
-            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len()
+            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len(),
         );
         for i in 0..(bit_width as usize) {
             let mask = 1 << i;
@@ -93,11 +93,14 @@ pub union U4 {
 #[test]
 fn bindgen_test_layout_U4() {
     assert_eq!(
-        ::std::mem::size_of:: < U4 > (), 4usize, concat!("Size of: ", stringify!(U4))
+        ::std::mem::size_of::<U4>(),
+        4usize,
+        concat!("Size of: ", stringify!(U4)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < U4 > (), 4usize, concat!("Alignment of ",
-        stringify!(U4))
+        ::std::mem::align_of::<U4>(),
+        4usize,
+        concat!("Alignment of ", stringify!(U4)),
     );
 }
 impl Default for U4 {
@@ -147,11 +150,11 @@ pub union B {
 }
 #[test]
 fn bindgen_test_layout_B() {
+    assert_eq!(::std::mem::size_of::<B>(), 4usize, concat!("Size of: ", stringify!(B)));
     assert_eq!(
-        ::std::mem::size_of:: < B > (), 4usize, concat!("Size of: ", stringify!(B))
-    );
-    assert_eq!(
-        ::std::mem::align_of:: < B > (), 4usize, concat!("Alignment of ", stringify!(B))
+        ::std::mem::align_of::<B>(),
+        4usize,
+        concat!("Alignment of ", stringify!(B)),
     );
 }
 impl Default for B {

--- a/bindgen-tests/tests/expectations/tests/union_bitfield_1_0.rs
+++ b/bindgen-tests/tests/expectations/tests/union_bitfield_1_0.rs
@@ -49,7 +49,7 @@ where
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < self.storage.as_ref().len());
         debug_assert!(
-            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len()
+            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len(),
         );
         let mut val = 0;
         for i in 0..(bit_width as usize) {
@@ -69,7 +69,7 @@ where
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < self.storage.as_ref().len());
         debug_assert!(
-            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len()
+            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len(),
         );
         for i in 0..(bit_width as usize) {
             let mask = 1 << i;
@@ -136,11 +136,14 @@ pub struct U4 {
 #[test]
 fn bindgen_test_layout_U4() {
     assert_eq!(
-        ::std::mem::size_of:: < U4 > (), 4usize, concat!("Size of: ", stringify!(U4))
+        ::std::mem::size_of::<U4>(),
+        4usize,
+        concat!("Size of: ", stringify!(U4)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < U4 > (), 4usize, concat!("Alignment of ",
-        stringify!(U4))
+        ::std::mem::align_of::<U4>(),
+        4usize,
+        concat!("Alignment of ", stringify!(U4)),
     );
 }
 impl Clone for U4 {
@@ -188,11 +191,11 @@ pub struct B {
 }
 #[test]
 fn bindgen_test_layout_B() {
+    assert_eq!(::std::mem::size_of::<B>(), 4usize, concat!("Size of: ", stringify!(B)));
     assert_eq!(
-        ::std::mem::size_of:: < B > (), 4usize, concat!("Size of: ", stringify!(B))
-    );
-    assert_eq!(
-        ::std::mem::align_of:: < B > (), 4usize, concat!("Alignment of ", stringify!(B))
+        ::std::mem::align_of::<B>(),
+        4usize,
+        concat!("Alignment of ", stringify!(B)),
     );
 }
 impl Clone for B {
@@ -264,8 +267,9 @@ pub struct HasBigBitfield {
 #[test]
 fn bindgen_test_layout_HasBigBitfield() {
     assert_eq!(
-        ::std::mem::size_of:: < HasBigBitfield > (), 16usize, concat!("Size of: ",
-        stringify!(HasBigBitfield))
+        ::std::mem::size_of::<HasBigBitfield>(),
+        16usize,
+        concat!("Size of: ", stringify!(HasBigBitfield)),
     );
 }
 impl Clone for HasBigBitfield {

--- a/bindgen-tests/tests/expectations/tests/union_dtor.rs
+++ b/bindgen-tests/tests/expectations/tests/union_dtor.rs
@@ -9,20 +9,24 @@ fn bindgen_test_layout_UnionWithDtor() {
     const UNINIT: ::std::mem::MaybeUninit<UnionWithDtor> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < UnionWithDtor > (), 8usize, concat!("Size of: ",
-        stringify!(UnionWithDtor))
+        ::std::mem::size_of::<UnionWithDtor>(),
+        8usize,
+        concat!("Size of: ", stringify!(UnionWithDtor)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < UnionWithDtor > (), 8usize, concat!("Alignment of ",
-        stringify!(UnionWithDtor))
+        ::std::mem::align_of::<UnionWithDtor>(),
+        8usize,
+        concat!("Alignment of ", stringify!(UnionWithDtor)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).mFoo) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(UnionWithDtor), "::", stringify!(mFoo))
+        unsafe { ::std::ptr::addr_of!((*ptr).mFoo) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(UnionWithDtor), "::", stringify!(mFoo)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).mBar) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(UnionWithDtor), "::", stringify!(mBar))
+        unsafe { ::std::ptr::addr_of!((*ptr).mBar) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(UnionWithDtor), "::", stringify!(mBar)),
     );
 }
 extern "C" {

--- a/bindgen-tests/tests/expectations/tests/union_dtor_1_0.rs
+++ b/bindgen-tests/tests/expectations/tests/union_dtor_1_0.rs
@@ -54,20 +54,24 @@ fn bindgen_test_layout_UnionWithDtor() {
     const UNINIT: ::std::mem::MaybeUninit<UnionWithDtor> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < UnionWithDtor > (), 8usize, concat!("Size of: ",
-        stringify!(UnionWithDtor))
+        ::std::mem::size_of::<UnionWithDtor>(),
+        8usize,
+        concat!("Size of: ", stringify!(UnionWithDtor)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < UnionWithDtor > (), 8usize, concat!("Alignment of ",
-        stringify!(UnionWithDtor))
+        ::std::mem::align_of::<UnionWithDtor>(),
+        8usize,
+        concat!("Alignment of ", stringify!(UnionWithDtor)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).mFoo) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(UnionWithDtor), "::", stringify!(mFoo))
+        unsafe { ::std::ptr::addr_of!((*ptr).mFoo) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(UnionWithDtor), "::", stringify!(mFoo)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).mBar) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(UnionWithDtor), "::", stringify!(mBar))
+        unsafe { ::std::ptr::addr_of!((*ptr).mBar) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(UnionWithDtor), "::", stringify!(mBar)),
     );
 }
 extern "C" {

--- a/bindgen-tests/tests/expectations/tests/union_fields.rs
+++ b/bindgen-tests/tests/expectations/tests/union_fields.rs
@@ -11,25 +11,34 @@ fn bindgen_test_layout_nsStyleUnion() {
     const UNINIT: ::std::mem::MaybeUninit<nsStyleUnion> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < nsStyleUnion > (), 8usize, concat!("Size of: ",
-        stringify!(nsStyleUnion))
+        ::std::mem::size_of::<nsStyleUnion>(),
+        8usize,
+        concat!("Size of: ", stringify!(nsStyleUnion)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < nsStyleUnion > (), 8usize, concat!("Alignment of ",
-        stringify!(nsStyleUnion))
+        ::std::mem::align_of::<nsStyleUnion>(),
+        8usize,
+        concat!("Alignment of ", stringify!(nsStyleUnion)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).mInt) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(nsStyleUnion), "::", stringify!(mInt))
+        unsafe { ::std::ptr::addr_of!((*ptr).mInt) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(nsStyleUnion), "::", stringify!(mInt)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).mFloat) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(nsStyleUnion), "::", stringify!(mFloat))
+        unsafe { ::std::ptr::addr_of!((*ptr).mFloat) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(nsStyleUnion), "::", stringify!(mFloat)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).mPointer) as usize - ptr as usize },
-        0usize, concat!("Offset of field: ", stringify!(nsStyleUnion), "::",
-        stringify!(mPointer))
+        unsafe { ::std::ptr::addr_of!((*ptr).mPointer) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(nsStyleUnion),
+            "::",
+            stringify!(mPointer),
+        ),
     );
 }
 impl Default for nsStyleUnion {

--- a/bindgen-tests/tests/expectations/tests/union_fields_1_0.rs
+++ b/bindgen-tests/tests/expectations/tests/union_fields_1_0.rs
@@ -55,25 +55,34 @@ fn bindgen_test_layout_nsStyleUnion() {
     const UNINIT: ::std::mem::MaybeUninit<nsStyleUnion> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < nsStyleUnion > (), 8usize, concat!("Size of: ",
-        stringify!(nsStyleUnion))
+        ::std::mem::size_of::<nsStyleUnion>(),
+        8usize,
+        concat!("Size of: ", stringify!(nsStyleUnion)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < nsStyleUnion > (), 8usize, concat!("Alignment of ",
-        stringify!(nsStyleUnion))
+        ::std::mem::align_of::<nsStyleUnion>(),
+        8usize,
+        concat!("Alignment of ", stringify!(nsStyleUnion)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).mInt) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(nsStyleUnion), "::", stringify!(mInt))
+        unsafe { ::std::ptr::addr_of!((*ptr).mInt) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(nsStyleUnion), "::", stringify!(mInt)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).mFloat) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(nsStyleUnion), "::", stringify!(mFloat))
+        unsafe { ::std::ptr::addr_of!((*ptr).mFloat) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(nsStyleUnion), "::", stringify!(mFloat)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).mPointer) as usize - ptr as usize },
-        0usize, concat!("Offset of field: ", stringify!(nsStyleUnion), "::",
-        stringify!(mPointer))
+        unsafe { ::std::ptr::addr_of!((*ptr).mPointer) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(nsStyleUnion),
+            "::",
+            stringify!(mPointer),
+        ),
     );
 }
 impl Clone for nsStyleUnion {

--- a/bindgen-tests/tests/expectations/tests/union_with_anon_struct.rs
+++ b/bindgen-tests/tests/expectations/tests/union_with_anon_struct.rs
@@ -15,20 +15,24 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<foo__bindgen_ty_1> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < foo__bindgen_ty_1 > (), 8usize, concat!("Size of: ",
-        stringify!(foo__bindgen_ty_1))
+        ::std::mem::size_of::<foo__bindgen_ty_1>(),
+        8usize,
+        concat!("Size of: ", stringify!(foo__bindgen_ty_1)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < foo__bindgen_ty_1 > (), 4usize, concat!("Alignment of ",
-        stringify!(foo__bindgen_ty_1))
+        ::std::mem::align_of::<foo__bindgen_ty_1>(),
+        4usize,
+        concat!("Alignment of ", stringify!(foo__bindgen_ty_1)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).a) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(foo__bindgen_ty_1), "::", stringify!(a))
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(foo__bindgen_ty_1), "::", stringify!(a)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).b) as usize - ptr as usize }, 4usize,
-        concat!("Offset of field: ", stringify!(foo__bindgen_ty_1), "::", stringify!(b))
+        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
+        4usize,
+        concat!("Offset of field: ", stringify!(foo__bindgen_ty_1), "::", stringify!(b)),
     );
 }
 #[test]
@@ -36,15 +40,19 @@ fn bindgen_test_layout_foo() {
     const UNINIT: ::std::mem::MaybeUninit<foo> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < foo > (), 8usize, concat!("Size of: ", stringify!(foo))
+        ::std::mem::size_of::<foo>(),
+        8usize,
+        concat!("Size of: ", stringify!(foo)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < foo > (), 4usize, concat!("Alignment of ",
-        stringify!(foo))
+        ::std::mem::align_of::<foo>(),
+        4usize,
+        concat!("Alignment of ", stringify!(foo)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).bar) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar))
+        unsafe { ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar)),
     );
 }
 impl Default for foo {

--- a/bindgen-tests/tests/expectations/tests/union_with_anon_struct_1_0.rs
+++ b/bindgen-tests/tests/expectations/tests/union_with_anon_struct_1_0.rs
@@ -59,20 +59,24 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<foo__bindgen_ty_1> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < foo__bindgen_ty_1 > (), 8usize, concat!("Size of: ",
-        stringify!(foo__bindgen_ty_1))
+        ::std::mem::size_of::<foo__bindgen_ty_1>(),
+        8usize,
+        concat!("Size of: ", stringify!(foo__bindgen_ty_1)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < foo__bindgen_ty_1 > (), 4usize, concat!("Alignment of ",
-        stringify!(foo__bindgen_ty_1))
+        ::std::mem::align_of::<foo__bindgen_ty_1>(),
+        4usize,
+        concat!("Alignment of ", stringify!(foo__bindgen_ty_1)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).a) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(foo__bindgen_ty_1), "::", stringify!(a))
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(foo__bindgen_ty_1), "::", stringify!(a)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).b) as usize - ptr as usize }, 4usize,
-        concat!("Offset of field: ", stringify!(foo__bindgen_ty_1), "::", stringify!(b))
+        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
+        4usize,
+        concat!("Offset of field: ", stringify!(foo__bindgen_ty_1), "::", stringify!(b)),
     );
 }
 impl Clone for foo__bindgen_ty_1 {
@@ -85,15 +89,19 @@ fn bindgen_test_layout_foo() {
     const UNINIT: ::std::mem::MaybeUninit<foo> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < foo > (), 8usize, concat!("Size of: ", stringify!(foo))
+        ::std::mem::size_of::<foo>(),
+        8usize,
+        concat!("Size of: ", stringify!(foo)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < foo > (), 4usize, concat!("Alignment of ",
-        stringify!(foo))
+        ::std::mem::align_of::<foo>(),
+        4usize,
+        concat!("Alignment of ", stringify!(foo)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).bar) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar))
+        unsafe { ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar)),
     );
 }
 impl Clone for foo {

--- a/bindgen-tests/tests/expectations/tests/union_with_anon_struct_bitfield.rs
+++ b/bindgen-tests/tests/expectations/tests/union_with_anon_struct_bitfield.rs
@@ -49,7 +49,7 @@ where
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < self.storage.as_ref().len());
         debug_assert!(
-            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len()
+            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len(),
         );
         let mut val = 0;
         for i in 0..(bit_width as usize) {
@@ -69,7 +69,7 @@ where
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < self.storage.as_ref().len());
         debug_assert!(
-            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len()
+            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len(),
         );
         for i in 0..(bit_width as usize) {
             let mask = 1 << i;
@@ -99,12 +99,14 @@ pub struct foo__bindgen_ty_1 {
 #[test]
 fn bindgen_test_layout_foo__bindgen_ty_1() {
     assert_eq!(
-        ::std::mem::size_of:: < foo__bindgen_ty_1 > (), 4usize, concat!("Size of: ",
-        stringify!(foo__bindgen_ty_1))
+        ::std::mem::size_of::<foo__bindgen_ty_1>(),
+        4usize,
+        concat!("Size of: ", stringify!(foo__bindgen_ty_1)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < foo__bindgen_ty_1 > (), 4usize, concat!("Alignment of ",
-        stringify!(foo__bindgen_ty_1))
+        ::std::mem::align_of::<foo__bindgen_ty_1>(),
+        4usize,
+        concat!("Alignment of ", stringify!(foo__bindgen_ty_1)),
     );
 }
 impl foo__bindgen_ty_1 {
@@ -162,15 +164,19 @@ fn bindgen_test_layout_foo() {
     const UNINIT: ::std::mem::MaybeUninit<foo> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < foo > (), 4usize, concat!("Size of: ", stringify!(foo))
+        ::std::mem::size_of::<foo>(),
+        4usize,
+        concat!("Size of: ", stringify!(foo)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < foo > (), 4usize, concat!("Alignment of ",
-        stringify!(foo))
+        ::std::mem::align_of::<foo>(),
+        4usize,
+        concat!("Alignment of ", stringify!(foo)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).a) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(a))
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(foo), "::", stringify!(a)),
     );
 }
 impl Default for foo {

--- a/bindgen-tests/tests/expectations/tests/union_with_anon_struct_bitfield_1_0.rs
+++ b/bindgen-tests/tests/expectations/tests/union_with_anon_struct_bitfield_1_0.rs
@@ -49,7 +49,7 @@ where
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < self.storage.as_ref().len());
         debug_assert!(
-            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len()
+            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len(),
         );
         let mut val = 0;
         for i in 0..(bit_width as usize) {
@@ -69,7 +69,7 @@ where
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < self.storage.as_ref().len());
         debug_assert!(
-            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len()
+            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len(),
         );
         for i in 0..(bit_width as usize) {
             let mask = 1 << i;
@@ -143,12 +143,14 @@ pub struct foo__bindgen_ty_1 {
 #[test]
 fn bindgen_test_layout_foo__bindgen_ty_1() {
     assert_eq!(
-        ::std::mem::size_of:: < foo__bindgen_ty_1 > (), 4usize, concat!("Size of: ",
-        stringify!(foo__bindgen_ty_1))
+        ::std::mem::size_of::<foo__bindgen_ty_1>(),
+        4usize,
+        concat!("Size of: ", stringify!(foo__bindgen_ty_1)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < foo__bindgen_ty_1 > (), 4usize, concat!("Alignment of ",
-        stringify!(foo__bindgen_ty_1))
+        ::std::mem::align_of::<foo__bindgen_ty_1>(),
+        4usize,
+        concat!("Alignment of ", stringify!(foo__bindgen_ty_1)),
     );
 }
 impl Clone for foo__bindgen_ty_1 {
@@ -211,15 +213,19 @@ fn bindgen_test_layout_foo() {
     const UNINIT: ::std::mem::MaybeUninit<foo> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < foo > (), 4usize, concat!("Size of: ", stringify!(foo))
+        ::std::mem::size_of::<foo>(),
+        4usize,
+        concat!("Size of: ", stringify!(foo)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < foo > (), 4usize, concat!("Alignment of ",
-        stringify!(foo))
+        ::std::mem::align_of::<foo>(),
+        4usize,
+        concat!("Alignment of ", stringify!(foo)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).a) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(a))
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(foo), "::", stringify!(a)),
     );
 }
 impl Clone for foo {

--- a/bindgen-tests/tests/expectations/tests/union_with_anon_union.rs
+++ b/bindgen-tests/tests/expectations/tests/union_with_anon_union.rs
@@ -15,20 +15,24 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<foo__bindgen_ty_1> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < foo__bindgen_ty_1 > (), 4usize, concat!("Size of: ",
-        stringify!(foo__bindgen_ty_1))
+        ::std::mem::size_of::<foo__bindgen_ty_1>(),
+        4usize,
+        concat!("Size of: ", stringify!(foo__bindgen_ty_1)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < foo__bindgen_ty_1 > (), 4usize, concat!("Alignment of ",
-        stringify!(foo__bindgen_ty_1))
+        ::std::mem::align_of::<foo__bindgen_ty_1>(),
+        4usize,
+        concat!("Alignment of ", stringify!(foo__bindgen_ty_1)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).a) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(foo__bindgen_ty_1), "::", stringify!(a))
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(foo__bindgen_ty_1), "::", stringify!(a)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).b) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(foo__bindgen_ty_1), "::", stringify!(b))
+        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(foo__bindgen_ty_1), "::", stringify!(b)),
     );
 }
 impl Default for foo__bindgen_ty_1 {
@@ -45,15 +49,19 @@ fn bindgen_test_layout_foo() {
     const UNINIT: ::std::mem::MaybeUninit<foo> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < foo > (), 4usize, concat!("Size of: ", stringify!(foo))
+        ::std::mem::size_of::<foo>(),
+        4usize,
+        concat!("Size of: ", stringify!(foo)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < foo > (), 4usize, concat!("Alignment of ",
-        stringify!(foo))
+        ::std::mem::align_of::<foo>(),
+        4usize,
+        concat!("Alignment of ", stringify!(foo)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).bar) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar))
+        unsafe { ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar)),
     );
 }
 impl Default for foo {

--- a/bindgen-tests/tests/expectations/tests/union_with_anon_union_1_0.rs
+++ b/bindgen-tests/tests/expectations/tests/union_with_anon_union_1_0.rs
@@ -60,20 +60,24 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<foo__bindgen_ty_1> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < foo__bindgen_ty_1 > (), 4usize, concat!("Size of: ",
-        stringify!(foo__bindgen_ty_1))
+        ::std::mem::size_of::<foo__bindgen_ty_1>(),
+        4usize,
+        concat!("Size of: ", stringify!(foo__bindgen_ty_1)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < foo__bindgen_ty_1 > (), 4usize, concat!("Alignment of ",
-        stringify!(foo__bindgen_ty_1))
+        ::std::mem::align_of::<foo__bindgen_ty_1>(),
+        4usize,
+        concat!("Alignment of ", stringify!(foo__bindgen_ty_1)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).a) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(foo__bindgen_ty_1), "::", stringify!(a))
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(foo__bindgen_ty_1), "::", stringify!(a)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).b) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(foo__bindgen_ty_1), "::", stringify!(b))
+        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(foo__bindgen_ty_1), "::", stringify!(b)),
     );
 }
 impl Clone for foo__bindgen_ty_1 {
@@ -86,15 +90,19 @@ fn bindgen_test_layout_foo() {
     const UNINIT: ::std::mem::MaybeUninit<foo> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < foo > (), 4usize, concat!("Size of: ", stringify!(foo))
+        ::std::mem::size_of::<foo>(),
+        4usize,
+        concat!("Size of: ", stringify!(foo)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < foo > (), 4usize, concat!("Alignment of ",
-        stringify!(foo))
+        ::std::mem::align_of::<foo>(),
+        4usize,
+        concat!("Alignment of ", stringify!(foo)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).bar) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar))
+        unsafe { ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar)),
     );
 }
 impl Clone for foo {

--- a/bindgen-tests/tests/expectations/tests/union_with_anon_unnamed_struct.rs
+++ b/bindgen-tests/tests/expectations/tests/union_with_anon_unnamed_struct.rs
@@ -18,32 +18,54 @@ fn bindgen_test_layout_pixel__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<pixel__bindgen_ty_1> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < pixel__bindgen_ty_1 > (), 4usize, concat!("Size of: ",
-        stringify!(pixel__bindgen_ty_1))
+        ::std::mem::size_of::<pixel__bindgen_ty_1>(),
+        4usize,
+        concat!("Size of: ", stringify!(pixel__bindgen_ty_1)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < pixel__bindgen_ty_1 > (), 1usize,
-        concat!("Alignment of ", stringify!(pixel__bindgen_ty_1))
+        ::std::mem::align_of::<pixel__bindgen_ty_1>(),
+        1usize,
+        concat!("Alignment of ", stringify!(pixel__bindgen_ty_1)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).r) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(pixel__bindgen_ty_1), "::",
-        stringify!(r))
+        unsafe { ::std::ptr::addr_of!((*ptr).r) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(pixel__bindgen_ty_1),
+            "::",
+            stringify!(r),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).g) as usize - ptr as usize }, 1usize,
-        concat!("Offset of field: ", stringify!(pixel__bindgen_ty_1), "::",
-        stringify!(g))
+        unsafe { ::std::ptr::addr_of!((*ptr).g) as usize - ptr as usize },
+        1usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(pixel__bindgen_ty_1),
+            "::",
+            stringify!(g),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).b) as usize - ptr as usize }, 2usize,
-        concat!("Offset of field: ", stringify!(pixel__bindgen_ty_1), "::",
-        stringify!(b))
+        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
+        2usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(pixel__bindgen_ty_1),
+            "::",
+            stringify!(b),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).a) as usize - ptr as usize }, 3usize,
-        concat!("Offset of field: ", stringify!(pixel__bindgen_ty_1), "::",
-        stringify!(a))
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
+        3usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(pixel__bindgen_ty_1),
+            "::",
+            stringify!(a),
+        ),
     );
 }
 #[test]
@@ -51,16 +73,19 @@ fn bindgen_test_layout_pixel() {
     const UNINIT: ::std::mem::MaybeUninit<pixel> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < pixel > (), 4usize, concat!("Size of: ",
-        stringify!(pixel))
+        ::std::mem::size_of::<pixel>(),
+        4usize,
+        concat!("Size of: ", stringify!(pixel)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < pixel > (), 4usize, concat!("Alignment of ",
-        stringify!(pixel))
+        ::std::mem::align_of::<pixel>(),
+        4usize,
+        concat!("Alignment of ", stringify!(pixel)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).rgba) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(pixel), "::", stringify!(rgba))
+        unsafe { ::std::ptr::addr_of!((*ptr).rgba) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(pixel), "::", stringify!(rgba)),
     );
 }
 impl Default for pixel {

--- a/bindgen-tests/tests/expectations/tests/union_with_anon_unnamed_struct_1_0.rs
+++ b/bindgen-tests/tests/expectations/tests/union_with_anon_unnamed_struct_1_0.rs
@@ -62,32 +62,54 @@ fn bindgen_test_layout_pixel__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<pixel__bindgen_ty_1> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < pixel__bindgen_ty_1 > (), 4usize, concat!("Size of: ",
-        stringify!(pixel__bindgen_ty_1))
+        ::std::mem::size_of::<pixel__bindgen_ty_1>(),
+        4usize,
+        concat!("Size of: ", stringify!(pixel__bindgen_ty_1)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < pixel__bindgen_ty_1 > (), 1usize,
-        concat!("Alignment of ", stringify!(pixel__bindgen_ty_1))
+        ::std::mem::align_of::<pixel__bindgen_ty_1>(),
+        1usize,
+        concat!("Alignment of ", stringify!(pixel__bindgen_ty_1)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).r) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(pixel__bindgen_ty_1), "::",
-        stringify!(r))
+        unsafe { ::std::ptr::addr_of!((*ptr).r) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(pixel__bindgen_ty_1),
+            "::",
+            stringify!(r),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).g) as usize - ptr as usize }, 1usize,
-        concat!("Offset of field: ", stringify!(pixel__bindgen_ty_1), "::",
-        stringify!(g))
+        unsafe { ::std::ptr::addr_of!((*ptr).g) as usize - ptr as usize },
+        1usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(pixel__bindgen_ty_1),
+            "::",
+            stringify!(g),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).b) as usize - ptr as usize }, 2usize,
-        concat!("Offset of field: ", stringify!(pixel__bindgen_ty_1), "::",
-        stringify!(b))
+        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
+        2usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(pixel__bindgen_ty_1),
+            "::",
+            stringify!(b),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).a) as usize - ptr as usize }, 3usize,
-        concat!("Offset of field: ", stringify!(pixel__bindgen_ty_1), "::",
-        stringify!(a))
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
+        3usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(pixel__bindgen_ty_1),
+            "::",
+            stringify!(a),
+        ),
     );
 }
 impl Clone for pixel__bindgen_ty_1 {
@@ -100,16 +122,19 @@ fn bindgen_test_layout_pixel() {
     const UNINIT: ::std::mem::MaybeUninit<pixel> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < pixel > (), 4usize, concat!("Size of: ",
-        stringify!(pixel))
+        ::std::mem::size_of::<pixel>(),
+        4usize,
+        concat!("Size of: ", stringify!(pixel)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < pixel > (), 4usize, concat!("Alignment of ",
-        stringify!(pixel))
+        ::std::mem::align_of::<pixel>(),
+        4usize,
+        concat!("Alignment of ", stringify!(pixel)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).rgba) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(pixel), "::", stringify!(rgba))
+        unsafe { ::std::ptr::addr_of!((*ptr).rgba) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(pixel), "::", stringify!(rgba)),
     );
 }
 impl Clone for pixel {

--- a/bindgen-tests/tests/expectations/tests/union_with_anon_unnamed_union.rs
+++ b/bindgen-tests/tests/expectations/tests/union_with_anon_unnamed_union.rs
@@ -16,20 +16,24 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<foo__bindgen_ty_1> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < foo__bindgen_ty_1 > (), 2usize, concat!("Size of: ",
-        stringify!(foo__bindgen_ty_1))
+        ::std::mem::size_of::<foo__bindgen_ty_1>(),
+        2usize,
+        concat!("Size of: ", stringify!(foo__bindgen_ty_1)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < foo__bindgen_ty_1 > (), 2usize, concat!("Alignment of ",
-        stringify!(foo__bindgen_ty_1))
+        ::std::mem::align_of::<foo__bindgen_ty_1>(),
+        2usize,
+        concat!("Alignment of ", stringify!(foo__bindgen_ty_1)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).b) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(foo__bindgen_ty_1), "::", stringify!(b))
+        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(foo__bindgen_ty_1), "::", stringify!(b)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).c) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(foo__bindgen_ty_1), "::", stringify!(c))
+        unsafe { ::std::ptr::addr_of!((*ptr).c) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(foo__bindgen_ty_1), "::", stringify!(c)),
     );
 }
 impl Default for foo__bindgen_ty_1 {
@@ -46,15 +50,19 @@ fn bindgen_test_layout_foo() {
     const UNINIT: ::std::mem::MaybeUninit<foo> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < foo > (), 4usize, concat!("Size of: ", stringify!(foo))
+        ::std::mem::size_of::<foo>(),
+        4usize,
+        concat!("Size of: ", stringify!(foo)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < foo > (), 4usize, concat!("Alignment of ",
-        stringify!(foo))
+        ::std::mem::align_of::<foo>(),
+        4usize,
+        concat!("Alignment of ", stringify!(foo)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).a) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(a))
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(foo), "::", stringify!(a)),
     );
 }
 impl Default for foo {

--- a/bindgen-tests/tests/expectations/tests/union_with_anon_unnamed_union_1_0.rs
+++ b/bindgen-tests/tests/expectations/tests/union_with_anon_unnamed_union_1_0.rs
@@ -61,20 +61,24 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<foo__bindgen_ty_1> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < foo__bindgen_ty_1 > (), 2usize, concat!("Size of: ",
-        stringify!(foo__bindgen_ty_1))
+        ::std::mem::size_of::<foo__bindgen_ty_1>(),
+        2usize,
+        concat!("Size of: ", stringify!(foo__bindgen_ty_1)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < foo__bindgen_ty_1 > (), 2usize, concat!("Alignment of ",
-        stringify!(foo__bindgen_ty_1))
+        ::std::mem::align_of::<foo__bindgen_ty_1>(),
+        2usize,
+        concat!("Alignment of ", stringify!(foo__bindgen_ty_1)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).b) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(foo__bindgen_ty_1), "::", stringify!(b))
+        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(foo__bindgen_ty_1), "::", stringify!(b)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).c) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(foo__bindgen_ty_1), "::", stringify!(c))
+        unsafe { ::std::ptr::addr_of!((*ptr).c) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(foo__bindgen_ty_1), "::", stringify!(c)),
     );
 }
 impl Clone for foo__bindgen_ty_1 {
@@ -87,15 +91,19 @@ fn bindgen_test_layout_foo() {
     const UNINIT: ::std::mem::MaybeUninit<foo> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < foo > (), 4usize, concat!("Size of: ", stringify!(foo))
+        ::std::mem::size_of::<foo>(),
+        4usize,
+        concat!("Size of: ", stringify!(foo)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < foo > (), 4usize, concat!("Alignment of ",
-        stringify!(foo))
+        ::std::mem::align_of::<foo>(),
+        4usize,
+        concat!("Alignment of ", stringify!(foo)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).a) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(a))
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(foo), "::", stringify!(a)),
     );
 }
 impl Clone for foo {

--- a/bindgen-tests/tests/expectations/tests/union_with_big_member.rs
+++ b/bindgen-tests/tests/expectations/tests/union_with_big_member.rs
@@ -10,20 +10,24 @@ fn bindgen_test_layout_WithBigArray() {
     const UNINIT: ::std::mem::MaybeUninit<WithBigArray> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < WithBigArray > (), 132usize, concat!("Size of: ",
-        stringify!(WithBigArray))
+        ::std::mem::size_of::<WithBigArray>(),
+        132usize,
+        concat!("Size of: ", stringify!(WithBigArray)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < WithBigArray > (), 4usize, concat!("Alignment of ",
-        stringify!(WithBigArray))
+        ::std::mem::align_of::<WithBigArray>(),
+        4usize,
+        concat!("Alignment of ", stringify!(WithBigArray)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).a) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(WithBigArray), "::", stringify!(a))
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(WithBigArray), "::", stringify!(a)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).b) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(WithBigArray), "::", stringify!(b))
+        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(WithBigArray), "::", stringify!(b)),
     );
 }
 impl Default for WithBigArray {
@@ -46,20 +50,24 @@ fn bindgen_test_layout_WithBigArray2() {
     const UNINIT: ::std::mem::MaybeUninit<WithBigArray2> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < WithBigArray2 > (), 36usize, concat!("Size of: ",
-        stringify!(WithBigArray2))
+        ::std::mem::size_of::<WithBigArray2>(),
+        36usize,
+        concat!("Size of: ", stringify!(WithBigArray2)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < WithBigArray2 > (), 4usize, concat!("Alignment of ",
-        stringify!(WithBigArray2))
+        ::std::mem::align_of::<WithBigArray2>(),
+        4usize,
+        concat!("Alignment of ", stringify!(WithBigArray2)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).a) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(WithBigArray2), "::", stringify!(a))
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(WithBigArray2), "::", stringify!(a)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).b) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(WithBigArray2), "::", stringify!(b))
+        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(WithBigArray2), "::", stringify!(b)),
     );
 }
 impl Default for WithBigArray2 {
@@ -82,20 +90,24 @@ fn bindgen_test_layout_WithBigMember() {
     const UNINIT: ::std::mem::MaybeUninit<WithBigMember> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < WithBigMember > (), 132usize, concat!("Size of: ",
-        stringify!(WithBigMember))
+        ::std::mem::size_of::<WithBigMember>(),
+        132usize,
+        concat!("Size of: ", stringify!(WithBigMember)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < WithBigMember > (), 4usize, concat!("Alignment of ",
-        stringify!(WithBigMember))
+        ::std::mem::align_of::<WithBigMember>(),
+        4usize,
+        concat!("Alignment of ", stringify!(WithBigMember)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).a) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(WithBigMember), "::", stringify!(a))
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(WithBigMember), "::", stringify!(a)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).b) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(WithBigMember), "::", stringify!(b))
+        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(WithBigMember), "::", stringify!(b)),
     );
 }
 impl Default for WithBigMember {

--- a/bindgen-tests/tests/expectations/tests/union_with_big_member_1_0.rs
+++ b/bindgen-tests/tests/expectations/tests/union_with_big_member_1_0.rs
@@ -54,20 +54,24 @@ fn bindgen_test_layout_WithBigArray() {
     const UNINIT: ::std::mem::MaybeUninit<WithBigArray> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < WithBigArray > (), 132usize, concat!("Size of: ",
-        stringify!(WithBigArray))
+        ::std::mem::size_of::<WithBigArray>(),
+        132usize,
+        concat!("Size of: ", stringify!(WithBigArray)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < WithBigArray > (), 4usize, concat!("Alignment of ",
-        stringify!(WithBigArray))
+        ::std::mem::align_of::<WithBigArray>(),
+        4usize,
+        concat!("Alignment of ", stringify!(WithBigArray)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).a) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(WithBigArray), "::", stringify!(a))
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(WithBigArray), "::", stringify!(a)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).b) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(WithBigArray), "::", stringify!(b))
+        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(WithBigArray), "::", stringify!(b)),
     );
 }
 impl Clone for WithBigArray {
@@ -96,20 +100,24 @@ fn bindgen_test_layout_WithBigArray2() {
     const UNINIT: ::std::mem::MaybeUninit<WithBigArray2> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < WithBigArray2 > (), 36usize, concat!("Size of: ",
-        stringify!(WithBigArray2))
+        ::std::mem::size_of::<WithBigArray2>(),
+        36usize,
+        concat!("Size of: ", stringify!(WithBigArray2)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < WithBigArray2 > (), 4usize, concat!("Alignment of ",
-        stringify!(WithBigArray2))
+        ::std::mem::align_of::<WithBigArray2>(),
+        4usize,
+        concat!("Alignment of ", stringify!(WithBigArray2)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).a) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(WithBigArray2), "::", stringify!(a))
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(WithBigArray2), "::", stringify!(a)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).b) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(WithBigArray2), "::", stringify!(b))
+        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(WithBigArray2), "::", stringify!(b)),
     );
 }
 impl Clone for WithBigArray2 {
@@ -129,20 +137,24 @@ fn bindgen_test_layout_WithBigMember() {
     const UNINIT: ::std::mem::MaybeUninit<WithBigMember> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < WithBigMember > (), 132usize, concat!("Size of: ",
-        stringify!(WithBigMember))
+        ::std::mem::size_of::<WithBigMember>(),
+        132usize,
+        concat!("Size of: ", stringify!(WithBigMember)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < WithBigMember > (), 4usize, concat!("Alignment of ",
-        stringify!(WithBigMember))
+        ::std::mem::align_of::<WithBigMember>(),
+        4usize,
+        concat!("Alignment of ", stringify!(WithBigMember)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).a) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(WithBigMember), "::", stringify!(a))
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(WithBigMember), "::", stringify!(a)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).b) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(WithBigMember), "::", stringify!(b))
+        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(WithBigMember), "::", stringify!(b)),
     );
 }
 impl Clone for WithBigMember {

--- a/bindgen-tests/tests/expectations/tests/union_with_nesting.rs
+++ b/bindgen-tests/tests/expectations/tests/union_with_nesting.rs
@@ -22,22 +22,34 @@ fn bindgen_test_layout_foo__bindgen_ty_1__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<foo__bindgen_ty_1__bindgen_ty_1> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < foo__bindgen_ty_1__bindgen_ty_1 > (), 2usize,
-        concat!("Size of: ", stringify!(foo__bindgen_ty_1__bindgen_ty_1))
+        ::std::mem::size_of::<foo__bindgen_ty_1__bindgen_ty_1>(),
+        2usize,
+        concat!("Size of: ", stringify!(foo__bindgen_ty_1__bindgen_ty_1)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < foo__bindgen_ty_1__bindgen_ty_1 > (), 2usize,
-        concat!("Alignment of ", stringify!(foo__bindgen_ty_1__bindgen_ty_1))
+        ::std::mem::align_of::<foo__bindgen_ty_1__bindgen_ty_1>(),
+        2usize,
+        concat!("Alignment of ", stringify!(foo__bindgen_ty_1__bindgen_ty_1)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).b1) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(foo__bindgen_ty_1__bindgen_ty_1), "::",
-        stringify!(b1))
+        unsafe { ::std::ptr::addr_of!((*ptr).b1) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(foo__bindgen_ty_1__bindgen_ty_1),
+            "::",
+            stringify!(b1),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).b2) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(foo__bindgen_ty_1__bindgen_ty_1), "::",
-        stringify!(b2))
+        unsafe { ::std::ptr::addr_of!((*ptr).b2) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(foo__bindgen_ty_1__bindgen_ty_1),
+            "::",
+            stringify!(b2),
+        ),
     );
 }
 impl Default for foo__bindgen_ty_1__bindgen_ty_1 {
@@ -60,22 +72,34 @@ fn bindgen_test_layout_foo__bindgen_ty_1__bindgen_ty_2() {
     const UNINIT: ::std::mem::MaybeUninit<foo__bindgen_ty_1__bindgen_ty_2> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < foo__bindgen_ty_1__bindgen_ty_2 > (), 2usize,
-        concat!("Size of: ", stringify!(foo__bindgen_ty_1__bindgen_ty_2))
+        ::std::mem::size_of::<foo__bindgen_ty_1__bindgen_ty_2>(),
+        2usize,
+        concat!("Size of: ", stringify!(foo__bindgen_ty_1__bindgen_ty_2)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < foo__bindgen_ty_1__bindgen_ty_2 > (), 2usize,
-        concat!("Alignment of ", stringify!(foo__bindgen_ty_1__bindgen_ty_2))
+        ::std::mem::align_of::<foo__bindgen_ty_1__bindgen_ty_2>(),
+        2usize,
+        concat!("Alignment of ", stringify!(foo__bindgen_ty_1__bindgen_ty_2)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).c1) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(foo__bindgen_ty_1__bindgen_ty_2), "::",
-        stringify!(c1))
+        unsafe { ::std::ptr::addr_of!((*ptr).c1) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(foo__bindgen_ty_1__bindgen_ty_2),
+            "::",
+            stringify!(c1),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).c2) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(foo__bindgen_ty_1__bindgen_ty_2), "::",
-        stringify!(c2))
+        unsafe { ::std::ptr::addr_of!((*ptr).c2) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(foo__bindgen_ty_1__bindgen_ty_2),
+            "::",
+            stringify!(c2),
+        ),
     );
 }
 impl Default for foo__bindgen_ty_1__bindgen_ty_2 {
@@ -90,12 +114,14 @@ impl Default for foo__bindgen_ty_1__bindgen_ty_2 {
 #[test]
 fn bindgen_test_layout_foo__bindgen_ty_1() {
     assert_eq!(
-        ::std::mem::size_of:: < foo__bindgen_ty_1 > (), 4usize, concat!("Size of: ",
-        stringify!(foo__bindgen_ty_1))
+        ::std::mem::size_of::<foo__bindgen_ty_1>(),
+        4usize,
+        concat!("Size of: ", stringify!(foo__bindgen_ty_1)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < foo__bindgen_ty_1 > (), 2usize, concat!("Alignment of ",
-        stringify!(foo__bindgen_ty_1))
+        ::std::mem::align_of::<foo__bindgen_ty_1>(),
+        2usize,
+        concat!("Alignment of ", stringify!(foo__bindgen_ty_1)),
     );
 }
 impl Default for foo__bindgen_ty_1 {
@@ -112,15 +138,19 @@ fn bindgen_test_layout_foo() {
     const UNINIT: ::std::mem::MaybeUninit<foo> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < foo > (), 4usize, concat!("Size of: ", stringify!(foo))
+        ::std::mem::size_of::<foo>(),
+        4usize,
+        concat!("Size of: ", stringify!(foo)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < foo > (), 4usize, concat!("Alignment of ",
-        stringify!(foo))
+        ::std::mem::align_of::<foo>(),
+        4usize,
+        concat!("Alignment of ", stringify!(foo)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).a) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(a))
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(foo), "::", stringify!(a)),
     );
 }
 impl Default for foo {

--- a/bindgen-tests/tests/expectations/tests/union_with_nesting_1_0.rs
+++ b/bindgen-tests/tests/expectations/tests/union_with_nesting_1_0.rs
@@ -67,22 +67,34 @@ fn bindgen_test_layout_foo__bindgen_ty_1__bindgen_ty_1() {
     const UNINIT: ::std::mem::MaybeUninit<foo__bindgen_ty_1__bindgen_ty_1> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < foo__bindgen_ty_1__bindgen_ty_1 > (), 2usize,
-        concat!("Size of: ", stringify!(foo__bindgen_ty_1__bindgen_ty_1))
+        ::std::mem::size_of::<foo__bindgen_ty_1__bindgen_ty_1>(),
+        2usize,
+        concat!("Size of: ", stringify!(foo__bindgen_ty_1__bindgen_ty_1)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < foo__bindgen_ty_1__bindgen_ty_1 > (), 2usize,
-        concat!("Alignment of ", stringify!(foo__bindgen_ty_1__bindgen_ty_1))
+        ::std::mem::align_of::<foo__bindgen_ty_1__bindgen_ty_1>(),
+        2usize,
+        concat!("Alignment of ", stringify!(foo__bindgen_ty_1__bindgen_ty_1)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).b1) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(foo__bindgen_ty_1__bindgen_ty_1), "::",
-        stringify!(b1))
+        unsafe { ::std::ptr::addr_of!((*ptr).b1) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(foo__bindgen_ty_1__bindgen_ty_1),
+            "::",
+            stringify!(b1),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).b2) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(foo__bindgen_ty_1__bindgen_ty_1), "::",
-        stringify!(b2))
+        unsafe { ::std::ptr::addr_of!((*ptr).b2) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(foo__bindgen_ty_1__bindgen_ty_1),
+            "::",
+            stringify!(b2),
+        ),
     );
 }
 impl Clone for foo__bindgen_ty_1__bindgen_ty_1 {
@@ -102,22 +114,34 @@ fn bindgen_test_layout_foo__bindgen_ty_1__bindgen_ty_2() {
     const UNINIT: ::std::mem::MaybeUninit<foo__bindgen_ty_1__bindgen_ty_2> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < foo__bindgen_ty_1__bindgen_ty_2 > (), 2usize,
-        concat!("Size of: ", stringify!(foo__bindgen_ty_1__bindgen_ty_2))
+        ::std::mem::size_of::<foo__bindgen_ty_1__bindgen_ty_2>(),
+        2usize,
+        concat!("Size of: ", stringify!(foo__bindgen_ty_1__bindgen_ty_2)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < foo__bindgen_ty_1__bindgen_ty_2 > (), 2usize,
-        concat!("Alignment of ", stringify!(foo__bindgen_ty_1__bindgen_ty_2))
+        ::std::mem::align_of::<foo__bindgen_ty_1__bindgen_ty_2>(),
+        2usize,
+        concat!("Alignment of ", stringify!(foo__bindgen_ty_1__bindgen_ty_2)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).c1) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(foo__bindgen_ty_1__bindgen_ty_2), "::",
-        stringify!(c1))
+        unsafe { ::std::ptr::addr_of!((*ptr).c1) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(foo__bindgen_ty_1__bindgen_ty_2),
+            "::",
+            stringify!(c1),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).c2) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(foo__bindgen_ty_1__bindgen_ty_2), "::",
-        stringify!(c2))
+        unsafe { ::std::ptr::addr_of!((*ptr).c2) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(foo__bindgen_ty_1__bindgen_ty_2),
+            "::",
+            stringify!(c2),
+        ),
     );
 }
 impl Clone for foo__bindgen_ty_1__bindgen_ty_2 {
@@ -128,12 +152,14 @@ impl Clone for foo__bindgen_ty_1__bindgen_ty_2 {
 #[test]
 fn bindgen_test_layout_foo__bindgen_ty_1() {
     assert_eq!(
-        ::std::mem::size_of:: < foo__bindgen_ty_1 > (), 4usize, concat!("Size of: ",
-        stringify!(foo__bindgen_ty_1))
+        ::std::mem::size_of::<foo__bindgen_ty_1>(),
+        4usize,
+        concat!("Size of: ", stringify!(foo__bindgen_ty_1)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < foo__bindgen_ty_1 > (), 2usize, concat!("Alignment of ",
-        stringify!(foo__bindgen_ty_1))
+        ::std::mem::align_of::<foo__bindgen_ty_1>(),
+        2usize,
+        concat!("Alignment of ", stringify!(foo__bindgen_ty_1)),
     );
 }
 impl Clone for foo__bindgen_ty_1 {
@@ -146,15 +172,19 @@ fn bindgen_test_layout_foo() {
     const UNINIT: ::std::mem::MaybeUninit<foo> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < foo > (), 4usize, concat!("Size of: ", stringify!(foo))
+        ::std::mem::size_of::<foo>(),
+        4usize,
+        concat!("Size of: ", stringify!(foo)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < foo > (), 4usize, concat!("Alignment of ",
-        stringify!(foo))
+        ::std::mem::align_of::<foo>(),
+        4usize,
+        concat!("Alignment of ", stringify!(foo)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).a) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(a))
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(foo), "::", stringify!(a)),
     );
 }
 impl Clone for foo {

--- a/bindgen-tests/tests/expectations/tests/union_with_non_copy_member.rs
+++ b/bindgen-tests/tests/expectations/tests/union_with_non_copy_member.rs
@@ -52,16 +52,19 @@ fn bindgen_test_layout_NonCopyType() {
     const UNINIT: ::std::mem::MaybeUninit<NonCopyType> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < NonCopyType > (), 4usize, concat!("Size of: ",
-        stringify!(NonCopyType))
+        ::std::mem::size_of::<NonCopyType>(),
+        4usize,
+        concat!("Size of: ", stringify!(NonCopyType)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < NonCopyType > (), 4usize, concat!("Alignment of ",
-        stringify!(NonCopyType))
+        ::std::mem::align_of::<NonCopyType>(),
+        4usize,
+        concat!("Alignment of ", stringify!(NonCopyType)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).foo) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(NonCopyType), "::", stringify!(foo))
+        unsafe { ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(NonCopyType), "::", stringify!(foo)),
     );
 }
 #[repr(C)]
@@ -75,22 +78,34 @@ fn bindgen_test_layout_WithBindgenGeneratedWrapper() {
     const UNINIT: ::std::mem::MaybeUninit<WithBindgenGeneratedWrapper> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < WithBindgenGeneratedWrapper > (), 4usize,
-        concat!("Size of: ", stringify!(WithBindgenGeneratedWrapper))
+        ::std::mem::size_of::<WithBindgenGeneratedWrapper>(),
+        4usize,
+        concat!("Size of: ", stringify!(WithBindgenGeneratedWrapper)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < WithBindgenGeneratedWrapper > (), 4usize,
-        concat!("Alignment of ", stringify!(WithBindgenGeneratedWrapper))
+        ::std::mem::align_of::<WithBindgenGeneratedWrapper>(),
+        4usize,
+        concat!("Alignment of ", stringify!(WithBindgenGeneratedWrapper)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).non_copy_type) as usize - ptr as usize },
-        0usize, concat!("Offset of field: ", stringify!(WithBindgenGeneratedWrapper),
-        "::", stringify!(non_copy_type))
+        unsafe { ::std::ptr::addr_of!((*ptr).non_copy_type) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(WithBindgenGeneratedWrapper),
+            "::",
+            stringify!(non_copy_type),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).bar) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(WithBindgenGeneratedWrapper), "::",
-        stringify!(bar))
+        unsafe { ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(WithBindgenGeneratedWrapper),
+            "::",
+            stringify!(bar),
+        ),
     );
 }
 impl Default for WithBindgenGeneratedWrapper {
@@ -112,21 +127,29 @@ fn bindgen_test_layout_WithManuallyDrop() {
     const UNINIT: ::std::mem::MaybeUninit<WithManuallyDrop> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < WithManuallyDrop > (), 4usize, concat!("Size of: ",
-        stringify!(WithManuallyDrop))
+        ::std::mem::size_of::<WithManuallyDrop>(),
+        4usize,
+        concat!("Size of: ", stringify!(WithManuallyDrop)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < WithManuallyDrop > (), 4usize, concat!("Alignment of ",
-        stringify!(WithManuallyDrop))
+        ::std::mem::align_of::<WithManuallyDrop>(),
+        4usize,
+        concat!("Alignment of ", stringify!(WithManuallyDrop)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).non_copy_type) as usize - ptr as usize },
-        0usize, concat!("Offset of field: ", stringify!(WithManuallyDrop), "::",
-        stringify!(non_copy_type))
+        unsafe { ::std::ptr::addr_of!((*ptr).non_copy_type) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(WithManuallyDrop),
+            "::",
+            stringify!(non_copy_type),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).bar) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(WithManuallyDrop), "::", stringify!(bar))
+        unsafe { ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(WithManuallyDrop), "::", stringify!(bar)),
     );
 }
 impl Default for WithManuallyDrop {
@@ -149,22 +172,34 @@ fn bindgen_test_layout_WithDefaultWrapper() {
     const UNINIT: ::std::mem::MaybeUninit<WithDefaultWrapper> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < WithDefaultWrapper > (), 4usize, concat!("Size of: ",
-        stringify!(WithDefaultWrapper))
+        ::std::mem::size_of::<WithDefaultWrapper>(),
+        4usize,
+        concat!("Size of: ", stringify!(WithDefaultWrapper)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < WithDefaultWrapper > (), 4usize,
-        concat!("Alignment of ", stringify!(WithDefaultWrapper))
+        ::std::mem::align_of::<WithDefaultWrapper>(),
+        4usize,
+        concat!("Alignment of ", stringify!(WithDefaultWrapper)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).non_copy_type) as usize - ptr as usize },
-        0usize, concat!("Offset of field: ", stringify!(WithDefaultWrapper), "::",
-        stringify!(non_copy_type))
+        unsafe { ::std::ptr::addr_of!((*ptr).non_copy_type) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(WithDefaultWrapper),
+            "::",
+            stringify!(non_copy_type),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).bar) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(WithDefaultWrapper), "::",
-        stringify!(bar))
+        unsafe { ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(WithDefaultWrapper),
+            "::",
+            stringify!(bar),
+        ),
     );
 }
 impl Default for WithDefaultWrapper {

--- a/bindgen-tests/tests/expectations/tests/unknown_attr.rs
+++ b/bindgen-tests/tests/expectations/tests/unknown_attr.rs
@@ -12,21 +12,37 @@ fn bindgen_test_layout_max_align_t() {
     const UNINIT: ::std::mem::MaybeUninit<max_align_t> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < max_align_t > (), 32usize, concat!("Size of: ",
-        stringify!(max_align_t))
+        ::std::mem::size_of::<max_align_t>(),
+        32usize,
+        concat!("Size of: ", stringify!(max_align_t)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < max_align_t > (), 16usize, concat!("Alignment of ",
-        stringify!(max_align_t))
+        ::std::mem::align_of::<max_align_t>(),
+        16usize,
+        concat!("Alignment of ", stringify!(max_align_t)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).__clang_max_align_nonce1) as usize - ptr as
-        usize }, 0usize, concat!("Offset of field: ", stringify!(max_align_t), "::",
-        stringify!(__clang_max_align_nonce1))
+        unsafe {
+            ::std::ptr::addr_of!((*ptr).__clang_max_align_nonce1) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(max_align_t),
+            "::",
+            stringify!(__clang_max_align_nonce1),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).__clang_max_align_nonce2) as usize - ptr as
-        usize }, 16usize, concat!("Offset of field: ", stringify!(max_align_t), "::",
-        stringify!(__clang_max_align_nonce2))
+        unsafe {
+            ::std::ptr::addr_of!((*ptr).__clang_max_align_nonce2) as usize - ptr as usize
+        },
+        16usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(max_align_t),
+            "::",
+            stringify!(__clang_max_align_nonce2),
+        ),
     );
 }

--- a/bindgen-tests/tests/expectations/tests/unsorted-items.rs
+++ b/bindgen-tests/tests/expectations/tests/unsorted-items.rs
@@ -17,20 +17,24 @@ fn bindgen_test_layout_Point() {
     const UNINIT: ::std::mem::MaybeUninit<Point> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < Point > (), 8usize, concat!("Size of: ",
-        stringify!(Point))
+        ::std::mem::size_of::<Point>(),
+        8usize,
+        concat!("Size of: ", stringify!(Point)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Point > (), 4usize, concat!("Alignment of ",
-        stringify!(Point))
+        ::std::mem::align_of::<Point>(),
+        4usize,
+        concat!("Alignment of ", stringify!(Point)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).x) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(Point), "::", stringify!(x))
+        unsafe { ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(Point), "::", stringify!(x)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).y) as usize - ptr as usize }, 4usize,
-        concat!("Offset of field: ", stringify!(Point), "::", stringify!(y))
+        unsafe { ::std::ptr::addr_of!((*ptr).y) as usize - ptr as usize },
+        4usize,
+        concat!("Offset of field: ", stringify!(Point), "::", stringify!(y)),
     );
 }
 #[repr(C)]
@@ -44,20 +48,24 @@ fn bindgen_test_layout_Angle() {
     const UNINIT: ::std::mem::MaybeUninit<Angle> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < Angle > (), 8usize, concat!("Size of: ",
-        stringify!(Angle))
+        ::std::mem::size_of::<Angle>(),
+        8usize,
+        concat!("Size of: ", stringify!(Angle)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Angle > (), 4usize, concat!("Alignment of ",
-        stringify!(Angle))
+        ::std::mem::align_of::<Angle>(),
+        4usize,
+        concat!("Alignment of ", stringify!(Angle)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).a) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(Angle), "::", stringify!(a))
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(Angle), "::", stringify!(a)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).b) as usize - ptr as usize }, 4usize,
-        concat!("Offset of field: ", stringify!(Angle), "::", stringify!(b))
+        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
+        4usize,
+        concat!("Offset of field: ", stringify!(Angle), "::", stringify!(b)),
     );
 }
 extern "C" {

--- a/bindgen-tests/tests/expectations/tests/use-core.rs
+++ b/bindgen-tests/tests/expectations/tests/use-core.rs
@@ -13,23 +13,29 @@ fn bindgen_test_layout_foo() {
     const UNINIT: ::core::mem::MaybeUninit<foo> = ::core::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::core::mem::size_of:: < foo > (), 16usize, concat!("Size of: ", stringify!(foo))
+        ::core::mem::size_of::<foo>(),
+        16usize,
+        concat!("Size of: ", stringify!(foo)),
     );
     assert_eq!(
-        ::core::mem::align_of:: < foo > (), 8usize, concat!("Alignment of ",
-        stringify!(foo))
+        ::core::mem::align_of::<foo>(),
+        8usize,
+        concat!("Alignment of ", stringify!(foo)),
     );
     assert_eq!(
-        unsafe { ::core::ptr::addr_of!((* ptr).a) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(a))
+        unsafe { ::core::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(foo), "::", stringify!(a)),
     );
     assert_eq!(
-        unsafe { ::core::ptr::addr_of!((* ptr).b) as usize - ptr as usize }, 4usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(b))
+        unsafe { ::core::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
+        4usize,
+        concat!("Offset of field: ", stringify!(foo), "::", stringify!(b)),
     );
     assert_eq!(
-        unsafe { ::core::ptr::addr_of!((* ptr).bar) as usize - ptr as usize }, 8usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar))
+        unsafe { ::core::ptr::addr_of!((*ptr).bar) as usize - ptr as usize },
+        8usize,
+        concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar)),
     );
 }
 impl Default for foo {
@@ -52,20 +58,24 @@ fn bindgen_test_layout__bindgen_ty_1() {
     const UNINIT: ::core::mem::MaybeUninit<_bindgen_ty_1> = ::core::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::core::mem::size_of:: < _bindgen_ty_1 > (), 8usize, concat!("Size of: ",
-        stringify!(_bindgen_ty_1))
+        ::core::mem::size_of::<_bindgen_ty_1>(),
+        8usize,
+        concat!("Size of: ", stringify!(_bindgen_ty_1)),
     );
     assert_eq!(
-        ::core::mem::align_of:: < _bindgen_ty_1 > (), 8usize, concat!("Alignment of ",
-        stringify!(_bindgen_ty_1))
+        ::core::mem::align_of::<_bindgen_ty_1>(),
+        8usize,
+        concat!("Alignment of ", stringify!(_bindgen_ty_1)),
     );
     assert_eq!(
-        unsafe { ::core::ptr::addr_of!((* ptr).bar) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(_bindgen_ty_1), "::", stringify!(bar))
+        unsafe { ::core::ptr::addr_of!((*ptr).bar) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(_bindgen_ty_1), "::", stringify!(bar)),
     );
     assert_eq!(
-        unsafe { ::core::ptr::addr_of!((* ptr).baz) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(_bindgen_ty_1), "::", stringify!(baz))
+        unsafe { ::core::ptr::addr_of!((*ptr).baz) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(_bindgen_ty_1), "::", stringify!(baz)),
     );
 }
 impl Default for _bindgen_ty_1 {

--- a/bindgen-tests/tests/expectations/tests/use-core_1_0.rs
+++ b/bindgen-tests/tests/expectations/tests/use-core_1_0.rs
@@ -55,23 +55,29 @@ fn bindgen_test_layout_foo() {
     const UNINIT: ::core::mem::MaybeUninit<foo> = ::core::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::core::mem::size_of:: < foo > (), 16usize, concat!("Size of: ", stringify!(foo))
+        ::core::mem::size_of::<foo>(),
+        16usize,
+        concat!("Size of: ", stringify!(foo)),
     );
     assert_eq!(
-        ::core::mem::align_of:: < foo > (), 8usize, concat!("Alignment of ",
-        stringify!(foo))
+        ::core::mem::align_of::<foo>(),
+        8usize,
+        concat!("Alignment of ", stringify!(foo)),
     );
     assert_eq!(
-        unsafe { ::core::ptr::addr_of!((* ptr).a) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(a))
+        unsafe { ::core::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(foo), "::", stringify!(a)),
     );
     assert_eq!(
-        unsafe { ::core::ptr::addr_of!((* ptr).b) as usize - ptr as usize }, 4usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(b))
+        unsafe { ::core::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
+        4usize,
+        concat!("Offset of field: ", stringify!(foo), "::", stringify!(b)),
     );
     assert_eq!(
-        unsafe { ::core::ptr::addr_of!((* ptr).bar) as usize - ptr as usize }, 8usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar))
+        unsafe { ::core::ptr::addr_of!((*ptr).bar) as usize - ptr as usize },
+        8usize,
+        concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar)),
     );
 }
 impl Clone for foo {
@@ -100,20 +106,24 @@ fn bindgen_test_layout__bindgen_ty_1() {
     const UNINIT: ::core::mem::MaybeUninit<_bindgen_ty_1> = ::core::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::core::mem::size_of:: < _bindgen_ty_1 > (), 8usize, concat!("Size of: ",
-        stringify!(_bindgen_ty_1))
+        ::core::mem::size_of::<_bindgen_ty_1>(),
+        8usize,
+        concat!("Size of: ", stringify!(_bindgen_ty_1)),
     );
     assert_eq!(
-        ::core::mem::align_of:: < _bindgen_ty_1 > (), 8usize, concat!("Alignment of ",
-        stringify!(_bindgen_ty_1))
+        ::core::mem::align_of::<_bindgen_ty_1>(),
+        8usize,
+        concat!("Alignment of ", stringify!(_bindgen_ty_1)),
     );
     assert_eq!(
-        unsafe { ::core::ptr::addr_of!((* ptr).bar) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(_bindgen_ty_1), "::", stringify!(bar))
+        unsafe { ::core::ptr::addr_of!((*ptr).bar) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(_bindgen_ty_1), "::", stringify!(bar)),
     );
     assert_eq!(
-        unsafe { ::core::ptr::addr_of!((* ptr).baz) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(_bindgen_ty_1), "::", stringify!(baz))
+        unsafe { ::core::ptr::addr_of!((*ptr).baz) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(_bindgen_ty_1), "::", stringify!(baz)),
     );
 }
 impl Clone for _bindgen_ty_1 {

--- a/bindgen-tests/tests/expectations/tests/var-tracing.rs
+++ b/bindgen-tests/tests/expectations/tests/var-tracing.rs
@@ -9,15 +9,19 @@ fn bindgen_test_layout_Bar() {
     const UNINIT: ::std::mem::MaybeUninit<Bar> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < Bar > (), 4usize, concat!("Size of: ", stringify!(Bar))
+        ::std::mem::size_of::<Bar>(),
+        4usize,
+        concat!("Size of: ", stringify!(Bar)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Bar > (), 4usize, concat!("Alignment of ",
-        stringify!(Bar))
+        ::std::mem::align_of::<Bar>(),
+        4usize,
+        concat!("Alignment of ", stringify!(Bar)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).m_baz) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(Bar), "::", stringify!(m_baz))
+        unsafe { ::std::ptr::addr_of!((*ptr).m_baz) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(Bar), "::", stringify!(m_baz)),
     );
 }
 extern "C" {
@@ -44,10 +48,13 @@ extern "C" {
 #[test]
 fn bindgen_test_layout_Baz() {
     assert_eq!(
-        ::std::mem::size_of:: < Baz > (), 1usize, concat!("Size of: ", stringify!(Baz))
+        ::std::mem::size_of::<Baz>(),
+        1usize,
+        concat!("Size of: ", stringify!(Baz)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Baz > (), 1usize, concat!("Alignment of ",
-        stringify!(Baz))
+        ::std::mem::align_of::<Baz>(),
+        1usize,
+        concat!("Alignment of ", stringify!(Baz)),
     );
 }

--- a/bindgen-tests/tests/expectations/tests/variadic-method.rs
+++ b/bindgen-tests/tests/expectations/tests/variadic-method.rs
@@ -11,11 +11,14 @@ pub struct Bar {
 #[test]
 fn bindgen_test_layout_Bar() {
     assert_eq!(
-        ::std::mem::size_of:: < Bar > (), 1usize, concat!("Size of: ", stringify!(Bar))
+        ::std::mem::size_of::<Bar>(),
+        1usize,
+        concat!("Size of: ", stringify!(Bar)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Bar > (), 1usize, concat!("Alignment of ",
-        stringify!(Bar))
+        ::std::mem::align_of::<Bar>(),
+        1usize,
+        concat!("Alignment of ", stringify!(Bar)),
     );
 }
 extern "C" {

--- a/bindgen-tests/tests/expectations/tests/vector.rs
+++ b/bindgen-tests/tests/expectations/tests/vector.rs
@@ -9,15 +9,19 @@ fn bindgen_test_layout_foo() {
     const UNINIT: ::std::mem::MaybeUninit<foo> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < foo > (), 8usize, concat!("Size of: ", stringify!(foo))
+        ::std::mem::size_of::<foo>(),
+        8usize,
+        concat!("Size of: ", stringify!(foo)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < foo > (), 8usize, concat!("Alignment of ",
-        stringify!(foo))
+        ::std::mem::align_of::<foo>(),
+        8usize,
+        concat!("Alignment of ", stringify!(foo)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).mMember) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(mMember))
+        unsafe { ::std::ptr::addr_of!((*ptr).mMember) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(foo), "::", stringify!(mMember)),
     );
 }
 pub type __m128 = [f32; 4usize];

--- a/bindgen-tests/tests/expectations/tests/virtual_dtor.rs
+++ b/bindgen-tests/tests/expectations/tests/virtual_dtor.rs
@@ -9,12 +9,14 @@ pub struct nsSlots {
 #[test]
 fn bindgen_test_layout_nsSlots() {
     assert_eq!(
-        ::std::mem::size_of:: < nsSlots > (), 8usize, concat!("Size of: ",
-        stringify!(nsSlots))
+        ::std::mem::size_of::<nsSlots>(),
+        8usize,
+        concat!("Size of: ", stringify!(nsSlots)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < nsSlots > (), 8usize, concat!("Alignment of ",
-        stringify!(nsSlots))
+        ::std::mem::align_of::<nsSlots>(),
+        8usize,
+        concat!("Alignment of ", stringify!(nsSlots)),
     );
 }
 impl Default for nsSlots {

--- a/bindgen-tests/tests/expectations/tests/virtual_interface.rs
+++ b/bindgen-tests/tests/expectations/tests/virtual_interface.rs
@@ -15,12 +15,14 @@ pub struct PureVirtualIFace {
 #[test]
 fn bindgen_test_layout_PureVirtualIFace() {
     assert_eq!(
-        ::std::mem::size_of:: < PureVirtualIFace > (), 8usize, concat!("Size of: ",
-        stringify!(PureVirtualIFace))
+        ::std::mem::size_of::<PureVirtualIFace>(),
+        8usize,
+        concat!("Size of: ", stringify!(PureVirtualIFace)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < PureVirtualIFace > (), 8usize, concat!("Alignment of ",
-        stringify!(PureVirtualIFace))
+        ::std::mem::align_of::<PureVirtualIFace>(),
+        8usize,
+        concat!("Alignment of ", stringify!(PureVirtualIFace)),
     );
 }
 impl Default for PureVirtualIFace {
@@ -44,12 +46,14 @@ pub struct AnotherInterface {
 #[test]
 fn bindgen_test_layout_AnotherInterface() {
     assert_eq!(
-        ::std::mem::size_of:: < AnotherInterface > (), 8usize, concat!("Size of: ",
-        stringify!(AnotherInterface))
+        ::std::mem::size_of::<AnotherInterface>(),
+        8usize,
+        concat!("Size of: ", stringify!(AnotherInterface)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < AnotherInterface > (), 8usize, concat!("Alignment of ",
-        stringify!(AnotherInterface))
+        ::std::mem::align_of::<AnotherInterface>(),
+        8usize,
+        concat!("Alignment of ", stringify!(AnotherInterface)),
     );
 }
 impl Default for AnotherInterface {
@@ -69,12 +73,14 @@ pub struct Implementation {
 #[test]
 fn bindgen_test_layout_Implementation() {
     assert_eq!(
-        ::std::mem::size_of:: < Implementation > (), 8usize, concat!("Size of: ",
-        stringify!(Implementation))
+        ::std::mem::size_of::<Implementation>(),
+        8usize,
+        concat!("Size of: ", stringify!(Implementation)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Implementation > (), 8usize, concat!("Alignment of ",
-        stringify!(Implementation))
+        ::std::mem::align_of::<Implementation>(),
+        8usize,
+        concat!("Alignment of ", stringify!(Implementation)),
     );
 }
 impl Default for Implementation {
@@ -95,12 +101,14 @@ pub struct DoubleImpl {
 #[test]
 fn bindgen_test_layout_DoubleImpl() {
     assert_eq!(
-        ::std::mem::size_of:: < DoubleImpl > (), 16usize, concat!("Size of: ",
-        stringify!(DoubleImpl))
+        ::std::mem::size_of::<DoubleImpl>(),
+        16usize,
+        concat!("Size of: ", stringify!(DoubleImpl)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < DoubleImpl > (), 8usize, concat!("Alignment of ",
-        stringify!(DoubleImpl))
+        ::std::mem::align_of::<DoubleImpl>(),
+        8usize,
+        concat!("Alignment of ", stringify!(DoubleImpl)),
     );
 }
 impl Default for DoubleImpl {

--- a/bindgen-tests/tests/expectations/tests/virtual_overloaded.rs
+++ b/bindgen-tests/tests/expectations/tests/virtual_overloaded.rs
@@ -11,11 +11,11 @@ pub struct C {
 }
 #[test]
 fn bindgen_test_layout_C() {
+    assert_eq!(::std::mem::size_of::<C>(), 8usize, concat!("Size of: ", stringify!(C)));
     assert_eq!(
-        ::std::mem::size_of:: < C > (), 8usize, concat!("Size of: ", stringify!(C))
-    );
-    assert_eq!(
-        ::std::mem::align_of:: < C > (), 8usize, concat!("Alignment of ", stringify!(C))
+        ::std::mem::align_of::<C>(),
+        8usize,
+        concat!("Alignment of ", stringify!(C)),
     );
 }
 impl Default for C {

--- a/bindgen-tests/tests/expectations/tests/vtable_recursive_sig.rs
+++ b/bindgen-tests/tests/expectations/tests/vtable_recursive_sig.rs
@@ -11,11 +11,14 @@ pub struct Base {
 #[test]
 fn bindgen_test_layout_Base() {
     assert_eq!(
-        ::std::mem::size_of:: < Base > (), 8usize, concat!("Size of: ", stringify!(Base))
+        ::std::mem::size_of::<Base>(),
+        8usize,
+        concat!("Size of: ", stringify!(Base)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Base > (), 8usize, concat!("Alignment of ",
-        stringify!(Base))
+        ::std::mem::align_of::<Base>(),
+        8usize,
+        concat!("Alignment of ", stringify!(Base)),
     );
 }
 impl Default for Base {
@@ -39,12 +42,14 @@ pub struct Derived {
 #[test]
 fn bindgen_test_layout_Derived() {
     assert_eq!(
-        ::std::mem::size_of:: < Derived > (), 8usize, concat!("Size of: ",
-        stringify!(Derived))
+        ::std::mem::size_of::<Derived>(),
+        8usize,
+        concat!("Size of: ", stringify!(Derived)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Derived > (), 8usize, concat!("Alignment of ",
-        stringify!(Derived))
+        ::std::mem::align_of::<Derived>(),
+        8usize,
+        concat!("Alignment of ", stringify!(Derived)),
     );
 }
 impl Default for Derived {

--- a/bindgen-tests/tests/expectations/tests/wasm-constructor-returns.rs
+++ b/bindgen-tests/tests/expectations/tests/wasm-constructor-returns.rs
@@ -7,11 +7,14 @@ pub struct Foo {
 #[test]
 fn bindgen_test_layout_Foo() {
     assert_eq!(
-        ::std::mem::size_of:: < Foo > (), 1usize, concat!("Size of: ", stringify!(Foo))
+        ::std::mem::size_of::<Foo>(),
+        1usize,
+        concat!("Size of: ", stringify!(Foo)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Foo > (), 1usize, concat!("Alignment of ",
-        stringify!(Foo))
+        ::std::mem::align_of::<Foo>(),
+        1usize,
+        concat!("Alignment of ", stringify!(Foo)),
     );
 }
 extern "C" {

--- a/bindgen-tests/tests/expectations/tests/weird_bitfields.rs
+++ b/bindgen-tests/tests/expectations/tests/weird_bitfields.rs
@@ -49,7 +49,7 @@ where
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < self.storage.as_ref().len());
         debug_assert!(
-            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len()
+            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len(),
         );
         let mut val = 0;
         for i in 0..(bit_width as usize) {
@@ -69,7 +69,7 @@ where
         debug_assert!(bit_width <= 64);
         debug_assert!(bit_offset / 8 < self.storage.as_ref().len());
         debug_assert!(
-            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len()
+            (bit_offset + (bit_width as usize)) / 8 <= self.storage.as_ref().len(),
         );
         for i in 0..(bit_width as usize) {
             let mask = 1 << i;
@@ -116,72 +116,111 @@ fn bindgen_test_layout_Weird() {
     const UNINIT: ::std::mem::MaybeUninit<Weird> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < Weird > (), 24usize, concat!("Size of: ",
-        stringify!(Weird))
+        ::std::mem::size_of::<Weird>(),
+        24usize,
+        concat!("Size of: ", stringify!(Weird)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Weird > (), 4usize, concat!("Alignment of ",
-        stringify!(Weird))
+        ::std::mem::align_of::<Weird>(),
+        4usize,
+        concat!("Alignment of ", stringify!(Weird)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).mStrokeDasharrayLength) as usize - ptr as
-        usize }, 0usize, concat!("Offset of field: ", stringify!(Weird), "::",
-        stringify!(mStrokeDasharrayLength))
+        unsafe {
+            ::std::ptr::addr_of!((*ptr).mStrokeDasharrayLength) as usize - ptr as usize
+        },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(Weird),
+            "::",
+            stringify!(mStrokeDasharrayLength),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).mClipRule) as usize - ptr as usize },
-        8usize, concat!("Offset of field: ", stringify!(Weird), "::",
-        stringify!(mClipRule))
+        unsafe { ::std::ptr::addr_of!((*ptr).mClipRule) as usize - ptr as usize },
+        8usize,
+        concat!("Offset of field: ", stringify!(Weird), "::", stringify!(mClipRule)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).mColorInterpolation) as usize - ptr as
-        usize }, 9usize, concat!("Offset of field: ", stringify!(Weird), "::",
-        stringify!(mColorInterpolation))
+        unsafe {
+            ::std::ptr::addr_of!((*ptr).mColorInterpolation) as usize - ptr as usize
+        },
+        9usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(Weird),
+            "::",
+            stringify!(mColorInterpolation),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).mColorInterpolationFilters) as usize - ptr
-        as usize }, 10usize, concat!("Offset of field: ", stringify!(Weird), "::",
-        stringify!(mColorInterpolationFilters))
+        unsafe {
+            ::std::ptr::addr_of!((*ptr).mColorInterpolationFilters) as usize
+                - ptr as usize
+        },
+        10usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(Weird),
+            "::",
+            stringify!(mColorInterpolationFilters),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).mFillRule) as usize - ptr as usize },
-        11usize, concat!("Offset of field: ", stringify!(Weird), "::",
-        stringify!(mFillRule))
+        unsafe { ::std::ptr::addr_of!((*ptr).mFillRule) as usize - ptr as usize },
+        11usize,
+        concat!("Offset of field: ", stringify!(Weird), "::", stringify!(mFillRule)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).mImageRendering) as usize - ptr as usize },
-        12usize, concat!("Offset of field: ", stringify!(Weird), "::",
-        stringify!(mImageRendering))
+        unsafe { ::std::ptr::addr_of!((*ptr).mImageRendering) as usize - ptr as usize },
+        12usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(Weird),
+            "::",
+            stringify!(mImageRendering),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).mPaintOrder) as usize - ptr as usize },
-        13usize, concat!("Offset of field: ", stringify!(Weird), "::",
-        stringify!(mPaintOrder))
+        unsafe { ::std::ptr::addr_of!((*ptr).mPaintOrder) as usize - ptr as usize },
+        13usize,
+        concat!("Offset of field: ", stringify!(Weird), "::", stringify!(mPaintOrder)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).mShapeRendering) as usize - ptr as usize },
-        14usize, concat!("Offset of field: ", stringify!(Weird), "::",
-        stringify!(mShapeRendering))
+        unsafe { ::std::ptr::addr_of!((*ptr).mShapeRendering) as usize - ptr as usize },
+        14usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(Weird),
+            "::",
+            stringify!(mShapeRendering),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).mStrokeLinecap) as usize - ptr as usize },
-        15usize, concat!("Offset of field: ", stringify!(Weird), "::",
-        stringify!(mStrokeLinecap))
+        unsafe { ::std::ptr::addr_of!((*ptr).mStrokeLinecap) as usize - ptr as usize },
+        15usize,
+        concat!("Offset of field: ", stringify!(Weird), "::", stringify!(mStrokeLinecap)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).mStrokeLinejoin) as usize - ptr as usize },
-        16usize, concat!("Offset of field: ", stringify!(Weird), "::",
-        stringify!(mStrokeLinejoin))
+        unsafe { ::std::ptr::addr_of!((*ptr).mStrokeLinejoin) as usize - ptr as usize },
+        16usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(Weird),
+            "::",
+            stringify!(mStrokeLinejoin),
+        ),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).mTextAnchor) as usize - ptr as usize },
-        17usize, concat!("Offset of field: ", stringify!(Weird), "::",
-        stringify!(mTextAnchor))
+        unsafe { ::std::ptr::addr_of!((*ptr).mTextAnchor) as usize - ptr as usize },
+        17usize,
+        concat!("Offset of field: ", stringify!(Weird), "::", stringify!(mTextAnchor)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).mTextRendering) as usize - ptr as usize },
-        18usize, concat!("Offset of field: ", stringify!(Weird), "::",
-        stringify!(mTextRendering))
+        unsafe { ::std::ptr::addr_of!((*ptr).mTextRendering) as usize - ptr as usize },
+        18usize,
+        concat!("Offset of field: ", stringify!(Weird), "::", stringify!(mTextRendering)),
     );
 }
 impl Default for Weird {

--- a/bindgen-tests/tests/expectations/tests/what_is_going_on.rs
+++ b/bindgen-tests/tests/expectations/tests/what_is_going_on.rs
@@ -7,12 +7,14 @@ pub struct UnknownUnits {
 #[test]
 fn bindgen_test_layout_UnknownUnits() {
     assert_eq!(
-        ::std::mem::size_of:: < UnknownUnits > (), 1usize, concat!("Size of: ",
-        stringify!(UnknownUnits))
+        ::std::mem::size_of::<UnknownUnits>(),
+        1usize,
+        concat!("Size of: ", stringify!(UnknownUnits)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < UnknownUnits > (), 1usize, concat!("Alignment of ",
-        stringify!(UnknownUnits))
+        ::std::mem::align_of::<UnknownUnits>(),
+        1usize,
+        concat!("Alignment of ", stringify!(UnknownUnits)),
     );
 }
 pub type Float = f32;

--- a/bindgen-tests/tests/expectations/tests/win32-thiscall_1_0.rs
+++ b/bindgen-tests/tests/expectations/tests/win32-thiscall_1_0.rs
@@ -7,11 +7,14 @@ pub struct Foo {
 #[test]
 fn bindgen_test_layout_Foo() {
     assert_eq!(
-        ::std::mem::size_of:: < Foo > (), 1usize, concat!("Size of: ", stringify!(Foo))
+        ::std::mem::size_of::<Foo>(),
+        1usize,
+        concat!("Size of: ", stringify!(Foo)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Foo > (), 1usize, concat!("Alignment of ",
-        stringify!(Foo))
+        ::std::mem::align_of::<Foo>(),
+        1usize,
+        concat!("Alignment of ", stringify!(Foo)),
     );
 }
 impl Clone for Foo {

--- a/bindgen-tests/tests/expectations/tests/win32-thiscall_nightly.rs
+++ b/bindgen-tests/tests/expectations/tests/win32-thiscall_nightly.rs
@@ -9,11 +9,14 @@ pub struct Foo {
 #[test]
 fn bindgen_test_layout_Foo() {
     assert_eq!(
-        ::std::mem::size_of:: < Foo > (), 1usize, concat!("Size of: ", stringify!(Foo))
+        ::std::mem::size_of::<Foo>(),
+        1usize,
+        concat!("Size of: ", stringify!(Foo)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < Foo > (), 1usize, concat!("Alignment of ",
-        stringify!(Foo))
+        ::std::mem::align_of::<Foo>(),
+        1usize,
+        concat!("Alignment of ", stringify!(Foo)),
     );
 }
 extern "thiscall" {

--- a/bindgen-tests/tests/expectations/tests/zero-size-array-align.rs
+++ b/bindgen-tests/tests/expectations/tests/zero-size-array-align.rs
@@ -41,23 +41,28 @@ fn bindgen_test_layout_dm_deps() {
     const UNINIT: ::std::mem::MaybeUninit<dm_deps> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < dm_deps > (), 8usize, concat!("Size of: ",
-        stringify!(dm_deps))
+        ::std::mem::size_of::<dm_deps>(),
+        8usize,
+        concat!("Size of: ", stringify!(dm_deps)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < dm_deps > (), 8usize, concat!("Alignment of ",
-        stringify!(dm_deps))
+        ::std::mem::align_of::<dm_deps>(),
+        8usize,
+        concat!("Alignment of ", stringify!(dm_deps)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).count) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(dm_deps), "::", stringify!(count))
+        unsafe { ::std::ptr::addr_of!((*ptr).count) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(dm_deps), "::", stringify!(count)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).filler) as usize - ptr as usize }, 4usize,
-        concat!("Offset of field: ", stringify!(dm_deps), "::", stringify!(filler))
+        unsafe { ::std::ptr::addr_of!((*ptr).filler) as usize - ptr as usize },
+        4usize,
+        concat!("Offset of field: ", stringify!(dm_deps), "::", stringify!(filler)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).device) as usize - ptr as usize }, 8usize,
-        concat!("Offset of field: ", stringify!(dm_deps), "::", stringify!(device))
+        unsafe { ::std::ptr::addr_of!((*ptr).device) as usize - ptr as usize },
+        8usize,
+        concat!("Offset of field: ", stringify!(dm_deps), "::", stringify!(device)),
     );
 }

--- a/bindgen-tests/tests/expectations/tests/zero-sized-array.rs
+++ b/bindgen-tests/tests/expectations/tests/zero-sized-array.rs
@@ -40,16 +40,19 @@ fn bindgen_test_layout_ZeroSizedArray() {
     const UNINIT: ::std::mem::MaybeUninit<ZeroSizedArray> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < ZeroSizedArray > (), 0usize, concat!("Size of: ",
-        stringify!(ZeroSizedArray))
+        ::std::mem::size_of::<ZeroSizedArray>(),
+        0usize,
+        concat!("Size of: ", stringify!(ZeroSizedArray)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < ZeroSizedArray > (), 1usize, concat!("Alignment of ",
-        stringify!(ZeroSizedArray))
+        ::std::mem::align_of::<ZeroSizedArray>(),
+        1usize,
+        concat!("Alignment of ", stringify!(ZeroSizedArray)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).arr) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(ZeroSizedArray), "::", stringify!(arr))
+        unsafe { ::std::ptr::addr_of!((*ptr).arr) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(ZeroSizedArray), "::", stringify!(arr)),
     );
 }
 /// And nor should this get an `_address` field.
@@ -63,17 +66,24 @@ fn bindgen_test_layout_ContainsZeroSizedArray() {
     const UNINIT: ::std::mem::MaybeUninit<ContainsZeroSizedArray> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
     assert_eq!(
-        ::std::mem::size_of:: < ContainsZeroSizedArray > (), 0usize, concat!("Size of: ",
-        stringify!(ContainsZeroSizedArray))
+        ::std::mem::size_of::<ContainsZeroSizedArray>(),
+        0usize,
+        concat!("Size of: ", stringify!(ContainsZeroSizedArray)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < ContainsZeroSizedArray > (), 1usize,
-        concat!("Alignment of ", stringify!(ContainsZeroSizedArray))
+        ::std::mem::align_of::<ContainsZeroSizedArray>(),
+        1usize,
+        concat!("Alignment of ", stringify!(ContainsZeroSizedArray)),
     );
     assert_eq!(
-        unsafe { ::std::ptr::addr_of!((* ptr).zsa) as usize - ptr as usize }, 0usize,
-        concat!("Offset of field: ", stringify!(ContainsZeroSizedArray), "::",
-        stringify!(zsa))
+        unsafe { ::std::ptr::addr_of!((*ptr).zsa) as usize - ptr as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(ContainsZeroSizedArray),
+            "::",
+            stringify!(zsa),
+        ),
     );
 }
 /** Inheriting from ZeroSizedArray shouldn't cause an `_address` to be inserted
@@ -86,12 +96,14 @@ pub struct InheritsZeroSizedArray {
 #[test]
 fn bindgen_test_layout_InheritsZeroSizedArray() {
     assert_eq!(
-        ::std::mem::size_of:: < InheritsZeroSizedArray > (), 0usize, concat!("Size of: ",
-        stringify!(InheritsZeroSizedArray))
+        ::std::mem::size_of::<InheritsZeroSizedArray>(),
+        0usize,
+        concat!("Size of: ", stringify!(InheritsZeroSizedArray)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < InheritsZeroSizedArray > (), 1usize,
-        concat!("Alignment of ", stringify!(InheritsZeroSizedArray))
+        ::std::mem::align_of::<InheritsZeroSizedArray>(),
+        1usize,
+        concat!("Alignment of ", stringify!(InheritsZeroSizedArray)),
     );
 }
 /// And this should not get an `_address` field either.
@@ -103,12 +115,14 @@ pub struct DynamicallySizedArray {
 #[test]
 fn bindgen_test_layout_DynamicallySizedArray() {
     assert_eq!(
-        ::std::mem::size_of:: < DynamicallySizedArray > (), 0usize, concat!("Size of: ",
-        stringify!(DynamicallySizedArray))
+        ::std::mem::size_of::<DynamicallySizedArray>(),
+        0usize,
+        concat!("Size of: ", stringify!(DynamicallySizedArray)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < DynamicallySizedArray > (), 1usize,
-        concat!("Alignment of ", stringify!(DynamicallySizedArray))
+        ::std::mem::align_of::<DynamicallySizedArray>(),
+        1usize,
+        concat!("Alignment of ", stringify!(DynamicallySizedArray)),
     );
 }
 /// No `_address` field here either.
@@ -120,11 +134,13 @@ pub struct ContainsDynamicallySizedArray {
 #[test]
 fn bindgen_test_layout_ContainsDynamicallySizedArray() {
     assert_eq!(
-        ::std::mem::size_of:: < ContainsDynamicallySizedArray > (), 0usize,
-        concat!("Size of: ", stringify!(ContainsDynamicallySizedArray))
+        ::std::mem::size_of::<ContainsDynamicallySizedArray>(),
+        0usize,
+        concat!("Size of: ", stringify!(ContainsDynamicallySizedArray)),
     );
     assert_eq!(
-        ::std::mem::align_of:: < ContainsDynamicallySizedArray > (), 1usize,
-        concat!("Alignment of ", stringify!(ContainsDynamicallySizedArray))
+        ::std::mem::align_of::<ContainsDynamicallySizedArray>(),
+        1usize,
+        concat!("Alignment of ", stringify!(ContainsDynamicallySizedArray)),
     );
 }

--- a/bindgen/Cargo.toml
+++ b/bindgen/Cargo.toml
@@ -33,7 +33,7 @@ lazy_static = "1"
 lazycell = "1"
 log = { version = "0.4", optional = true }
 peeking_take_while = "0.1.2"
-prettyplease = { version = "0.2.0", optional = true }
+prettyplease = { version = "0.2.7", optional = true, features = ["verbatim"] }
 proc-macro2 = { version = "1", default-features = false }
 quote = { version = "1", default-features = false }
 regex = { version = "1.5", default-features = false, features = ["std", "unicode"] }


### PR DESCRIPTION
**Before:**

```rust
assert_eq!(
    ::std::mem::size_of:: < rte_ipv4_tuple > (), 12usize, concat!("Size of: ",
    stringify!(rte_ipv4_tuple))
);
```

**After:**

```rust
assert_eq!(
    ::std::mem::size_of::<rte_ipv4_tuple>(),
    12usize,
    concat!("Size of: ", stringify!(rte_ipv4_tuple)),
);
```