### PR TITLE
chore: updating shlex regarding RUSTSEC-2024-0006

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -565,9 +565,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.1.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "similar"


### PR DESCRIPTION
Hello !


Here's a little PR updating `shlex` regarding the [RUSTSEC-2024-0006](https://rustsec.org/advisories/RUSTSEC-2024-0006).
The changelog of `shlex` which was in `1.1.0` to `1.3.0` is visible [here](https://github.com/comex/rust-shlex/blob/master/CHANGELOG.md).

Feel free to tell me if this PR isn't suitable, I read the contribution file but see nothing about dependency update for vulnerability issues.

Thanks !