### PR TITLE
Add thiscall_abi to stable version Rust 1.73.

### DIFF
--- a/bindgen-tests/tests/expectations/tests/win32-thiscall_1_73.rs
+++ b/bindgen-tests/tests/expectations/tests/win32-thiscall_1_73.rs
@@ -1,0 +1,41 @@
+#![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
+#![cfg(target = "i686-pc-windows-msvc")]
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct Foo {
+    pub _address: u8,
+}
+#[test]
+fn bindgen_test_layout_Foo() {
+    assert_eq!(
+        ::std::mem::size_of::<Foo>(),
+        1usize,
+        concat!("Size of: ", stringify!(Foo)),
+    );
+    assert_eq!(
+        ::std::mem::align_of::<Foo>(),
+        1usize,
+        concat!("Alignment of ", stringify!(Foo)),
+    );
+}
+extern "thiscall" {
+    #[link_name = "\u{1}?test@Foo@@QAEXXZ"]
+    pub fn Foo_test(this: *mut Foo);
+}
+extern "thiscall" {
+    #[link_name = "\u{1}?test2@Foo@@QAEHH@Z"]
+    pub fn Foo_test2(
+        this: *mut Foo,
+        var: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+impl Foo {
+    #[inline]
+    pub unsafe fn test(&mut self) {
+        Foo_test(self)
+    }
+    #[inline]
+    pub unsafe fn test2(&mut self, var: ::std::os::raw::c_int) -> ::std::os::raw::c_int {
+        Foo_test2(self, var)
+    }
+}

--- a/bindgen-tests/tests/headers/win32-thiscall_1_73.hpp
+++ b/bindgen-tests/tests/headers/win32-thiscall_1_73.hpp
@@ -1,0 +1,7 @@
+// bindgen-flags: --rust-target=1.73 --raw-line '#![cfg(target = "i686-pc-windows-msvc")]' -- --target=i686-pc-windows-msvc
+
+class Foo {
+  public:
+    void test();
+    int test2(int var);
+};

--- a/bindgen/features.rs
+++ b/bindgen/features.rs
@@ -95,9 +95,9 @@ macro_rules! define_rust_targets {
 // not stable.
 define_rust_targets! {
     Nightly => {
-        thiscall_abi: #42202,
         vectorcall_abi,
     },
+    Stable_1_73(73) => { thiscall_abi: #42202 },
     Stable_1_71(71) => { c_unwind_abi: #106075 },
     Stable_1_68(68) => { abi_efiapi: #105795 },
     Stable_1_64(64) => { core_ffi_c: #94503 },


### PR DESCRIPTION
1.73 Changelog:
- https://github.com/rust-lang/rust/releases/tag/1.73.0

Stabilization issue:
- https://github.com/rust-lang/rust/pull/114562/

----
 Maybe there are some tests to be fixed. I'm not quite sure how to review those.