### PR TITLE
Add a triagebot.toml file

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -1,0 +1,28 @@
+[relabel]
+allow-unauthenticated = [
+    "A-*",
+    "C-*",
+    "E-*",
+    "I-*",
+    "S-*",
+    "bug",
+    "dependencies",
+    "enhancement",
+    "good first issue",
+    "hacktoberfest",
+    "help wanted",
+    "invalid",
+    "meta",
+    "msvc",
+    "next-release",
+    "question",
+    "This Week In Servo (TWiS)",
+    "windows",
+]
+
+[autolabel."A-C++"]
+trigger_files = [
+    "**/*.cpp",
+    "**/*.cc",
+    "**/*.hpp",
+]


### PR DESCRIPTION
This allows non-maintainers to set labels with `@rustbot`.

This won't work until https://github.com/rust-lang/team/pull/1200 merges.