### PR TITLE
Better working destructors on windows

### DIFF
--- a/bindgen-tests/tests/expectations/tests/win32-dtors.rs
+++ b/bindgen-tests/tests/expectations/tests/win32-dtors.rs
@@ -1,0 +1,201 @@
+#![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
+#[repr(C)]
+#[derive(Debug, Default)]
+pub struct CppObj {
+    pub x: ::std::os::raw::c_int,
+}
+#[test]
+fn bindgen_test_layout_CppObj() {
+    const UNINIT: ::std::mem::MaybeUninit<CppObj> = ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
+    assert_eq!(
+        ::std::mem::size_of::<CppObj>(),
+        4usize,
+        concat!("Size of: ", stringify!(CppObj)),
+    );
+    assert_eq!(
+        ::std::mem::align_of::<CppObj>(),
+        4usize,
+        concat!("Alignment of ", stringify!(CppObj)),
+    );
+    assert_eq!(
+        unsafe { ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(CppObj), "::", stringify!(x)),
+    );
+}
+extern "C" {
+    #[link_name = "\u{1}??0CppObj@@QEAA@H@Z"]
+    pub fn CppObj_CppObj(this: *mut CppObj, x: ::std::os::raw::c_int);
+}
+extern "C" {
+    #[link_name = "\u{1}??1CppObj@@QEAA@XZ"]
+    pub fn CppObj_CppObj_destructor(this: *mut CppObj);
+}
+impl CppObj {
+    #[inline]
+    pub unsafe fn new(x: ::std::os::raw::c_int) -> Self {
+        let mut __bindgen_tmp = ::std::mem::uninitialized();
+        CppObj_CppObj(&mut __bindgen_tmp, x);
+        __bindgen_tmp
+    }
+    #[inline]
+    pub unsafe fn destruct(&mut self) {
+        CppObj_CppObj_destructor(self)
+    }
+}
+#[repr(C)]
+pub struct CppObj2__bindgen_vtable(::std::os::raw::c_void);
+#[repr(C)]
+#[derive(Debug)]
+pub struct CppObj2 {
+    pub vtable_: *const CppObj2__bindgen_vtable,
+    pub x: ::std::os::raw::c_int,
+}
+#[test]
+fn bindgen_test_layout_CppObj2() {
+    const UNINIT: ::std::mem::MaybeUninit<CppObj2> = ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
+    assert_eq!(
+        ::std::mem::size_of::<CppObj2>(),
+        16usize,
+        concat!("Size of: ", stringify!(CppObj2)),
+    );
+    assert_eq!(
+        ::std::mem::align_of::<CppObj2>(),
+        8usize,
+        concat!("Alignment of ", stringify!(CppObj2)),
+    );
+    assert_eq!(
+        unsafe { ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize },
+        8usize,
+        concat!("Offset of field: ", stringify!(CppObj2), "::", stringify!(x)),
+    );
+}
+extern "C" {
+    #[link_name = "\u{1}??0CppObj2@@QEAA@H@Z"]
+    pub fn CppObj2_CppObj2(this: *mut CppObj2, x: ::std::os::raw::c_int);
+}
+impl Default for CppObj2 {
+    fn default() -> Self {
+        unsafe {
+            let mut s: Self = ::std::mem::uninitialized();
+            ::std::ptr::write_bytes(&mut s, 0, 1);
+            s
+        }
+    }
+}
+impl CppObj2 {
+    #[inline]
+    pub unsafe fn new(x: ::std::os::raw::c_int) -> Self {
+        let mut __bindgen_tmp = ::std::mem::uninitialized();
+        CppObj2_CppObj2(&mut __bindgen_tmp, x);
+        __bindgen_tmp
+    }
+}
+extern "C" {
+    #[link_name = "\u{1}??1CppObj2@@UEAA@XZ"]
+    pub fn CppObj2_CppObj2_destructor(this: *mut CppObj2);
+}
+#[repr(C)]
+#[derive(Debug)]
+pub struct CppObj3 {
+    pub _base: CppObj2,
+    pub x: ::std::os::raw::c_int,
+}
+#[test]
+fn bindgen_test_layout_CppObj3() {
+    const UNINIT: ::std::mem::MaybeUninit<CppObj3> = ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
+    assert_eq!(
+        ::std::mem::size_of::<CppObj3>(),
+        24usize,
+        concat!("Size of: ", stringify!(CppObj3)),
+    );
+    assert_eq!(
+        ::std::mem::align_of::<CppObj3>(),
+        8usize,
+        concat!("Alignment of ", stringify!(CppObj3)),
+    );
+    assert_eq!(
+        unsafe { ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize },
+        16usize,
+        concat!("Offset of field: ", stringify!(CppObj3), "::", stringify!(x)),
+    );
+}
+extern "C" {
+    #[link_name = "\u{1}??0CppObj3@@QEAA@H@Z"]
+    pub fn CppObj3_CppObj3(this: *mut CppObj3, x: ::std::os::raw::c_int);
+}
+impl Default for CppObj3 {
+    fn default() -> Self {
+        unsafe {
+            let mut s: Self = ::std::mem::uninitialized();
+            ::std::ptr::write_bytes(&mut s, 0, 1);
+            s
+        }
+    }
+}
+impl CppObj3 {
+    #[inline]
+    pub unsafe fn new(x: ::std::os::raw::c_int) -> Self {
+        let mut __bindgen_tmp = ::std::mem::uninitialized();
+        CppObj3_CppObj3(&mut __bindgen_tmp, x);
+        __bindgen_tmp
+    }
+}
+extern "C" {
+    #[link_name = "\u{1}??1CppObj3@@UEAA@XZ"]
+    pub fn CppObj3_CppObj3_destructor(this: *mut CppObj3);
+}
+#[repr(C)]
+#[derive(Debug)]
+pub struct CppObj4 {
+    pub _base: CppObj2,
+    pub x: ::std::os::raw::c_int,
+}
+#[test]
+fn bindgen_test_layout_CppObj4() {
+    const UNINIT: ::std::mem::MaybeUninit<CppObj4> = ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
+    assert_eq!(
+        ::std::mem::size_of::<CppObj4>(),
+        24usize,
+        concat!("Size of: ", stringify!(CppObj4)),
+    );
+    assert_eq!(
+        ::std::mem::align_of::<CppObj4>(),
+        8usize,
+        concat!("Alignment of ", stringify!(CppObj4)),
+    );
+    assert_eq!(
+        unsafe { ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize },
+        16usize,
+        concat!("Offset of field: ", stringify!(CppObj4), "::", stringify!(x)),
+    );
+}
+extern "C" {
+    #[link_name = "\u{1}??0CppObj4@@QEAA@H@Z"]
+    pub fn CppObj4_CppObj4(this: *mut CppObj4, x: ::std::os::raw::c_int);
+}
+impl Default for CppObj4 {
+    fn default() -> Self {
+        unsafe {
+            let mut s: Self = ::std::mem::uninitialized();
+            ::std::ptr::write_bytes(&mut s, 0, 1);
+            s
+        }
+    }
+}
+impl CppObj4 {
+    #[inline]
+    pub unsafe fn new(x: ::std::os::raw::c_int) -> Self {
+        let mut __bindgen_tmp = ::std::mem::uninitialized();
+        CppObj4_CppObj4(&mut __bindgen_tmp, x);
+        __bindgen_tmp
+    }
+}
+extern "C" {
+    #[link_name = "\u{1}??1CppObj4@@UEAA@XZ"]
+    pub fn CppObj4_CppObj4_destructor(this: *mut CppObj4);
+}

