### PR TITLE
publish from GitHub release page

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
-      - name: Publish bindden (lib)
+      - name: Publish bindgen (lib)
         run: cargo publish --package bindgen --token ${CRATES_TOKEN}
-      - name: Publish bindden-cli
+      - name: Publish bindgen-cli
         run: cargo publish --package bindgen-cli --token ${CRATES_TOKEN}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,21 @@
+# To trigger this:
+# - go to Actions > Publish
+# - click the Run Workflow dropdown in the top-right
+name: Publish
+on: workflow_dispatch
+env:
+  CRATES_TOKEN: ${{ secrets.CRATES_TOKEN }}
+jobs:
+  cargo-publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+      - name: Publish bindden (lib)
+        run: cargo publish --package bindgen --token ${CRATES_TOKEN}
+      - name: Publish bindden-cli
+        run: cargo publish --package bindgen-cli --token ${CRATES_TOKEN}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -566,6 +566,7 @@ Once you're in the right branch, do:
 ```
 cargo release [patch|minor] --execute
 ```
+
 This does the following:
 
 - Tag (`git tag`) the HEAD commit

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -564,7 +564,7 @@ important fix) you can skip this.
 Once you're in the right branch, do:
 
 ```
-cargo release [patch|minor] --execute
+cargo release [patch|minor] --no-publish --execute
 ```
 
 This does the following:


### PR DESCRIPTION
This results in requiring a manual button push to publish to crates.io, to avoid having published crates if there is a failed release workflow.