### PR TITLE
Update minimum regex version to fix compile error

### DIFF
--- a/bindgen/Cargo.toml
+++ b/bindgen/Cargo.toml
@@ -36,7 +36,7 @@ peeking_take_while = "0.1.2"
 prettyplease = { version = "0.2.7", optional = true, features = ["verbatim"] }
 proc-macro2 = { version = "1", default-features = false }
 quote = { version = "1", default-features = false }
-regex = { version = "1.5", default-features = false, features = ["std", "unicode-perl"] }
+regex = { version = "1.5.3", default-features = false, features = ["std", "unicode-perl"] }
 rustc-hash = "1.0.1"
 shlex = "1"
 syn = { version = "2.0", features = ["full", "extra-traits", "visit-mut"] }


### PR DESCRIPTION
regex 1.5.3 solves the compile error with unicode-perl feature. https://github.com/rust-lang/regex/blob/master/CHANGELOG.md#153-2021-05-01

Specifing wrong version as the minimum version can cause compile errors on products which depend on bindgen. Minimum versions can be checked with this cargo command.

```
cargo +nightly update -Z minimal-versions
```