### PR TITLE
Move phantom fields to start of struct to avoid interfering with flexible array members

### DIFF
--- a/bindgen-tests/tests/expectations/tests/allowlist_basic.rs
+++ b/bindgen-tests/tests/expectations/tests/allowlist_basic.rs
@@ -2,15 +2,15 @@
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct AllowlistMe<T> {
+    pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
     pub foo: ::std::os::raw::c_int,
     pub bar: AllowlistMe_Inner<T>,
-    pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct AllowlistMe_Inner<T> {
-    pub bar: T,
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
+    pub bar: T,
 }
 impl<T> Default for AllowlistMe_Inner<T> {
     fn default() -> Self {

--- a/bindgen-tests/tests/expectations/tests/anonymous-template-types.rs
+++ b/bindgen-tests/tests/expectations/tests/anonymous-template-types.rs
@@ -2,8 +2,8 @@
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct Foo<T> {
-    pub t_member: T,
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
+    pub t_member: T,
 }
 impl<T> Default for Foo<T> {
     fn default() -> Self {
@@ -22,8 +22,8 @@ pub struct Bar {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct Quux<V> {
-    pub v_member: V,
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<V>>,
+    pub v_member: V,
 }
 impl<V> Default for Quux<V> {
     fn default() -> Self {

--- a/bindgen-tests/tests/expectations/tests/canonical-types.rs
+++ b/bindgen-tests/tests/expectations/tests/canonical-types.rs
@@ -7,8 +7,8 @@ pub struct ClassA {
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct ClassA_ClassAInner<T> {
-    pub x: *mut T,
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
+    pub x: *mut T,
 }
 impl<T> Default for ClassA_ClassAInner<T> {
     fn default() -> Self {

--- a/bindgen-tests/tests/expectations/tests/class_nested.rs
+++ b/bindgen-tests/tests/expectations/tests/class_nested.rs
@@ -32,8 +32,8 @@ fn bindgen_test_layout_A_B() {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct A_D<T> {
-    pub foo: T,
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
+    pub foo: T,
 }
 impl<T> Default for A_D<T> {
     fn default() -> Self {
@@ -134,14 +134,14 @@ fn bindgen_test_layout_D() {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct Templated<T> {
-    pub member: T,
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
+    pub member: T,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct Templated_Templated_inner<T> {
-    pub member_ptr: *mut T,
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
+    pub member_ptr: *mut T,
 }
 impl<T> Default for Templated_Templated_inner<T> {
     fn default() -> Self {

--- a/bindgen-tests/tests/expectations/tests/class_with_dtor.rs
+++ b/bindgen-tests/tests/expectations/tests/class_with_dtor.rs
@@ -2,8 +2,8 @@
 #[repr(C)]
 #[derive(Debug, Hash, PartialEq, Eq)]
 pub struct HandleWithDtor<T> {
-    pub ptr: *mut T,
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
+    pub ptr: *mut T,
 }
 impl<T> Default for HandleWithDtor<T> {
     fn default() -> Self {

--- a/bindgen-tests/tests/expectations/tests/const_tparam.rs
+++ b/bindgen-tests/tests/expectations/tests/const_tparam.rs
@@ -2,9 +2,9 @@
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct C<T> {
+    pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
     pub foo: *const T,
     pub bar: *const T,
-    pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
 }
 impl<T> Default for C<T> {
     fn default() -> Self {

--- a/bindgen-tests/tests/expectations/tests/constify-module-enums-types.rs
+++ b/bindgen-tests/tests/expectations/tests/constify-module-enums-types.rs
@@ -211,8 +211,8 @@ extern "C" {
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct Thing<T> {
-    pub thing: T,
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
+    pub thing: T,
 }
 impl<T> Default for Thing<T> {
     fn default() -> Self {

--- a/bindgen-tests/tests/expectations/tests/default-template-parameter.rs
+++ b/bindgen-tests/tests/expectations/tests/default-template-parameter.rs
@@ -2,10 +2,10 @@
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct Foo<T, U> {
-    pub t: T,
-    pub u: U,
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
     pub _phantom_1: ::std::marker::PhantomData<::std::cell::UnsafeCell<U>>,
+    pub t: T,
+    pub u: U,
 }
 impl<T, U> Default for Foo<T, U> {
     fn default() -> Self {

--- a/bindgen-tests/tests/expectations/tests/derive-debug-generic.rs
+++ b/bindgen-tests/tests/expectations/tests/derive-debug-generic.rs
@@ -1,8 +1,8 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
 pub struct Generic<T> {
-    pub t: [T; 40usize],
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
+    pub t: [T; 40usize],
 }
 impl<T> Default for Generic<T> {
     fn default() -> Self {

--- a/bindgen-tests/tests/expectations/tests/derive-hash-template-def-float.rs
+++ b/bindgen-tests/tests/expectations/tests/derive-hash-template-def-float.rs
@@ -3,9 +3,9 @@
 #[repr(C)]
 #[derive(Debug, Copy, Clone, PartialOrd, PartialEq)]
 pub struct foo<T> {
+    pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
     pub data: T,
     pub b: f32,
-    pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
 }
 impl<T> Default for foo<T> {
     fn default() -> Self {

--- a/bindgen-tests/tests/expectations/tests/derive-hash-template-inst-float.rs
+++ b/bindgen-tests/tests/expectations/tests/derive-hash-template-inst-float.rs
@@ -3,8 +3,8 @@
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub struct foo<T> {
-    pub data: T,
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
+    pub data: T,
 }
 impl<T> Default for foo<T> {
     fn default() -> Self {

--- a/bindgen-tests/tests/expectations/tests/forward-declaration-autoptr.rs
+++ b/bindgen-tests/tests/expectations/tests/forward-declaration-autoptr.rs
@@ -7,8 +7,8 @@ pub struct Foo {
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct RefPtr<T> {
-    pub m_inner: *mut T,
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
+    pub m_inner: *mut T,
 }
 impl<T> Default for RefPtr<T> {
     fn default() -> Self {

--- a/bindgen-tests/tests/expectations/tests/forward-inherit-struct-with-fields.rs
+++ b/bindgen-tests/tests/expectations/tests/forward-inherit-struct-with-fields.rs
@@ -2,9 +2,9 @@
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct js_RootedBase<T> {
+    pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
     pub foo: *mut T,
     pub next: *mut Rooted<T>,
-    pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
 }
 impl<T> Default for js_RootedBase<T> {
     fn default() -> Self {
@@ -18,8 +18,8 @@ impl<T> Default for js_RootedBase<T> {
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct Rooted<T> {
-    pub _base: js_RootedBase<T>,
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
+    pub _base: js_RootedBase<T>,
 }
 impl<T> Default for Rooted<T> {
     fn default() -> Self {

--- a/bindgen-tests/tests/expectations/tests/inherit-from-template-instantiation-with-vtable.rs
+++ b/bindgen-tests/tests/expectations/tests/inherit-from-template-instantiation-with-vtable.rs
@@ -5,9 +5,9 @@ pub struct BaseWithVtable__bindgen_vtable {}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct BaseWithVtable<T> {
+    pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
     pub vtable_: *const BaseWithVtable__bindgen_vtable,
     pub t: T,
-    pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
 }
 impl<T> Default for BaseWithVtable<T> {
     fn default() -> Self {
@@ -78,8 +78,8 @@ impl Default for DerivedWithVirtualMethods {
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct BaseWithoutVtable<U> {
-    pub u: U,
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<U>>,
+    pub u: U,
 }
 impl<U> Default for BaseWithoutVtable<U> {
     fn default() -> Self {

--- a/bindgen-tests/tests/expectations/tests/inherit_named.rs
+++ b/bindgen-tests/tests/expectations/tests/inherit_named.rs
@@ -7,8 +7,8 @@ pub struct Wohoo {
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct Weeee<T> {
-    pub _base: T,
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
+    pub _base: T,
 }
 impl<T> Default for Weeee<T> {
     fn default() -> Self {

--- a/bindgen-tests/tests/expectations/tests/inline_namespace_no_ns_enabled.rs
+++ b/bindgen-tests/tests/expectations/tests/inline_namespace_no_ns_enabled.rs
@@ -2,10 +2,10 @@
 #[repr(C)]
 #[derive(Debug)]
 pub struct std_basic_string<CharT> {
+    pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<CharT>>,
     pub hider: std_basic_string_Alloc_hider,
     pub length: ::std::os::raw::c_ulong,
     pub __bindgen_anon_1: std_basic_string__bindgen_ty_1<CharT>,
-    pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<CharT>>,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -24,8 +24,8 @@ impl Default for std_basic_string_Alloc_hider {
 #[repr(C)]
 #[derive(Debug)]
 pub struct std_basic_string__bindgen_ty_1<CharT> {
-    pub inline_storage: [CharT; 4usize],
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<CharT>>,
+    pub inline_storage: [CharT; 4usize],
 }
 impl<CharT> Default for std_basic_string__bindgen_ty_1<CharT> {
     fn default() -> Self {

--- a/bindgen-tests/tests/expectations/tests/inner-typedef-gh422.rs
+++ b/bindgen-tests/tests/expectations/tests/inner-typedef-gh422.rs
@@ -7,8 +7,8 @@ pub struct Foo {
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct Foo_InnerType<T> {
-    pub t: T,
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
+    pub t: T,
 }
 impl<T> Default for Foo_InnerType<T> {
     fn default() -> Self {

--- a/bindgen-tests/tests/expectations/tests/issue-1113-template-references.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-1113-template-references.rs
@@ -2,10 +2,10 @@
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct Entry<K, V> {
-    pub _base: K,
-    pub mData: V,
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<K>>,
     pub _phantom_1: ::std::marker::PhantomData<::std::cell::UnsafeCell<V>>,
+    pub _base: K,
+    pub mData: V,
 }
 impl<K, V> Default for Entry<K, V> {
     fn default() -> Self {
@@ -25,10 +25,10 @@ pub type nsBaseHashtable_EntryType<K, V> = Entry<K, V>;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nsBaseHashtable_EntryPtr<K, V> {
-    pub mEntry: *mut nsBaseHashtable_EntryType<K, V>,
-    pub mExistingEntry: bool,
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<K>>,
     pub _phantom_1: ::std::marker::PhantomData<::std::cell::UnsafeCell<V>>,
+    pub mEntry: *mut nsBaseHashtable_EntryType<K, V>,
+    pub mExistingEntry: bool,
 }
 impl<K, V> Default for nsBaseHashtable_EntryPtr<K, V> {
     fn default() -> Self {

--- a/bindgen-tests/tests/expectations/tests/issue-1514.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-1514.rs
@@ -7,8 +7,8 @@ pub struct Thing {
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct Thing_Inner<T> {
-    pub ptr: *mut T,
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
+    pub ptr: *mut T,
 }
 impl<T> Default for Thing_Inner<T> {
     fn default() -> Self {
@@ -22,8 +22,8 @@ impl<T> Default for Thing_Inner<T> {
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct Thing_AnotherInner<T> {
-    pub _base: Thing_Inner<T>,
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
+    pub _base: Thing_Inner<T>,
 }
 impl<T> Default for Thing_AnotherInner<T> {
     fn default() -> Self {

--- a/bindgen-tests/tests/expectations/tests/issue-1977-larger-arrays.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-1977-larger-arrays.rs
@@ -32,8 +32,8 @@ impl Default for S {
 #[repr(C)]
 #[derive(Debug, Hash, PartialEq, Eq)]
 pub struct ST<T> {
-    pub large_array: [T; 33usize],
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
+    pub large_array: [T; 33usize],
 }
 impl<T> Default for ST<T> {
     fn default() -> Self {

--- a/bindgen-tests/tests/expectations/tests/issue-584-stylo-template-analysis-panic.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-584-stylo-template-analysis-panic.rs
@@ -17,8 +17,8 @@ fn bindgen_test_layout_A() {
 }
 #[repr(C)]
 pub struct e<c> {
-    pub d: RefPtr<c>,
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<c>>,
+    pub d: RefPtr<c>,
 }
 impl<c> Default for e<c> {
     fn default() -> Self {

--- a/bindgen-tests/tests/expectations/tests/issue-638-stylo-cannot-find-T-in-this-scope.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-638-stylo-cannot-find-T-in-this-scope.rs
@@ -2,8 +2,8 @@
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct RefPtr<T> {
-    pub use_of_t: T,
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
+    pub use_of_t: T,
 }
 impl<T> Default for RefPtr<T> {
     fn default() -> Self {
@@ -17,8 +17,8 @@ impl<T> Default for RefPtr<T> {
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct UsesRefPtrWithAliasedTypeParam<U> {
-    pub member: RefPtr<UsesRefPtrWithAliasedTypeParam_V<U>>,
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<U>>,
+    pub member: RefPtr<UsesRefPtrWithAliasedTypeParam_V<U>>,
 }
 pub type UsesRefPtrWithAliasedTypeParam_V<U> = U;
 impl<U> Default for UsesRefPtrWithAliasedTypeParam<U> {

--- a/bindgen-tests/tests/expectations/tests/issue-645-cannot-find-type-T-in-this-scope.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-645-cannot-find-type-T-in-this-scope.rs
@@ -3,8 +3,8 @@
 pub struct RefPtr<T>(T);
 #[repr(C)]
 pub struct HasRefPtr<T> {
-    pub refptr_member: RefPtr<HasRefPtr_TypedefOfT<T>>,
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
+    pub refptr_member: RefPtr<HasRefPtr_TypedefOfT<T>>,
 }
 pub type HasRefPtr_TypedefOfT<T> = T;
 impl<T> Default for HasRefPtr<T> {

--- a/bindgen-tests/tests/expectations/tests/issue-662-cannot-find-T-in-this-scope.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-662-cannot-find-T-in-this-scope.rs
@@ -2,8 +2,8 @@
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct RefPtr<T> {
-    pub a: T,
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
+    pub a: T,
 }
 impl<T> Default for RefPtr<T> {
     fn default() -> Self {
@@ -17,8 +17,8 @@ impl<T> Default for RefPtr<T> {
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nsMainThreadPtrHolder<T> {
-    pub a: T,
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
+    pub a: T,
 }
 impl<T> Default for nsMainThreadPtrHolder<T> {
     fn default() -> Self {
@@ -32,8 +32,8 @@ impl<T> Default for nsMainThreadPtrHolder<T> {
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nsMainThreadPtrHandle<T> {
-    pub mPtr: RefPtr<nsMainThreadPtrHolder<T>>,
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
+    pub mPtr: RefPtr<nsMainThreadPtrHolder<T>>,
 }
 impl<T> Default for nsMainThreadPtrHandle<T> {
     fn default() -> Self {

--- a/bindgen-tests/tests/expectations/tests/issue-662-part-2.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-662-part-2.rs
@@ -4,8 +4,8 @@ pub struct RefPtr<T>(T);
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nsMainThreadPtrHolder<T> {
-    pub a: T,
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
+    pub a: T,
 }
 impl<T> Default for nsMainThreadPtrHolder<T> {
     fn default() -> Self {
@@ -18,8 +18,8 @@ impl<T> Default for nsMainThreadPtrHolder<T> {
 }
 #[repr(C)]
 pub struct nsMainThreadPtrHandle<U> {
-    pub mPtr: RefPtr<nsMainThreadPtrHolder<U>>,
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<U>>,
+    pub mPtr: RefPtr<nsMainThreadPtrHolder<U>>,
 }
 impl<U> Default for nsMainThreadPtrHandle<U> {
     fn default() -> Self {

--- a/bindgen-tests/tests/expectations/tests/issue-769-bad-instantiation-test.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-769-bad-instantiation-test.rs
@@ -6,8 +6,8 @@ pub mod root {
     #[repr(C)]
     #[derive(Debug, Copy, Clone)]
     pub struct Rooted<T> {
-        pub member: T,
         pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
+        pub member: T,
     }
     impl<T> Default for Rooted<T> {
         fn default() -> Self {

--- a/bindgen-tests/tests/expectations/tests/issue-848-replacement-system-include.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-848-replacement-system-include.rs
@@ -8,8 +8,8 @@
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nsTArray<T> {
-    pub m: *mut T,
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
+    pub m: *mut T,
 }
 impl<T> Default for nsTArray<T> {
     fn default() -> Self {

--- a/bindgen-tests/tests/expectations/tests/namespace.rs
+++ b/bindgen-tests/tests/expectations/tests/namespace.rs
@@ -49,11 +49,11 @@ pub mod root {
     #[repr(C)]
     #[derive(Debug)]
     pub struct C<T> {
+        pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
         pub _base: root::_bindgen_mod_id_17::A,
         pub m_c: T,
         pub m_c_ptr: *mut T,
         pub m_c_arr: [T; 10usize],
-        pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
     }
     impl<T> Default for C<T> {
         fn default() -> Self {
@@ -71,8 +71,8 @@ pub mod root {
         #[repr(C)]
         #[derive(Debug)]
         pub struct D<T> {
-            pub m_c: root::C<T>,
             pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
+            pub m_c: root::C<T>,
         }
         impl<T> Default for D<T> {
             fn default() -> Self {

--- a/bindgen-tests/tests/expectations/tests/no_debug_bypass_impl_debug.rs
+++ b/bindgen-tests/tests/expectations/tests/no_debug_bypass_impl_debug.rs
@@ -1,8 +1,8 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
 pub struct Generic<T> {
-    pub t: [T; 40usize],
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
+    pub t: [T; 40usize],
 }
 impl<T> Default for Generic<T> {
     fn default() -> Self {
@@ -20,8 +20,8 @@ impl<T> ::std::fmt::Debug for Generic<T> {
 }
 #[repr(C)]
 pub struct NoDebug<T> {
-    pub t: [T; 40usize],
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
+    pub t: [T; 40usize],
 }
 impl<T> Default for NoDebug<T> {
     fn default() -> Self {

--- a/bindgen-tests/tests/expectations/tests/no_default_bypass_derive_default.rs
+++ b/bindgen-tests/tests/expectations/tests/no_default_bypass_derive_default.rs
@@ -1,8 +1,8 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
 pub struct Generic<T> {
-    pub t: [T; 40usize],
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
+    pub t: [T; 40usize],
 }
 impl<T> Default for Generic<T> {
     fn default() -> Self {
@@ -15,6 +15,6 @@ impl<T> Default for Generic<T> {
 }
 #[repr(C)]
 pub struct NoDefault<T> {
-    pub t: [T; 40usize],
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
+    pub t: [T; 40usize],
 }

--- a/bindgen-tests/tests/expectations/tests/nsStyleAutoArray.rs
+++ b/bindgen-tests/tests/expectations/tests/nsStyleAutoArray.rs
@@ -2,8 +2,8 @@
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nsTArray<T> {
-    pub mBuff: *mut T,
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
+    pub mBuff: *mut T,
 }
 impl<T> Default for nsTArray<T> {
     fn default() -> Self {
@@ -17,9 +17,9 @@ impl<T> Default for nsTArray<T> {
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct nsStyleAutoArray<T> {
+    pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
     pub mFirstElement: T,
     pub mOtherElements: nsTArray<T>,
-    pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
 }
 #[repr(i32)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]

--- a/bindgen-tests/tests/expectations/tests/opaque-template-instantiation-namespaced.rs
+++ b/bindgen-tests/tests/expectations/tests/opaque-template-instantiation-namespaced.rs
@@ -9,8 +9,8 @@ pub mod root {
         #[repr(C)]
         #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
         pub struct Template<T> {
-            pub member: T,
             pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
+            pub member: T,
         }
         impl<T> Default for Template<T> {
             fn default() -> Self {

--- a/bindgen-tests/tests/expectations/tests/opaque-template-instantiation.rs
+++ b/bindgen-tests/tests/expectations/tests/opaque-template-instantiation.rs
@@ -2,8 +2,8 @@
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct Template<T> {
-    pub member: T,
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
+    pub member: T,
 }
 impl<T> Default for Template<T> {
     fn default() -> Self {

--- a/bindgen-tests/tests/expectations/tests/replace_template_alias.rs
+++ b/bindgen-tests/tests/expectations/tests/replace_template_alias.rs
@@ -6,8 +6,8 @@ pub type JS_detail_MaybeWrapped<T> = T;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct JS_Rooted<T> {
-    pub ptr: JS_detail_MaybeWrapped<T>,
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
+    pub ptr: JS_detail_MaybeWrapped<T>,
 }
 impl<T> Default for JS_Rooted<T> {
     fn default() -> Self {

--- a/bindgen-tests/tests/expectations/tests/replaces_double.rs
+++ b/bindgen-tests/tests/expectations/tests/replaces_double.rs
@@ -2,8 +2,8 @@
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct Wrapper_Wrapped<T> {
-    pub t: T,
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
+    pub t: T,
 }
 impl<T> Default for Wrapper_Wrapped<T> {
     fn default() -> Self {
@@ -18,8 +18,8 @@ pub type Wrapper_Type<T> = Wrapper_Wrapped<T>;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct Rooted<T> {
-    pub ptr: Rooted_MaybeWrapped<T>,
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
+    pub ptr: Rooted_MaybeWrapped<T>,
 }
 /// <div rustbindgen replaces="Rooted_MaybeWrapped"></div>
 pub type Rooted_MaybeWrapped<T> = T;

--- a/bindgen-tests/tests/expectations/tests/struct_with_large_array.rs
+++ b/bindgen-tests/tests/expectations/tests/struct_with_large_array.rs
@@ -31,8 +31,8 @@ impl Default for S {
 }
 #[repr(C)]
 pub struct ST<T> {
-    pub large_array: [T; 33usize],
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
+    pub large_array: [T; 33usize],
 }
 impl<T> Default for ST<T> {
     fn default() -> Self {

--- a/bindgen-tests/tests/expectations/tests/template-param-usage-0.rs
+++ b/bindgen-tests/tests/expectations/tests/template-param-usage-0.rs
@@ -2,8 +2,8 @@
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct UsesTemplateParameter<T> {
-    pub t: T,
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
+    pub t: T,
 }
 impl<T> Default for UsesTemplateParameter<T> {
     fn default() -> Self {

--- a/bindgen-tests/tests/expectations/tests/template-param-usage-10.rs
+++ b/bindgen-tests/tests/expectations/tests/template-param-usage-10.rs
@@ -2,19 +2,19 @@
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct DoublyIndirectUsage<T, U> {
-    pub doubly_indirect: DoublyIndirectUsage_IndirectUsage<T, U>,
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
     pub _phantom_1: ::std::marker::PhantomData<::std::cell::UnsafeCell<U>>,
+    pub doubly_indirect: DoublyIndirectUsage_IndirectUsage<T, U>,
 }
 pub type DoublyIndirectUsage_Aliased<T> = T;
 pub type DoublyIndirectUsage_Typedefed<U> = U;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct DoublyIndirectUsage_IndirectUsage<T, U> {
-    pub member: DoublyIndirectUsage_Aliased<T>,
-    pub another: DoublyIndirectUsage_Typedefed<U>,
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
     pub _phantom_1: ::std::marker::PhantomData<::std::cell::UnsafeCell<U>>,
+    pub member: DoublyIndirectUsage_Aliased<T>,
+    pub another: DoublyIndirectUsage_Typedefed<U>,
 }
 impl<T, U> Default for DoublyIndirectUsage_IndirectUsage<T, U> {
     fn default() -> Self {

--- a/bindgen-tests/tests/expectations/tests/template-param-usage-12.rs
+++ b/bindgen-tests/tests/expectations/tests/template-param-usage-12.rs
@@ -2,8 +2,8 @@
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct BaseUsesT<T> {
-    pub t: *mut T,
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
+    pub t: *mut T,
 }
 impl<T> Default for BaseUsesT<T> {
     fn default() -> Self {
@@ -17,9 +17,9 @@ impl<T> Default for BaseUsesT<T> {
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct CrtpUsesU<U> {
+    pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<U>>,
     pub _base: BaseUsesT<CrtpUsesU<U>>,
     pub usage: U,
-    pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<U>>,
 }
 impl<U> Default for CrtpUsesU<U> {
     fn default() -> Self {

--- a/bindgen-tests/tests/expectations/tests/template-param-usage-13.rs
+++ b/bindgen-tests/tests/expectations/tests/template-param-usage-13.rs
@@ -7,9 +7,9 @@ pub struct BaseIgnoresT {
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct CrtpUsesU<U> {
+    pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<U>>,
     pub _base: BaseIgnoresT,
     pub usage: U,
-    pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<U>>,
 }
 impl<U> Default for CrtpUsesU<U> {
     fn default() -> Self {

--- a/bindgen-tests/tests/expectations/tests/template-param-usage-15.rs
+++ b/bindgen-tests/tests/expectations/tests/template-param-usage-15.rs
@@ -2,8 +2,8 @@
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct BaseUsesT<T> {
-    pub usage: *mut T,
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
+    pub usage: *mut T,
 }
 impl<T> Default for BaseUsesT<T> {
     fn default() -> Self {

--- a/bindgen-tests/tests/expectations/tests/template-param-usage-2.rs
+++ b/bindgen-tests/tests/expectations/tests/template-param-usage-2.rs
@@ -2,14 +2,14 @@
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct UsesTemplateParameter<T> {
-    pub t: T,
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
+    pub t: T,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct UsesTemplateParameter_AlsoUsesTemplateParameter<T> {
-    pub also: T,
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
+    pub also: T,
 }
 impl<T> Default for UsesTemplateParameter_AlsoUsesTemplateParameter<T> {
     fn default() -> Self {

--- a/bindgen-tests/tests/expectations/tests/template-param-usage-3.rs
+++ b/bindgen-tests/tests/expectations/tests/template-param-usage-3.rs
@@ -2,16 +2,16 @@
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct UsesTemplateParameter<T> {
-    pub t: T,
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
+    pub t: T,
 }
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct UsesTemplateParameter_AlsoUsesTemplateParameterAndMore<T, U> {
-    pub also: T,
-    pub more: U,
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
     pub _phantom_1: ::std::marker::PhantomData<::std::cell::UnsafeCell<U>>,
+    pub also: T,
+    pub more: U,
 }
 impl<T, U> Default for UsesTemplateParameter_AlsoUsesTemplateParameterAndMore<T, U> {
     fn default() -> Self {

--- a/bindgen-tests/tests/expectations/tests/template-param-usage-4.rs
+++ b/bindgen-tests/tests/expectations/tests/template-param-usage-4.rs
@@ -2,8 +2,8 @@
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct UsesTemplateParameter<T> {
-    pub t: T,
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
+    pub t: T,
 }
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]

--- a/bindgen-tests/tests/expectations/tests/template-param-usage-5.rs
+++ b/bindgen-tests/tests/expectations/tests/template-param-usage-5.rs
@@ -2,8 +2,8 @@
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct IndirectlyUsesTemplateParameter<T> {
-    pub aliased: IndirectlyUsesTemplateParameter_Aliased<T>,
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
+    pub aliased: IndirectlyUsesTemplateParameter_Aliased<T>,
 }
 pub type IndirectlyUsesTemplateParameter_Aliased<T> = T;
 impl<T> Default for IndirectlyUsesTemplateParameter<T> {

--- a/bindgen-tests/tests/expectations/tests/template-param-usage-7.rs
+++ b/bindgen-tests/tests/expectations/tests/template-param-usage-7.rs
@@ -2,10 +2,10 @@
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct DoesNotUseU<T, V> {
-    pub t: T,
-    pub v: V,
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
     pub _phantom_1: ::std::marker::PhantomData<::std::cell::UnsafeCell<V>>,
+    pub t: T,
+    pub v: V,
 }
 impl<T, V> Default for DoesNotUseU<T, V> {
     fn default() -> Self {

--- a/bindgen-tests/tests/expectations/tests/template-param-usage-8.rs
+++ b/bindgen-tests/tests/expectations/tests/template-param-usage-8.rs
@@ -2,10 +2,10 @@
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct IndirectUsage<T, U> {
-    pub member1: IndirectUsage_Typedefed<T>,
-    pub member2: IndirectUsage_Aliased<U>,
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
     pub _phantom_1: ::std::marker::PhantomData<::std::cell::UnsafeCell<U>>,
+    pub member1: IndirectUsage_Typedefed<T>,
+    pub member2: IndirectUsage_Aliased<U>,
 }
 pub type IndirectUsage_Typedefed<T> = T;
 pub type IndirectUsage_Aliased<U> = U;

--- a/bindgen-tests/tests/expectations/tests/template-param-usage-9.rs
+++ b/bindgen-tests/tests/expectations/tests/template-param-usage-9.rs
@@ -9,10 +9,10 @@ pub type DoesNotUse_Typedefed<U> = U;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct DoesNotUse_IndirectUsage<T, U> {
-    pub member: DoesNotUse_Aliased<T>,
-    pub another: DoesNotUse_Typedefed<U>,
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
     pub _phantom_1: ::std::marker::PhantomData<::std::cell::UnsafeCell<U>>,
+    pub member: DoesNotUse_Aliased<T>,
+    pub another: DoesNotUse_Typedefed<U>,
 }
 impl<T, U> Default for DoesNotUse_IndirectUsage<T, U> {
     fn default() -> Self {

--- a/bindgen-tests/tests/expectations/tests/template.rs
+++ b/bindgen-tests/tests/expectations/tests/template.rs
@@ -2,10 +2,10 @@
 #[repr(C)]
 #[derive(Debug, Hash, PartialEq, Eq)]
 pub struct Foo<T> {
+    pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
     pub m_member: T,
     pub m_member_ptr: *mut T,
     pub m_member_arr: [T; 1usize],
-    pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
 }
 impl<T> Default for Foo<T> {
     fn default() -> Self {
@@ -19,8 +19,8 @@ impl<T> Default for Foo<T> {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct B<T> {
-    pub m_member: T,
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
+    pub m_member: T,
 }
 impl<T> Default for B<T> {
     fn default() -> Self {
@@ -180,9 +180,9 @@ pub type D_MyFoo = Foo<::std::os::raw::c_int>;
 #[repr(C)]
 #[derive(Debug, Hash, PartialEq, Eq)]
 pub struct D_U<Z> {
+    pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<Z>>,
     pub m_nested_foo: D_MyFoo,
     pub m_baz: Z,
-    pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<Z>>,
 }
 impl<Z> Default for D_U<Z> {
     fn default() -> Self {
@@ -205,10 +205,10 @@ impl Default for D {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct Rooted<T> {
+    pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
     pub prev: *mut T,
     pub next: *mut Rooted<*mut ::std::os::raw::c_void>,
     pub ptr: T,
-    pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
 }
 impl<T> Default for Rooted<T> {
     fn default() -> Self {
@@ -257,8 +257,8 @@ pub type WithDtorIntFwd = WithDtor<::std::os::raw::c_int>;
 #[repr(C)]
 #[derive(Debug, Hash, PartialEq, Eq)]
 pub struct WithDtor<T> {
-    pub member: T,
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
+    pub member: T,
 }
 impl<T> Default for WithDtor<T> {
     fn default() -> Self {
@@ -343,8 +343,8 @@ fn bindgen_test_layout_POD() {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct NestedReplaced<T> {
-    pub buff: *mut T,
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
+    pub buff: *mut T,
 }
 impl<T> Default for NestedReplaced<T> {
     fn default() -> Self {
@@ -358,8 +358,8 @@ impl<T> Default for NestedReplaced<T> {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct NestedBase<T> {
-    pub buff: *mut T,
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
+    pub buff: *mut T,
 }
 impl<T> Default for NestedBase<T> {
     fn default() -> Self {
@@ -373,10 +373,10 @@ impl<T> Default for NestedBase<T> {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct NestedContainer<T> {
+    pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
     pub c: T,
     pub nested: NestedReplaced<T>,
     pub inc: Incomplete<T>,
-    pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
 }
 impl<T> Default for NestedContainer<T> {
     fn default() -> Self {
@@ -390,8 +390,8 @@ impl<T> Default for NestedContainer<T> {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct Incomplete<T> {
-    pub d: T,
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
+    pub d: T,
 }
 impl<T> Default for Incomplete<T> {
     fn default() -> Self {
@@ -432,8 +432,8 @@ pub struct Templated {
 #[repr(C)]
 #[derive(Debug, Hash, PartialEq, Eq)]
 pub struct ReplacedWithoutDestructor<T> {
-    pub buff: *mut T,
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
+    pub buff: *mut T,
 }
 impl<T> Default for ReplacedWithoutDestructor<T> {
     fn default() -> Self {
@@ -447,8 +447,8 @@ impl<T> Default for ReplacedWithoutDestructor<T> {
 #[repr(C)]
 #[derive(Debug, Hash, PartialEq, Eq)]
 pub struct ShouldNotBeCopiable<T> {
-    pub m_member: ReplacedWithoutDestructor<T>,
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
+    pub m_member: ReplacedWithoutDestructor<T>,
 }
 impl<T> Default for ShouldNotBeCopiable<T> {
     fn default() -> Self {
@@ -462,8 +462,8 @@ impl<T> Default for ShouldNotBeCopiable<T> {
 #[repr(C)]
 #[derive(Debug, Hash, PartialEq, Eq)]
 pub struct ShouldNotBeCopiableAsWell<U> {
-    pub m_member: ReplacedWithoutDestructorFwd<U>,
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<U>>,
+    pub m_member: ReplacedWithoutDestructorFwd<U>,
 }
 impl<U> Default for ShouldNotBeCopiableAsWell<U> {
     fn default() -> Self {
@@ -481,8 +481,8 @@ impl<U> Default for ShouldNotBeCopiableAsWell<U> {
 #[repr(C)]
 #[derive(Debug, Hash, PartialEq, Eq)]
 pub struct ReplacedWithoutDestructorFwd<T> {
-    pub buff: *mut T,
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
+    pub buff: *mut T,
 }
 impl<T> Default for ReplacedWithoutDestructorFwd<T> {
     fn default() -> Self {

--- a/bindgen-tests/tests/expectations/tests/template_alias.rs
+++ b/bindgen-tests/tests/expectations/tests/template_alias.rs
@@ -3,8 +3,8 @@ pub type JS_detail_Wrapped<T> = T;
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct JS_Rooted<T> {
-    pub ptr: JS_detail_Wrapped<T>,
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
+    pub ptr: JS_detail_Wrapped<T>,
 }
 impl<T> Default for JS_Rooted<T> {
     fn default() -> Self {

--- a/bindgen-tests/tests/expectations/tests/template_alias_namespace.rs
+++ b/bindgen-tests/tests/expectations/tests/template_alias_namespace.rs
@@ -14,8 +14,8 @@ pub mod root {
         #[repr(C)]
         #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
         pub struct Rooted<T> {
-            pub ptr: root::JS::detail::Wrapped<T>,
             pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
+            pub ptr: root::JS::detail::Wrapped<T>,
         }
         impl<T> Default for Rooted<T> {
             fn default() -> Self {

--- a/bindgen-tests/tests/expectations/tests/template_typedef_transitive_param.rs
+++ b/bindgen-tests/tests/expectations/tests/template_typedef_transitive_param.rs
@@ -7,8 +7,8 @@ pub struct Wrapper {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct Wrapper_Wrapped<T> {
-    pub t: T,
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
+    pub t: T,
 }
 impl<T> Default for Wrapper_Wrapped<T> {
     fn default() -> Self {

--- a/bindgen-tests/tests/expectations/tests/transform-op.rs
+++ b/bindgen-tests/tests/expectations/tests/transform-op.rs
@@ -45,9 +45,9 @@ impl<T> ::std::cmp::Eq for __BindgenUnionField<T> {}
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct StylePoint<T> {
+    pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
     pub x: T,
     pub y: T,
-    pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
 }
 impl<T> Default for StylePoint<T> {
     fn default() -> Self {
@@ -61,12 +61,12 @@ impl<T> Default for StylePoint<T> {
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct StyleFoo<T> {
+    pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
     pub __bindgen_anon_1: __BindgenUnionField<StyleFoo__bindgen_ty_1>,
     pub foo: __BindgenUnionField<StyleFoo_Foo_Body<T>>,
     pub bar: __BindgenUnionField<StyleFoo_Bar_Body<T>>,
     pub baz: __BindgenUnionField<StyleFoo_Baz_Body<T>>,
     pub bindgen_union_field: [u8; 0usize],
-    pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
 }
 pub const StyleFoo_Tag_Foo: StyleFoo_Tag = 0;
 pub const StyleFoo_Tag_Bar: StyleFoo_Tag = 0;
@@ -76,11 +76,11 @@ pub type StyleFoo_Tag = u8;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct StyleFoo_Foo_Body<T> {
+    pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
     pub tag: StyleFoo_Tag,
     pub x: i32,
     pub y: StylePoint<T>,
     pub z: StylePoint<f32>,
-    pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
 }
 impl<T> Default for StyleFoo_Foo_Body<T> {
     fn default() -> Self {
@@ -94,9 +94,9 @@ impl<T> Default for StyleFoo_Foo_Body<T> {
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct StyleFoo_Bar_Body<T> {
+    pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
     pub tag: StyleFoo_Tag,
     pub _0: T,
-    pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
 }
 impl<T> Default for StyleFoo_Bar_Body<T> {
     fn default() -> Self {
@@ -110,9 +110,9 @@ impl<T> Default for StyleFoo_Bar_Body<T> {
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct StyleFoo_Baz_Body<T> {
+    pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
     pub tag: StyleFoo_Tag,
     pub _0: StylePoint<T>,
-    pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
 }
 impl<T> Default for StyleFoo_Baz_Body<T> {
     fn default() -> Self {
@@ -140,9 +140,9 @@ impl Default for StyleFoo__bindgen_ty_1 {
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct StyleBar<T> {
+    pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
     pub tag: StyleBar_Tag,
     pub __bindgen_anon_1: StyleBar__bindgen_ty_1<T>,
-    pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
 }
 pub const StyleBar_Tag_Bar1: StyleBar_Tag = 0;
 pub const StyleBar_Tag_Bar2: StyleBar_Tag = 0;
@@ -152,10 +152,10 @@ pub type StyleBar_Tag = ::std::os::raw::c_int;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct StyleBar_StyleBar1_Body<T> {
+    pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
     pub x: i32,
     pub y: StylePoint<T>,
     pub z: StylePoint<f32>,
-    pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
 }
 impl<T> Default for StyleBar_StyleBar1_Body<T> {
     fn default() -> Self {
@@ -169,8 +169,8 @@ impl<T> Default for StyleBar_StyleBar1_Body<T> {
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct StyleBar_StyleBar2_Body<T> {
-    pub _0: T,
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
+    pub _0: T,
 }
 impl<T> Default for StyleBar_StyleBar2_Body<T> {
     fn default() -> Self {
@@ -184,8 +184,8 @@ impl<T> Default for StyleBar_StyleBar2_Body<T> {
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct StyleBar_StyleBar3_Body<T> {
-    pub _0: StylePoint<T>,
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
+    pub _0: StylePoint<T>,
 }
 impl<T> Default for StyleBar_StyleBar3_Body<T> {
     fn default() -> Self {
@@ -199,11 +199,11 @@ impl<T> Default for StyleBar_StyleBar3_Body<T> {
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct StyleBar__bindgen_ty_1<T> {
+    pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
     pub bar1: __BindgenUnionField<StyleBar_StyleBar1_Body<T>>,
     pub bar2: __BindgenUnionField<StyleBar_StyleBar2_Body<T>>,
     pub bar3: __BindgenUnionField<StyleBar_StyleBar3_Body<T>>,
     pub bindgen_union_field: [u8; 0usize],
-    pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
 }
 impl<T> Default for StyleBar<T> {
     fn default() -> Self {

--- a/bindgen-tests/tests/expectations/tests/type_alias_partial_template_especialization.rs
+++ b/bindgen-tests/tests/expectations/tests/type_alias_partial_template_especialization.rs
@@ -3,8 +3,8 @@ pub type MaybeWrapped<A> = A;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct Rooted<T> {
-    pub ptr: MaybeWrapped<T>,
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
+    pub ptr: MaybeWrapped<T>,
 }
 impl<T> Default for Rooted<T> {
     fn default() -> Self {

--- a/bindgen-tests/tests/expectations/tests/using.rs
+++ b/bindgen-tests/tests/expectations/tests/using.rs
@@ -2,9 +2,9 @@
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct Point<T> {
+    pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
     pub x: T,
     pub y: T,
-    pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
 }
 impl<T> Default for Point<T> {
     fn default() -> Self {

--- a/bindgen-tests/tests/expectations/tests/what_is_going_on.rs
+++ b/bindgen-tests/tests/expectations/tests/what_is_going_on.rs
@@ -21,9 +21,9 @@ pub type Float = f32;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct PointTyped<F> {
+    pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<F>>,
     pub x: F,
     pub y: F,
-    pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<F>>,
 }
 impl<F> Default for PointTyped<F> {
     fn default() -> Self {

--- a/bindgen/codegen/mod.rs
+++ b/bindgen/codegen/mod.rs
@@ -2194,11 +2194,11 @@ impl CodeGenerator for CompInfo {
             let generic_param_names = generic_param_names.clone();
             quote! {
                 < #( #generic_param_names ),* >
-            } 
+            }
         } else {
-            quote !{}
+            quote! {}
         };
-        
+
         let mut attributes = vec![];
         let mut needs_clone_impl = false;
         let mut needs_default_impl = false;


### PR DESCRIPTION
PR #2772 adds support for representing C flexible array members as  Rust DSTs, but these must always be the last field. This moves the PhantomData fields to the front of the structure so they're out of the way.

This is a noisy change as it updates a bunch of test fixtures, but should be a functional no-op.