### PR TITLE
Filter out lookup_can_derive_copy for template type

### DIFF
--- a/bindgen/ir/context.rs
+++ b/bindgen/ir/context.rs
@@ -2767,6 +2767,7 @@ If you encounter an error missing from this list, please file an issue or a PR!"
         let id = id.into();
 
         !self.lookup_has_type_param_in_array(id) &&
+            !self.lookup_is_type_param_after_resolve(id) &&
             !self.cannot_derive_copy.as_ref().unwrap().contains(&id)
     }
 
@@ -2794,6 +2795,25 @@ If you encounter an error missing from this list, please file an issue or a PR!"
             .as_ref()
             .unwrap()
             .contains(&id.into())
+    }
+
+    /// Look up whether the item with `id` is type parameter after resolve.
+    fn lookup_is_type_param_after_resolve<Id: Into<ItemId>>(
+        &self,
+        id: Id,
+    ) -> bool {
+        if let Some(t) = id
+            .into()
+            .into_resolver()
+            .through_type_refs()
+            .resolve(self)
+            .kind()
+            .as_type()
+        {
+            t.is_type_param()
+        } else {
+            false
+        }
     }
 
     /// Compute whether the type has float.


### PR DESCRIPTION
Template type in tagged union should not be copiable field as it requires ManuallyDrop. Filter out copy derive when the variable is resolved to template type.

Fix: #2157

Now the input.hpp in the issue will generate non rust union or correct ManuallyDrop for generic type.

```
rust-bindgen$ target/debug/bindgen input.hpp
/* automatically generated by rust-bindgen 0.69.4 */

#[repr(C)]
pub struct __BindgenUnionField<T>(::std::marker::PhantomData<T>);
impl<T> __BindgenUnionField<T> {
    #[inline]
    pub const fn new() -> Self {
        __BindgenUnionField(::std::marker::PhantomData)
    }
    #[inline]
    pub unsafe fn as_ref(&self) -> &T {
        ::std::mem::transmute(self)
    }
    #[inline]
    pub unsafe fn as_mut(&mut self) -> &mut T {
        ::std::mem::transmute(self)
    }
}
impl<T> ::std::default::Default for __BindgenUnionField<T> {
    #[inline]
    fn default() -> Self {
        Self::new()
    }
}
impl<T> ::std::clone::Clone for __BindgenUnionField<T> {
    #[inline]
    fn clone(&self) -> Self {
        *self
    }
}
impl<T> ::std::marker::Copy for __BindgenUnionField<T> {}
impl<T> ::std::fmt::Debug for __BindgenUnionField<T> {
    fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
        fmt.write_str("__BindgenUnionField")
    }
}
impl<T> ::std::hash::Hash for __BindgenUnionField<T> {
    fn hash<H: ::std::hash::Hasher>(&self, _state: &mut H) {}
}
impl<T> ::std::cmp::PartialEq for __BindgenUnionField<T> {
    fn eq(&self, _other: &__BindgenUnionField<T>) -> bool {
        true
    }
}
impl<T> ::std::cmp::Eq for __BindgenUnionField<T> {}
#[repr(C)]
#[derive(Debug, Copy, Clone)]
pub struct _Vector_base {
    pub _address: u8,
}
#[repr(C)]
pub struct _Vector_base__Storage<_Tp> {
    pub _M_byte: __BindgenUnionField<::std::os::raw::c_uchar>,
    pub _M_val: __BindgenUnionField<_Tp>,
    pub bindgen_union_field: u8,
    pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<_Tp>>,
}
```

```
rust-bindgen$ target/debug/bindgen input.hpp --default-non-copy-union-style manually_drop
/* automatically generated by rust-bindgen 0.69.4 */

#[repr(C)]
#[derive(Debug, Copy, Clone)]
pub struct _Vector_base {
    pub _address: u8,
}
#[repr(C)]
pub union _Vector_base__Storage<_Tp> {
    pub _M_byte: ::std::mem::ManuallyDrop<::std::os::raw::c_uchar>,
    pub _M_val: ::std::mem::ManuallyDrop<_Tp>,
    pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<_Tp>>,
}
```