### PR TITLE
[RFC, V1] try to exclude packed attr for types that contain aligned types

### DIFF
--- a/bindgen-tests/tests/expectations/tests/packed_embeds_aligned.rs
+++ b/bindgen-tests/tests/expectations/tests/packed_embeds_aligned.rs
@@ -1,0 +1,126 @@
+#![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
+#[repr(C)]
+#[repr(align(2))]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct inner1 {
+    pub a: ::std::os::raw::c_char,
+    pub b: ::std::os::raw::c_char,
+}
+#[test]
+fn bindgen_test_layout_inner1() {
+    const UNINIT: ::std::mem::MaybeUninit<inner1> = ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
+    assert_eq!(
+        ::std::mem::size_of::<inner1>(),
+        2usize,
+        concat!("Size of: ", stringify!(inner1)),
+    );
+    assert_eq!(
+        ::std::mem::align_of::<inner1>(),
+        2usize,
+        concat!("Alignment of ", stringify!(inner1)),
+    );
+    assert_eq!(
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(inner1), "::", stringify!(a)),
+    );
+    assert_eq!(
+        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
+        1usize,
+        concat!("Offset of field: ", stringify!(inner1), "::", stringify!(b)),
+    );
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct inner2 {
+    pub a: inner1,
+    pub b: inner1,
+}
+#[test]
+fn bindgen_test_layout_inner2() {
+    const UNINIT: ::std::mem::MaybeUninit<inner2> = ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
+    assert_eq!(
+        ::std::mem::size_of::<inner2>(),
+        4usize,
+        concat!("Size of: ", stringify!(inner2)),
+    );
+    assert_eq!(
+        ::std::mem::align_of::<inner2>(),
+        2usize,
+        concat!("Alignment of ", stringify!(inner2)),
+    );
+    assert_eq!(
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(inner2), "::", stringify!(a)),
+    );
+    assert_eq!(
+        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
+        2usize,
+        concat!("Offset of field: ", stringify!(inner2), "::", stringify!(b)),
+    );
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct outer1 {
+    pub a: ::std::os::raw::c_short,
+    pub b: inner1,
+}
+#[test]
+fn bindgen_test_layout_outer1() {
+    const UNINIT: ::std::mem::MaybeUninit<outer1> = ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
+    assert_eq!(
+        ::std::mem::size_of::<outer1>(),
+        4usize,
+        concat!("Size of: ", stringify!(outer1)),
+    );
+    assert_eq!(
+        ::std::mem::align_of::<outer1>(),
+        2usize,
+        concat!("Alignment of ", stringify!(outer1)),
+    );
+    assert_eq!(
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(outer1), "::", stringify!(a)),
+    );
+    assert_eq!(
+        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
+        2usize,
+        concat!("Offset of field: ", stringify!(outer1), "::", stringify!(b)),
+    );
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct outer2 {
+    pub a: ::std::os::raw::c_short,
+    pub b: inner2,
+}
+#[test]
+fn bindgen_test_layout_outer2() {
+    const UNINIT: ::std::mem::MaybeUninit<outer2> = ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
+    assert_eq!(
+        ::std::mem::size_of::<outer2>(),
+        6usize,
+        concat!("Size of: ", stringify!(outer2)),
+    );
+    assert_eq!(
+        ::std::mem::align_of::<outer2>(),
+        2usize,
+        concat!("Alignment of ", stringify!(outer2)),
+    );
+    assert_eq!(
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(outer2), "::", stringify!(a)),
+    );
+    assert_eq!(
+        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
+        2usize,
+        concat!("Offset of field: ", stringify!(outer2), "::", stringify!(b)),
+    );
+}

--- a/bindgen-tests/tests/headers/packed_embeds_aligned.h
+++ b/bindgen-tests/tests/headers/packed_embeds_aligned.h
@@ -1,0 +1,19 @@
+struct inner1 {
+	char a;
+	char b;
+} __attribute__((aligned(2)));
+
+struct inner2 {
+	struct inner1 a;
+	struct inner1 b;
+} __attribute__((aligned(2)));
+
+struct outer1 {
+	short a;
+	struct inner1 b;
+} __attribute__((packed, aligned(2)));
+
+struct outer2 {
+	short a;
+	struct inner2 b;
+} __attribute__((packed, aligned(2)));

