### PR TITLE
Use `CargoCallbacks::new()` instead of `bindgen::CargoCallbacks`

### DIFF
--- a/book/src/tutorial-3.md
+++ b/book/src/tutorial-3.md
@@ -33,7 +33,7 @@ fn main() {
         .header("wrapper.h")
         // Tell cargo to invalidate the built crate whenever any of the
         // included header files changed.
-        .parse_callbacks(Box::new(bindgen::CargoCallbacks))
+        .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))
         // Finish the builder and generate the bindings.
         .generate()
         // Unwrap the Result and panic on failure.


### PR DESCRIPTION
#2740 A simple little update to the tutorial book.