### PR TITLE
Turn collections of `String` into collections of `Box<str>`

### DIFF
--- a/bindgen/clang.rs
+++ b/bindgen/clang.rs
@@ -1923,9 +1923,9 @@ pub(crate) struct UnsavedFile {
 
 impl UnsavedFile {
     /// Construct a new unsaved file with the given `name` and `contents`.
-    pub(crate) fn new(name: Box<str>, contents: Box<str>) -> UnsavedFile {
-        let name = CString::new(name.into_boxed_bytes()).unwrap();
-        let contents = CString::new(contents.into_boxed_bytes()).unwrap();
+    pub(crate) fn new(name: &str, contents: &str) -> UnsavedFile {
+        let name = CString::new(name.as_bytes()).unwrap();
+        let contents = CString::new(contents.as_bytes()).unwrap();
         let x = CXUnsavedFile {
             Filename: name.as_ptr(),
             Contents: contents.as_ptr(),

--- a/bindgen/clang.rs
+++ b/bindgen/clang.rs
@@ -1923,9 +1923,9 @@ pub(crate) struct UnsavedFile {
 
 impl UnsavedFile {
     /// Construct a new unsaved file with the given `name` and `contents`.
-    pub(crate) fn new(name: String, contents: String) -> UnsavedFile {
-        let name = CString::new(name).unwrap();
-        let contents = CString::new(contents).unwrap();
+    pub(crate) fn new(name: Box<str>, contents: Box<str>) -> UnsavedFile {
+        let name = CString::new(name.into_boxed_bytes()).unwrap();
+        let contents = CString::new(contents.into_boxed_bytes()).unwrap();
         let x = CXUnsavedFile {
             Filename: name.as_ptr(),
             Contents: contents.as_ptr(),

--- a/bindgen/clang.rs
+++ b/bindgen/clang.rs
@@ -1813,14 +1813,14 @@ impl TranslationUnit {
     pub(crate) fn parse(
         ix: &Index,
         file: &str,
-        cmd_args: &[String],
+        cmd_args: &[Box<str>],
         unsaved: &[UnsavedFile],
         opts: CXTranslationUnit_Flags,
     ) -> Option<TranslationUnit> {
         let fname = CString::new(file).unwrap();
         let _c_args: Vec<CString> = cmd_args
             .iter()
-            .map(|s| CString::new(s.clone()).unwrap())
+            .map(|s| CString::new(s.clone().into_boxed_bytes()).unwrap())
             .collect();
         let c_args: Vec<*const c_char> =
             _c_args.iter().map(|s| s.as_ptr()).collect();

--- a/bindgen/codegen/mod.rs
+++ b/bindgen/codegen/mod.rs
@@ -601,7 +601,10 @@ impl CodeGenerator for Module {
         let inner_items = result.inner(|result| {
             result.push(root_import(ctx, item));
 
-            let path = item.namespace_aware_canonical_path(ctx).join("::");
+            let path = item
+                .namespace_aware_canonical_path(ctx)
+                .join("::")
+                .into_boxed_str();
             if let Some(raw_lines) = ctx.options().module_lines.get(&path) {
                 for raw_line in raw_lines {
                     found_any = true;

--- a/bindgen/deps.rs
+++ b/bindgen/deps.rs
@@ -8,11 +8,11 @@ pub(crate) struct DepfileSpec {
 }
 
 impl DepfileSpec {
-    pub fn write(&self, deps: &BTreeSet<String>) -> std::io::Result<()> {
+    pub fn write(&self, deps: &BTreeSet<Box<str>>) -> std::io::Result<()> {
         std::fs::write(&self.depfile_path, self.to_string(deps))
     }
 
-    fn to_string(&self, deps: &BTreeSet<String>) -> String {
+    fn to_string(&self, deps: &BTreeSet<Box<str>>) -> String {
         // Transforms a string by escaping spaces and backslashes.
         let escape = |s: &str| s.replace('\\', "\\\\").replace(' ', "\\ ");
 
@@ -35,14 +35,14 @@ mod tests {
             depfile_path: PathBuf::new(),
         };
 
-        let deps: BTreeSet<String> = vec![
-            r"/absolute/path".to_owned(),
-            r"C:\win\absolute\path".to_owned(),
-            r"../relative/path".to_owned(),
-            r"..\win\relative\path".to_owned(),
-            r"../path/with spaces/in/it".to_owned(),
-            r"..\win\path\with spaces\in\it".to_owned(),
-            r"path\with/mixed\separators".to_owned(),
+        let deps: BTreeSet<_> = vec![
+            r"/absolute/path".into(),
+            r"C:\win\absolute\path".into(),
+            r"../relative/path".into(),
+            r"..\win\relative\path".into(),
+            r"../path/with spaces/in/it".into(),
+            r"..\win\path\with spaces\in\it".into(),
+            r"path\with/mixed\separators".into(),
         ]
         .into_iter()
         .collect();

--- a/bindgen/ir/context.rs
+++ b/bindgen/ir/context.rs
@@ -365,7 +365,7 @@ pub(crate) struct BindgenContext {
     includes: StdHashMap<String, (String, usize)>,
 
     /// A set of all the included filenames.
-    deps: BTreeSet<String>,
+    deps: BTreeSet<Box<str>>,
 
     /// The active replacements collected from replaces="xxx" annotations.
     replacements: HashMap<Vec<String>, ItemId>,
@@ -664,12 +664,12 @@ If you encounter an error missing from this list, please file an issue or a PR!"
     }
 
     /// Add an included file.
-    pub(crate) fn add_dep(&mut self, dep: String) {
+    pub(crate) fn add_dep(&mut self, dep: Box<str>) {
         self.deps.insert(dep);
     }
 
     /// Get any included files.
-    pub(crate) fn deps(&self) -> &BTreeSet<String> {
+    pub(crate) fn deps(&self) -> &BTreeSet<Box<str>> {
         &self.deps
     }
 

--- a/bindgen/ir/item.rs
+++ b/bindgen/ir/item.rs
@@ -1465,7 +1465,7 @@ impl Item {
                                 cb.include_file(&included_file);
                             }
 
-                            ctx.add_dep(included_file);
+                            ctx.add_dep(included_file.into_boxed_str());
                         }
                     }
                 }

--- a/bindgen/lib.rs
+++ b/bindgen/lib.rs
@@ -336,7 +336,9 @@ impl Builder {
         let input_unsaved_files =
             std::mem::take(&mut self.options.input_header_contents)
                 .into_iter()
-                .map(|(name, contents)| clang::UnsavedFile::new(name.as_ref(), contents.as_ref()))
+                .map(|(name, contents)| {
+                    clang::UnsavedFile::new(name.as_ref(), contents.as_ref())
+                })
                 .collect::<Vec<_>>();
 
         Bindings::generate(self.options, input_unsaved_files)

--- a/bindgen/lib.rs
+++ b/bindgen/lib.rs
@@ -849,7 +849,7 @@ impl Bindings {
         }
 
         if let Some(h) = options.input_headers.last() {
-            let path = Path::new(h);
+            let path = Path::new(h.as_ref());
             if let Ok(md) = std::fs::metadata(path) {
                 if md.is_dir() {
                     return Err(BindgenError::FolderAsHeader(path.into()));
@@ -860,7 +860,7 @@ impl Bindings {
                     ));
                 }
                 let h = h.clone();
-                options.clang_args.push(h);
+                options.clang_args.push(h.into());
             } else {
                 return Err(BindgenError::NotExist(path.into()));
             }

--- a/bindgen/lib.rs
+++ b/bindgen/lib.rs
@@ -336,7 +336,7 @@ impl Builder {
         let input_unsaved_files =
             std::mem::take(&mut self.options.input_header_contents)
                 .into_iter()
-                .map(|(name, contents)| clang::UnsavedFile::new(name, contents))
+                .map(|(name, contents)| clang::UnsavedFile::new(name.as_ref(), contents.as_ref()))
                 .collect::<Vec<_>>();
 
         Bindings::generate(self.options, input_unsaved_files)

--- a/bindgen/options/as_args.rs
+++ b/bindgen/options/as_args.rs
@@ -24,7 +24,7 @@ impl AsArgs for bool {
 impl AsArgs for RegexSet {
     fn as_args(&self, args: &mut Vec<String>, flag: &str) {
         for item in self.get_items() {
-            args.extend_from_slice(&[flag.to_owned(), item.clone()]);
+            args.extend_from_slice(&[flag.to_owned(), item.clone().into()]);
         }
     }
 }

--- a/bindgen/options/mod.rs
+++ b/bindgen/options/mod.rs
@@ -114,7 +114,7 @@ macro_rules! options {
                 let headers = match self.options.input_headers.split_last() {
                     Some((header, headers)) => {
                         // The last input header is passed as an argument in the first position.
-                        args.push(header.clone());
+                        args.push(header.clone().into());
                         headers
                     },
                     None => &[]
@@ -141,7 +141,7 @@ macro_rules! options {
                 // We need to pass all but the last header via the `-include` clang argument.
                 for header in headers {
                     args.push("-include".to_owned());
-                    args.push(header.clone());
+                    args.push(header.clone().into());
                 }
 
                 args
@@ -1119,7 +1119,7 @@ options! {
         },
     },
     /// The input header files.
-    input_headers:  Vec<String> {
+    input_headers:  Vec<Box<str>> {
         methods: {
             /// Add an input C/C++ header to generate bindings for.
             ///
@@ -1143,7 +1143,7 @@ options! {
             ///     .unwrap();
             /// ```
             pub fn header<T: Into<String>>(mut self, header: T) -> Builder {
-                self.options.input_headers.push(header.into());
+                self.options.input_headers.push(header.into().into_boxed_str());
                 self
             }
         },

--- a/bindgen/options/mod.rs
+++ b/bindgen/options/mod.rs
@@ -1173,7 +1173,7 @@ options! {
         as_args: ignore,
     },
     /// Tuples of unsaved file contents of the form (name, contents).
-    input_header_contents: Vec<(String, String)> {
+    input_header_contents: Vec<(Box<str>, Box<str>)> {
         methods: {
             /// Add `contents` as an input C/C++ header named `name`.
             ///
@@ -1187,7 +1187,7 @@ options! {
                     .join(name)
                     .to_str()
                     .expect("Cannot convert current directory name to string")
-                    .to_owned();
+                    .into();
                 self.options
                     .input_header_contents
                     .push((absolute_path, contents.into()));

--- a/bindgen/options/mod.rs
+++ b/bindgen/options/mod.rs
@@ -1089,7 +1089,7 @@ options! {
         },
     },
     /// The set of raw lines to prepend to different modules.
-    module_lines: HashMap<String, Vec<String>> {
+    module_lines: HashMap<Box<str>, Vec<Box<str>>> {
         methods: {
             /// Add a given line to the beginning of a given module.
             ///
@@ -1102,9 +1102,9 @@ options! {
             {
                 self.options
                     .module_lines
-                    .entry(module.into())
+                    .entry(module.into().into_boxed_str())
                     .or_insert_with(Vec::new)
-                    .push(line.into());
+                    .push(line.into().into_boxed_str());
                 self
             }
         },
@@ -1112,8 +1112,8 @@ options! {
             for (module, lines) in module_lines {
                 for line in lines.iter() {
                     args.push("--module-raw-line".to_owned());
-                    args.push(module.clone());
-                    args.push(line.clone());
+                    args.push(module.clone().into());
+                    args.push(line.clone().into());
                 }
             }
         },

--- a/bindgen/options/mod.rs
+++ b/bindgen/options/mod.rs
@@ -1072,19 +1072,19 @@ options! {
         as_args: |value, args| (!value).as_args(args, "--no-convert-floats"),
     },
     /// The set of raw lines to be prepended to the top-level module of the generated Rust code.
-    raw_lines: Vec<String> {
+    raw_lines: Vec<Box<str>> {
         methods: {
             /// Add a line of Rust code at the beginning of the generated bindings. The string is
             /// passed through without any modification.
             pub fn raw_line<T: Into<String>>(mut self, arg: T) -> Self {
-                self.options.raw_lines.push(arg.into());
+                self.options.raw_lines.push(arg.into().into_boxed_str());
                 self
             }
         },
         as_args: |raw_lines, args| {
             for line in raw_lines {
                 args.push("--raw-line".to_owned());
-                args.push(line.clone());
+                args.push(line.clone().into());
             }
         },
     },

--- a/bindgen/options/mod.rs
+++ b/bindgen/options/mod.rs
@@ -135,7 +135,7 @@ macro_rules! options {
                 args.push("--".to_owned());
 
                 if !self.options.clang_args.is_empty() {
-                    args.extend_from_slice(&self.options.clang_args);
+                    args.extend(self.options.clang_args.iter().map(|s| s.clone().into()));
                 }
 
                 // We need to pass all but the last header via the `-include` clang argument.
@@ -1151,11 +1151,11 @@ options! {
         as_args: ignore,
     },
     /// The set of arguments to be passed straight through to Clang.
-    clang_args: Vec<String> {
+    clang_args: Vec<Box<str>> {
         methods: {
             /// Add an argument to be passed straight through to Clang.
             pub fn clang_arg<T: Into<String>>(self, arg: T) -> Builder {
-                self.clang_args([arg.into()])
+                self.clang_args([arg.into().into_boxed_str()])
             }
 
             /// Add several arguments to be passed straight through to Clang.
@@ -1164,7 +1164,7 @@ options! {
                 I::Item: AsRef<str>,
             {
                 for arg in args {
-                    self.options.clang_args.push(arg.as_ref().to_owned());
+                    self.options.clang_args.push(arg.as_ref().to_owned().into_boxed_str());
                 }
                 self
             }


### PR DESCRIPTION
This PR changes all the bindgen options that are collections of `String`s into collections of `Box<str>`.

These changes should slightly diminish the amount of memory used by bindgen which could be relevant for larger projects using it, specially if they use heavily one or more of the following options:
- `Builder::header`.
- `Builder::header_contents`.
- `Builder::raw_line`.
- `Builder::clang_arg` or `Builder::clang_args`.
- Any regex based option.

There are no changes to the public API and this doesn't increase bindgen's codebase complexity other than some `.into_boxed_str()` calls here and there.

cc @tshepang @emilio. These changes are better reviewed commit-per-commit.