### PR TITLE
Add parent directory creation to write_to_file function

### DIFF
--- a/bindgen-integration/build.rs
+++ b/bindgen-integration/build.rs
@@ -168,7 +168,7 @@ fn setup_macro_test() {
     let macros = Arc::new(RwLock::new(HashSet::new()));
 
     let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
-    let out_rust_file = out_path.join("test.rs");
+    let out_rust_file = out_path.join("test/test.rs");
     let out_rust_file_relative = out_rust_file
         .strip_prefix(std::env::current_dir().unwrap().parent().unwrap())
         .unwrap();

--- a/bindgen-integration/src/lib.rs
+++ b/bindgen-integration/src/lib.rs
@@ -1,7 +1,7 @@
 #![allow(warnings)]
 
 mod bindings {
-    include!(concat!(env!("OUT_DIR"), "/test.rs"));
+    include!(concat!(env!("OUT_DIR"), "/test/test.rs"));
 }
 
 mod extern_bindings {

--- a/bindgen/lib.rs
+++ b/bindgen/lib.rs
@@ -900,6 +900,10 @@ impl Bindings {
 
     /// Write these bindings as source text to a file.
     pub fn write_to_file<P: AsRef<Path>>(&self, path: P) -> io::Result<()> {
+        if let Some(parent_dir) = path.as_ref().parent() {
+            std::fs::create_dir_all(parent_dir)?;
+        }
+
         let file = OpenOptions::new()
             .write(true)
             .truncate(true)


### PR DESCRIPTION
This commit adds the ability to create parent directories if they don't exist before writing a file in the write_to_file function. Additionally, an integration test has been changed to validate the behavior of the updated write_to_file function with parent directory creation.

This feature enables preserving the hierarchical structure of C/C++ projects where header files with the same name exist in different folders when generating bindings.

Additionally, this enhancement could have been implemented as an optional parameter if desired. If preferred, I can try refactor the changes to incorporate the functionality as an optional parameter.

@emilio 