### PR TITLE
Fix escaping for objective-C identifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -176,6 +176,9 @@
   the `incorrect_clone_impl_on_copy_type` Clippy lint.
 ## Removed
 ## Fixed
+- Bindgen no longer panics when parsing an objective-C header that includes a
+  Rust keyword that cannot be a raw identifier, such as: `self`, `crate`,
+  `super` or `Self`.
 ## Security
 
 # 0.66.1

--- a/bindgen-tests/tests/expectations/tests/objc_escape.rs
+++ b/bindgen-tests/tests/expectations/tests/objc_escape.rs
@@ -26,4 +26,10 @@ pub trait IA: Sized + std::ops::Deref {
     {
         msg_send!(* self, f : arg1 r#as : arg2)
     }
+    unsafe fn crate_(&self, self_: ::std::os::raw::c_int)
+    where
+        <Self as std::ops::Deref>::Target: objc::Message + Sized,
+    {
+        msg_send!(* self, crate_ : self_)
+    }
 }

--- a/bindgen-tests/tests/headers/objc_escape.h
+++ b/bindgen-tests/tests/headers/objc_escape.h
@@ -3,4 +3,5 @@
 
 @interface A
 -(void)f:(int)arg1 as:(int)arg2;
+-(void)crate:(int)self;
 @end


### PR DESCRIPTION
Fixes #2486