--- a/bindgen-tests/tests/headers/win32-dtors.hpp
+++ b/bindgen-tests/tests/headers/win32-dtors.hpp
@@ -1,0 +1,29 @@
+// bindgen-flags: --rust-target 1.0 -- --target=x86_64-pc-windows-msvc
+
+struct CppObj {
+    int x;
+
+    CppObj(int x);
+    ~CppObj();
+};
+
+struct CppObj2 {
+    int x;
+
+    CppObj2(int x);
+    virtual ~CppObj2();
+};
+
+struct CppObj3 : CppObj2 {
+    int x;
+
+    CppObj3(int x);
+    virtual ~CppObj3();
+};
+
+struct CppObj4 : CppObj2 {
+    int x;
+
+    CppObj4(int x);
+    ~CppObj4();
+};

--- a/bindgen/ir/context.rs
+++ b/bindgen/ir/context.rs
@@ -19,7 +19,7 @@ use super::module::{Module, ModuleKind};
 use super::template::{TemplateInstantiation, TemplateParameters};
 use super::traversal::{self, Edge, ItemTraversal};
 use super::ty::{FloatKind, Type, TypeKind};
-use crate::clang::{self, Cursor};
+use crate::clang::{self, ABIKind, Cursor};
 use crate::codegen::CodegenError;
 use crate::BindgenOptions;
 use crate::{Entry, HashMap, HashSet};
