### PR TITLE
Fix `Clone` implementation for `__BindgenUnionField`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -172,6 +172,8 @@
 
 ## Added
 ## Changed
+- The `Clone` implementation for `_BindgenUnionField` has been changed to pass
+  the `incorrect_clone_impl_on_copy_type` Clippy lint.
 ## Removed
 ## Fixed
 ## Security

--- a/bindgen-tests/tests/expectations/tests/16-byte-alignment_1_0.rs
+++ b/bindgen-tests/tests/expectations/tests/16-byte-alignment_1_0.rs
@@ -24,7 +24,7 @@ impl<T> ::std::default::Default for __BindgenUnionField<T> {
 impl<T> ::std::clone::Clone for __BindgenUnionField<T> {
     #[inline]
     fn clone(&self) -> Self {
-        Self::new()
+        *self
     }
 }
 impl<T> ::std::marker::Copy for __BindgenUnionField<T> {}

--- a/bindgen-tests/tests/expectations/tests/anon_struct_in_union_1_0.rs
+++ b/bindgen-tests/tests/expectations/tests/anon_struct_in_union_1_0.rs
@@ -24,7 +24,7 @@ impl<T> ::std::default::Default for __BindgenUnionField<T> {
 impl<T> ::std::clone::Clone for __BindgenUnionField<T> {
     #[inline]
     fn clone(&self) -> Self {
-        Self::new()
+        *self
     }
 }
 impl<T> ::std::marker::Copy for __BindgenUnionField<T> {}

--- a/bindgen-tests/tests/expectations/tests/anon_union_1_0.rs
+++ b/bindgen-tests/tests/expectations/tests/anon_union_1_0.rs
@@ -24,7 +24,7 @@ impl<T> ::std::default::Default for __BindgenUnionField<T> {
 impl<T> ::std::clone::Clone for __BindgenUnionField<T> {
     #[inline]
     fn clone(&self) -> Self {
-        Self::new()
+        *self
     }
 }
 impl<T> ::std::marker::Copy for __BindgenUnionField<T> {}

--- a/bindgen-tests/tests/expectations/tests/bindgen-union-inside-namespace.rs
+++ b/bindgen-tests/tests/expectations/tests/bindgen-union-inside-namespace.rs
@@ -26,7 +26,7 @@ pub mod root {
     impl<T> ::std::clone::Clone for __BindgenUnionField<T> {
         #[inline]
         fn clone(&self) -> Self {
-            Self::new()
+            *self
         }
     }
     impl<T> ::std::marker::Copy for __BindgenUnionField<T> {}

--- a/bindgen-tests/tests/expectations/tests/class_1_0.rs
+++ b/bindgen-tests/tests/expectations/tests/class_1_0.rs
@@ -54,7 +54,7 @@ impl<T> ::std::default::Default for __BindgenUnionField<T> {
 impl<T> ::std::clone::Clone for __BindgenUnionField<T> {
     #[inline]
     fn clone(&self) -> Self {
-        Self::new()
+        *self
     }
 }
 impl<T> ::std::marker::Copy for __BindgenUnionField<T> {}

--- a/bindgen-tests/tests/expectations/tests/class_with_inner_struct_1_0.rs
+++ b/bindgen-tests/tests/expectations/tests/class_with_inner_struct_1_0.rs
@@ -24,7 +24,7 @@ impl<T> ::std::default::Default for __BindgenUnionField<T> {
 impl<T> ::std::clone::Clone for __BindgenUnionField<T> {
     #[inline]
     fn clone(&self) -> Self {
-        Self::new()
+        *self
     }
 }
 impl<T> ::std::marker::Copy for __BindgenUnionField<T> {}

--- a/bindgen-tests/tests/expectations/tests/derive-partialeq-union_1_0.rs
+++ b/bindgen-tests/tests/expectations/tests/derive-partialeq-union_1_0.rs
@@ -24,7 +24,7 @@ impl<T> ::std::default::Default for __BindgenUnionField<T> {
 impl<T> ::std::clone::Clone for __BindgenUnionField<T> {
     #[inline]
     fn clone(&self) -> Self {
-        Self::new()
+        *self
     }
 }
 impl<T> ::std::marker::Copy for __BindgenUnionField<T> {}

--- a/bindgen-tests/tests/expectations/tests/disable-untagged-union.rs
+++ b/bindgen-tests/tests/expectations/tests/disable-untagged-union.rs
@@ -24,7 +24,7 @@ impl<T> ::std::default::Default for __BindgenUnionField<T> {
 impl<T> ::std::clone::Clone for __BindgenUnionField<T> {
     #[inline]
     fn clone(&self) -> Self {
-        Self::new()
+        *self
     }
 }
 impl<T> ::std::marker::Copy for __BindgenUnionField<T> {}

--- a/bindgen-tests/tests/expectations/tests/issue-493.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-493.rs
@@ -24,7 +24,7 @@ impl<T> ::std::default::Default for __BindgenUnionField<T> {
 impl<T> ::std::clone::Clone for __BindgenUnionField<T> {
     #[inline]
     fn clone(&self) -> Self {
-        Self::new()
+        *self
     }
 }
 impl<T> ::std::marker::Copy for __BindgenUnionField<T> {}

--- a/bindgen-tests/tests/expectations/tests/issue-493_1_0.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-493_1_0.rs
@@ -24,7 +24,7 @@ impl<T> ::std::default::Default for __BindgenUnionField<T> {
 impl<T> ::std::clone::Clone for __BindgenUnionField<T> {
     #[inline]
     fn clone(&self) -> Self {
-        Self::new()
+        *self
     }
 }
 impl<T> ::std::marker::Copy for __BindgenUnionField<T> {}

--- a/bindgen-tests/tests/expectations/tests/jsval_layout_opaque_1_0.rs
+++ b/bindgen-tests/tests/expectations/tests/jsval_layout_opaque_1_0.rs
@@ -108,7 +108,7 @@ impl<T> ::std::default::Default for __BindgenUnionField<T> {
 impl<T> ::std::clone::Clone for __BindgenUnionField<T> {
     #[inline]
     fn clone(&self) -> Self {
-        Self::new()
+        *self
     }
 }
 impl<T> ::std::marker::Copy for __BindgenUnionField<T> {}

--- a/bindgen-tests/tests/expectations/tests/layout_eth_conf_1_0.rs
+++ b/bindgen-tests/tests/expectations/tests/layout_eth_conf_1_0.rs
@@ -108,7 +108,7 @@ impl<T> ::std::default::Default for __BindgenUnionField<T> {
 impl<T> ::std::clone::Clone for __BindgenUnionField<T> {
     #[inline]
     fn clone(&self) -> Self {
-        Self::new()
+        *self
     }
 }
 impl<T> ::std::marker::Copy for __BindgenUnionField<T> {}

--- a/bindgen-tests/tests/expectations/tests/layout_mbuf_1_0.rs
+++ b/bindgen-tests/tests/expectations/tests/layout_mbuf_1_0.rs
@@ -108,7 +108,7 @@ impl<T> ::std::default::Default for __BindgenUnionField<T> {
 impl<T> ::std::clone::Clone for __BindgenUnionField<T> {
     #[inline]
     fn clone(&self) -> Self {
-        Self::new()
+        *self
     }
 }
 impl<T> ::std::marker::Copy for __BindgenUnionField<T> {}

--- a/bindgen-tests/tests/expectations/tests/libclang-9/class_1_0.rs
+++ b/bindgen-tests/tests/expectations/tests/libclang-9/class_1_0.rs
@@ -54,7 +54,7 @@ impl<T> ::std::default::Default for __BindgenUnionField<T> {
 impl<T> ::std::clone::Clone for __BindgenUnionField<T> {
     #[inline]
     fn clone(&self) -> Self {
-        Self::new()
+        *self
     }
 }
 impl<T> ::std::marker::Copy for __BindgenUnionField<T> {}

--- a/bindgen-tests/tests/expectations/tests/struct_with_anon_union_1_0.rs
+++ b/bindgen-tests/tests/expectations/tests/struct_with_anon_union_1_0.rs
@@ -24,7 +24,7 @@ impl<T> ::std::default::Default for __BindgenUnionField<T> {
 impl<T> ::std::clone::Clone for __BindgenUnionField<T> {
     #[inline]
     fn clone(&self) -> Self {
-        Self::new()
+        *self
     }
 }
 impl<T> ::std::marker::Copy for __BindgenUnionField<T> {}

--- a/bindgen-tests/tests/expectations/tests/struct_with_anon_unnamed_union_1_0.rs
+++ b/bindgen-tests/tests/expectations/tests/struct_with_anon_unnamed_union_1_0.rs
@@ -24,7 +24,7 @@ impl<T> ::std::default::Default for __BindgenUnionField<T> {
 impl<T> ::std::clone::Clone for __BindgenUnionField<T> {
     #[inline]
     fn clone(&self) -> Self {
-        Self::new()
+        *self
     }
 }
 impl<T> ::std::marker::Copy for __BindgenUnionField<T> {}

--- a/bindgen-tests/tests/expectations/tests/struct_with_nesting_1_0.rs
+++ b/bindgen-tests/tests/expectations/tests/struct_with_nesting_1_0.rs
@@ -24,7 +24,7 @@ impl<T> ::std::default::Default for __BindgenUnionField<T> {
 impl<T> ::std::clone::Clone for __BindgenUnionField<T> {
     #[inline]
     fn clone(&self) -> Self {
-        Self::new()
+        *self
     }
 }
 impl<T> ::std::marker::Copy for __BindgenUnionField<T> {}

--- a/bindgen-tests/tests/expectations/tests/transform-op.rs
+++ b/bindgen-tests/tests/expectations/tests/transform-op.rs
@@ -24,7 +24,7 @@ impl<T> ::std::default::Default for __BindgenUnionField<T> {
 impl<T> ::std::clone::Clone for __BindgenUnionField<T> {
     #[inline]
     fn clone(&self) -> Self {
-        Self::new()
+        *self
     }
 }
 impl<T> ::std::marker::Copy for __BindgenUnionField<T> {}

--- a/bindgen-tests/tests/expectations/tests/typeref_1_0.rs
+++ b/bindgen-tests/tests/expectations/tests/typeref_1_0.rs
@@ -24,7 +24,7 @@ impl<T> ::std::default::Default for __BindgenUnionField<T> {
 impl<T> ::std::clone::Clone for __BindgenUnionField<T> {
     #[inline]
     fn clone(&self) -> Self {
-        Self::new()
+        *self
     }
 }
 impl<T> ::std::marker::Copy for __BindgenUnionField<T> {}

--- a/bindgen-tests/tests/expectations/tests/union-in-ns_1_0.rs
+++ b/bindgen-tests/tests/expectations/tests/union-in-ns_1_0.rs
@@ -26,7 +26,7 @@ pub mod root {
     impl<T> ::std::clone::Clone for __BindgenUnionField<T> {
         #[inline]
         fn clone(&self) -> Self {
-            Self::new()
+            *self
         }
     }
     impl<T> ::std::marker::Copy for __BindgenUnionField<T> {}

--- a/bindgen-tests/tests/expectations/tests/union_bitfield_1_0.rs
+++ b/bindgen-tests/tests/expectations/tests/union_bitfield_1_0.rs
@@ -108,7 +108,7 @@ impl<T> ::std::default::Default for __BindgenUnionField<T> {
 impl<T> ::std::clone::Clone for __BindgenUnionField<T> {
     #[inline]
     fn clone(&self) -> Self {
-        Self::new()
+        *self
     }
 }
 impl<T> ::std::marker::Copy for __BindgenUnionField<T> {}

--- a/bindgen-tests/tests/expectations/tests/union_dtor_1_0.rs
+++ b/bindgen-tests/tests/expectations/tests/union_dtor_1_0.rs
@@ -24,7 +24,7 @@ impl<T> ::std::default::Default for __BindgenUnionField<T> {
 impl<T> ::std::clone::Clone for __BindgenUnionField<T> {
     #[inline]
     fn clone(&self) -> Self {
-        Self::new()
+        *self
     }
 }
 impl<T> ::std::marker::Copy for __BindgenUnionField<T> {}

--- a/bindgen-tests/tests/expectations/tests/union_fields_1_0.rs
+++ b/bindgen-tests/tests/expectations/tests/union_fields_1_0.rs
@@ -24,7 +24,7 @@ impl<T> ::std::default::Default for __BindgenUnionField<T> {
 impl<T> ::std::clone::Clone for __BindgenUnionField<T> {
     #[inline]
     fn clone(&self) -> Self {
-        Self::new()
+        *self
     }
 }
 impl<T> ::std::marker::Copy for __BindgenUnionField<T> {}

--- a/bindgen-tests/tests/expectations/tests/union_template_1_0.rs
+++ b/bindgen-tests/tests/expectations/tests/union_template_1_0.rs
@@ -24,7 +24,7 @@ impl<T> ::std::default::Default for __BindgenUnionField<T> {
 impl<T> ::std::clone::Clone for __BindgenUnionField<T> {
     #[inline]
     fn clone(&self) -> Self {
-        Self::new()
+        *self
     }
 }
 impl<T> ::std::marker::Copy for __BindgenUnionField<T> {}

--- a/bindgen-tests/tests/expectations/tests/union_with_anon_struct_1_0.rs
+++ b/bindgen-tests/tests/expectations/tests/union_with_anon_struct_1_0.rs
@@ -24,7 +24,7 @@ impl<T> ::std::default::Default for __BindgenUnionField<T> {
 impl<T> ::std::clone::Clone for __BindgenUnionField<T> {
     #[inline]
     fn clone(&self) -> Self {
-        Self::new()
+        *self
     }
 }
 impl<T> ::std::marker::Copy for __BindgenUnionField<T> {}

--- a/bindgen-tests/tests/expectations/tests/union_with_anon_struct_bitfield_1_0.rs
+++ b/bindgen-tests/tests/expectations/tests/union_with_anon_struct_bitfield_1_0.rs
@@ -108,7 +108,7 @@ impl<T> ::std::default::Default for __BindgenUnionField<T> {
 impl<T> ::std::clone::Clone for __BindgenUnionField<T> {
     #[inline]
     fn clone(&self) -> Self {
-        Self::new()
+        *self
     }
 }
 impl<T> ::std::marker::Copy for __BindgenUnionField<T> {}

--- a/bindgen-tests/tests/expectations/tests/union_with_anon_union_1_0.rs
+++ b/bindgen-tests/tests/expectations/tests/union_with_anon_union_1_0.rs
@@ -24,7 +24,7 @@ impl<T> ::std::default::Default for __BindgenUnionField<T> {
 impl<T> ::std::clone::Clone for __BindgenUnionField<T> {
     #[inline]
     fn clone(&self) -> Self {
-        Self::new()
+        *self
     }
 }
 impl<T> ::std::marker::Copy for __BindgenUnionField<T> {}

--- a/bindgen-tests/tests/expectations/tests/union_with_anon_unnamed_struct_1_0.rs
+++ b/bindgen-tests/tests/expectations/tests/union_with_anon_unnamed_struct_1_0.rs
@@ -24,7 +24,7 @@ impl<T> ::std::default::Default for __BindgenUnionField<T> {
 impl<T> ::std::clone::Clone for __BindgenUnionField<T> {
     #[inline]
     fn clone(&self) -> Self {
-        Self::new()
+        *self
     }
 }
 impl<T> ::std::marker::Copy for __BindgenUnionField<T> {}

--- a/bindgen-tests/tests/expectations/tests/union_with_anon_unnamed_union_1_0.rs
+++ b/bindgen-tests/tests/expectations/tests/union_with_anon_unnamed_union_1_0.rs
@@ -24,7 +24,7 @@ impl<T> ::std::default::Default for __BindgenUnionField<T> {
 impl<T> ::std::clone::Clone for __BindgenUnionField<T> {
     #[inline]
     fn clone(&self) -> Self {
-        Self::new()
+        *self
     }
 }
 impl<T> ::std::marker::Copy for __BindgenUnionField<T> {}

--- a/bindgen-tests/tests/expectations/tests/union_with_big_member_1_0.rs
+++ b/bindgen-tests/tests/expectations/tests/union_with_big_member_1_0.rs
@@ -24,7 +24,7 @@ impl<T> ::std::default::Default for __BindgenUnionField<T> {
 impl<T> ::std::clone::Clone for __BindgenUnionField<T> {
     #[inline]
     fn clone(&self) -> Self {
-        Self::new()
+        *self
     }
 }
 impl<T> ::std::marker::Copy for __BindgenUnionField<T> {}

--- a/bindgen-tests/tests/expectations/tests/union_with_nesting_1_0.rs
+++ b/bindgen-tests/tests/expectations/tests/union_with_nesting_1_0.rs
@@ -24,7 +24,7 @@ impl<T> ::std::default::Default for __BindgenUnionField<T> {
 impl<T> ::std::clone::Clone for __BindgenUnionField<T> {
     #[inline]
     fn clone(&self) -> Self {
-        Self::new()
+        *self
     }
 }
 impl<T> ::std::marker::Copy for __BindgenUnionField<T> {}

--- a/bindgen-tests/tests/expectations/tests/union_with_non_copy_member.rs
+++ b/bindgen-tests/tests/expectations/tests/union_with_non_copy_member.rs
@@ -24,7 +24,7 @@ impl<T> ::std::default::Default for __BindgenUnionField<T> {
 impl<T> ::std::clone::Clone for __BindgenUnionField<T> {
     #[inline]
     fn clone(&self) -> Self {
-        Self::new()
+        *self
     }
 }
 impl<T> ::std::marker::Copy for __BindgenUnionField<T> {}

--- a/bindgen-tests/tests/expectations/tests/use-core_1_0.rs
+++ b/bindgen-tests/tests/expectations/tests/use-core_1_0.rs
@@ -25,7 +25,7 @@ impl<T> ::core::default::Default for __BindgenUnionField<T> {
 impl<T> ::core::clone::Clone for __BindgenUnionField<T> {
     #[inline]
     fn clone(&self) -> Self {
-        Self::new()
+        *self
     }
 }
 impl<T> ::core::marker::Copy for __BindgenUnionField<T> {}

--- a/bindgen-tests/tests/expectations/tests/wrap_unsafe_ops_anon_union_1_0.rs
+++ b/bindgen-tests/tests/expectations/tests/wrap_unsafe_ops_anon_union_1_0.rs
@@ -24,7 +24,7 @@ impl<T> ::std::default::Default for __BindgenUnionField<T> {
 impl<T> ::std::clone::Clone for __BindgenUnionField<T> {
     #[inline]
     fn clone(&self) -> Self {
-        Self::new()
+        *self
     }
 }
 impl<T> ::std::marker::Copy for __BindgenUnionField<T> {}

--- a/bindgen/codegen/mod.rs
+++ b/bindgen/codegen/mod.rs
@@ -4990,7 +4990,7 @@ pub(crate) mod utils {
             impl<T> ::#prefix::clone::Clone for __BindgenUnionField<T> {
                 #[inline]
                 fn clone(&self) -> Self {
-                    Self::new()
+                    *self
                 }
             }
         };


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust-bindgen/issues/2582

cc @emilio 