### PR TITLE
Add test for quoted Env variables passed with BINDGEN_EXTRA_CLANG_ARGS.

### DIFF
--- a/bindgen-tests/tests/tests.rs
+++ b/bindgen-tests/tests/tests.rs
@@ -390,7 +390,7 @@ fn test_clang_env_args() {
             "test.hpp",
             "#ifdef _ENV_ONE\nextern const int x[] = { 42 };\n#endif\n\
              #ifdef _ENV_TWO\nextern const int y[] = { 42 };\n#endif\n\
-             #ifdef NOT_THREE\nextern const int z[] = { 42 };\n#endif\n",
+             #if defined NOT_THREE && NOT_THREE == 1\nextern const int z[] = { 42 };\n#endif\n",
         )
         .generate()
         .unwrap()


### PR DESCRIPTION
Before the test was too broad and just tested for existence of the variable. With this test we can ensure that quoting was indeed managed.

Context: I don't know if it's mandatory to check this kind of shell quoting detail, but wandering the code due to the [shlex advisory](https://rustsec.org/advisories/RUSTSEC-2024-0006.html) I found this case not covered so I submit a patch!

It's used here:

```
rg -C 5 shlex
[...[
bindgen/lib.rs
308-        Some(s) => s,
309-    };
310-
311-    // Try to parse it with shell quoting. If we fail, make it one single big argument.
312:    if let Some(strings) = shlex::split(&extra_clang_args) {
313-        return strings;
314-    }
315-    vec![extra_clang_args]
316-}
```
Edited: has some not commited stuff in the rg cmd