### PR TITLE
Update itertools and allow itertools 0.10 too.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -198,6 +198,7 @@
 # Unreleased
 ## Added
 ## Changed
+- Allow older itertools. (#2745)
 ## Removed
 ## Fixed
 ## Security

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -301,9 +301,9 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25db6b064527c5d482d0423354fcd07a89a2dfe07b67892e62411946db7f07b0"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
 dependencies = [
  "either",
 ]

--- a/bindgen/Cargo.toml
+++ b/bindgen/Cargo.toml
@@ -29,7 +29,7 @@ annotate-snippets = { version = "0.9.1", features = ["color"], optional = true }
 bitflags = "2.2.1"
 cexpr = "0.6"
 clang-sys = { version = "1", features = ["clang_6_0"] }
-itertools = { version = "0.12.0", default-features = false }
+itertools = { version = ">=0.10,<0.13", default-features = false }
 lazy_static = "1"
 lazycell = "1"
 log = { version = "0.4", optional = true }


### PR DESCRIPTION
This can help avoid duplicate dependencies when using bindgen as a library.