### PR TITLE
[RFC, V2] exclude packed attr for types that contain aligned types when possible

### DIFF
--- a/bindgen-tests/tests/expectations/tests/packed_embeds_aligned.rs
+++ b/bindgen-tests/tests/expectations/tests/packed_embeds_aligned.rs
@@ -1,0 +1,126 @@
+#![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
+#[repr(C)]
+#[repr(align(2))]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct inner1 {
+    pub a: ::std::os::raw::c_char,
+    pub b: ::std::os::raw::c_char,
+}
+#[test]
+fn bindgen_test_layout_inner1() {
+    const UNINIT: ::std::mem::MaybeUninit<inner1> = ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
+    assert_eq!(
+        ::std::mem::size_of::<inner1>(),
+        2usize,
+        concat!("Size of: ", stringify!(inner1)),
+    );
+    assert_eq!(
+        ::std::mem::align_of::<inner1>(),
+        2usize,
+        concat!("Alignment of ", stringify!(inner1)),
+    );
+    assert_eq!(
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(inner1), "::", stringify!(a)),
+    );
+    assert_eq!(
+        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
+        1usize,
+        concat!("Offset of field: ", stringify!(inner1), "::", stringify!(b)),
+    );
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct inner2 {
+    pub a: inner1,
+    pub b: inner1,
+}
+#[test]
+fn bindgen_test_layout_inner2() {
+    const UNINIT: ::std::mem::MaybeUninit<inner2> = ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
+    assert_eq!(
+        ::std::mem::size_of::<inner2>(),
+        4usize,
+        concat!("Size of: ", stringify!(inner2)),
+    );
+    assert_eq!(
+        ::std::mem::align_of::<inner2>(),
+        2usize,
+        concat!("Alignment of ", stringify!(inner2)),
+    );
+    assert_eq!(
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(inner2), "::", stringify!(a)),
+    );
+    assert_eq!(
+        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
+        2usize,
+        concat!("Offset of field: ", stringify!(inner2), "::", stringify!(b)),
+    );
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct outer1 {
+    pub a: ::std::os::raw::c_short,
+    pub b: inner1,
+}
+#[test]
+fn bindgen_test_layout_outer1() {
+    const UNINIT: ::std::mem::MaybeUninit<outer1> = ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
+    assert_eq!(
+        ::std::mem::size_of::<outer1>(),
+        4usize,
+        concat!("Size of: ", stringify!(outer1)),
+    );
+    assert_eq!(
+        ::std::mem::align_of::<outer1>(),
+        2usize,
+        concat!("Alignment of ", stringify!(outer1)),
+    );
+    assert_eq!(
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(outer1), "::", stringify!(a)),
+    );
+    assert_eq!(
+        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
+        2usize,
+        concat!("Offset of field: ", stringify!(outer1), "::", stringify!(b)),
+    );
+}
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct outer2 {
+    pub a: ::std::os::raw::c_short,
+    pub b: inner2,
+}
+#[test]
+fn bindgen_test_layout_outer2() {
+    const UNINIT: ::std::mem::MaybeUninit<outer2> = ::std::mem::MaybeUninit::uninit();
+    let ptr = UNINIT.as_ptr();
+    assert_eq!(
+        ::std::mem::size_of::<outer2>(),
+        6usize,
+        concat!("Size of: ", stringify!(outer2)),
+    );
+    assert_eq!(
+        ::std::mem::align_of::<outer2>(),
+        2usize,
+        concat!("Alignment of ", stringify!(outer2)),
+    );
+    assert_eq!(
+        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
+        0usize,
+        concat!("Offset of field: ", stringify!(outer2), "::", stringify!(a)),
+    );
+    assert_eq!(
+        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
+        2usize,
+        concat!("Offset of field: ", stringify!(outer2), "::", stringify!(b)),
+    );
+}

--- a/bindgen-tests/tests/headers/packed_embeds_aligned.h
+++ b/bindgen-tests/tests/headers/packed_embeds_aligned.h
@@ -1,0 +1,19 @@
+struct inner1 {
+	char a;
+	char b;
+} __attribute__((aligned(2)));
+
+struct inner2 {
+	struct inner1 a;
+	struct inner1 b;
+} __attribute__((aligned(2)));
+
+struct outer1 {
+	short a;
+	struct inner1 b;
+} __attribute__((packed, aligned(2)));
+
+struct outer2 {
+	short a;
+	struct inner2 b;
+} __attribute__((packed, aligned(2)));

--- a/bindgen/codegen/mod.rs
+++ b/bindgen/codegen/mod.rs
@@ -2124,7 +2124,7 @@ impl CodeGenerator for CompInfo {
             }
 
             if let Some(layout) = layout {
-                if struct_layout.requires_explicit_align(layout) {
+                if self.needs_explicit_align() {
                     if layout.align == 1 {
                         packed = true;
                     } else {
@@ -2145,7 +2145,7 @@ impl CodeGenerator for CompInfo {
             // TODO(emilio): It'd be nice to unify this with the struct path
             // above somehow.
             let layout = layout.expect("Unable to get layout information?");
-            if struct_layout.requires_explicit_align(layout) {
+            if self.needs_explicit_align() {
                 explicit_align = Some(layout.align);
             }
 
@@ -2202,8 +2202,8 @@ impl CodeGenerator for CompInfo {
         // "packed" attr is redundant, and do not include it if so.
         if packed &&
             !is_opaque &&
-            !(explicit_align.is_some() &&
-                self.already_packed(ctx).unwrap_or(false))
+            !((explicit_align.is_some() || self.contains_aligned_type(ctx)) &&
+                self.already_packed(ctx, layout).unwrap_or(false))
         {
             let n = layout.map_or(1, |l| l.align);
             assert!(ctx.options().rust_features().repr_packed_n || n == 1);


### PR DESCRIPTION
NOTE: I know this can use some cleanups and more documentation / comments, etc. but for now I'm just uploading it as an RFC to see if you like the general approach. If you do, then I'll clean it up, but if not I won't bother.

----------------

This patch aims to work around a limitation of rustc in which it will not compile types with a `packed` attr that contain types with an `align(N)` attr. If the `packed` attr on the outer/parent type is redundant, and can be removed without changing the type's layout, then this patch will remove that attr so that the type can be compiled under rustc. If the type's `packed` attr cannot be removed without changing the layout, then it will be left alone.

Handling this correctly requires a change to when bindgen determines whether a type requires an `align` attr. Currently, this happens during the code generation phase. However, we cannot in general assume anything about the order in which code is generated for types, and in particular codegen may occur for a parent type before codegen for all child types contained in that parent. However, in order to strip the `packed` attr in cases where we want to do so, we already need to know about the alignment of all children.

In order to make that possible, this patch moves the logic to check if a type requires an explicit `align` attr earlier. This now happens before codegen starts for the first type, so we can use information about the alignment of all child types to determine whether to place a `packed` attr on any given type.