### PR TITLE
Don't release anything by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ targets = [
 [workspace.metadata.release]
 shared-version = true # ensures published packages share the same version
 tag-name = "v{{version}}"
+release = false
 
 # The profile that 'cargo dist' will build with
 [profile.dist]

--- a/bindgen-cli/Cargo.toml
+++ b/bindgen-cli/Cargo.toml
@@ -41,3 +41,6 @@ which-rustfmt = ["bindgen/which-rustfmt"]
 __testing_only_extra_assertions = ["bindgen/__testing_only_extra_assertions"]
 __testing_only_libclang_9 = ["bindgen/__testing_only_libclang_9"]
 __testing_only_libclang_5 = ["bindgen/__testing_only_libclang_5"]
+
+[package.metadata.release]
+release = true

--- a/bindgen/Cargo.toml
+++ b/bindgen/Cargo.toml
@@ -62,3 +62,6 @@ __testing_only_libclang_5 = []
 
 [package.metadata.docs.rs]
 features = ["experimental"]
+
+[package.metadata.release]
+release = true


### PR DESCRIPTION
This PR marks the whole workspace with `release = false` so `cargo
release` doesn't release any packages and then marks `bindgen` and
`bindgen-cli` with `release = true` so they are the only packages being
released.
