### PR TITLE
Update minimum regex version to fix compile error

### DIFF
--- a/bindgen/Cargo.toml
+++ b/bindgen/Cargo.toml
@@ -36,7 +36,7 @@ peeking_take_while = "0.1.2"
 prettyplease = { version = "0.2.7", optional = true, features = ["verbatim"] }
 proc-macro2 = { version = "1", default-features = false }
 quote = { version = "1", default-features = false }
-regex = { version = "1.5.1", default-features = false, features = ["std", "unicode-perl"] }
+regex = { version = "1.5.3", default-features = false, features = ["std", "unicode-perl"] }
 rustc-hash = "1.0.1"
 shlex = "1"
 syn = { version = "2.0", features = ["full", "extra-traits", "visit-mut"] }


### PR DESCRIPTION
This is reopened PR of https://github.com/rust-lang/rust-bindgen/pull/2717 because I don't have the permission to reopen it.

Even with regex 1.5.1, bindgen fails to build with `-Z minimal-versions`.

```
$ cd path/to/rust-bindgen
$ cargo +nightly update -Z minimal-versions
$ cargo build
   Compiling regex-syntax v0.6.24
error[E0433]: failed to resolve: use of undeclared crate or module `unicode_tables`
   --> /home/kawasin/.cargo/registry/src/index.crates.io-6f17d22bba15001f/regex-syntax-0.6.24/src/unicode.rs:351:13
    |
351 |         use unicode_tables::perl_space::WHITE_SPACE;
    |             ^^^^^^^^^^^^^^ use of undeclared crate or module `unicode_tables`

error[E0433]: failed to resolve: use of undeclared crate or module `unicode_tables`
   --> /home/kawasin/.cargo/registry/src/index.crates.io-6f17d22bba15001f/regex-syntax-0.6.24/src/unicode.rs:375:13
    |
375 |         use unicode_tables::perl_decimal::DECIMAL_NUMBER;
    |             ^^^^^^^^^^^^^^ use of undeclared crate or module `unicode_tables`

For more information about this error, try `rustc --explain E0433`.
error: could not compile `regex-syntax` (lib) due to 2 previous errors

```

---

regex 1.5.3 solves the compile error with unicode-perl feature. https://github.com/rust-lang/regex/blob/master/CHANGELOG.md#153-2021-05-01

Specifing wrong version as the minimum version can cause compile errors on products which depend on bindgen. Minimum versions can be checked with this cargo command.

```
cargo +nightly update -Z minimal-versions
```