### PR TITLE
Deactivate many `regex` Unicode crate features

### DIFF
--- a/bindgen/Cargo.toml
+++ b/bindgen/Cargo.toml
@@ -36,7 +36,7 @@ peeking_take_while = "0.1.2"
 prettyplease = { version = "0.2.7", optional = true, features = ["verbatim"] }
 proc-macro2 = { version = "1", default-features = false }
 quote = { version = "1", default-features = false }
-regex = { version = "1.5", default-features = false, features = ["std", "unicode"] }
+regex = { version = "1.5", default-features = false, features = ["std", "unicode-perl"] }
 rustc-hash = "1.0.1"
 shlex = "1"
 syn = { version = "2.0", features = ["full", "extra-traits", "visit-mut"] }
@@ -53,9 +53,9 @@ experimental = ["dep:annotate-snippets"]
 
 ## The following features are for internal use and they shouldn't be used if
 ## you're not hacking on bindgen
-# Features used by `bindgen-cli` 
+# Features used by `bindgen-cli`
 __cli = []
-# Features used for CI testing 
+# Features used for CI testing
 __testing_only_extra_assertions = []
 __testing_only_libclang_9 = []
 __testing_only_libclang_5 = []


### PR DESCRIPTION
rust-lang/rust-bindgen#1643 disabled many deafault features of the `regex` crate but left the `unicode` meta feature enabled. With the `unicode` feature enabled and `bindgen` as a build dependency, `regex-syntax` (a direct dependency of the `regex` crate) takes 7 seconds to compile as a build dependency in my application.

The `unicode` feature includes support for many Unicode character class lookups which I find unlikely that bindgen uses. Even without the `unicode` feature enabled, the `regex` crate supports Unicode. The various `unicode-*` features only remove compiled in data tables that support various types of character classes.

From https://docs.rs/regex/latest/regex/#unicode-features:

> - **unicode-age** - Provide the data for the Unicode Age property. This makes it possible to use classes like `\p{Age:6.0}` to refer to all codepoints first introduced in Unicode 6.0
> - **unicode-bool** - Provide the data for numerous Unicode boolean properties. The full list is not included here, but contains properties like `Alphabetic`, `Emoji`, `Lowercase`, `Math`, `Uppercase` and `White_Space`.
> - **unicode-case** - Provide the data for case insensitive matching using Unicode's "simple loose matches" specification.
> - **unicode-gencat** - Provide the data for Unicode general categories. This includes, but is not limited to, `Decimal_Number`, `Letter`, `Math_Symbol`, `Number` and `Punctuation`.
> - **unicode-script** - Provide the data for Unicode scripts and script extensions. This includes, but is not limited to, `Arabic`, `Cyrillic`, `Hebrew`, `Latin` and `Thai`.
> - **unicode-segment** - Provide the data necessary to provide the properties used to implement the Unicode text segmentation algorithms. This enables using classes like `\p{gcb=Extend}`, `\p{wb=Katakana}` and `\p{sb=ATerm}`.

I have retained the **unicode-perl** feature, which gives support for `\w`, `\s` and `\d`, because these character classes were required to get tests to pass.

Removing support for these character classes removes the need to compile many data tables, which should significantly reduce compile times.