--- a/bindgen/codegen/mod.rs
+++ b/bindgen/codegen/mod.rs
@@ -2202,8 +2202,13 @@ impl CodeGenerator for CompInfo {
         // "packed" attr is redundant, and do not include it if so.
         if packed &&
             !is_opaque &&
-            !(explicit_align.is_some() &&
-                self.already_packed(ctx).unwrap_or(false))
+            !((explicit_align.is_some() || self.may_contain_aligned_type()) &&
+                self.already_packed(
+                    ctx,
+                    struct_layout.max_field_align(),
+                    layout,
+                )
+                .unwrap_or(false))
         {
             let n = layout.map_or(1, |l| l.align);
             assert!(ctx.options().rust_features().repr_packed_n || n == 1);

--- a/bindgen/codegen/struct_layout.rs
+++ b/bindgen/codegen/struct_layout.rs
@@ -121,6 +121,10 @@ impl<'a> StructLayoutTracker<'a> {
         self.is_rust_union
     }
 
+    pub(crate) fn max_field_align(&self) -> usize {
+        self.max_field_align
+    }
+
     pub(crate) fn saw_vtable(&mut self) {
         debug!("saw vtable for {}", self.name);
 

--- a/bindgen/ir/ty.rs
+++ b/bindgen/ir/ty.rs
@@ -52,6 +52,15 @@ impl Type {
         }
     }
 
+    /// Get the underlying `CompInfo` for this type as an immutable reference, or
+    /// `None` if this is some other kind of type.
+    pub(crate) fn as_comp(&self) -> Option<&CompInfo> {
+        match self.kind {
+            TypeKind::Comp(ref ci) => Some(ci),
+            _ => None,
+        }
+    }
+
     /// Construct a new `Type`.
     pub(crate) fn new(
         name: Option<String>,
@@ -806,6 +815,7 @@ impl Type {
                             ty,
                             Some(location),
                             ctx,
+                            layout.as_ref(),
                         )
                         .expect("C'mon");
                         TypeKind::Comp(complex)
@@ -868,6 +878,7 @@ impl Type {
                                     ty,
                                     Some(location),
                                     ctx,
+                                    layout.as_ref(),
                                 );
                                 match complex {
                                     Ok(complex) => TypeKind::Comp(complex),
@@ -1134,6 +1145,7 @@ impl Type {
                         ty,
                         Some(location),
                         ctx,
+                        layout.as_ref(),
                     )
                     .expect("Not a complex type?");
 


### PR DESCRIPTION
NOTE: I know this can use some cleanups and more documentation / comments, etc. but for now I'm just uploading it as an RFC to see if you like the general approach. If you do, then I'll clean it up, but if not I won't bother.

----------------

This patch handles some (but not all) cases of types with a `packed` attribute that contain a type with an `align(N)` attribute.

This uses information available in the Clang IR about types' layout to determine if a given type is likely to have an alignment attribute placed on it during the code generation phase. This is just a heuristic; the decision to actually place an alignment attribute depends on information that is not known until code generation, so the logic here may result in both false positives and false negatives.

Using the real information from codegen on whether an alignment attribute was placed on a child type is not possible in general, because the order in which types are generated is not guaranteed. In some cases code may be generated for parent types before code is generated for child types contained in that parent. Then, it will be impossible to make an accurate decision regarding whether to remove the `packed` attribute from the parent type.

The impact of a false negative is that an outer type may have a `packed` attr even when an inner type as an `align` attr. Such a type would not compile under rustc, but it already would not compile so this has no harmful impact.

The impact of a false positive is that an outer type may have its `packed` attr stripped needlessly, because no inner types actually have an `align` attr. Because we only remove the `packed` attr when we can confirm that there will be no change to the type's layout, this also should have no harmful impact.