### PR TITLE
[Doc] Add missing entry for allowlist-item.

### DIFF
--- a/book/src/allowlisting.md
+++ b/book/src/allowlisting.md
@@ -20,6 +20,7 @@ transitively used by a definition that matches them.
 * [`bindgen::Builder::allowlist_function`](https://docs.rs/bindgen/latest/bindgen/struct.Builder.html#method.allowlist_function)
 * [`bindgen::Builder::allowlist_var`](https://docs.rs/bindgen/latest/bindgen/struct.Builder.html#method.allowlist_var)
 * [`bindgen::Builder::allowlist_file`](https://docs.rs/bindgen/latest/bindgen/struct.Builder.html#method.allowlist_file)
+* [`bindgen::Builder::allowlist_item`](https://docs.rs/bindgen/latest/bindgen/struct.Builder.html#method.allowlist_item)
 
 ### Command Line
 
@@ -27,6 +28,7 @@ transitively used by a definition that matches them.
 * `--allowlist-function <function>`
 * `--allowlist-var <var>`
 * `--allowlist-file <path>`
+* `--allowlist-item <item>`
 
 ### Annotations
 


### PR DESCRIPTION
While playing with bindgen, I noticed that the entry for allowlist-item is missing from the official doc. This patch helps add it.

I've checked that the doc for allowlist_* and blocklist_* are up-to-date.