### PR TITLE
Add `--allowlist-item`

### DIFF
--- a/bindgen-cli/options.rs
+++ b/bindgen-cli/options.rs
@@ -258,6 +258,9 @@ struct BindgenCommand {
     /// Allowlist all contents of PATH.
     #[arg(long, value_name = "PATH")]
     allowlist_file: Vec<String>,
+    /// Allowlist all items matching REGEX. Other non-allowlisted items will not be generated.
+    #[arg(long, value_name = "REGEX")]
+    allowlist_item: Vec<String>,
     /// Print verbose error messages.
     #[arg(long)]
     verbose: bool,
@@ -471,6 +474,7 @@ where
         allowlist_type,
         allowlist_var,
         allowlist_file,
+        allowlist_item,
         verbose,
         dump_preprocessed_input,
         no_record_matches,
@@ -827,6 +831,10 @@ where
 
     for file in allowlist_file {
         builder = builder.allowlist_file(file);
+    }
+
+    for item in allowlist_item {
+        builder = builder.allowlist_item(item);
     }
 
     for arg in clang_args {

--- a/bindgen-tests/tests/expectations/tests/allowlist_item.rs
+++ b/bindgen-tests/tests/expectations/tests/allowlist_item.rs
@@ -1,0 +1,30 @@
+#![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
+pub const FooDefault: u32 = 0;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct Foo {
+    pub field: ::std::os::raw::c_int,
+}
+#[test]
+fn bindgen_test_layout_Foo() {
+    const UNINIT: ::std::mem::MaybeUninit<Foo> = ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
+    assert_eq!(
+        ::std::mem::size_of::<Foo>(),
+        4usize,
+        concat!("Size of: ", stringify!(Foo)),
+    );
+    assert_eq!(
+        ::std::mem::align_of::<Foo>(),
+        4usize,
+        concat!("Alignment of ", stringify!(Foo)),
+    );
+    assert_eq!(
+        unsafe { ::std::ptr::addr_of!((*ptr).field) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(Foo), "::", stringify!(field)),
+    );
+}
+extern "C" {
+    pub fn FooNew(value: ::std::os::raw::c_int) -> Foo;
+}

--- a/bindgen-tests/tests/headers/allowlist_item.h
+++ b/bindgen-tests/tests/headers/allowlist_item.h
@@ -1,0 +1,17 @@
+// bindgen-flags: --allowlist-item 'Foo.*'
+
+struct Foo {
+  int field;
+};
+
+struct Foo FooNew(int value);
+
+#define FooDefault 0 
+
+struct Bar {
+  int field;
+};
+
+struct Foo BarNew(int value);
+
+#define BarDefault 0  

--- a/bindgen/ir/context.rs
+++ b/bindgen/ir/context.rs
@@ -2343,7 +2343,8 @@ If you encounter an error missing from this list, please file an issue or a PR!"
                     if self.options().allowlisted_types.is_empty() &&
                         self.options().allowlisted_functions.is_empty() &&
                         self.options().allowlisted_vars.is_empty() &&
-                        self.options().allowlisted_files.is_empty()
+                        self.options().allowlisted_files.is_empty() &&
+                        self.options().allowlisted_items.is_empty()
                     {
                         return true;
                     }
@@ -2373,6 +2374,11 @@ If you encounter an error missing from this list, please file an issue or a PR!"
 
                     let name = item.path_for_allowlisting(self)[1..].join("::");
                     debug!("allowlisted_items: testing {:?}", name);
+
+                    if self.options().allowlisted_items.matches(&name) {
+                        return true;
+                    }
+
                     match *item.kind() {
                         ItemKind::Module(..) => true,
                         ItemKind::Function(_) => {
@@ -2495,6 +2501,10 @@ If you encounter an error missing from this list, please file an issue or a PR!"
 
         for item in self.options().allowlisted_types.unmatched_items() {
             unused_regex_diagnostic(item, "--allowlist-type", self);
+        }
+
+        for item in self.options().allowlisted_items.unmatched_items() {
+            unused_regex_diagnostic(item, "--allowlist-items", self);
         }
     }
 

--- a/bindgen/lib.rs
+++ b/bindgen/lib.rs
@@ -435,18 +435,19 @@ impl Builder {
 
 impl BindgenOptions {
     fn build(&mut self) {
-        const REGEX_SETS_LEN: usize = 27;
+        const REGEX_SETS_LEN: usize = 28;
 
         let regex_sets: [_; REGEX_SETS_LEN] = [
-            &mut self.allowlisted_vars,
-            &mut self.allowlisted_types,
-            &mut self.allowlisted_functions,
-            &mut self.allowlisted_files,
             &mut self.blocklisted_types,
             &mut self.blocklisted_functions,
             &mut self.blocklisted_items,
             &mut self.blocklisted_files,
             &mut self.opaque_types,
+            &mut self.allowlisted_vars,
+            &mut self.allowlisted_types,
+            &mut self.allowlisted_functions,
+            &mut self.allowlisted_files,
+            &mut self.allowlisted_items,
             &mut self.bitfield_enums,
             &mut self.constified_enums,
             &mut self.constified_enum_modules,
@@ -482,6 +483,7 @@ impl BindgenOptions {
                     "--allowlist-function",
                     "--allowlist-var",
                     "--allowlist-file",
+                    "--allowlist-item",
                     "--bitfield-enum",
                     "--newtype-enum",
                     "--newtype-global-enum",

--- a/bindgen/options/mod.rs
+++ b/bindgen/options/mod.rs
@@ -345,6 +345,23 @@ options! {
         },
         as_args: "--allowlist-file",
     },
+    /// Items that have been allowlisted and should appear in the generated code.
+    allowlisted_items: RegexSet {
+        methods: {
+            regex_option! {
+                /// Generate bindings for the given item, regardless of whether it is a type,
+                /// function, module, etc.
+                ///
+                /// This option is transitive by default. Check the documentation of the
+                /// [`Builder::allowlist_recursively`] method for further information.
+                pub fn allowlist_item<T: AsRef<str>>(mut self, arg: T) -> Builder {
+                    self.options.allowlisted_items.insert(arg);
+                    self
+                }
+            }
+        },
+        as_args: "--allowlist-item",
+    },
     /// The default style of for generated `enum`s.
     default_enum_style: EnumVariation {
         methods: {


### PR DESCRIPTION
This PR adds a `Builder::allowlist_item` and the equivalent `--allowlist-item`
CLI flag to allowlist item regardless of their kind (functions, vars, types,
etc).

Fixes #2598
