### PR TITLE
Use CargoCallbacks::new() in the book

### DIFF
--- a/book/src/non-system-libraries.md
+++ b/book/src/non-system-libraries.md
@@ -91,7 +91,7 @@ fn main() {
         .header(headers_path_str)
         // Tell cargo to invalidate the built crate whenever any of the
         // included header files changed.
-        .parse_callbacks(Box::new(CargoCallbacks))
+        .parse_callbacks(Box::new(CargoCallbacks::new()))
         // Finish the builder and generate the bindings.
         .generate()
         // Unwrap the Result and panic on failure.

--- a/book/src/tutorial-3.md
+++ b/book/src/tutorial-3.md
@@ -33,7 +33,7 @@ fn main() {
         .header("wrapper.h")
         // Tell cargo to invalidate the built crate whenever any of the
         // included header files changed.
-        .parse_callbacks(Box::new(bindgen::CargoCallbacks))
+        .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))
         // Finish the builder and generate the bindings.
         .generate()
         // Unwrap the Result and panic on failure.


### PR DESCRIPTION
[`bindgen::CargoCallbacks`](https://docs.rs/bindgen/latest/bindgen/constant.CargoCallbacks.html) is deprecated.