### PR TITLE
Use CargoCallbacks::new() in documentation

### DIFF
--- a/bindgen/lib.rs
+++ b/bindgen/lib.rs
@@ -1239,7 +1239,7 @@ fn get_target_dependent_env_var(
 /// use bindgen::builder;
 /// let bindings = builder()
 ///     .header("path/to/input/header")
-///     .parse_callbacks(Box::new(bindgen::CargoCallbacks))
+///     .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))
 ///     .generate();
 /// ```
 #[derive(Debug)]

--- a/book/src/non-system-libraries.md
+++ b/book/src/non-system-libraries.md
@@ -48,9 +48,6 @@ fn main() {
     // automatically know it must look for a `libhello.a` file.
     println!("cargo:rustc-link-lib=hello");
 
-    // Tell cargo to invalidate the built crate whenever the header changes.
-    println!("cargo:rerun-if-changed={}", headers_path_str);
-
     // Run `clang` to compile the `hello.c` file into a `hello.o` object file.
     // Unwrap if it is not possible to spawn the process.
     if !std::process::Command::new("clang")
@@ -91,7 +88,7 @@ fn main() {
         .header(headers_path_str)
         // Tell cargo to invalidate the built crate whenever any of the
         // included header files changed.
-        .parse_callbacks(Box::new(CargoCallbacks))
+        .parse_callbacks(Box::new(CargoCallbacks::new()))
         // Finish the builder and generate the bindings.
         .generate()
         // Unwrap the Result and panic on failure.

--- a/book/src/tutorial-3.md
+++ b/book/src/tutorial-3.md
@@ -21,9 +21,6 @@ fn main() {
     // shared library.
     println!("cargo:rustc-link-lib=bz2");
 
-    // Tell cargo to invalidate the built crate whenever the wrapper changes
-    println!("cargo:rerun-if-changed=wrapper.h");
-
     // The bindgen::Builder is the main entry point
     // to bindgen, and lets you build up options for
     // the resulting bindings.
@@ -33,7 +30,7 @@ fn main() {
         .header("wrapper.h")
         // Tell cargo to invalidate the built crate whenever any of the
         // included header files changed.
-        .parse_callbacks(Box::new(bindgen::CargoCallbacks))
+        .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))
         // Finish the builder and generate the bindings.
         .generate()
         // Unwrap the Result and panic on failure.


### PR DESCRIPTION
Use `CargoCallbacks::new()` to fix:
```
warning: use of deprecated constant `bindgen::CargoCallbacks`: Use `CargoCallbacks::new()` instead. Please, check the documentation for further information.
  --> build.rs:11:44
   |
11 |         .parse_callbacks(Box::new(bindgen::CargoCallbacks))
```