@@ -620,6 +620,11 @@ If you encounter an error missing from this list, please file an issue or a PR!"
     /// translation.
     pub(crate) fn target_pointer_size(&self) -> usize {
         self.target_info.pointer_width / 8
+    }
+
+    /// Returns the ABI, which is mostly useful for determining the mangling kind.
+    pub(crate) fn abi_kind(&self) -> ABIKind {
+        self.target_info.abi
     }
 
     /// Get the stack of partially parsed types that we are in the middle of

--- a/bindgen/ir/function.rs
+++ b/bindgen/ir/function.rs
@@ -7,7 +7,7 @@ use super::item::Item;
 use super::traversal::{EdgeKind, Trace, Tracer};
 use super::ty::TypeKind;
 use crate::callbacks::{ItemInfo, ItemKind};
-use crate::clang::{self, Attribute};
+use crate::clang::{self, ABIKind, Attribute};
 use crate::parse::{ClangSubItemParser, ParseError, ParseResult};
 use clang_sys::{self, CXCallingConv};
 
@@ -323,11 +323,12 @@ pub(crate) fn cursor_mangling(
         return None;
     }
 
+    let is_itanium_abi = ctx.abi_kind() == ABIKind::GenericItanium;
     let is_destructor = cursor.kind() == clang_sys::CXCursor_Destructor;
     if let Ok(mut manglings) = cursor.cxx_manglings() {
         while let Some(m) = manglings.pop() {
             // Only generate the destructor group 1, see below.
-            if is_destructor && !m.ends_with("D1Ev") {
+            if is_itanium_abi && is_destructor && !m.ends_with("D1Ev") {
                 continue;
             }
 
@@ -340,7 +341,7 @@ pub(crate) fn cursor_mangling(
         return None;
     }
 
-    if is_destructor {
+    if is_itanium_abi && is_destructor {
         // With old (3.8-) libclang versions, and the Itanium ABI, clang returns
         // the "destructor group 0" symbol, which means that it'll try to free
         // memory, which definitely isn't what we want.


### PR DESCRIPTION
Tries to solve #1725 and #2092.

I found that clang can only generate one entry when calling `clang_Cursor_getCXXManglings` with the Microsoft ABI. Also the conditions for "group 1" destructors don't apply at all on the MS ABI, having a completely different mangling format.

Also, it seems like the entry from `clang_Cursor_getCXXManglings` will always be the regular "base" destructor that is most interesting usually, while the entry from `clang_Cursor_getMangling` will always be the "vbase destructor" that's supposed to be able to destroy anything. However, only the base destructor is always available, the other ones being generated on the fly when the code actually needs it.

So far, the code always chose the vbase dtor that happened to never exist, and this is why the code always failed with a link error.

What I wish I figured out how to do was to get the information from clang under which ABI we operate at the moment, but I couldn't find a way to do this, so I just checked if we run under Windows instead. I suspect this might not work well with the MinGW target.

With the `main` branch unmodified I get one failed test under WSL and over 500 under Windows. I did not see whether I could have Windows only tests, but it looked like a lot of effort to get all tests working under Windows at this point, so I don't know if I could add any tests at the moment.

[Here](https://gist.github.com/xTachyon/7d2e7ca801521c47cb152d9bea5e7895) is the manual test I performed. Most usual things seems to work fine, except for classes that use virtual inheritance (the vbase destructor) because it's not the correct destructor to call directly. It seems to crash in a deterministic fashion on my machine from a null pointer access, _so it might be fine?_ This is just trying to make the best of out of a bad situation.

Is there anything I could do make it better? Sorry for the rambly description.