### PR TITLE
Fix bindgen-cli support link static libclang

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -183,6 +183,7 @@
   argument use `void` as its sole argument.
 ## Removed
 ## Fixed
+- Allow compiling `bindgen-cli` with a static libclang.
 ## Security
 
 # 0.68.1

--- a/bindgen-cli/Cargo.toml
+++ b/bindgen-cli/Cargo.toml
@@ -20,7 +20,7 @@ path = "main.rs"
 name = "bindgen"
 
 [dependencies]
-bindgen = { path = "../bindgen", version = "=0.68.1", features = ["__cli", "experimental"] }
+bindgen = { path = "../bindgen", version = "=0.68.1",  default-features = false, features = ["__cli", "experimental"] }
 clap = { version = "4", features = ["derive"] }
 clap_complete = "4"
 env_logger = { version = "0.10.0", optional = true }


### PR DESCRIPTION
Before we link bindgen with default features including runtime libclang.
After the pr, we can build bindgen-cli with no-defautl-features to link static libclang, such as 'cargo install --locked --no-default-features -F static,logging --path .'
If not , runtime and static feature will be confict reported by the clang-sys.