### PR TITLE
Use at least `regex 1.5.1` to avoid build build failures without `perf-literal` feature

### DIFF
--- a/bindgen/Cargo.toml
+++ b/bindgen/Cargo.toml
@@ -36,7 +36,7 @@ peeking_take_while = "0.1.2"
 prettyplease = { version = "0.2.7", optional = true, features = ["verbatim"] }
 proc-macro2 = { version = "1", default-features = false }
 quote = { version = "1", default-features = false }
-regex = { version = "1.5", default-features = false, features = ["std", "unicode-perl"] }
+regex = { version = "1.5.1", default-features = false, features = ["std", "unicode-perl"] }
 rustc-hash = "1.0.1"
 shlex = "1"
 syn = { version = "2.0", features = ["full", "extra-traits", "visit-mut"] }


### PR DESCRIPTION

When building a crate that depends on `bindgen` with `-Zminimal-features`, `cargo` ends up selecting `regex 1.5.0` which fails to compile when its `perf-literal` feature isn't enabled. This was aptly fixed in `1.5.1`, albeit without yanking the `1.5.0` release.

https://github.com/rust-lang/regex/issues/931