### PR TITLE
Update Rust Code of Conduct link in Contribution guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,7 @@ and introduce yourself.
 
 We abide by the [Rust Code of Conduct][coc] and ask that you do as well.
 
-[coc]: https://www.rust-lang.org/en-US/conduct.html
+[coc]: https://www.rust-lang.org/policies/code-of-conduct
 
 ## Filing an Issue
 


### PR DESCRIPTION
The contribution guide seems to be pointing at a dead link. This
commit updates the link to a working version.

I was not sure if this is the link we were looking for. An alternative is:

https://foundation.rust-lang.org/policies/code-of-conduct/
