### PR TITLE
Allow custom derives on new-type alias

### DIFF
--- a/bindgen-integration/build.rs
+++ b/bindgen-integration/build.rs
@@ -128,6 +128,8 @@ impl ParseCallbacks for MacroCallback {
             vec!["PartialEq".into()]
         } else if info.name == "MyOrderedEnum" {
             vec!["std::cmp::PartialOrd".into()]
+        } else if info.name == "TestDeriveOnAlias" {
+            vec!["std::cmp::PartialEq".into(), "std::cmp::PartialOrd".into()]
         } else {
             vec![]
         }
@@ -193,6 +195,7 @@ fn setup_macro_test() {
         .blocklist_function("my_prefixed_function_to_remove")
         .constified_enum("my_prefixed_enum_to_be_constified")
         .opaque_type("my_prefixed_templated_foo<my_prefixed_baz>")
+        .new_type_alias("TestDeriveOnAlias")
         .depfile(out_rust_file_relative.display().to_string(), &out_dep_file)
         .generate()
         .expect("Unable to generate bindings");

--- a/bindgen-integration/cpp/Test.h
+++ b/bindgen-integration/cpp/Test.h
@@ -241,3 +241,6 @@ enum MyOrderedEnum {
   METER,
   LIGHTYEAR,
 };
+
+// Used to test custom derives on new-type alias. See `test_custom_derive`.
+typedef int TestDeriveOnAlias;

--- a/bindgen-integration/src/lib.rs
+++ b/bindgen-integration/src/lib.rs
@@ -289,6 +289,13 @@ fn test_custom_derive() {
 
     assert!(meter < lightyear);
     assert!(meter > micron);
+
+    // The `add_derives` callback should have added `#[derive(PartialEq, PartialOrd)]`
+    // to the `TestDeriveOnAlias` new-type alias. If it didn't, this will fail to compile.
+    let test1 = unsafe { bindings::TestDeriveOnAlias(5) };
+    let test2 = unsafe { bindings::TestDeriveOnAlias(6) };
+    assert!(test1 < test2);
+    assert!(!(test1 > test2));
 }
 
 #[test]


### PR DESCRIPTION
This allows custom derives on new-type aliases which brings them in line with other structs and enums regarding derive callbacks.

The implementation was mostly copied from https://github.com/rust-lang/rust-bindgen/pull/2117.