### PR TITLE
Add "experimental" features to docs.rs

### DIFF
--- a/bindgen/Cargo.toml
+++ b/bindgen/Cargo.toml
@@ -59,3 +59,6 @@ __cli = []
 __testing_only_extra_assertions = []
 __testing_only_libclang_9 = []
 __testing_only_libclang_5 = []
+
+[package.metadata.docs.rs]
+features = ["default", "experimental"]

--- a/bindgen/Cargo.toml
+++ b/bindgen/Cargo.toml
@@ -61,4 +61,4 @@ __testing_only_libclang_9 = []
 __testing_only_libclang_5 = []
 
 [package.metadata.docs.rs]
-features = ["default", "experimental"]
+features = ["experimental"]


### PR DESCRIPTION
docs.rs/bindgen doesn't contain the documentation for things under the `"experimental"` feature. This means that no-one can see the `emit_diagnostics` replacement for `emit_warnings()`. 

This fixes that. I'm not sure if you need to add more features, but feel free to do so.
