### PR TITLE
Correctly handle  __attribute__((noreturn)) in function arguments

### DIFF
--- a/bindgen-tests/tests/expectations/tests/noreturn.rs
+++ b/bindgen-tests/tests/expectations/tests/noreturn.rs
@@ -11,3 +11,11 @@ extern "C" {
     #[link_name = "\u{1}_Z1hv"]
     pub fn h() -> !;
 }
+extern "C" {
+    #[link_name = "\u{1}_Z1iPFvvE"]
+    pub fn i(arg: ::std::option::Option<unsafe extern "C" fn() -> !>);
+}
+extern "C" {
+    #[link_name = "\u{1}_Z1jPFvvE"]
+    pub fn j(arg: ::std::option::Option<unsafe extern "C" fn() -> !>) -> !;
+}

--- a/bindgen-tests/tests/headers/noreturn.hpp
+++ b/bindgen-tests/tests/headers/noreturn.hpp
@@ -2,3 +2,5 @@
 _Noreturn void f(void);
 __attribute__((noreturn)) void g(void);
 [[noreturn]] void h(void);
+void i(__attribute__((noreturn)) void (*arg)(void));
+__attribute__((noreturn)) void j(__attribute__((noreturn)) void (*arg)(void));

--- a/bindgen/ir/function.rs
+++ b/bindgen/ir/function.rs
@@ -505,10 +505,24 @@ impl FunctionSig {
                 Default::default()
             };
 
-        // This looks easy to break but the clang parser keeps the type spelling clean even if
-        // other attributes are added.
-        is_divergent =
-            is_divergent || ty.spelling().contains("__attribute__((noreturn))");
+        // Check if the type contains __attribute__((noreturn)) outside of parentheses. This is
+        // somewhat fragile, but it seems to be the only way to get at this information as of
+        // libclang 9.
+        let ty_spelling = ty.spelling();
+        let has_attribute_noreturn = ty_spelling
+            .match_indices("__attribute__((noreturn))")
+            .any(|(i, _)| {
+                let depth = ty_spelling[..i]
+                    .bytes()
+                    .filter_map(|ch| match ch {
+                        b'(' => Some(1),
+                        b')' => Some(-1),
+                        _ => None,
+                    })
+                    .sum::<isize>();
+                depth == 0
+            });
+        is_divergent = is_divergent || has_attribute_noreturn;
 
         let is_method = kind == CXCursor_CXXMethod;
         let is_constructor = kind == CXCursor_Constructor;


### PR DESCRIPTION
Fixes #2715.

I have not been able to find a way to get at this information directly through the C API of libclang 9, so instead this patch just checks how deeply nested in parentheses the `__attribute__((noreturn))` qualifier is.