### PR TITLE
Compile time layout tests

### DIFF
--- a/bindgen-tests/tests/expectations/tests/16-byte-alignment.rs
+++ b/bindgen-tests/tests/expectations/tests/16-byte-alignment.rs
@@ -18,66 +18,33 @@ pub struct rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1 {
     pub dport: u16,
     pub sport: u16,
 }
-#[test]
-fn bindgen_test_layout_rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1() {
-    const UNINIT: ::std::mem::MaybeUninit<rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1>(),
-        4usize,
-        concat!("Size of: ", stringify!(rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1>(),
-        2usize,
-        concat!("Alignment of ", stringify!(rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).dport) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1),
-            "::",
-            stringify!(dport),
-        ),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).sport) as usize - ptr as usize },
-        2usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1),
-            "::",
-            stringify!(sport),
-        ),
-    );
-}
-#[test]
-fn bindgen_test_layout_rte_ipv4_tuple__bindgen_ty_1() {
-    const UNINIT: ::std::mem::MaybeUninit<rte_ipv4_tuple__bindgen_ty_1> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<rte_ipv4_tuple__bindgen_ty_1>(),
-        4usize,
-        concat!("Size of: ", stringify!(rte_ipv4_tuple__bindgen_ty_1)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<rte_ipv4_tuple__bindgen_ty_1>(),
-        4usize,
-        concat!("Alignment of ", stringify!(rte_ipv4_tuple__bindgen_ty_1)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).sctp_tag) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_ipv4_tuple__bindgen_ty_1),
-            "::",
-            stringify!(sctp_tag),
-        ),
-    );
-}
+const _: () = {
+    [
+        "Size of rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1",
+    ][::std::mem::size_of::<rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1>() - 4usize];
+    [
+        "Alignment of rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1",
+    ][::std::mem::align_of::<rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1>() - 2usize];
+    [
+        "Offset of field: rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1::dport",
+    ][::std::mem::offset_of!(rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1, dport)
+        - 0usize];
+    [
+        "Offset of field: rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1::sport",
+    ][::std::mem::offset_of!(rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1, sport)
+        - 2usize];
+};
+const _: () = {
+    [
+        "Size of rte_ipv4_tuple__bindgen_ty_1",
+    ][::std::mem::size_of::<rte_ipv4_tuple__bindgen_ty_1>() - 4usize];
+    [
+        "Alignment of rte_ipv4_tuple__bindgen_ty_1",
+    ][::std::mem::align_of::<rte_ipv4_tuple__bindgen_ty_1>() - 4usize];
+    [
+        "Offset of field: rte_ipv4_tuple__bindgen_ty_1::sctp_tag",
+    ][::std::mem::offset_of!(rte_ipv4_tuple__bindgen_ty_1, sctp_tag) - 0usize];
+};
 impl Default for rte_ipv4_tuple__bindgen_ty_1 {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
@@ -87,41 +54,16 @@ impl Default for rte_ipv4_tuple__bindgen_ty_1 {
         }
     }
 }
-#[test]
-fn bindgen_test_layout_rte_ipv4_tuple() {
-    const UNINIT: ::std::mem::MaybeUninit<rte_ipv4_tuple> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<rte_ipv4_tuple>(),
-        12usize,
-        concat!("Size of: ", stringify!(rte_ipv4_tuple)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<rte_ipv4_tuple>(),
-        4usize,
-        concat!("Alignment of ", stringify!(rte_ipv4_tuple)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).src_addr) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_ipv4_tuple),
-            "::",
-            stringify!(src_addr),
-        ),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).dst_addr) as usize - ptr as usize },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_ipv4_tuple),
-            "::",
-            stringify!(dst_addr),
-        ),
-    );
-}
+const _: () = {
+    ["Size of rte_ipv4_tuple"][::std::mem::size_of::<rte_ipv4_tuple>() - 12usize];
+    ["Alignment of rte_ipv4_tuple"][::std::mem::align_of::<rte_ipv4_tuple>() - 4usize];
+    [
+        "Offset of field: rte_ipv4_tuple::src_addr",
+    ][::std::mem::offset_of!(rte_ipv4_tuple, src_addr) - 0usize];
+    [
+        "Offset of field: rte_ipv4_tuple::dst_addr",
+    ][::std::mem::offset_of!(rte_ipv4_tuple, dst_addr) - 4usize];
+};
 impl Default for rte_ipv4_tuple {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
@@ -150,66 +92,33 @@ pub struct rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1 {
     pub dport: u16,
     pub sport: u16,
 }
-#[test]
-fn bindgen_test_layout_rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1() {
-    const UNINIT: ::std::mem::MaybeUninit<rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1>(),
-        4usize,
-        concat!("Size of: ", stringify!(rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1>(),
-        2usize,
-        concat!("Alignment of ", stringify!(rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).dport) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1),
-            "::",
-            stringify!(dport),
-        ),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).sport) as usize - ptr as usize },
-        2usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1),
-            "::",
-            stringify!(sport),
-        ),
-    );
-}
-#[test]
-fn bindgen_test_layout_rte_ipv6_tuple__bindgen_ty_1() {
-    const UNINIT: ::std::mem::MaybeUninit<rte_ipv6_tuple__bindgen_ty_1> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<rte_ipv6_tuple__bindgen_ty_1>(),
-        4usize,
-        concat!("Size of: ", stringify!(rte_ipv6_tuple__bindgen_ty_1)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<rte_ipv6_tuple__bindgen_ty_1>(),
-        4usize,
-        concat!("Alignment of ", stringify!(rte_ipv6_tuple__bindgen_ty_1)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).sctp_tag) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_ipv6_tuple__bindgen_ty_1),
-            "::",
-            stringify!(sctp_tag),
-        ),
-    );
-}
+const _: () = {
+    [
+        "Size of rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1",
+    ][::std::mem::size_of::<rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1>() - 4usize];
+    [
+        "Alignment of rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1",
+    ][::std::mem::align_of::<rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1>() - 2usize];
+    [
+        "Offset of field: rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1::dport",
+    ][::std::mem::offset_of!(rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1, dport)
+        - 0usize];
+    [
+        "Offset of field: rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1::sport",
+    ][::std::mem::offset_of!(rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1, sport)
+        - 2usize];
+};
+const _: () = {
+    [
+        "Size of rte_ipv6_tuple__bindgen_ty_1",
+    ][::std::mem::size_of::<rte_ipv6_tuple__bindgen_ty_1>() - 4usize];
+    [
+        "Alignment of rte_ipv6_tuple__bindgen_ty_1",
+    ][::std::mem::align_of::<rte_ipv6_tuple__bindgen_ty_1>() - 4usize];
+    [
+        "Offset of field: rte_ipv6_tuple__bindgen_ty_1::sctp_tag",
+    ][::std::mem::offset_of!(rte_ipv6_tuple__bindgen_ty_1, sctp_tag) - 0usize];
+};
 impl Default for rte_ipv6_tuple__bindgen_ty_1 {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
@@ -219,41 +128,16 @@ impl Default for rte_ipv6_tuple__bindgen_ty_1 {
         }
     }
 }
-#[test]
-fn bindgen_test_layout_rte_ipv6_tuple() {
-    const UNINIT: ::std::mem::MaybeUninit<rte_ipv6_tuple> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<rte_ipv6_tuple>(),
-        36usize,
-        concat!("Size of: ", stringify!(rte_ipv6_tuple)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<rte_ipv6_tuple>(),
-        4usize,
-        concat!("Alignment of ", stringify!(rte_ipv6_tuple)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).src_addr) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_ipv6_tuple),
-            "::",
-            stringify!(src_addr),
-        ),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).dst_addr) as usize - ptr as usize },
-        16usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_ipv6_tuple),
-            "::",
-            stringify!(dst_addr),
-        ),
-    );
-}
+const _: () = {
+    ["Size of rte_ipv6_tuple"][::std::mem::size_of::<rte_ipv6_tuple>() - 36usize];
+    ["Alignment of rte_ipv6_tuple"][::std::mem::align_of::<rte_ipv6_tuple>() - 4usize];
+    [
+        "Offset of field: rte_ipv6_tuple::src_addr",
+    ][::std::mem::offset_of!(rte_ipv6_tuple, src_addr) - 0usize];
+    [
+        "Offset of field: rte_ipv6_tuple::dst_addr",
+    ][::std::mem::offset_of!(rte_ipv6_tuple, dst_addr) - 16usize];
+};
 impl Default for rte_ipv6_tuple {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
@@ -270,31 +154,18 @@ pub union rte_thash_tuple {
     pub v4: rte_ipv4_tuple,
     pub v6: rte_ipv6_tuple,
 }
-#[test]
-fn bindgen_test_layout_rte_thash_tuple() {
-    const UNINIT: ::std::mem::MaybeUninit<rte_thash_tuple> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<rte_thash_tuple>(),
-        48usize,
-        concat!("Size of: ", stringify!(rte_thash_tuple)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<rte_thash_tuple>(),
-        16usize,
-        concat!("Alignment of ", stringify!(rte_thash_tuple)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).v4) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(rte_thash_tuple), "::", stringify!(v4)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).v6) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(rte_thash_tuple), "::", stringify!(v6)),
-    );
-}
+const _: () = {
+    ["Size of rte_thash_tuple"][::std::mem::size_of::<rte_thash_tuple>() - 48usize];
+    [
+        "Alignment of rte_thash_tuple",
+    ][::std::mem::align_of::<rte_thash_tuple>() - 16usize];
+    [
+        "Offset of field: rte_thash_tuple::v4",
+    ][::std::mem::offset_of!(rte_thash_tuple, v4) - 0usize];
+    [
+        "Offset of field: rte_thash_tuple::v6",
+    ][::std::mem::offset_of!(rte_thash_tuple, v6) - 0usize];
+};
 impl Default for rte_thash_tuple {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();

--- a/bindgen-tests/tests/expectations/tests/16-byte-alignment_1_0.rs
+++ b/bindgen-tests/tests/expectations/tests/16-byte-alignment_1_0.rs
@@ -71,32 +71,22 @@ fn bindgen_test_layout_rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1() {
     assert_eq!(
         ::std::mem::size_of::<rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1>(),
         4usize,
-        concat!("Size of: ", stringify!(rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1)),
+        "Size of rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1",
     );
     assert_eq!(
         ::std::mem::align_of::<rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1>(),
         2usize,
-        concat!("Alignment of ", stringify!(rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1)),
+        "Alignment of rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).dport) as usize - ptr as usize },
         0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1),
-            "::",
-            stringify!(dport),
-        ),
+        "Offset of field: rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1::dport",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).sport) as usize - ptr as usize },
         2usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1),
-            "::",
-            stringify!(sport),
-        ),
+        "Offset of field: rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1::sport",
     );
 }
 impl Clone for rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1 {
@@ -111,22 +101,17 @@ fn bindgen_test_layout_rte_ipv4_tuple__bindgen_ty_1() {
     assert_eq!(
         ::std::mem::size_of::<rte_ipv4_tuple__bindgen_ty_1>(),
         4usize,
-        concat!("Size of: ", stringify!(rte_ipv4_tuple__bindgen_ty_1)),
+        "Size of rte_ipv4_tuple__bindgen_ty_1",
     );
     assert_eq!(
         ::std::mem::align_of::<rte_ipv4_tuple__bindgen_ty_1>(),
         4usize,
-        concat!("Alignment of ", stringify!(rte_ipv4_tuple__bindgen_ty_1)),
+        "Alignment of rte_ipv4_tuple__bindgen_ty_1",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).sctp_tag) as usize - ptr as usize },
         0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_ipv4_tuple__bindgen_ty_1),
-            "::",
-            stringify!(sctp_tag),
-        ),
+        "Offset of field: rte_ipv4_tuple__bindgen_ty_1::sctp_tag",
     );
 }
 impl Clone for rte_ipv4_tuple__bindgen_ty_1 {
@@ -141,32 +126,22 @@ fn bindgen_test_layout_rte_ipv4_tuple() {
     assert_eq!(
         ::std::mem::size_of::<rte_ipv4_tuple>(),
         12usize,
-        concat!("Size of: ", stringify!(rte_ipv4_tuple)),
+        "Size of rte_ipv4_tuple",
     );
     assert_eq!(
         ::std::mem::align_of::<rte_ipv4_tuple>(),
         4usize,
-        concat!("Alignment of ", stringify!(rte_ipv4_tuple)),
+        "Alignment of rte_ipv4_tuple",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).src_addr) as usize - ptr as usize },
         0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_ipv4_tuple),
-            "::",
-            stringify!(src_addr),
-        ),
+        "Offset of field: rte_ipv4_tuple::src_addr",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).dst_addr) as usize - ptr as usize },
         4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_ipv4_tuple),
-            "::",
-            stringify!(dst_addr),
-        ),
+        "Offset of field: rte_ipv4_tuple::dst_addr",
     );
 }
 impl Clone for rte_ipv4_tuple {
@@ -203,32 +178,22 @@ fn bindgen_test_layout_rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1() {
     assert_eq!(
         ::std::mem::size_of::<rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1>(),
         4usize,
-        concat!("Size of: ", stringify!(rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1)),
+        "Size of rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1",
     );
     assert_eq!(
         ::std::mem::align_of::<rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1>(),
         2usize,
-        concat!("Alignment of ", stringify!(rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1)),
+        "Alignment of rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).dport) as usize - ptr as usize },
         0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1),
-            "::",
-            stringify!(dport),
-        ),
+        "Offset of field: rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1::dport",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).sport) as usize - ptr as usize },
         2usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1),
-            "::",
-            stringify!(sport),
-        ),
+        "Offset of field: rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1::sport",
     );
 }
 impl Clone for rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1 {
@@ -243,22 +208,17 @@ fn bindgen_test_layout_rte_ipv6_tuple__bindgen_ty_1() {
     assert_eq!(
         ::std::mem::size_of::<rte_ipv6_tuple__bindgen_ty_1>(),
         4usize,
-        concat!("Size of: ", stringify!(rte_ipv6_tuple__bindgen_ty_1)),
+        "Size of rte_ipv6_tuple__bindgen_ty_1",
     );
     assert_eq!(
         ::std::mem::align_of::<rte_ipv6_tuple__bindgen_ty_1>(),
         4usize,
-        concat!("Alignment of ", stringify!(rte_ipv6_tuple__bindgen_ty_1)),
+        "Alignment of rte_ipv6_tuple__bindgen_ty_1",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).sctp_tag) as usize - ptr as usize },
         0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_ipv6_tuple__bindgen_ty_1),
-            "::",
-            stringify!(sctp_tag),
-        ),
+        "Offset of field: rte_ipv6_tuple__bindgen_ty_1::sctp_tag",
     );
 }
 impl Clone for rte_ipv6_tuple__bindgen_ty_1 {
@@ -273,32 +233,22 @@ fn bindgen_test_layout_rte_ipv6_tuple() {
     assert_eq!(
         ::std::mem::size_of::<rte_ipv6_tuple>(),
         36usize,
-        concat!("Size of: ", stringify!(rte_ipv6_tuple)),
+        "Size of rte_ipv6_tuple",
     );
     assert_eq!(
         ::std::mem::align_of::<rte_ipv6_tuple>(),
         4usize,
-        concat!("Alignment of ", stringify!(rte_ipv6_tuple)),
+        "Alignment of rte_ipv6_tuple",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).src_addr) as usize - ptr as usize },
         0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_ipv6_tuple),
-            "::",
-            stringify!(src_addr),
-        ),
+        "Offset of field: rte_ipv6_tuple::src_addr",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).dst_addr) as usize - ptr as usize },
         16usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_ipv6_tuple),
-            "::",
-            stringify!(dst_addr),
-        ),
+        "Offset of field: rte_ipv6_tuple::dst_addr",
     );
 }
 impl Clone for rte_ipv6_tuple {
@@ -320,17 +270,17 @@ fn bindgen_test_layout_rte_thash_tuple() {
     assert_eq!(
         ::std::mem::size_of::<rte_thash_tuple>(),
         48usize,
-        concat!("Size of: ", stringify!(rte_thash_tuple)),
+        "Size of rte_thash_tuple",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).v4) as usize - ptr as usize },
         0usize,
-        concat!("Offset of field: ", stringify!(rte_thash_tuple), "::", stringify!(v4)),
+        "Offset of field: rte_thash_tuple::v4",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).v6) as usize - ptr as usize },
         0usize,
-        concat!("Offset of field: ", stringify!(rte_thash_tuple), "::", stringify!(v6)),
+        "Offset of field: rte_thash_tuple::v6",
     );
 }
 impl Clone for rte_thash_tuple {

--- a/bindgen-tests/tests/expectations/tests/accessors.rs
+++ b/bindgen-tests/tests/expectations/tests/accessors.rs
@@ -10,63 +10,22 @@ pub struct SomeAccessors {
     /// <div rustbindgen accessor="immutable"></div>
     pub mImmutableAccessor: ::std::os::raw::c_int,
 }
-#[test]
-fn bindgen_test_layout_SomeAccessors() {
-    const UNINIT: ::std::mem::MaybeUninit<SomeAccessors> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<SomeAccessors>(),
-        16usize,
-        concat!("Size of: ", stringify!(SomeAccessors)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<SomeAccessors>(),
-        4usize,
-        concat!("Alignment of ", stringify!(SomeAccessors)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).mNoAccessor) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(SomeAccessors),
-            "::",
-            stringify!(mNoAccessor),
-        ),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).mBothAccessors) as usize - ptr as usize },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(SomeAccessors),
-            "::",
-            stringify!(mBothAccessors),
-        ),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).mUnsafeAccessors) as usize - ptr as usize },
-        8usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(SomeAccessors),
-            "::",
-            stringify!(mUnsafeAccessors),
-        ),
-    );
-    assert_eq!(
-        unsafe {
-            ::std::ptr::addr_of!((*ptr).mImmutableAccessor) as usize - ptr as usize
-        },
-        12usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(SomeAccessors),
-            "::",
-            stringify!(mImmutableAccessor),
-        ),
-    );
-}
+const _: () = {
+    ["Size of SomeAccessors"][::std::mem::size_of::<SomeAccessors>() - 16usize];
+    ["Alignment of SomeAccessors"][::std::mem::align_of::<SomeAccessors>() - 4usize];
+    [
+        "Offset of field: SomeAccessors::mNoAccessor",
+    ][::std::mem::offset_of!(SomeAccessors, mNoAccessor) - 0usize];
+    [
+        "Offset of field: SomeAccessors::mBothAccessors",
+    ][::std::mem::offset_of!(SomeAccessors, mBothAccessors) - 4usize];
+    [
+        "Offset of field: SomeAccessors::mUnsafeAccessors",
+    ][::std::mem::offset_of!(SomeAccessors, mUnsafeAccessors) - 8usize];
+    [
+        "Offset of field: SomeAccessors::mImmutableAccessor",
+    ][::std::mem::offset_of!(SomeAccessors, mImmutableAccessor) - 12usize];
+};
 impl SomeAccessors {
     #[inline]
     pub fn get_mBothAccessors(&self) -> &::std::os::raw::c_int {
@@ -96,43 +55,16 @@ pub struct AllAccessors {
     pub mBothAccessors: ::std::os::raw::c_int,
     pub mAlsoBothAccessors: ::std::os::raw::c_int,
 }
-#[test]
-fn bindgen_test_layout_AllAccessors() {
-    const UNINIT: ::std::mem::MaybeUninit<AllAccessors> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<AllAccessors>(),
-        8usize,
-        concat!("Size of: ", stringify!(AllAccessors)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<AllAccessors>(),
-        4usize,
-        concat!("Alignment of ", stringify!(AllAccessors)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).mBothAccessors) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(AllAccessors),
-            "::",
-            stringify!(mBothAccessors),
-        ),
-    );
-    assert_eq!(
-        unsafe {
-            ::std::ptr::addr_of!((*ptr).mAlsoBothAccessors) as usize - ptr as usize
-        },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(AllAccessors),
-            "::",
-            stringify!(mAlsoBothAccessors),
-        ),
-    );
-}
+const _: () = {
+    ["Size of AllAccessors"][::std::mem::size_of::<AllAccessors>() - 8usize];
+    ["Alignment of AllAccessors"][::std::mem::align_of::<AllAccessors>() - 4usize];
+    [
+        "Offset of field: AllAccessors::mBothAccessors",
+    ][::std::mem::offset_of!(AllAccessors, mBothAccessors) - 0usize];
+    [
+        "Offset of field: AllAccessors::mAlsoBothAccessors",
+    ][::std::mem::offset_of!(AllAccessors, mAlsoBothAccessors) - 4usize];
+};
 impl AllAccessors {
     #[inline]
     pub fn get_mBothAccessors(&self) -> &::std::os::raw::c_int {
@@ -158,43 +90,18 @@ pub struct AllUnsafeAccessors {
     pub mBothAccessors: ::std::os::raw::c_int,
     pub mAlsoBothAccessors: ::std::os::raw::c_int,
 }
-#[test]
-fn bindgen_test_layout_AllUnsafeAccessors() {
-    const UNINIT: ::std::mem::MaybeUninit<AllUnsafeAccessors> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<AllUnsafeAccessors>(),
-        8usize,
-        concat!("Size of: ", stringify!(AllUnsafeAccessors)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<AllUnsafeAccessors>(),
-        4usize,
-        concat!("Alignment of ", stringify!(AllUnsafeAccessors)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).mBothAccessors) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(AllUnsafeAccessors),
-            "::",
-            stringify!(mBothAccessors),
-        ),
-    );
-    assert_eq!(
-        unsafe {
-            ::std::ptr::addr_of!((*ptr).mAlsoBothAccessors) as usize - ptr as usize
-        },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(AllUnsafeAccessors),
-            "::",
-            stringify!(mAlsoBothAccessors),
-        ),
-    );
-}
+const _: () = {
+    ["Size of AllUnsafeAccessors"][::std::mem::size_of::<AllUnsafeAccessors>() - 8usize];
+    [
+        "Alignment of AllUnsafeAccessors",
+    ][::std::mem::align_of::<AllUnsafeAccessors>() - 4usize];
+    [
+        "Offset of field: AllUnsafeAccessors::mBothAccessors",
+    ][::std::mem::offset_of!(AllUnsafeAccessors, mBothAccessors) - 0usize];
+    [
+        "Offset of field: AllUnsafeAccessors::mAlsoBothAccessors",
+    ][::std::mem::offset_of!(AllUnsafeAccessors, mAlsoBothAccessors) - 4usize];
+};
 impl AllUnsafeAccessors {
     #[inline]
     pub unsafe fn get_mBothAccessors(&self) -> &::std::os::raw::c_int {
@@ -225,63 +132,26 @@ pub struct ContradictAccessors {
     /// <div rustbindgen accessor="immutable"></div>
     pub mImmutableAccessor: ::std::os::raw::c_int,
 }
-#[test]
-fn bindgen_test_layout_ContradictAccessors() {
-    const UNINIT: ::std::mem::MaybeUninit<ContradictAccessors> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<ContradictAccessors>(),
-        16usize,
-        concat!("Size of: ", stringify!(ContradictAccessors)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<ContradictAccessors>(),
-        4usize,
-        concat!("Alignment of ", stringify!(ContradictAccessors)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).mBothAccessors) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(ContradictAccessors),
-            "::",
-            stringify!(mBothAccessors),
-        ),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).mNoAccessors) as usize - ptr as usize },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(ContradictAccessors),
-            "::",
-            stringify!(mNoAccessors),
-        ),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).mUnsafeAccessors) as usize - ptr as usize },
-        8usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(ContradictAccessors),
-            "::",
-            stringify!(mUnsafeAccessors),
-        ),
-    );
-    assert_eq!(
-        unsafe {
-            ::std::ptr::addr_of!((*ptr).mImmutableAccessor) as usize - ptr as usize
-        },
-        12usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(ContradictAccessors),
-            "::",
-            stringify!(mImmutableAccessor),
-        ),
-    );
-}
+const _: () = {
+    [
+        "Size of ContradictAccessors",
+    ][::std::mem::size_of::<ContradictAccessors>() - 16usize];
+    [
+        "Alignment of ContradictAccessors",
+    ][::std::mem::align_of::<ContradictAccessors>() - 4usize];
+    [
+        "Offset of field: ContradictAccessors::mBothAccessors",
+    ][::std::mem::offset_of!(ContradictAccessors, mBothAccessors) - 0usize];
+    [
+        "Offset of field: ContradictAccessors::mNoAccessors",
+    ][::std::mem::offset_of!(ContradictAccessors, mNoAccessors) - 4usize];
+    [
+        "Offset of field: ContradictAccessors::mUnsafeAccessors",
+    ][::std::mem::offset_of!(ContradictAccessors, mUnsafeAccessors) - 8usize];
+    [
+        "Offset of field: ContradictAccessors::mImmutableAccessor",
+    ][::std::mem::offset_of!(ContradictAccessors, mImmutableAccessor) - 12usize];
+};
 impl ContradictAccessors {
     #[inline]
     pub fn get_mBothAccessors(&self) -> &::std::os::raw::c_int {
@@ -310,26 +180,13 @@ impl ContradictAccessors {
 pub struct Replaced {
     pub mAccessor: ::std::os::raw::c_int,
 }
-#[test]
-fn bindgen_test_layout_Replaced() {
-    const UNINIT: ::std::mem::MaybeUninit<Replaced> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<Replaced>(),
-        4usize,
-        concat!("Size of: ", stringify!(Replaced)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Replaced>(),
-        4usize,
-        concat!("Alignment of ", stringify!(Replaced)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).mAccessor) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(Replaced), "::", stringify!(mAccessor)),
-    );
-}
+const _: () = {
+    ["Size of Replaced"][::std::mem::size_of::<Replaced>() - 4usize];
+    ["Alignment of Replaced"][::std::mem::align_of::<Replaced>() - 4usize];
+    [
+        "Offset of field: Replaced::mAccessor",
+    ][::std::mem::offset_of!(Replaced, mAccessor) - 0usize];
+};
 impl Replaced {
     #[inline]
     pub fn get_mAccessor(&self) -> &::std::os::raw::c_int {
@@ -346,26 +203,13 @@ impl Replaced {
 pub struct Wrapper {
     pub mReplaced: Replaced,
 }
-#[test]
-fn bindgen_test_layout_Wrapper() {
-    const UNINIT: ::std::mem::MaybeUninit<Wrapper> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<Wrapper>(),
-        4usize,
-        concat!("Size of: ", stringify!(Wrapper)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Wrapper>(),
-        4usize,
-        concat!("Alignment of ", stringify!(Wrapper)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).mReplaced) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(Wrapper), "::", stringify!(mReplaced)),
-    );
-}
+const _: () = {
+    ["Size of Wrapper"][::std::mem::size_of::<Wrapper>() - 4usize];
+    ["Alignment of Wrapper"][::std::mem::align_of::<Wrapper>() - 4usize];
+    [
+        "Offset of field: Wrapper::mReplaced",
+    ][::std::mem::offset_of!(Wrapper, mReplaced) - 0usize];
+};
 impl Wrapper {
     #[inline]
     pub fn get_mReplaced(&self) -> &Replaced {

--- a/bindgen-tests/tests/expectations/tests/allowlist-file.rs
+++ b/bindgen-tests/tests/expectations/tests/allowlist-file.rs
@@ -12,19 +12,10 @@ extern "C" {
 pub struct someClass {
     pub _address: u8,
 }
-#[test]
-fn bindgen_test_layout_someClass() {
-    assert_eq!(
-        ::std::mem::size_of::<someClass>(),
-        1usize,
-        concat!("Size of: ", stringify!(someClass)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<someClass>(),
-        1usize,
-        concat!("Alignment of ", stringify!(someClass)),
-    );
-}
+const _: () = {
+    ["Size of someClass"][::std::mem::size_of::<someClass>() - 1usize];
+    ["Alignment of someClass"][::std::mem::align_of::<someClass>() - 1usize];
+};
 extern "C" {
     #[link_name = "\u{1}_ZN9someClass16somePublicMethodEi"]
     pub fn someClass_somePublicMethod(this: *mut someClass, foo: ::std::os::raw::c_int);
@@ -47,31 +38,17 @@ extern "C" {
 pub struct StructWithAllowlistedDefinition {
     pub other: *mut StructWithAllowlistedFwdDecl,
 }
-#[test]
-fn bindgen_test_layout_StructWithAllowlistedDefinition() {
-    const UNINIT: ::std::mem::MaybeUninit<StructWithAllowlistedDefinition> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<StructWithAllowlistedDefinition>(),
-        8usize,
-        concat!("Size of: ", stringify!(StructWithAllowlistedDefinition)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<StructWithAllowlistedDefinition>(),
-        8usize,
-        concat!("Alignment of ", stringify!(StructWithAllowlistedDefinition)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).other) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(StructWithAllowlistedDefinition),
-            "::",
-            stringify!(other),
-        ),
-    );
-}
+const _: () = {
+    [
+        "Size of StructWithAllowlistedDefinition",
+    ][::std::mem::size_of::<StructWithAllowlistedDefinition>() - 8usize];
+    [
+        "Alignment of StructWithAllowlistedDefinition",
+    ][::std::mem::align_of::<StructWithAllowlistedDefinition>() - 8usize];
+    [
+        "Offset of field: StructWithAllowlistedDefinition::other",
+    ][::std::mem::offset_of!(StructWithAllowlistedDefinition, other) - 0usize];
+};
 impl Default for StructWithAllowlistedDefinition {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
@@ -86,53 +63,26 @@ impl Default for StructWithAllowlistedDefinition {
 pub struct StructWithAllowlistedFwdDecl {
     pub b: ::std::os::raw::c_int,
 }
-#[test]
-fn bindgen_test_layout_StructWithAllowlistedFwdDecl() {
-    const UNINIT: ::std::mem::MaybeUninit<StructWithAllowlistedFwdDecl> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<StructWithAllowlistedFwdDecl>(),
-        4usize,
-        concat!("Size of: ", stringify!(StructWithAllowlistedFwdDecl)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<StructWithAllowlistedFwdDecl>(),
-        4usize,
-        concat!("Alignment of ", stringify!(StructWithAllowlistedFwdDecl)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(StructWithAllowlistedFwdDecl),
-            "::",
-            stringify!(b),
-        ),
-    );
-}
+const _: () = {
+    [
+        "Size of StructWithAllowlistedFwdDecl",
+    ][::std::mem::size_of::<StructWithAllowlistedFwdDecl>() - 4usize];
+    [
+        "Alignment of StructWithAllowlistedFwdDecl",
+    ][::std::mem::align_of::<StructWithAllowlistedFwdDecl>() - 4usize];
+    [
+        "Offset of field: StructWithAllowlistedFwdDecl::b",
+    ][::std::mem::offset_of!(StructWithAllowlistedFwdDecl, b) - 0usize];
+};
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct AllowlistMe {
     pub foo: ::std::os::raw::c_int,
 }
-#[test]
-fn bindgen_test_layout_AllowlistMe() {
-    const UNINIT: ::std::mem::MaybeUninit<AllowlistMe> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<AllowlistMe>(),
-        4usize,
-        concat!("Size of: ", stringify!(AllowlistMe)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<AllowlistMe>(),
-        4usize,
-        concat!("Alignment of ", stringify!(AllowlistMe)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(AllowlistMe), "::", stringify!(foo)),
-    );
-}
+const _: () = {
+    ["Size of AllowlistMe"][::std::mem::size_of::<AllowlistMe>() - 4usize];
+    ["Alignment of AllowlistMe"][::std::mem::align_of::<AllowlistMe>() - 4usize];
+    [
+        "Offset of field: AllowlistMe::foo",
+    ][::std::mem::offset_of!(AllowlistMe, foo) - 0usize];
+};

--- a/bindgen-tests/tests/expectations/tests/allowlist-namespaces-basic.rs
+++ b/bindgen-tests/tests/expectations/tests/allowlist-namespaces-basic.rs
@@ -14,19 +14,10 @@ pub mod root {
             pub struct Helper {
                 pub _address: u8,
             }
-            #[test]
-            fn bindgen_test_layout_Helper() {
-                assert_eq!(
-                    ::std::mem::size_of::<Helper>(),
-                    1usize,
-                    concat!("Size of: ", stringify!(Helper)),
-                );
-                assert_eq!(
-                    ::std::mem::align_of::<Helper>(),
-                    1usize,
-                    concat!("Alignment of ", stringify!(Helper)),
-                );
-            }
+            const _: () = {
+                ["Size of Helper"][::std::mem::size_of::<Helper>() - 1usize];
+                ["Alignment of Helper"][::std::mem::align_of::<Helper>() - 1usize];
+            };
         }
     }
 }

--- a/bindgen-tests/tests/expectations/tests/allowlist-namespaces.rs
+++ b/bindgen-tests/tests/expectations/tests/allowlist-namespaces.rs
@@ -14,44 +14,22 @@ pub mod root {
             pub struct Helper {
                 pub _address: u8,
             }
-            #[test]
-            fn bindgen_test_layout_Helper() {
-                assert_eq!(
-                    ::std::mem::size_of::<Helper>(),
-                    1usize,
-                    concat!("Size of: ", stringify!(Helper)),
-                );
-                assert_eq!(
-                    ::std::mem::align_of::<Helper>(),
-                    1usize,
-                    concat!("Alignment of ", stringify!(Helper)),
-                );
-            }
+            const _: () = {
+                ["Size of Helper"][::std::mem::size_of::<Helper>() - 1usize];
+                ["Alignment of Helper"][::std::mem::align_of::<Helper>() - 1usize];
+            };
         }
         #[repr(C)]
         #[derive(Debug, Default, Copy, Clone)]
         pub struct Test {
             pub helper: root::outer::inner::Helper,
         }
-        #[test]
-        fn bindgen_test_layout_Test() {
-            const UNINIT: ::std::mem::MaybeUninit<Test> = ::std::mem::MaybeUninit::uninit();
-            let ptr = UNINIT.as_ptr();
-            assert_eq!(
-                ::std::mem::size_of::<Test>(),
-                1usize,
-                concat!("Size of: ", stringify!(Test)),
-            );
-            assert_eq!(
-                ::std::mem::align_of::<Test>(),
-                1usize,
-                concat!("Alignment of ", stringify!(Test)),
-            );
-            assert_eq!(
-                unsafe { ::std::ptr::addr_of!((*ptr).helper) as usize - ptr as usize },
-                0usize,
-                concat!("Offset of field: ", stringify!(Test), "::", stringify!(helper)),
-            );
-        }
+        const _: () = {
+            ["Size of Test"][::std::mem::size_of::<Test>() - 1usize];
+            ["Alignment of Test"][::std::mem::align_of::<Test>() - 1usize];
+            [
+                "Offset of field: Test::helper",
+            ][::std::mem::offset_of!(Test, helper) - 0usize];
+        };
     }
 }

--- a/bindgen-tests/tests/expectations/tests/allowlist_item.rs
+++ b/bindgen-tests/tests/expectations/tests/allowlist_item.rs
@@ -5,26 +5,11 @@ pub const FooDefault: u32 = 0;
 pub struct Foo {
     pub field: ::std::os::raw::c_int,
 }
-#[test]
-fn bindgen_test_layout_Foo() {
-    const UNINIT: ::std::mem::MaybeUninit<Foo> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<Foo>(),
-        4usize,
-        concat!("Size of: ", stringify!(Foo)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Foo>(),
-        4usize,
-        concat!("Alignment of ", stringify!(Foo)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).field) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(Foo), "::", stringify!(field)),
-    );
-}
+const _: () = {
+    ["Size of Foo"][::std::mem::size_of::<Foo>() - 4usize];
+    ["Alignment of Foo"][::std::mem::align_of::<Foo>() - 4usize];
+    ["Offset of field: Foo::field"][::std::mem::offset_of!(Foo, field) - 0usize];
+};
 extern "C" {
     pub fn FooNew(value: ::std::os::raw::c_int) -> Foo;
 }

--- a/bindgen-tests/tests/expectations/tests/allowlisted-item-references-no-hash.rs
+++ b/bindgen-tests/tests/expectations/tests/allowlisted-item-references-no-hash.rs
@@ -4,41 +4,17 @@
 pub struct NoHash {
     pub _address: u8,
 }
-#[test]
-fn bindgen_test_layout_NoHash() {
-    assert_eq!(
-        ::std::mem::size_of::<NoHash>(),
-        1usize,
-        concat!("Size of: ", stringify!(NoHash)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<NoHash>(),
-        1usize,
-        concat!("Alignment of ", stringify!(NoHash)),
-    );
-}
+const _: () = {
+    ["Size of NoHash"][::std::mem::size_of::<NoHash>() - 1usize];
+    ["Alignment of NoHash"][::std::mem::align_of::<NoHash>() - 1usize];
+};
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct AllowlistMe {
     pub a: NoHash,
 }
-#[test]
-fn bindgen_test_layout_AllowlistMe() {
-    const UNINIT: ::std::mem::MaybeUninit<AllowlistMe> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<AllowlistMe>(),
-        1usize,
-        concat!("Size of: ", stringify!(AllowlistMe)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<AllowlistMe>(),
-        1usize,
-        concat!("Alignment of ", stringify!(AllowlistMe)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(AllowlistMe), "::", stringify!(a)),
-    );
-}
+const _: () = {
+    ["Size of AllowlistMe"][::std::mem::size_of::<AllowlistMe>() - 1usize];
+    ["Alignment of AllowlistMe"][::std::mem::align_of::<AllowlistMe>() - 1usize];
+    ["Offset of field: AllowlistMe::a"][::std::mem::offset_of!(AllowlistMe, a) - 0usize];
+};

--- a/bindgen-tests/tests/expectations/tests/allowlisted-item-references-no-partialeq.rs
+++ b/bindgen-tests/tests/expectations/tests/allowlisted-item-references-no-partialeq.rs
@@ -4,41 +4,17 @@
 pub struct NoPartialEq {
     pub _address: u8,
 }
-#[test]
-fn bindgen_test_layout_NoPartialEq() {
-    assert_eq!(
-        ::std::mem::size_of::<NoPartialEq>(),
-        1usize,
-        concat!("Size of: ", stringify!(NoPartialEq)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<NoPartialEq>(),
-        1usize,
-        concat!("Alignment of ", stringify!(NoPartialEq)),
-    );
-}
+const _: () = {
+    ["Size of NoPartialEq"][::std::mem::size_of::<NoPartialEq>() - 1usize];
+    ["Alignment of NoPartialEq"][::std::mem::align_of::<NoPartialEq>() - 1usize];
+};
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct AllowlistMe {
     pub a: NoPartialEq,
 }
-#[test]
-fn bindgen_test_layout_AllowlistMe() {
-    const UNINIT: ::std::mem::MaybeUninit<AllowlistMe> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<AllowlistMe>(),
-        1usize,
-        concat!("Size of: ", stringify!(AllowlistMe)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<AllowlistMe>(),
-        1usize,
-        concat!("Alignment of ", stringify!(AllowlistMe)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(AllowlistMe), "::", stringify!(a)),
-    );
-}
+const _: () = {
+    ["Size of AllowlistMe"][::std::mem::size_of::<AllowlistMe>() - 1usize];
+    ["Alignment of AllowlistMe"][::std::mem::align_of::<AllowlistMe>() - 1usize];
+    ["Offset of field: AllowlistMe::a"][::std::mem::offset_of!(AllowlistMe, a) - 0usize];
+};

--- a/bindgen-tests/tests/expectations/tests/allowlisted_item_references_no_copy.rs
+++ b/bindgen-tests/tests/expectations/tests/allowlisted_item_references_no_copy.rs
@@ -4,41 +4,17 @@
 pub struct NoCopy {
     pub _address: u8,
 }
-#[test]
-fn bindgen_test_layout_NoCopy() {
-    assert_eq!(
-        ::std::mem::size_of::<NoCopy>(),
-        1usize,
-        concat!("Size of: ", stringify!(NoCopy)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<NoCopy>(),
-        1usize,
-        concat!("Alignment of ", stringify!(NoCopy)),
-    );
-}
+const _: () = {
+    ["Size of NoCopy"][::std::mem::size_of::<NoCopy>() - 1usize];
+    ["Alignment of NoCopy"][::std::mem::align_of::<NoCopy>() - 1usize];
+};
 #[repr(C)]
 #[derive(Debug, Default)]
 pub struct AllowlistMe {
     pub a: NoCopy,
 }
-#[test]
-fn bindgen_test_layout_AllowlistMe() {
-    const UNINIT: ::std::mem::MaybeUninit<AllowlistMe> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<AllowlistMe>(),
-        1usize,
-        concat!("Size of: ", stringify!(AllowlistMe)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<AllowlistMe>(),
-        1usize,
-        concat!("Alignment of ", stringify!(AllowlistMe)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(AllowlistMe), "::", stringify!(a)),
-    );
-}
+const _: () = {
+    ["Size of AllowlistMe"][::std::mem::size_of::<AllowlistMe>() - 1usize];
+    ["Alignment of AllowlistMe"][::std::mem::align_of::<AllowlistMe>() - 1usize];
+    ["Offset of field: AllowlistMe::a"][::std::mem::offset_of!(AllowlistMe, a) - 0usize];
+};

--- a/bindgen-tests/tests/expectations/tests/annotation_hide.rs
+++ b/bindgen-tests/tests/expectations/tests/annotation_hide.rs
@@ -6,37 +6,19 @@
 pub struct D {
     pub _bindgen_opaque_blob: u32,
 }
-#[test]
-fn bindgen_test_layout_D() {
-    assert_eq!(::std::mem::size_of::<D>(), 4usize, concat!("Size of: ", stringify!(D)));
-    assert_eq!(
-        ::std::mem::align_of::<D>(),
-        4usize,
-        concat!("Alignment of ", stringify!(D)),
-    );
-}
+const _: () = {
+    ["Size of D"][::std::mem::size_of::<D>() - 4usize];
+    ["Alignment of D"][::std::mem::align_of::<D>() - 4usize];
+};
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct NotAnnotated {
     pub f: ::std::os::raw::c_int,
 }
-#[test]
-fn bindgen_test_layout_NotAnnotated() {
-    const UNINIT: ::std::mem::MaybeUninit<NotAnnotated> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<NotAnnotated>(),
-        4usize,
-        concat!("Size of: ", stringify!(NotAnnotated)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<NotAnnotated>(),
-        4usize,
-        concat!("Alignment of ", stringify!(NotAnnotated)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).f) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(NotAnnotated), "::", stringify!(f)),
-    );
-}
+const _: () = {
+    ["Size of NotAnnotated"][::std::mem::size_of::<NotAnnotated>() - 4usize];
+    ["Alignment of NotAnnotated"][::std::mem::align_of::<NotAnnotated>() - 4usize];
+    [
+        "Offset of field: NotAnnotated::f",
+    ][::std::mem::offset_of!(NotAnnotated, f) - 0usize];
+};

--- a/bindgen-tests/tests/expectations/tests/anon-fields-prefix.rs
+++ b/bindgen-tests/tests/expectations/tests/anon-fields-prefix.rs
@@ -13,51 +13,23 @@ pub struct color__bindgen_ty_1 {
     pub g: ::std::os::raw::c_uchar,
     pub b: ::std::os::raw::c_uchar,
 }
-#[test]
-fn bindgen_test_layout_color__bindgen_ty_1() {
-    const UNINIT: ::std::mem::MaybeUninit<color__bindgen_ty_1> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<color__bindgen_ty_1>(),
-        3usize,
-        concat!("Size of: ", stringify!(color__bindgen_ty_1)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<color__bindgen_ty_1>(),
-        1usize,
-        concat!("Alignment of ", stringify!(color__bindgen_ty_1)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).r) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(color__bindgen_ty_1),
-            "::",
-            stringify!(r),
-        ),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).g) as usize - ptr as usize },
-        1usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(color__bindgen_ty_1),
-            "::",
-            stringify!(g),
-        ),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
-        2usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(color__bindgen_ty_1),
-            "::",
-            stringify!(b),
-        ),
-    );
-}
+const _: () = {
+    [
+        "Size of color__bindgen_ty_1",
+    ][::std::mem::size_of::<color__bindgen_ty_1>() - 3usize];
+    [
+        "Alignment of color__bindgen_ty_1",
+    ][::std::mem::align_of::<color__bindgen_ty_1>() - 1usize];
+    [
+        "Offset of field: color__bindgen_ty_1::r",
+    ][::std::mem::offset_of!(color__bindgen_ty_1, r) - 0usize];
+    [
+        "Offset of field: color__bindgen_ty_1::g",
+    ][::std::mem::offset_of!(color__bindgen_ty_1, g) - 1usize];
+    [
+        "Offset of field: color__bindgen_ty_1::b",
+    ][::std::mem::offset_of!(color__bindgen_ty_1, b) - 2usize];
+};
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct color__bindgen_ty_2 {
@@ -65,71 +37,28 @@ pub struct color__bindgen_ty_2 {
     pub u: ::std::os::raw::c_uchar,
     pub v: ::std::os::raw::c_uchar,
 }
-#[test]
-fn bindgen_test_layout_color__bindgen_ty_2() {
-    const UNINIT: ::std::mem::MaybeUninit<color__bindgen_ty_2> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<color__bindgen_ty_2>(),
-        3usize,
-        concat!("Size of: ", stringify!(color__bindgen_ty_2)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<color__bindgen_ty_2>(),
-        1usize,
-        concat!("Alignment of ", stringify!(color__bindgen_ty_2)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).y) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(color__bindgen_ty_2),
-            "::",
-            stringify!(y),
-        ),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).u) as usize - ptr as usize },
-        1usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(color__bindgen_ty_2),
-            "::",
-            stringify!(u),
-        ),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).v) as usize - ptr as usize },
-        2usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(color__bindgen_ty_2),
-            "::",
-            stringify!(v),
-        ),
-    );
-}
-#[test]
-fn bindgen_test_layout_color() {
-    const UNINIT: ::std::mem::MaybeUninit<color> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<color>(),
-        3usize,
-        concat!("Size of: ", stringify!(color)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<color>(),
-        1usize,
-        concat!("Alignment of ", stringify!(color)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).v3) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(color), "::", stringify!(v3)),
-    );
-}
+const _: () = {
+    [
+        "Size of color__bindgen_ty_2",
+    ][::std::mem::size_of::<color__bindgen_ty_2>() - 3usize];
+    [
+        "Alignment of color__bindgen_ty_2",
+    ][::std::mem::align_of::<color__bindgen_ty_2>() - 1usize];
+    [
+        "Offset of field: color__bindgen_ty_2::y",
+    ][::std::mem::offset_of!(color__bindgen_ty_2, y) - 0usize];
+    [
+        "Offset of field: color__bindgen_ty_2::u",
+    ][::std::mem::offset_of!(color__bindgen_ty_2, u) - 1usize];
+    [
+        "Offset of field: color__bindgen_ty_2::v",
+    ][::std::mem::offset_of!(color__bindgen_ty_2, v) - 2usize];
+};
+const _: () = {
+    ["Size of color"][::std::mem::size_of::<color>() - 3usize];
+    ["Alignment of color"][::std::mem::align_of::<color>() - 1usize];
+    ["Offset of field: color::v3"][::std::mem::offset_of!(color, v3) - 0usize];
+};
 impl Default for color {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();

--- a/bindgen-tests/tests/expectations/tests/anon_enum.rs
+++ b/bindgen-tests/tests/expectations/tests/anon_enum.rs
@@ -11,31 +11,12 @@ pub const Test_T_NONE: Test__bindgen_ty_1 = Test__bindgen_ty_1::T_NONE;
 pub enum Test__bindgen_ty_1 {
     T_NONE = 0,
 }
-#[test]
-fn bindgen_test_layout_Test() {
-    const UNINIT: ::std::mem::MaybeUninit<Test> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<Test>(),
-        8usize,
-        concat!("Size of: ", stringify!(Test)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Test>(),
-        4usize,
-        concat!("Alignment of ", stringify!(Test)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(Test), "::", stringify!(foo)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize },
-        4usize,
-        concat!("Offset of field: ", stringify!(Test), "::", stringify!(bar)),
-    );
-}
+const _: () = {
+    ["Size of Test"][::std::mem::size_of::<Test>() - 8usize];
+    ["Alignment of Test"][::std::mem::align_of::<Test>() - 4usize];
+    ["Offset of field: Test::foo"][::std::mem::offset_of!(Test, foo) - 0usize];
+    ["Offset of field: Test::bar"][::std::mem::offset_of!(Test, bar) - 4usize];
+};
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum Baz {

--- a/bindgen-tests/tests/expectations/tests/anon_enum_trait.rs
+++ b/bindgen-tests/tests/expectations/tests/anon_enum_trait.rs
@@ -30,16 +30,7 @@ pub const Foo_Baz: Foo__bindgen_ty_1 = Foo__bindgen_ty_1::Bar;
 pub enum Foo__bindgen_ty_1 {
     Bar = 0,
 }
-#[test]
-fn bindgen_test_layout_Foo() {
-    assert_eq!(
-        ::std::mem::size_of::<Foo>(),
-        1usize,
-        concat!("Size of: ", stringify!(Foo)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Foo>(),
-        1usize,
-        concat!("Alignment of ", stringify!(Foo)),
-    );
-}
+const _: () = {
+    ["Size of Foo"][::std::mem::size_of::<Foo>() - 1usize];
+    ["Alignment of Foo"][::std::mem::align_of::<Foo>() - 1usize];
+};

--- a/bindgen-tests/tests/expectations/tests/anon_struct_in_union.rs
+++ b/bindgen-tests/tests/expectations/tests/anon_struct_in_union.rs
@@ -14,56 +14,24 @@ pub union s__bindgen_ty_1 {
 pub struct s__bindgen_ty_1_inner {
     pub b: ::std::os::raw::c_int,
 }
-#[test]
-fn bindgen_test_layout_s__bindgen_ty_1_inner() {
-    const UNINIT: ::std::mem::MaybeUninit<s__bindgen_ty_1_inner> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<s__bindgen_ty_1_inner>(),
-        4usize,
-        concat!("Size of: ", stringify!(s__bindgen_ty_1_inner)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<s__bindgen_ty_1_inner>(),
-        4usize,
-        concat!("Alignment of ", stringify!(s__bindgen_ty_1_inner)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(s__bindgen_ty_1_inner),
-            "::",
-            stringify!(b),
-        ),
-    );
-}
-#[test]
-fn bindgen_test_layout_s__bindgen_ty_1() {
-    const UNINIT: ::std::mem::MaybeUninit<s__bindgen_ty_1> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<s__bindgen_ty_1>(),
-        4usize,
-        concat!("Size of: ", stringify!(s__bindgen_ty_1)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<s__bindgen_ty_1>(),
-        4usize,
-        concat!("Alignment of ", stringify!(s__bindgen_ty_1)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).field) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(s__bindgen_ty_1),
-            "::",
-            stringify!(field),
-        ),
-    );
-}
+const _: () = {
+    [
+        "Size of s__bindgen_ty_1_inner",
+    ][::std::mem::size_of::<s__bindgen_ty_1_inner>() - 4usize];
+    [
+        "Alignment of s__bindgen_ty_1_inner",
+    ][::std::mem::align_of::<s__bindgen_ty_1_inner>() - 4usize];
+    [
+        "Offset of field: s__bindgen_ty_1_inner::b",
+    ][::std::mem::offset_of!(s__bindgen_ty_1_inner, b) - 0usize];
+};
+const _: () = {
+    ["Size of s__bindgen_ty_1"][::std::mem::size_of::<s__bindgen_ty_1>() - 4usize];
+    ["Alignment of s__bindgen_ty_1"][::std::mem::align_of::<s__bindgen_ty_1>() - 4usize];
+    [
+        "Offset of field: s__bindgen_ty_1::field",
+    ][::std::mem::offset_of!(s__bindgen_ty_1, field) - 0usize];
+};
 impl Default for s__bindgen_ty_1 {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
@@ -73,22 +41,11 @@ impl Default for s__bindgen_ty_1 {
         }
     }
 }
-#[test]
-fn bindgen_test_layout_s() {
-    const UNINIT: ::std::mem::MaybeUninit<s> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(::std::mem::size_of::<s>(), 4usize, concat!("Size of: ", stringify!(s)));
-    assert_eq!(
-        ::std::mem::align_of::<s>(),
-        4usize,
-        concat!("Alignment of ", stringify!(s)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).u) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(s), "::", stringify!(u)),
-    );
-}
+const _: () = {
+    ["Size of s"][::std::mem::size_of::<s>() - 4usize];
+    ["Alignment of s"][::std::mem::align_of::<s>() - 4usize];
+    ["Offset of field: s::u"][::std::mem::offset_of!(s, u) - 0usize];
+};
 impl Default for s {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();

--- a/bindgen-tests/tests/expectations/tests/anon_struct_in_union_1_0.rs
+++ b/bindgen-tests/tests/expectations/tests/anon_struct_in_union_1_0.rs
@@ -65,22 +65,17 @@ fn bindgen_test_layout_s__bindgen_ty_1_inner() {
     assert_eq!(
         ::std::mem::size_of::<s__bindgen_ty_1_inner>(),
         4usize,
-        concat!("Size of: ", stringify!(s__bindgen_ty_1_inner)),
+        "Size of s__bindgen_ty_1_inner",
     );
     assert_eq!(
         ::std::mem::align_of::<s__bindgen_ty_1_inner>(),
         4usize,
-        concat!("Alignment of ", stringify!(s__bindgen_ty_1_inner)),
+        "Alignment of s__bindgen_ty_1_inner",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
         0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(s__bindgen_ty_1_inner),
-            "::",
-            stringify!(b),
-        ),
+        "Offset of field: s__bindgen_ty_1_inner::b",
     );
 }
 impl Clone for s__bindgen_ty_1_inner {
@@ -95,22 +90,17 @@ fn bindgen_test_layout_s__bindgen_ty_1() {
     assert_eq!(
         ::std::mem::size_of::<s__bindgen_ty_1>(),
         4usize,
-        concat!("Size of: ", stringify!(s__bindgen_ty_1)),
+        "Size of s__bindgen_ty_1",
     );
     assert_eq!(
         ::std::mem::align_of::<s__bindgen_ty_1>(),
         4usize,
-        concat!("Alignment of ", stringify!(s__bindgen_ty_1)),
+        "Alignment of s__bindgen_ty_1",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).field) as usize - ptr as usize },
         0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(s__bindgen_ty_1),
-            "::",
-            stringify!(field),
-        ),
+        "Offset of field: s__bindgen_ty_1::field",
     );
 }
 impl Clone for s__bindgen_ty_1 {
@@ -122,16 +112,12 @@ impl Clone for s__bindgen_ty_1 {
 fn bindgen_test_layout_s() {
     const UNINIT: ::std::mem::MaybeUninit<s> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
-    assert_eq!(::std::mem::size_of::<s>(), 4usize, concat!("Size of: ", stringify!(s)));
-    assert_eq!(
-        ::std::mem::align_of::<s>(),
-        4usize,
-        concat!("Alignment of ", stringify!(s)),
-    );
+    assert_eq!(::std::mem::size_of::<s>(), 4usize, "Size of s");
+    assert_eq!(::std::mem::align_of::<s>(), 4usize, "Alignment of s");
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).u) as usize - ptr as usize },
         0usize,
-        concat!("Offset of field: ", stringify!(s), "::", stringify!(u)),
+        "Offset of field: s::u",
     );
 }
 impl Clone for s {

--- a/bindgen-tests/tests/expectations/tests/anon_union.rs
+++ b/bindgen-tests/tests/expectations/tests/anon_union.rs
@@ -51,19 +51,10 @@ impl Default for TErrorResult {
 pub struct ErrorResult {
     pub _base: TErrorResult,
 }
-#[test]
-fn bindgen_test_layout_ErrorResult() {
-    assert_eq!(
-        ::std::mem::size_of::<ErrorResult>(),
-        24usize,
-        concat!("Size of: ", stringify!(ErrorResult)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<ErrorResult>(),
-        8usize,
-        concat!("Alignment of ", stringify!(ErrorResult)),
-    );
-}
+const _: () = {
+    ["Size of ErrorResult"][::std::mem::size_of::<ErrorResult>() - 24usize];
+    ["Alignment of ErrorResult"][::std::mem::align_of::<ErrorResult>() - 8usize];
+};
 impl Default for ErrorResult {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
@@ -73,16 +64,11 @@ impl Default for ErrorResult {
         }
     }
 }
-#[test]
-fn __bindgen_test_layout_TErrorResult_open0_int_close0_instantiation() {
-    assert_eq!(
-        ::std::mem::size_of::<TErrorResult>(),
-        24usize,
-        concat!("Size of template specialization: ", stringify!(TErrorResult)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<TErrorResult>(),
-        8usize,
-        concat!("Alignment of template specialization: ", stringify!(TErrorResult)),
-    );
-}
+const _: () = {
+    [
+        "Size of template specialization: TErrorResult_open0_int_close0",
+    ][::std::mem::size_of::<TErrorResult>() - 24usize];
+    [
+        "Align of template specialization: TErrorResult_open0_int_close0",
+    ][::std::mem::align_of::<TErrorResult>() - 8usize];
+};

--- a/bindgen-tests/tests/expectations/tests/anon_union_1_0.rs
+++ b/bindgen-tests/tests/expectations/tests/anon_union_1_0.rs
@@ -89,15 +89,11 @@ pub struct ErrorResult {
 }
 #[test]
 fn bindgen_test_layout_ErrorResult() {
-    assert_eq!(
-        ::std::mem::size_of::<ErrorResult>(),
-        24usize,
-        concat!("Size of: ", stringify!(ErrorResult)),
-    );
+    assert_eq!(::std::mem::size_of::<ErrorResult>(), 24usize, "Size of ErrorResult");
     assert_eq!(
         ::std::mem::align_of::<ErrorResult>(),
         8usize,
-        concat!("Alignment of ", stringify!(ErrorResult)),
+        "Alignment of ErrorResult",
     );
 }
 impl Clone for ErrorResult {
@@ -119,11 +115,11 @@ fn __bindgen_test_layout_TErrorResult_open0_int_close0_instantiation() {
     assert_eq!(
         ::std::mem::size_of::<TErrorResult>(),
         24usize,
-        concat!("Size of template specialization: ", stringify!(TErrorResult)),
+        "Size of template specialization: TErrorResult_open0_int_close0",
     );
     assert_eq!(
         ::std::mem::align_of::<TErrorResult>(),
         8usize,
-        concat!("Alignment of template specialization: ", stringify!(TErrorResult)),
+        "Align of template specialization: TErrorResult_open0_int_close0",
     );
 }

--- a/bindgen-tests/tests/expectations/tests/array-of-zero-sized-types.rs
+++ b/bindgen-tests/tests/expectations/tests/array-of-zero-sized-types.rs
@@ -5,19 +5,10 @@
 pub struct Empty {
     pub _address: u8,
 }
-#[test]
-fn bindgen_test_layout_Empty() {
-    assert_eq!(
-        ::std::mem::size_of::<Empty>(),
-        1usize,
-        concat!("Size of: ", stringify!(Empty)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Empty>(),
-        1usize,
-        concat!("Alignment of ", stringify!(Empty)),
-    );
-}
+const _: () = {
+    ["Size of Empty"][::std::mem::size_of::<Empty>() - 1usize];
+    ["Alignment of Empty"][::std::mem::align_of::<Empty>() - 1usize];
+};
 /** This should not get an `_address` byte, since each `Empty` gets one, meaning
  that this object is addressable.*/
 #[repr(C)]
@@ -25,28 +16,10 @@ fn bindgen_test_layout_Empty() {
 pub struct HasArrayOfEmpty {
     pub empties: [Empty; 10usize],
 }
-#[test]
-fn bindgen_test_layout_HasArrayOfEmpty() {
-    const UNINIT: ::std::mem::MaybeUninit<HasArrayOfEmpty> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<HasArrayOfEmpty>(),
-        10usize,
-        concat!("Size of: ", stringify!(HasArrayOfEmpty)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<HasArrayOfEmpty>(),
-        1usize,
-        concat!("Alignment of ", stringify!(HasArrayOfEmpty)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).empties) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(HasArrayOfEmpty),
-            "::",
-            stringify!(empties),
-        ),
-    );
-}
+const _: () = {
+    ["Size of HasArrayOfEmpty"][::std::mem::size_of::<HasArrayOfEmpty>() - 10usize];
+    ["Alignment of HasArrayOfEmpty"][::std::mem::align_of::<HasArrayOfEmpty>() - 1usize];
+    [
+        "Offset of field: HasArrayOfEmpty::empties",
+    ][::std::mem::offset_of!(HasArrayOfEmpty, empties) - 0usize];
+};

--- a/bindgen-tests/tests/expectations/tests/attribute_warn_unused_result.rs
+++ b/bindgen-tests/tests/expectations/tests/attribute_warn_unused_result.rs
@@ -6,16 +6,8 @@ pub struct Foo {
 }
 #[test]
 fn bindgen_test_layout_Foo() {
-    assert_eq!(
-        ::std::mem::size_of::<Foo>(),
-        1usize,
-        concat!("Size of: ", stringify!(Foo)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Foo>(),
-        1usize,
-        concat!("Alignment of ", stringify!(Foo)),
-    );
+    assert_eq!(::std::mem::size_of::<Foo>(), 1usize, "Size of Foo");
+    assert_eq!(::std::mem::align_of::<Foo>(), 1usize, "Alignment of Foo");
 }
 extern "C" {
     #[must_use]

--- a/bindgen-tests/tests/expectations/tests/attribute_warn_unused_result_no_attribute_detection.rs
+++ b/bindgen-tests/tests/expectations/tests/attribute_warn_unused_result_no_attribute_detection.rs
@@ -6,16 +6,8 @@ pub struct Foo {
 }
 #[test]
 fn bindgen_test_layout_Foo() {
-    assert_eq!(
-        ::std::mem::size_of::<Foo>(),
-        1usize,
-        concat!("Size of: ", stringify!(Foo)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Foo>(),
-        1usize,
-        concat!("Alignment of ", stringify!(Foo)),
-    );
+    assert_eq!(::std::mem::size_of::<Foo>(), 1usize, "Size of Foo");
+    assert_eq!(::std::mem::align_of::<Foo>(), 1usize, "Alignment of Foo");
 }
 extern "C" {
     #[link_name = "\u{1}_ZN3Foo3fooEi"]

--- a/bindgen-tests/tests/expectations/tests/attribute_warn_unused_result_pre_1_27.rs
+++ b/bindgen-tests/tests/expectations/tests/attribute_warn_unused_result_pre_1_27.rs
@@ -4,19 +4,10 @@
 pub struct Foo {
     pub _address: u8,
 }
-#[test]
-fn bindgen_test_layout_Foo() {
-    assert_eq!(
-        ::std::mem::size_of::<Foo>(),
-        1usize,
-        concat!("Size of: ", stringify!(Foo)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Foo>(),
-        1usize,
-        concat!("Alignment of ", stringify!(Foo)),
-    );
-}
+const _: () = {
+    ["Size of Foo"][::std::mem::size_of::<Foo>() - 1usize];
+    ["Alignment of Foo"][::std::mem::align_of::<Foo>() - 1usize];
+};
 extern "C" {
     #[link_name = "\u{1}_ZN3Foo3fooEi"]
     pub fn Foo_foo(this: *mut Foo, arg1: ::std::os::raw::c_int) -> ::std::os::raw::c_int;

--- a/bindgen-tests/tests/expectations/tests/auto.rs
+++ b/bindgen-tests/tests/expectations/tests/auto.rs
@@ -5,19 +5,10 @@ pub struct Foo {
     pub _address: u8,
 }
 pub const Foo_kFoo: bool = true;
-#[test]
-fn bindgen_test_layout_Foo() {
-    assert_eq!(
-        ::std::mem::size_of::<Foo>(),
-        1usize,
-        concat!("Size of: ", stringify!(Foo)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Foo>(),
-        1usize,
-        concat!("Alignment of ", stringify!(Foo)),
-    );
-}
+const _: () = {
+    ["Size of Foo"][::std::mem::size_of::<Foo>() - 1usize];
+    ["Alignment of Foo"][::std::mem::align_of::<Foo>() - 1usize];
+};
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct Bar {

--- a/bindgen-tests/tests/expectations/tests/base-to-derived.rs
+++ b/bindgen-tests/tests/expectations/tests/base-to-derived.rs
@@ -4,16 +4,7 @@
 pub struct false_type {
     pub _address: u8,
 }
-#[test]
-fn bindgen_test_layout_false_type() {
-    assert_eq!(
-        ::std::mem::size_of::<false_type>(),
-        1usize,
-        concat!("Size of: ", stringify!(false_type)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<false_type>(),
-        1usize,
-        concat!("Alignment of ", stringify!(false_type)),
-    );
-}
+const _: () = {
+    ["Size of false_type"][::std::mem::size_of::<false_type>() - 1usize];
+    ["Alignment of false_type"][::std::mem::align_of::<false_type>() - 1usize];
+};

--- a/bindgen-tests/tests/expectations/tests/bindgen-union-inside-namespace.rs
+++ b/bindgen-tests/tests/expectations/tests/bindgen-union-inside-namespace.rs
@@ -60,25 +60,17 @@ pub mod root {
         fn bindgen_test_layout_Bar() {
             const UNINIT: ::std::mem::MaybeUninit<Bar> = ::std::mem::MaybeUninit::uninit();
             let ptr = UNINIT.as_ptr();
-            assert_eq!(
-                ::std::mem::size_of::<Bar>(),
-                4usize,
-                concat!("Size of: ", stringify!(Bar)),
-            );
-            assert_eq!(
-                ::std::mem::align_of::<Bar>(),
-                4usize,
-                concat!("Alignment of ", stringify!(Bar)),
-            );
+            assert_eq!(::std::mem::size_of::<Bar>(), 4usize, "Size of Bar");
+            assert_eq!(::std::mem::align_of::<Bar>(), 4usize, "Alignment of Bar");
             assert_eq!(
                 unsafe { ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize },
                 0usize,
-                concat!("Offset of field: ", stringify!(Bar), "::", stringify!(foo)),
+                "Offset of field: Bar::foo",
             );
             assert_eq!(
                 unsafe { ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize },
                 0usize,
-                concat!("Offset of field: ", stringify!(Bar), "::", stringify!(bar)),
+                "Offset of field: Bar::bar",
             );
         }
         impl Clone for Bar {

--- a/bindgen-tests/tests/expectations/tests/bitfield-32bit-overflow.rs
+++ b/bindgen-tests/tests/expectations/tests/bitfield-32bit-overflow.rs
@@ -89,19 +89,10 @@ pub struct MuchBitfield {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 5usize]>,
 }
-#[test]
-fn bindgen_test_layout_MuchBitfield() {
-    assert_eq!(
-        ::std::mem::size_of::<MuchBitfield>(),
-        5usize,
-        concat!("Size of: ", stringify!(MuchBitfield)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<MuchBitfield>(),
-        1usize,
-        concat!("Alignment of ", stringify!(MuchBitfield)),
-    );
-}
+const _: () = {
+    ["Size of MuchBitfield"][::std::mem::size_of::<MuchBitfield>() - 5usize];
+    ["Alignment of MuchBitfield"][::std::mem::align_of::<MuchBitfield>() - 1usize];
+};
 impl MuchBitfield {
     #[inline]
     pub fn m0(&self) -> ::std::os::raw::c_char {

--- a/bindgen-tests/tests/expectations/tests/bitfield-enum-basic.rs
+++ b/bindgen-tests/tests/expectations/tests/bitfield-enum-basic.rs
@@ -148,16 +148,7 @@ impl ::std::ops::BitAndAssign for Dummy__bindgen_ty_1 {
 #[repr(transparent)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct Dummy__bindgen_ty_1(pub ::std::os::raw::c_uint);
-#[test]
-fn bindgen_test_layout_Dummy() {
-    assert_eq!(
-        ::std::mem::size_of::<Dummy>(),
-        1usize,
-        concat!("Size of: ", stringify!(Dummy)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Dummy>(),
-        1usize,
-        concat!("Alignment of ", stringify!(Dummy)),
-    );
-}
+const _: () = {
+    ["Size of Dummy"][::std::mem::size_of::<Dummy>() - 1usize];
+    ["Alignment of Dummy"][::std::mem::align_of::<Dummy>() - 1usize];
+};

--- a/bindgen-tests/tests/expectations/tests/bitfield-large.rs
+++ b/bindgen-tests/tests/expectations/tests/bitfield-large.rs
@@ -90,19 +90,10 @@ pub struct HasBigBitfield {
     pub _bitfield_align_1: [u64; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 16usize]>,
 }
-#[test]
-fn bindgen_test_layout_HasBigBitfield() {
-    assert_eq!(
-        ::std::mem::size_of::<HasBigBitfield>(),
-        16usize,
-        concat!("Size of: ", stringify!(HasBigBitfield)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<HasBigBitfield>(),
-        16usize,
-        concat!("Alignment of ", stringify!(HasBigBitfield)),
-    );
-}
+const _: () = {
+    ["Size of HasBigBitfield"][::std::mem::size_of::<HasBigBitfield>() - 16usize];
+    ["Alignment of HasBigBitfield"][::std::mem::align_of::<HasBigBitfield>() - 16usize];
+};
 impl HasBigBitfield {
     #[inline]
     pub fn x(&self) -> i128 {
@@ -137,19 +128,14 @@ pub struct HasTwoBigBitfields {
     pub _bitfield_align_1: [u64; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 16usize]>,
 }
-#[test]
-fn bindgen_test_layout_HasTwoBigBitfields() {
-    assert_eq!(
-        ::std::mem::size_of::<HasTwoBigBitfields>(),
-        16usize,
-        concat!("Size of: ", stringify!(HasTwoBigBitfields)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<HasTwoBigBitfields>(),
-        16usize,
-        concat!("Alignment of ", stringify!(HasTwoBigBitfields)),
-    );
-}
+const _: () = {
+    [
+        "Size of HasTwoBigBitfields",
+    ][::std::mem::size_of::<HasTwoBigBitfields>() - 16usize];
+    [
+        "Alignment of HasTwoBigBitfields",
+    ][::std::mem::align_of::<HasTwoBigBitfields>() - 16usize];
+};
 impl HasTwoBigBitfields {
     #[inline]
     pub fn x(&self) -> i128 {

--- a/bindgen-tests/tests/expectations/tests/bitfield-linux-32.rs
+++ b/bindgen-tests/tests/expectations/tests/bitfield-linux-32.rs
@@ -90,26 +90,11 @@ pub struct Test {
     pub _bitfield_align_1: [u64; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 8usize]>,
 }
-#[test]
-fn bindgen_test_layout_Test() {
-    const UNINIT: ::std::mem::MaybeUninit<Test> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<Test>(),
-        16usize,
-        concat!("Size of: ", stringify!(Test)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Test>(),
-        4usize,
-        concat!("Alignment of ", stringify!(Test)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(Test), "::", stringify!(foo)),
-    );
-}
+const _: () = {
+    ["Size of Test"][::std::mem::size_of::<Test>() - 16usize];
+    ["Alignment of Test"][::std::mem::align_of::<Test>() - 4usize];
+    ["Offset of field: Test::foo"][::std::mem::offset_of!(Test, foo) - 0usize];
+};
 impl Test {
     #[inline]
     pub fn x(&self) -> u64 {

--- a/bindgen-tests/tests/expectations/tests/bitfield-method-same-name.rs
+++ b/bindgen-tests/tests/expectations/tests/bitfield-method-same-name.rs
@@ -89,19 +89,10 @@ pub struct Foo {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
 }
-#[test]
-fn bindgen_test_layout_Foo() {
-    assert_eq!(
-        ::std::mem::size_of::<Foo>(),
-        1usize,
-        concat!("Size of: ", stringify!(Foo)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Foo>(),
-        1usize,
-        concat!("Alignment of ", stringify!(Foo)),
-    );
-}
+const _: () = {
+    ["Size of Foo"][::std::mem::size_of::<Foo>() - 1usize];
+    ["Alignment of Foo"][::std::mem::align_of::<Foo>() - 1usize];
+};
 extern "C" {
     #[link_name = "\u{1}_ZN3Foo4typeEv"]
     pub fn Foo_type(this: *mut Foo) -> ::std::os::raw::c_char;

--- a/bindgen-tests/tests/expectations/tests/bitfield_align.rs
+++ b/bindgen-tests/tests/expectations/tests/bitfield_align.rs
@@ -92,27 +92,12 @@ pub struct A {
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 2usize]>,
     pub y: ::std::os::raw::c_uchar,
 }
-#[test]
-fn bindgen_test_layout_A() {
-    const UNINIT: ::std::mem::MaybeUninit<A> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(::std::mem::size_of::<A>(), 4usize, concat!("Size of: ", stringify!(A)));
-    assert_eq!(
-        ::std::mem::align_of::<A>(),
-        4usize,
-        concat!("Alignment of ", stringify!(A)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(A), "::", stringify!(x)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).y) as usize - ptr as usize },
-        3usize,
-        concat!("Offset of field: ", stringify!(A), "::", stringify!(y)),
-    );
-}
+const _: () = {
+    ["Size of A"][::std::mem::size_of::<A>() - 4usize];
+    ["Alignment of A"][::std::mem::align_of::<A>() - 4usize];
+    ["Offset of field: A::x"][::std::mem::offset_of!(A, x) - 0usize];
+    ["Offset of field: A::y"][::std::mem::offset_of!(A, y) - 3usize];
+};
 impl A {
     #[inline]
     pub fn b1(&self) -> ::std::os::raw::c_uint {
@@ -337,15 +322,10 @@ pub struct B {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
 }
-#[test]
-fn bindgen_test_layout_B() {
-    assert_eq!(::std::mem::size_of::<B>(), 4usize, concat!("Size of: ", stringify!(B)));
-    assert_eq!(
-        ::std::mem::align_of::<B>(),
-        4usize,
-        concat!("Alignment of ", stringify!(B)),
-    );
-}
+const _: () = {
+    ["Size of B"][::std::mem::size_of::<B>() - 4usize];
+    ["Alignment of B"][::std::mem::align_of::<B>() - 4usize];
+};
 impl B {
     #[inline]
     pub fn foo(&self) -> ::std::os::raw::c_uint {
@@ -404,27 +384,12 @@ pub struct C {
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
     pub baz: ::std::os::raw::c_uint,
 }
-#[test]
-fn bindgen_test_layout_C() {
-    const UNINIT: ::std::mem::MaybeUninit<C> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(::std::mem::size_of::<C>(), 8usize, concat!("Size of: ", stringify!(C)));
-    assert_eq!(
-        ::std::mem::align_of::<C>(),
-        4usize,
-        concat!("Alignment of ", stringify!(C)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(C), "::", stringify!(x)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize },
-        4usize,
-        concat!("Offset of field: ", stringify!(C), "::", stringify!(baz)),
-    );
-}
+const _: () = {
+    ["Size of C"][::std::mem::size_of::<C>() - 8usize];
+    ["Alignment of C"][::std::mem::align_of::<C>() - 4usize];
+    ["Offset of field: C::x"][::std::mem::offset_of!(C, x) - 0usize];
+    ["Offset of field: C::baz"][::std::mem::offset_of!(C, baz) - 4usize];
+};
 impl C {
     #[inline]
     pub fn b1(&self) -> ::std::os::raw::c_uint {
@@ -483,19 +448,10 @@ pub struct Date1 {
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 3usize]>,
     pub __bindgen_padding_0: u8,
 }
-#[test]
-fn bindgen_test_layout_Date1() {
-    assert_eq!(
-        ::std::mem::size_of::<Date1>(),
-        4usize,
-        concat!("Size of: ", stringify!(Date1)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Date1>(),
-        2usize,
-        concat!("Alignment of ", stringify!(Date1)),
-    );
-}
+const _: () = {
+    ["Size of Date1"][::std::mem::size_of::<Date1>() - 4usize];
+    ["Alignment of Date1"][::std::mem::align_of::<Date1>() - 2usize];
+};
 impl Date1 {
     #[inline]
     pub fn nWeekDay(&self) -> ::std::os::raw::c_ushort {
@@ -595,19 +551,10 @@ pub struct Date2 {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
 }
-#[test]
-fn bindgen_test_layout_Date2() {
-    assert_eq!(
-        ::std::mem::size_of::<Date2>(),
-        4usize,
-        concat!("Size of: ", stringify!(Date2)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Date2>(),
-        2usize,
-        concat!("Alignment of ", stringify!(Date2)),
-    );
-}
+const _: () = {
+    ["Size of Date2"][::std::mem::size_of::<Date2>() - 4usize];
+    ["Alignment of Date2"][::std::mem::align_of::<Date2>() - 2usize];
+};
 impl Date2 {
     #[inline]
     pub fn nWeekDay(&self) -> ::std::os::raw::c_ushort {
@@ -729,26 +676,11 @@ pub struct Date3 {
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 3usize]>,
     pub byte: ::std::os::raw::c_uchar,
 }
-#[test]
-fn bindgen_test_layout_Date3() {
-    const UNINIT: ::std::mem::MaybeUninit<Date3> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<Date3>(),
-        4usize,
-        concat!("Size of: ", stringify!(Date3)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Date3>(),
-        2usize,
-        concat!("Alignment of ", stringify!(Date3)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).byte) as usize - ptr as usize },
-        3usize,
-        concat!("Offset of field: ", stringify!(Date3), "::", stringify!(byte)),
-    );
-}
+const _: () = {
+    ["Size of Date3"][::std::mem::size_of::<Date3>() - 4usize];
+    ["Alignment of Date3"][::std::mem::align_of::<Date3>() - 2usize];
+    ["Offset of field: Date3::byte"][::std::mem::offset_of!(Date3, byte) - 3usize];
+};
 impl Date3 {
     #[inline]
     pub fn nWeekDay(&self) -> ::std::os::raw::c_ushort {

--- a/bindgen-tests/tests/expectations/tests/bitfield_align_2.rs
+++ b/bindgen-tests/tests/expectations/tests/bitfield_align_2.rs
@@ -98,19 +98,10 @@ pub struct TaggedPtr {
     pub _bitfield_align_1: [u64; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 8usize]>,
 }
-#[test]
-fn bindgen_test_layout_TaggedPtr() {
-    assert_eq!(
-        ::std::mem::size_of::<TaggedPtr>(),
-        8usize,
-        concat!("Size of: ", stringify!(TaggedPtr)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<TaggedPtr>(),
-        8usize,
-        concat!("Alignment of ", stringify!(TaggedPtr)),
-    );
-}
+const _: () = {
+    ["Size of TaggedPtr"][::std::mem::size_of::<TaggedPtr>() - 8usize];
+    ["Alignment of TaggedPtr"][::std::mem::align_of::<TaggedPtr>() - 8usize];
+};
 impl Default for TaggedPtr {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();

--- a/bindgen-tests/tests/expectations/tests/bitfield_large_overflow.rs
+++ b/bindgen-tests/tests/expectations/tests/bitfield_large_overflow.rs
@@ -5,19 +5,10 @@
 pub struct _bindgen_ty_1 {
     pub _bindgen_opaque_blob: [u64; 10usize],
 }
-#[test]
-fn bindgen_test_layout__bindgen_ty_1() {
-    assert_eq!(
-        ::std::mem::size_of::<_bindgen_ty_1>(),
-        80usize,
-        concat!("Size of: ", stringify!(_bindgen_ty_1)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<_bindgen_ty_1>(),
-        8usize,
-        concat!("Alignment of ", stringify!(_bindgen_ty_1)),
-    );
-}
+const _: () = {
+    ["Size of _bindgen_ty_1"][::std::mem::size_of::<_bindgen_ty_1>() - 80usize];
+    ["Alignment of _bindgen_ty_1"][::std::mem::align_of::<_bindgen_ty_1>() - 8usize];
+};
 extern "C" {
     pub static mut a: _bindgen_ty_1;
 }

--- a/bindgen-tests/tests/expectations/tests/bitfield_method_mangling.rs
+++ b/bindgen-tests/tests/expectations/tests/bitfield_method_mangling.rs
@@ -89,19 +89,14 @@ pub struct mach_msg_type_descriptor_t {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
 }
-#[test]
-fn bindgen_test_layout_mach_msg_type_descriptor_t() {
-    assert_eq!(
-        ::std::mem::size_of::<mach_msg_type_descriptor_t>(),
-        4usize,
-        concat!("Size of: ", stringify!(mach_msg_type_descriptor_t)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<mach_msg_type_descriptor_t>(),
-        4usize,
-        concat!("Alignment of ", stringify!(mach_msg_type_descriptor_t)),
-    );
-}
+const _: () = {
+    [
+        "Size of mach_msg_type_descriptor_t",
+    ][::std::mem::size_of::<mach_msg_type_descriptor_t>() - 4usize];
+    [
+        "Alignment of mach_msg_type_descriptor_t",
+    ][::std::mem::align_of::<mach_msg_type_descriptor_t>() - 4usize];
+};
 impl mach_msg_type_descriptor_t {
     #[inline]
     pub fn pad3(&self) -> ::std::os::raw::c_uint {

--- a/bindgen-tests/tests/expectations/tests/bitfield_pragma_packed.rs
+++ b/bindgen-tests/tests/expectations/tests/bitfield_pragma_packed.rs
@@ -89,19 +89,10 @@ pub struct Struct {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
 }
-#[test]
-fn bindgen_test_layout_Struct() {
-    assert_eq!(
-        ::std::mem::size_of::<Struct>(),
-        4usize,
-        concat!("Size of: ", stringify!(Struct)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Struct>(),
-        1usize,
-        concat!("Alignment of ", stringify!(Struct)),
-    );
-}
+const _: () = {
+    ["Size of Struct"][::std::mem::size_of::<Struct>() - 4usize];
+    ["Alignment of Struct"][::std::mem::align_of::<Struct>() - 1usize];
+};
 impl Struct {
     #[inline]
     pub fn a(&self) -> ::std::os::raw::c_uchar {
@@ -221,19 +212,10 @@ pub struct Inner {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
 }
-#[test]
-fn bindgen_test_layout_Inner() {
-    assert_eq!(
-        ::std::mem::size_of::<Inner>(),
-        4usize,
-        concat!("Size of: ", stringify!(Inner)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Inner>(),
-        2usize,
-        concat!("Alignment of ", stringify!(Inner)),
-    );
-}
+const _: () = {
+    ["Size of Inner"][::std::mem::size_of::<Inner>() - 4usize];
+    ["Alignment of Inner"][::std::mem::align_of::<Inner>() - 2usize];
+};
 impl Inner {
     #[inline]
     pub fn a(&self) -> ::std::os::raw::c_ushort {
@@ -289,23 +271,8 @@ impl Inner {
 pub struct Outer {
     pub inner: Inner,
 }
-#[test]
-fn bindgen_test_layout_Outer() {
-    const UNINIT: ::std::mem::MaybeUninit<Outer> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<Outer>(),
-        4usize,
-        concat!("Size of: ", stringify!(Outer)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Outer>(),
-        1usize,
-        concat!("Alignment of ", stringify!(Outer)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).inner) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(Outer), "::", stringify!(inner)),
-    );
-}
+const _: () = {
+    ["Size of Outer"][::std::mem::size_of::<Outer>() - 4usize];
+    ["Alignment of Outer"][::std::mem::align_of::<Outer>() - 1usize];
+    ["Offset of field: Outer::inner"][::std::mem::offset_of!(Outer, inner) - 0usize];
+};

--- a/bindgen-tests/tests/expectations/tests/blocklist-and-impl-debug.rs
+++ b/bindgen-tests/tests/expectations/tests/blocklist-and-impl-debug.rs
@@ -5,31 +5,17 @@ pub struct BlocklistMe(u8);
 pub struct ShouldManuallyImplDebug {
     pub a: BlocklistMe,
 }
-#[test]
-fn bindgen_test_layout_ShouldManuallyImplDebug() {
-    const UNINIT: ::std::mem::MaybeUninit<ShouldManuallyImplDebug> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<ShouldManuallyImplDebug>(),
-        1usize,
-        concat!("Size of: ", stringify!(ShouldManuallyImplDebug)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<ShouldManuallyImplDebug>(),
-        1usize,
-        concat!("Alignment of ", stringify!(ShouldManuallyImplDebug)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(ShouldManuallyImplDebug),
-            "::",
-            stringify!(a),
-        ),
-    );
-}
+const _: () = {
+    [
+        "Size of ShouldManuallyImplDebug",
+    ][::std::mem::size_of::<ShouldManuallyImplDebug>() - 1usize];
+    [
+        "Alignment of ShouldManuallyImplDebug",
+    ][::std::mem::align_of::<ShouldManuallyImplDebug>() - 1usize];
+    [
+        "Offset of field: ShouldManuallyImplDebug::a",
+    ][::std::mem::offset_of!(ShouldManuallyImplDebug, a) - 0usize];
+};
 impl Default for ShouldManuallyImplDebug {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();

--- a/bindgen-tests/tests/expectations/tests/blocklist-file.rs
+++ b/bindgen-tests/tests/expectations/tests/blocklist-file.rs
@@ -6,63 +6,32 @@ pub struct SizedIntegers {
     pub y: u16,
     pub z: u32,
 }
-#[test]
-fn bindgen_test_layout_SizedIntegers() {
-    const UNINIT: ::std::mem::MaybeUninit<SizedIntegers> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<SizedIntegers>(),
-        8usize,
-        concat!("Size of: ", stringify!(SizedIntegers)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<SizedIntegers>(),
-        4usize,
-        concat!("Alignment of ", stringify!(SizedIntegers)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(SizedIntegers), "::", stringify!(x)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).y) as usize - ptr as usize },
-        2usize,
-        concat!("Offset of field: ", stringify!(SizedIntegers), "::", stringify!(y)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).z) as usize - ptr as usize },
-        4usize,
-        concat!("Offset of field: ", stringify!(SizedIntegers), "::", stringify!(z)),
-    );
-}
+const _: () = {
+    ["Size of SizedIntegers"][::std::mem::size_of::<SizedIntegers>() - 8usize];
+    ["Alignment of SizedIntegers"][::std::mem::align_of::<SizedIntegers>() - 4usize];
+    [
+        "Offset of field: SizedIntegers::x",
+    ][::std::mem::offset_of!(SizedIntegers, x) - 0usize];
+    [
+        "Offset of field: SizedIntegers::y",
+    ][::std::mem::offset_of!(SizedIntegers, y) - 2usize];
+    [
+        "Offset of field: SizedIntegers::z",
+    ][::std::mem::offset_of!(SizedIntegers, z) - 4usize];
+};
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct StructWithBlocklistedFwdDecl {
     pub b: u8,
 }
-#[test]
-fn bindgen_test_layout_StructWithBlocklistedFwdDecl() {
-    const UNINIT: ::std::mem::MaybeUninit<StructWithBlocklistedFwdDecl> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<StructWithBlocklistedFwdDecl>(),
-        1usize,
-        concat!("Size of: ", stringify!(StructWithBlocklistedFwdDecl)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<StructWithBlocklistedFwdDecl>(),
-        1usize,
-        concat!("Alignment of ", stringify!(StructWithBlocklistedFwdDecl)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(StructWithBlocklistedFwdDecl),
-            "::",
-            stringify!(b),
-        ),
-    );
-}
+const _: () = {
+    [
+        "Size of StructWithBlocklistedFwdDecl",
+    ][::std::mem::size_of::<StructWithBlocklistedFwdDecl>() - 1usize];
+    [
+        "Alignment of StructWithBlocklistedFwdDecl",
+    ][::std::mem::align_of::<StructWithBlocklistedFwdDecl>() - 1usize];
+    [
+        "Offset of field: StructWithBlocklistedFwdDecl::b",
+    ][::std::mem::offset_of!(StructWithBlocklistedFwdDecl, b) - 0usize];
+};

--- a/bindgen-tests/tests/expectations/tests/blocklist-function.rs
+++ b/bindgen-tests/tests/expectations/tests/blocklist-function.rs
@@ -20,17 +20,8 @@ pub mod root {
     pub struct C {
         pub _address: u8,
     }
-    #[test]
-    fn bindgen_test_layout_C() {
-        assert_eq!(
-            ::std::mem::size_of::<C>(),
-            1usize,
-            concat!("Size of: ", stringify!(C)),
-        );
-        assert_eq!(
-            ::std::mem::align_of::<C>(),
-            1usize,
-            concat!("Alignment of ", stringify!(C)),
-        );
-    }
+    const _: () = {
+        ["Size of C"][::std::mem::size_of::<C>() - 1usize];
+        ["Alignment of C"][::std::mem::align_of::<C>() - 1usize];
+    };
 }

--- a/bindgen-tests/tests/expectations/tests/blocklist-methods.rs
+++ b/bindgen-tests/tests/expectations/tests/blocklist-methods.rs
@@ -4,19 +4,10 @@
 pub struct Foo {
     pub _address: u8,
 }
-#[test]
-fn bindgen_test_layout_Foo() {
-    assert_eq!(
-        ::std::mem::size_of::<Foo>(),
-        1usize,
-        concat!("Size of: ", stringify!(Foo)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Foo>(),
-        1usize,
-        concat!("Alignment of ", stringify!(Foo)),
-    );
-}
+const _: () = {
+    ["Size of Foo"][::std::mem::size_of::<Foo>() - 1usize];
+    ["Alignment of Foo"][::std::mem::align_of::<Foo>() - 1usize];
+};
 extern "C" {
     #[link_name = "\u{1}_ZN3Foo3fooEv"]
     pub fn Foo_foo(this: *mut Foo) -> ::std::os::raw::c_int;

--- a/bindgen-tests/tests/expectations/tests/blocks-signature.rs
+++ b/bindgen-tests/tests/expectations/tests/blocks-signature.rs
@@ -28,41 +28,20 @@ pub struct contains_block_pointers {
     pub val: contains_block_pointers__bindgen_ty_id_61,
     pub ptr_val: *mut _bindgen_ty_id_68,
 }
-#[test]
-fn bindgen_test_layout_contains_block_pointers() {
-    const UNINIT: ::std::mem::MaybeUninit<contains_block_pointers> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<contains_block_pointers>(),
-        16usize,
-        concat!("Size of: ", stringify!(contains_block_pointers)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<contains_block_pointers>(),
-        8usize,
-        concat!("Alignment of ", stringify!(contains_block_pointers)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).val) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(contains_block_pointers),
-            "::",
-            stringify!(val),
-        ),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).ptr_val) as usize - ptr as usize },
-        8usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(contains_block_pointers),
-            "::",
-            stringify!(ptr_val),
-        ),
-    );
-}
+const _: () = {
+    [
+        "Size of contains_block_pointers",
+    ][::std::mem::size_of::<contains_block_pointers>() - 16usize];
+    [
+        "Alignment of contains_block_pointers",
+    ][::std::mem::align_of::<contains_block_pointers>() - 8usize];
+    [
+        "Offset of field: contains_block_pointers::val",
+    ][::std::mem::offset_of!(contains_block_pointers, val) - 0usize];
+    [
+        "Offset of field: contains_block_pointers::ptr_val",
+    ][::std::mem::offset_of!(contains_block_pointers, ptr_val) - 8usize];
+};
 impl Default for contains_block_pointers {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();

--- a/bindgen-tests/tests/expectations/tests/blocks.rs
+++ b/bindgen-tests/tests/expectations/tests/blocks.rs
@@ -27,41 +27,20 @@ pub struct contains_block_pointers {
     pub val: *mut ::std::os::raw::c_void,
     pub ptr_val: *mut *mut ::std::os::raw::c_void,
 }
-#[test]
-fn bindgen_test_layout_contains_block_pointers() {
-    const UNINIT: ::std::mem::MaybeUninit<contains_block_pointers> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<contains_block_pointers>(),
-        16usize,
-        concat!("Size of: ", stringify!(contains_block_pointers)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<contains_block_pointers>(),
-        8usize,
-        concat!("Alignment of ", stringify!(contains_block_pointers)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).val) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(contains_block_pointers),
-            "::",
-            stringify!(val),
-        ),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).ptr_val) as usize - ptr as usize },
-        8usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(contains_block_pointers),
-            "::",
-            stringify!(ptr_val),
-        ),
-    );
-}
+const _: () = {
+    [
+        "Size of contains_block_pointers",
+    ][::std::mem::size_of::<contains_block_pointers>() - 16usize];
+    [
+        "Alignment of contains_block_pointers",
+    ][::std::mem::align_of::<contains_block_pointers>() - 8usize];
+    [
+        "Offset of field: contains_block_pointers::val",
+    ][::std::mem::offset_of!(contains_block_pointers, val) - 0usize];
+    [
+        "Offset of field: contains_block_pointers::ptr_val",
+    ][::std::mem::offset_of!(contains_block_pointers, ptr_val) - 8usize];
+};
 impl Default for contains_block_pointers {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();

--- a/bindgen-tests/tests/expectations/tests/bug-1529681.rs
+++ b/bindgen-tests/tests/expectations/tests/bug-1529681.rs
@@ -4,16 +4,7 @@
 pub struct BrowsingContext {
     pub _address: u8,
 }
-#[test]
-fn bindgen_test_layout_BrowsingContext() {
-    assert_eq!(
-        ::std::mem::size_of::<BrowsingContext>(),
-        1usize,
-        concat!("Size of: ", stringify!(BrowsingContext)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<BrowsingContext>(),
-        1usize,
-        concat!("Alignment of ", stringify!(BrowsingContext)),
-    );
-}
+const _: () = {
+    ["Size of BrowsingContext"][::std::mem::size_of::<BrowsingContext>() - 1usize];
+    ["Alignment of BrowsingContext"][::std::mem::align_of::<BrowsingContext>() - 1usize];
+};

--- a/bindgen-tests/tests/expectations/tests/c-empty-layout.rs
+++ b/bindgen-tests/tests/expectations/tests/c-empty-layout.rs
@@ -2,16 +2,7 @@
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct Foo {}
-#[test]
-fn bindgen_test_layout_Foo() {
-    assert_eq!(
-        ::std::mem::size_of::<Foo>(),
-        0usize,
-        concat!("Size of: ", stringify!(Foo)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Foo>(),
-        1usize,
-        concat!("Alignment of ", stringify!(Foo)),
-    );
-}
+const _: () = {
+    ["Size of Foo"][::std::mem::size_of::<Foo>() - 0usize];
+    ["Alignment of Foo"][::std::mem::align_of::<Foo>() - 1usize];
+};

--- a/bindgen-tests/tests/expectations/tests/c_naming.rs
+++ b/bindgen-tests/tests/expectations/tests/c_naming.rs
@@ -4,26 +4,11 @@
 pub struct struct_a {
     pub a: ::std::os::raw::c_int,
 }
-#[test]
-fn bindgen_test_layout_struct_a() {
-    const UNINIT: ::std::mem::MaybeUninit<struct_a> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<struct_a>(),
-        4usize,
-        concat!("Size of: ", stringify!(struct_a)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<struct_a>(),
-        4usize,
-        concat!("Alignment of ", stringify!(struct_a)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(struct_a), "::", stringify!(a)),
-    );
-}
+const _: () = {
+    ["Size of struct_a"][::std::mem::size_of::<struct_a>() - 4usize];
+    ["Alignment of struct_a"][::std::mem::align_of::<struct_a>() - 4usize];
+    ["Offset of field: struct_a::a"][::std::mem::offset_of!(struct_a, a) - 0usize];
+};
 pub type a = *const struct_a;
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -31,31 +16,12 @@ pub union union_b {
     pub a: ::std::os::raw::c_int,
     pub b: ::std::os::raw::c_int,
 }
-#[test]
-fn bindgen_test_layout_union_b() {
-    const UNINIT: ::std::mem::MaybeUninit<union_b> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<union_b>(),
-        4usize,
-        concat!("Size of: ", stringify!(union_b)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<union_b>(),
-        4usize,
-        concat!("Alignment of ", stringify!(union_b)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(union_b), "::", stringify!(a)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(union_b), "::", stringify!(b)),
-    );
-}
+const _: () = {
+    ["Size of union_b"][::std::mem::size_of::<union_b>() - 4usize];
+    ["Alignment of union_b"][::std::mem::align_of::<union_b>() - 4usize];
+    ["Offset of field: union_b::a"][::std::mem::offset_of!(union_b, a) - 0usize];
+    ["Offset of field: union_b::b"][::std::mem::offset_of!(union_b, b) - 0usize];
+};
 impl Default for union_b {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();

--- a/bindgen-tests/tests/expectations/tests/call-conv-field.rs
+++ b/bindgen-tests/tests/expectations/tests/call-conv-field.rs
@@ -10,41 +10,20 @@ pub struct JNINativeInterface_ {
     >,
     pub __hack: ::std::os::raw::c_ulonglong,
 }
-#[test]
-fn bindgen_test_layout_JNINativeInterface_() {
-    const UNINIT: ::std::mem::MaybeUninit<JNINativeInterface_> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<JNINativeInterface_>(),
-        16usize,
-        concat!("Size of: ", stringify!(JNINativeInterface_)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<JNINativeInterface_>(),
-        8usize,
-        concat!("Alignment of ", stringify!(JNINativeInterface_)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).GetVersion) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(JNINativeInterface_),
-            "::",
-            stringify!(GetVersion),
-        ),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).__hack) as usize - ptr as usize },
-        8usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(JNINativeInterface_),
-            "::",
-            stringify!(__hack),
-        ),
-    );
-}
+const _: () = {
+    [
+        "Size of JNINativeInterface_",
+    ][::std::mem::size_of::<JNINativeInterface_>() - 16usize];
+    [
+        "Alignment of JNINativeInterface_",
+    ][::std::mem::align_of::<JNINativeInterface_>() - 8usize];
+    [
+        "Offset of field: JNINativeInterface_::GetVersion",
+    ][::std::mem::offset_of!(JNINativeInterface_, GetVersion) - 0usize];
+    [
+        "Offset of field: JNINativeInterface_::__hack",
+    ][::std::mem::offset_of!(JNINativeInterface_, __hack) - 8usize];
+};
 extern "stdcall" {
     pub fn bar();
 }

--- a/bindgen-tests/tests/expectations/tests/canonical-types.rs
+++ b/bindgen-tests/tests/expectations/tests/canonical-types.rs
@@ -76,19 +76,10 @@ impl Default for ClassC_ClassCInnerCRTP {
 pub struct ClassD {
     pub _address: u8,
 }
-#[test]
-fn bindgen_test_layout_ClassD() {
-    assert_eq!(
-        ::std::mem::size_of::<ClassD>(),
-        1usize,
-        concat!("Size of: ", stringify!(ClassD)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<ClassD>(),
-        1usize,
-        concat!("Alignment of ", stringify!(ClassD)),
-    );
-}
+const _: () = {
+    ["Size of ClassD"][::std::mem::size_of::<ClassD>() - 1usize];
+    ["Alignment of ClassD"][::std::mem::align_of::<ClassD>() - 1usize];
+};
 impl Default for ClassD {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
@@ -98,37 +89,23 @@ impl Default for ClassD {
         }
     }
 }
-#[test]
-fn __bindgen_test_layout_ClassB_open0_ClassD_ClassCInnerCRTP_close0_instantiation() {
-    assert_eq!(
-        ::std::mem::size_of::<ClassB>(),
-        1usize,
-        concat!("Size of template specialization: ", stringify!(ClassB)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<ClassB>(),
-        1usize,
-        concat!("Alignment of template specialization: ", stringify!(ClassB)),
-    );
-}
+const _: () = {
+    [
+        "Size of template specialization: ClassB_open0_ClassD_ClassCInnerCRTP_close0",
+    ][::std::mem::size_of::<ClassB>() - 1usize];
+    [
+        "Align of template specialization: ClassB_open0_ClassD_ClassCInnerCRTP_close0",
+    ][::std::mem::align_of::<ClassB>() - 1usize];
+};
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct ClassCInnerCRTP {
     pub _address: u8,
 }
-#[test]
-fn bindgen_test_layout_ClassCInnerCRTP() {
-    assert_eq!(
-        ::std::mem::size_of::<ClassCInnerCRTP>(),
-        1usize,
-        concat!("Size of: ", stringify!(ClassCInnerCRTP)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<ClassCInnerCRTP>(),
-        1usize,
-        concat!("Alignment of ", stringify!(ClassCInnerCRTP)),
-    );
-}
+const _: () = {
+    ["Size of ClassCInnerCRTP"][::std::mem::size_of::<ClassCInnerCRTP>() - 1usize];
+    ["Alignment of ClassCInnerCRTP"][::std::mem::align_of::<ClassCInnerCRTP>() - 1usize];
+};
 impl Default for ClassCInnerCRTP {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
@@ -138,44 +115,24 @@ impl Default for ClassCInnerCRTP {
         }
     }
 }
-#[test]
-fn __bindgen_test_layout_ClassB_open0_ClassCInnerCRTP_ClassAInner_close0_instantiation() {
-    assert_eq!(
-        ::std::mem::size_of::<ClassB>(),
-        1usize,
-        concat!("Size of template specialization: ", stringify!(ClassB)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<ClassB>(),
-        1usize,
-        concat!("Alignment of template specialization: ", stringify!(ClassB)),
-    );
-}
+const _: () = {
+    [
+        "Size of template specialization: ClassB_open0_ClassCInnerCRTP_ClassAInner_close0",
+    ][::std::mem::size_of::<ClassB>() - 1usize];
+    [
+        "Align of template specialization: ClassB_open0_ClassCInnerCRTP_ClassAInner_close0",
+    ][::std::mem::align_of::<ClassB>() - 1usize];
+};
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct ClassAInner {
     pub x: *mut ClassCInnerA,
 }
-#[test]
-fn bindgen_test_layout_ClassAInner() {
-    const UNINIT: ::std::mem::MaybeUninit<ClassAInner> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<ClassAInner>(),
-        8usize,
-        concat!("Size of: ", stringify!(ClassAInner)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<ClassAInner>(),
-        8usize,
-        concat!("Alignment of ", stringify!(ClassAInner)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(ClassAInner), "::", stringify!(x)),
-    );
-}
+const _: () = {
+    ["Size of ClassAInner"][::std::mem::size_of::<ClassAInner>() - 8usize];
+    ["Alignment of ClassAInner"][::std::mem::align_of::<ClassAInner>() - 8usize];
+    ["Offset of field: ClassAInner::x"][::std::mem::offset_of!(ClassAInner, x) - 0usize];
+};
 impl Default for ClassAInner {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
@@ -190,26 +147,13 @@ impl Default for ClassAInner {
 pub struct ClassCInnerA {
     pub member: *mut ClassCInnerB,
 }
-#[test]
-fn bindgen_test_layout_ClassCInnerA() {
-    const UNINIT: ::std::mem::MaybeUninit<ClassCInnerA> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<ClassCInnerA>(),
-        8usize,
-        concat!("Size of: ", stringify!(ClassCInnerA)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<ClassCInnerA>(),
-        8usize,
-        concat!("Alignment of ", stringify!(ClassCInnerA)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).member) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(ClassCInnerA), "::", stringify!(member)),
-    );
-}
+const _: () = {
+    ["Size of ClassCInnerA"][::std::mem::size_of::<ClassCInnerA>() - 8usize];
+    ["Alignment of ClassCInnerA"][::std::mem::align_of::<ClassCInnerA>() - 8usize];
+    [
+        "Offset of field: ClassCInnerA::member",
+    ][::std::mem::offset_of!(ClassCInnerA, member) - 0usize];
+};
 impl Default for ClassCInnerA {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
@@ -224,26 +168,13 @@ impl Default for ClassCInnerA {
 pub struct ClassCInnerB {
     pub cache: *mut ClassCInnerA,
 }
-#[test]
-fn bindgen_test_layout_ClassCInnerB() {
-    const UNINIT: ::std::mem::MaybeUninit<ClassCInnerB> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<ClassCInnerB>(),
-        8usize,
-        concat!("Size of: ", stringify!(ClassCInnerB)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<ClassCInnerB>(),
-        8usize,
-        concat!("Alignment of ", stringify!(ClassCInnerB)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).cache) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(ClassCInnerB), "::", stringify!(cache)),
-    );
-}
+const _: () = {
+    ["Size of ClassCInnerB"][::std::mem::size_of::<ClassCInnerB>() - 8usize];
+    ["Alignment of ClassCInnerB"][::std::mem::align_of::<ClassCInnerB>() - 8usize];
+    [
+        "Offset of field: ClassCInnerB::cache",
+    ][::std::mem::offset_of!(ClassCInnerB, cache) - 0usize];
+};
 impl Default for ClassCInnerB {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();

--- a/bindgen-tests/tests/expectations/tests/canonical_path_without_namespacing.rs
+++ b/bindgen-tests/tests/expectations/tests/canonical_path_without_namespacing.rs
@@ -4,19 +4,10 @@
 pub struct Bar {
     pub _address: u8,
 }
-#[test]
-fn bindgen_test_layout_Bar() {
-    assert_eq!(
-        ::std::mem::size_of::<Bar>(),
-        1usize,
-        concat!("Size of: ", stringify!(Bar)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Bar>(),
-        1usize,
-        concat!("Alignment of ", stringify!(Bar)),
-    );
-}
+const _: () = {
+    ["Size of Bar"][::std::mem::size_of::<Bar>() - 1usize];
+    ["Alignment of Bar"][::std::mem::align_of::<Bar>() - 1usize];
+};
 extern "C" {
     #[link_name = "\u{1}_Z3bazPN3foo3BarE"]
     pub fn baz(arg1: *mut Bar);

--- a/bindgen-tests/tests/expectations/tests/char.rs
+++ b/bindgen-tests/tests/expectations/tests/char.rs
@@ -18,78 +18,19 @@ pub struct Test {
     pub Ccu: UChar,
     pub Ccd: SChar,
 }
-#[test]
-fn bindgen_test_layout_Test() {
-    const UNINIT: ::std::mem::MaybeUninit<Test> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<Test>(),
-        12usize,
-        concat!("Size of: ", stringify!(Test)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Test>(),
-        1usize,
-        concat!("Alignment of ", stringify!(Test)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).ch) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(Test), "::", stringify!(ch)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).u) as usize - ptr as usize },
-        1usize,
-        concat!("Offset of field: ", stringify!(Test), "::", stringify!(u)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize },
-        2usize,
-        concat!("Offset of field: ", stringify!(Test), "::", stringify!(d)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).cch) as usize - ptr as usize },
-        3usize,
-        concat!("Offset of field: ", stringify!(Test), "::", stringify!(cch)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).cu) as usize - ptr as usize },
-        4usize,
-        concat!("Offset of field: ", stringify!(Test), "::", stringify!(cu)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).cd) as usize - ptr as usize },
-        5usize,
-        concat!("Offset of field: ", stringify!(Test), "::", stringify!(cd)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).Cch) as usize - ptr as usize },
-        6usize,
-        concat!("Offset of field: ", stringify!(Test), "::", stringify!(Cch)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).Cu) as usize - ptr as usize },
-        7usize,
-        concat!("Offset of field: ", stringify!(Test), "::", stringify!(Cu)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).Cd) as usize - ptr as usize },
-        8usize,
-        concat!("Offset of field: ", stringify!(Test), "::", stringify!(Cd)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).Ccch) as usize - ptr as usize },
-        9usize,
-        concat!("Offset of field: ", stringify!(Test), "::", stringify!(Ccch)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).Ccu) as usize - ptr as usize },
-        10usize,
-        concat!("Offset of field: ", stringify!(Test), "::", stringify!(Ccu)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).Ccd) as usize - ptr as usize },
-        11usize,
-        concat!("Offset of field: ", stringify!(Test), "::", stringify!(Ccd)),
-    );
-}
+const _: () = {
+    ["Size of Test"][::std::mem::size_of::<Test>() - 12usize];
+    ["Alignment of Test"][::std::mem::align_of::<Test>() - 1usize];
+    ["Offset of field: Test::ch"][::std::mem::offset_of!(Test, ch) - 0usize];
+    ["Offset of field: Test::u"][::std::mem::offset_of!(Test, u) - 1usize];
+    ["Offset of field: Test::d"][::std::mem::offset_of!(Test, d) - 2usize];
+    ["Offset of field: Test::cch"][::std::mem::offset_of!(Test, cch) - 3usize];
+    ["Offset of field: Test::cu"][::std::mem::offset_of!(Test, cu) - 4usize];
+    ["Offset of field: Test::cd"][::std::mem::offset_of!(Test, cd) - 5usize];
+    ["Offset of field: Test::Cch"][::std::mem::offset_of!(Test, Cch) - 6usize];
+    ["Offset of field: Test::Cu"][::std::mem::offset_of!(Test, Cu) - 7usize];
+    ["Offset of field: Test::Cd"][::std::mem::offset_of!(Test, Cd) - 8usize];
+    ["Offset of field: Test::Ccch"][::std::mem::offset_of!(Test, Ccch) - 9usize];
+    ["Offset of field: Test::Ccu"][::std::mem::offset_of!(Test, Ccu) - 10usize];
+    ["Offset of field: Test::Ccd"][::std::mem::offset_of!(Test, Ccd) - 11usize];
+};

--- a/bindgen-tests/tests/expectations/tests/class.rs
+++ b/bindgen-tests/tests/expectations/tests/class.rs
@@ -39,21 +39,17 @@ pub struct C {
 fn bindgen_test_layout_C() {
     const UNINIT: ::std::mem::MaybeUninit<C> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
-    assert_eq!(::std::mem::size_of::<C>(), 40usize, concat!("Size of: ", stringify!(C)));
-    assert_eq!(
-        ::std::mem::align_of::<C>(),
-        4usize,
-        concat!("Alignment of ", stringify!(C)),
-    );
+    assert_eq!(::std::mem::size_of::<C>(), 40usize, "Size of C");
+    assert_eq!(::std::mem::align_of::<C>(), 4usize, "Alignment of C");
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
         0usize,
-        concat!("Offset of field: ", stringify!(C), "::", stringify!(a)),
+        "Offset of field: C::a",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).big_array) as usize - ptr as usize },
         4usize,
-        concat!("Offset of field: ", stringify!(C), "::", stringify!(big_array)),
+        "Offset of field: C::big_array",
     );
 }
 impl Default for C {
@@ -78,44 +74,29 @@ fn bindgen_test_layout_C_with_zero_length_array() {
     assert_eq!(
         ::std::mem::size_of::<C_with_zero_length_array>(),
         40usize,
-        concat!("Size of: ", stringify!(C_with_zero_length_array)),
+        "Size of C_with_zero_length_array",
     );
     assert_eq!(
         ::std::mem::align_of::<C_with_zero_length_array>(),
         4usize,
-        concat!("Alignment of ", stringify!(C_with_zero_length_array)),
+        "Alignment of C_with_zero_length_array",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
         0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C_with_zero_length_array),
-            "::",
-            stringify!(a),
-        ),
+        "Offset of field: C_with_zero_length_array::a",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).big_array) as usize - ptr as usize },
         4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C_with_zero_length_array),
-            "::",
-            stringify!(big_array),
-        ),
+        "Offset of field: C_with_zero_length_array::big_array",
     );
     assert_eq!(
         unsafe {
             ::std::ptr::addr_of!((*ptr).zero_length_array) as usize - ptr as usize
         },
         37usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C_with_zero_length_array),
-            "::",
-            stringify!(zero_length_array),
-        ),
+        "Offset of field: C_with_zero_length_array::zero_length_array",
     );
 }
 impl Default for C_with_zero_length_array {
@@ -140,34 +121,24 @@ fn bindgen_test_layout_C_with_zero_length_array_2() {
     assert_eq!(
         ::std::mem::size_of::<C_with_zero_length_array_2>(),
         4usize,
-        concat!("Size of: ", stringify!(C_with_zero_length_array_2)),
+        "Size of C_with_zero_length_array_2",
     );
     assert_eq!(
         ::std::mem::align_of::<C_with_zero_length_array_2>(),
         4usize,
-        concat!("Alignment of ", stringify!(C_with_zero_length_array_2)),
+        "Alignment of C_with_zero_length_array_2",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
         0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C_with_zero_length_array_2),
-            "::",
-            stringify!(a),
-        ),
+        "Offset of field: C_with_zero_length_array_2::a",
     );
     assert_eq!(
         unsafe {
             ::std::ptr::addr_of!((*ptr).zero_length_array) as usize - ptr as usize
         },
         4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C_with_zero_length_array_2),
-            "::",
-            stringify!(zero_length_array),
-        ),
+        "Offset of field: C_with_zero_length_array_2::zero_length_array",
     );
 }
 #[repr(C)]
@@ -183,42 +154,27 @@ fn bindgen_test_layout_C_with_incomplete_array() {
     assert_eq!(
         ::std::mem::size_of::<C_with_incomplete_array>(),
         40usize,
-        concat!("Size of: ", stringify!(C_with_incomplete_array)),
+        "Size of C_with_incomplete_array",
     );
     assert_eq!(
         ::std::mem::align_of::<C_with_incomplete_array>(),
         4usize,
-        concat!("Alignment of ", stringify!(C_with_incomplete_array)),
+        "Alignment of C_with_incomplete_array",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
         0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C_with_incomplete_array),
-            "::",
-            stringify!(a),
-        ),
+        "Offset of field: C_with_incomplete_array::a",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).big_array) as usize - ptr as usize },
         4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C_with_incomplete_array),
-            "::",
-            stringify!(big_array),
-        ),
+        "Offset of field: C_with_incomplete_array::big_array",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).incomplete_array) as usize - ptr as usize },
         37usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C_with_incomplete_array),
-            "::",
-            stringify!(incomplete_array),
-        ),
+        "Offset of field: C_with_incomplete_array::incomplete_array",
     );
 }
 impl Default for C_with_incomplete_array {
@@ -243,32 +199,22 @@ fn bindgen_test_layout_C_with_incomplete_array_2() {
     assert_eq!(
         ::std::mem::size_of::<C_with_incomplete_array_2>(),
         4usize,
-        concat!("Size of: ", stringify!(C_with_incomplete_array_2)),
+        "Size of C_with_incomplete_array_2",
     );
     assert_eq!(
         ::std::mem::align_of::<C_with_incomplete_array_2>(),
         4usize,
-        concat!("Alignment of ", stringify!(C_with_incomplete_array_2)),
+        "Alignment of C_with_incomplete_array_2",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
         0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C_with_incomplete_array_2),
-            "::",
-            stringify!(a),
-        ),
+        "Offset of field: C_with_incomplete_array_2::a",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).incomplete_array) as usize - ptr as usize },
         4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C_with_incomplete_array_2),
-            "::",
-            stringify!(incomplete_array),
-        ),
+        "Offset of field: C_with_incomplete_array_2::incomplete_array",
     );
 }
 #[repr(C)]
@@ -287,57 +233,34 @@ fn bindgen_test_layout_C_with_zero_length_array_and_incomplete_array() {
     assert_eq!(
         ::std::mem::size_of::<C_with_zero_length_array_and_incomplete_array>(),
         40usize,
-        concat!("Size of: ", stringify!(C_with_zero_length_array_and_incomplete_array)),
+        "Size of C_with_zero_length_array_and_incomplete_array",
     );
     assert_eq!(
         ::std::mem::align_of::<C_with_zero_length_array_and_incomplete_array>(),
         4usize,
-        concat!(
-            "Alignment of ",
-            stringify!(C_with_zero_length_array_and_incomplete_array),
-        ),
+        "Alignment of C_with_zero_length_array_and_incomplete_array",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
         0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C_with_zero_length_array_and_incomplete_array),
-            "::",
-            stringify!(a),
-        ),
+        "Offset of field: C_with_zero_length_array_and_incomplete_array::a",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).big_array) as usize - ptr as usize },
         4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C_with_zero_length_array_and_incomplete_array),
-            "::",
-            stringify!(big_array),
-        ),
+        "Offset of field: C_with_zero_length_array_and_incomplete_array::big_array",
     );
     assert_eq!(
         unsafe {
             ::std::ptr::addr_of!((*ptr).zero_length_array) as usize - ptr as usize
         },
         37usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C_with_zero_length_array_and_incomplete_array),
-            "::",
-            stringify!(zero_length_array),
-        ),
+        "Offset of field: C_with_zero_length_array_and_incomplete_array::zero_length_array",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).incomplete_array) as usize - ptr as usize },
         37usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C_with_zero_length_array_and_incomplete_array),
-            "::",
-            stringify!(incomplete_array),
-        ),
+        "Offset of field: C_with_zero_length_array_and_incomplete_array::incomplete_array",
     );
 }
 impl Default for C_with_zero_length_array_and_incomplete_array {
@@ -365,47 +288,29 @@ fn bindgen_test_layout_C_with_zero_length_array_and_incomplete_array_2() {
     assert_eq!(
         ::std::mem::size_of::<C_with_zero_length_array_and_incomplete_array_2>(),
         4usize,
-        concat!("Size of: ", stringify!(C_with_zero_length_array_and_incomplete_array_2)),
+        "Size of C_with_zero_length_array_and_incomplete_array_2",
     );
     assert_eq!(
         ::std::mem::align_of::<C_with_zero_length_array_and_incomplete_array_2>(),
         4usize,
-        concat!(
-            "Alignment of ",
-            stringify!(C_with_zero_length_array_and_incomplete_array_2),
-        ),
+        "Alignment of C_with_zero_length_array_and_incomplete_array_2",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
         0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C_with_zero_length_array_and_incomplete_array_2),
-            "::",
-            stringify!(a),
-        ),
+        "Offset of field: C_with_zero_length_array_and_incomplete_array_2::a",
     );
     assert_eq!(
         unsafe {
             ::std::ptr::addr_of!((*ptr).zero_length_array) as usize - ptr as usize
         },
         4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C_with_zero_length_array_and_incomplete_array_2),
-            "::",
-            stringify!(zero_length_array),
-        ),
+        "Offset of field: C_with_zero_length_array_and_incomplete_array_2::zero_length_array",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).incomplete_array) as usize - ptr as usize },
         4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C_with_zero_length_array_and_incomplete_array_2),
-            "::",
-            stringify!(incomplete_array),
-        ),
+        "Offset of field: C_with_zero_length_array_and_incomplete_array_2::incomplete_array",
     );
 }
 #[repr(C)]
@@ -417,20 +322,12 @@ pub struct WithDtor {
 fn bindgen_test_layout_WithDtor() {
     const UNINIT: ::std::mem::MaybeUninit<WithDtor> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<WithDtor>(),
-        4usize,
-        concat!("Size of: ", stringify!(WithDtor)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<WithDtor>(),
-        4usize,
-        concat!("Alignment of ", stringify!(WithDtor)),
-    );
+    assert_eq!(::std::mem::size_of::<WithDtor>(), 4usize, "Size of WithDtor");
+    assert_eq!(::std::mem::align_of::<WithDtor>(), 4usize, "Alignment of WithDtor");
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
         0usize,
-        concat!("Offset of field: ", stringify!(WithDtor), "::", stringify!(b)),
+        "Offset of field: WithDtor::b",
     );
 }
 #[repr(C)]
@@ -445,32 +342,22 @@ fn bindgen_test_layout_IncompleteArrayNonCopiable() {
     assert_eq!(
         ::std::mem::size_of::<IncompleteArrayNonCopiable>(),
         8usize,
-        concat!("Size of: ", stringify!(IncompleteArrayNonCopiable)),
+        "Size of IncompleteArrayNonCopiable",
     );
     assert_eq!(
         ::std::mem::align_of::<IncompleteArrayNonCopiable>(),
         8usize,
-        concat!("Alignment of ", stringify!(IncompleteArrayNonCopiable)),
+        "Alignment of IncompleteArrayNonCopiable",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).whatever) as usize - ptr as usize },
         0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(IncompleteArrayNonCopiable),
-            "::",
-            stringify!(whatever),
-        ),
+        "Offset of field: IncompleteArrayNonCopiable::whatever",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).incomplete_array) as usize - ptr as usize },
         8usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(IncompleteArrayNonCopiable),
-            "::",
-            stringify!(incomplete_array),
-        ),
+        "Offset of field: IncompleteArrayNonCopiable::incomplete_array",
     );
 }
 impl Default for IncompleteArrayNonCopiable {
@@ -492,25 +379,17 @@ pub union Union {
 fn bindgen_test_layout_Union() {
     const UNINIT: ::std::mem::MaybeUninit<Union> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<Union>(),
-        4usize,
-        concat!("Size of: ", stringify!(Union)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Union>(),
-        4usize,
-        concat!("Alignment of ", stringify!(Union)),
-    );
+    assert_eq!(::std::mem::size_of::<Union>(), 4usize, "Size of Union");
+    assert_eq!(::std::mem::align_of::<Union>(), 4usize, "Alignment of Union");
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize },
         0usize,
-        concat!("Offset of field: ", stringify!(Union), "::", stringify!(d)),
+        "Offset of field: Union::d",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).i) as usize - ptr as usize },
         0usize,
-        concat!("Offset of field: ", stringify!(Union), "::", stringify!(i)),
+        "Offset of field: Union::i",
     );
 }
 impl Default for Union {
@@ -531,20 +410,12 @@ pub struct WithUnion {
 fn bindgen_test_layout_WithUnion() {
     const UNINIT: ::std::mem::MaybeUninit<WithUnion> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<WithUnion>(),
-        4usize,
-        concat!("Size of: ", stringify!(WithUnion)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<WithUnion>(),
-        4usize,
-        concat!("Alignment of ", stringify!(WithUnion)),
-    );
+    assert_eq!(::std::mem::size_of::<WithUnion>(), 4usize, "Size of WithUnion");
+    assert_eq!(::std::mem::align_of::<WithUnion>(), 4usize, "Alignment of WithUnion");
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).data) as usize - ptr as usize },
         0usize,
-        concat!("Offset of field: ", stringify!(WithUnion), "::", stringify!(data)),
+        "Offset of field: WithUnion::data",
     );
 }
 impl Default for WithUnion {
@@ -566,12 +437,12 @@ fn bindgen_test_layout_RealAbstractionWithTonsOfMethods() {
     assert_eq!(
         ::std::mem::size_of::<RealAbstractionWithTonsOfMethods>(),
         1usize,
-        concat!("Size of: ", stringify!(RealAbstractionWithTonsOfMethods)),
+        "Size of RealAbstractionWithTonsOfMethods",
     );
     assert_eq!(
         ::std::mem::align_of::<RealAbstractionWithTonsOfMethods>(),
         1usize,
-        concat!("Alignment of ", stringify!(RealAbstractionWithTonsOfMethods)),
+        "Alignment of RealAbstractionWithTonsOfMethods",
     );
 }
 extern "C" {

--- a/bindgen-tests/tests/expectations/tests/class_1_0.rs
+++ b/bindgen-tests/tests/expectations/tests/class_1_0.rs
@@ -82,21 +82,17 @@ pub struct C {
 fn bindgen_test_layout_C() {
     const UNINIT: ::std::mem::MaybeUninit<C> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
-    assert_eq!(::std::mem::size_of::<C>(), 40usize, concat!("Size of: ", stringify!(C)));
-    assert_eq!(
-        ::std::mem::align_of::<C>(),
-        4usize,
-        concat!("Alignment of ", stringify!(C)),
-    );
+    assert_eq!(::std::mem::size_of::<C>(), 40usize, "Size of C");
+    assert_eq!(::std::mem::align_of::<C>(), 4usize, "Alignment of C");
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
         0usize,
-        concat!("Offset of field: ", stringify!(C), "::", stringify!(a)),
+        "Offset of field: C::a",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).big_array) as usize - ptr as usize },
         4usize,
-        concat!("Offset of field: ", stringify!(C), "::", stringify!(big_array)),
+        "Offset of field: C::big_array",
     );
 }
 impl Clone for C {
@@ -131,44 +127,29 @@ fn bindgen_test_layout_C_with_zero_length_array() {
     assert_eq!(
         ::std::mem::size_of::<C_with_zero_length_array>(),
         40usize,
-        concat!("Size of: ", stringify!(C_with_zero_length_array)),
+        "Size of C_with_zero_length_array",
     );
     assert_eq!(
         ::std::mem::align_of::<C_with_zero_length_array>(),
         4usize,
-        concat!("Alignment of ", stringify!(C_with_zero_length_array)),
+        "Alignment of C_with_zero_length_array",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
         0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C_with_zero_length_array),
-            "::",
-            stringify!(a),
-        ),
+        "Offset of field: C_with_zero_length_array::a",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).big_array) as usize - ptr as usize },
         4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C_with_zero_length_array),
-            "::",
-            stringify!(big_array),
-        ),
+        "Offset of field: C_with_zero_length_array::big_array",
     );
     assert_eq!(
         unsafe {
             ::std::ptr::addr_of!((*ptr).zero_length_array) as usize - ptr as usize
         },
         37usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C_with_zero_length_array),
-            "::",
-            stringify!(zero_length_array),
-        ),
+        "Offset of field: C_with_zero_length_array::zero_length_array",
     );
 }
 impl Default for C_with_zero_length_array {
@@ -193,34 +174,24 @@ fn bindgen_test_layout_C_with_zero_length_array_2() {
     assert_eq!(
         ::std::mem::size_of::<C_with_zero_length_array_2>(),
         4usize,
-        concat!("Size of: ", stringify!(C_with_zero_length_array_2)),
+        "Size of C_with_zero_length_array_2",
     );
     assert_eq!(
         ::std::mem::align_of::<C_with_zero_length_array_2>(),
         4usize,
-        concat!("Alignment of ", stringify!(C_with_zero_length_array_2)),
+        "Alignment of C_with_zero_length_array_2",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
         0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C_with_zero_length_array_2),
-            "::",
-            stringify!(a),
-        ),
+        "Offset of field: C_with_zero_length_array_2::a",
     );
     assert_eq!(
         unsafe {
             ::std::ptr::addr_of!((*ptr).zero_length_array) as usize - ptr as usize
         },
         4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C_with_zero_length_array_2),
-            "::",
-            stringify!(zero_length_array),
-        ),
+        "Offset of field: C_with_zero_length_array_2::zero_length_array",
     );
 }
 #[repr(C)]
@@ -236,42 +207,27 @@ fn bindgen_test_layout_C_with_incomplete_array() {
     assert_eq!(
         ::std::mem::size_of::<C_with_incomplete_array>(),
         40usize,
-        concat!("Size of: ", stringify!(C_with_incomplete_array)),
+        "Size of C_with_incomplete_array",
     );
     assert_eq!(
         ::std::mem::align_of::<C_with_incomplete_array>(),
         4usize,
-        concat!("Alignment of ", stringify!(C_with_incomplete_array)),
+        "Alignment of C_with_incomplete_array",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
         0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C_with_incomplete_array),
-            "::",
-            stringify!(a),
-        ),
+        "Offset of field: C_with_incomplete_array::a",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).big_array) as usize - ptr as usize },
         4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C_with_incomplete_array),
-            "::",
-            stringify!(big_array),
-        ),
+        "Offset of field: C_with_incomplete_array::big_array",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).incomplete_array) as usize - ptr as usize },
         37usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C_with_incomplete_array),
-            "::",
-            stringify!(incomplete_array),
-        ),
+        "Offset of field: C_with_incomplete_array::incomplete_array",
     );
 }
 impl Default for C_with_incomplete_array {
@@ -296,32 +252,22 @@ fn bindgen_test_layout_C_with_incomplete_array_2() {
     assert_eq!(
         ::std::mem::size_of::<C_with_incomplete_array_2>(),
         4usize,
-        concat!("Size of: ", stringify!(C_with_incomplete_array_2)),
+        "Size of C_with_incomplete_array_2",
     );
     assert_eq!(
         ::std::mem::align_of::<C_with_incomplete_array_2>(),
         4usize,
-        concat!("Alignment of ", stringify!(C_with_incomplete_array_2)),
+        "Alignment of C_with_incomplete_array_2",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
         0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C_with_incomplete_array_2),
-            "::",
-            stringify!(a),
-        ),
+        "Offset of field: C_with_incomplete_array_2::a",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).incomplete_array) as usize - ptr as usize },
         4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C_with_incomplete_array_2),
-            "::",
-            stringify!(incomplete_array),
-        ),
+        "Offset of field: C_with_incomplete_array_2::incomplete_array",
     );
 }
 #[repr(C)]
@@ -340,57 +286,34 @@ fn bindgen_test_layout_C_with_zero_length_array_and_incomplete_array() {
     assert_eq!(
         ::std::mem::size_of::<C_with_zero_length_array_and_incomplete_array>(),
         40usize,
-        concat!("Size of: ", stringify!(C_with_zero_length_array_and_incomplete_array)),
+        "Size of C_with_zero_length_array_and_incomplete_array",
     );
     assert_eq!(
         ::std::mem::align_of::<C_with_zero_length_array_and_incomplete_array>(),
         4usize,
-        concat!(
-            "Alignment of ",
-            stringify!(C_with_zero_length_array_and_incomplete_array),
-        ),
+        "Alignment of C_with_zero_length_array_and_incomplete_array",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
         0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C_with_zero_length_array_and_incomplete_array),
-            "::",
-            stringify!(a),
-        ),
+        "Offset of field: C_with_zero_length_array_and_incomplete_array::a",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).big_array) as usize - ptr as usize },
         4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C_with_zero_length_array_and_incomplete_array),
-            "::",
-            stringify!(big_array),
-        ),
+        "Offset of field: C_with_zero_length_array_and_incomplete_array::big_array",
     );
     assert_eq!(
         unsafe {
             ::std::ptr::addr_of!((*ptr).zero_length_array) as usize - ptr as usize
         },
         37usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C_with_zero_length_array_and_incomplete_array),
-            "::",
-            stringify!(zero_length_array),
-        ),
+        "Offset of field: C_with_zero_length_array_and_incomplete_array::zero_length_array",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).incomplete_array) as usize - ptr as usize },
         37usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C_with_zero_length_array_and_incomplete_array),
-            "::",
-            stringify!(incomplete_array),
-        ),
+        "Offset of field: C_with_zero_length_array_and_incomplete_array::incomplete_array",
     );
 }
 impl Default for C_with_zero_length_array_and_incomplete_array {
@@ -418,47 +341,29 @@ fn bindgen_test_layout_C_with_zero_length_array_and_incomplete_array_2() {
     assert_eq!(
         ::std::mem::size_of::<C_with_zero_length_array_and_incomplete_array_2>(),
         4usize,
-        concat!("Size of: ", stringify!(C_with_zero_length_array_and_incomplete_array_2)),
+        "Size of C_with_zero_length_array_and_incomplete_array_2",
     );
     assert_eq!(
         ::std::mem::align_of::<C_with_zero_length_array_and_incomplete_array_2>(),
         4usize,
-        concat!(
-            "Alignment of ",
-            stringify!(C_with_zero_length_array_and_incomplete_array_2),
-        ),
+        "Alignment of C_with_zero_length_array_and_incomplete_array_2",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
         0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C_with_zero_length_array_and_incomplete_array_2),
-            "::",
-            stringify!(a),
-        ),
+        "Offset of field: C_with_zero_length_array_and_incomplete_array_2::a",
     );
     assert_eq!(
         unsafe {
             ::std::ptr::addr_of!((*ptr).zero_length_array) as usize - ptr as usize
         },
         4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C_with_zero_length_array_and_incomplete_array_2),
-            "::",
-            stringify!(zero_length_array),
-        ),
+        "Offset of field: C_with_zero_length_array_and_incomplete_array_2::zero_length_array",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).incomplete_array) as usize - ptr as usize },
         4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C_with_zero_length_array_and_incomplete_array_2),
-            "::",
-            stringify!(incomplete_array),
-        ),
+        "Offset of field: C_with_zero_length_array_and_incomplete_array_2::incomplete_array",
     );
 }
 #[repr(C)]
@@ -470,20 +375,12 @@ pub struct WithDtor {
 fn bindgen_test_layout_WithDtor() {
     const UNINIT: ::std::mem::MaybeUninit<WithDtor> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<WithDtor>(),
-        4usize,
-        concat!("Size of: ", stringify!(WithDtor)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<WithDtor>(),
-        4usize,
-        concat!("Alignment of ", stringify!(WithDtor)),
-    );
+    assert_eq!(::std::mem::size_of::<WithDtor>(), 4usize, "Size of WithDtor");
+    assert_eq!(::std::mem::align_of::<WithDtor>(), 4usize, "Alignment of WithDtor");
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
         0usize,
-        concat!("Offset of field: ", stringify!(WithDtor), "::", stringify!(b)),
+        "Offset of field: WithDtor::b",
     );
 }
 #[repr(C)]
@@ -498,32 +395,22 @@ fn bindgen_test_layout_IncompleteArrayNonCopiable() {
     assert_eq!(
         ::std::mem::size_of::<IncompleteArrayNonCopiable>(),
         8usize,
-        concat!("Size of: ", stringify!(IncompleteArrayNonCopiable)),
+        "Size of IncompleteArrayNonCopiable",
     );
     assert_eq!(
         ::std::mem::align_of::<IncompleteArrayNonCopiable>(),
         8usize,
-        concat!("Alignment of ", stringify!(IncompleteArrayNonCopiable)),
+        "Alignment of IncompleteArrayNonCopiable",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).whatever) as usize - ptr as usize },
         0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(IncompleteArrayNonCopiable),
-            "::",
-            stringify!(whatever),
-        ),
+        "Offset of field: IncompleteArrayNonCopiable::whatever",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).incomplete_array) as usize - ptr as usize },
         8usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(IncompleteArrayNonCopiable),
-            "::",
-            stringify!(incomplete_array),
-        ),
+        "Offset of field: IncompleteArrayNonCopiable::incomplete_array",
     );
 }
 impl Default for IncompleteArrayNonCopiable {
@@ -546,25 +433,17 @@ pub struct Union {
 fn bindgen_test_layout_Union() {
     const UNINIT: ::std::mem::MaybeUninit<Union> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<Union>(),
-        4usize,
-        concat!("Size of: ", stringify!(Union)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Union>(),
-        4usize,
-        concat!("Alignment of ", stringify!(Union)),
-    );
+    assert_eq!(::std::mem::size_of::<Union>(), 4usize, "Size of Union");
+    assert_eq!(::std::mem::align_of::<Union>(), 4usize, "Alignment of Union");
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize },
         0usize,
-        concat!("Offset of field: ", stringify!(Union), "::", stringify!(d)),
+        "Offset of field: Union::d",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).i) as usize - ptr as usize },
         0usize,
-        concat!("Offset of field: ", stringify!(Union), "::", stringify!(i)),
+        "Offset of field: Union::i",
     );
 }
 impl Clone for Union {
@@ -581,20 +460,12 @@ pub struct WithUnion {
 fn bindgen_test_layout_WithUnion() {
     const UNINIT: ::std::mem::MaybeUninit<WithUnion> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<WithUnion>(),
-        4usize,
-        concat!("Size of: ", stringify!(WithUnion)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<WithUnion>(),
-        4usize,
-        concat!("Alignment of ", stringify!(WithUnion)),
-    );
+    assert_eq!(::std::mem::size_of::<WithUnion>(), 4usize, "Size of WithUnion");
+    assert_eq!(::std::mem::align_of::<WithUnion>(), 4usize, "Alignment of WithUnion");
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).data) as usize - ptr as usize },
         0usize,
-        concat!("Offset of field: ", stringify!(WithUnion), "::", stringify!(data)),
+        "Offset of field: WithUnion::data",
     );
 }
 impl Clone for WithUnion {
@@ -612,12 +483,12 @@ fn bindgen_test_layout_RealAbstractionWithTonsOfMethods() {
     assert_eq!(
         ::std::mem::size_of::<RealAbstractionWithTonsOfMethods>(),
         1usize,
-        concat!("Size of: ", stringify!(RealAbstractionWithTonsOfMethods)),
+        "Size of RealAbstractionWithTonsOfMethods",
     );
     assert_eq!(
         ::std::mem::align_of::<RealAbstractionWithTonsOfMethods>(),
         1usize,
-        concat!("Alignment of ", stringify!(RealAbstractionWithTonsOfMethods)),
+        "Alignment of RealAbstractionWithTonsOfMethods",
     );
 }
 extern "C" {

--- a/bindgen-tests/tests/expectations/tests/class_nested.rs
+++ b/bindgen-tests/tests/expectations/tests/class_nested.rs
@@ -9,26 +9,11 @@ pub struct A {
 pub struct A_B {
     pub member_b: ::std::os::raw::c_int,
 }
-#[test]
-fn bindgen_test_layout_A_B() {
-    const UNINIT: ::std::mem::MaybeUninit<A_B> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<A_B>(),
-        4usize,
-        concat!("Size of: ", stringify!(A_B)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<A_B>(),
-        4usize,
-        concat!("Alignment of ", stringify!(A_B)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).member_b) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(A_B), "::", stringify!(member_b)),
-    );
-}
+const _: () = {
+    ["Size of A_B"][::std::mem::size_of::<A_B>() - 4usize];
+    ["Alignment of A_B"][::std::mem::align_of::<A_B>() - 4usize];
+    ["Offset of field: A_B::member_b"][::std::mem::offset_of!(A_B, member_b) - 0usize];
+};
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct A_D<T> {
@@ -44,69 +29,32 @@ impl<T> Default for A_D<T> {
         }
     }
 }
-#[test]
-fn bindgen_test_layout_A() {
-    const UNINIT: ::std::mem::MaybeUninit<A> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(::std::mem::size_of::<A>(), 4usize, concat!("Size of: ", stringify!(A)));
-    assert_eq!(
-        ::std::mem::align_of::<A>(),
-        4usize,
-        concat!("Alignment of ", stringify!(A)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).member_a) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(A), "::", stringify!(member_a)),
-    );
-}
+const _: () = {
+    ["Size of A"][::std::mem::size_of::<A>() - 4usize];
+    ["Alignment of A"][::std::mem::align_of::<A>() - 4usize];
+    ["Offset of field: A::member_a"][::std::mem::offset_of!(A, member_a) - 0usize];
+};
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct A_C {
     pub baz: ::std::os::raw::c_int,
 }
-#[test]
-fn bindgen_test_layout_A_C() {
-    const UNINIT: ::std::mem::MaybeUninit<A_C> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<A_C>(),
-        4usize,
-        concat!("Size of: ", stringify!(A_C)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<A_C>(),
-        4usize,
-        concat!("Alignment of ", stringify!(A_C)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(A_C), "::", stringify!(baz)),
-    );
-}
+const _: () = {
+    ["Size of A_C"][::std::mem::size_of::<A_C>() - 4usize];
+    ["Alignment of A_C"][::std::mem::align_of::<A_C>() - 4usize];
+    ["Offset of field: A_C::baz"][::std::mem::offset_of!(A_C, baz) - 0usize];
+};
 extern "C" {
     pub static mut var: A_B;
 }
-#[test]
-fn __bindgen_test_layout_A_D_open0_int_close0_instantiation() {
-    assert_eq!(
-        ::std::mem::size_of::<A_D<::std::os::raw::c_int>>(),
-        4usize,
-        concat!(
-            "Size of template specialization: ",
-            stringify!(A_D < ::std::os::raw::c_int >),
-        ),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<A_D<::std::os::raw::c_int>>(),
-        4usize,
-        concat!(
-            "Alignment of template specialization: ",
-            stringify!(A_D < ::std::os::raw::c_int >),
-        ),
-    );
-}
+const _: () = {
+    [
+        "Size of template specialization: A_D_open0_int_close0",
+    ][::std::mem::size_of::<A_D<::std::os::raw::c_int>>() - 4usize];
+    [
+        "Align of template specialization: A_D_open0_int_close0",
+    ][::std::mem::align_of::<A_D<::std::os::raw::c_int>>() - 4usize];
+};
 extern "C" {
     pub static mut baz: A_D<::std::os::raw::c_int>;
 }
@@ -115,22 +63,11 @@ extern "C" {
 pub struct D {
     pub member: A_B,
 }
-#[test]
-fn bindgen_test_layout_D() {
-    const UNINIT: ::std::mem::MaybeUninit<D> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(::std::mem::size_of::<D>(), 4usize, concat!("Size of: ", stringify!(D)));
-    assert_eq!(
-        ::std::mem::align_of::<D>(),
-        4usize,
-        concat!("Alignment of ", stringify!(D)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).member) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(D), "::", stringify!(member)),
-    );
-}
+const _: () = {
+    ["Size of D"][::std::mem::size_of::<D>() - 4usize];
+    ["Alignment of D"][::std::mem::align_of::<D>() - 4usize];
+    ["Offset of field: D::member"][::std::mem::offset_of!(D, member) - 0usize];
+};
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct Templated<T> {

--- a/bindgen-tests/tests/expectations/tests/class_no_members.rs
+++ b/bindgen-tests/tests/expectations/tests/class_no_members.rs
@@ -4,64 +4,32 @@
 pub struct whatever {
     pub _address: u8,
 }
-#[test]
-fn bindgen_test_layout_whatever() {
-    assert_eq!(
-        ::std::mem::size_of::<whatever>(),
-        1usize,
-        concat!("Size of: ", stringify!(whatever)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<whatever>(),
-        1usize,
-        concat!("Alignment of ", stringify!(whatever)),
-    );
-}
+const _: () = {
+    ["Size of whatever"][::std::mem::size_of::<whatever>() - 1usize];
+    ["Alignment of whatever"][::std::mem::align_of::<whatever>() - 1usize];
+};
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct whatever_child {
     pub _address: u8,
 }
-#[test]
-fn bindgen_test_layout_whatever_child() {
-    assert_eq!(
-        ::std::mem::size_of::<whatever_child>(),
-        1usize,
-        concat!("Size of: ", stringify!(whatever_child)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<whatever_child>(),
-        1usize,
-        concat!("Alignment of ", stringify!(whatever_child)),
-    );
-}
+const _: () = {
+    ["Size of whatever_child"][::std::mem::size_of::<whatever_child>() - 1usize];
+    ["Alignment of whatever_child"][::std::mem::align_of::<whatever_child>() - 1usize];
+};
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct whatever_child_with_member {
     pub m_member: ::std::os::raw::c_int,
 }
-#[test]
-fn bindgen_test_layout_whatever_child_with_member() {
-    const UNINIT: ::std::mem::MaybeUninit<whatever_child_with_member> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<whatever_child_with_member>(),
-        4usize,
-        concat!("Size of: ", stringify!(whatever_child_with_member)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<whatever_child_with_member>(),
-        4usize,
-        concat!("Alignment of ", stringify!(whatever_child_with_member)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).m_member) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(whatever_child_with_member),
-            "::",
-            stringify!(m_member),
-        ),
-    );
-}
+const _: () = {
+    [
+        "Size of whatever_child_with_member",
+    ][::std::mem::size_of::<whatever_child_with_member>() - 4usize];
+    [
+        "Alignment of whatever_child_with_member",
+    ][::std::mem::align_of::<whatever_child_with_member>() - 4usize];
+    [
+        "Offset of field: whatever_child_with_member::m_member",
+    ][::std::mem::offset_of!(whatever_child_with_member, m_member) - 0usize];
+};

--- a/bindgen-tests/tests/expectations/tests/class_static.rs
+++ b/bindgen-tests/tests/expectations/tests/class_static.rs
@@ -12,19 +12,10 @@ extern "C" {
     #[link_name = "\u{1}_ZN7MyClass26example_check_no_collisionE"]
     pub static mut MyClass_example_check_no_collision: *const ::std::os::raw::c_int;
 }
-#[test]
-fn bindgen_test_layout_MyClass() {
-    assert_eq!(
-        ::std::mem::size_of::<MyClass>(),
-        1usize,
-        concat!("Size of: ", stringify!(MyClass)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<MyClass>(),
-        1usize,
-        concat!("Alignment of ", stringify!(MyClass)),
-    );
-}
+const _: () = {
+    ["Size of MyClass"][::std::mem::size_of::<MyClass>() - 1usize];
+    ["Alignment of MyClass"][::std::mem::align_of::<MyClass>() - 1usize];
+};
 extern "C" {
     #[link_name = "\u{1}_ZL26example_check_no_collision"]
     pub static mut example_check_no_collision: *const ::std::os::raw::c_int;

--- a/bindgen-tests/tests/expectations/tests/class_static_const.rs
+++ b/bindgen-tests/tests/expectations/tests/class_static_const.rs
@@ -7,12 +7,7 @@ pub struct A {
 pub const A_a: ::std::os::raw::c_int = 0;
 pub const A_b: i32 = 63;
 pub const A_c: u32 = 255;
-#[test]
-fn bindgen_test_layout_A() {
-    assert_eq!(::std::mem::size_of::<A>(), 1usize, concat!("Size of: ", stringify!(A)));
-    assert_eq!(
-        ::std::mem::align_of::<A>(),
-        1usize,
-        concat!("Alignment of ", stringify!(A)),
-    );
-}
+const _: () = {
+    ["Size of A"][::std::mem::size_of::<A>() - 1usize];
+    ["Alignment of A"][::std::mem::align_of::<A>() - 1usize];
+};

--- a/bindgen-tests/tests/expectations/tests/class_use_as.rs
+++ b/bindgen-tests/tests/expectations/tests/class_use_as.rs
@@ -5,48 +5,20 @@
 pub struct whatever {
     pub replacement: ::std::os::raw::c_int,
 }
-#[test]
-fn bindgen_test_layout_whatever() {
-    const UNINIT: ::std::mem::MaybeUninit<whatever> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<whatever>(),
-        4usize,
-        concat!("Size of: ", stringify!(whatever)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<whatever>(),
-        4usize,
-        concat!("Alignment of ", stringify!(whatever)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).replacement) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(whatever), "::", stringify!(replacement)),
-    );
-}
+const _: () = {
+    ["Size of whatever"][::std::mem::size_of::<whatever>() - 4usize];
+    ["Alignment of whatever"][::std::mem::align_of::<whatever>() - 4usize];
+    [
+        "Offset of field: whatever::replacement",
+    ][::std::mem::offset_of!(whatever, replacement) - 0usize];
+};
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct container {
     pub c: whatever,
 }
-#[test]
-fn bindgen_test_layout_container() {
-    const UNINIT: ::std::mem::MaybeUninit<container> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<container>(),
-        4usize,
-        concat!("Size of: ", stringify!(container)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<container>(),
-        4usize,
-        concat!("Alignment of ", stringify!(container)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).c) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(container), "::", stringify!(c)),
-    );
-}
+const _: () = {
+    ["Size of container"][::std::mem::size_of::<container>() - 4usize];
+    ["Alignment of container"][::std::mem::align_of::<container>() - 4usize];
+    ["Offset of field: container::c"][::std::mem::offset_of!(container, c) - 0usize];
+};

--- a/bindgen-tests/tests/expectations/tests/class_with_dtor.rs
+++ b/bindgen-tests/tests/expectations/tests/class_with_dtor.rs
@@ -20,31 +20,13 @@ pub type HandleValue = HandleWithDtor<::std::os::raw::c_int>;
 pub struct WithoutDtor {
     pub shouldBeWithDtor: HandleValue,
 }
-#[test]
-fn bindgen_test_layout_WithoutDtor() {
-    const UNINIT: ::std::mem::MaybeUninit<WithoutDtor> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<WithoutDtor>(),
-        8usize,
-        concat!("Size of: ", stringify!(WithoutDtor)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<WithoutDtor>(),
-        8usize,
-        concat!("Alignment of ", stringify!(WithoutDtor)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).shouldBeWithDtor) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(WithoutDtor),
-            "::",
-            stringify!(shouldBeWithDtor),
-        ),
-    );
-}
+const _: () = {
+    ["Size of WithoutDtor"][::std::mem::size_of::<WithoutDtor>() - 8usize];
+    ["Alignment of WithoutDtor"][::std::mem::align_of::<WithoutDtor>() - 8usize];
+    [
+        "Offset of field: WithoutDtor::shouldBeWithDtor",
+    ][::std::mem::offset_of!(WithoutDtor, shouldBeWithDtor) - 0usize];
+};
 impl Default for WithoutDtor {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
@@ -54,22 +36,11 @@ impl Default for WithoutDtor {
         }
     }
 }
-#[test]
-fn __bindgen_test_layout_HandleWithDtor_open0_int_close0_instantiation() {
-    assert_eq!(
-        ::std::mem::size_of::<HandleWithDtor<::std::os::raw::c_int>>(),
-        8usize,
-        concat!(
-            "Size of template specialization: ",
-            stringify!(HandleWithDtor < ::std::os::raw::c_int >),
-        ),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<HandleWithDtor<::std::os::raw::c_int>>(),
-        8usize,
-        concat!(
-            "Alignment of template specialization: ",
-            stringify!(HandleWithDtor < ::std::os::raw::c_int >),
-        ),
-    );
-}
+const _: () = {
+    [
+        "Size of template specialization: HandleWithDtor_open0_int_close0",
+    ][::std::mem::size_of::<HandleWithDtor<::std::os::raw::c_int>>() - 8usize];
+    [
+        "Align of template specialization: HandleWithDtor_open0_int_close0",
+    ][::std::mem::align_of::<HandleWithDtor<::std::os::raw::c_int>>() - 8usize];
+};

--- a/bindgen-tests/tests/expectations/tests/class_with_inner_struct.rs
+++ b/bindgen-tests/tests/expectations/tests/class_with_inner_struct.rs
@@ -12,56 +12,26 @@ pub struct A_Segment {
     pub begin: ::std::os::raw::c_int,
     pub end: ::std::os::raw::c_int,
 }
-#[test]
-fn bindgen_test_layout_A_Segment() {
-    const UNINIT: ::std::mem::MaybeUninit<A_Segment> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<A_Segment>(),
-        8usize,
-        concat!("Size of: ", stringify!(A_Segment)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<A_Segment>(),
-        4usize,
-        concat!("Alignment of ", stringify!(A_Segment)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).begin) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(A_Segment), "::", stringify!(begin)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).end) as usize - ptr as usize },
-        4usize,
-        concat!("Offset of field: ", stringify!(A_Segment), "::", stringify!(end)),
-    );
-}
+const _: () = {
+    ["Size of A_Segment"][::std::mem::size_of::<A_Segment>() - 8usize];
+    ["Alignment of A_Segment"][::std::mem::align_of::<A_Segment>() - 4usize];
+    [
+        "Offset of field: A_Segment::begin",
+    ][::std::mem::offset_of!(A_Segment, begin) - 0usize];
+    ["Offset of field: A_Segment::end"][::std::mem::offset_of!(A_Segment, end) - 4usize];
+};
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union A__bindgen_ty_1 {
     pub f: ::std::os::raw::c_int,
 }
-#[test]
-fn bindgen_test_layout_A__bindgen_ty_1() {
-    const UNINIT: ::std::mem::MaybeUninit<A__bindgen_ty_1> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<A__bindgen_ty_1>(),
-        4usize,
-        concat!("Size of: ", stringify!(A__bindgen_ty_1)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<A__bindgen_ty_1>(),
-        4usize,
-        concat!("Alignment of ", stringify!(A__bindgen_ty_1)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).f) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(A__bindgen_ty_1), "::", stringify!(f)),
-    );
-}
+const _: () = {
+    ["Size of A__bindgen_ty_1"][::std::mem::size_of::<A__bindgen_ty_1>() - 4usize];
+    ["Alignment of A__bindgen_ty_1"][::std::mem::align_of::<A__bindgen_ty_1>() - 4usize];
+    [
+        "Offset of field: A__bindgen_ty_1::f",
+    ][::std::mem::offset_of!(A__bindgen_ty_1, f) - 0usize];
+};
 impl Default for A__bindgen_ty_1 {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
@@ -76,26 +46,13 @@ impl Default for A__bindgen_ty_1 {
 pub union A__bindgen_ty_2 {
     pub d: ::std::os::raw::c_int,
 }
-#[test]
-fn bindgen_test_layout_A__bindgen_ty_2() {
-    const UNINIT: ::std::mem::MaybeUninit<A__bindgen_ty_2> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<A__bindgen_ty_2>(),
-        4usize,
-        concat!("Size of: ", stringify!(A__bindgen_ty_2)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<A__bindgen_ty_2>(),
-        4usize,
-        concat!("Alignment of ", stringify!(A__bindgen_ty_2)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(A__bindgen_ty_2), "::", stringify!(d)),
-    );
-}
+const _: () = {
+    ["Size of A__bindgen_ty_2"][::std::mem::size_of::<A__bindgen_ty_2>() - 4usize];
+    ["Alignment of A__bindgen_ty_2"][::std::mem::align_of::<A__bindgen_ty_2>() - 4usize];
+    [
+        "Offset of field: A__bindgen_ty_2::d",
+    ][::std::mem::offset_of!(A__bindgen_ty_2, d) - 0usize];
+};
 impl Default for A__bindgen_ty_2 {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
@@ -105,27 +62,12 @@ impl Default for A__bindgen_ty_2 {
         }
     }
 }
-#[test]
-fn bindgen_test_layout_A() {
-    const UNINIT: ::std::mem::MaybeUninit<A> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(::std::mem::size_of::<A>(), 12usize, concat!("Size of: ", stringify!(A)));
-    assert_eq!(
-        ::std::mem::align_of::<A>(),
-        4usize,
-        concat!("Alignment of ", stringify!(A)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).c) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(A), "::", stringify!(c)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).named_union) as usize - ptr as usize },
-        4usize,
-        concat!("Offset of field: ", stringify!(A), "::", stringify!(named_union)),
-    );
-}
+const _: () = {
+    ["Size of A"][::std::mem::size_of::<A>() - 12usize];
+    ["Alignment of A"][::std::mem::align_of::<A>() - 4usize];
+    ["Offset of field: A::c"][::std::mem::offset_of!(A, c) - 0usize];
+    ["Offset of field: A::named_union"][::std::mem::offset_of!(A, named_union) - 4usize];
+};
 impl Default for A {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
@@ -146,47 +88,19 @@ pub struct B_Segment {
     pub begin: ::std::os::raw::c_int,
     pub end: ::std::os::raw::c_int,
 }
-#[test]
-fn bindgen_test_layout_B_Segment() {
-    const UNINIT: ::std::mem::MaybeUninit<B_Segment> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<B_Segment>(),
-        8usize,
-        concat!("Size of: ", stringify!(B_Segment)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<B_Segment>(),
-        4usize,
-        concat!("Alignment of ", stringify!(B_Segment)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).begin) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(B_Segment), "::", stringify!(begin)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).end) as usize - ptr as usize },
-        4usize,
-        concat!("Offset of field: ", stringify!(B_Segment), "::", stringify!(end)),
-    );
-}
-#[test]
-fn bindgen_test_layout_B() {
-    const UNINIT: ::std::mem::MaybeUninit<B> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(::std::mem::size_of::<B>(), 4usize, concat!("Size of: ", stringify!(B)));
-    assert_eq!(
-        ::std::mem::align_of::<B>(),
-        4usize,
-        concat!("Alignment of ", stringify!(B)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(B), "::", stringify!(d)),
-    );
-}
+const _: () = {
+    ["Size of B_Segment"][::std::mem::size_of::<B_Segment>() - 8usize];
+    ["Alignment of B_Segment"][::std::mem::align_of::<B_Segment>() - 4usize];
+    [
+        "Offset of field: B_Segment::begin",
+    ][::std::mem::offset_of!(B_Segment, begin) - 0usize];
+    ["Offset of field: B_Segment::end"][::std::mem::offset_of!(B_Segment, end) - 4usize];
+};
+const _: () = {
+    ["Size of B"][::std::mem::size_of::<B>() - 4usize];
+    ["Alignment of B"][::std::mem::align_of::<B>() - 4usize];
+    ["Offset of field: B::d"][::std::mem::offset_of!(B, d) - 0usize];
+};
 #[repr(i32)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum StepSyntax {
@@ -215,102 +129,46 @@ pub struct C__bindgen_ty_1__bindgen_ty_1 {
     pub mX2: f32,
     pub mY2: f32,
 }
-#[test]
-fn bindgen_test_layout_C__bindgen_ty_1__bindgen_ty_1() {
-    const UNINIT: ::std::mem::MaybeUninit<C__bindgen_ty_1__bindgen_ty_1> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<C__bindgen_ty_1__bindgen_ty_1>(),
-        16usize,
-        concat!("Size of: ", stringify!(C__bindgen_ty_1__bindgen_ty_1)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<C__bindgen_ty_1__bindgen_ty_1>(),
-        4usize,
-        concat!("Alignment of ", stringify!(C__bindgen_ty_1__bindgen_ty_1)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).mX1) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C__bindgen_ty_1__bindgen_ty_1),
-            "::",
-            stringify!(mX1),
-        ),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).mY1) as usize - ptr as usize },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C__bindgen_ty_1__bindgen_ty_1),
-            "::",
-            stringify!(mY1),
-        ),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).mX2) as usize - ptr as usize },
-        8usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C__bindgen_ty_1__bindgen_ty_1),
-            "::",
-            stringify!(mX2),
-        ),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).mY2) as usize - ptr as usize },
-        12usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C__bindgen_ty_1__bindgen_ty_1),
-            "::",
-            stringify!(mY2),
-        ),
-    );
-}
+const _: () = {
+    [
+        "Size of C__bindgen_ty_1__bindgen_ty_1",
+    ][::std::mem::size_of::<C__bindgen_ty_1__bindgen_ty_1>() - 16usize];
+    [
+        "Alignment of C__bindgen_ty_1__bindgen_ty_1",
+    ][::std::mem::align_of::<C__bindgen_ty_1__bindgen_ty_1>() - 4usize];
+    [
+        "Offset of field: C__bindgen_ty_1__bindgen_ty_1::mX1",
+    ][::std::mem::offset_of!(C__bindgen_ty_1__bindgen_ty_1, mX1) - 0usize];
+    [
+        "Offset of field: C__bindgen_ty_1__bindgen_ty_1::mY1",
+    ][::std::mem::offset_of!(C__bindgen_ty_1__bindgen_ty_1, mY1) - 4usize];
+    [
+        "Offset of field: C__bindgen_ty_1__bindgen_ty_1::mX2",
+    ][::std::mem::offset_of!(C__bindgen_ty_1__bindgen_ty_1, mX2) - 8usize];
+    [
+        "Offset of field: C__bindgen_ty_1__bindgen_ty_1::mY2",
+    ][::std::mem::offset_of!(C__bindgen_ty_1__bindgen_ty_1, mY2) - 12usize];
+};
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct C__bindgen_ty_1__bindgen_ty_2 {
     pub mStepSyntax: StepSyntax,
     pub mSteps: ::std::os::raw::c_uint,
 }
-#[test]
-fn bindgen_test_layout_C__bindgen_ty_1__bindgen_ty_2() {
-    const UNINIT: ::std::mem::MaybeUninit<C__bindgen_ty_1__bindgen_ty_2> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<C__bindgen_ty_1__bindgen_ty_2>(),
-        8usize,
-        concat!("Size of: ", stringify!(C__bindgen_ty_1__bindgen_ty_2)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<C__bindgen_ty_1__bindgen_ty_2>(),
-        4usize,
-        concat!("Alignment of ", stringify!(C__bindgen_ty_1__bindgen_ty_2)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).mStepSyntax) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C__bindgen_ty_1__bindgen_ty_2),
-            "::",
-            stringify!(mStepSyntax),
-        ),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).mSteps) as usize - ptr as usize },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C__bindgen_ty_1__bindgen_ty_2),
-            "::",
-            stringify!(mSteps),
-        ),
-    );
-}
+const _: () = {
+    [
+        "Size of C__bindgen_ty_1__bindgen_ty_2",
+    ][::std::mem::size_of::<C__bindgen_ty_1__bindgen_ty_2>() - 8usize];
+    [
+        "Alignment of C__bindgen_ty_1__bindgen_ty_2",
+    ][::std::mem::align_of::<C__bindgen_ty_1__bindgen_ty_2>() - 4usize];
+    [
+        "Offset of field: C__bindgen_ty_1__bindgen_ty_2::mStepSyntax",
+    ][::std::mem::offset_of!(C__bindgen_ty_1__bindgen_ty_2, mStepSyntax) - 0usize];
+    [
+        "Offset of field: C__bindgen_ty_1__bindgen_ty_2::mSteps",
+    ][::std::mem::offset_of!(C__bindgen_ty_1__bindgen_ty_2, mSteps) - 4usize];
+};
 impl Default for C__bindgen_ty_1__bindgen_ty_2 {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
@@ -320,31 +178,13 @@ impl Default for C__bindgen_ty_1__bindgen_ty_2 {
         }
     }
 }
-#[test]
-fn bindgen_test_layout_C__bindgen_ty_1() {
-    const UNINIT: ::std::mem::MaybeUninit<C__bindgen_ty_1> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<C__bindgen_ty_1>(),
-        16usize,
-        concat!("Size of: ", stringify!(C__bindgen_ty_1)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<C__bindgen_ty_1>(),
-        4usize,
-        concat!("Alignment of ", stringify!(C__bindgen_ty_1)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).mFunc) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C__bindgen_ty_1),
-            "::",
-            stringify!(mFunc),
-        ),
-    );
-}
+const _: () = {
+    ["Size of C__bindgen_ty_1"][::std::mem::size_of::<C__bindgen_ty_1>() - 16usize];
+    ["Alignment of C__bindgen_ty_1"][::std::mem::align_of::<C__bindgen_ty_1>() - 4usize];
+    [
+        "Offset of field: C__bindgen_ty_1::mFunc",
+    ][::std::mem::offset_of!(C__bindgen_ty_1, mFunc) - 0usize];
+};
 impl Default for C__bindgen_ty_1 {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
@@ -360,47 +200,19 @@ pub struct C_Segment {
     pub begin: ::std::os::raw::c_int,
     pub end: ::std::os::raw::c_int,
 }
-#[test]
-fn bindgen_test_layout_C_Segment() {
-    const UNINIT: ::std::mem::MaybeUninit<C_Segment> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<C_Segment>(),
-        8usize,
-        concat!("Size of: ", stringify!(C_Segment)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<C_Segment>(),
-        4usize,
-        concat!("Alignment of ", stringify!(C_Segment)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).begin) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(C_Segment), "::", stringify!(begin)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).end) as usize - ptr as usize },
-        4usize,
-        concat!("Offset of field: ", stringify!(C_Segment), "::", stringify!(end)),
-    );
-}
-#[test]
-fn bindgen_test_layout_C() {
-    const UNINIT: ::std::mem::MaybeUninit<C> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(::std::mem::size_of::<C>(), 20usize, concat!("Size of: ", stringify!(C)));
-    assert_eq!(
-        ::std::mem::align_of::<C>(),
-        4usize,
-        concat!("Alignment of ", stringify!(C)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(C), "::", stringify!(d)),
-    );
-}
+const _: () = {
+    ["Size of C_Segment"][::std::mem::size_of::<C_Segment>() - 8usize];
+    ["Alignment of C_Segment"][::std::mem::align_of::<C_Segment>() - 4usize];
+    [
+        "Offset of field: C_Segment::begin",
+    ][::std::mem::offset_of!(C_Segment, begin) - 0usize];
+    ["Offset of field: C_Segment::end"][::std::mem::offset_of!(C_Segment, end) - 4usize];
+};
+const _: () = {
+    ["Size of C"][::std::mem::size_of::<C>() - 20usize];
+    ["Alignment of C"][::std::mem::align_of::<C>() - 4usize];
+    ["Offset of field: C::d"][::std::mem::offset_of!(C, d) - 0usize];
+};
 impl Default for C {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();

--- a/bindgen-tests/tests/expectations/tests/class_with_inner_struct_1_0.rs
+++ b/bindgen-tests/tests/expectations/tests/class_with_inner_struct_1_0.rs
@@ -59,25 +59,17 @@ pub struct A_Segment {
 fn bindgen_test_layout_A_Segment() {
     const UNINIT: ::std::mem::MaybeUninit<A_Segment> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<A_Segment>(),
-        8usize,
-        concat!("Size of: ", stringify!(A_Segment)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<A_Segment>(),
-        4usize,
-        concat!("Alignment of ", stringify!(A_Segment)),
-    );
+    assert_eq!(::std::mem::size_of::<A_Segment>(), 8usize, "Size of A_Segment");
+    assert_eq!(::std::mem::align_of::<A_Segment>(), 4usize, "Alignment of A_Segment");
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).begin) as usize - ptr as usize },
         0usize,
-        concat!("Offset of field: ", stringify!(A_Segment), "::", stringify!(begin)),
+        "Offset of field: A_Segment::begin",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).end) as usize - ptr as usize },
         4usize,
-        concat!("Offset of field: ", stringify!(A_Segment), "::", stringify!(end)),
+        "Offset of field: A_Segment::end",
     );
 }
 impl Clone for A_Segment {
@@ -98,17 +90,17 @@ fn bindgen_test_layout_A__bindgen_ty_1() {
     assert_eq!(
         ::std::mem::size_of::<A__bindgen_ty_1>(),
         4usize,
-        concat!("Size of: ", stringify!(A__bindgen_ty_1)),
+        "Size of A__bindgen_ty_1",
     );
     assert_eq!(
         ::std::mem::align_of::<A__bindgen_ty_1>(),
         4usize,
-        concat!("Alignment of ", stringify!(A__bindgen_ty_1)),
+        "Alignment of A__bindgen_ty_1",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).f) as usize - ptr as usize },
         0usize,
-        concat!("Offset of field: ", stringify!(A__bindgen_ty_1), "::", stringify!(f)),
+        "Offset of field: A__bindgen_ty_1::f",
     );
 }
 impl Clone for A__bindgen_ty_1 {
@@ -129,17 +121,17 @@ fn bindgen_test_layout_A__bindgen_ty_2() {
     assert_eq!(
         ::std::mem::size_of::<A__bindgen_ty_2>(),
         4usize,
-        concat!("Size of: ", stringify!(A__bindgen_ty_2)),
+        "Size of A__bindgen_ty_2",
     );
     assert_eq!(
         ::std::mem::align_of::<A__bindgen_ty_2>(),
         4usize,
-        concat!("Alignment of ", stringify!(A__bindgen_ty_2)),
+        "Alignment of A__bindgen_ty_2",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize },
         0usize,
-        concat!("Offset of field: ", stringify!(A__bindgen_ty_2), "::", stringify!(d)),
+        "Offset of field: A__bindgen_ty_2::d",
     );
 }
 impl Clone for A__bindgen_ty_2 {
@@ -151,21 +143,17 @@ impl Clone for A__bindgen_ty_2 {
 fn bindgen_test_layout_A() {
     const UNINIT: ::std::mem::MaybeUninit<A> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
-    assert_eq!(::std::mem::size_of::<A>(), 12usize, concat!("Size of: ", stringify!(A)));
-    assert_eq!(
-        ::std::mem::align_of::<A>(),
-        4usize,
-        concat!("Alignment of ", stringify!(A)),
-    );
+    assert_eq!(::std::mem::size_of::<A>(), 12usize, "Size of A");
+    assert_eq!(::std::mem::align_of::<A>(), 4usize, "Alignment of A");
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).c) as usize - ptr as usize },
         0usize,
-        concat!("Offset of field: ", stringify!(A), "::", stringify!(c)),
+        "Offset of field: A::c",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).named_union) as usize - ptr as usize },
         4usize,
-        concat!("Offset of field: ", stringify!(A), "::", stringify!(named_union)),
+        "Offset of field: A::named_union",
     );
 }
 impl Clone for A {
@@ -188,25 +176,17 @@ pub struct B_Segment {
 fn bindgen_test_layout_B_Segment() {
     const UNINIT: ::std::mem::MaybeUninit<B_Segment> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<B_Segment>(),
-        8usize,
-        concat!("Size of: ", stringify!(B_Segment)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<B_Segment>(),
-        4usize,
-        concat!("Alignment of ", stringify!(B_Segment)),
-    );
+    assert_eq!(::std::mem::size_of::<B_Segment>(), 8usize, "Size of B_Segment");
+    assert_eq!(::std::mem::align_of::<B_Segment>(), 4usize, "Alignment of B_Segment");
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).begin) as usize - ptr as usize },
         0usize,
-        concat!("Offset of field: ", stringify!(B_Segment), "::", stringify!(begin)),
+        "Offset of field: B_Segment::begin",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).end) as usize - ptr as usize },
         4usize,
-        concat!("Offset of field: ", stringify!(B_Segment), "::", stringify!(end)),
+        "Offset of field: B_Segment::end",
     );
 }
 impl Clone for B_Segment {
@@ -218,16 +198,12 @@ impl Clone for B_Segment {
 fn bindgen_test_layout_B() {
     const UNINIT: ::std::mem::MaybeUninit<B> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
-    assert_eq!(::std::mem::size_of::<B>(), 4usize, concat!("Size of: ", stringify!(B)));
-    assert_eq!(
-        ::std::mem::align_of::<B>(),
-        4usize,
-        concat!("Alignment of ", stringify!(B)),
-    );
+    assert_eq!(::std::mem::size_of::<B>(), 4usize, "Size of B");
+    assert_eq!(::std::mem::align_of::<B>(), 4usize, "Alignment of B");
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize },
         0usize,
-        concat!("Offset of field: ", stringify!(B), "::", stringify!(d)),
+        "Offset of field: B::d",
     );
 }
 impl Clone for B {
@@ -271,52 +247,32 @@ fn bindgen_test_layout_C__bindgen_ty_1__bindgen_ty_1() {
     assert_eq!(
         ::std::mem::size_of::<C__bindgen_ty_1__bindgen_ty_1>(),
         16usize,
-        concat!("Size of: ", stringify!(C__bindgen_ty_1__bindgen_ty_1)),
+        "Size of C__bindgen_ty_1__bindgen_ty_1",
     );
     assert_eq!(
         ::std::mem::align_of::<C__bindgen_ty_1__bindgen_ty_1>(),
         4usize,
-        concat!("Alignment of ", stringify!(C__bindgen_ty_1__bindgen_ty_1)),
+        "Alignment of C__bindgen_ty_1__bindgen_ty_1",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).mX1) as usize - ptr as usize },
         0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C__bindgen_ty_1__bindgen_ty_1),
-            "::",
-            stringify!(mX1),
-        ),
+        "Offset of field: C__bindgen_ty_1__bindgen_ty_1::mX1",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).mY1) as usize - ptr as usize },
         4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C__bindgen_ty_1__bindgen_ty_1),
-            "::",
-            stringify!(mY1),
-        ),
+        "Offset of field: C__bindgen_ty_1__bindgen_ty_1::mY1",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).mX2) as usize - ptr as usize },
         8usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C__bindgen_ty_1__bindgen_ty_1),
-            "::",
-            stringify!(mX2),
-        ),
+        "Offset of field: C__bindgen_ty_1__bindgen_ty_1::mX2",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).mY2) as usize - ptr as usize },
         12usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C__bindgen_ty_1__bindgen_ty_1),
-            "::",
-            stringify!(mY2),
-        ),
+        "Offset of field: C__bindgen_ty_1__bindgen_ty_1::mY2",
     );
 }
 impl Clone for C__bindgen_ty_1__bindgen_ty_1 {
@@ -337,32 +293,22 @@ fn bindgen_test_layout_C__bindgen_ty_1__bindgen_ty_2() {
     assert_eq!(
         ::std::mem::size_of::<C__bindgen_ty_1__bindgen_ty_2>(),
         8usize,
-        concat!("Size of: ", stringify!(C__bindgen_ty_1__bindgen_ty_2)),
+        "Size of C__bindgen_ty_1__bindgen_ty_2",
     );
     assert_eq!(
         ::std::mem::align_of::<C__bindgen_ty_1__bindgen_ty_2>(),
         4usize,
-        concat!("Alignment of ", stringify!(C__bindgen_ty_1__bindgen_ty_2)),
+        "Alignment of C__bindgen_ty_1__bindgen_ty_2",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).mStepSyntax) as usize - ptr as usize },
         0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C__bindgen_ty_1__bindgen_ty_2),
-            "::",
-            stringify!(mStepSyntax),
-        ),
+        "Offset of field: C__bindgen_ty_1__bindgen_ty_2::mStepSyntax",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).mSteps) as usize - ptr as usize },
         4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C__bindgen_ty_1__bindgen_ty_2),
-            "::",
-            stringify!(mSteps),
-        ),
+        "Offset of field: C__bindgen_ty_1__bindgen_ty_2::mSteps",
     );
 }
 impl Clone for C__bindgen_ty_1__bindgen_ty_2 {
@@ -386,22 +332,17 @@ fn bindgen_test_layout_C__bindgen_ty_1() {
     assert_eq!(
         ::std::mem::size_of::<C__bindgen_ty_1>(),
         16usize,
-        concat!("Size of: ", stringify!(C__bindgen_ty_1)),
+        "Size of C__bindgen_ty_1",
     );
     assert_eq!(
         ::std::mem::align_of::<C__bindgen_ty_1>(),
         4usize,
-        concat!("Alignment of ", stringify!(C__bindgen_ty_1)),
+        "Alignment of C__bindgen_ty_1",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).mFunc) as usize - ptr as usize },
         0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C__bindgen_ty_1),
-            "::",
-            stringify!(mFunc),
-        ),
+        "Offset of field: C__bindgen_ty_1::mFunc",
     );
 }
 impl Clone for C__bindgen_ty_1 {
@@ -419,25 +360,17 @@ pub struct C_Segment {
 fn bindgen_test_layout_C_Segment() {
     const UNINIT: ::std::mem::MaybeUninit<C_Segment> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<C_Segment>(),
-        8usize,
-        concat!("Size of: ", stringify!(C_Segment)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<C_Segment>(),
-        4usize,
-        concat!("Alignment of ", stringify!(C_Segment)),
-    );
+    assert_eq!(::std::mem::size_of::<C_Segment>(), 8usize, "Size of C_Segment");
+    assert_eq!(::std::mem::align_of::<C_Segment>(), 4usize, "Alignment of C_Segment");
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).begin) as usize - ptr as usize },
         0usize,
-        concat!("Offset of field: ", stringify!(C_Segment), "::", stringify!(begin)),
+        "Offset of field: C_Segment::begin",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).end) as usize - ptr as usize },
         4usize,
-        concat!("Offset of field: ", stringify!(C_Segment), "::", stringify!(end)),
+        "Offset of field: C_Segment::end",
     );
 }
 impl Clone for C_Segment {
@@ -449,16 +382,12 @@ impl Clone for C_Segment {
 fn bindgen_test_layout_C() {
     const UNINIT: ::std::mem::MaybeUninit<C> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
-    assert_eq!(::std::mem::size_of::<C>(), 20usize, concat!("Size of: ", stringify!(C)));
-    assert_eq!(
-        ::std::mem::align_of::<C>(),
-        4usize,
-        concat!("Alignment of ", stringify!(C)),
-    );
+    assert_eq!(::std::mem::size_of::<C>(), 20usize, "Size of C");
+    assert_eq!(::std::mem::align_of::<C>(), 4usize, "Alignment of C");
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize },
         0usize,
-        concat!("Offset of field: ", stringify!(C), "::", stringify!(d)),
+        "Offset of field: C::d",
     );
 }
 impl Clone for C {

--- a/bindgen-tests/tests/expectations/tests/class_with_typedef.rs
+++ b/bindgen-tests/tests/expectations/tests/class_with_typedef.rs
@@ -11,42 +11,15 @@ pub struct C {
 }
 pub type C_MyInt = ::std::os::raw::c_int;
 pub type C_Lookup = *const ::std::os::raw::c_char;
-#[test]
-fn bindgen_test_layout_C() {
-    const UNINIT: ::std::mem::MaybeUninit<C> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(::std::mem::size_of::<C>(), 72usize, concat!("Size of: ", stringify!(C)));
-    assert_eq!(
-        ::std::mem::align_of::<C>(),
-        8usize,
-        concat!("Alignment of ", stringify!(C)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).c) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(C), "::", stringify!(c)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).ptr) as usize - ptr as usize },
-        8usize,
-        concat!("Offset of field: ", stringify!(C), "::", stringify!(ptr)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).arr) as usize - ptr as usize },
-        16usize,
-        concat!("Offset of field: ", stringify!(C), "::", stringify!(arr)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize },
-        56usize,
-        concat!("Offset of field: ", stringify!(C), "::", stringify!(d)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).other_ptr) as usize - ptr as usize },
-        64usize,
-        concat!("Offset of field: ", stringify!(C), "::", stringify!(other_ptr)),
-    );
-}
+const _: () = {
+    ["Size of C"][::std::mem::size_of::<C>() - 72usize];
+    ["Alignment of C"][::std::mem::align_of::<C>() - 8usize];
+    ["Offset of field: C::c"][::std::mem::offset_of!(C, c) - 0usize];
+    ["Offset of field: C::ptr"][::std::mem::offset_of!(C, ptr) - 8usize];
+    ["Offset of field: C::arr"][::std::mem::offset_of!(C, arr) - 16usize];
+    ["Offset of field: C::d"][::std::mem::offset_of!(C, d) - 56usize];
+    ["Offset of field: C::other_ptr"][::std::mem::offset_of!(C, other_ptr) - 64usize];
+};
 extern "C" {
     #[link_name = "\u{1}_ZN1C6methodEi"]
     pub fn C_method(this: *mut C, c: C_MyInt);
@@ -96,22 +69,11 @@ pub struct D {
     pub _base: C,
     pub ptr: *mut C_MyInt,
 }
-#[test]
-fn bindgen_test_layout_D() {
-    const UNINIT: ::std::mem::MaybeUninit<D> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(::std::mem::size_of::<D>(), 80usize, concat!("Size of: ", stringify!(D)));
-    assert_eq!(
-        ::std::mem::align_of::<D>(),
-        8usize,
-        concat!("Alignment of ", stringify!(D)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).ptr) as usize - ptr as usize },
-        72usize,
-        concat!("Offset of field: ", stringify!(D), "::", stringify!(ptr)),
-    );
-}
+const _: () = {
+    ["Size of D"][::std::mem::size_of::<D>() - 80usize];
+    ["Alignment of D"][::std::mem::align_of::<D>() - 8usize];
+    ["Offset of field: D::ptr"][::std::mem::offset_of!(D, ptr) - 72usize];
+};
 impl Default for D {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();

--- a/bindgen-tests/tests/expectations/tests/comment-indent.rs
+++ b/bindgen-tests/tests/expectations/tests/comment-indent.rs
@@ -19,32 +19,14 @@ pub mod root {
     pub struct Foo_Bar {
         pub _address: u8,
     }
-    #[test]
-    fn bindgen_test_layout_Foo_Bar() {
-        assert_eq!(
-            ::std::mem::size_of::<Foo_Bar>(),
-            1usize,
-            concat!("Size of: ", stringify!(Foo_Bar)),
-        );
-        assert_eq!(
-            ::std::mem::align_of::<Foo_Bar>(),
-            1usize,
-            concat!("Alignment of ", stringify!(Foo_Bar)),
-        );
-    }
-    #[test]
-    fn bindgen_test_layout_Foo() {
-        assert_eq!(
-            ::std::mem::size_of::<Foo>(),
-            1usize,
-            concat!("Size of: ", stringify!(Foo)),
-        );
-        assert_eq!(
-            ::std::mem::align_of::<Foo>(),
-            1usize,
-            concat!("Alignment of ", stringify!(Foo)),
-        );
-    }
+    const _: () = {
+        ["Size of Foo_Bar"][::std::mem::size_of::<Foo_Bar>() - 1usize];
+        ["Alignment of Foo_Bar"][::std::mem::align_of::<Foo_Bar>() - 1usize];
+    };
+    const _: () = {
+        ["Size of Foo"][::std::mem::size_of::<Foo>() - 1usize];
+        ["Alignment of Foo"][::std::mem::align_of::<Foo>() - 1usize];
+    };
     pub mod test {
         #[allow(unused_imports)]
         use self::super::super::root;
@@ -62,26 +44,13 @@ pub mod root {
  +------+          +-------+*/
             pub member: ::std::os::raw::c_int,
         }
-        #[test]
-        fn bindgen_test_layout_Baz() {
-            const UNINIT: ::std::mem::MaybeUninit<Baz> = ::std::mem::MaybeUninit::uninit();
-            let ptr = UNINIT.as_ptr();
-            assert_eq!(
-                ::std::mem::size_of::<Baz>(),
-                4usize,
-                concat!("Size of: ", stringify!(Baz)),
-            );
-            assert_eq!(
-                ::std::mem::align_of::<Baz>(),
-                4usize,
-                concat!("Alignment of ", stringify!(Baz)),
-            );
-            assert_eq!(
-                unsafe { ::std::ptr::addr_of!((*ptr).member) as usize - ptr as usize },
-                0usize,
-                concat!("Offset of field: ", stringify!(Baz), "::", stringify!(member)),
-            );
-        }
+        const _: () = {
+            ["Size of Baz"][::std::mem::size_of::<Baz>() - 4usize];
+            ["Alignment of Baz"][::std::mem::align_of::<Baz>() - 4usize];
+            [
+                "Offset of field: Baz::member",
+            ][::std::mem::offset_of!(Baz, member) - 0usize];
+        };
         /** I'm in an inline namespace, and as such I shouldn't get generated inside
  a rust module, except when the relevant option is specified. Also, this
  comment shouldn't be misaligned.*/
@@ -90,36 +59,18 @@ pub mod root {
         pub struct InInlineNS {
             pub _address: u8,
         }
-        #[test]
-        fn bindgen_test_layout_InInlineNS() {
-            assert_eq!(
-                ::std::mem::size_of::<InInlineNS>(),
-                1usize,
-                concat!("Size of: ", stringify!(InInlineNS)),
-            );
-            assert_eq!(
-                ::std::mem::align_of::<InInlineNS>(),
-                1usize,
-                concat!("Alignment of ", stringify!(InInlineNS)),
-            );
-        }
+        const _: () = {
+            ["Size of InInlineNS"][::std::mem::size_of::<InInlineNS>() - 1usize];
+            ["Alignment of InInlineNS"][::std::mem::align_of::<InInlineNS>() - 1usize];
+        };
         #[repr(C)]
         #[derive(Debug, Default, Copy, Clone)]
         pub struct Bazz {
             pub _address: u8,
         }
-        #[test]
-        fn bindgen_test_layout_Bazz() {
-            assert_eq!(
-                ::std::mem::size_of::<Bazz>(),
-                1usize,
-                concat!("Size of: ", stringify!(Bazz)),
-            );
-            assert_eq!(
-                ::std::mem::align_of::<Bazz>(),
-                1usize,
-                concat!("Alignment of ", stringify!(Bazz)),
-            );
-        }
+        const _: () = {
+            ["Size of Bazz"][::std::mem::size_of::<Bazz>() - 1usize];
+            ["Alignment of Bazz"][::std::mem::align_of::<Bazz>() - 1usize];
+        };
     }
 }

--- a/bindgen-tests/tests/expectations/tests/complex.rs
+++ b/bindgen-tests/tests/expectations/tests/complex.rs
@@ -10,56 +10,25 @@ pub struct __BindgenComplex<T> {
 pub struct TestDouble {
     pub mMember: __BindgenComplex<f64>,
 }
-#[test]
-fn bindgen_test_layout_TestDouble() {
-    const UNINIT: ::std::mem::MaybeUninit<TestDouble> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<TestDouble>(),
-        16usize,
-        concat!("Size of: ", stringify!(TestDouble)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<TestDouble>(),
-        8usize,
-        concat!("Alignment of ", stringify!(TestDouble)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).mMember) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(TestDouble), "::", stringify!(mMember)),
-    );
-}
+const _: () = {
+    ["Size of TestDouble"][::std::mem::size_of::<TestDouble>() - 16usize];
+    ["Alignment of TestDouble"][::std::mem::align_of::<TestDouble>() - 8usize];
+    [
+        "Offset of field: TestDouble::mMember",
+    ][::std::mem::offset_of!(TestDouble, mMember) - 0usize];
+};
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct TestDoublePtr {
     pub mMember: *mut __BindgenComplex<f64>,
 }
-#[test]
-fn bindgen_test_layout_TestDoublePtr() {
-    const UNINIT: ::std::mem::MaybeUninit<TestDoublePtr> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<TestDoublePtr>(),
-        8usize,
-        concat!("Size of: ", stringify!(TestDoublePtr)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<TestDoublePtr>(),
-        8usize,
-        concat!("Alignment of ", stringify!(TestDoublePtr)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).mMember) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(TestDoublePtr),
-            "::",
-            stringify!(mMember),
-        ),
-    );
-}
+const _: () = {
+    ["Size of TestDoublePtr"][::std::mem::size_of::<TestDoublePtr>() - 8usize];
+    ["Alignment of TestDoublePtr"][::std::mem::align_of::<TestDoublePtr>() - 8usize];
+    [
+        "Offset of field: TestDoublePtr::mMember",
+    ][::std::mem::offset_of!(TestDoublePtr, mMember) - 0usize];
+};
 impl Default for TestDoublePtr {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
@@ -74,51 +43,25 @@ impl Default for TestDoublePtr {
 pub struct TestFloat {
     pub mMember: __BindgenComplex<f32>,
 }
-#[test]
-fn bindgen_test_layout_TestFloat() {
-    const UNINIT: ::std::mem::MaybeUninit<TestFloat> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<TestFloat>(),
-        8usize,
-        concat!("Size of: ", stringify!(TestFloat)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<TestFloat>(),
-        4usize,
-        concat!("Alignment of ", stringify!(TestFloat)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).mMember) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(TestFloat), "::", stringify!(mMember)),
-    );
-}
+const _: () = {
+    ["Size of TestFloat"][::std::mem::size_of::<TestFloat>() - 8usize];
+    ["Alignment of TestFloat"][::std::mem::align_of::<TestFloat>() - 4usize];
+    [
+        "Offset of field: TestFloat::mMember",
+    ][::std::mem::offset_of!(TestFloat, mMember) - 0usize];
+};
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct TestFloatPtr {
     pub mMember: *mut __BindgenComplex<f32>,
 }
-#[test]
-fn bindgen_test_layout_TestFloatPtr() {
-    const UNINIT: ::std::mem::MaybeUninit<TestFloatPtr> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<TestFloatPtr>(),
-        8usize,
-        concat!("Size of: ", stringify!(TestFloatPtr)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<TestFloatPtr>(),
-        8usize,
-        concat!("Alignment of ", stringify!(TestFloatPtr)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).mMember) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(TestFloatPtr), "::", stringify!(mMember)),
-    );
-}
+const _: () = {
+    ["Size of TestFloatPtr"][::std::mem::size_of::<TestFloatPtr>() - 8usize];
+    ["Alignment of TestFloatPtr"][::std::mem::align_of::<TestFloatPtr>() - 8usize];
+    [
+        "Offset of field: TestFloatPtr::mMember",
+    ][::std::mem::offset_of!(TestFloatPtr, mMember) - 0usize];
+};
 impl Default for TestFloatPtr {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();

--- a/bindgen-tests/tests/expectations/tests/const-const-mut-ptr.rs
+++ b/bindgen-tests/tests/expectations/tests/const-const-mut-ptr.rs
@@ -4,26 +4,11 @@
 pub struct foo {
     pub bar: *const *const *mut *const ::std::os::raw::c_int,
 }
-#[test]
-fn bindgen_test_layout_foo() {
-    const UNINIT: ::std::mem::MaybeUninit<foo> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<foo>(),
-        8usize,
-        concat!("Size of: ", stringify!(foo)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<foo>(),
-        8usize,
-        concat!("Alignment of ", stringify!(foo)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar)),
-    );
-}
+const _: () = {
+    ["Size of foo"][::std::mem::size_of::<foo>() - 8usize];
+    ["Alignment of foo"][::std::mem::align_of::<foo>() - 8usize];
+    ["Offset of field: foo::bar"][::std::mem::offset_of!(foo, bar) - 0usize];
+};
 impl Default for foo {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();

--- a/bindgen-tests/tests/expectations/tests/const_array_typedef.rs
+++ b/bindgen-tests/tests/expectations/tests/const_array_typedef.rs
@@ -4,26 +4,11 @@
 pub struct strct {
     pub field: ::std::os::raw::c_int,
 }
-#[test]
-fn bindgen_test_layout_strct() {
-    const UNINIT: ::std::mem::MaybeUninit<strct> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<strct>(),
-        4usize,
-        concat!("Size of: ", stringify!(strct)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<strct>(),
-        4usize,
-        concat!("Alignment of ", stringify!(strct)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).field) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(strct), "::", stringify!(field)),
-    );
-}
+const _: () = {
+    ["Size of strct"][::std::mem::size_of::<strct>() - 4usize];
+    ["Alignment of strct"][::std::mem::align_of::<strct>() - 4usize];
+    ["Offset of field: strct::field"][::std::mem::offset_of!(strct, field) - 0usize];
+};
 pub type typ = [strct; 1usize];
 extern "C" {
     pub static mut w: typ;

--- a/bindgen-tests/tests/expectations/tests/const_bool.rs
+++ b/bindgen-tests/tests/expectations/tests/const_bool.rs
@@ -6,14 +6,9 @@ pub struct A {
     pub _address: u8,
 }
 pub const A_k: bool = false;
-#[test]
-fn bindgen_test_layout_A() {
-    assert_eq!(::std::mem::size_of::<A>(), 1usize, concat!("Size of: ", stringify!(A)));
-    assert_eq!(
-        ::std::mem::align_of::<A>(),
-        1usize,
-        concat!("Alignment of ", stringify!(A)),
-    );
-}
+const _: () = {
+    ["Size of A"][::std::mem::size_of::<A>() - 1usize];
+    ["Alignment of A"][::std::mem::align_of::<A>() - 1usize];
+};
 pub type foo = bool;
 pub const k2: foo = true;

--- a/bindgen-tests/tests/expectations/tests/const_enum_unnamed.rs
+++ b/bindgen-tests/tests/expectations/tests/const_enum_unnamed.rs
@@ -18,16 +18,7 @@ pub const Foo_FOO_BAR: Foo__bindgen_ty_1 = Foo__bindgen_ty_1::FOO_BAR;
 pub enum Foo__bindgen_ty_1 {
     FOO_BAR = 10,
 }
-#[test]
-fn bindgen_test_layout_Foo() {
-    assert_eq!(
-        ::std::mem::size_of::<Foo>(),
-        1usize,
-        concat!("Size of: ", stringify!(Foo)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Foo>(),
-        1usize,
-        concat!("Alignment of ", stringify!(Foo)),
-    );
-}
+const _: () = {
+    ["Size of Foo"][::std::mem::size_of::<Foo>() - 1usize];
+    ["Alignment of Foo"][::std::mem::align_of::<Foo>() - 1usize];
+};

--- a/bindgen-tests/tests/expectations/tests/constified-enum-module-overflow.rs
+++ b/bindgen-tests/tests/expectations/tests/constified-enum-module-overflow.rs
@@ -15,45 +15,24 @@ pub type C_U = B;
 pub struct A {
     pub u: B,
 }
-#[test]
-fn bindgen_test_layout_A() {
-    const UNINIT: ::std::mem::MaybeUninit<A> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(::std::mem::size_of::<A>(), 1usize, concat!("Size of: ", stringify!(A)));
-    assert_eq!(
-        ::std::mem::align_of::<A>(),
-        1usize,
-        concat!("Alignment of ", stringify!(A)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).u) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(A), "::", stringify!(u)),
-    );
-}
-#[test]
-fn __bindgen_test_layout_C_open0_A_close0_instantiation() {
-    assert_eq!(
-        ::std::mem::size_of::<C>(),
-        1usize,
-        concat!("Size of template specialization: ", stringify!(C)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<C>(),
-        1usize,
-        concat!("Alignment of template specialization: ", stringify!(C)),
-    );
-}
-#[test]
-fn __bindgen_test_layout_B_open0_A_close0_instantiation() {
-    assert_eq!(
-        ::std::mem::size_of::<B>(),
-        1usize,
-        concat!("Size of template specialization: ", stringify!(B)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<B>(),
-        1usize,
-        concat!("Alignment of template specialization: ", stringify!(B)),
-    );
-}
+const _: () = {
+    ["Size of A"][::std::mem::size_of::<A>() - 1usize];
+    ["Alignment of A"][::std::mem::align_of::<A>() - 1usize];
+    ["Offset of field: A::u"][::std::mem::offset_of!(A, u) - 0usize];
+};
+const _: () = {
+    [
+        "Size of template specialization: C_open0_A_close0",
+    ][::std::mem::size_of::<C>() - 1usize];
+    [
+        "Align of template specialization: C_open0_A_close0",
+    ][::std::mem::align_of::<C>() - 1usize];
+};
+const _: () = {
+    [
+        "Size of template specialization: B_open0_A_close0",
+    ][::std::mem::size_of::<B>() - 1usize];
+    [
+        "Align of template specialization: B_open0_A_close0",
+    ][::std::mem::align_of::<B>() - 1usize];
+};

--- a/bindgen-tests/tests/expectations/tests/constify-all-enums.rs
+++ b/bindgen-tests/tests/expectations/tests/constify-all-enums.rs
@@ -8,26 +8,13 @@ pub type foo = ::std::os::raw::c_uint;
 pub struct bar {
     pub this_should_work: foo,
 }
-#[test]
-fn bindgen_test_layout_bar() {
-    const UNINIT: ::std::mem::MaybeUninit<bar> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<bar>(),
-        4usize,
-        concat!("Size of: ", stringify!(bar)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<bar>(),
-        4usize,
-        concat!("Alignment of ", stringify!(bar)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).this_should_work) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(bar), "::", stringify!(this_should_work)),
-    );
-}
+const _: () = {
+    ["Size of bar"][::std::mem::size_of::<bar>() - 4usize];
+    ["Alignment of bar"][::std::mem::align_of::<bar>() - 4usize];
+    [
+        "Offset of field: bar::this_should_work",
+    ][::std::mem::offset_of!(bar, this_should_work) - 0usize];
+};
 impl Default for bar {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();

--- a/bindgen-tests/tests/expectations/tests/constify-module-enums-basic.rs
+++ b/bindgen-tests/tests/expectations/tests/constify-module-enums-basic.rs
@@ -12,26 +12,13 @@ pub use self::foo_alias1 as foo_alias2;
 pub struct bar {
     pub this_should_work: foo::Type,
 }
-#[test]
-fn bindgen_test_layout_bar() {
-    const UNINIT: ::std::mem::MaybeUninit<bar> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<bar>(),
-        4usize,
-        concat!("Size of: ", stringify!(bar)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<bar>(),
-        4usize,
-        concat!("Alignment of ", stringify!(bar)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).this_should_work) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(bar), "::", stringify!(this_should_work)),
-    );
-}
+const _: () = {
+    ["Size of bar"][::std::mem::size_of::<bar>() - 4usize];
+    ["Alignment of bar"][::std::mem::align_of::<bar>() - 4usize];
+    [
+        "Offset of field: bar::this_should_work",
+    ][::std::mem::offset_of!(bar, this_should_work) - 0usize];
+};
 impl Default for bar {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();

--- a/bindgen-tests/tests/expectations/tests/constify-module-enums-namespace.rs
+++ b/bindgen-tests/tests/expectations/tests/constify-module-enums-namespace.rs
@@ -24,34 +24,13 @@ pub mod root {
             pub struct bar {
                 pub this_should_work: root::ns1::ns2::foo::Type,
             }
-            #[test]
-            fn bindgen_test_layout_bar() {
-                const UNINIT: ::std::mem::MaybeUninit<bar> = ::std::mem::MaybeUninit::uninit();
-                let ptr = UNINIT.as_ptr();
-                assert_eq!(
-                    ::std::mem::size_of::<bar>(),
-                    4usize,
-                    concat!("Size of: ", stringify!(bar)),
-                );
-                assert_eq!(
-                    ::std::mem::align_of::<bar>(),
-                    4usize,
-                    concat!("Alignment of ", stringify!(bar)),
-                );
-                assert_eq!(
-                    unsafe {
-                        ::std::ptr::addr_of!((*ptr).this_should_work) as usize
-                            - ptr as usize
-                    },
-                    0usize,
-                    concat!(
-                        "Offset of field: ",
-                        stringify!(bar),
-                        "::",
-                        stringify!(this_should_work),
-                    ),
-                );
-            }
+            const _: () = {
+                ["Size of bar"][::std::mem::size_of::<bar>() - 4usize];
+                ["Alignment of bar"][::std::mem::align_of::<bar>() - 4usize];
+                [
+                    "Offset of field: bar::this_should_work",
+                ][::std::mem::offset_of!(bar, this_should_work) - 0usize];
+            };
             impl Default for bar {
                 fn default() -> Self {
                     let mut s = ::std::mem::MaybeUninit::<Self>::uninit();

--- a/bindgen-tests/tests/expectations/tests/constify-module-enums-shadow-name.rs
+++ b/bindgen-tests/tests/expectations/tests/constify-module-enums-shadow-name.rs
@@ -11,26 +11,11 @@ pub mod foo {
 pub struct bar {
     pub member: foo::Type,
 }
-#[test]
-fn bindgen_test_layout_bar() {
-    const UNINIT: ::std::mem::MaybeUninit<bar> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<bar>(),
-        4usize,
-        concat!("Size of: ", stringify!(bar)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<bar>(),
-        4usize,
-        concat!("Alignment of ", stringify!(bar)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).member) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(bar), "::", stringify!(member)),
-    );
-}
+const _: () = {
+    ["Size of bar"][::std::mem::size_of::<bar>() - 4usize];
+    ["Alignment of bar"][::std::mem::align_of::<bar>() - 4usize];
+    ["Offset of field: bar::member"][::std::mem::offset_of!(bar, member) - 0usize];
+};
 impl Default for bar {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();

--- a/bindgen-tests/tests/expectations/tests/constify-module-enums-simple-alias.rs
+++ b/bindgen-tests/tests/expectations/tests/constify-module-enums-simple-alias.rs
@@ -20,61 +20,18 @@ pub struct Bar {
     pub baz_ptr3: *mut Foo_alias2,
     pub baz_ptr4: *mut Foo_alias3,
 }
-#[test]
-fn bindgen_test_layout_Bar() {
-    const UNINIT: ::std::mem::MaybeUninit<Bar> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<Bar>(),
-        48usize,
-        concat!("Size of: ", stringify!(Bar)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Bar>(),
-        8usize,
-        concat!("Alignment of ", stringify!(Bar)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).baz1) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(Bar), "::", stringify!(baz1)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).baz2) as usize - ptr as usize },
-        4usize,
-        concat!("Offset of field: ", stringify!(Bar), "::", stringify!(baz2)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).baz3) as usize - ptr as usize },
-        8usize,
-        concat!("Offset of field: ", stringify!(Bar), "::", stringify!(baz3)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).baz4) as usize - ptr as usize },
-        12usize,
-        concat!("Offset of field: ", stringify!(Bar), "::", stringify!(baz4)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).baz_ptr1) as usize - ptr as usize },
-        16usize,
-        concat!("Offset of field: ", stringify!(Bar), "::", stringify!(baz_ptr1)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).baz_ptr2) as usize - ptr as usize },
-        24usize,
-        concat!("Offset of field: ", stringify!(Bar), "::", stringify!(baz_ptr2)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).baz_ptr3) as usize - ptr as usize },
-        32usize,
-        concat!("Offset of field: ", stringify!(Bar), "::", stringify!(baz_ptr3)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).baz_ptr4) as usize - ptr as usize },
-        40usize,
-        concat!("Offset of field: ", stringify!(Bar), "::", stringify!(baz_ptr4)),
-    );
-}
+const _: () = {
+    ["Size of Bar"][::std::mem::size_of::<Bar>() - 48usize];
+    ["Alignment of Bar"][::std::mem::align_of::<Bar>() - 8usize];
+    ["Offset of field: Bar::baz1"][::std::mem::offset_of!(Bar, baz1) - 0usize];
+    ["Offset of field: Bar::baz2"][::std::mem::offset_of!(Bar, baz2) - 4usize];
+    ["Offset of field: Bar::baz3"][::std::mem::offset_of!(Bar, baz3) - 8usize];
+    ["Offset of field: Bar::baz4"][::std::mem::offset_of!(Bar, baz4) - 12usize];
+    ["Offset of field: Bar::baz_ptr1"][::std::mem::offset_of!(Bar, baz_ptr1) - 16usize];
+    ["Offset of field: Bar::baz_ptr2"][::std::mem::offset_of!(Bar, baz_ptr2) - 24usize];
+    ["Offset of field: Bar::baz_ptr3"][::std::mem::offset_of!(Bar, baz_ptr3) - 32usize];
+    ["Offset of field: Bar::baz_ptr4"][::std::mem::offset_of!(Bar, baz_ptr4) - 40usize];
+};
 impl Default for Bar {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();

--- a/bindgen-tests/tests/expectations/tests/constify-module-enums-simple-nonamespace.rs
+++ b/bindgen-tests/tests/expectations/tests/constify-module-enums-simple-nonamespace.rs
@@ -10,31 +10,12 @@ pub struct Bar {
     pub baz1: one_Foo::Type,
     pub baz2: *mut one_Foo::Type,
 }
-#[test]
-fn bindgen_test_layout_Bar() {
-    const UNINIT: ::std::mem::MaybeUninit<Bar> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<Bar>(),
-        16usize,
-        concat!("Size of: ", stringify!(Bar)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Bar>(),
-        8usize,
-        concat!("Alignment of ", stringify!(Bar)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).baz1) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(Bar), "::", stringify!(baz1)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).baz2) as usize - ptr as usize },
-        8usize,
-        concat!("Offset of field: ", stringify!(Bar), "::", stringify!(baz2)),
-    );
-}
+const _: () = {
+    ["Size of Bar"][::std::mem::size_of::<Bar>() - 16usize];
+    ["Alignment of Bar"][::std::mem::align_of::<Bar>() - 8usize];
+    ["Offset of field: Bar::baz1"][::std::mem::offset_of!(Bar, baz1) - 0usize];
+    ["Offset of field: Bar::baz2"][::std::mem::offset_of!(Bar, baz2) - 8usize];
+};
 impl Default for Bar {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();

--- a/bindgen-tests/tests/expectations/tests/constify-module-enums-types.rs
+++ b/bindgen-tests/tests/expectations/tests/constify-module-enums-types.rs
@@ -45,71 +45,20 @@ pub struct bar {
     pub member9: anon_enum_alias2,
     pub member10: anon_enum_alias3,
 }
-#[test]
-fn bindgen_test_layout_bar() {
-    const UNINIT: ::std::mem::MaybeUninit<bar> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<bar>(),
-        48usize,
-        concat!("Size of: ", stringify!(bar)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<bar>(),
-        8usize,
-        concat!("Alignment of ", stringify!(bar)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).member1) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(bar), "::", stringify!(member1)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).member2) as usize - ptr as usize },
-        4usize,
-        concat!("Offset of field: ", stringify!(bar), "::", stringify!(member2)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).member3) as usize - ptr as usize },
-        8usize,
-        concat!("Offset of field: ", stringify!(bar), "::", stringify!(member3)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).member4) as usize - ptr as usize },
-        12usize,
-        concat!("Offset of field: ", stringify!(bar), "::", stringify!(member4)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).member5) as usize - ptr as usize },
-        16usize,
-        concat!("Offset of field: ", stringify!(bar), "::", stringify!(member5)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).member6) as usize - ptr as usize },
-        24usize,
-        concat!("Offset of field: ", stringify!(bar), "::", stringify!(member6)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).member7) as usize - ptr as usize },
-        32usize,
-        concat!("Offset of field: ", stringify!(bar), "::", stringify!(member7)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).member8) as usize - ptr as usize },
-        36usize,
-        concat!("Offset of field: ", stringify!(bar), "::", stringify!(member8)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).member9) as usize - ptr as usize },
-        40usize,
-        concat!("Offset of field: ", stringify!(bar), "::", stringify!(member9)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).member10) as usize - ptr as usize },
-        44usize,
-        concat!("Offset of field: ", stringify!(bar), "::", stringify!(member10)),
-    );
-}
+const _: () = {
+    ["Size of bar"][::std::mem::size_of::<bar>() - 48usize];
+    ["Alignment of bar"][::std::mem::align_of::<bar>() - 8usize];
+    ["Offset of field: bar::member1"][::std::mem::offset_of!(bar, member1) - 0usize];
+    ["Offset of field: bar::member2"][::std::mem::offset_of!(bar, member2) - 4usize];
+    ["Offset of field: bar::member3"][::std::mem::offset_of!(bar, member3) - 8usize];
+    ["Offset of field: bar::member4"][::std::mem::offset_of!(bar, member4) - 12usize];
+    ["Offset of field: bar::member5"][::std::mem::offset_of!(bar, member5) - 16usize];
+    ["Offset of field: bar::member6"][::std::mem::offset_of!(bar, member6) - 24usize];
+    ["Offset of field: bar::member7"][::std::mem::offset_of!(bar, member7) - 32usize];
+    ["Offset of field: bar::member8"][::std::mem::offset_of!(bar, member8) - 36usize];
+    ["Offset of field: bar::member9"][::std::mem::offset_of!(bar, member9) - 40usize];
+    ["Offset of field: bar::member10"][::std::mem::offset_of!(bar, member10) - 44usize];
+};
 impl Default for bar {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
@@ -124,26 +73,11 @@ impl Default for bar {
 pub struct Baz {
     pub member1: ns2_Foo::Type,
 }
-#[test]
-fn bindgen_test_layout_Baz() {
-    const UNINIT: ::std::mem::MaybeUninit<Baz> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<Baz>(),
-        4usize,
-        concat!("Size of: ", stringify!(Baz)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Baz>(),
-        4usize,
-        concat!("Alignment of ", stringify!(Baz)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).member1) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(Baz), "::", stringify!(member1)),
-    );
-}
+const _: () = {
+    ["Size of Baz"][::std::mem::size_of::<Baz>() - 4usize];
+    ["Alignment of Baz"][::std::mem::align_of::<Baz>() - 4usize];
+    ["Offset of field: Baz::member1"][::std::mem::offset_of!(Baz, member1) - 0usize];
+};
 impl Default for Baz {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
@@ -163,26 +97,11 @@ pub mod one_Foo {
 pub struct Bar {
     pub baz: *mut one_Foo::Type,
 }
-#[test]
-fn bindgen_test_layout_Bar() {
-    const UNINIT: ::std::mem::MaybeUninit<Bar> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<Bar>(),
-        8usize,
-        concat!("Size of: ", stringify!(Bar)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Bar>(),
-        8usize,
-        concat!("Alignment of ", stringify!(Bar)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(Bar), "::", stringify!(baz)),
-    );
-}
+const _: () = {
+    ["Size of Bar"][::std::mem::size_of::<Bar>() - 8usize];
+    ["Alignment of Bar"][::std::mem::align_of::<Bar>() - 8usize];
+    ["Offset of field: Bar::baz"][::std::mem::offset_of!(Bar, baz) - 0usize];
+};
 impl Default for Bar {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();

--- a/bindgen-tests/tests/expectations/tests/constructor-tp.rs
+++ b/bindgen-tests/tests/expectations/tests/constructor-tp.rs
@@ -9,19 +9,10 @@ pub struct Foo {
 pub struct Bar {
     pub _address: u8,
 }
-#[test]
-fn bindgen_test_layout_Bar() {
-    assert_eq!(
-        ::std::mem::size_of::<Bar>(),
-        1usize,
-        concat!("Size of: ", stringify!(Bar)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Bar>(),
-        1usize,
-        concat!("Alignment of ", stringify!(Bar)),
-    );
-}
+const _: () = {
+    ["Size of Bar"][::std::mem::size_of::<Bar>() - 1usize];
+    ["Alignment of Bar"][::std::mem::align_of::<Bar>() - 1usize];
+};
 extern "C" {
     #[link_name = "\u{1}_ZN3BarC1Ev"]
     pub fn Bar_Bar(this: *mut Bar);

--- a/bindgen-tests/tests/expectations/tests/constructors.rs
+++ b/bindgen-tests/tests/expectations/tests/constructors.rs
@@ -4,19 +4,10 @@
 pub struct TestOverload {
     pub _address: u8,
 }
-#[test]
-fn bindgen_test_layout_TestOverload() {
-    assert_eq!(
-        ::std::mem::size_of::<TestOverload>(),
-        1usize,
-        concat!("Size of: ", stringify!(TestOverload)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<TestOverload>(),
-        1usize,
-        concat!("Alignment of ", stringify!(TestOverload)),
-    );
-}
+const _: () = {
+    ["Size of TestOverload"][::std::mem::size_of::<TestOverload>() - 1usize];
+    ["Alignment of TestOverload"][::std::mem::align_of::<TestOverload>() - 1usize];
+};
 extern "C" {
     #[link_name = "\u{1}_ZN12TestOverloadC1Ei"]
     pub fn TestOverload_TestOverload(
@@ -47,19 +38,12 @@ impl TestOverload {
 pub struct TestPublicNoArgs {
     pub _address: u8,
 }
-#[test]
-fn bindgen_test_layout_TestPublicNoArgs() {
-    assert_eq!(
-        ::std::mem::size_of::<TestPublicNoArgs>(),
-        1usize,
-        concat!("Size of: ", stringify!(TestPublicNoArgs)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<TestPublicNoArgs>(),
-        1usize,
-        concat!("Alignment of ", stringify!(TestPublicNoArgs)),
-    );
-}
+const _: () = {
+    ["Size of TestPublicNoArgs"][::std::mem::size_of::<TestPublicNoArgs>() - 1usize];
+    [
+        "Alignment of TestPublicNoArgs",
+    ][::std::mem::align_of::<TestPublicNoArgs>() - 1usize];
+};
 extern "C" {
     #[link_name = "\u{1}_ZN16TestPublicNoArgsC1Ev"]
     pub fn TestPublicNoArgs_TestPublicNoArgs(this: *mut TestPublicNoArgs);

--- a/bindgen-tests/tests/expectations/tests/constructors_1_33.rs
+++ b/bindgen-tests/tests/expectations/tests/constructors_1_33.rs
@@ -6,15 +6,11 @@ pub struct TestOverload {
 }
 #[test]
 fn bindgen_test_layout_TestOverload() {
-    assert_eq!(
-        ::std::mem::size_of::<TestOverload>(),
-        1usize,
-        concat!("Size of: ", stringify!(TestOverload)),
-    );
+    assert_eq!(::std::mem::size_of::<TestOverload>(), 1usize, "Size of TestOverload");
     assert_eq!(
         ::std::mem::align_of::<TestOverload>(),
         1usize,
-        concat!("Alignment of ", stringify!(TestOverload)),
+        "Alignment of TestOverload",
     );
 }
 extern "C" {
@@ -54,12 +50,12 @@ fn bindgen_test_layout_TestPublicNoArgs() {
     assert_eq!(
         ::std::mem::size_of::<TestPublicNoArgs>(),
         1usize,
-        concat!("Size of: ", stringify!(TestPublicNoArgs)),
+        "Size of TestPublicNoArgs",
     );
     assert_eq!(
         ::std::mem::align_of::<TestPublicNoArgs>(),
         1usize,
-        concat!("Alignment of ", stringify!(TestPublicNoArgs)),
+        "Alignment of TestPublicNoArgs",
     );
 }
 extern "C" {

--- a/bindgen-tests/tests/expectations/tests/contains-vs-inherits-zero-sized.rs
+++ b/bindgen-tests/tests/expectations/tests/contains-vs-inherits-zero-sized.rs
@@ -5,19 +5,10 @@
 pub struct Empty {
     pub _address: u8,
 }
-#[test]
-fn bindgen_test_layout_Empty() {
-    assert_eq!(
-        ::std::mem::size_of::<Empty>(),
-        1usize,
-        concat!("Size of: ", stringify!(Empty)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Empty>(),
-        1usize,
-        concat!("Alignment of ", stringify!(Empty)),
-    );
-}
+const _: () = {
+    ["Size of Empty"][::std::mem::size_of::<Empty>() - 1usize];
+    ["Alignment of Empty"][::std::mem::align_of::<Empty>() - 1usize];
+};
 /** This should not get an `_address` byte, so `sizeof(Inherits)` should be
  `1`.*/
 #[repr(C)]
@@ -25,26 +16,11 @@ fn bindgen_test_layout_Empty() {
 pub struct Inherits {
     pub b: bool,
 }
-#[test]
-fn bindgen_test_layout_Inherits() {
-    const UNINIT: ::std::mem::MaybeUninit<Inherits> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<Inherits>(),
-        1usize,
-        concat!("Size of: ", stringify!(Inherits)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Inherits>(),
-        1usize,
-        concat!("Alignment of ", stringify!(Inherits)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(Inherits), "::", stringify!(b)),
-    );
-}
+const _: () = {
+    ["Size of Inherits"][::std::mem::size_of::<Inherits>() - 1usize];
+    ["Alignment of Inherits"][::std::mem::align_of::<Inherits>() - 1usize];
+    ["Offset of field: Inherits::b"][::std::mem::offset_of!(Inherits, b) - 0usize];
+};
 /** This should not get an `_address` byte, but contains `Empty` which *does* get
  one, so `sizeof(Contains)` should be `1 + 1`.*/
 #[repr(C)]
@@ -53,28 +29,11 @@ pub struct Contains {
     pub empty: Empty,
     pub b: bool,
 }
-#[test]
-fn bindgen_test_layout_Contains() {
-    const UNINIT: ::std::mem::MaybeUninit<Contains> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<Contains>(),
-        2usize,
-        concat!("Size of: ", stringify!(Contains)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Contains>(),
-        1usize,
-        concat!("Alignment of ", stringify!(Contains)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).empty) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(Contains), "::", stringify!(empty)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
-        1usize,
-        concat!("Offset of field: ", stringify!(Contains), "::", stringify!(b)),
-    );
-}
+const _: () = {
+    ["Size of Contains"][::std::mem::size_of::<Contains>() - 2usize];
+    ["Alignment of Contains"][::std::mem::align_of::<Contains>() - 1usize];
+    [
+        "Offset of field: Contains::empty",
+    ][::std::mem::offset_of!(Contains, empty) - 0usize];
+    ["Offset of field: Contains::b"][::std::mem::offset_of!(Contains, b) - 1usize];
+};

--- a/bindgen-tests/tests/expectations/tests/convert-floats.rs
+++ b/bindgen-tests/tests/expectations/tests/convert-floats.rs
@@ -15,51 +15,20 @@ pub struct foo {
     pub complexFloat: __BindgenComplex<::std::os::raw::c_float>,
     pub complexDouble: __BindgenComplex<::std::os::raw::c_double>,
 }
-#[test]
-fn bindgen_test_layout_foo() {
-    const UNINIT: ::std::mem::MaybeUninit<foo> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<foo>(),
-        48usize,
-        concat!("Size of: ", stringify!(foo)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<foo>(),
-        8usize,
-        concat!("Alignment of ", stringify!(foo)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize },
-        4usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(baz)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).bazz) as usize - ptr as usize },
-        8usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(bazz)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).bazzz) as usize - ptr as usize },
-        16usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(bazzz)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).complexFloat) as usize - ptr as usize },
-        24usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(complexFloat)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).complexDouble) as usize - ptr as usize },
-        32usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(complexDouble)),
-    );
-}
+const _: () = {
+    ["Size of foo"][::std::mem::size_of::<foo>() - 48usize];
+    ["Alignment of foo"][::std::mem::align_of::<foo>() - 8usize];
+    ["Offset of field: foo::bar"][::std::mem::offset_of!(foo, bar) - 0usize];
+    ["Offset of field: foo::baz"][::std::mem::offset_of!(foo, baz) - 4usize];
+    ["Offset of field: foo::bazz"][::std::mem::offset_of!(foo, bazz) - 8usize];
+    ["Offset of field: foo::bazzz"][::std::mem::offset_of!(foo, bazzz) - 16usize];
+    [
+        "Offset of field: foo::complexFloat",
+    ][::std::mem::offset_of!(foo, complexFloat) - 24usize];
+    [
+        "Offset of field: foo::complexDouble",
+    ][::std::mem::offset_of!(foo, complexDouble) - 32usize];
+};
 impl Default for foo {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();

--- a/bindgen-tests/tests/expectations/tests/cpp-empty-layout.rs
+++ b/bindgen-tests/tests/expectations/tests/cpp-empty-layout.rs
@@ -4,16 +4,7 @@
 pub struct Foo {
     pub _address: u8,
 }
-#[test]
-fn bindgen_test_layout_Foo() {
-    assert_eq!(
-        ::std::mem::size_of::<Foo>(),
-        1usize,
-        concat!("Size of: ", stringify!(Foo)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Foo>(),
-        1usize,
-        concat!("Alignment of ", stringify!(Foo)),
-    );
-}
+const _: () = {
+    ["Size of Foo"][::std::mem::size_of::<Foo>() - 1usize];
+    ["Alignment of Foo"][::std::mem::align_of::<Foo>() - 1usize];
+};

--- a/bindgen-tests/tests/expectations/tests/crtp.rs
+++ b/bindgen-tests/tests/expectations/tests/crtp.rs
@@ -9,19 +9,10 @@ pub struct Base {
 pub struct Derived {
     pub _address: u8,
 }
-#[test]
-fn bindgen_test_layout_Derived() {
-    assert_eq!(
-        ::std::mem::size_of::<Derived>(),
-        1usize,
-        concat!("Size of: ", stringify!(Derived)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Derived>(),
-        1usize,
-        concat!("Alignment of ", stringify!(Derived)),
-    );
-}
+const _: () = {
+    ["Size of Derived"][::std::mem::size_of::<Derived>() - 1usize];
+    ["Alignment of Derived"][::std::mem::align_of::<Derived>() - 1usize];
+};
 #[repr(C)]
 #[derive(Debug, Default)]
 pub struct BaseWithDestructor {
@@ -32,42 +23,27 @@ pub struct BaseWithDestructor {
 pub struct DerivedFromBaseWithDestructor {
     pub _address: u8,
 }
-#[test]
-fn bindgen_test_layout_DerivedFromBaseWithDestructor() {
-    assert_eq!(
-        ::std::mem::size_of::<DerivedFromBaseWithDestructor>(),
-        1usize,
-        concat!("Size of: ", stringify!(DerivedFromBaseWithDestructor)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<DerivedFromBaseWithDestructor>(),
-        1usize,
-        concat!("Alignment of ", stringify!(DerivedFromBaseWithDestructor)),
-    );
-}
-#[test]
-fn __bindgen_test_layout_Base_open0_Derived_close0_instantiation() {
-    assert_eq!(
-        ::std::mem::size_of::<Base>(),
-        1usize,
-        concat!("Size of template specialization: ", stringify!(Base)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Base>(),
-        1usize,
-        concat!("Alignment of template specialization: ", stringify!(Base)),
-    );
-}
-#[test]
-fn __bindgen_test_layout_BaseWithDestructor_open0_DerivedFromBaseWithDestructor_close0_instantiation() {
-    assert_eq!(
-        ::std::mem::size_of::<BaseWithDestructor>(),
-        1usize,
-        concat!("Size of template specialization: ", stringify!(BaseWithDestructor)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<BaseWithDestructor>(),
-        1usize,
-        concat!("Alignment of template specialization: ", stringify!(BaseWithDestructor)),
-    );
-}
+const _: () = {
+    [
+        "Size of DerivedFromBaseWithDestructor",
+    ][::std::mem::size_of::<DerivedFromBaseWithDestructor>() - 1usize];
+    [
+        "Alignment of DerivedFromBaseWithDestructor",
+    ][::std::mem::align_of::<DerivedFromBaseWithDestructor>() - 1usize];
+};
+const _: () = {
+    [
+        "Size of template specialization: Base_open0_Derived_close0",
+    ][::std::mem::size_of::<Base>() - 1usize];
+    [
+        "Align of template specialization: Base_open0_Derived_close0",
+    ][::std::mem::align_of::<Base>() - 1usize];
+};
+const _: () = {
+    [
+        "Size of template specialization: BaseWithDestructor_open0_DerivedFromBaseWithDestructor_close0",
+    ][::std::mem::size_of::<BaseWithDestructor>() - 1usize];
+    [
+        "Align of template specialization: BaseWithDestructor_open0_DerivedFromBaseWithDestructor_close0",
+    ][::std::mem::align_of::<BaseWithDestructor>() - 1usize];
+};

--- a/bindgen-tests/tests/expectations/tests/ctypes-prefix-path.rs
+++ b/bindgen-tests/tests/expectations/tests/ctypes-prefix-path.rs
@@ -13,36 +13,13 @@ pub struct foo {
     pub b: libc::foo::c_int,
     pub bar: *mut libc::foo::c_void,
 }
-#[test]
-fn bindgen_test_layout_foo() {
-    const UNINIT: ::core::mem::MaybeUninit<foo> = ::core::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::core::mem::size_of::<foo>(),
-        16usize,
-        concat!("Size of: ", stringify!(foo)),
-    );
-    assert_eq!(
-        ::core::mem::align_of::<foo>(),
-        8usize,
-        concat!("Alignment of ", stringify!(foo)),
-    );
-    assert_eq!(
-        unsafe { ::core::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(a)),
-    );
-    assert_eq!(
-        unsafe { ::core::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
-        4usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(b)),
-    );
-    assert_eq!(
-        unsafe { ::core::ptr::addr_of!((*ptr).bar) as usize - ptr as usize },
-        8usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar)),
-    );
-}
+const _: () = {
+    ["Size of foo"][::core::mem::size_of::<foo>() - 16usize];
+    ["Alignment of foo"][::core::mem::align_of::<foo>() - 8usize];
+    ["Offset of field: foo::a"][::core::mem::offset_of!(foo, a) - 0usize];
+    ["Offset of field: foo::b"][::core::mem::offset_of!(foo, b) - 4usize];
+    ["Offset of field: foo::bar"][::core::mem::offset_of!(foo, bar) - 8usize];
+};
 impl Default for foo {
     fn default() -> Self {
         let mut s = ::core::mem::MaybeUninit::<Self>::uninit();

--- a/bindgen-tests/tests/expectations/tests/default-template-parameter.rs
+++ b/bindgen-tests/tests/expectations/tests/default-template-parameter.rs
@@ -16,25 +16,14 @@ impl<T, U> Default for Foo<T, U> {
         }
     }
 }
-#[test]
-fn __bindgen_test_layout_Foo_open0_bool__int_close0_instantiation() {
-    assert_eq!(
-        ::std::mem::size_of::<Foo<bool, ::std::os::raw::c_int>>(),
-        8usize,
-        concat!(
-            "Size of template specialization: ",
-            stringify!(Foo < bool, ::std::os::raw::c_int >),
-        ),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Foo<bool, ::std::os::raw::c_int>>(),
-        4usize,
-        concat!(
-            "Alignment of template specialization: ",
-            stringify!(Foo < bool, ::std::os::raw::c_int >),
-        ),
-    );
-}
+const _: () = {
+    [
+        "Size of template specialization: Foo_open0_bool__int_close0",
+    ][::std::mem::size_of::<Foo<bool, ::std::os::raw::c_int>>() - 8usize];
+    [
+        "Align of template specialization: Foo_open0_bool__int_close0",
+    ][::std::mem::align_of::<Foo<bool, ::std::os::raw::c_int>>() - 4usize];
+};
 extern "C" {
     #[link_name = "\u{1}_ZL3bar"]
     pub static mut bar: Foo<bool, ::std::os::raw::c_int>;

--- a/bindgen-tests/tests/expectations/tests/deleted-function.rs
+++ b/bindgen-tests/tests/expectations/tests/deleted-function.rs
@@ -4,15 +4,10 @@
 pub struct A {
     pub _address: u8,
 }
-#[test]
-fn bindgen_test_layout_A() {
-    assert_eq!(::std::mem::size_of::<A>(), 1usize, concat!("Size of: ", stringify!(A)));
-    assert_eq!(
-        ::std::mem::align_of::<A>(),
-        1usize,
-        concat!("Alignment of ", stringify!(A)),
-    );
-}
+const _: () = {
+    ["Size of A"][::std::mem::size_of::<A>() - 1usize];
+    ["Alignment of A"][::std::mem::align_of::<A>() - 1usize];
+};
 extern "C" {
     #[link_name = "\u{1}_ZN1A17inline_definitionEv"]
     pub fn A_inline_definition(this: *mut A);
@@ -36,29 +31,19 @@ impl A {
 pub struct B {
     pub _address: u8,
 }
-#[test]
-fn bindgen_test_layout_B() {
-    assert_eq!(::std::mem::size_of::<B>(), 1usize, concat!("Size of: ", stringify!(B)));
-    assert_eq!(
-        ::std::mem::align_of::<B>(),
-        1usize,
-        concat!("Alignment of ", stringify!(B)),
-    );
-}
+const _: () = {
+    ["Size of B"][::std::mem::size_of::<B>() - 1usize];
+    ["Alignment of B"][::std::mem::align_of::<B>() - 1usize];
+};
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct C {
     pub _address: u8,
 }
-#[test]
-fn bindgen_test_layout_C() {
-    assert_eq!(::std::mem::size_of::<C>(), 1usize, concat!("Size of: ", stringify!(C)));
-    assert_eq!(
-        ::std::mem::align_of::<C>(),
-        1usize,
-        concat!("Alignment of ", stringify!(C)),
-    );
-}
+const _: () = {
+    ["Size of C"][::std::mem::size_of::<C>() - 1usize];
+    ["Alignment of C"][::std::mem::align_of::<C>() - 1usize];
+};
 extern "C" {
     #[link_name = "\u{1}_ZN1CC1ERS_"]
     pub fn C_C(this: *mut C, arg1: *mut C);

--- a/bindgen-tests/tests/expectations/tests/derive-bitfield-method-same-name.rs
+++ b/bindgen-tests/tests/expectations/tests/derive-bitfield-method-same-name.rs
@@ -98,20 +98,12 @@ pub struct Foo {
 fn bindgen_test_layout_Foo() {
     const UNINIT: ::std::mem::MaybeUninit<Foo> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<Foo>(),
-        136usize,
-        concat!("Size of: ", stringify!(Foo)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Foo>(),
-        4usize,
-        concat!("Alignment of ", stringify!(Foo)),
-    );
+    assert_eq!(::std::mem::size_of::<Foo>(), 136usize, "Size of Foo");
+    assert_eq!(::std::mem::align_of::<Foo>(), 4usize, "Alignment of Foo");
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).large) as usize - ptr as usize },
         0usize,
-        concat!("Offset of field: ", stringify!(Foo), "::", stringify!(large)),
+        "Offset of field: Foo::large",
     );
 }
 extern "C" {

--- a/bindgen-tests/tests/expectations/tests/derive-clone.rs
+++ b/bindgen-tests/tests/expectations/tests/derive-clone.rs
@@ -12,22 +12,17 @@ fn bindgen_test_layout_ShouldDeriveClone() {
     assert_eq!(
         ::std::mem::size_of::<ShouldDeriveClone>(),
         132usize,
-        concat!("Size of: ", stringify!(ShouldDeriveClone)),
+        "Size of ShouldDeriveClone",
     );
     assert_eq!(
         ::std::mem::align_of::<ShouldDeriveClone>(),
         4usize,
-        concat!("Alignment of ", stringify!(ShouldDeriveClone)),
+        "Alignment of ShouldDeriveClone",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).large) as usize - ptr as usize },
         0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(ShouldDeriveClone),
-            "::",
-            stringify!(large),
-        ),
+        "Offset of field: ShouldDeriveClone::large",
     );
 }
 impl Default for ShouldDeriveClone {

--- a/bindgen-tests/tests/expectations/tests/derive-clone_1_0.rs
+++ b/bindgen-tests/tests/expectations/tests/derive-clone_1_0.rs
@@ -13,22 +13,17 @@ fn bindgen_test_layout_ShouldImplClone() {
     assert_eq!(
         ::std::mem::size_of::<ShouldImplClone>(),
         132usize,
-        concat!("Size of: ", stringify!(ShouldImplClone)),
+        "Size of ShouldImplClone",
     );
     assert_eq!(
         ::std::mem::align_of::<ShouldImplClone>(),
         4usize,
-        concat!("Alignment of ", stringify!(ShouldImplClone)),
+        "Alignment of ShouldImplClone",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).large) as usize - ptr as usize },
         0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(ShouldImplClone),
-            "::",
-            stringify!(large),
-        ),
+        "Offset of field: ShouldImplClone::large",
     );
 }
 impl Clone for ShouldImplClone {

--- a/bindgen-tests/tests/expectations/tests/derive-custom-cli.rs
+++ b/bindgen-tests/tests/expectations/tests/derive-custom-cli.rs
@@ -4,26 +4,13 @@
 pub struct foo_struct {
     pub inner: ::std::os::raw::c_int,
 }
-#[test]
-fn bindgen_test_layout_foo_struct() {
-    const UNINIT: ::std::mem::MaybeUninit<foo_struct> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<foo_struct>(),
-        4usize,
-        concat!("Size of: ", stringify!(foo_struct)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<foo_struct>(),
-        4usize,
-        concat!("Alignment of ", stringify!(foo_struct)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).inner) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(foo_struct), "::", stringify!(inner)),
-    );
-}
+const _: () = {
+    ["Size of foo_struct"][::std::mem::size_of::<foo_struct>() - 4usize];
+    ["Alignment of foo_struct"][::std::mem::align_of::<foo_struct>() - 4usize];
+    [
+        "Offset of field: foo_struct::inner",
+    ][::std::mem::offset_of!(foo_struct, inner) - 0usize];
+};
 #[repr(u32)]
 #[derive(Clone, Hash, PartialEq, Eq, Copy)]
 pub enum foo_enum {
@@ -35,52 +22,20 @@ pub union foo_union {
     pub fst: ::std::mem::ManuallyDrop<::std::os::raw::c_int>,
     pub snd: ::std::mem::ManuallyDrop<f32>,
 }
-#[test]
-fn bindgen_test_layout_foo_union() {
-    const UNINIT: ::std::mem::MaybeUninit<foo_union> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<foo_union>(),
-        4usize,
-        concat!("Size of: ", stringify!(foo_union)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<foo_union>(),
-        4usize,
-        concat!("Alignment of ", stringify!(foo_union)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).fst) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(foo_union), "::", stringify!(fst)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).snd) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(foo_union), "::", stringify!(snd)),
-    );
-}
+const _: () = {
+    ["Size of foo_union"][::std::mem::size_of::<foo_union>() - 4usize];
+    ["Alignment of foo_union"][::std::mem::align_of::<foo_union>() - 4usize];
+    ["Offset of field: foo_union::fst"][::std::mem::offset_of!(foo_union, fst) - 0usize];
+    ["Offset of field: foo_union::snd"][::std::mem::offset_of!(foo_union, snd) - 0usize];
+};
 #[repr(C)]
 pub struct non_matching {
     pub inner: ::std::os::raw::c_int,
 }
-#[test]
-fn bindgen_test_layout_non_matching() {
-    const UNINIT: ::std::mem::MaybeUninit<non_matching> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<non_matching>(),
-        4usize,
-        concat!("Size of: ", stringify!(non_matching)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<non_matching>(),
-        4usize,
-        concat!("Alignment of ", stringify!(non_matching)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).inner) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(non_matching), "::", stringify!(inner)),
-    );
-}
+const _: () = {
+    ["Size of non_matching"][::std::mem::size_of::<non_matching>() - 4usize];
+    ["Alignment of non_matching"][::std::mem::align_of::<non_matching>() - 4usize];
+    [
+        "Offset of field: non_matching::inner",
+    ][::std::mem::offset_of!(non_matching, inner) - 0usize];
+};

--- a/bindgen-tests/tests/expectations/tests/derive-debug-bitfield-core.rs
+++ b/bindgen-tests/tests/expectations/tests/derive-debug-bitfield-core.rs
@@ -95,20 +95,12 @@ pub struct C {
 fn bindgen_test_layout_C() {
     const UNINIT: ::core::mem::MaybeUninit<C> = ::core::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::core::mem::size_of::<C>(),
-        204usize,
-        concat!("Size of: ", stringify!(C)),
-    );
-    assert_eq!(
-        ::core::mem::align_of::<C>(),
-        4usize,
-        concat!("Alignment of ", stringify!(C)),
-    );
+    assert_eq!(::core::mem::size_of::<C>(), 204usize, "Size of C");
+    assert_eq!(::core::mem::align_of::<C>(), 4usize, "Alignment of C");
     assert_eq!(
         unsafe { ::core::ptr::addr_of!((*ptr).large_array) as usize - ptr as usize },
         4usize,
-        concat!("Offset of field: ", stringify!(C), "::", stringify!(large_array)),
+        "Offset of field: C::large_array",
     );
 }
 impl Default for C {

--- a/bindgen-tests/tests/expectations/tests/derive-debug-bitfield.rs
+++ b/bindgen-tests/tests/expectations/tests/derive-debug-bitfield.rs
@@ -94,20 +94,12 @@ pub struct C {
 fn bindgen_test_layout_C() {
     const UNINIT: ::std::mem::MaybeUninit<C> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<C>(),
-        204usize,
-        concat!("Size of: ", stringify!(C)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<C>(),
-        4usize,
-        concat!("Alignment of ", stringify!(C)),
-    );
+    assert_eq!(::std::mem::size_of::<C>(), 204usize, "Size of C");
+    assert_eq!(::std::mem::align_of::<C>(), 4usize, "Alignment of C");
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).large_array) as usize - ptr as usize },
         4usize,
-        concat!("Offset of field: ", stringify!(C), "::", stringify!(large_array)),
+        "Offset of field: C::large_array",
     );
 }
 impl Default for C {

--- a/bindgen-tests/tests/expectations/tests/derive-debug-function-pointer.rs
+++ b/bindgen-tests/tests/expectations/tests/derive-debug-function-pointer.rs
@@ -12,25 +12,17 @@ pub type Nice_Function = ::std::option::Option<
 fn bindgen_test_layout_Nice() {
     const UNINIT: ::std::mem::MaybeUninit<Nice> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<Nice>(),
-        144usize,
-        concat!("Size of: ", stringify!(Nice)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Nice>(),
-        8usize,
-        concat!("Alignment of ", stringify!(Nice)),
-    );
+    assert_eq!(::std::mem::size_of::<Nice>(), 144usize, "Size of Nice");
+    assert_eq!(::std::mem::align_of::<Nice>(), 8usize, "Alignment of Nice");
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).pointer) as usize - ptr as usize },
         0usize,
-        concat!("Offset of field: ", stringify!(Nice), "::", stringify!(pointer)),
+        "Offset of field: Nice::pointer",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).large_array) as usize - ptr as usize },
         8usize,
-        concat!("Offset of field: ", stringify!(Nice), "::", stringify!(large_array)),
+        "Offset of field: Nice::large_array",
     );
 }
 impl Default for Nice {

--- a/bindgen-tests/tests/expectations/tests/derive-debug-mangle-name.rs
+++ b/bindgen-tests/tests/expectations/tests/derive-debug-mangle-name.rs
@@ -12,41 +12,20 @@ pub union perf_event_attr__bindgen_ty_1 {
     pub b: ::std::os::raw::c_int,
     pub c: ::std::os::raw::c_int,
 }
-#[test]
-fn bindgen_test_layout_perf_event_attr__bindgen_ty_1() {
-    const UNINIT: ::std::mem::MaybeUninit<perf_event_attr__bindgen_ty_1> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<perf_event_attr__bindgen_ty_1>(),
-        4usize,
-        concat!("Size of: ", stringify!(perf_event_attr__bindgen_ty_1)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<perf_event_attr__bindgen_ty_1>(),
-        4usize,
-        concat!("Alignment of ", stringify!(perf_event_attr__bindgen_ty_1)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(perf_event_attr__bindgen_ty_1),
-            "::",
-            stringify!(b),
-        ),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).c) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(perf_event_attr__bindgen_ty_1),
-            "::",
-            stringify!(c),
-        ),
-    );
-}
+const _: () = {
+    [
+        "Size of perf_event_attr__bindgen_ty_1",
+    ][::std::mem::size_of::<perf_event_attr__bindgen_ty_1>() - 4usize];
+    [
+        "Alignment of perf_event_attr__bindgen_ty_1",
+    ][::std::mem::align_of::<perf_event_attr__bindgen_ty_1>() - 4usize];
+    [
+        "Offset of field: perf_event_attr__bindgen_ty_1::b",
+    ][::std::mem::offset_of!(perf_event_attr__bindgen_ty_1, b) - 0usize];
+    [
+        "Offset of field: perf_event_attr__bindgen_ty_1::c",
+    ][::std::mem::offset_of!(perf_event_attr__bindgen_ty_1, c) - 0usize];
+};
 impl Default for perf_event_attr__bindgen_ty_1 {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
@@ -61,36 +40,16 @@ impl ::std::fmt::Debug for perf_event_attr__bindgen_ty_1 {
         write!(f, "perf_event_attr__bindgen_ty_1 {{ union }}")
     }
 }
-#[test]
-fn bindgen_test_layout_perf_event_attr() {
-    const UNINIT: ::std::mem::MaybeUninit<perf_event_attr> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<perf_event_attr>(),
-        12usize,
-        concat!("Size of: ", stringify!(perf_event_attr)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<perf_event_attr>(),
-        4usize,
-        concat!("Alignment of ", stringify!(perf_event_attr)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).type_) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(perf_event_attr),
-            "::",
-            stringify!(type_),
-        ),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
-        4usize,
-        concat!("Offset of field: ", stringify!(perf_event_attr), "::", stringify!(a)),
-    );
-}
+const _: () = {
+    ["Size of perf_event_attr"][::std::mem::size_of::<perf_event_attr>() - 12usize];
+    ["Alignment of perf_event_attr"][::std::mem::align_of::<perf_event_attr>() - 4usize];
+    [
+        "Offset of field: perf_event_attr::type_",
+    ][::std::mem::offset_of!(perf_event_attr, type_) - 0usize];
+    [
+        "Offset of field: perf_event_attr::a",
+    ][::std::mem::offset_of!(perf_event_attr, a) - 4usize];
+};
 impl Default for perf_event_attr {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();

--- a/bindgen-tests/tests/expectations/tests/derive-debug-opaque-template-instantiation.rs
+++ b/bindgen-tests/tests/expectations/tests/derive-debug-opaque-template-instantiation.rs
@@ -7,20 +7,12 @@ pub struct Instance {
 fn bindgen_test_layout_Instance() {
     const UNINIT: ::std::mem::MaybeUninit<Instance> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<Instance>(),
-        200usize,
-        concat!("Size of: ", stringify!(Instance)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Instance>(),
-        4usize,
-        concat!("Alignment of ", stringify!(Instance)),
-    );
+    assert_eq!(::std::mem::size_of::<Instance>(), 200usize, "Size of Instance");
+    assert_eq!(::std::mem::align_of::<Instance>(), 4usize, "Alignment of Instance");
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).val) as usize - ptr as usize },
         0usize,
-        concat!("Offset of field: ", stringify!(Instance), "::", stringify!(val)),
+        "Offset of field: Instance::val",
     );
 }
 impl Default for Instance {

--- a/bindgen-tests/tests/expectations/tests/derive-debug-opaque.rs
+++ b/bindgen-tests/tests/expectations/tests/derive-debug-opaque.rs
@@ -6,16 +6,8 @@ pub struct Opaque {
 }
 #[test]
 fn bindgen_test_layout_Opaque() {
-    assert_eq!(
-        ::std::mem::size_of::<Opaque>(),
-        164usize,
-        concat!("Size of: ", stringify!(Opaque)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Opaque>(),
-        4usize,
-        concat!("Alignment of ", stringify!(Opaque)),
-    );
+    assert_eq!(::std::mem::size_of::<Opaque>(), 164usize, "Size of Opaque");
+    assert_eq!(::std::mem::align_of::<Opaque>(), 4usize, "Alignment of Opaque");
 }
 impl Default for Opaque {
     fn default() -> Self {
@@ -39,20 +31,12 @@ pub struct OpaqueUser {
 fn bindgen_test_layout_OpaqueUser() {
     const UNINIT: ::std::mem::MaybeUninit<OpaqueUser> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<OpaqueUser>(),
-        164usize,
-        concat!("Size of: ", stringify!(OpaqueUser)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<OpaqueUser>(),
-        4usize,
-        concat!("Alignment of ", stringify!(OpaqueUser)),
-    );
+    assert_eq!(::std::mem::size_of::<OpaqueUser>(), 164usize, "Size of OpaqueUser");
+    assert_eq!(::std::mem::align_of::<OpaqueUser>(), 4usize, "Alignment of OpaqueUser");
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).opaque) as usize - ptr as usize },
         0usize,
-        concat!("Offset of field: ", stringify!(OpaqueUser), "::", stringify!(opaque)),
+        "Offset of field: OpaqueUser::opaque",
     );
 }
 impl Default for OpaqueUser {

--- a/bindgen-tests/tests/expectations/tests/derive-default-and-blocklist.rs
+++ b/bindgen-tests/tests/expectations/tests/derive-default-and-blocklist.rs
@@ -6,31 +6,17 @@ pub struct BlocklistMe(u8);
 pub struct ShouldNotDeriveDefault {
     pub a: BlocklistMe,
 }
-#[test]
-fn bindgen_test_layout_ShouldNotDeriveDefault() {
-    const UNINIT: ::std::mem::MaybeUninit<ShouldNotDeriveDefault> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<ShouldNotDeriveDefault>(),
-        1usize,
-        concat!("Size of: ", stringify!(ShouldNotDeriveDefault)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<ShouldNotDeriveDefault>(),
-        1usize,
-        concat!("Alignment of ", stringify!(ShouldNotDeriveDefault)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(ShouldNotDeriveDefault),
-            "::",
-            stringify!(a),
-        ),
-    );
-}
+const _: () = {
+    [
+        "Size of ShouldNotDeriveDefault",
+    ][::std::mem::size_of::<ShouldNotDeriveDefault>() - 1usize];
+    [
+        "Alignment of ShouldNotDeriveDefault",
+    ][::std::mem::align_of::<ShouldNotDeriveDefault>() - 1usize];
+    [
+        "Offset of field: ShouldNotDeriveDefault::a",
+    ][::std::mem::offset_of!(ShouldNotDeriveDefault, a) - 0usize];
+};
 impl Default for ShouldNotDeriveDefault {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();

--- a/bindgen-tests/tests/expectations/tests/derive-fn-ptr.rs
+++ b/bindgen-tests/tests/expectations/tests/derive-fn-ptr.rs
@@ -24,26 +24,11 @@ pub type my_fun_t = ::std::option::Option<
 pub struct Foo {
     pub callback: my_fun_t,
 }
-#[test]
-fn bindgen_test_layout_Foo() {
-    const UNINIT: ::std::mem::MaybeUninit<Foo> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<Foo>(),
-        8usize,
-        concat!("Size of: ", stringify!(Foo)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Foo>(),
-        8usize,
-        concat!("Alignment of ", stringify!(Foo)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).callback) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(Foo), "::", stringify!(callback)),
-    );
-}
+const _: () = {
+    ["Size of Foo"][::std::mem::size_of::<Foo>() - 8usize];
+    ["Alignment of Foo"][::std::mem::align_of::<Foo>() - 8usize];
+    ["Offset of field: Foo::callback"][::std::mem::offset_of!(Foo, callback) - 0usize];
+};
 pub type my_fun2_t = ::std::option::Option<
     unsafe extern "C" fn(
         arg1: ::std::os::raw::c_int,
@@ -65,23 +50,8 @@ pub type my_fun2_t = ::std::option::Option<
 pub struct Bar {
     pub callback: my_fun2_t,
 }
-#[test]
-fn bindgen_test_layout_Bar() {
-    const UNINIT: ::std::mem::MaybeUninit<Bar> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<Bar>(),
-        8usize,
-        concat!("Size of: ", stringify!(Bar)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Bar>(),
-        8usize,
-        concat!("Alignment of ", stringify!(Bar)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).callback) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(Bar), "::", stringify!(callback)),
-    );
-}
+const _: () = {
+    ["Size of Bar"][::std::mem::size_of::<Bar>() - 8usize];
+    ["Alignment of Bar"][::std::mem::align_of::<Bar>() - 8usize];
+    ["Offset of field: Bar::callback"][::std::mem::offset_of!(Bar, callback) - 0usize];
+};

--- a/bindgen-tests/tests/expectations/tests/derive-hash-and-blocklist.rs
+++ b/bindgen-tests/tests/expectations/tests/derive-hash-and-blocklist.rs
@@ -5,31 +5,17 @@ pub struct BlocklistMe(u8);
 pub struct ShouldNotDeriveHash {
     pub a: BlocklistMe,
 }
-#[test]
-fn bindgen_test_layout_ShouldNotDeriveHash() {
-    const UNINIT: ::std::mem::MaybeUninit<ShouldNotDeriveHash> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<ShouldNotDeriveHash>(),
-        1usize,
-        concat!("Size of: ", stringify!(ShouldNotDeriveHash)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<ShouldNotDeriveHash>(),
-        1usize,
-        concat!("Alignment of ", stringify!(ShouldNotDeriveHash)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(ShouldNotDeriveHash),
-            "::",
-            stringify!(a),
-        ),
-    );
-}
+const _: () = {
+    [
+        "Size of ShouldNotDeriveHash",
+    ][::std::mem::size_of::<ShouldNotDeriveHash>() - 1usize];
+    [
+        "Alignment of ShouldNotDeriveHash",
+    ][::std::mem::align_of::<ShouldNotDeriveHash>() - 1usize];
+    [
+        "Offset of field: ShouldNotDeriveHash::a",
+    ][::std::mem::offset_of!(ShouldNotDeriveHash, a) - 0usize];
+};
 impl Default for ShouldNotDeriveHash {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();

--- a/bindgen-tests/tests/expectations/tests/derive-hash-blocklisting.rs
+++ b/bindgen-tests/tests/expectations/tests/derive-hash-blocklisting.rs
@@ -11,26 +11,13 @@ pub struct Blocklisted<T> {
 pub struct AllowlistedOne {
     pub a: Blocklisted<::std::os::raw::c_int>,
 }
-#[test]
-fn bindgen_test_layout_AllowlistedOne() {
-    const UNINIT: ::std::mem::MaybeUninit<AllowlistedOne> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<AllowlistedOne>(),
-        4usize,
-        concat!("Size of: ", stringify!(AllowlistedOne)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<AllowlistedOne>(),
-        4usize,
-        concat!("Alignment of ", stringify!(AllowlistedOne)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(AllowlistedOne), "::", stringify!(a)),
-    );
-}
+const _: () = {
+    ["Size of AllowlistedOne"][::std::mem::size_of::<AllowlistedOne>() - 4usize];
+    ["Alignment of AllowlistedOne"][::std::mem::align_of::<AllowlistedOne>() - 4usize];
+    [
+        "Offset of field: AllowlistedOne::a",
+    ][::std::mem::offset_of!(AllowlistedOne, a) - 0usize];
+};
 impl Default for AllowlistedOne {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
@@ -45,26 +32,13 @@ impl Default for AllowlistedOne {
 pub struct AllowlistedTwo {
     pub b: Blocklisted<f32>,
 }
-#[test]
-fn bindgen_test_layout_AllowlistedTwo() {
-    const UNINIT: ::std::mem::MaybeUninit<AllowlistedTwo> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<AllowlistedTwo>(),
-        4usize,
-        concat!("Size of: ", stringify!(AllowlistedTwo)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<AllowlistedTwo>(),
-        4usize,
-        concat!("Alignment of ", stringify!(AllowlistedTwo)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(AllowlistedTwo), "::", stringify!(b)),
-    );
-}
+const _: () = {
+    ["Size of AllowlistedTwo"][::std::mem::size_of::<AllowlistedTwo>() - 4usize];
+    ["Alignment of AllowlistedTwo"][::std::mem::align_of::<AllowlistedTwo>() - 4usize];
+    [
+        "Offset of field: AllowlistedTwo::b",
+    ][::std::mem::offset_of!(AllowlistedTwo, b) - 0usize];
+};
 impl Default for AllowlistedTwo {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();

--- a/bindgen-tests/tests/expectations/tests/derive-hash-struct-with-anon-struct-float.rs
+++ b/bindgen-tests/tests/expectations/tests/derive-hash-struct-with-anon-struct-float.rs
@@ -11,48 +11,20 @@ pub struct foo__bindgen_ty_1 {
     pub a: f32,
     pub b: f32,
 }
-#[test]
-fn bindgen_test_layout_foo__bindgen_ty_1() {
-    const UNINIT: ::std::mem::MaybeUninit<foo__bindgen_ty_1> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<foo__bindgen_ty_1>(),
-        8usize,
-        concat!("Size of: ", stringify!(foo__bindgen_ty_1)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<foo__bindgen_ty_1>(),
-        4usize,
-        concat!("Alignment of ", stringify!(foo__bindgen_ty_1)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(foo__bindgen_ty_1), "::", stringify!(a)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
-        4usize,
-        concat!("Offset of field: ", stringify!(foo__bindgen_ty_1), "::", stringify!(b)),
-    );
-}
-#[test]
-fn bindgen_test_layout_foo() {
-    const UNINIT: ::std::mem::MaybeUninit<foo> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<foo>(),
-        8usize,
-        concat!("Size of: ", stringify!(foo)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<foo>(),
-        4usize,
-        concat!("Alignment of ", stringify!(foo)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar)),
-    );
-}
+const _: () = {
+    ["Size of foo__bindgen_ty_1"][::std::mem::size_of::<foo__bindgen_ty_1>() - 8usize];
+    [
+        "Alignment of foo__bindgen_ty_1",
+    ][::std::mem::align_of::<foo__bindgen_ty_1>() - 4usize];
+    [
+        "Offset of field: foo__bindgen_ty_1::a",
+    ][::std::mem::offset_of!(foo__bindgen_ty_1, a) - 0usize];
+    [
+        "Offset of field: foo__bindgen_ty_1::b",
+    ][::std::mem::offset_of!(foo__bindgen_ty_1, b) - 4usize];
+};
+const _: () = {
+    ["Size of foo"][::std::mem::size_of::<foo>() - 8usize];
+    ["Alignment of foo"][::std::mem::align_of::<foo>() - 4usize];
+    ["Offset of field: foo::bar"][::std::mem::offset_of!(foo, bar) - 0usize];
+};

--- a/bindgen-tests/tests/expectations/tests/derive-hash-struct-with-float-array.rs
+++ b/bindgen-tests/tests/expectations/tests/derive-hash-struct-with-float-array.rs
@@ -5,23 +5,8 @@
 pub struct foo {
     pub bar: [f32; 3usize],
 }
-#[test]
-fn bindgen_test_layout_foo() {
-    const UNINIT: ::std::mem::MaybeUninit<foo> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<foo>(),
-        12usize,
-        concat!("Size of: ", stringify!(foo)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<foo>(),
-        4usize,
-        concat!("Alignment of ", stringify!(foo)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar)),
-    );
-}
+const _: () = {
+    ["Size of foo"][::std::mem::size_of::<foo>() - 12usize];
+    ["Alignment of foo"][::std::mem::align_of::<foo>() - 4usize];
+    ["Offset of field: foo::bar"][::std::mem::offset_of!(foo, bar) - 0usize];
+};

--- a/bindgen-tests/tests/expectations/tests/derive-hash-struct-with-incomplete-array.rs
+++ b/bindgen-tests/tests/expectations/tests/derive-hash-struct-with-incomplete-array.rs
@@ -35,74 +35,28 @@ pub struct test {
     pub a: ::std::os::raw::c_int,
     pub zero_length_array: __IncompleteArrayField<::std::os::raw::c_char>,
 }
-#[test]
-fn bindgen_test_layout_test() {
-    const UNINIT: ::std::mem::MaybeUninit<test> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<test>(),
-        4usize,
-        concat!("Size of: ", stringify!(test)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<test>(),
-        4usize,
-        concat!("Alignment of ", stringify!(test)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(test), "::", stringify!(a)),
-    );
-    assert_eq!(
-        unsafe {
-            ::std::ptr::addr_of!((*ptr).zero_length_array) as usize - ptr as usize
-        },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(test),
-            "::",
-            stringify!(zero_length_array),
-        ),
-    );
-}
+const _: () = {
+    ["Size of test"][::std::mem::size_of::<test>() - 4usize];
+    ["Alignment of test"][::std::mem::align_of::<test>() - 4usize];
+    ["Offset of field: test::a"][::std::mem::offset_of!(test, a) - 0usize];
+    [
+        "Offset of field: test::zero_length_array",
+    ][::std::mem::offset_of!(test, zero_length_array) - 4usize];
+};
 #[repr(C)]
 #[derive(Debug, Default)]
 pub struct test2 {
     pub a: ::std::os::raw::c_int,
     pub incomplete_array: __IncompleteArrayField<::std::os::raw::c_char>,
 }
-#[test]
-fn bindgen_test_layout_test2() {
-    const UNINIT: ::std::mem::MaybeUninit<test2> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<test2>(),
-        4usize,
-        concat!("Size of: ", stringify!(test2)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<test2>(),
-        4usize,
-        concat!("Alignment of ", stringify!(test2)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(test2), "::", stringify!(a)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).incomplete_array) as usize - ptr as usize },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(test2),
-            "::",
-            stringify!(incomplete_array),
-        ),
-    );
-}
+const _: () = {
+    ["Size of test2"][::std::mem::size_of::<test2>() - 4usize];
+    ["Alignment of test2"][::std::mem::align_of::<test2>() - 4usize];
+    ["Offset of field: test2::a"][::std::mem::offset_of!(test2, a) - 0usize];
+    [
+        "Offset of field: test2::incomplete_array",
+    ][::std::mem::offset_of!(test2, incomplete_array) - 4usize];
+};
 #[repr(C)]
 #[derive(Debug, Default)]
 pub struct test3 {
@@ -110,45 +64,14 @@ pub struct test3 {
     pub zero_length_array: __IncompleteArrayField<::std::os::raw::c_char>,
     pub incomplete_array: __IncompleteArrayField<::std::os::raw::c_char>,
 }
-#[test]
-fn bindgen_test_layout_test3() {
-    const UNINIT: ::std::mem::MaybeUninit<test3> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<test3>(),
-        4usize,
-        concat!("Size of: ", stringify!(test3)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<test3>(),
-        4usize,
-        concat!("Alignment of ", stringify!(test3)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(test3), "::", stringify!(a)),
-    );
-    assert_eq!(
-        unsafe {
-            ::std::ptr::addr_of!((*ptr).zero_length_array) as usize - ptr as usize
-        },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(test3),
-            "::",
-            stringify!(zero_length_array),
-        ),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).incomplete_array) as usize - ptr as usize },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(test3),
-            "::",
-            stringify!(incomplete_array),
-        ),
-    );
-}
+const _: () = {
+    ["Size of test3"][::std::mem::size_of::<test3>() - 4usize];
+    ["Alignment of test3"][::std::mem::align_of::<test3>() - 4usize];
+    ["Offset of field: test3::a"][::std::mem::offset_of!(test3, a) - 0usize];
+    [
+        "Offset of field: test3::zero_length_array",
+    ][::std::mem::offset_of!(test3, zero_length_array) - 4usize];
+    [
+        "Offset of field: test3::incomplete_array",
+    ][::std::mem::offset_of!(test3, incomplete_array) - 4usize];
+};

--- a/bindgen-tests/tests/expectations/tests/derive-hash-struct-with-pointer.rs
+++ b/bindgen-tests/tests/expectations/tests/derive-hash-struct-with-pointer.rs
@@ -5,26 +5,13 @@
 pub struct ConstPtrMutObj {
     pub bar: *mut ::std::os::raw::c_int,
 }
-#[test]
-fn bindgen_test_layout_ConstPtrMutObj() {
-    const UNINIT: ::std::mem::MaybeUninit<ConstPtrMutObj> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<ConstPtrMutObj>(),
-        8usize,
-        concat!("Size of: ", stringify!(ConstPtrMutObj)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<ConstPtrMutObj>(),
-        8usize,
-        concat!("Alignment of ", stringify!(ConstPtrMutObj)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(ConstPtrMutObj), "::", stringify!(bar)),
-    );
-}
+const _: () = {
+    ["Size of ConstPtrMutObj"][::std::mem::size_of::<ConstPtrMutObj>() - 8usize];
+    ["Alignment of ConstPtrMutObj"][::std::mem::align_of::<ConstPtrMutObj>() - 8usize];
+    [
+        "Offset of field: ConstPtrMutObj::bar",
+    ][::std::mem::offset_of!(ConstPtrMutObj, bar) - 0usize];
+};
 impl Default for ConstPtrMutObj {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
@@ -39,26 +26,13 @@ impl Default for ConstPtrMutObj {
 pub struct MutPtrMutObj {
     pub bar: *mut ::std::os::raw::c_int,
 }
-#[test]
-fn bindgen_test_layout_MutPtrMutObj() {
-    const UNINIT: ::std::mem::MaybeUninit<MutPtrMutObj> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<MutPtrMutObj>(),
-        8usize,
-        concat!("Size of: ", stringify!(MutPtrMutObj)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<MutPtrMutObj>(),
-        8usize,
-        concat!("Alignment of ", stringify!(MutPtrMutObj)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(MutPtrMutObj), "::", stringify!(bar)),
-    );
-}
+const _: () = {
+    ["Size of MutPtrMutObj"][::std::mem::size_of::<MutPtrMutObj>() - 8usize];
+    ["Alignment of MutPtrMutObj"][::std::mem::align_of::<MutPtrMutObj>() - 8usize];
+    [
+        "Offset of field: MutPtrMutObj::bar",
+    ][::std::mem::offset_of!(MutPtrMutObj, bar) - 0usize];
+};
 impl Default for MutPtrMutObj {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
@@ -73,26 +47,13 @@ impl Default for MutPtrMutObj {
 pub struct MutPtrConstObj {
     pub bar: *const ::std::os::raw::c_int,
 }
-#[test]
-fn bindgen_test_layout_MutPtrConstObj() {
-    const UNINIT: ::std::mem::MaybeUninit<MutPtrConstObj> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<MutPtrConstObj>(),
-        8usize,
-        concat!("Size of: ", stringify!(MutPtrConstObj)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<MutPtrConstObj>(),
-        8usize,
-        concat!("Alignment of ", stringify!(MutPtrConstObj)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(MutPtrConstObj), "::", stringify!(bar)),
-    );
-}
+const _: () = {
+    ["Size of MutPtrConstObj"][::std::mem::size_of::<MutPtrConstObj>() - 8usize];
+    ["Alignment of MutPtrConstObj"][::std::mem::align_of::<MutPtrConstObj>() - 8usize];
+    [
+        "Offset of field: MutPtrConstObj::bar",
+    ][::std::mem::offset_of!(MutPtrConstObj, bar) - 0usize];
+};
 impl Default for MutPtrConstObj {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
@@ -107,26 +68,15 @@ impl Default for MutPtrConstObj {
 pub struct ConstPtrConstObj {
     pub bar: *const ::std::os::raw::c_int,
 }
-#[test]
-fn bindgen_test_layout_ConstPtrConstObj() {
-    const UNINIT: ::std::mem::MaybeUninit<ConstPtrConstObj> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<ConstPtrConstObj>(),
-        8usize,
-        concat!("Size of: ", stringify!(ConstPtrConstObj)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<ConstPtrConstObj>(),
-        8usize,
-        concat!("Alignment of ", stringify!(ConstPtrConstObj)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(ConstPtrConstObj), "::", stringify!(bar)),
-    );
-}
+const _: () = {
+    ["Size of ConstPtrConstObj"][::std::mem::size_of::<ConstPtrConstObj>() - 8usize];
+    [
+        "Alignment of ConstPtrConstObj",
+    ][::std::mem::align_of::<ConstPtrConstObj>() - 8usize];
+    [
+        "Offset of field: ConstPtrConstObj::bar",
+    ][::std::mem::offset_of!(ConstPtrConstObj, bar) - 0usize];
+};
 impl Default for ConstPtrConstObj {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();

--- a/bindgen-tests/tests/expectations/tests/derive-hash-template-inst-float.rs
+++ b/bindgen-tests/tests/expectations/tests/derive-hash-template-inst-float.rs
@@ -21,26 +21,11 @@ impl<T> Default for foo<T> {
 pub struct IntStr {
     pub a: foo<::std::os::raw::c_int>,
 }
-#[test]
-fn bindgen_test_layout_IntStr() {
-    const UNINIT: ::std::mem::MaybeUninit<IntStr> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<IntStr>(),
-        4usize,
-        concat!("Size of: ", stringify!(IntStr)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<IntStr>(),
-        4usize,
-        concat!("Alignment of ", stringify!(IntStr)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(IntStr), "::", stringify!(a)),
-    );
-}
+const _: () = {
+    ["Size of IntStr"][::std::mem::size_of::<IntStr>() - 4usize];
+    ["Alignment of IntStr"][::std::mem::align_of::<IntStr>() - 4usize];
+    ["Offset of field: IntStr::a"][::std::mem::offset_of!(IntStr, a) - 0usize];
+};
 impl Default for IntStr {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
@@ -56,26 +41,11 @@ impl Default for IntStr {
 pub struct FloatStr {
     pub a: foo<f32>,
 }
-#[test]
-fn bindgen_test_layout_FloatStr() {
-    const UNINIT: ::std::mem::MaybeUninit<FloatStr> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<FloatStr>(),
-        4usize,
-        concat!("Size of: ", stringify!(FloatStr)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<FloatStr>(),
-        4usize,
-        concat!("Alignment of ", stringify!(FloatStr)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(FloatStr), "::", stringify!(a)),
-    );
-}
+const _: () = {
+    ["Size of FloatStr"][::std::mem::size_of::<FloatStr>() - 4usize];
+    ["Alignment of FloatStr"][::std::mem::align_of::<FloatStr>() - 4usize];
+    ["Offset of field: FloatStr::a"][::std::mem::offset_of!(FloatStr, a) - 0usize];
+};
 impl Default for FloatStr {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
@@ -85,35 +55,19 @@ impl Default for FloatStr {
         }
     }
 }
-#[test]
-fn __bindgen_test_layout_foo_open0_int_close0_instantiation() {
-    assert_eq!(
-        ::std::mem::size_of::<foo<::std::os::raw::c_int>>(),
-        4usize,
-        concat!(
-            "Size of template specialization: ",
-            stringify!(foo < ::std::os::raw::c_int >),
-        ),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<foo<::std::os::raw::c_int>>(),
-        4usize,
-        concat!(
-            "Alignment of template specialization: ",
-            stringify!(foo < ::std::os::raw::c_int >),
-        ),
-    );
-}
-#[test]
-fn __bindgen_test_layout_foo_open0_float_close0_instantiation() {
-    assert_eq!(
-        ::std::mem::size_of::<foo<f32>>(),
-        4usize,
-        concat!("Size of template specialization: ", stringify!(foo < f32 >)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<foo<f32>>(),
-        4usize,
-        concat!("Alignment of template specialization: ", stringify!(foo < f32 >)),
-    );
-}
+const _: () = {
+    [
+        "Size of template specialization: foo_open0_int_close0",
+    ][::std::mem::size_of::<foo<::std::os::raw::c_int>>() - 4usize];
+    [
+        "Align of template specialization: foo_open0_int_close0",
+    ][::std::mem::align_of::<foo<::std::os::raw::c_int>>() - 4usize];
+};
+const _: () = {
+    [
+        "Size of template specialization: foo_open0_float_close0",
+    ][::std::mem::size_of::<foo<f32>>() - 4usize];
+    [
+        "Align of template specialization: foo_open0_float_close0",
+    ][::std::mem::align_of::<foo<f32>>() - 4usize];
+};

--- a/bindgen-tests/tests/expectations/tests/derive-partialeq-and-blocklist.rs
+++ b/bindgen-tests/tests/expectations/tests/derive-partialeq-and-blocklist.rs
@@ -6,31 +6,17 @@ pub struct BlocklistMe(u8);
 pub struct ShouldNotDerivePartialEq {
     pub a: BlocklistMe,
 }
-#[test]
-fn bindgen_test_layout_ShouldNotDerivePartialEq() {
-    const UNINIT: ::std::mem::MaybeUninit<ShouldNotDerivePartialEq> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<ShouldNotDerivePartialEq>(),
-        1usize,
-        concat!("Size of: ", stringify!(ShouldNotDerivePartialEq)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<ShouldNotDerivePartialEq>(),
-        1usize,
-        concat!("Alignment of ", stringify!(ShouldNotDerivePartialEq)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(ShouldNotDerivePartialEq),
-            "::",
-            stringify!(a),
-        ),
-    );
-}
+const _: () = {
+    [
+        "Size of ShouldNotDerivePartialEq",
+    ][::std::mem::size_of::<ShouldNotDerivePartialEq>() - 1usize];
+    [
+        "Alignment of ShouldNotDerivePartialEq",
+    ][::std::mem::align_of::<ShouldNotDerivePartialEq>() - 1usize];
+    [
+        "Offset of field: ShouldNotDerivePartialEq::a",
+    ][::std::mem::offset_of!(ShouldNotDerivePartialEq, a) - 0usize];
+};
 impl Default for ShouldNotDerivePartialEq {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();

--- a/bindgen-tests/tests/expectations/tests/derive-partialeq-anonfield.rs
+++ b/bindgen-tests/tests/expectations/tests/derive-partialeq-anonfield.rs
@@ -11,19 +11,14 @@ pub struct rte_mbuf {
 pub struct rte_mbuf__bindgen_ty_1 {
     pub bindgen_union_field: [u8; 0usize],
 }
-#[test]
-fn bindgen_test_layout_rte_mbuf__bindgen_ty_1() {
-    assert_eq!(
-        ::std::mem::size_of::<rte_mbuf__bindgen_ty_1>(),
-        0usize,
-        concat!("Size of: ", stringify!(rte_mbuf__bindgen_ty_1)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<rte_mbuf__bindgen_ty_1>(),
-        1usize,
-        concat!("Alignment of ", stringify!(rte_mbuf__bindgen_ty_1)),
-    );
-}
+const _: () = {
+    [
+        "Size of rte_mbuf__bindgen_ty_1",
+    ][::std::mem::size_of::<rte_mbuf__bindgen_ty_1>() - 0usize];
+    [
+        "Alignment of rte_mbuf__bindgen_ty_1",
+    ][::std::mem::align_of::<rte_mbuf__bindgen_ty_1>() - 1usize];
+};
 impl Default for rte_mbuf__bindgen_ty_1 {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
@@ -33,19 +28,10 @@ impl Default for rte_mbuf__bindgen_ty_1 {
         }
     }
 }
-#[test]
-fn bindgen_test_layout_rte_mbuf() {
-    assert_eq!(
-        ::std::mem::size_of::<rte_mbuf>(),
-        0usize,
-        concat!("Size of: ", stringify!(rte_mbuf)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<rte_mbuf>(),
-        64usize,
-        concat!("Alignment of ", stringify!(rte_mbuf)),
-    );
-}
+const _: () = {
+    ["Size of rte_mbuf"][::std::mem::size_of::<rte_mbuf>() - 0usize];
+    ["Alignment of rte_mbuf"][::std::mem::align_of::<rte_mbuf>() - 64usize];
+};
 impl Default for rte_mbuf {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();

--- a/bindgen-tests/tests/expectations/tests/derive-partialeq-base.rs
+++ b/bindgen-tests/tests/expectations/tests/derive-partialeq-base.rs
@@ -8,20 +8,12 @@ pub struct Base {
 fn bindgen_test_layout_Base() {
     const UNINIT: ::std::mem::MaybeUninit<Base> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<Base>(),
-        132usize,
-        concat!("Size of: ", stringify!(Base)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Base>(),
-        4usize,
-        concat!("Alignment of ", stringify!(Base)),
-    );
+    assert_eq!(::std::mem::size_of::<Base>(), 132usize, "Size of Base");
+    assert_eq!(::std::mem::align_of::<Base>(), 4usize, "Alignment of Base");
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).large) as usize - ptr as usize },
         0usize,
-        concat!("Offset of field: ", stringify!(Base), "::", stringify!(large)),
+        "Offset of field: Base::large",
     );
 }
 impl Default for Base {
@@ -48,12 +40,12 @@ fn bindgen_test_layout_ShouldDerivePartialEq() {
     assert_eq!(
         ::std::mem::size_of::<ShouldDerivePartialEq>(),
         132usize,
-        concat!("Size of: ", stringify!(ShouldDerivePartialEq)),
+        "Size of ShouldDerivePartialEq",
     );
     assert_eq!(
         ::std::mem::align_of::<ShouldDerivePartialEq>(),
         4usize,
-        concat!("Alignment of ", stringify!(ShouldDerivePartialEq)),
+        "Alignment of ShouldDerivePartialEq",
     );
 }
 impl Default for ShouldDerivePartialEq {

--- a/bindgen-tests/tests/expectations/tests/derive-partialeq-bitfield.rs
+++ b/bindgen-tests/tests/expectations/tests/derive-partialeq-bitfield.rs
@@ -94,20 +94,12 @@ pub struct C {
 fn bindgen_test_layout_C() {
     const UNINIT: ::std::mem::MaybeUninit<C> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<C>(),
-        204usize,
-        concat!("Size of: ", stringify!(C)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<C>(),
-        4usize,
-        concat!("Alignment of ", stringify!(C)),
-    );
+    assert_eq!(::std::mem::size_of::<C>(), 204usize, "Size of C");
+    assert_eq!(::std::mem::align_of::<C>(), 4usize, "Alignment of C");
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).large_array) as usize - ptr as usize },
         4usize,
-        concat!("Offset of field: ", stringify!(C), "::", stringify!(large_array)),
+        "Offset of field: C::large_array",
     );
 }
 impl Default for C {

--- a/bindgen-tests/tests/expectations/tests/derive-partialeq-core.rs
+++ b/bindgen-tests/tests/expectations/tests/derive-partialeq-core.rs
@@ -9,20 +9,12 @@ pub struct C {
 fn bindgen_test_layout_C() {
     const UNINIT: ::core::mem::MaybeUninit<C> = ::core::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::core::mem::size_of::<C>(),
-        1680usize,
-        concat!("Size of: ", stringify!(C)),
-    );
-    assert_eq!(
-        ::core::mem::align_of::<C>(),
-        4usize,
-        concat!("Alignment of ", stringify!(C)),
-    );
+    assert_eq!(::core::mem::size_of::<C>(), 1680usize, "Size of C");
+    assert_eq!(::core::mem::align_of::<C>(), 4usize, "Alignment of C");
     assert_eq!(
         unsafe { ::core::ptr::addr_of!((*ptr).large_array) as usize - ptr as usize },
         0usize,
-        concat!("Offset of field: ", stringify!(C), "::", stringify!(large_array)),
+        "Offset of field: C::large_array",
     );
 }
 impl Default for C {

--- a/bindgen-tests/tests/expectations/tests/derive-partialeq-pointer.rs
+++ b/bindgen-tests/tests/expectations/tests/derive-partialeq-pointer.rs
@@ -4,26 +4,11 @@
 pub struct Bar {
     pub b: *mut a,
 }
-#[test]
-fn bindgen_test_layout_Bar() {
-    const UNINIT: ::std::mem::MaybeUninit<Bar> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<Bar>(),
-        8usize,
-        concat!("Size of: ", stringify!(Bar)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Bar>(),
-        8usize,
-        concat!("Alignment of ", stringify!(Bar)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(Bar), "::", stringify!(b)),
-    );
-}
+const _: () = {
+    ["Size of Bar"][::std::mem::size_of::<Bar>() - 8usize];
+    ["Alignment of Bar"][::std::mem::align_of::<Bar>() - 8usize];
+    ["Offset of field: Bar::b"][::std::mem::offset_of!(Bar, b) - 0usize];
+};
 impl Default for Bar {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
@@ -43,19 +28,10 @@ pub struct c {
 pub union c__bindgen_ty_1 {
     pub _address: u8,
 }
-#[test]
-fn bindgen_test_layout_c__bindgen_ty_1() {
-    assert_eq!(
-        ::std::mem::size_of::<c__bindgen_ty_1>(),
-        1usize,
-        concat!("Size of: ", stringify!(c__bindgen_ty_1)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<c__bindgen_ty_1>(),
-        1usize,
-        concat!("Alignment of ", stringify!(c__bindgen_ty_1)),
-    );
-}
+const _: () = {
+    ["Size of c__bindgen_ty_1"][::std::mem::size_of::<c__bindgen_ty_1>() - 1usize];
+    ["Alignment of c__bindgen_ty_1"][::std::mem::align_of::<c__bindgen_ty_1>() - 1usize];
+};
 impl Default for c__bindgen_ty_1 {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
@@ -65,15 +41,10 @@ impl Default for c__bindgen_ty_1 {
         }
     }
 }
-#[test]
-fn bindgen_test_layout_c() {
-    assert_eq!(::std::mem::size_of::<c>(), 1usize, concat!("Size of: ", stringify!(c)));
-    assert_eq!(
-        ::std::mem::align_of::<c>(),
-        1usize,
-        concat!("Alignment of ", stringify!(c)),
-    );
-}
+const _: () = {
+    ["Size of c"][::std::mem::size_of::<c>() - 1usize];
+    ["Alignment of c"][::std::mem::align_of::<c>() - 1usize];
+};
 impl Default for c {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
@@ -88,22 +59,11 @@ impl Default for c {
 pub struct a {
     pub d: c,
 }
-#[test]
-fn bindgen_test_layout_a() {
-    const UNINIT: ::std::mem::MaybeUninit<a> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(::std::mem::size_of::<a>(), 1usize, concat!("Size of: ", stringify!(a)));
-    assert_eq!(
-        ::std::mem::align_of::<a>(),
-        1usize,
-        concat!("Alignment of ", stringify!(a)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(a), "::", stringify!(d)),
-    );
-}
+const _: () = {
+    ["Size of a"][::std::mem::size_of::<a>() - 1usize];
+    ["Alignment of a"][::std::mem::align_of::<a>() - 1usize];
+    ["Offset of field: a::d"][::std::mem::offset_of!(a, d) - 0usize];
+};
 impl Default for a {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();

--- a/bindgen-tests/tests/expectations/tests/derive-partialeq-union.rs
+++ b/bindgen-tests/tests/expectations/tests/derive-partialeq-union.rs
@@ -6,41 +6,20 @@ pub union ShouldNotDerivePartialEq {
     pub a: ::std::os::raw::c_char,
     pub b: ::std::os::raw::c_int,
 }
-#[test]
-fn bindgen_test_layout_ShouldNotDerivePartialEq() {
-    const UNINIT: ::std::mem::MaybeUninit<ShouldNotDerivePartialEq> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<ShouldNotDerivePartialEq>(),
-        4usize,
-        concat!("Size of: ", stringify!(ShouldNotDerivePartialEq)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<ShouldNotDerivePartialEq>(),
-        4usize,
-        concat!("Alignment of ", stringify!(ShouldNotDerivePartialEq)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(ShouldNotDerivePartialEq),
-            "::",
-            stringify!(a),
-        ),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(ShouldNotDerivePartialEq),
-            "::",
-            stringify!(b),
-        ),
-    );
-}
+const _: () = {
+    [
+        "Size of ShouldNotDerivePartialEq",
+    ][::std::mem::size_of::<ShouldNotDerivePartialEq>() - 4usize];
+    [
+        "Alignment of ShouldNotDerivePartialEq",
+    ][::std::mem::align_of::<ShouldNotDerivePartialEq>() - 4usize];
+    [
+        "Offset of field: ShouldNotDerivePartialEq::a",
+    ][::std::mem::offset_of!(ShouldNotDerivePartialEq, a) - 0usize];
+    [
+        "Offset of field: ShouldNotDerivePartialEq::b",
+    ][::std::mem::offset_of!(ShouldNotDerivePartialEq, b) - 0usize];
+};
 impl Default for ShouldNotDerivePartialEq {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();

--- a/bindgen-tests/tests/expectations/tests/derive-partialeq-union_1_0.rs
+++ b/bindgen-tests/tests/expectations/tests/derive-partialeq-union_1_0.rs
@@ -57,32 +57,22 @@ fn bindgen_test_layout_ShouldDerivePartialEq() {
     assert_eq!(
         ::std::mem::size_of::<ShouldDerivePartialEq>(),
         152usize,
-        concat!("Size of: ", stringify!(ShouldDerivePartialEq)),
+        "Size of ShouldDerivePartialEq",
     );
     assert_eq!(
         ::std::mem::align_of::<ShouldDerivePartialEq>(),
         4usize,
-        concat!("Alignment of ", stringify!(ShouldDerivePartialEq)),
+        "Alignment of ShouldDerivePartialEq",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
         0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(ShouldDerivePartialEq),
-            "::",
-            stringify!(a),
-        ),
+        "Offset of field: ShouldDerivePartialEq::a",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
         0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(ShouldDerivePartialEq),
-            "::",
-            stringify!(b),
-        ),
+        "Offset of field: ShouldDerivePartialEq::b",
     );
 }
 impl Clone for ShouldDerivePartialEq {

--- a/bindgen-tests/tests/expectations/tests/disable-nested-struct-naming.rs
+++ b/bindgen-tests/tests/expectations/tests/disable-nested-struct-naming.rs
@@ -27,141 +27,50 @@ pub struct bar1__bindgen_ty_1__bindgen_ty_1 {
 pub struct bar4 {
     pub x4: ::std::os::raw::c_int,
 }
-#[test]
-fn bindgen_test_layout_bar4() {
-    const UNINIT: ::std::mem::MaybeUninit<bar4> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<bar4>(),
-        4usize,
-        concat!("Size of: ", stringify!(bar4)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<bar4>(),
-        4usize,
-        concat!("Alignment of ", stringify!(bar4)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).x4) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(bar4), "::", stringify!(x4)),
-    );
-}
-#[test]
-fn bindgen_test_layout_bar1__bindgen_ty_1__bindgen_ty_1() {
-    const UNINIT: ::std::mem::MaybeUninit<bar1__bindgen_ty_1__bindgen_ty_1> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<bar1__bindgen_ty_1__bindgen_ty_1>(),
-        8usize,
-        concat!("Size of: ", stringify!(bar1__bindgen_ty_1__bindgen_ty_1)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<bar1__bindgen_ty_1__bindgen_ty_1>(),
-        4usize,
-        concat!("Alignment of ", stringify!(bar1__bindgen_ty_1__bindgen_ty_1)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).x3) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(bar1__bindgen_ty_1__bindgen_ty_1),
-            "::",
-            stringify!(x3),
-        ),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).b4) as usize - ptr as usize },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(bar1__bindgen_ty_1__bindgen_ty_1),
-            "::",
-            stringify!(b4),
-        ),
-    );
-}
-#[test]
-fn bindgen_test_layout_bar1__bindgen_ty_1() {
-    const UNINIT: ::std::mem::MaybeUninit<bar1__bindgen_ty_1> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<bar1__bindgen_ty_1>(),
-        12usize,
-        concat!("Size of: ", stringify!(bar1__bindgen_ty_1)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<bar1__bindgen_ty_1>(),
-        4usize,
-        concat!("Alignment of ", stringify!(bar1__bindgen_ty_1)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).x2) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(bar1__bindgen_ty_1),
-            "::",
-            stringify!(x2),
-        ),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).b3) as usize - ptr as usize },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(bar1__bindgen_ty_1),
-            "::",
-            stringify!(b3),
-        ),
-    );
-}
-#[test]
-fn bindgen_test_layout_bar1() {
-    const UNINIT: ::std::mem::MaybeUninit<bar1> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<bar1>(),
-        16usize,
-        concat!("Size of: ", stringify!(bar1)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<bar1>(),
-        4usize,
-        concat!("Alignment of ", stringify!(bar1)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).x1) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(bar1), "::", stringify!(x1)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).b2) as usize - ptr as usize },
-        4usize,
-        concat!("Offset of field: ", stringify!(bar1), "::", stringify!(b2)),
-    );
-}
-#[test]
-fn bindgen_test_layout_foo() {
-    const UNINIT: ::std::mem::MaybeUninit<foo> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<foo>(),
-        16usize,
-        concat!("Size of: ", stringify!(foo)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<foo>(),
-        4usize,
-        concat!("Alignment of ", stringify!(foo)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).b1) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(b1)),
-    );
-}
+const _: () = {
+    ["Size of bar4"][::std::mem::size_of::<bar4>() - 4usize];
+    ["Alignment of bar4"][::std::mem::align_of::<bar4>() - 4usize];
+    ["Offset of field: bar4::x4"][::std::mem::offset_of!(bar4, x4) - 0usize];
+};
+const _: () = {
+    [
+        "Size of bar1__bindgen_ty_1__bindgen_ty_1",
+    ][::std::mem::size_of::<bar1__bindgen_ty_1__bindgen_ty_1>() - 8usize];
+    [
+        "Alignment of bar1__bindgen_ty_1__bindgen_ty_1",
+    ][::std::mem::align_of::<bar1__bindgen_ty_1__bindgen_ty_1>() - 4usize];
+    [
+        "Offset of field: bar1__bindgen_ty_1__bindgen_ty_1::x3",
+    ][::std::mem::offset_of!(bar1__bindgen_ty_1__bindgen_ty_1, x3) - 0usize];
+    [
+        "Offset of field: bar1__bindgen_ty_1__bindgen_ty_1::b4",
+    ][::std::mem::offset_of!(bar1__bindgen_ty_1__bindgen_ty_1, b4) - 4usize];
+};
+const _: () = {
+    [
+        "Size of bar1__bindgen_ty_1",
+    ][::std::mem::size_of::<bar1__bindgen_ty_1>() - 12usize];
+    [
+        "Alignment of bar1__bindgen_ty_1",
+    ][::std::mem::align_of::<bar1__bindgen_ty_1>() - 4usize];
+    [
+        "Offset of field: bar1__bindgen_ty_1::x2",
+    ][::std::mem::offset_of!(bar1__bindgen_ty_1, x2) - 0usize];
+    [
+        "Offset of field: bar1__bindgen_ty_1::b3",
+    ][::std::mem::offset_of!(bar1__bindgen_ty_1, b3) - 4usize];
+};
+const _: () = {
+    ["Size of bar1"][::std::mem::size_of::<bar1>() - 16usize];
+    ["Alignment of bar1"][::std::mem::align_of::<bar1>() - 4usize];
+    ["Offset of field: bar1::x1"][::std::mem::offset_of!(bar1, x1) - 0usize];
+    ["Offset of field: bar1::b2"][::std::mem::offset_of!(bar1, b2) - 4usize];
+};
+const _: () = {
+    ["Size of foo"][::std::mem::size_of::<foo>() - 16usize];
+    ["Alignment of foo"][::std::mem::align_of::<foo>() - 4usize];
+    ["Offset of field: foo::b1"][::std::mem::offset_of!(foo, b1) - 0usize];
+};
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct _bindgen_ty_1 {
@@ -177,71 +86,29 @@ pub struct _bindgen_ty_1__bindgen_ty_1 {
 pub struct baz {
     pub x: ::std::os::raw::c_int,
 }
-#[test]
-fn bindgen_test_layout_baz() {
-    const UNINIT: ::std::mem::MaybeUninit<baz> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<baz>(),
-        4usize,
-        concat!("Size of: ", stringify!(baz)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<baz>(),
-        4usize,
-        concat!("Alignment of ", stringify!(baz)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(baz), "::", stringify!(x)),
-    );
-}
-#[test]
-fn bindgen_test_layout__bindgen_ty_1__bindgen_ty_1() {
-    const UNINIT: ::std::mem::MaybeUninit<_bindgen_ty_1__bindgen_ty_1> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<_bindgen_ty_1__bindgen_ty_1>(),
-        4usize,
-        concat!("Size of: ", stringify!(_bindgen_ty_1__bindgen_ty_1)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<_bindgen_ty_1__bindgen_ty_1>(),
-        4usize,
-        concat!("Alignment of ", stringify!(_bindgen_ty_1__bindgen_ty_1)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(_bindgen_ty_1__bindgen_ty_1),
-            "::",
-            stringify!(b),
-        ),
-    );
-}
-#[test]
-fn bindgen_test_layout__bindgen_ty_1() {
-    const UNINIT: ::std::mem::MaybeUninit<_bindgen_ty_1> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<_bindgen_ty_1>(),
-        4usize,
-        concat!("Size of: ", stringify!(_bindgen_ty_1)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<_bindgen_ty_1>(),
-        4usize,
-        concat!("Alignment of ", stringify!(_bindgen_ty_1)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).anon2) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(_bindgen_ty_1), "::", stringify!(anon2)),
-    );
-}
+const _: () = {
+    ["Size of baz"][::std::mem::size_of::<baz>() - 4usize];
+    ["Alignment of baz"][::std::mem::align_of::<baz>() - 4usize];
+    ["Offset of field: baz::x"][::std::mem::offset_of!(baz, x) - 0usize];
+};
+const _: () = {
+    [
+        "Size of _bindgen_ty_1__bindgen_ty_1",
+    ][::std::mem::size_of::<_bindgen_ty_1__bindgen_ty_1>() - 4usize];
+    [
+        "Alignment of _bindgen_ty_1__bindgen_ty_1",
+    ][::std::mem::align_of::<_bindgen_ty_1__bindgen_ty_1>() - 4usize];
+    [
+        "Offset of field: _bindgen_ty_1__bindgen_ty_1::b",
+    ][::std::mem::offset_of!(_bindgen_ty_1__bindgen_ty_1, b) - 0usize];
+};
+const _: () = {
+    ["Size of _bindgen_ty_1"][::std::mem::size_of::<_bindgen_ty_1>() - 4usize];
+    ["Alignment of _bindgen_ty_1"][::std::mem::align_of::<_bindgen_ty_1>() - 4usize];
+    [
+        "Offset of field: _bindgen_ty_1::anon2",
+    ][::std::mem::offset_of!(_bindgen_ty_1, anon2) - 0usize];
+};
 extern "C" {
     pub static mut anon1: _bindgen_ty_1;
 }

--- a/bindgen-tests/tests/expectations/tests/disable-untagged-union.rs
+++ b/bindgen-tests/tests/expectations/tests/disable-untagged-union.rs
@@ -49,28 +49,9 @@ pub struct Foo {
     pub baz: __BindgenUnionField<::std::os::raw::c_uint>,
     pub bindgen_union_field: u32,
 }
-#[test]
-fn bindgen_test_layout_Foo() {
-    const UNINIT: ::std::mem::MaybeUninit<Foo> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<Foo>(),
-        4usize,
-        concat!("Size of: ", stringify!(Foo)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Foo>(),
-        4usize,
-        concat!("Alignment of ", stringify!(Foo)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(Foo), "::", stringify!(bar)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(Foo), "::", stringify!(baz)),
-    );
-}
+const _: () = {
+    ["Size of Foo"][::std::mem::size_of::<Foo>() - 4usize];
+    ["Alignment of Foo"][::std::mem::align_of::<Foo>() - 4usize];
+    ["Offset of field: Foo::bar"][::std::mem::offset_of!(Foo, bar) - 0usize];
+    ["Offset of field: Foo::baz"][::std::mem::offset_of!(Foo, baz) - 0usize];
+};

--- a/bindgen-tests/tests/expectations/tests/do-not-derive-copy.rs
+++ b/bindgen-tests/tests/expectations/tests/do-not-derive-copy.rs
@@ -4,28 +4,14 @@
 pub struct WouldBeCopyButWeAreNotDerivingCopy {
     pub x: ::std::os::raw::c_int,
 }
-#[test]
-fn bindgen_test_layout_WouldBeCopyButWeAreNotDerivingCopy() {
-    const UNINIT: ::std::mem::MaybeUninit<WouldBeCopyButWeAreNotDerivingCopy> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<WouldBeCopyButWeAreNotDerivingCopy>(),
-        4usize,
-        concat!("Size of: ", stringify!(WouldBeCopyButWeAreNotDerivingCopy)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<WouldBeCopyButWeAreNotDerivingCopy>(),
-        4usize,
-        concat!("Alignment of ", stringify!(WouldBeCopyButWeAreNotDerivingCopy)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(WouldBeCopyButWeAreNotDerivingCopy),
-            "::",
-            stringify!(x),
-        ),
-    );
-}
+const _: () = {
+    [
+        "Size of WouldBeCopyButWeAreNotDerivingCopy",
+    ][::std::mem::size_of::<WouldBeCopyButWeAreNotDerivingCopy>() - 4usize];
+    [
+        "Alignment of WouldBeCopyButWeAreNotDerivingCopy",
+    ][::std::mem::align_of::<WouldBeCopyButWeAreNotDerivingCopy>() - 4usize];
+    [
+        "Offset of field: WouldBeCopyButWeAreNotDerivingCopy::x",
+    ][::std::mem::offset_of!(WouldBeCopyButWeAreNotDerivingCopy, x) - 0usize];
+};

--- a/bindgen-tests/tests/expectations/tests/doggo-or-null.rs
+++ b/bindgen-tests/tests/expectations/tests/doggo-or-null.rs
@@ -4,44 +4,20 @@
 pub struct Doggo {
     pub x: ::std::os::raw::c_int,
 }
-#[test]
-fn bindgen_test_layout_Doggo() {
-    const UNINIT: ::std::mem::MaybeUninit<Doggo> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<Doggo>(),
-        4usize,
-        concat!("Size of: ", stringify!(Doggo)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Doggo>(),
-        4usize,
-        concat!("Alignment of ", stringify!(Doggo)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(Doggo), "::", stringify!(x)),
-    );
-}
+const _: () = {
+    ["Size of Doggo"][::std::mem::size_of::<Doggo>() - 4usize];
+    ["Alignment of Doggo"][::std::mem::align_of::<Doggo>() - 4usize];
+    ["Offset of field: Doggo::x"][::std::mem::offset_of!(Doggo, x) - 0usize];
+};
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, Hash, PartialEq)]
 pub struct Null {
     pub _address: u8,
 }
-#[test]
-fn bindgen_test_layout_Null() {
-    assert_eq!(
-        ::std::mem::size_of::<Null>(),
-        1usize,
-        concat!("Size of: ", stringify!(Null)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Null>(),
-        1usize,
-        concat!("Alignment of ", stringify!(Null)),
-    );
-}
+const _: () = {
+    ["Size of Null"][::std::mem::size_of::<Null>() - 1usize];
+    ["Alignment of Null"][::std::mem::align_of::<Null>() - 1usize];
+};
 /** This type is an opaque union. Unions can't derive anything interesting like
  Debug or Default, even if their layout can, because it would require knowing
  which variant is in use. Opaque unions still end up as a `union` in the Rust
@@ -54,19 +30,10 @@ fn bindgen_test_layout_Null() {
 pub union DoggoOrNull {
     pub _bindgen_opaque_blob: u32,
 }
-#[test]
-fn bindgen_test_layout_DoggoOrNull() {
-    assert_eq!(
-        ::std::mem::size_of::<DoggoOrNull>(),
-        4usize,
-        concat!("Size of: ", stringify!(DoggoOrNull)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<DoggoOrNull>(),
-        4usize,
-        concat!("Alignment of ", stringify!(DoggoOrNull)),
-    );
-}
+const _: () = {
+    ["Size of DoggoOrNull"][::std::mem::size_of::<DoggoOrNull>() - 4usize];
+    ["Alignment of DoggoOrNull"][::std::mem::align_of::<DoggoOrNull>() - 4usize];
+};
 impl Default for DoggoOrNull {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();

--- a/bindgen-tests/tests/expectations/tests/duplicated-definition-count.rs
+++ b/bindgen-tests/tests/expectations/tests/duplicated-definition-count.rs
@@ -4,19 +4,10 @@
 pub struct BitStream {
     pub _address: u8,
 }
-#[test]
-fn bindgen_test_layout_BitStream() {
-    assert_eq!(
-        ::std::mem::size_of::<BitStream>(),
-        1usize,
-        concat!("Size of: ", stringify!(BitStream)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<BitStream>(),
-        1usize,
-        concat!("Alignment of ", stringify!(BitStream)),
-    );
-}
+const _: () = {
+    ["Size of BitStream"][::std::mem::size_of::<BitStream>() - 1usize];
+    ["Alignment of BitStream"][::std::mem::align_of::<BitStream>() - 1usize];
+};
 extern "C" {
     #[link_name = "\u{1}_ZN9BitStream5WriteEPKcj"]
     pub fn BitStream_Write(

--- a/bindgen-tests/tests/expectations/tests/duplicated-namespaces-definitions.rs
+++ b/bindgen-tests/tests/expectations/tests/duplicated-namespaces-definitions.rs
@@ -12,31 +12,12 @@ pub mod root {
             pub foo: ::std::os::raw::c_int,
             pub baz: bool,
         }
-        #[test]
-        fn bindgen_test_layout_Bar() {
-            const UNINIT: ::std::mem::MaybeUninit<Bar> = ::std::mem::MaybeUninit::uninit();
-            let ptr = UNINIT.as_ptr();
-            assert_eq!(
-                ::std::mem::size_of::<Bar>(),
-                8usize,
-                concat!("Size of: ", stringify!(Bar)),
-            );
-            assert_eq!(
-                ::std::mem::align_of::<Bar>(),
-                4usize,
-                concat!("Alignment of ", stringify!(Bar)),
-            );
-            assert_eq!(
-                unsafe { ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize },
-                0usize,
-                concat!("Offset of field: ", stringify!(Bar), "::", stringify!(foo)),
-            );
-            assert_eq!(
-                unsafe { ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize },
-                4usize,
-                concat!("Offset of field: ", stringify!(Bar), "::", stringify!(baz)),
-            );
-        }
+        const _: () = {
+            ["Size of Bar"][::std::mem::size_of::<Bar>() - 8usize];
+            ["Alignment of Bar"][::std::mem::align_of::<Bar>() - 4usize];
+            ["Offset of field: Bar::foo"][::std::mem::offset_of!(Bar, foo) - 0usize];
+            ["Offset of field: Bar::baz"][::std::mem::offset_of!(Bar, baz) - 4usize];
+        };
     }
     pub mod bar {
         #[allow(unused_imports)]
@@ -46,26 +27,11 @@ pub mod root {
         pub struct Foo {
             pub ptr: *mut root::foo::Bar,
         }
-        #[test]
-        fn bindgen_test_layout_Foo() {
-            const UNINIT: ::std::mem::MaybeUninit<Foo> = ::std::mem::MaybeUninit::uninit();
-            let ptr = UNINIT.as_ptr();
-            assert_eq!(
-                ::std::mem::size_of::<Foo>(),
-                8usize,
-                concat!("Size of: ", stringify!(Foo)),
-            );
-            assert_eq!(
-                ::std::mem::align_of::<Foo>(),
-                8usize,
-                concat!("Alignment of ", stringify!(Foo)),
-            );
-            assert_eq!(
-                unsafe { ::std::ptr::addr_of!((*ptr).ptr) as usize - ptr as usize },
-                0usize,
-                concat!("Offset of field: ", stringify!(Foo), "::", stringify!(ptr)),
-            );
-        }
+        const _: () = {
+            ["Size of Foo"][::std::mem::size_of::<Foo>() - 8usize];
+            ["Alignment of Foo"][::std::mem::align_of::<Foo>() - 8usize];
+            ["Offset of field: Foo::ptr"][::std::mem::offset_of!(Foo, ptr) - 0usize];
+        };
         impl Default for Foo {
             fn default() -> Self {
                 let mut s = ::std::mem::MaybeUninit::<Self>::uninit();

--- a/bindgen-tests/tests/expectations/tests/dynamic_loading_with_blocklist.rs
+++ b/bindgen-tests/tests/expectations/tests/dynamic_loading_with_blocklist.rs
@@ -4,22 +4,11 @@
 pub struct X {
     pub _x: ::std::os::raw::c_int,
 }
-#[test]
-fn bindgen_test_layout_X() {
-    const UNINIT: ::std::mem::MaybeUninit<X> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(::std::mem::size_of::<X>(), 4usize, concat!("Size of: ", stringify!(X)));
-    assert_eq!(
-        ::std::mem::align_of::<X>(),
-        4usize,
-        concat!("Alignment of ", stringify!(X)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr)._x) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(X), "::", stringify!(_x)),
-    );
-}
+const _: () = {
+    ["Size of X"][::std::mem::size_of::<X>() - 4usize];
+    ["Alignment of X"][::std::mem::align_of::<X>() - 4usize];
+    ["Offset of field: X::_x"][::std::mem::offset_of!(X, _x) - 0usize];
+};
 extern "C" {
     #[link_name = "\u{1}_ZN1X13some_functionEv"]
     pub fn X_some_function(this: *mut X);

--- a/bindgen-tests/tests/expectations/tests/dynamic_loading_with_class.rs
+++ b/bindgen-tests/tests/expectations/tests/dynamic_loading_with_class.rs
@@ -4,22 +4,11 @@
 pub struct A {
     pub _x: ::std::os::raw::c_int,
 }
-#[test]
-fn bindgen_test_layout_A() {
-    const UNINIT: ::std::mem::MaybeUninit<A> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(::std::mem::size_of::<A>(), 4usize, concat!("Size of: ", stringify!(A)));
-    assert_eq!(
-        ::std::mem::align_of::<A>(),
-        4usize,
-        concat!("Alignment of ", stringify!(A)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr)._x) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(A), "::", stringify!(_x)),
-    );
-}
+const _: () = {
+    ["Size of A"][::std::mem::size_of::<A>() - 4usize];
+    ["Alignment of A"][::std::mem::align_of::<A>() - 4usize];
+    ["Offset of field: A::_x"][::std::mem::offset_of!(A, _x) - 0usize];
+};
 extern "C" {
     #[link_name = "\u{1}_ZN1A13some_functionEv"]
     pub fn A_some_function(this: *mut A);

--- a/bindgen-tests/tests/expectations/tests/enum-default-bitfield.rs
+++ b/bindgen-tests/tests/expectations/tests/enum-default-bitfield.rs
@@ -35,26 +35,11 @@ impl ::std::ops::BitAndAssign for foo__bindgen_ty_1 {
 #[repr(transparent)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct foo__bindgen_ty_1(pub ::std::os::raw::c_uint);
-#[test]
-fn bindgen_test_layout_foo() {
-    const UNINIT: ::std::mem::MaybeUninit<foo> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<foo>(),
-        4usize,
-        concat!("Size of: ", stringify!(foo)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<foo>(),
-        4usize,
-        concat!("Alignment of ", stringify!(foo)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).member) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(member)),
-    );
-}
+const _: () = {
+    ["Size of foo"][::std::mem::size_of::<foo>() - 4usize];
+    ["Alignment of foo"][::std::mem::align_of::<foo>() - 4usize];
+    ["Offset of field: foo::member"][::std::mem::offset_of!(foo, member) - 0usize];
+};
 impl Default for foo {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();

--- a/bindgen-tests/tests/expectations/tests/enum-default-consts.rs
+++ b/bindgen-tests/tests/expectations/tests/enum-default-consts.rs
@@ -7,26 +7,11 @@ pub struct foo {
 pub const foo_FOO_A: foo__bindgen_ty_1 = 0;
 pub const foo_FOO_B: foo__bindgen_ty_1 = 1;
 pub type foo__bindgen_ty_1 = ::std::os::raw::c_uint;
-#[test]
-fn bindgen_test_layout_foo() {
-    const UNINIT: ::std::mem::MaybeUninit<foo> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<foo>(),
-        4usize,
-        concat!("Size of: ", stringify!(foo)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<foo>(),
-        4usize,
-        concat!("Alignment of ", stringify!(foo)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).member) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(member)),
-    );
-}
+const _: () = {
+    ["Size of foo"][::std::mem::size_of::<foo>() - 4usize];
+    ["Alignment of foo"][::std::mem::align_of::<foo>() - 4usize];
+    ["Offset of field: foo::member"][::std::mem::offset_of!(foo, member) - 0usize];
+};
 impl Default for foo {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();

--- a/bindgen-tests/tests/expectations/tests/enum-default-module.rs
+++ b/bindgen-tests/tests/expectations/tests/enum-default-module.rs
@@ -9,26 +9,11 @@ pub mod foo__bindgen_ty_1 {
     pub const FOO_A: Type = 0;
     pub const FOO_B: Type = 1;
 }
-#[test]
-fn bindgen_test_layout_foo() {
-    const UNINIT: ::std::mem::MaybeUninit<foo> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<foo>(),
-        4usize,
-        concat!("Size of: ", stringify!(foo)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<foo>(),
-        4usize,
-        concat!("Alignment of ", stringify!(foo)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).member) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(member)),
-    );
-}
+const _: () = {
+    ["Size of foo"][::std::mem::size_of::<foo>() - 4usize];
+    ["Alignment of foo"][::std::mem::align_of::<foo>() - 4usize];
+    ["Offset of field: foo::member"][::std::mem::offset_of!(foo, member) - 0usize];
+};
 impl Default for foo {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();

--- a/bindgen-tests/tests/expectations/tests/enum-default-rust.rs
+++ b/bindgen-tests/tests/expectations/tests/enum-default-rust.rs
@@ -12,26 +12,11 @@ pub enum foo__bindgen_ty_1 {
     FOO_A = 0,
     FOO_B = 1,
 }
-#[test]
-fn bindgen_test_layout_foo() {
-    const UNINIT: ::std::mem::MaybeUninit<foo> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<foo>(),
-        4usize,
-        concat!("Size of: ", stringify!(foo)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<foo>(),
-        4usize,
-        concat!("Alignment of ", stringify!(foo)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).member) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(member)),
-    );
-}
+const _: () = {
+    ["Size of foo"][::std::mem::size_of::<foo>() - 4usize];
+    ["Alignment of foo"][::std::mem::align_of::<foo>() - 4usize];
+    ["Offset of field: foo::member"][::std::mem::offset_of!(foo, member) - 0usize];
+};
 impl Default for foo {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();

--- a/bindgen-tests/tests/expectations/tests/enum-no-debug-rust.rs
+++ b/bindgen-tests/tests/expectations/tests/enum-no-debug-rust.rs
@@ -12,26 +12,11 @@ pub enum foo__bindgen_ty_1 {
     FOO_A = 0,
     FOO_B = 1,
 }
-#[test]
-fn bindgen_test_layout_foo() {
-    const UNINIT: ::std::mem::MaybeUninit<foo> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<foo>(),
-        4usize,
-        concat!("Size of: ", stringify!(foo)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<foo>(),
-        4usize,
-        concat!("Alignment of ", stringify!(foo)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).member) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(member)),
-    );
-}
+const _: () = {
+    ["Size of foo"][::std::mem::size_of::<foo>() - 4usize];
+    ["Alignment of foo"][::std::mem::align_of::<foo>() - 4usize];
+    ["Offset of field: foo::member"][::std::mem::offset_of!(foo, member) - 0usize];
+};
 impl Default for foo {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();

--- a/bindgen-tests/tests/expectations/tests/enum.rs
+++ b/bindgen-tests/tests/expectations/tests/enum.rs
@@ -7,26 +7,11 @@ pub struct foo {
 pub const foo_FOO_A: foo__bindgen_ty_1 = 0;
 pub const foo_FOO_B: foo__bindgen_ty_1 = 1;
 pub type foo__bindgen_ty_1 = ::std::os::raw::c_uint;
-#[test]
-fn bindgen_test_layout_foo() {
-    const UNINIT: ::std::mem::MaybeUninit<foo> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<foo>(),
-        4usize,
-        concat!("Size of: ", stringify!(foo)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<foo>(),
-        4usize,
-        concat!("Alignment of ", stringify!(foo)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).member) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(member)),
-    );
-}
+const _: () = {
+    ["Size of foo"][::std::mem::size_of::<foo>() - 4usize];
+    ["Alignment of foo"][::std::mem::align_of::<foo>() - 4usize];
+    ["Offset of field: foo::member"][::std::mem::offset_of!(foo, member) - 0usize];
+};
 impl Default for foo {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();

--- a/bindgen-tests/tests/expectations/tests/enum_and_vtable_mangling.rs
+++ b/bindgen-tests/tests/expectations/tests/enum_and_vtable_mangling.rs
@@ -17,22 +17,11 @@ pub struct C {
     pub vtable_: *const C__bindgen_vtable,
     pub i: ::std::os::raw::c_int,
 }
-#[test]
-fn bindgen_test_layout_C() {
-    const UNINIT: ::std::mem::MaybeUninit<C> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(::std::mem::size_of::<C>(), 16usize, concat!("Size of: ", stringify!(C)));
-    assert_eq!(
-        ::std::mem::align_of::<C>(),
-        8usize,
-        concat!("Alignment of ", stringify!(C)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).i) as usize - ptr as usize },
-        8usize,
-        concat!("Offset of field: ", stringify!(C), "::", stringify!(i)),
-    );
-}
+const _: () = {
+    ["Size of C"][::std::mem::size_of::<C>() - 16usize];
+    ["Alignment of C"][::std::mem::align_of::<C>() - 8usize];
+    ["Offset of field: C::i"][::std::mem::offset_of!(C, i) - 8usize];
+};
 impl Default for C {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();

--- a/bindgen-tests/tests/expectations/tests/explicit-padding.rs
+++ b/bindgen-tests/tests/expectations/tests/explicit-padding.rs
@@ -8,36 +8,13 @@ pub struct pad_me {
     pub third: u16,
     pub __bindgen_padding_1: [u8; 2usize],
 }
-#[test]
-fn bindgen_test_layout_pad_me() {
-    const UNINIT: ::std::mem::MaybeUninit<pad_me> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<pad_me>(),
-        12usize,
-        concat!("Size of: ", stringify!(pad_me)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<pad_me>(),
-        4usize,
-        concat!("Alignment of ", stringify!(pad_me)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).first) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(pad_me), "::", stringify!(first)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).second) as usize - ptr as usize },
-        4usize,
-        concat!("Offset of field: ", stringify!(pad_me), "::", stringify!(second)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).third) as usize - ptr as usize },
-        8usize,
-        concat!("Offset of field: ", stringify!(pad_me), "::", stringify!(third)),
-    );
-}
+const _: () = {
+    ["Size of pad_me"][::std::mem::size_of::<pad_me>() - 12usize];
+    ["Alignment of pad_me"][::std::mem::align_of::<pad_me>() - 4usize];
+    ["Offset of field: pad_me::first"][::std::mem::offset_of!(pad_me, first) - 0usize];
+    ["Offset of field: pad_me::second"][::std::mem::offset_of!(pad_me, second) - 4usize];
+    ["Offset of field: pad_me::third"][::std::mem::offset_of!(pad_me, third) - 8usize];
+};
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union dont_pad_me {
@@ -45,36 +22,19 @@ pub union dont_pad_me {
     pub second: u32,
     pub third: u16,
 }
-#[test]
-fn bindgen_test_layout_dont_pad_me() {
-    const UNINIT: ::std::mem::MaybeUninit<dont_pad_me> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<dont_pad_me>(),
-        4usize,
-        concat!("Size of: ", stringify!(dont_pad_me)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<dont_pad_me>(),
-        4usize,
-        concat!("Alignment of ", stringify!(dont_pad_me)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).first) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(dont_pad_me), "::", stringify!(first)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).second) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(dont_pad_me), "::", stringify!(second)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).third) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(dont_pad_me), "::", stringify!(third)),
-    );
-}
+const _: () = {
+    ["Size of dont_pad_me"][::std::mem::size_of::<dont_pad_me>() - 4usize];
+    ["Alignment of dont_pad_me"][::std::mem::align_of::<dont_pad_me>() - 4usize];
+    [
+        "Offset of field: dont_pad_me::first",
+    ][::std::mem::offset_of!(dont_pad_me, first) - 0usize];
+    [
+        "Offset of field: dont_pad_me::second",
+    ][::std::mem::offset_of!(dont_pad_me, second) - 0usize];
+    [
+        "Offset of field: dont_pad_me::third",
+    ][::std::mem::offset_of!(dont_pad_me, third) - 0usize];
+};
 impl Default for dont_pad_me {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();

--- a/bindgen-tests/tests/expectations/tests/extern-const-struct.rs
+++ b/bindgen-tests/tests/expectations/tests/extern-const-struct.rs
@@ -8,20 +8,12 @@ pub struct nsFoo {
 fn bindgen_test_layout_nsFoo() {
     const UNINIT: ::std::mem::MaybeUninit<nsFoo> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<nsFoo>(),
-        1600usize,
-        concat!("Size of: ", stringify!(nsFoo)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<nsFoo>(),
-        4usize,
-        concat!("Alignment of ", stringify!(nsFoo)),
-    );
+    assert_eq!(::std::mem::size_of::<nsFoo>(), 1600usize, "Size of nsFoo");
+    assert_eq!(::std::mem::align_of::<nsFoo>(), 4usize, "Alignment of nsFoo");
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).details) as usize - ptr as usize },
         0usize,
-        concat!("Offset of field: ", stringify!(nsFoo), "::", stringify!(details)),
+        "Offset of field: nsFoo::details",
     );
 }
 impl Default for nsFoo {

--- a/bindgen-tests/tests/expectations/tests/field-visibility-callback.rs
+++ b/bindgen-tests/tests/expectations/tests/field-visibility-callback.rs
@@ -92,31 +92,14 @@ pub struct my_struct {
     _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
     __bindgen_padding_0: [u8; 3usize],
 }
-#[test]
-fn bindgen_test_layout_my_struct() {
-    const UNINIT: ::std::mem::MaybeUninit<my_struct> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<my_struct>(),
-        12usize,
-        concat!("Size of: ", stringify!(my_struct)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<my_struct>(),
-        4usize,
-        concat!("Alignment of ", stringify!(my_struct)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(my_struct), "::", stringify!(a)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).private_b) as usize - ptr as usize },
-        4usize,
-        concat!("Offset of field: ", stringify!(my_struct), "::", stringify!(private_b)),
-    );
-}
+const _: () = {
+    ["Size of my_struct"][::std::mem::size_of::<my_struct>() - 12usize];
+    ["Alignment of my_struct"][::std::mem::align_of::<my_struct>() - 4usize];
+    ["Offset of field: my_struct::a"][::std::mem::offset_of!(my_struct, a) - 0usize];
+    [
+        "Offset of field: my_struct::private_b",
+    ][::std::mem::offset_of!(my_struct, private_b) - 4usize];
+};
 impl my_struct {
     #[inline]
     pub fn c(&self) -> ::std::os::raw::c_int {

--- a/bindgen-tests/tests/expectations/tests/field-visibility.rs
+++ b/bindgen-tests/tests/expectations/tests/field-visibility.rs
@@ -91,19 +91,10 @@ pub struct my_struct1 {
     _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
     __bindgen_padding_0: [u8; 3usize],
 }
-#[test]
-fn bindgen_test_layout_my_struct1() {
-    assert_eq!(
-        ::std::mem::size_of::<my_struct1>(),
-        4usize,
-        concat!("Size of: ", stringify!(my_struct1)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<my_struct1>(),
-        4usize,
-        concat!("Alignment of ", stringify!(my_struct1)),
-    );
-}
+const _: () = {
+    ["Size of my_struct1"][::std::mem::size_of::<my_struct1>() - 4usize];
+    ["Alignment of my_struct1"][::std::mem::align_of::<my_struct1>() - 4usize];
+};
 impl my_struct1 {
     #[inline]
     fn a(&self) -> ::std::os::raw::c_int {
@@ -139,19 +130,10 @@ pub struct my_struct2 {
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
     pub __bindgen_padding_0: [u8; 3usize],
 }
-#[test]
-fn bindgen_test_layout_my_struct2() {
-    assert_eq!(
-        ::std::mem::size_of::<my_struct2>(),
-        4usize,
-        concat!("Size of: ", stringify!(my_struct2)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<my_struct2>(),
-        4usize,
-        concat!("Alignment of ", stringify!(my_struct2)),
-    );
-}
+const _: () = {
+    ["Size of my_struct2"][::std::mem::size_of::<my_struct2>() - 4usize];
+    ["Alignment of my_struct2"][::std::mem::align_of::<my_struct2>() - 4usize];
+};
 impl my_struct2 {
     #[inline]
     pub fn a(&self) -> ::std::os::raw::c_int {

--- a/bindgen-tests/tests/expectations/tests/float16.rs
+++ b/bindgen-tests/tests/expectations/tests/float16.rs
@@ -10,51 +10,27 @@ extern "C" {
 pub struct Test__Float16 {
     pub f: __BindgenFloat16,
 }
-#[test]
-fn bindgen_test_layout_Test__Float16() {
-    const UNINIT: ::std::mem::MaybeUninit<Test__Float16> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<Test__Float16>(),
-        2usize,
-        concat!("Size of: ", stringify!(Test__Float16)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Test__Float16>(),
-        2usize,
-        concat!("Alignment of ", stringify!(Test__Float16)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).f) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(Test__Float16), "::", stringify!(f)),
-    );
-}
+const _: () = {
+    ["Size of Test__Float16"][::std::mem::size_of::<Test__Float16>() - 2usize];
+    ["Alignment of Test__Float16"][::std::mem::align_of::<Test__Float16>() - 2usize];
+    [
+        "Offset of field: Test__Float16::f",
+    ][::std::mem::offset_of!(Test__Float16, f) - 0usize];
+};
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct Test__Float16Ref {
     pub f: *mut __BindgenFloat16,
 }
-#[test]
-fn bindgen_test_layout_Test__Float16Ref() {
-    const UNINIT: ::std::mem::MaybeUninit<Test__Float16Ref> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<Test__Float16Ref>(),
-        8usize,
-        concat!("Size of: ", stringify!(Test__Float16Ref)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Test__Float16Ref>(),
-        8usize,
-        concat!("Alignment of ", stringify!(Test__Float16Ref)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).f) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(Test__Float16Ref), "::", stringify!(f)),
-    );
-}
+const _: () = {
+    ["Size of Test__Float16Ref"][::std::mem::size_of::<Test__Float16Ref>() - 8usize];
+    [
+        "Alignment of Test__Float16Ref",
+    ][::std::mem::align_of::<Test__Float16Ref>() - 8usize];
+    [
+        "Offset of field: Test__Float16Ref::f",
+    ][::std::mem::offset_of!(Test__Float16Ref, f) - 0usize];
+};
 impl Default for Test__Float16Ref {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();

--- a/bindgen-tests/tests/expectations/tests/forward-declaration-autoptr.rs
+++ b/bindgen-tests/tests/expectations/tests/forward-declaration-autoptr.rs
@@ -24,26 +24,11 @@ impl<T> Default for RefPtr<T> {
 pub struct Bar {
     pub m_member: RefPtr<Foo>,
 }
-#[test]
-fn bindgen_test_layout_Bar() {
-    const UNINIT: ::std::mem::MaybeUninit<Bar> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<Bar>(),
-        8usize,
-        concat!("Size of: ", stringify!(Bar)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Bar>(),
-        8usize,
-        concat!("Alignment of ", stringify!(Bar)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).m_member) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(Bar), "::", stringify!(m_member)),
-    );
-}
+const _: () = {
+    ["Size of Bar"][::std::mem::size_of::<Bar>() - 8usize];
+    ["Alignment of Bar"][::std::mem::align_of::<Bar>() - 8usize];
+    ["Offset of field: Bar::m_member"][::std::mem::offset_of!(Bar, m_member) - 0usize];
+};
 impl Default for Bar {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
@@ -53,16 +38,11 @@ impl Default for Bar {
         }
     }
 }
-#[test]
-fn __bindgen_test_layout_RefPtr_open0_Foo_close0_instantiation() {
-    assert_eq!(
-        ::std::mem::size_of::<RefPtr<Foo>>(),
-        8usize,
-        concat!("Size of template specialization: ", stringify!(RefPtr < Foo >)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<RefPtr<Foo>>(),
-        8usize,
-        concat!("Alignment of template specialization: ", stringify!(RefPtr < Foo >)),
-    );
-}
+const _: () = {
+    [
+        "Size of template specialization: RefPtr_open0_Foo_close0",
+    ][::std::mem::size_of::<RefPtr<Foo>>() - 8usize];
+    [
+        "Align of template specialization: RefPtr_open0_Foo_close0",
+    ][::std::mem::align_of::<RefPtr<Foo>>() - 8usize];
+};

--- a/bindgen-tests/tests/expectations/tests/forward_declared_complex_types.rs
+++ b/bindgen-tests/tests/expectations/tests/forward_declared_complex_types.rs
@@ -4,19 +4,10 @@
 pub struct Foo_empty {
     pub _address: u8,
 }
-#[test]
-fn bindgen_test_layout_Foo_empty() {
-    assert_eq!(
-        ::std::mem::size_of::<Foo_empty>(),
-        1usize,
-        concat!("Size of: ", stringify!(Foo_empty)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Foo_empty>(),
-        1usize,
-        concat!("Alignment of ", stringify!(Foo_empty)),
-    );
-}
+const _: () = {
+    ["Size of Foo_empty"][::std::mem::size_of::<Foo_empty>() - 1usize];
+    ["Alignment of Foo_empty"][::std::mem::align_of::<Foo_empty>() - 1usize];
+};
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct Foo {
@@ -27,26 +18,11 @@ pub struct Foo {
 pub struct Bar {
     pub f: *mut Foo,
 }
-#[test]
-fn bindgen_test_layout_Bar() {
-    const UNINIT: ::std::mem::MaybeUninit<Bar> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<Bar>(),
-        8usize,
-        concat!("Size of: ", stringify!(Bar)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Bar>(),
-        8usize,
-        concat!("Alignment of ", stringify!(Bar)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).f) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(Bar), "::", stringify!(f)),
-    );
-}
+const _: () = {
+    ["Size of Bar"][::std::mem::size_of::<Bar>() - 8usize];
+    ["Alignment of Bar"][::std::mem::align_of::<Bar>() - 8usize];
+    ["Offset of field: Bar::f"][::std::mem::offset_of!(Bar, f) - 0usize];
+};
 impl Default for Bar {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();

--- a/bindgen-tests/tests/expectations/tests/forward_declared_complex_types_1_0.rs
+++ b/bindgen-tests/tests/expectations/tests/forward_declared_complex_types_1_0.rs
@@ -6,16 +6,8 @@ pub struct Foo_empty {
 }
 #[test]
 fn bindgen_test_layout_Foo_empty() {
-    assert_eq!(
-        ::std::mem::size_of::<Foo_empty>(),
-        1usize,
-        concat!("Size of: ", stringify!(Foo_empty)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Foo_empty>(),
-        1usize,
-        concat!("Alignment of ", stringify!(Foo_empty)),
-    );
+    assert_eq!(::std::mem::size_of::<Foo_empty>(), 1usize, "Size of Foo_empty");
+    assert_eq!(::std::mem::align_of::<Foo_empty>(), 1usize, "Alignment of Foo_empty");
 }
 impl Clone for Foo_empty {
     fn clone(&self) -> Self {
@@ -41,20 +33,12 @@ pub struct Bar {
 fn bindgen_test_layout_Bar() {
     const UNINIT: ::std::mem::MaybeUninit<Bar> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<Bar>(),
-        8usize,
-        concat!("Size of: ", stringify!(Bar)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Bar>(),
-        8usize,
-        concat!("Alignment of ", stringify!(Bar)),
-    );
+    assert_eq!(::std::mem::size_of::<Bar>(), 8usize, "Size of Bar");
+    assert_eq!(::std::mem::align_of::<Bar>(), 8usize, "Alignment of Bar");
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).f) as usize - ptr as usize },
         0usize,
-        concat!("Offset of field: ", stringify!(Bar), "::", stringify!(f)),
+        "Offset of field: Bar::f",
     );
 }
 impl Clone for Bar {

--- a/bindgen-tests/tests/expectations/tests/forward_declared_struct.rs
+++ b/bindgen-tests/tests/expectations/tests/forward_declared_struct.rs
@@ -4,40 +4,18 @@
 pub struct a {
     pub b: ::std::os::raw::c_int,
 }
-#[test]
-fn bindgen_test_layout_a() {
-    const UNINIT: ::std::mem::MaybeUninit<a> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(::std::mem::size_of::<a>(), 4usize, concat!("Size of: ", stringify!(a)));
-    assert_eq!(
-        ::std::mem::align_of::<a>(),
-        4usize,
-        concat!("Alignment of ", stringify!(a)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(a), "::", stringify!(b)),
-    );
-}
+const _: () = {
+    ["Size of a"][::std::mem::size_of::<a>() - 4usize];
+    ["Alignment of a"][::std::mem::align_of::<a>() - 4usize];
+    ["Offset of field: a::b"][::std::mem::offset_of!(a, b) - 0usize];
+};
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct c {
     pub d: ::std::os::raw::c_int,
 }
-#[test]
-fn bindgen_test_layout_c() {
-    const UNINIT: ::std::mem::MaybeUninit<c> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(::std::mem::size_of::<c>(), 4usize, concat!("Size of: ", stringify!(c)));
-    assert_eq!(
-        ::std::mem::align_of::<c>(),
-        4usize,
-        concat!("Alignment of ", stringify!(c)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(c), "::", stringify!(d)),
-    );
-}
+const _: () = {
+    ["Size of c"][::std::mem::size_of::<c>() - 4usize];
+    ["Alignment of c"][::std::mem::align_of::<c>() - 4usize];
+    ["Offset of field: c::d"][::std::mem::offset_of!(c, d) - 0usize];
+};

--- a/bindgen-tests/tests/expectations/tests/func_ptr_in_struct.rs
+++ b/bindgen-tests/tests/expectations/tests/func_ptr_in_struct.rs
@@ -11,23 +11,8 @@ pub struct Foo {
         unsafe extern "C" fn(x: ::std::os::raw::c_int, y: ::std::os::raw::c_int) -> baz,
     >,
 }
-#[test]
-fn bindgen_test_layout_Foo() {
-    const UNINIT: ::std::mem::MaybeUninit<Foo> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<Foo>(),
-        8usize,
-        concat!("Size of: ", stringify!(Foo)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Foo>(),
-        8usize,
-        concat!("Alignment of ", stringify!(Foo)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(Foo), "::", stringify!(bar)),
-    );
-}
+const _: () = {
+    ["Size of Foo"][::std::mem::size_of::<Foo>() - 8usize];
+    ["Alignment of Foo"][::std::mem::align_of::<Foo>() - 8usize];
+    ["Offset of field: Foo::bar"][::std::mem::offset_of!(Foo, bar) - 0usize];
+};

--- a/bindgen-tests/tests/expectations/tests/func_return_must_use.rs
+++ b/bindgen-tests/tests/expectations/tests/func_return_must_use.rs
@@ -28,19 +28,10 @@ extern "C" {
 #[derive(Debug, Default, Copy, Clone)]
 #[must_use]
 pub struct AnnotatedStruct {}
-#[test]
-fn bindgen_test_layout_AnnotatedStruct() {
-    assert_eq!(
-        ::std::mem::size_of::<AnnotatedStruct>(),
-        0usize,
-        concat!("Size of: ", stringify!(AnnotatedStruct)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<AnnotatedStruct>(),
-        1usize,
-        concat!("Alignment of ", stringify!(AnnotatedStruct)),
-    );
-}
+const _: () = {
+    ["Size of AnnotatedStruct"][::std::mem::size_of::<AnnotatedStruct>() - 0usize];
+    ["Alignment of AnnotatedStruct"][::std::mem::align_of::<AnnotatedStruct>() - 1usize];
+};
 extern "C" {
     #[must_use]
     pub fn return_annotated_struct() -> AnnotatedStruct;
@@ -48,19 +39,10 @@ extern "C" {
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct PlainStruct {}
-#[test]
-fn bindgen_test_layout_PlainStruct() {
-    assert_eq!(
-        ::std::mem::size_of::<PlainStruct>(),
-        0usize,
-        concat!("Size of: ", stringify!(PlainStruct)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<PlainStruct>(),
-        1usize,
-        concat!("Alignment of ", stringify!(PlainStruct)),
-    );
-}
+const _: () = {
+    ["Size of PlainStruct"][::std::mem::size_of::<PlainStruct>() - 0usize];
+    ["Alignment of PlainStruct"][::std::mem::align_of::<PlainStruct>() - 1usize];
+};
 /// <div rustbindgen mustusetype></div>
 pub type TypedefPlainStruct = PlainStruct;
 extern "C" {

--- a/bindgen-tests/tests/expectations/tests/gen-constructors-neg.rs
+++ b/bindgen-tests/tests/expectations/tests/gen-constructors-neg.rs
@@ -4,16 +4,7 @@
 pub struct Foo {
     pub _address: u8,
 }
-#[test]
-fn bindgen_test_layout_Foo() {
-    assert_eq!(
-        ::std::mem::size_of::<Foo>(),
-        1usize,
-        concat!("Size of: ", stringify!(Foo)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Foo>(),
-        1usize,
-        concat!("Alignment of ", stringify!(Foo)),
-    );
-}
+const _: () = {
+    ["Size of Foo"][::std::mem::size_of::<Foo>() - 1usize];
+    ["Alignment of Foo"][::std::mem::align_of::<Foo>() - 1usize];
+};

--- a/bindgen-tests/tests/expectations/tests/gen-constructors.rs
+++ b/bindgen-tests/tests/expectations/tests/gen-constructors.rs
@@ -4,19 +4,10 @@
 pub struct Foo {
     pub _address: u8,
 }
-#[test]
-fn bindgen_test_layout_Foo() {
-    assert_eq!(
-        ::std::mem::size_of::<Foo>(),
-        1usize,
-        concat!("Size of: ", stringify!(Foo)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Foo>(),
-        1usize,
-        concat!("Alignment of ", stringify!(Foo)),
-    );
-}
+const _: () = {
+    ["Size of Foo"][::std::mem::size_of::<Foo>() - 1usize];
+    ["Alignment of Foo"][::std::mem::align_of::<Foo>() - 1usize];
+};
 extern "C" {
     #[link_name = "\u{1}_ZN3FooC1Ei"]
     pub fn Foo_Foo(this: *mut Foo, a: ::std::os::raw::c_int);

--- a/bindgen-tests/tests/expectations/tests/gen-destructors-neg.rs
+++ b/bindgen-tests/tests/expectations/tests/gen-destructors-neg.rs
@@ -4,23 +4,8 @@
 pub struct Foo {
     pub bar: ::std::os::raw::c_int,
 }
-#[test]
-fn bindgen_test_layout_Foo() {
-    const UNINIT: ::std::mem::MaybeUninit<Foo> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<Foo>(),
-        4usize,
-        concat!("Size of: ", stringify!(Foo)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Foo>(),
-        4usize,
-        concat!("Alignment of ", stringify!(Foo)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(Foo), "::", stringify!(bar)),
-    );
-}
+const _: () = {
+    ["Size of Foo"][::std::mem::size_of::<Foo>() - 4usize];
+    ["Alignment of Foo"][::std::mem::align_of::<Foo>() - 4usize];
+    ["Offset of field: Foo::bar"][::std::mem::offset_of!(Foo, bar) - 0usize];
+};

--- a/bindgen-tests/tests/expectations/tests/gen-destructors.rs
+++ b/bindgen-tests/tests/expectations/tests/gen-destructors.rs
@@ -4,26 +4,11 @@
 pub struct Foo {
     pub bar: ::std::os::raw::c_int,
 }
-#[test]
-fn bindgen_test_layout_Foo() {
-    const UNINIT: ::std::mem::MaybeUninit<Foo> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<Foo>(),
-        4usize,
-        concat!("Size of: ", stringify!(Foo)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Foo>(),
-        4usize,
-        concat!("Alignment of ", stringify!(Foo)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(Foo), "::", stringify!(bar)),
-    );
-}
+const _: () = {
+    ["Size of Foo"][::std::mem::size_of::<Foo>() - 4usize];
+    ["Alignment of Foo"][::std::mem::align_of::<Foo>() - 4usize];
+    ["Offset of field: Foo::bar"][::std::mem::offset_of!(Foo, bar) - 0usize];
+};
 extern "C" {
     #[link_name = "\u{1}_ZN3FooD1Ev"]
     pub fn Foo_Foo_destructor(this: *mut Foo);

--- a/bindgen-tests/tests/expectations/tests/generate-inline.rs
+++ b/bindgen-tests/tests/expectations/tests/generate-inline.rs
@@ -4,19 +4,10 @@
 pub struct Foo {
     pub _address: u8,
 }
-#[test]
-fn bindgen_test_layout_Foo() {
-    assert_eq!(
-        ::std::mem::size_of::<Foo>(),
-        1usize,
-        concat!("Size of: ", stringify!(Foo)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Foo>(),
-        1usize,
-        concat!("Alignment of ", stringify!(Foo)),
-    );
-}
+const _: () = {
+    ["Size of Foo"][::std::mem::size_of::<Foo>() - 1usize];
+    ["Alignment of Foo"][::std::mem::align_of::<Foo>() - 1usize];
+};
 extern "C" {
     #[link_name = "\u{1}_ZN3Foo3barEv"]
     pub fn Foo_bar() -> ::std::os::raw::c_int;

--- a/bindgen-tests/tests/expectations/tests/i128.rs
+++ b/bindgen-tests/tests/expectations/tests/i128.rs
@@ -10,24 +10,16 @@ pub struct foo {
 fn bindgen_test_layout_foo() {
     const UNINIT: ::std::mem::MaybeUninit<foo> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<foo>(),
-        32usize,
-        concat!("Size of: ", stringify!(foo)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<foo>(),
-        16usize,
-        concat!("Alignment of ", stringify!(foo)),
-    );
+    assert_eq!(::std::mem::size_of::<foo>(), 32usize, "Size of foo");
+    assert_eq!(::std::mem::align_of::<foo>(), 16usize, "Alignment of foo");
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).my_signed) as usize - ptr as usize },
         0usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(my_signed)),
+        "Offset of field: foo::my_signed",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).my_unsigned) as usize - ptr as usize },
         16usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(my_unsigned)),
+        "Offset of field: foo::my_unsigned",
     );
 }

--- a/bindgen-tests/tests/expectations/tests/incomplete-array-padding.rs
+++ b/bindgen-tests/tests/expectations/tests/incomplete-array-padding.rs
@@ -120,26 +120,11 @@ pub struct foo {
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
     pub b: __IncompleteArrayField<*mut ::std::os::raw::c_void>,
 }
-#[test]
-fn bindgen_test_layout_foo() {
-    const UNINIT: ::std::mem::MaybeUninit<foo> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<foo>(),
-        8usize,
-        concat!("Size of: ", stringify!(foo)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<foo>(),
-        8usize,
-        concat!("Alignment of ", stringify!(foo)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
-        8usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(b)),
-    );
-}
+const _: () = {
+    ["Size of foo"][::std::mem::size_of::<foo>() - 8usize];
+    ["Alignment of foo"][::std::mem::align_of::<foo>() - 8usize];
+    ["Offset of field: foo::b"][::std::mem::offset_of!(foo, b) - 8usize];
+};
 impl Default for foo {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();

--- a/bindgen-tests/tests/expectations/tests/inherit-from-template-instantiation-with-vtable.rs
+++ b/bindgen-tests/tests/expectations/tests/inherit-from-template-instantiation-with-vtable.rs
@@ -24,19 +24,14 @@ impl<T> Default for BaseWithVtable<T> {
 pub struct DerivedWithNoVirtualMethods {
     pub _base: BaseWithVtable<*mut ::std::os::raw::c_char>,
 }
-#[test]
-fn bindgen_test_layout_DerivedWithNoVirtualMethods() {
-    assert_eq!(
-        ::std::mem::size_of::<DerivedWithNoVirtualMethods>(),
-        16usize,
-        concat!("Size of: ", stringify!(DerivedWithNoVirtualMethods)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<DerivedWithNoVirtualMethods>(),
-        8usize,
-        concat!("Alignment of ", stringify!(DerivedWithNoVirtualMethods)),
-    );
-}
+const _: () = {
+    [
+        "Size of DerivedWithNoVirtualMethods",
+    ][::std::mem::size_of::<DerivedWithNoVirtualMethods>() - 16usize];
+    [
+        "Alignment of DerivedWithNoVirtualMethods",
+    ][::std::mem::align_of::<DerivedWithNoVirtualMethods>() - 8usize];
+};
 impl Default for DerivedWithNoVirtualMethods {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
@@ -52,19 +47,14 @@ impl Default for DerivedWithNoVirtualMethods {
 pub struct DerivedWithVirtualMethods {
     pub _base: BaseWithVtable<*mut ::std::os::raw::c_char>,
 }
-#[test]
-fn bindgen_test_layout_DerivedWithVirtualMethods() {
-    assert_eq!(
-        ::std::mem::size_of::<DerivedWithVirtualMethods>(),
-        16usize,
-        concat!("Size of: ", stringify!(DerivedWithVirtualMethods)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<DerivedWithVirtualMethods>(),
-        8usize,
-        concat!("Alignment of ", stringify!(DerivedWithVirtualMethods)),
-    );
-}
+const _: () = {
+    [
+        "Size of DerivedWithVirtualMethods",
+    ][::std::mem::size_of::<DerivedWithVirtualMethods>() - 16usize];
+    [
+        "Alignment of DerivedWithVirtualMethods",
+    ][::std::mem::align_of::<DerivedWithVirtualMethods>() - 8usize];
+};
 impl Default for DerivedWithVirtualMethods {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
@@ -99,19 +89,12 @@ pub struct DerivedWithVtable {
     pub vtable_: *const DerivedWithVtable__bindgen_vtable,
     pub _base: BaseWithoutVtable<*mut ::std::os::raw::c_char>,
 }
-#[test]
-fn bindgen_test_layout_DerivedWithVtable() {
-    assert_eq!(
-        ::std::mem::size_of::<DerivedWithVtable>(),
-        16usize,
-        concat!("Size of: ", stringify!(DerivedWithVtable)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<DerivedWithVtable>(),
-        8usize,
-        concat!("Alignment of ", stringify!(DerivedWithVtable)),
-    );
-}
+const _: () = {
+    ["Size of DerivedWithVtable"][::std::mem::size_of::<DerivedWithVtable>() - 16usize];
+    [
+        "Alignment of DerivedWithVtable",
+    ][::std::mem::align_of::<DerivedWithVtable>() - 8usize];
+};
 impl Default for DerivedWithVtable {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
@@ -127,19 +110,14 @@ impl Default for DerivedWithVtable {
 pub struct DerivedWithoutVtable {
     pub _base: BaseWithoutVtable<*mut ::std::os::raw::c_char>,
 }
-#[test]
-fn bindgen_test_layout_DerivedWithoutVtable() {
-    assert_eq!(
-        ::std::mem::size_of::<DerivedWithoutVtable>(),
-        8usize,
-        concat!("Size of: ", stringify!(DerivedWithoutVtable)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<DerivedWithoutVtable>(),
-        8usize,
-        concat!("Alignment of ", stringify!(DerivedWithoutVtable)),
-    );
-}
+const _: () = {
+    [
+        "Size of DerivedWithoutVtable",
+    ][::std::mem::size_of::<DerivedWithoutVtable>() - 8usize];
+    [
+        "Alignment of DerivedWithoutVtable",
+    ][::std::mem::align_of::<DerivedWithoutVtable>() - 8usize];
+};
 impl Default for DerivedWithoutVtable {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
@@ -149,79 +127,35 @@ impl Default for DerivedWithoutVtable {
         }
     }
 }
-#[test]
-fn __bindgen_test_layout_BaseWithVtable_open0_ptr_char_close0_instantiation() {
-    assert_eq!(
-        ::std::mem::size_of::<BaseWithVtable<*mut ::std::os::raw::c_char>>(),
-        16usize,
-        concat!(
-            "Size of template specialization: ",
-            stringify!(BaseWithVtable < * mut ::std::os::raw::c_char >),
-        ),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<BaseWithVtable<*mut ::std::os::raw::c_char>>(),
-        8usize,
-        concat!(
-            "Alignment of template specialization: ",
-            stringify!(BaseWithVtable < * mut ::std::os::raw::c_char >),
-        ),
-    );
-}
-#[test]
-fn __bindgen_test_layout_BaseWithVtable_open0_ptr_char_close0_instantiation_1() {
-    assert_eq!(
-        ::std::mem::size_of::<BaseWithVtable<*mut ::std::os::raw::c_char>>(),
-        16usize,
-        concat!(
-            "Size of template specialization: ",
-            stringify!(BaseWithVtable < * mut ::std::os::raw::c_char >),
-        ),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<BaseWithVtable<*mut ::std::os::raw::c_char>>(),
-        8usize,
-        concat!(
-            "Alignment of template specialization: ",
-            stringify!(BaseWithVtable < * mut ::std::os::raw::c_char >),
-        ),
-    );
-}
-#[test]
-fn __bindgen_test_layout_BaseWithoutVtable_open0_ptr_char_close0_instantiation() {
-    assert_eq!(
-        ::std::mem::size_of::<BaseWithoutVtable<*mut ::std::os::raw::c_char>>(),
-        8usize,
-        concat!(
-            "Size of template specialization: ",
-            stringify!(BaseWithoutVtable < * mut ::std::os::raw::c_char >),
-        ),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<BaseWithoutVtable<*mut ::std::os::raw::c_char>>(),
-        8usize,
-        concat!(
-            "Alignment of template specialization: ",
-            stringify!(BaseWithoutVtable < * mut ::std::os::raw::c_char >),
-        ),
-    );
-}
-#[test]
-fn __bindgen_test_layout_BaseWithoutVtable_open0_ptr_char_close0_instantiation_1() {
-    assert_eq!(
-        ::std::mem::size_of::<BaseWithoutVtable<*mut ::std::os::raw::c_char>>(),
-        8usize,
-        concat!(
-            "Size of template specialization: ",
-            stringify!(BaseWithoutVtable < * mut ::std::os::raw::c_char >),
-        ),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<BaseWithoutVtable<*mut ::std::os::raw::c_char>>(),
-        8usize,
-        concat!(
-            "Alignment of template specialization: ",
-            stringify!(BaseWithoutVtable < * mut ::std::os::raw::c_char >),
-        ),
-    );
-}
+const _: () = {
+    [
+        "Size of template specialization: BaseWithVtable_open0_ptr_char_close0",
+    ][::std::mem::size_of::<BaseWithVtable<*mut ::std::os::raw::c_char>>() - 16usize];
+    [
+        "Align of template specialization: BaseWithVtable_open0_ptr_char_close0",
+    ][::std::mem::align_of::<BaseWithVtable<*mut ::std::os::raw::c_char>>() - 8usize];
+};
+const _: () = {
+    [
+        "Size of template specialization: BaseWithVtable_open0_ptr_char_close0",
+    ][::std::mem::size_of::<BaseWithVtable<*mut ::std::os::raw::c_char>>() - 16usize];
+    [
+        "Align of template specialization: BaseWithVtable_open0_ptr_char_close0",
+    ][::std::mem::align_of::<BaseWithVtable<*mut ::std::os::raw::c_char>>() - 8usize];
+};
+const _: () = {
+    [
+        "Size of template specialization: BaseWithoutVtable_open0_ptr_char_close0",
+    ][::std::mem::size_of::<BaseWithoutVtable<*mut ::std::os::raw::c_char>>() - 8usize];
+    [
+        "Align of template specialization: BaseWithoutVtable_open0_ptr_char_close0",
+    ][::std::mem::align_of::<BaseWithoutVtable<*mut ::std::os::raw::c_char>>() - 8usize];
+};
+const _: () = {
+    [
+        "Size of template specialization: BaseWithoutVtable_open0_ptr_char_close0",
+    ][::std::mem::size_of::<BaseWithoutVtable<*mut ::std::os::raw::c_char>>() - 8usize];
+    [
+        "Align of template specialization: BaseWithoutVtable_open0_ptr_char_close0",
+    ][::std::mem::align_of::<BaseWithoutVtable<*mut ::std::os::raw::c_char>>() - 8usize];
+};

--- a/bindgen-tests/tests/expectations/tests/inherit_multiple_interfaces.rs
+++ b/bindgen-tests/tests/expectations/tests/inherit_multiple_interfaces.rs
@@ -7,22 +7,11 @@ pub struct A {
     pub vtable_: *const A__bindgen_vtable,
     pub member: ::std::os::raw::c_int,
 }
-#[test]
-fn bindgen_test_layout_A() {
-    const UNINIT: ::std::mem::MaybeUninit<A> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(::std::mem::size_of::<A>(), 16usize, concat!("Size of: ", stringify!(A)));
-    assert_eq!(
-        ::std::mem::align_of::<A>(),
-        8usize,
-        concat!("Alignment of ", stringify!(A)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).member) as usize - ptr as usize },
-        8usize,
-        concat!("Offset of field: ", stringify!(A), "::", stringify!(member)),
-    );
-}
+const _: () = {
+    ["Size of A"][::std::mem::size_of::<A>() - 16usize];
+    ["Alignment of A"][::std::mem::align_of::<A>() - 8usize];
+    ["Offset of field: A::member"][::std::mem::offset_of!(A, member) - 8usize];
+};
 impl Default for A {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
@@ -40,22 +29,11 @@ pub struct B {
     pub vtable_: *const B__bindgen_vtable,
     pub member2: *mut ::std::os::raw::c_void,
 }
-#[test]
-fn bindgen_test_layout_B() {
-    const UNINIT: ::std::mem::MaybeUninit<B> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(::std::mem::size_of::<B>(), 16usize, concat!("Size of: ", stringify!(B)));
-    assert_eq!(
-        ::std::mem::align_of::<B>(),
-        8usize,
-        concat!("Alignment of ", stringify!(B)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).member2) as usize - ptr as usize },
-        8usize,
-        concat!("Offset of field: ", stringify!(B), "::", stringify!(member2)),
-    );
-}
+const _: () = {
+    ["Size of B"][::std::mem::size_of::<B>() - 16usize];
+    ["Alignment of B"][::std::mem::align_of::<B>() - 8usize];
+    ["Offset of field: B::member2"][::std::mem::offset_of!(B, member2) - 8usize];
+};
 impl Default for B {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
@@ -72,22 +50,11 @@ pub struct C {
     pub _base_1: B,
     pub member3: f32,
 }
-#[test]
-fn bindgen_test_layout_C() {
-    const UNINIT: ::std::mem::MaybeUninit<C> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(::std::mem::size_of::<C>(), 40usize, concat!("Size of: ", stringify!(C)));
-    assert_eq!(
-        ::std::mem::align_of::<C>(),
-        8usize,
-        concat!("Alignment of ", stringify!(C)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).member3) as usize - ptr as usize },
-        32usize,
-        concat!("Offset of field: ", stringify!(C), "::", stringify!(member3)),
-    );
-}
+const _: () = {
+    ["Size of C"][::std::mem::size_of::<C>() - 40usize];
+    ["Alignment of C"][::std::mem::align_of::<C>() - 8usize];
+    ["Offset of field: C::member3"][::std::mem::offset_of!(C, member3) - 32usize];
+};
 impl Default for C {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();

--- a/bindgen-tests/tests/expectations/tests/inherit_typedef.rs
+++ b/bindgen-tests/tests/expectations/tests/inherit_typedef.rs
@@ -4,35 +4,17 @@
 pub struct Foo {
     pub _address: u8,
 }
-#[test]
-fn bindgen_test_layout_Foo() {
-    assert_eq!(
-        ::std::mem::size_of::<Foo>(),
-        1usize,
-        concat!("Size of: ", stringify!(Foo)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Foo>(),
-        1usize,
-        concat!("Alignment of ", stringify!(Foo)),
-    );
-}
+const _: () = {
+    ["Size of Foo"][::std::mem::size_of::<Foo>() - 1usize];
+    ["Alignment of Foo"][::std::mem::align_of::<Foo>() - 1usize];
+};
 pub type TypedefedFoo = Foo;
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct Bar {
     pub _address: u8,
 }
-#[test]
-fn bindgen_test_layout_Bar() {
-    assert_eq!(
-        ::std::mem::size_of::<Bar>(),
-        1usize,
-        concat!("Size of: ", stringify!(Bar)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Bar>(),
-        1usize,
-        concat!("Alignment of ", stringify!(Bar)),
-    );
-}
+const _: () = {
+    ["Size of Bar"][::std::mem::size_of::<Bar>() - 1usize];
+    ["Alignment of Bar"][::std::mem::align_of::<Bar>() - 1usize];
+};

--- a/bindgen-tests/tests/expectations/tests/inline_namespace.rs
+++ b/bindgen-tests/tests/expectations/tests/inline_namespace.rs
@@ -13,24 +13,9 @@ pub mod root {
     pub struct Bar {
         pub baz: root::foo::Ty,
     }
-    #[test]
-    fn bindgen_test_layout_Bar() {
-        const UNINIT: ::std::mem::MaybeUninit<Bar> = ::std::mem::MaybeUninit::uninit();
-        let ptr = UNINIT.as_ptr();
-        assert_eq!(
-            ::std::mem::size_of::<Bar>(),
-            4usize,
-            concat!("Size of: ", stringify!(Bar)),
-        );
-        assert_eq!(
-            ::std::mem::align_of::<Bar>(),
-            4usize,
-            concat!("Alignment of ", stringify!(Bar)),
-        );
-        assert_eq!(
-            unsafe { ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize },
-            0usize,
-            concat!("Offset of field: ", stringify!(Bar), "::", stringify!(baz)),
-        );
-    }
+    const _: () = {
+        ["Size of Bar"][::std::mem::size_of::<Bar>() - 4usize];
+        ["Alignment of Bar"][::std::mem::align_of::<Bar>() - 4usize];
+        ["Offset of field: Bar::baz"][::std::mem::offset_of!(Bar, baz) - 0usize];
+    };
 }

--- a/bindgen-tests/tests/expectations/tests/inline_namespace_conservative.rs
+++ b/bindgen-tests/tests/expectations/tests/inline_namespace_conservative.rs
@@ -18,24 +18,9 @@ pub mod root {
     pub struct Bar {
         pub baz: root::foo::bar::Ty,
     }
-    #[test]
-    fn bindgen_test_layout_Bar() {
-        const UNINIT: ::std::mem::MaybeUninit<Bar> = ::std::mem::MaybeUninit::uninit();
-        let ptr = UNINIT.as_ptr();
-        assert_eq!(
-            ::std::mem::size_of::<Bar>(),
-            4usize,
-            concat!("Size of: ", stringify!(Bar)),
-        );
-        assert_eq!(
-            ::std::mem::align_of::<Bar>(),
-            4usize,
-            concat!("Alignment of ", stringify!(Bar)),
-        );
-        assert_eq!(
-            unsafe { ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize },
-            0usize,
-            concat!("Offset of field: ", stringify!(Bar), "::", stringify!(baz)),
-        );
-    }
+    const _: () = {
+        ["Size of Bar"][::std::mem::size_of::<Bar>() - 4usize];
+        ["Alignment of Bar"][::std::mem::align_of::<Bar>() - 4usize];
+        ["Offset of field: Bar::baz"][::std::mem::offset_of!(Bar, baz) - 0usize];
+    };
 }

--- a/bindgen-tests/tests/expectations/tests/inner_const.rs
+++ b/bindgen-tests/tests/expectations/tests/inner_const.rs
@@ -12,23 +12,8 @@ extern "C" {
     #[link_name = "\u{1}_ZN3Foo8whateverE"]
     pub static mut Foo_whatever: Foo;
 }
-#[test]
-fn bindgen_test_layout_Foo() {
-    const UNINIT: ::std::mem::MaybeUninit<Foo> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<Foo>(),
-        4usize,
-        concat!("Size of: ", stringify!(Foo)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Foo>(),
-        4usize,
-        concat!("Alignment of ", stringify!(Foo)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(Foo), "::", stringify!(bar)),
-    );
-}
+const _: () = {
+    ["Size of Foo"][::std::mem::size_of::<Foo>() - 4usize];
+    ["Alignment of Foo"][::std::mem::align_of::<Foo>() - 4usize];
+    ["Offset of field: Foo::bar"][::std::mem::offset_of!(Foo, bar) - 0usize];
+};

--- a/bindgen-tests/tests/expectations/tests/inner_template_self.rs
+++ b/bindgen-tests/tests/expectations/tests/inner_template_self.rs
@@ -19,26 +19,13 @@ impl Default for LinkedList {
 pub struct InstantiateIt {
     pub m_list: LinkedList,
 }
-#[test]
-fn bindgen_test_layout_InstantiateIt() {
-    const UNINIT: ::std::mem::MaybeUninit<InstantiateIt> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<InstantiateIt>(),
-        16usize,
-        concat!("Size of: ", stringify!(InstantiateIt)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<InstantiateIt>(),
-        8usize,
-        concat!("Alignment of ", stringify!(InstantiateIt)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).m_list) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(InstantiateIt), "::", stringify!(m_list)),
-    );
-}
+const _: () = {
+    ["Size of InstantiateIt"][::std::mem::size_of::<InstantiateIt>() - 16usize];
+    ["Alignment of InstantiateIt"][::std::mem::align_of::<InstantiateIt>() - 8usize];
+    [
+        "Offset of field: InstantiateIt::m_list",
+    ][::std::mem::offset_of!(InstantiateIt, m_list) - 0usize];
+};
 impl Default for InstantiateIt {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
@@ -48,16 +35,11 @@ impl Default for InstantiateIt {
         }
     }
 }
-#[test]
-fn __bindgen_test_layout_LinkedList_open0_int_close0_instantiation() {
-    assert_eq!(
-        ::std::mem::size_of::<LinkedList>(),
-        16usize,
-        concat!("Size of template specialization: ", stringify!(LinkedList)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<LinkedList>(),
-        8usize,
-        concat!("Alignment of template specialization: ", stringify!(LinkedList)),
-    );
-}
+const _: () = {
+    [
+        "Size of template specialization: LinkedList_open0_int_close0",
+    ][::std::mem::size_of::<LinkedList>() - 16usize];
+    [
+        "Align of template specialization: LinkedList_open0_int_close0",
+    ][::std::mem::align_of::<LinkedList>() - 8usize];
+};

--- a/bindgen-tests/tests/expectations/tests/issue-1034.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-1034.rs
@@ -89,19 +89,10 @@ pub struct S2 {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 2usize]>,
 }
-#[test]
-fn bindgen_test_layout_S2() {
-    assert_eq!(
-        ::std::mem::size_of::<S2>(),
-        2usize,
-        concat!("Size of: ", stringify!(S2)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<S2>(),
-        1usize,
-        concat!("Alignment of ", stringify!(S2)),
-    );
-}
+const _: () = {
+    ["Size of S2"][::std::mem::size_of::<S2>() - 2usize];
+    ["Alignment of S2"][::std::mem::align_of::<S2>() - 1usize];
+};
 impl S2 {
     #[inline]
     pub fn new_bitfield_1() -> __BindgenBitfieldUnit<[u8; 2usize]> {

--- a/bindgen-tests/tests/expectations/tests/issue-1076-unnamed-bitfield-alignment.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-1076-unnamed-bitfield-alignment.rs
@@ -89,19 +89,10 @@ pub struct S1 {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 3usize]>,
 }
-#[test]
-fn bindgen_test_layout_S1() {
-    assert_eq!(
-        ::std::mem::size_of::<S1>(),
-        3usize,
-        concat!("Size of: ", stringify!(S1)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<S1>(),
-        1usize,
-        concat!("Alignment of ", stringify!(S1)),
-    );
-}
+const _: () = {
+    ["Size of S1"][::std::mem::size_of::<S1>() - 3usize];
+    ["Alignment of S1"][::std::mem::align_of::<S1>() - 1usize];
+};
 impl S1 {
     #[inline]
     pub fn new_bitfield_1() -> __BindgenBitfieldUnit<[u8; 3usize]> {

--- a/bindgen-tests/tests/expectations/tests/issue-1118-using-forward-decl.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-1118-using-forward-decl.rs
@@ -5,26 +5,13 @@ pub type c = nsTArray;
 pub struct nsTArray_base {
     pub d: *mut ::std::os::raw::c_int,
 }
-#[test]
-fn bindgen_test_layout_nsTArray_base() {
-    const UNINIT: ::std::mem::MaybeUninit<nsTArray_base> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<nsTArray_base>(),
-        8usize,
-        concat!("Size of: ", stringify!(nsTArray_base)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<nsTArray_base>(),
-        8usize,
-        concat!("Alignment of ", stringify!(nsTArray_base)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(nsTArray_base), "::", stringify!(d)),
-    );
-}
+const _: () = {
+    ["Size of nsTArray_base"][::std::mem::size_of::<nsTArray_base>() - 8usize];
+    ["Alignment of nsTArray_base"][::std::mem::align_of::<nsTArray_base>() - 8usize];
+    [
+        "Offset of field: nsTArray_base::d",
+    ][::std::mem::offset_of!(nsTArray_base, d) - 0usize];
+};
 impl Default for nsTArray_base {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
@@ -53,26 +40,13 @@ impl Default for nsTArray {
 pub struct nsIContent {
     pub foo: nsTArray,
 }
-#[test]
-fn bindgen_test_layout_nsIContent() {
-    const UNINIT: ::std::mem::MaybeUninit<nsIContent> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<nsIContent>(),
-        8usize,
-        concat!("Size of: ", stringify!(nsIContent)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<nsIContent>(),
-        8usize,
-        concat!("Alignment of ", stringify!(nsIContent)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(nsIContent), "::", stringify!(foo)),
-    );
-}
+const _: () = {
+    ["Size of nsIContent"][::std::mem::size_of::<nsIContent>() - 8usize];
+    ["Alignment of nsIContent"][::std::mem::align_of::<nsIContent>() - 8usize];
+    [
+        "Offset of field: nsIContent::foo",
+    ][::std::mem::offset_of!(nsIContent, foo) - 0usize];
+};
 impl Default for nsIContent {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
@@ -86,29 +60,19 @@ extern "C" {
     #[link_name = "\u{1}_Z35Gecko_GetAnonymousContentForElementv"]
     pub fn Gecko_GetAnonymousContentForElement() -> *mut nsTArray;
 }
-#[test]
-fn __bindgen_test_layout_nsTArray_open0_ptr_nsIContent_close0_instantiation() {
-    assert_eq!(
-        ::std::mem::size_of::<nsTArray>(),
-        8usize,
-        concat!("Size of template specialization: ", stringify!(nsTArray)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<nsTArray>(),
-        8usize,
-        concat!("Alignment of template specialization: ", stringify!(nsTArray)),
-    );
-}
-#[test]
-fn __bindgen_test_layout_nsTArray_open0_ptr_nsIContent_close0_instantiation_1() {
-    assert_eq!(
-        ::std::mem::size_of::<nsTArray>(),
-        8usize,
-        concat!("Size of template specialization: ", stringify!(nsTArray)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<nsTArray>(),
-        8usize,
-        concat!("Alignment of template specialization: ", stringify!(nsTArray)),
-    );
-}
+const _: () = {
+    [
+        "Size of template specialization: nsTArray_open0_ptr_nsIContent_close0",
+    ][::std::mem::size_of::<nsTArray>() - 8usize];
+    [
+        "Align of template specialization: nsTArray_open0_ptr_nsIContent_close0",
+    ][::std::mem::align_of::<nsTArray>() - 8usize];
+};
+const _: () = {
+    [
+        "Size of template specialization: nsTArray_open0_ptr_nsIContent_close0",
+    ][::std::mem::size_of::<nsTArray>() - 8usize];
+    [
+        "Align of template specialization: nsTArray_open0_ptr_nsIContent_close0",
+    ][::std::mem::align_of::<nsTArray>() - 8usize];
+};

--- a/bindgen-tests/tests/expectations/tests/issue-1197-pure-virtual-stuff.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-1197-pure-virtual-stuff.rs
@@ -6,19 +6,10 @@ pub struct Foo__bindgen_vtable(::std::os::raw::c_void);
 pub struct Foo {
     pub vtable_: *const Foo__bindgen_vtable,
 }
-#[test]
-fn bindgen_test_layout_Foo() {
-    assert_eq!(
-        ::std::mem::size_of::<Foo>(),
-        8usize,
-        concat!("Size of: ", stringify!(Foo)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Foo>(),
-        8usize,
-        concat!("Alignment of ", stringify!(Foo)),
-    );
-}
+const _: () = {
+    ["Size of Foo"][::std::mem::size_of::<Foo>() - 8usize];
+    ["Alignment of Foo"][::std::mem::align_of::<Foo>() - 8usize];
+};
 impl Default for Foo {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();

--- a/bindgen-tests/tests/expectations/tests/issue-1216-variadic-member.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-1216-variadic-member.rs
@@ -14,23 +14,8 @@ pub struct Foo {
         ),
     >,
 }
-#[test]
-fn bindgen_test_layout_Foo() {
-    const UNINIT: ::std::mem::MaybeUninit<Foo> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<Foo>(),
-        8usize,
-        concat!("Size of: ", stringify!(Foo)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Foo>(),
-        8usize,
-        concat!("Alignment of ", stringify!(Foo)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).f) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(Foo), "::", stringify!(f)),
-    );
-}
+const _: () = {
+    ["Size of Foo"][::std::mem::size_of::<Foo>() - 8usize];
+    ["Alignment of Foo"][::std::mem::align_of::<Foo>() - 8usize];
+    ["Offset of field: Foo::f"][::std::mem::offset_of!(Foo, f) - 0usize];
+};

--- a/bindgen-tests/tests/expectations/tests/issue-1281.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-1281.rs
@@ -9,69 +9,24 @@ pub struct bar {
 pub struct foo {
     pub foo: ::std::os::raw::c_int,
 }
-#[test]
-fn bindgen_test_layout_foo() {
-    const UNINIT: ::std::mem::MaybeUninit<foo> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<foo>(),
-        4usize,
-        concat!("Size of: ", stringify!(foo)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<foo>(),
-        4usize,
-        concat!("Alignment of ", stringify!(foo)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(foo)),
-    );
-}
-#[test]
-fn bindgen_test_layout_bar() {
-    const UNINIT: ::std::mem::MaybeUninit<bar> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<bar>(),
-        4usize,
-        concat!("Size of: ", stringify!(bar)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<bar>(),
-        4usize,
-        concat!("Alignment of ", stringify!(bar)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).u) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(bar), "::", stringify!(u)),
-    );
-}
+const _: () = {
+    ["Size of foo"][::std::mem::size_of::<foo>() - 4usize];
+    ["Alignment of foo"][::std::mem::align_of::<foo>() - 4usize];
+    ["Offset of field: foo::foo"][::std::mem::offset_of!(foo, foo) - 0usize];
+};
+const _: () = {
+    ["Size of bar"][::std::mem::size_of::<bar>() - 4usize];
+    ["Alignment of bar"][::std::mem::align_of::<bar>() - 4usize];
+    ["Offset of field: bar::u"][::std::mem::offset_of!(bar, u) - 0usize];
+};
 pub type bar_t = bar;
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct baz {
     pub f: foo,
 }
-#[test]
-fn bindgen_test_layout_baz() {
-    const UNINIT: ::std::mem::MaybeUninit<baz> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<baz>(),
-        4usize,
-        concat!("Size of: ", stringify!(baz)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<baz>(),
-        4usize,
-        concat!("Alignment of ", stringify!(baz)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).f) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(baz), "::", stringify!(f)),
-    );
-}
+const _: () = {
+    ["Size of baz"][::std::mem::size_of::<baz>() - 4usize];
+    ["Alignment of baz"][::std::mem::align_of::<baz>() - 4usize];
+    ["Offset of field: baz::f"][::std::mem::offset_of!(baz, f) - 0usize];
+};

--- a/bindgen-tests/tests/expectations/tests/issue-1285.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-1285.rs
@@ -10,31 +10,18 @@ pub union foo__bindgen_ty_1 {
     pub a: ::std::os::raw::c_uint,
     pub b: ::std::os::raw::c_ushort,
 }
-#[test]
-fn bindgen_test_layout_foo__bindgen_ty_1() {
-    const UNINIT: ::std::mem::MaybeUninit<foo__bindgen_ty_1> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<foo__bindgen_ty_1>(),
-        4usize,
-        concat!("Size of: ", stringify!(foo__bindgen_ty_1)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<foo__bindgen_ty_1>(),
-        4usize,
-        concat!("Alignment of ", stringify!(foo__bindgen_ty_1)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(foo__bindgen_ty_1), "::", stringify!(a)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(foo__bindgen_ty_1), "::", stringify!(b)),
-    );
-}
+const _: () = {
+    ["Size of foo__bindgen_ty_1"][::std::mem::size_of::<foo__bindgen_ty_1>() - 4usize];
+    [
+        "Alignment of foo__bindgen_ty_1",
+    ][::std::mem::align_of::<foo__bindgen_ty_1>() - 4usize];
+    [
+        "Offset of field: foo__bindgen_ty_1::a",
+    ][::std::mem::offset_of!(foo__bindgen_ty_1, a) - 0usize];
+    [
+        "Offset of field: foo__bindgen_ty_1::b",
+    ][::std::mem::offset_of!(foo__bindgen_ty_1, b) - 0usize];
+};
 impl Default for foo__bindgen_ty_1 {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
@@ -44,26 +31,11 @@ impl Default for foo__bindgen_ty_1 {
         }
     }
 }
-#[test]
-fn bindgen_test_layout_foo() {
-    const UNINIT: ::std::mem::MaybeUninit<foo> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<foo>(),
-        4usize,
-        concat!("Size of: ", stringify!(foo)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<foo>(),
-        4usize,
-        concat!("Alignment of ", stringify!(foo)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar)),
-    );
-}
+const _: () = {
+    ["Size of foo"][::std::mem::size_of::<foo>() - 4usize];
+    ["Alignment of foo"][::std::mem::align_of::<foo>() - 4usize];
+    ["Offset of field: foo::bar"][::std::mem::offset_of!(foo, bar) - 0usize];
+};
 impl Default for foo {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();

--- a/bindgen-tests/tests/expectations/tests/issue-1291.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-1291.rs
@@ -23,89 +23,81 @@ pub struct RTCRay {
 fn bindgen_test_layout_RTCRay() {
     const UNINIT: ::std::mem::MaybeUninit<RTCRay> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<RTCRay>(),
-        96usize,
-        concat!("Size of: ", stringify!(RTCRay)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<RTCRay>(),
-        16usize,
-        concat!("Alignment of ", stringify!(RTCRay)),
-    );
+    assert_eq!(::std::mem::size_of::<RTCRay>(), 96usize, "Size of RTCRay");
+    assert_eq!(::std::mem::align_of::<RTCRay>(), 16usize, "Alignment of RTCRay");
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).org) as usize - ptr as usize },
         0usize,
-        concat!("Offset of field: ", stringify!(RTCRay), "::", stringify!(org)),
+        "Offset of field: RTCRay::org",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).align0) as usize - ptr as usize },
         12usize,
-        concat!("Offset of field: ", stringify!(RTCRay), "::", stringify!(align0)),
+        "Offset of field: RTCRay::align0",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).dir) as usize - ptr as usize },
         16usize,
-        concat!("Offset of field: ", stringify!(RTCRay), "::", stringify!(dir)),
+        "Offset of field: RTCRay::dir",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).align1) as usize - ptr as usize },
         28usize,
-        concat!("Offset of field: ", stringify!(RTCRay), "::", stringify!(align1)),
+        "Offset of field: RTCRay::align1",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).tnear) as usize - ptr as usize },
         32usize,
-        concat!("Offset of field: ", stringify!(RTCRay), "::", stringify!(tnear)),
+        "Offset of field: RTCRay::tnear",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).tfar) as usize - ptr as usize },
         36usize,
-        concat!("Offset of field: ", stringify!(RTCRay), "::", stringify!(tfar)),
+        "Offset of field: RTCRay::tfar",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).time) as usize - ptr as usize },
         40usize,
-        concat!("Offset of field: ", stringify!(RTCRay), "::", stringify!(time)),
+        "Offset of field: RTCRay::time",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).mask) as usize - ptr as usize },
         44usize,
-        concat!("Offset of field: ", stringify!(RTCRay), "::", stringify!(mask)),
+        "Offset of field: RTCRay::mask",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).Ng) as usize - ptr as usize },
         48usize,
-        concat!("Offset of field: ", stringify!(RTCRay), "::", stringify!(Ng)),
+        "Offset of field: RTCRay::Ng",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).align2) as usize - ptr as usize },
         60usize,
-        concat!("Offset of field: ", stringify!(RTCRay), "::", stringify!(align2)),
+        "Offset of field: RTCRay::align2",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).u) as usize - ptr as usize },
         64usize,
-        concat!("Offset of field: ", stringify!(RTCRay), "::", stringify!(u)),
+        "Offset of field: RTCRay::u",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).v) as usize - ptr as usize },
         68usize,
-        concat!("Offset of field: ", stringify!(RTCRay), "::", stringify!(v)),
+        "Offset of field: RTCRay::v",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).geomID) as usize - ptr as usize },
         72usize,
-        concat!("Offset of field: ", stringify!(RTCRay), "::", stringify!(geomID)),
+        "Offset of field: RTCRay::geomID",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).primID) as usize - ptr as usize },
         76usize,
-        concat!("Offset of field: ", stringify!(RTCRay), "::", stringify!(primID)),
+        "Offset of field: RTCRay::primID",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).instID) as usize - ptr as usize },
         80usize,
-        concat!("Offset of field: ", stringify!(RTCRay), "::", stringify!(instID)),
+        "Offset of field: RTCRay::instID",
     );
 }

--- a/bindgen-tests/tests/expectations/tests/issue-1382-rust-primitive-types.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-1382-rust-primitive-types.rs
@@ -25,88 +25,21 @@ pub struct Foo {
     pub f32_: ::std::os::raw::c_int,
     pub f64_: ::std::os::raw::c_int,
 }
-#[test]
-fn bindgen_test_layout_Foo() {
-    const UNINIT: ::std::mem::MaybeUninit<Foo> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<Foo>(),
-        56usize,
-        concat!("Size of: ", stringify!(Foo)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Foo>(),
-        4usize,
-        concat!("Alignment of ", stringify!(Foo)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).i8_) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(Foo), "::", stringify!(i8_)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).u8_) as usize - ptr as usize },
-        4usize,
-        concat!("Offset of field: ", stringify!(Foo), "::", stringify!(u8_)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).i16_) as usize - ptr as usize },
-        8usize,
-        concat!("Offset of field: ", stringify!(Foo), "::", stringify!(i16_)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).u16_) as usize - ptr as usize },
-        12usize,
-        concat!("Offset of field: ", stringify!(Foo), "::", stringify!(u16_)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).i32_) as usize - ptr as usize },
-        16usize,
-        concat!("Offset of field: ", stringify!(Foo), "::", stringify!(i32_)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).u32_) as usize - ptr as usize },
-        20usize,
-        concat!("Offset of field: ", stringify!(Foo), "::", stringify!(u32_)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).i64_) as usize - ptr as usize },
-        24usize,
-        concat!("Offset of field: ", stringify!(Foo), "::", stringify!(i64_)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).u64_) as usize - ptr as usize },
-        28usize,
-        concat!("Offset of field: ", stringify!(Foo), "::", stringify!(u64_)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).i128_) as usize - ptr as usize },
-        32usize,
-        concat!("Offset of field: ", stringify!(Foo), "::", stringify!(i128_)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).u128_) as usize - ptr as usize },
-        36usize,
-        concat!("Offset of field: ", stringify!(Foo), "::", stringify!(u128_)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).isize_) as usize - ptr as usize },
-        40usize,
-        concat!("Offset of field: ", stringify!(Foo), "::", stringify!(isize_)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).usize_) as usize - ptr as usize },
-        44usize,
-        concat!("Offset of field: ", stringify!(Foo), "::", stringify!(usize_)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).f32_) as usize - ptr as usize },
-        48usize,
-        concat!("Offset of field: ", stringify!(Foo), "::", stringify!(f32_)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).f64_) as usize - ptr as usize },
-        52usize,
-        concat!("Offset of field: ", stringify!(Foo), "::", stringify!(f64_)),
-    );
-}
+const _: () = {
+    ["Size of Foo"][::std::mem::size_of::<Foo>() - 56usize];
+    ["Alignment of Foo"][::std::mem::align_of::<Foo>() - 4usize];
+    ["Offset of field: Foo::i8_"][::std::mem::offset_of!(Foo, i8_) - 0usize];
+    ["Offset of field: Foo::u8_"][::std::mem::offset_of!(Foo, u8_) - 4usize];
+    ["Offset of field: Foo::i16_"][::std::mem::offset_of!(Foo, i16_) - 8usize];
+    ["Offset of field: Foo::u16_"][::std::mem::offset_of!(Foo, u16_) - 12usize];
+    ["Offset of field: Foo::i32_"][::std::mem::offset_of!(Foo, i32_) - 16usize];
+    ["Offset of field: Foo::u32_"][::std::mem::offset_of!(Foo, u32_) - 20usize];
+    ["Offset of field: Foo::i64_"][::std::mem::offset_of!(Foo, i64_) - 24usize];
+    ["Offset of field: Foo::u64_"][::std::mem::offset_of!(Foo, u64_) - 28usize];
+    ["Offset of field: Foo::i128_"][::std::mem::offset_of!(Foo, i128_) - 32usize];
+    ["Offset of field: Foo::u128_"][::std::mem::offset_of!(Foo, u128_) - 36usize];
+    ["Offset of field: Foo::isize_"][::std::mem::offset_of!(Foo, isize_) - 40usize];
+    ["Offset of field: Foo::usize_"][::std::mem::offset_of!(Foo, usize_) - 44usize];
+    ["Offset of field: Foo::f32_"][::std::mem::offset_of!(Foo, f32_) - 48usize];
+    ["Offset of field: Foo::f64_"][::std::mem::offset_of!(Foo, f64_) - 52usize];
+};

--- a/bindgen-tests/tests/expectations/tests/issue-1443.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-1443.rs
@@ -10,31 +10,12 @@ pub struct Bar {
     pub f: *const Foo,
     pub m: ::std::os::raw::c_uint,
 }
-#[test]
-fn bindgen_test_layout_Bar() {
-    const UNINIT: ::std::mem::MaybeUninit<Bar> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<Bar>(),
-        16usize,
-        concat!("Size of: ", stringify!(Bar)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Bar>(),
-        8usize,
-        concat!("Alignment of ", stringify!(Bar)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).f) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(Bar), "::", stringify!(f)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).m) as usize - ptr as usize },
-        8usize,
-        concat!("Offset of field: ", stringify!(Bar), "::", stringify!(m)),
-    );
-}
+const _: () = {
+    ["Size of Bar"][::std::mem::size_of::<Bar>() - 16usize];
+    ["Alignment of Bar"][::std::mem::align_of::<Bar>() - 8usize];
+    ["Offset of field: Bar::f"][::std::mem::offset_of!(Bar, f) - 0usize];
+    ["Offset of field: Bar::m"][::std::mem::offset_of!(Bar, m) - 8usize];
+};
 impl Default for Bar {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
@@ -50,31 +31,12 @@ pub struct Baz {
     pub f: *mut Foo,
     pub m: ::std::os::raw::c_uint,
 }
-#[test]
-fn bindgen_test_layout_Baz() {
-    const UNINIT: ::std::mem::MaybeUninit<Baz> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<Baz>(),
-        16usize,
-        concat!("Size of: ", stringify!(Baz)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Baz>(),
-        8usize,
-        concat!("Alignment of ", stringify!(Baz)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).f) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(Baz), "::", stringify!(f)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).m) as usize - ptr as usize },
-        8usize,
-        concat!("Offset of field: ", stringify!(Baz), "::", stringify!(m)),
-    );
-}
+const _: () = {
+    ["Size of Baz"][::std::mem::size_of::<Baz>() - 16usize];
+    ["Alignment of Baz"][::std::mem::align_of::<Baz>() - 8usize];
+    ["Offset of field: Baz::f"][::std::mem::offset_of!(Baz, f) - 0usize];
+    ["Offset of field: Baz::m"][::std::mem::offset_of!(Baz, m) - 8usize];
+};
 impl Default for Baz {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
@@ -90,31 +52,12 @@ pub struct Tar {
     pub f: *const Foo,
     pub m: ::std::os::raw::c_uint,
 }
-#[test]
-fn bindgen_test_layout_Tar() {
-    const UNINIT: ::std::mem::MaybeUninit<Tar> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<Tar>(),
-        16usize,
-        concat!("Size of: ", stringify!(Tar)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Tar>(),
-        8usize,
-        concat!("Alignment of ", stringify!(Tar)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).f) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(Tar), "::", stringify!(f)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).m) as usize - ptr as usize },
-        8usize,
-        concat!("Offset of field: ", stringify!(Tar), "::", stringify!(m)),
-    );
-}
+const _: () = {
+    ["Size of Tar"][::std::mem::size_of::<Tar>() - 16usize];
+    ["Alignment of Tar"][::std::mem::align_of::<Tar>() - 8usize];
+    ["Offset of field: Tar::f"][::std::mem::offset_of!(Tar, f) - 0usize];
+    ["Offset of field: Tar::m"][::std::mem::offset_of!(Tar, m) - 8usize];
+};
 impl Default for Tar {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
@@ -130,31 +73,12 @@ pub struct Taz {
     pub f: *mut Foo,
     pub m: ::std::os::raw::c_uint,
 }
-#[test]
-fn bindgen_test_layout_Taz() {
-    const UNINIT: ::std::mem::MaybeUninit<Taz> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<Taz>(),
-        16usize,
-        concat!("Size of: ", stringify!(Taz)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Taz>(),
-        8usize,
-        concat!("Alignment of ", stringify!(Taz)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).f) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(Taz), "::", stringify!(f)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).m) as usize - ptr as usize },
-        8usize,
-        concat!("Offset of field: ", stringify!(Taz), "::", stringify!(m)),
-    );
-}
+const _: () = {
+    ["Size of Taz"][::std::mem::size_of::<Taz>() - 16usize];
+    ["Alignment of Taz"][::std::mem::align_of::<Taz>() - 8usize];
+    ["Offset of field: Taz::f"][::std::mem::offset_of!(Taz, f) - 0usize];
+    ["Offset of field: Taz::m"][::std::mem::offset_of!(Taz, m) - 8usize];
+};
 impl Default for Taz {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();

--- a/bindgen-tests/tests/expectations/tests/issue-1454.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-1454.rs
@@ -7,23 +7,10 @@ pub struct extern_type;
 pub struct local_type {
     pub inner: extern_type,
 }
-#[test]
-fn bindgen_test_layout_local_type() {
-    const UNINIT: ::std::mem::MaybeUninit<local_type> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<local_type>(),
-        0usize,
-        concat!("Size of: ", stringify!(local_type)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<local_type>(),
-        1usize,
-        concat!("Alignment of ", stringify!(local_type)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).inner) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(local_type), "::", stringify!(inner)),
-    );
-}
+const _: () = {
+    ["Size of local_type"][::std::mem::size_of::<local_type>() - 0usize];
+    ["Alignment of local_type"][::std::mem::align_of::<local_type>() - 1usize];
+    [
+        "Offset of field: local_type::inner",
+    ][::std::mem::offset_of!(local_type, inner) - 0usize];
+};

--- a/bindgen-tests/tests/expectations/tests/issue-1498.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-1498.rs
@@ -24,41 +24,20 @@ pub union rte_memseg__bindgen_ty_1 {
     ///< Makes sure addr is always 64 bits
     pub addr_64: u64,
 }
-#[test]
-fn bindgen_test_layout_rte_memseg__bindgen_ty_1() {
-    const UNINIT: ::std::mem::MaybeUninit<rte_memseg__bindgen_ty_1> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<rte_memseg__bindgen_ty_1>(),
-        8usize,
-        concat!("Size of: ", stringify!(rte_memseg__bindgen_ty_1)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<rte_memseg__bindgen_ty_1>(),
-        8usize,
-        concat!("Alignment of ", stringify!(rte_memseg__bindgen_ty_1)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).addr) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_memseg__bindgen_ty_1),
-            "::",
-            stringify!(addr),
-        ),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).addr_64) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_memseg__bindgen_ty_1),
-            "::",
-            stringify!(addr_64),
-        ),
-    );
-}
+const _: () = {
+    [
+        "Size of rte_memseg__bindgen_ty_1",
+    ][::std::mem::size_of::<rte_memseg__bindgen_ty_1>() - 8usize];
+    [
+        "Alignment of rte_memseg__bindgen_ty_1",
+    ][::std::mem::align_of::<rte_memseg__bindgen_ty_1>() - 8usize];
+    [
+        "Offset of field: rte_memseg__bindgen_ty_1::addr",
+    ][::std::mem::offset_of!(rte_memseg__bindgen_ty_1, addr) - 0usize];
+    [
+        "Offset of field: rte_memseg__bindgen_ty_1::addr_64",
+    ][::std::mem::offset_of!(rte_memseg__bindgen_ty_1, addr_64) - 0usize];
+};
 impl Default for rte_memseg__bindgen_ty_1 {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
@@ -68,56 +47,28 @@ impl Default for rte_memseg__bindgen_ty_1 {
         }
     }
 }
-#[test]
-fn bindgen_test_layout_rte_memseg() {
-    const UNINIT: ::std::mem::MaybeUninit<rte_memseg> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<rte_memseg>(),
-        44usize,
-        concat!("Size of: ", stringify!(rte_memseg)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<rte_memseg>(),
-        1usize,
-        concat!("Alignment of ", stringify!(rte_memseg)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).phys_addr) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(rte_memseg), "::", stringify!(phys_addr)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).len) as usize - ptr as usize },
-        16usize,
-        concat!("Offset of field: ", stringify!(rte_memseg), "::", stringify!(len)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).hugepage_sz) as usize - ptr as usize },
-        24usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_memseg),
-            "::",
-            stringify!(hugepage_sz),
-        ),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).socket_id) as usize - ptr as usize },
-        32usize,
-        concat!("Offset of field: ", stringify!(rte_memseg), "::", stringify!(socket_id)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).nchannel) as usize - ptr as usize },
-        36usize,
-        concat!("Offset of field: ", stringify!(rte_memseg), "::", stringify!(nchannel)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).nrank) as usize - ptr as usize },
-        40usize,
-        concat!("Offset of field: ", stringify!(rte_memseg), "::", stringify!(nrank)),
-    );
-}
+const _: () = {
+    ["Size of rte_memseg"][::std::mem::size_of::<rte_memseg>() - 44usize];
+    ["Alignment of rte_memseg"][::std::mem::align_of::<rte_memseg>() - 1usize];
+    [
+        "Offset of field: rte_memseg::phys_addr",
+    ][::std::mem::offset_of!(rte_memseg, phys_addr) - 0usize];
+    [
+        "Offset of field: rte_memseg::len",
+    ][::std::mem::offset_of!(rte_memseg, len) - 16usize];
+    [
+        "Offset of field: rte_memseg::hugepage_sz",
+    ][::std::mem::offset_of!(rte_memseg, hugepage_sz) - 24usize];
+    [
+        "Offset of field: rte_memseg::socket_id",
+    ][::std::mem::offset_of!(rte_memseg, socket_id) - 32usize];
+    [
+        "Offset of field: rte_memseg::nchannel",
+    ][::std::mem::offset_of!(rte_memseg, nchannel) - 36usize];
+    [
+        "Offset of field: rte_memseg::nrank",
+    ][::std::mem::offset_of!(rte_memseg, nrank) - 40usize];
+};
 impl Default for rte_memseg {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();

--- a/bindgen-tests/tests/expectations/tests/issue-1947.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-1947.rs
@@ -96,36 +96,13 @@ pub struct V56AMDY {
     pub _bitfield_2: __BindgenBitfieldUnit<[u8; 3usize]>,
     pub _rB_: U8,
 }
-#[test]
-fn bindgen_test_layout_V56AMDY() {
-    const UNINIT: ::std::mem::MaybeUninit<V56AMDY> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<V56AMDY>(),
-        8usize,
-        concat!("Size of: ", stringify!(V56AMDY)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<V56AMDY>(),
-        2usize,
-        concat!("Alignment of ", stringify!(V56AMDY)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).MADK) as usize - ptr as usize },
-        2usize,
-        concat!("Offset of field: ", stringify!(V56AMDY), "::", stringify!(MADK)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).MABR) as usize - ptr as usize },
-        3usize,
-        concat!("Offset of field: ", stringify!(V56AMDY), "::", stringify!(MABR)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr)._rB_) as usize - ptr as usize },
-        7usize,
-        concat!("Offset of field: ", stringify!(V56AMDY), "::", stringify!(_rB_)),
-    );
-}
+const _: () = {
+    ["Size of V56AMDY"][::std::mem::size_of::<V56AMDY>() - 8usize];
+    ["Alignment of V56AMDY"][::std::mem::align_of::<V56AMDY>() - 2usize];
+    ["Offset of field: V56AMDY::MADK"][::std::mem::offset_of!(V56AMDY, MADK) - 2usize];
+    ["Offset of field: V56AMDY::MABR"][::std::mem::offset_of!(V56AMDY, MABR) - 3usize];
+    ["Offset of field: V56AMDY::_rB_"][::std::mem::offset_of!(V56AMDY, _rB_) - 7usize];
+};
 impl V56AMDY {
     #[inline]
     pub fn MADZ(&self) -> U16 {

--- a/bindgen-tests/tests/expectations/tests/issue-1977-larger-arrays.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-1977-larger-arrays.rs
@@ -4,22 +4,11 @@
 pub struct S {
     pub large_array: [::std::os::raw::c_char; 33usize],
 }
-#[test]
-fn bindgen_test_layout_S() {
-    const UNINIT: ::std::mem::MaybeUninit<S> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(::std::mem::size_of::<S>(), 33usize, concat!("Size of: ", stringify!(S)));
-    assert_eq!(
-        ::std::mem::align_of::<S>(),
-        1usize,
-        concat!("Alignment of ", stringify!(S)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).large_array) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(S), "::", stringify!(large_array)),
-    );
-}
+const _: () = {
+    ["Size of S"][::std::mem::size_of::<S>() - 33usize];
+    ["Alignment of S"][::std::mem::align_of::<S>() - 1usize];
+    ["Offset of field: S::large_array"][::std::mem::offset_of!(S, large_array) - 0usize];
+};
 impl Default for S {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();

--- a/bindgen-tests/tests/expectations/tests/issue-1995.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-1995.rs
@@ -11,23 +11,8 @@ pub const FOO: ::std::os::raw::c_int = 1;
 pub struct Bar {
     pub baz: ::std::os::raw::c_int,
 }
-#[test]
-fn bindgen_test_layout_Bar() {
-    const UNINIT: ::std::mem::MaybeUninit<Bar> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<Bar>(),
-        4usize,
-        concat!("Size of: ", stringify!(Bar)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Bar>(),
-        4usize,
-        concat!("Alignment of ", stringify!(Bar)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(Bar), "::", stringify!(baz)),
-    );
-}
+const _: () = {
+    ["Size of Bar"][::std::mem::size_of::<Bar>() - 4usize];
+    ["Alignment of Bar"][::std::mem::align_of::<Bar>() - 4usize];
+    ["Offset of field: Bar::baz"][::std::mem::offset_of!(Bar, baz) - 0usize];
+};

--- a/bindgen-tests/tests/expectations/tests/issue-2019.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-2019.rs
@@ -4,22 +4,11 @@
 pub struct A {
     pub a: ::std::os::raw::c_int,
 }
-#[test]
-fn bindgen_test_layout_A() {
-    const UNINIT: ::std::mem::MaybeUninit<A> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(::std::mem::size_of::<A>(), 4usize, concat!("Size of: ", stringify!(A)));
-    assert_eq!(
-        ::std::mem::align_of::<A>(),
-        4usize,
-        concat!("Alignment of ", stringify!(A)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(A), "::", stringify!(a)),
-    );
-}
+const _: () = {
+    ["Size of A"][::std::mem::size_of::<A>() - 4usize];
+    ["Alignment of A"][::std::mem::align_of::<A>() - 4usize];
+    ["Offset of field: A::a"][::std::mem::offset_of!(A, a) - 0usize];
+};
 extern "C" {
     #[link_name = "\u{1}_ZN1A4makeEv"]
     pub fn make() -> A;
@@ -35,22 +24,11 @@ impl A {
 pub struct B {
     pub b: ::std::os::raw::c_int,
 }
-#[test]
-fn bindgen_test_layout_B() {
-    const UNINIT: ::std::mem::MaybeUninit<B> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(::std::mem::size_of::<B>(), 4usize, concat!("Size of: ", stringify!(B)));
-    assert_eq!(
-        ::std::mem::align_of::<B>(),
-        4usize,
-        concat!("Alignment of ", stringify!(B)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(B), "::", stringify!(b)),
-    );
-}
+const _: () = {
+    ["Size of B"][::std::mem::size_of::<B>() - 4usize];
+    ["Alignment of B"][::std::mem::align_of::<B>() - 4usize];
+    ["Offset of field: B::b"][::std::mem::offset_of!(B, b) - 0usize];
+};
 extern "C" {
     #[link_name = "\u{1}_ZN1B4makeEv"]
     pub fn make1() -> B;

--- a/bindgen-tests/tests/expectations/tests/issue-2556.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-2556.rs
@@ -9,31 +9,16 @@ pub mod root {
         pub width: ::std::os::raw::c_int,
         pub height: ::std::os::raw::c_int,
     }
-    #[test]
-    fn bindgen_test_layout_nsSize() {
-        const UNINIT: ::std::mem::MaybeUninit<nsSize> = ::std::mem::MaybeUninit::uninit();
-        let ptr = UNINIT.as_ptr();
-        assert_eq!(
-            ::std::mem::size_of::<nsSize>(),
-            8usize,
-            concat!("Size of: ", stringify!(nsSize)),
-        );
-        assert_eq!(
-            ::std::mem::align_of::<nsSize>(),
-            4usize,
-            concat!("Alignment of ", stringify!(nsSize)),
-        );
-        assert_eq!(
-            unsafe { ::std::ptr::addr_of!((*ptr).width) as usize - ptr as usize },
-            0usize,
-            concat!("Offset of field: ", stringify!(nsSize), "::", stringify!(width)),
-        );
-        assert_eq!(
-            unsafe { ::std::ptr::addr_of!((*ptr).height) as usize - ptr as usize },
-            4usize,
-            concat!("Offset of field: ", stringify!(nsSize), "::", stringify!(height)),
-        );
-    }
+    const _: () = {
+        ["Size of nsSize"][::std::mem::size_of::<nsSize>() - 8usize];
+        ["Alignment of nsSize"][::std::mem::align_of::<nsSize>() - 4usize];
+        [
+            "Offset of field: nsSize::width",
+        ][::std::mem::offset_of!(nsSize, width) - 0usize];
+        [
+            "Offset of field: nsSize::height",
+        ][::std::mem::offset_of!(nsSize, height) - 4usize];
+    };
     pub mod foo {
         #[allow(unused_imports)]
         use self::super::super::root;

--- a/bindgen-tests/tests/expectations/tests/issue-2695.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-2695.rs
@@ -8,38 +8,11 @@ pub struct Test {
     pub c: ::std::os::raw::c_char,
     pub __bindgen_padding_0: u8,
 }
-#[test]
-fn bindgen_test_layout_Test() {
-    const UNINIT: ::std::mem::MaybeUninit<Test> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<Test>(),
-        12usize,
-        concat!("Size of: ", stringify!(Test)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Test>(),
-        2usize,
-        concat!("Alignment of ", stringify!(Test)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(Test), "::", stringify!(x)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
-        8usize,
-        concat!("Offset of field: ", stringify!(Test), "::", stringify!(a)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
-        9usize,
-        concat!("Offset of field: ", stringify!(Test), "::", stringify!(b)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).c) as usize - ptr as usize },
-        10usize,
-        concat!("Offset of field: ", stringify!(Test), "::", stringify!(c)),
-    );
-}
+const _: () = {
+    ["Size of Test"][::std::mem::size_of::<Test>() - 12usize];
+    ["Alignment of Test"][::std::mem::align_of::<Test>() - 2usize];
+    ["Offset of field: Test::x"][::std::mem::offset_of!(Test, x) - 0usize];
+    ["Offset of field: Test::a"][::std::mem::offset_of!(Test, a) - 8usize];
+    ["Offset of field: Test::b"][::std::mem::offset_of!(Test, b) - 9usize];
+    ["Offset of field: Test::c"][::std::mem::offset_of!(Test, c) - 10usize];
+};

--- a/bindgen-tests/tests/expectations/tests/issue-372.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-372.rs
@@ -14,30 +14,22 @@ pub mod root {
     fn bindgen_test_layout_i() {
         const UNINIT: ::std::mem::MaybeUninit<i> = ::std::mem::MaybeUninit::uninit();
         let ptr = UNINIT.as_ptr();
-        assert_eq!(
-            ::std::mem::size_of::<i>(),
-            24usize,
-            concat!("Size of: ", stringify!(i)),
-        );
-        assert_eq!(
-            ::std::mem::align_of::<i>(),
-            8usize,
-            concat!("Alignment of ", stringify!(i)),
-        );
+        assert_eq!(::std::mem::size_of::<i>(), 24usize, "Size of i");
+        assert_eq!(::std::mem::align_of::<i>(), 8usize, "Alignment of i");
         assert_eq!(
             unsafe { ::std::ptr::addr_of!((*ptr).j) as usize - ptr as usize },
             0usize,
-            concat!("Offset of field: ", stringify!(i), "::", stringify!(j)),
+            "Offset of field: i::j",
         );
         assert_eq!(
             unsafe { ::std::ptr::addr_of!((*ptr).k) as usize - ptr as usize },
             8usize,
-            concat!("Offset of field: ", stringify!(i), "::", stringify!(k)),
+            "Offset of field: i::k",
         );
         assert_eq!(
             unsafe { ::std::ptr::addr_of!((*ptr).l) as usize - ptr as usize },
             16usize,
-            concat!("Offset of field: ", stringify!(i), "::", stringify!(l)),
+            "Offset of field: i::l",
         );
     }
     impl Default for i {
@@ -58,20 +50,12 @@ pub mod root {
     fn bindgen_test_layout_d() {
         const UNINIT: ::std::mem::MaybeUninit<d> = ::std::mem::MaybeUninit::uninit();
         let ptr = UNINIT.as_ptr();
-        assert_eq!(
-            ::std::mem::size_of::<d>(),
-            24usize,
-            concat!("Size of: ", stringify!(d)),
-        );
-        assert_eq!(
-            ::std::mem::align_of::<d>(),
-            8usize,
-            concat!("Alignment of ", stringify!(d)),
-        );
+        assert_eq!(::std::mem::size_of::<d>(), 24usize, "Size of d");
+        assert_eq!(::std::mem::align_of::<d>(), 8usize, "Alignment of d");
         assert_eq!(
             unsafe { ::std::ptr::addr_of!((*ptr).m) as usize - ptr as usize },
             0usize,
-            concat!("Offset of field: ", stringify!(d), "::", stringify!(m)),
+            "Offset of field: d::m",
         );
     }
     impl Default for d {
@@ -107,20 +91,12 @@ pub mod root {
     fn bindgen_test_layout_F() {
         const UNINIT: ::std::mem::MaybeUninit<F> = ::std::mem::MaybeUninit::uninit();
         let ptr = UNINIT.as_ptr();
-        assert_eq!(
-            ::std::mem::size_of::<F>(),
-            264usize,
-            concat!("Size of: ", stringify!(F)),
-        );
-        assert_eq!(
-            ::std::mem::align_of::<F>(),
-            8usize,
-            concat!("Alignment of ", stringify!(F)),
-        );
+        assert_eq!(::std::mem::size_of::<F>(), 264usize, "Size of F");
+        assert_eq!(::std::mem::align_of::<F>(), 8usize, "Alignment of F");
         assert_eq!(
             unsafe { ::std::ptr::addr_of!((*ptr).w) as usize - ptr as usize },
             0usize,
-            concat!("Offset of field: ", stringify!(F), "::", stringify!(w)),
+            "Offset of field: F::w",
         );
     }
     impl Default for F {

--- a/bindgen-tests/tests/expectations/tests/issue-410.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-410.rs
@@ -11,19 +11,10 @@ pub mod root {
         pub struct Value {
             pub _address: u8,
         }
-        #[test]
-        fn bindgen_test_layout_Value() {
-            assert_eq!(
-                ::std::mem::size_of::<Value>(),
-                1usize,
-                concat!("Size of: ", stringify!(Value)),
-            );
-            assert_eq!(
-                ::std::mem::align_of::<Value>(),
-                1usize,
-                concat!("Alignment of ", stringify!(Value)),
-            );
-        }
+        const _: () = {
+            ["Size of Value"][::std::mem::size_of::<Value>() - 1usize];
+            ["Alignment of Value"][::std::mem::align_of::<Value>() - 1usize];
+        };
         extern "C" {
             #[link_name = "\u{1}_ZN2JS5Value1aE10JSWhyMagic"]
             pub fn Value_a(this: *mut root::JS::Value, arg1: root::JSWhyMagic);

--- a/bindgen-tests/tests/expectations/tests/issue-447.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-447.rs
@@ -14,19 +14,14 @@ pub mod root {
             pub struct GuardObjectNotifier {
                 pub _address: u8,
             }
-            #[test]
-            fn bindgen_test_layout_GuardObjectNotifier() {
-                assert_eq!(
-                    ::std::mem::size_of::<GuardObjectNotifier>(),
-                    1usize,
-                    concat!("Size of: ", stringify!(GuardObjectNotifier)),
-                );
-                assert_eq!(
-                    ::std::mem::align_of::<GuardObjectNotifier>(),
-                    1usize,
-                    concat!("Alignment of ", stringify!(GuardObjectNotifier)),
-                );
-            }
+            const _: () = {
+                [
+                    "Size of GuardObjectNotifier",
+                ][::std::mem::size_of::<GuardObjectNotifier>() - 1usize];
+                [
+                    "Alignment of GuardObjectNotifier",
+                ][::std::mem::align_of::<GuardObjectNotifier>() - 1usize];
+            };
         }
     }
     #[repr(C)]
@@ -34,19 +29,14 @@ pub mod root {
     pub struct JSAutoCompartment {
         pub _address: u8,
     }
-    #[test]
-    fn bindgen_test_layout_JSAutoCompartment() {
-        assert_eq!(
-            ::std::mem::size_of::<JSAutoCompartment>(),
-            1usize,
-            concat!("Size of: ", stringify!(JSAutoCompartment)),
-        );
-        assert_eq!(
-            ::std::mem::align_of::<JSAutoCompartment>(),
-            1usize,
-            concat!("Alignment of ", stringify!(JSAutoCompartment)),
-        );
-    }
+    const _: () = {
+        [
+            "Size of JSAutoCompartment",
+        ][::std::mem::size_of::<JSAutoCompartment>() - 1usize];
+        [
+            "Alignment of JSAutoCompartment",
+        ][::std::mem::align_of::<JSAutoCompartment>() - 1usize];
+    };
     extern "C" {
         #[link_name = "\u{1}_ZN17JSAutoCompartmentC1EN7mozilla6detail19GuardObjectNotifierE"]
         pub fn JSAutoCompartment_JSAutoCompartment(

--- a/bindgen-tests/tests/expectations/tests/issue-537-repr-packed-n.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-537-repr-packed-n.rs
@@ -11,20 +11,16 @@ pub struct AlignedToOne {
 fn bindgen_test_layout_AlignedToOne() {
     const UNINIT: ::std::mem::MaybeUninit<AlignedToOne> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<AlignedToOne>(),
-        4usize,
-        concat!("Size of: ", stringify!(AlignedToOne)),
-    );
+    assert_eq!(::std::mem::size_of::<AlignedToOne>(), 4usize, "Size of AlignedToOne");
     assert_eq!(
         ::std::mem::align_of::<AlignedToOne>(),
         1usize,
-        concat!("Alignment of ", stringify!(AlignedToOne)),
+        "Alignment of AlignedToOne",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).i) as usize - ptr as usize },
         0usize,
-        concat!("Offset of field: ", stringify!(AlignedToOne), "::", stringify!(i)),
+        "Offset of field: AlignedToOne::i",
     );
 }
 /// This should be be packed because Rust 1.33 has `#[repr(packed(N))]`.
@@ -37,20 +33,16 @@ pub struct AlignedToTwo {
 fn bindgen_test_layout_AlignedToTwo() {
     const UNINIT: ::std::mem::MaybeUninit<AlignedToTwo> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<AlignedToTwo>(),
-        4usize,
-        concat!("Size of: ", stringify!(AlignedToTwo)),
-    );
+    assert_eq!(::std::mem::size_of::<AlignedToTwo>(), 4usize, "Size of AlignedToTwo");
     assert_eq!(
         ::std::mem::align_of::<AlignedToTwo>(),
         2usize,
-        concat!("Alignment of ", stringify!(AlignedToTwo)),
+        "Alignment of AlignedToTwo",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).i) as usize - ptr as usize },
         0usize,
-        concat!("Offset of field: ", stringify!(AlignedToTwo), "::", stringify!(i)),
+        "Offset of field: AlignedToTwo::i",
     );
 }
 /** This should not be opaque because although `libclang` doesn't give us the
@@ -66,25 +58,21 @@ pub struct PackedToOne {
 fn bindgen_test_layout_PackedToOne() {
     const UNINIT: ::std::mem::MaybeUninit<PackedToOne> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<PackedToOne>(),
-        8usize,
-        concat!("Size of: ", stringify!(PackedToOne)),
-    );
+    assert_eq!(::std::mem::size_of::<PackedToOne>(), 8usize, "Size of PackedToOne");
     assert_eq!(
         ::std::mem::align_of::<PackedToOne>(),
         1usize,
-        concat!("Alignment of ", stringify!(PackedToOne)),
+        "Alignment of PackedToOne",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize },
         0usize,
-        concat!("Offset of field: ", stringify!(PackedToOne), "::", stringify!(x)),
+        "Offset of field: PackedToOne::x",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).y) as usize - ptr as usize },
         4usize,
-        concat!("Offset of field: ", stringify!(PackedToOne), "::", stringify!(y)),
+        "Offset of field: PackedToOne::y",
     );
 }
 /// This should be be packed because Rust 1.33 has `#[repr(packed(N))]`.
@@ -98,24 +86,20 @@ pub struct PackedToTwo {
 fn bindgen_test_layout_PackedToTwo() {
     const UNINIT: ::std::mem::MaybeUninit<PackedToTwo> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<PackedToTwo>(),
-        8usize,
-        concat!("Size of: ", stringify!(PackedToTwo)),
-    );
+    assert_eq!(::std::mem::size_of::<PackedToTwo>(), 8usize, "Size of PackedToTwo");
     assert_eq!(
         ::std::mem::align_of::<PackedToTwo>(),
         2usize,
-        concat!("Alignment of ", stringify!(PackedToTwo)),
+        "Alignment of PackedToTwo",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize },
         0usize,
-        concat!("Offset of field: ", stringify!(PackedToTwo), "::", stringify!(x)),
+        "Offset of field: PackedToTwo::x",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).y) as usize - ptr as usize },
         4usize,
-        concat!("Offset of field: ", stringify!(PackedToTwo), "::", stringify!(y)),
+        "Offset of field: PackedToTwo::y",
     );
 }

--- a/bindgen-tests/tests/expectations/tests/issue-537.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-537.rs
@@ -6,26 +6,13 @@
 pub struct AlignedToOne {
     pub i: ::std::os::raw::c_int,
 }
-#[test]
-fn bindgen_test_layout_AlignedToOne() {
-    const UNINIT: ::std::mem::MaybeUninit<AlignedToOne> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<AlignedToOne>(),
-        4usize,
-        concat!("Size of: ", stringify!(AlignedToOne)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<AlignedToOne>(),
-        1usize,
-        concat!("Alignment of ", stringify!(AlignedToOne)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).i) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(AlignedToOne), "::", stringify!(i)),
-    );
-}
+const _: () = {
+    ["Size of AlignedToOne"][::std::mem::size_of::<AlignedToOne>() - 4usize];
+    ["Alignment of AlignedToOne"][::std::mem::align_of::<AlignedToOne>() - 1usize];
+    [
+        "Offset of field: AlignedToOne::i",
+    ][::std::mem::offset_of!(AlignedToOne, i) - 0usize];
+};
 /** This should be opaque because although we can see the attributes, Rust before
  1.33 doesn't have `#[repr(packed(N))]`.*/
 #[repr(C, packed(2))]
@@ -33,26 +20,13 @@ fn bindgen_test_layout_AlignedToOne() {
 pub struct AlignedToTwo {
     pub i: ::std::os::raw::c_int,
 }
-#[test]
-fn bindgen_test_layout_AlignedToTwo() {
-    const UNINIT: ::std::mem::MaybeUninit<AlignedToTwo> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<AlignedToTwo>(),
-        4usize,
-        concat!("Size of: ", stringify!(AlignedToTwo)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<AlignedToTwo>(),
-        2usize,
-        concat!("Alignment of ", stringify!(AlignedToTwo)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).i) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(AlignedToTwo), "::", stringify!(i)),
-    );
-}
+const _: () = {
+    ["Size of AlignedToTwo"][::std::mem::size_of::<AlignedToTwo>() - 4usize];
+    ["Alignment of AlignedToTwo"][::std::mem::align_of::<AlignedToTwo>() - 2usize];
+    [
+        "Offset of field: AlignedToTwo::i",
+    ][::std::mem::offset_of!(AlignedToTwo, i) - 0usize];
+};
 /** This should not be opaque because although `libclang` doesn't give us the
  `#pragma pack(1)`, we can detect that alignment is 1 and add
  `#[repr(packed)]` to the struct ourselves.*/
@@ -62,31 +36,12 @@ pub struct PackedToOne {
     pub x: ::std::os::raw::c_int,
     pub y: ::std::os::raw::c_int,
 }
-#[test]
-fn bindgen_test_layout_PackedToOne() {
-    const UNINIT: ::std::mem::MaybeUninit<PackedToOne> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<PackedToOne>(),
-        8usize,
-        concat!("Size of: ", stringify!(PackedToOne)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<PackedToOne>(),
-        1usize,
-        concat!("Alignment of ", stringify!(PackedToOne)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(PackedToOne), "::", stringify!(x)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).y) as usize - ptr as usize },
-        4usize,
-        concat!("Offset of field: ", stringify!(PackedToOne), "::", stringify!(y)),
-    );
-}
+const _: () = {
+    ["Size of PackedToOne"][::std::mem::size_of::<PackedToOne>() - 8usize];
+    ["Alignment of PackedToOne"][::std::mem::align_of::<PackedToOne>() - 1usize];
+    ["Offset of field: PackedToOne::x"][::std::mem::offset_of!(PackedToOne, x) - 0usize];
+    ["Offset of field: PackedToOne::y"][::std::mem::offset_of!(PackedToOne, y) - 4usize];
+};
 /** In this case, even if we can detect the weird alignment triggered by
  `#pragma pack(2)`, we can't do anything about it because Rust before 1.33
  doesn't have `#[repr(packed(N))]`. Therefore, we must make it opaque.*/
@@ -96,28 +51,9 @@ pub struct PackedToTwo {
     pub x: ::std::os::raw::c_int,
     pub y: ::std::os::raw::c_int,
 }
-#[test]
-fn bindgen_test_layout_PackedToTwo() {
-    const UNINIT: ::std::mem::MaybeUninit<PackedToTwo> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<PackedToTwo>(),
-        8usize,
-        concat!("Size of: ", stringify!(PackedToTwo)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<PackedToTwo>(),
-        2usize,
-        concat!("Alignment of ", stringify!(PackedToTwo)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(PackedToTwo), "::", stringify!(x)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).y) as usize - ptr as usize },
-        4usize,
-        concat!("Offset of field: ", stringify!(PackedToTwo), "::", stringify!(y)),
-    );
-}
+const _: () = {
+    ["Size of PackedToTwo"][::std::mem::size_of::<PackedToTwo>() - 8usize];
+    ["Alignment of PackedToTwo"][::std::mem::align_of::<PackedToTwo>() - 2usize];
+    ["Offset of field: PackedToTwo::x"][::std::mem::offset_of!(PackedToTwo, x) - 0usize];
+    ["Offset of field: PackedToTwo::y"][::std::mem::offset_of!(PackedToTwo, y) - 4usize];
+};

--- a/bindgen-tests/tests/expectations/tests/issue-569-non-type-template-params-causing-layout-test-failures.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-569-non-type-template-params-causing-layout-test-failures.rs
@@ -27,19 +27,10 @@ impl Default for JS_Base {
 pub struct JS_AutoIdVector {
     pub _base: JS_Base,
 }
-#[test]
-fn bindgen_test_layout_JS_AutoIdVector() {
-    assert_eq!(
-        ::std::mem::size_of::<JS_AutoIdVector>(),
-        1usize,
-        concat!("Size of: ", stringify!(JS_AutoIdVector)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<JS_AutoIdVector>(),
-        1usize,
-        concat!("Alignment of ", stringify!(JS_AutoIdVector)),
-    );
-}
+const _: () = {
+    ["Size of JS_AutoIdVector"][::std::mem::size_of::<JS_AutoIdVector>() - 1usize];
+    ["Alignment of JS_AutoIdVector"][::std::mem::align_of::<JS_AutoIdVector>() - 1usize];
+};
 impl Default for JS_AutoIdVector {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
@@ -49,16 +40,11 @@ impl Default for JS_AutoIdVector {
         }
     }
 }
-#[test]
-fn __bindgen_test_layout_JS_Base_open0_int_close0_instantiation() {
-    assert_eq!(
-        ::std::mem::size_of::<JS_Base>(),
-        1usize,
-        concat!("Size of template specialization: ", stringify!(JS_Base)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<JS_Base>(),
-        1usize,
-        concat!("Alignment of template specialization: ", stringify!(JS_Base)),
-    );
-}
+const _: () = {
+    [
+        "Size of template specialization: JS_Base_open0_int_close0",
+    ][::std::mem::size_of::<JS_Base>() - 1usize];
+    [
+        "Align of template specialization: JS_Base_open0_int_close0",
+    ][::std::mem::align_of::<JS_Base>() - 1usize];
+};

--- a/bindgen-tests/tests/expectations/tests/issue-573-layout-test-failures.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-573-layout-test-failures.rs
@@ -9,36 +9,18 @@ pub struct Outer {
 pub struct AutoIdVector {
     pub ar: Outer,
 }
-#[test]
-fn bindgen_test_layout_AutoIdVector() {
-    const UNINIT: ::std::mem::MaybeUninit<AutoIdVector> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<AutoIdVector>(),
-        1usize,
-        concat!("Size of: ", stringify!(AutoIdVector)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<AutoIdVector>(),
-        1usize,
-        concat!("Alignment of ", stringify!(AutoIdVector)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).ar) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(AutoIdVector), "::", stringify!(ar)),
-    );
-}
-#[test]
-fn __bindgen_test_layout_Outer_open0_int_close0_instantiation() {
-    assert_eq!(
-        ::std::mem::size_of::<Outer>(),
-        1usize,
-        concat!("Size of template specialization: ", stringify!(Outer)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Outer>(),
-        1usize,
-        concat!("Alignment of template specialization: ", stringify!(Outer)),
-    );
-}
+const _: () = {
+    ["Size of AutoIdVector"][::std::mem::size_of::<AutoIdVector>() - 1usize];
+    ["Alignment of AutoIdVector"][::std::mem::align_of::<AutoIdVector>() - 1usize];
+    [
+        "Offset of field: AutoIdVector::ar",
+    ][::std::mem::offset_of!(AutoIdVector, ar) - 0usize];
+};
+const _: () = {
+    [
+        "Size of template specialization: Outer_open0_int_close0",
+    ][::std::mem::size_of::<Outer>() - 1usize];
+    [
+        "Align of template specialization: Outer_open0_int_close0",
+    ][::std::mem::align_of::<Outer>() - 1usize];
+};

--- a/bindgen-tests/tests/expectations/tests/issue-574-assertion-failure-in-codegen.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-574-assertion-failure-in-codegen.rs
@@ -9,39 +9,21 @@ pub struct a {
 pub struct _bindgen_ty_1 {
     pub ar: a,
 }
-#[test]
-fn bindgen_test_layout__bindgen_ty_1() {
-    const UNINIT: ::std::mem::MaybeUninit<_bindgen_ty_1> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<_bindgen_ty_1>(),
-        1usize,
-        concat!("Size of: ", stringify!(_bindgen_ty_1)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<_bindgen_ty_1>(),
-        1usize,
-        concat!("Alignment of ", stringify!(_bindgen_ty_1)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).ar) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(_bindgen_ty_1), "::", stringify!(ar)),
-    );
-}
+const _: () = {
+    ["Size of _bindgen_ty_1"][::std::mem::size_of::<_bindgen_ty_1>() - 1usize];
+    ["Alignment of _bindgen_ty_1"][::std::mem::align_of::<_bindgen_ty_1>() - 1usize];
+    [
+        "Offset of field: _bindgen_ty_1::ar",
+    ][::std::mem::offset_of!(_bindgen_ty_1, ar) - 0usize];
+};
 extern "C" {
     pub static mut AutoIdVector: _bindgen_ty_1;
 }
-#[test]
-fn __bindgen_test_layout_a_open0_int_close0_instantiation() {
-    assert_eq!(
-        ::std::mem::size_of::<a>(),
-        1usize,
-        concat!("Size of template specialization: ", stringify!(a)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<a>(),
-        1usize,
-        concat!("Alignment of template specialization: ", stringify!(a)),
-    );
-}
+const _: () = {
+    [
+        "Size of template specialization: a_open0_int_close0",
+    ][::std::mem::size_of::<a>() - 1usize];
+    [
+        "Align of template specialization: a_open0_int_close0",
+    ][::std::mem::align_of::<a>() - 1usize];
+};

--- a/bindgen-tests/tests/expectations/tests/issue-584-stylo-template-analysis-panic.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-584-stylo-template-analysis-panic.rs
@@ -6,15 +6,10 @@ pub struct A {
     pub _address: u8,
 }
 pub type A_a = b;
-#[test]
-fn bindgen_test_layout_A() {
-    assert_eq!(::std::mem::size_of::<A>(), 1usize, concat!("Size of: ", stringify!(A)));
-    assert_eq!(
-        ::std::mem::align_of::<A>(),
-        1usize,
-        concat!("Alignment of ", stringify!(A)),
-    );
-}
+const _: () = {
+    ["Size of A"][::std::mem::size_of::<A>() - 1usize];
+    ["Alignment of A"][::std::mem::align_of::<A>() - 1usize];
+};
 #[repr(C)]
 pub struct e<c> {
     pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<c>>,
@@ -38,22 +33,11 @@ pub struct f {
 pub struct g {
     pub h: f,
 }
-#[test]
-fn bindgen_test_layout_g() {
-    const UNINIT: ::std::mem::MaybeUninit<g> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(::std::mem::size_of::<g>(), 1usize, concat!("Size of: ", stringify!(g)));
-    assert_eq!(
-        ::std::mem::align_of::<g>(),
-        1usize,
-        concat!("Alignment of ", stringify!(g)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).h) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(g), "::", stringify!(h)),
-    );
-}
+const _: () = {
+    ["Size of g"][::std::mem::size_of::<g>() - 1usize];
+    ["Alignment of g"][::std::mem::align_of::<g>() - 1usize];
+    ["Offset of field: g::h"][::std::mem::offset_of!(g, h) - 0usize];
+};
 impl Default for g {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
@@ -67,15 +51,10 @@ impl Default for g {
 pub struct b {
     pub _base: g,
 }
-#[test]
-fn bindgen_test_layout_b() {
-    assert_eq!(::std::mem::size_of::<b>(), 1usize, concat!("Size of: ", stringify!(b)));
-    assert_eq!(
-        ::std::mem::align_of::<b>(),
-        1usize,
-        concat!("Alignment of ", stringify!(b)),
-    );
-}
+const _: () = {
+    ["Size of b"][::std::mem::size_of::<b>() - 1usize];
+    ["Alignment of b"][::std::mem::align_of::<b>() - 1usize];
+};
 impl Default for b {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
@@ -89,16 +68,11 @@ extern "C" {
     #[link_name = "\u{1}_Z25Servo_Element_GetSnapshotv"]
     pub fn Servo_Element_GetSnapshot() -> A;
 }
-#[test]
-fn __bindgen_test_layout_f_open0_e_open1_int_close1_close0_instantiation() {
-    assert_eq!(
-        ::std::mem::size_of::<f>(),
-        1usize,
-        concat!("Size of template specialization: ", stringify!(f)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<f>(),
-        1usize,
-        concat!("Alignment of template specialization: ", stringify!(f)),
-    );
-}
+const _: () = {
+    [
+        "Size of template specialization: f_open0_e_open1_int_close1_close0",
+    ][::std::mem::size_of::<f>() - 1usize];
+    [
+        "Align of template specialization: f_open0_e_open1_int_close1_close0",
+    ][::std::mem::align_of::<f>() - 1usize];
+};

--- a/bindgen-tests/tests/expectations/tests/issue-639-typedef-anon-field.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-639-typedef-anon-field.rs
@@ -9,46 +9,16 @@ pub struct Foo {
 pub struct Foo_Bar {
     pub abc: ::std::os::raw::c_int,
 }
-#[test]
-fn bindgen_test_layout_Foo_Bar() {
-    const UNINIT: ::std::mem::MaybeUninit<Foo_Bar> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<Foo_Bar>(),
-        4usize,
-        concat!("Size of: ", stringify!(Foo_Bar)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Foo_Bar>(),
-        4usize,
-        concat!("Alignment of ", stringify!(Foo_Bar)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).abc) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(Foo_Bar), "::", stringify!(abc)),
-    );
-}
-#[test]
-fn bindgen_test_layout_Foo() {
-    const UNINIT: ::std::mem::MaybeUninit<Foo> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<Foo>(),
-        4usize,
-        concat!("Size of: ", stringify!(Foo)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Foo>(),
-        4usize,
-        concat!("Alignment of ", stringify!(Foo)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(Foo), "::", stringify!(bar)),
-    );
-}
+const _: () = {
+    ["Size of Foo_Bar"][::std::mem::size_of::<Foo_Bar>() - 4usize];
+    ["Alignment of Foo_Bar"][::std::mem::align_of::<Foo_Bar>() - 4usize];
+    ["Offset of field: Foo_Bar::abc"][::std::mem::offset_of!(Foo_Bar, abc) - 0usize];
+};
+const _: () = {
+    ["Size of Foo"][::std::mem::size_of::<Foo>() - 4usize];
+    ["Alignment of Foo"][::std::mem::align_of::<Foo>() - 4usize];
+    ["Offset of field: Foo::bar"][::std::mem::offset_of!(Foo, bar) - 0usize];
+};
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct Baz {
@@ -59,36 +29,12 @@ pub struct Baz {
 pub struct Baz_Bar {
     pub abc: ::std::os::raw::c_int,
 }
-#[test]
-fn bindgen_test_layout_Baz_Bar() {
-    const UNINIT: ::std::mem::MaybeUninit<Baz_Bar> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<Baz_Bar>(),
-        4usize,
-        concat!("Size of: ", stringify!(Baz_Bar)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Baz_Bar>(),
-        4usize,
-        concat!("Alignment of ", stringify!(Baz_Bar)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).abc) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(Baz_Bar), "::", stringify!(abc)),
-    );
-}
-#[test]
-fn bindgen_test_layout_Baz() {
-    assert_eq!(
-        ::std::mem::size_of::<Baz>(),
-        1usize,
-        concat!("Size of: ", stringify!(Baz)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Baz>(),
-        1usize,
-        concat!("Alignment of ", stringify!(Baz)),
-    );
-}
+const _: () = {
+    ["Size of Baz_Bar"][::std::mem::size_of::<Baz_Bar>() - 4usize];
+    ["Alignment of Baz_Bar"][::std::mem::align_of::<Baz_Bar>() - 4usize];
+    ["Offset of field: Baz_Bar::abc"][::std::mem::offset_of!(Baz_Bar, abc) - 0usize];
+};
+const _: () = {
+    ["Size of Baz"][::std::mem::size_of::<Baz>() - 1usize];
+    ["Alignment of Baz"][::std::mem::align_of::<Baz>() - 1usize];
+};

--- a/bindgen-tests/tests/expectations/tests/issue-643-inner-struct.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-643-inner-struct.rs
@@ -42,96 +42,39 @@ pub struct rte_ring {
 pub struct rte_ring_prod {
     pub watermark: ::std::os::raw::c_uint,
 }
-#[test]
-fn bindgen_test_layout_rte_ring_prod() {
-    const UNINIT: ::std::mem::MaybeUninit<rte_ring_prod> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<rte_ring_prod>(),
-        4usize,
-        concat!("Size of: ", stringify!(rte_ring_prod)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<rte_ring_prod>(),
-        4usize,
-        concat!("Alignment of ", stringify!(rte_ring_prod)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).watermark) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_ring_prod),
-            "::",
-            stringify!(watermark),
-        ),
-    );
-}
+const _: () = {
+    ["Size of rte_ring_prod"][::std::mem::size_of::<rte_ring_prod>() - 4usize];
+    ["Alignment of rte_ring_prod"][::std::mem::align_of::<rte_ring_prod>() - 4usize];
+    [
+        "Offset of field: rte_ring_prod::watermark",
+    ][::std::mem::offset_of!(rte_ring_prod, watermark) - 0usize];
+};
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct rte_ring_cons {
     pub sc_dequeue: ::std::os::raw::c_uint,
 }
-#[test]
-fn bindgen_test_layout_rte_ring_cons() {
-    const UNINIT: ::std::mem::MaybeUninit<rte_ring_cons> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<rte_ring_cons>(),
-        4usize,
-        concat!("Size of: ", stringify!(rte_ring_cons)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<rte_ring_cons>(),
-        4usize,
-        concat!("Alignment of ", stringify!(rte_ring_cons)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).sc_dequeue) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_ring_cons),
-            "::",
-            stringify!(sc_dequeue),
-        ),
-    );
-}
-#[test]
-fn bindgen_test_layout_rte_ring() {
-    const UNINIT: ::std::mem::MaybeUninit<rte_ring> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<rte_ring>(),
-        16usize,
-        concat!("Size of: ", stringify!(rte_ring)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<rte_ring>(),
-        8usize,
-        concat!("Alignment of ", stringify!(rte_ring)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).memzone) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(rte_ring), "::", stringify!(memzone)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).prod) as usize - ptr as usize },
-        8usize,
-        concat!("Offset of field: ", stringify!(rte_ring), "::", stringify!(prod)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).cons) as usize - ptr as usize },
-        12usize,
-        concat!("Offset of field: ", stringify!(rte_ring), "::", stringify!(cons)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).ring) as usize - ptr as usize },
-        16usize,
-        concat!("Offset of field: ", stringify!(rte_ring), "::", stringify!(ring)),
-    );
-}
+const _: () = {
+    ["Size of rte_ring_cons"][::std::mem::size_of::<rte_ring_cons>() - 4usize];
+    ["Alignment of rte_ring_cons"][::std::mem::align_of::<rte_ring_cons>() - 4usize];
+    [
+        "Offset of field: rte_ring_cons::sc_dequeue",
+    ][::std::mem::offset_of!(rte_ring_cons, sc_dequeue) - 0usize];
+};
+const _: () = {
+    ["Size of rte_ring"][::std::mem::size_of::<rte_ring>() - 16usize];
+    ["Alignment of rte_ring"][::std::mem::align_of::<rte_ring>() - 8usize];
+    [
+        "Offset of field: rte_ring::memzone",
+    ][::std::mem::offset_of!(rte_ring, memzone) - 0usize];
+    ["Offset of field: rte_ring::prod"][::std::mem::offset_of!(rte_ring, prod) - 8usize];
+    [
+        "Offset of field: rte_ring::cons",
+    ][::std::mem::offset_of!(rte_ring, cons) - 12usize];
+    [
+        "Offset of field: rte_ring::ring",
+    ][::std::mem::offset_of!(rte_ring, ring) - 16usize];
+};
 impl Default for rte_ring {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();

--- a/bindgen-tests/tests/expectations/tests/issue-648-derive-debug-with-padding.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-648-derive-debug-with-padding.rs
@@ -11,20 +11,12 @@ pub struct NoDebug {
 fn bindgen_test_layout_NoDebug() {
     const UNINIT: ::std::mem::MaybeUninit<NoDebug> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<NoDebug>(),
-        64usize,
-        concat!("Size of: ", stringify!(NoDebug)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<NoDebug>(),
-        64usize,
-        concat!("Alignment of ", stringify!(NoDebug)),
-    );
+    assert_eq!(::std::mem::size_of::<NoDebug>(), 64usize, "Size of NoDebug");
+    assert_eq!(::std::mem::align_of::<NoDebug>(), 64usize, "Alignment of NoDebug");
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).c) as usize - ptr as usize },
         0usize,
-        concat!("Offset of field: ", stringify!(NoDebug), "::", stringify!(c)),
+        "Offset of field: NoDebug::c",
     );
 }
 impl Default for NoDebug {
@@ -59,32 +51,22 @@ fn bindgen_test_layout_ShouldDeriveDebugButDoesNot() {
     assert_eq!(
         ::std::mem::size_of::<ShouldDeriveDebugButDoesNot>(),
         64usize,
-        concat!("Size of: ", stringify!(ShouldDeriveDebugButDoesNot)),
+        "Size of ShouldDeriveDebugButDoesNot",
     );
     assert_eq!(
         ::std::mem::align_of::<ShouldDeriveDebugButDoesNot>(),
         64usize,
-        concat!("Alignment of ", stringify!(ShouldDeriveDebugButDoesNot)),
+        "Alignment of ShouldDeriveDebugButDoesNot",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).c) as usize - ptr as usize },
         0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(ShouldDeriveDebugButDoesNot),
-            "::",
-            stringify!(c),
-        ),
+        "Offset of field: ShouldDeriveDebugButDoesNot::c",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize },
         32usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(ShouldDeriveDebugButDoesNot),
-            "::",
-            stringify!(d),
-        ),
+        "Offset of field: ShouldDeriveDebugButDoesNot::d",
     );
 }
 impl Default for ShouldDeriveDebugButDoesNot {

--- a/bindgen-tests/tests/expectations/tests/issue-674-1.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-674-1.rs
@@ -18,29 +18,15 @@ pub mod root {
     pub struct CapturingContentInfo {
         pub a: u8,
     }
-    #[test]
-    fn bindgen_test_layout_CapturingContentInfo() {
-        const UNINIT: ::std::mem::MaybeUninit<CapturingContentInfo> = ::std::mem::MaybeUninit::uninit();
-        let ptr = UNINIT.as_ptr();
-        assert_eq!(
-            ::std::mem::size_of::<CapturingContentInfo>(),
-            1usize,
-            concat!("Size of: ", stringify!(CapturingContentInfo)),
-        );
-        assert_eq!(
-            ::std::mem::align_of::<CapturingContentInfo>(),
-            1usize,
-            concat!("Alignment of ", stringify!(CapturingContentInfo)),
-        );
-        assert_eq!(
-            unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(CapturingContentInfo),
-                "::",
-                stringify!(a),
-            ),
-        );
-    }
+    const _: () = {
+        [
+            "Size of CapturingContentInfo",
+        ][::std::mem::size_of::<CapturingContentInfo>() - 1usize];
+        [
+            "Alignment of CapturingContentInfo",
+        ][::std::mem::align_of::<CapturingContentInfo>() - 1usize];
+        [
+            "Offset of field: CapturingContentInfo::a",
+        ][::std::mem::offset_of!(CapturingContentInfo, a) - 0usize];
+    };
 }

--- a/bindgen-tests/tests/expectations/tests/issue-674-2.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-674-2.rs
@@ -18,70 +18,32 @@ pub mod root {
     pub struct c {
         pub b: u8,
     }
-    #[test]
-    fn bindgen_test_layout_c() {
-        const UNINIT: ::std::mem::MaybeUninit<c> = ::std::mem::MaybeUninit::uninit();
-        let ptr = UNINIT.as_ptr();
-        assert_eq!(
-            ::std::mem::size_of::<c>(),
-            1usize,
-            concat!("Size of: ", stringify!(c)),
-        );
-        assert_eq!(
-            ::std::mem::align_of::<c>(),
-            1usize,
-            concat!("Alignment of ", stringify!(c)),
-        );
-        assert_eq!(
-            unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
-            0usize,
-            concat!("Offset of field: ", stringify!(c), "::", stringify!(b)),
-        );
-    }
+    const _: () = {
+        ["Size of c"][::std::mem::size_of::<c>() - 1usize];
+        ["Alignment of c"][::std::mem::align_of::<c>() - 1usize];
+        ["Offset of field: c::b"][::std::mem::offset_of!(c, b) - 0usize];
+    };
     #[repr(C)]
     #[derive(Debug, Default, Copy, Clone)]
     pub struct B {
         pub a: root::c,
     }
-    #[test]
-    fn bindgen_test_layout_B() {
-        const UNINIT: ::std::mem::MaybeUninit<B> = ::std::mem::MaybeUninit::uninit();
-        let ptr = UNINIT.as_ptr();
-        assert_eq!(
-            ::std::mem::size_of::<B>(),
-            1usize,
-            concat!("Size of: ", stringify!(B)),
-        );
-        assert_eq!(
-            ::std::mem::align_of::<B>(),
-            1usize,
-            concat!("Alignment of ", stringify!(B)),
-        );
-        assert_eq!(
-            unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
-            0usize,
-            concat!("Offset of field: ", stringify!(B), "::", stringify!(a)),
-        );
-    }
+    const _: () = {
+        ["Size of B"][::std::mem::size_of::<B>() - 1usize];
+        ["Alignment of B"][::std::mem::align_of::<B>() - 1usize];
+        ["Offset of field: B::a"][::std::mem::offset_of!(B, a) - 0usize];
+    };
     #[repr(C)]
     #[derive(Debug, Default, Copy, Clone)]
     pub struct StaticRefPtr {
         pub _address: u8,
     }
-    #[test]
-    fn __bindgen_test_layout_StaticRefPtr_open0_B_close0_instantiation() {
-        assert_eq!(
-            ::std::mem::size_of::<root::StaticRefPtr>(),
-            1usize,
-            concat!("Size of template specialization: ", stringify!(root::StaticRefPtr)),
-        );
-        assert_eq!(
-            ::std::mem::align_of::<root::StaticRefPtr>(),
-            1usize,
-            concat!(
-                "Alignment of template specialization: ",
-                stringify!(root::StaticRefPtr),
-            ),
-        );
-    }
+    const _: () = {
+        [
+            "Size of template specialization: StaticRefPtr_open0_B_close0",
+        ][::std::mem::size_of::<root::StaticRefPtr>() - 1usize];
+        [
+            "Align of template specialization: StaticRefPtr_open0_B_close0",
+        ][::std::mem::align_of::<root::StaticRefPtr>() - 1usize];
+    };
 }

--- a/bindgen-tests/tests/expectations/tests/issue-674-3.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-674-3.rs
@@ -14,49 +14,21 @@ pub mod root {
     pub struct a {
         pub b: u8,
     }
-    #[test]
-    fn bindgen_test_layout_a() {
-        const UNINIT: ::std::mem::MaybeUninit<a> = ::std::mem::MaybeUninit::uninit();
-        let ptr = UNINIT.as_ptr();
-        assert_eq!(
-            ::std::mem::size_of::<a>(),
-            1usize,
-            concat!("Size of: ", stringify!(a)),
-        );
-        assert_eq!(
-            ::std::mem::align_of::<a>(),
-            1usize,
-            concat!("Alignment of ", stringify!(a)),
-        );
-        assert_eq!(
-            unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
-            0usize,
-            concat!("Offset of field: ", stringify!(a), "::", stringify!(b)),
-        );
-    }
+    const _: () = {
+        ["Size of a"][::std::mem::size_of::<a>() - 1usize];
+        ["Alignment of a"][::std::mem::align_of::<a>() - 1usize];
+        ["Offset of field: a::b"][::std::mem::offset_of!(a, b) - 0usize];
+    };
     #[repr(C)]
     #[derive(Debug, Default, Copy, Clone)]
     pub struct nsCSSValue {
         pub c: root::a,
     }
-    #[test]
-    fn bindgen_test_layout_nsCSSValue() {
-        const UNINIT: ::std::mem::MaybeUninit<nsCSSValue> = ::std::mem::MaybeUninit::uninit();
-        let ptr = UNINIT.as_ptr();
-        assert_eq!(
-            ::std::mem::size_of::<nsCSSValue>(),
-            1usize,
-            concat!("Size of: ", stringify!(nsCSSValue)),
-        );
-        assert_eq!(
-            ::std::mem::align_of::<nsCSSValue>(),
-            1usize,
-            concat!("Alignment of ", stringify!(nsCSSValue)),
-        );
-        assert_eq!(
-            unsafe { ::std::ptr::addr_of!((*ptr).c) as usize - ptr as usize },
-            0usize,
-            concat!("Offset of field: ", stringify!(nsCSSValue), "::", stringify!(c)),
-        );
-    }
+    const _: () = {
+        ["Size of nsCSSValue"][::std::mem::size_of::<nsCSSValue>() - 1usize];
+        ["Alignment of nsCSSValue"][::std::mem::align_of::<nsCSSValue>() - 1usize];
+        [
+            "Offset of field: nsCSSValue::c",
+        ][::std::mem::offset_of!(nsCSSValue, c) - 0usize];
+    };
 }

--- a/bindgen-tests/tests/expectations/tests/issue-691-template-parameter-virtual.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-691-template-parameter-virtual.rs
@@ -6,19 +6,10 @@ pub struct VirtualMethods__bindgen_vtable {}
 pub struct VirtualMethods {
     pub vtable_: *const VirtualMethods__bindgen_vtable,
 }
-#[test]
-fn bindgen_test_layout_VirtualMethods() {
-    assert_eq!(
-        ::std::mem::size_of::<VirtualMethods>(),
-        8usize,
-        concat!("Size of: ", stringify!(VirtualMethods)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<VirtualMethods>(),
-        8usize,
-        concat!("Alignment of ", stringify!(VirtualMethods)),
-    );
-}
+const _: () = {
+    ["Size of VirtualMethods"][::std::mem::size_of::<VirtualMethods>() - 8usize];
+    ["Alignment of VirtualMethods"][::std::mem::align_of::<VirtualMethods>() - 8usize];
+};
 impl Default for VirtualMethods {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
@@ -38,19 +29,14 @@ pub struct Set {
 pub struct ServoElementSnapshotTable {
     pub _base: Set,
 }
-#[test]
-fn bindgen_test_layout_ServoElementSnapshotTable() {
-    assert_eq!(
-        ::std::mem::size_of::<ServoElementSnapshotTable>(),
-        4usize,
-        concat!("Size of: ", stringify!(ServoElementSnapshotTable)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<ServoElementSnapshotTable>(),
-        4usize,
-        concat!("Alignment of ", stringify!(ServoElementSnapshotTable)),
-    );
-}
+const _: () = {
+    [
+        "Size of ServoElementSnapshotTable",
+    ][::std::mem::size_of::<ServoElementSnapshotTable>() - 4usize];
+    [
+        "Alignment of ServoElementSnapshotTable",
+    ][::std::mem::align_of::<ServoElementSnapshotTable>() - 4usize];
+};
 impl Default for ServoElementSnapshotTable {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
@@ -60,16 +46,11 @@ impl Default for ServoElementSnapshotTable {
         }
     }
 }
-#[test]
-fn __bindgen_test_layout_Set_open0_VirtualMethods_close0_instantiation() {
-    assert_eq!(
-        ::std::mem::size_of::<Set>(),
-        4usize,
-        concat!("Size of template specialization: ", stringify!(Set)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Set>(),
-        4usize,
-        concat!("Alignment of template specialization: ", stringify!(Set)),
-    );
-}
+const _: () = {
+    [
+        "Size of template specialization: Set_open0_VirtualMethods_close0",
+    ][::std::mem::size_of::<Set>() - 4usize];
+    [
+        "Align of template specialization: Set_open0_VirtualMethods_close0",
+    ][::std::mem::align_of::<Set>() - 4usize];
+};

--- a/bindgen-tests/tests/expectations/tests/issue-739-pointer-wide-bitfield.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-739-pointer-wide-bitfield.rs
@@ -90,19 +90,10 @@ pub struct Foo {
     pub _bitfield_align_1: [u64; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 32usize]>,
 }
-#[test]
-fn bindgen_test_layout_Foo() {
-    assert_eq!(
-        ::std::mem::size_of::<Foo>(),
-        32usize,
-        concat!("Size of: ", stringify!(Foo)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Foo>(),
-        8usize,
-        concat!("Alignment of ", stringify!(Foo)),
-    );
-}
+const _: () = {
+    ["Size of Foo"][::std::mem::size_of::<Foo>() - 32usize];
+    ["Alignment of Foo"][::std::mem::align_of::<Foo>() - 8usize];
+};
 impl Foo {
     #[inline]
     pub fn m_bitfield(&self) -> ::std::os::raw::c_ulong {

--- a/bindgen-tests/tests/expectations/tests/issue-769-bad-instantiation-test.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-769-bad-instantiation-test.rs
@@ -19,42 +19,20 @@ pub mod root {
         }
     }
     pub type AutoValueVector_Alias = ::std::os::raw::c_int;
-    #[test]
-    fn __bindgen_test_layout_Rooted_open0_int_close0_instantiation() {
-        assert_eq!(
-            ::std::mem::size_of::<root::Rooted<::std::os::raw::c_int>>(),
-            4usize,
-            concat!(
-                "Size of template specialization: ",
-                stringify!(root::Rooted < ::std::os::raw::c_int >),
-            ),
-        );
-        assert_eq!(
-            ::std::mem::align_of::<root::Rooted<::std::os::raw::c_int>>(),
-            4usize,
-            concat!(
-                "Alignment of template specialization: ",
-                stringify!(root::Rooted < ::std::os::raw::c_int >),
-            ),
-        );
-    }
-    #[test]
-    fn __bindgen_test_layout_Rooted_open0_AutoValueVector_Alias_close0_instantiation() {
-        assert_eq!(
-            ::std::mem::size_of::<root::Rooted<root::AutoValueVector_Alias>>(),
-            4usize,
-            concat!(
-                "Size of template specialization: ",
-                stringify!(root::Rooted < root::AutoValueVector_Alias >),
-            ),
-        );
-        assert_eq!(
-            ::std::mem::align_of::<root::Rooted<root::AutoValueVector_Alias>>(),
-            4usize,
-            concat!(
-                "Alignment of template specialization: ",
-                stringify!(root::Rooted < root::AutoValueVector_Alias >),
-            ),
-        );
-    }
+    const _: () = {
+        [
+            "Size of template specialization: Rooted_open0_int_close0",
+        ][::std::mem::size_of::<root::Rooted<::std::os::raw::c_int>>() - 4usize];
+        [
+            "Align of template specialization: Rooted_open0_int_close0",
+        ][::std::mem::align_of::<root::Rooted<::std::os::raw::c_int>>() - 4usize];
+    };
+    const _: () = {
+        [
+            "Size of template specialization: Rooted_open0_AutoValueVector_Alias_close0",
+        ][::std::mem::size_of::<root::Rooted<root::AutoValueVector_Alias>>() - 4usize];
+        [
+            "Align of template specialization: Rooted_open0_AutoValueVector_Alias_close0",
+        ][::std::mem::align_of::<root::Rooted<root::AutoValueVector_Alias>>() - 4usize];
+    };
 }

--- a/bindgen-tests/tests/expectations/tests/issue-801-opaque-sloppiness.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-801-opaque-sloppiness.rs
@@ -10,15 +10,10 @@ pub struct A {
 pub struct B {
     pub _bindgen_opaque_blob: u8,
 }
-#[test]
-fn bindgen_test_layout_B() {
-    assert_eq!(::std::mem::size_of::<B>(), 1usize, concat!("Size of: ", stringify!(B)));
-    assert_eq!(
-        ::std::mem::align_of::<B>(),
-        1usize,
-        concat!("Alignment of ", stringify!(B)),
-    );
-}
+const _: () = {
+    ["Size of B"][::std::mem::size_of::<B>() - 1usize];
+    ["Alignment of B"][::std::mem::align_of::<B>() - 1usize];
+};
 extern "C" {
     #[link_name = "\u{1}_ZN1B1aE"]
     pub static mut B_a: A;
@@ -28,19 +23,8 @@ extern "C" {
 pub struct C {
     pub b: B,
 }
-#[test]
-fn bindgen_test_layout_C() {
-    const UNINIT: ::std::mem::MaybeUninit<C> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(::std::mem::size_of::<C>(), 1usize, concat!("Size of: ", stringify!(C)));
-    assert_eq!(
-        ::std::mem::align_of::<C>(),
-        1usize,
-        concat!("Alignment of ", stringify!(C)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(C), "::", stringify!(b)),
-    );
-}
+const _: () = {
+    ["Size of C"][::std::mem::size_of::<C>() - 1usize];
+    ["Alignment of C"][::std::mem::align_of::<C>() - 1usize];
+    ["Offset of field: C::b"][::std::mem::offset_of!(C, b) - 0usize];
+};

--- a/bindgen-tests/tests/expectations/tests/issue-807-opaque-types-methods-being-generated.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-807-opaque-types-methods-being-generated.rs
@@ -4,74 +4,38 @@
 pub struct Pupper {
     pub _address: u8,
 }
-#[test]
-fn bindgen_test_layout_Pupper() {
-    assert_eq!(
-        ::std::mem::size_of::<Pupper>(),
-        1usize,
-        concat!("Size of: ", stringify!(Pupper)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Pupper>(),
-        1usize,
-        concat!("Alignment of ", stringify!(Pupper)),
-    );
-}
+const _: () = {
+    ["Size of Pupper"][::std::mem::size_of::<Pupper>() - 1usize];
+    ["Alignment of Pupper"][::std::mem::align_of::<Pupper>() - 1usize];
+};
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct Doggo {
     pub _address: u8,
 }
-#[test]
-fn bindgen_test_layout_Doggo() {
-    assert_eq!(
-        ::std::mem::size_of::<Doggo>(),
-        1usize,
-        concat!("Size of: ", stringify!(Doggo)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Doggo>(),
-        1usize,
-        concat!("Alignment of ", stringify!(Doggo)),
-    );
-}
+const _: () = {
+    ["Size of Doggo"][::std::mem::size_of::<Doggo>() - 1usize];
+    ["Alignment of Doggo"][::std::mem::align_of::<Doggo>() - 1usize];
+};
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct SuchWow {
     pub _address: u8,
 }
-#[test]
-fn bindgen_test_layout_SuchWow() {
-    assert_eq!(
-        ::std::mem::size_of::<SuchWow>(),
-        1usize,
-        concat!("Size of: ", stringify!(SuchWow)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<SuchWow>(),
-        1usize,
-        concat!("Alignment of ", stringify!(SuchWow)),
-    );
-}
+const _: () = {
+    ["Size of SuchWow"][::std::mem::size_of::<SuchWow>() - 1usize];
+    ["Alignment of SuchWow"][::std::mem::align_of::<SuchWow>() - 1usize];
+};
 #[repr(C)]
 #[repr(align(1))]
 #[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct Opaque {
     pub _bindgen_opaque_blob: u8,
 }
-#[test]
-fn bindgen_test_layout_Opaque() {
-    assert_eq!(
-        ::std::mem::size_of::<Opaque>(),
-        1usize,
-        concat!("Size of: ", stringify!(Opaque)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Opaque>(),
-        1usize,
-        concat!("Alignment of ", stringify!(Opaque)),
-    );
-}
+const _: () = {
+    ["Size of Opaque"][::std::mem::size_of::<Opaque>() - 1usize];
+    ["Alignment of Opaque"][::std::mem::align_of::<Opaque>() - 1usize];
+};
 extern "C" {
     #[link_name = "\u{1}_ZN6Opaque17eleven_out_of_tenEv"]
     pub fn Opaque_eleven_out_of_ten(this: *mut Opaque) -> SuchWow;
@@ -101,28 +65,10 @@ extern "C" {
 pub struct Allowlisted {
     pub some_member: Opaque,
 }
-#[test]
-fn bindgen_test_layout_Allowlisted() {
-    const UNINIT: ::std::mem::MaybeUninit<Allowlisted> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<Allowlisted>(),
-        1usize,
-        concat!("Size of: ", stringify!(Allowlisted)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Allowlisted>(),
-        1usize,
-        concat!("Alignment of ", stringify!(Allowlisted)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).some_member) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(Allowlisted),
-            "::",
-            stringify!(some_member),
-        ),
-    );
-}
+const _: () = {
+    ["Size of Allowlisted"][::std::mem::size_of::<Allowlisted>() - 1usize];
+    ["Alignment of Allowlisted"][::std::mem::align_of::<Allowlisted>() - 1usize];
+    [
+        "Offset of field: Allowlisted::some_member",
+    ][::std::mem::offset_of!(Allowlisted, some_member) - 0usize];
+};

--- a/bindgen-tests/tests/expectations/tests/issue-816.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-816.rs
@@ -90,19 +90,10 @@ pub struct capabilities {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 16usize]>,
 }
-#[test]
-fn bindgen_test_layout_capabilities() {
-    assert_eq!(
-        ::std::mem::size_of::<capabilities>(),
-        16usize,
-        concat!("Size of: ", stringify!(capabilities)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<capabilities>(),
-        4usize,
-        concat!("Alignment of ", stringify!(capabilities)),
-    );
-}
+const _: () = {
+    ["Size of capabilities"][::std::mem::size_of::<capabilities>() - 16usize];
+    ["Alignment of capabilities"][::std::mem::align_of::<capabilities>() - 4usize];
+};
 impl capabilities {
     #[inline]
     pub fn bit_1(&self) -> ::std::os::raw::c_uint {

--- a/bindgen-tests/tests/expectations/tests/issue-826-generating-methods-when-asked-not-to.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-826-generating-methods-when-asked-not-to.rs
@@ -4,16 +4,7 @@
 pub struct Foo {
     pub _address: u8,
 }
-#[test]
-fn bindgen_test_layout_Foo() {
-    assert_eq!(
-        ::std::mem::size_of::<Foo>(),
-        1usize,
-        concat!("Size of: ", stringify!(Foo)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Foo>(),
-        1usize,
-        concat!("Alignment of ", stringify!(Foo)),
-    );
-}
+const _: () = {
+    ["Size of Foo"][::std::mem::size_of::<Foo>() - 1usize];
+    ["Alignment of Foo"][::std::mem::align_of::<Foo>() - 1usize];
+};

--- a/bindgen-tests/tests/expectations/tests/issue-834.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-834.rs
@@ -4,12 +4,7 @@
 pub struct U {
     pub _address: u8,
 }
-#[test]
-fn bindgen_test_layout_U() {
-    assert_eq!(::std::mem::size_of::<U>(), 1usize, concat!("Size of: ", stringify!(U)));
-    assert_eq!(
-        ::std::mem::align_of::<U>(),
-        1usize,
-        concat!("Alignment of ", stringify!(U)),
-    );
-}
+const _: () = {
+    ["Size of U"][::std::mem::size_of::<U>() - 1usize];
+    ["Alignment of U"][::std::mem::align_of::<U>() - 1usize];
+};

--- a/bindgen-tests/tests/expectations/tests/issue-888-enum-var-decl-jump.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-888-enum-var-decl-jump.rs
@@ -15,19 +15,10 @@ pub mod root {
             #[link_name = "\u{1}_ZN6Halide4Type1bE"]
             pub static mut Type_b: root::a;
         }
-        #[test]
-        fn bindgen_test_layout_Type() {
-            assert_eq!(
-                ::std::mem::size_of::<Type>(),
-                1usize,
-                concat!("Size of: ", stringify!(Type)),
-            );
-            assert_eq!(
-                ::std::mem::align_of::<Type>(),
-                1usize,
-                concat!("Alignment of ", stringify!(Type)),
-            );
-        }
+        const _: () = {
+            ["Size of Type"][::std::mem::size_of::<Type>() - 1usize];
+            ["Alignment of Type"][::std::mem::align_of::<Type>() - 1usize];
+        };
     }
     #[repr(u32)]
     #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]

--- a/bindgen-tests/tests/expectations/tests/issue-944-derive-copy-and-blocklisting.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-944-derive-copy-and-blocklisting.rs
@@ -5,26 +5,13 @@ pub struct BlocklistMe(u8);
 pub struct ShouldNotBeCopy {
     pub a: BlocklistMe,
 }
-#[test]
-fn bindgen_test_layout_ShouldNotBeCopy() {
-    const UNINIT: ::std::mem::MaybeUninit<ShouldNotBeCopy> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<ShouldNotBeCopy>(),
-        1usize,
-        concat!("Size of: ", stringify!(ShouldNotBeCopy)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<ShouldNotBeCopy>(),
-        1usize,
-        concat!("Alignment of ", stringify!(ShouldNotBeCopy)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(ShouldNotBeCopy), "::", stringify!(a)),
-    );
-}
+const _: () = {
+    ["Size of ShouldNotBeCopy"][::std::mem::size_of::<ShouldNotBeCopy>() - 1usize];
+    ["Alignment of ShouldNotBeCopy"][::std::mem::align_of::<ShouldNotBeCopy>() - 1usize];
+    [
+        "Offset of field: ShouldNotBeCopy::a",
+    ][::std::mem::offset_of!(ShouldNotBeCopy, a) - 0usize];
+};
 impl Default for ShouldNotBeCopy {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();

--- a/bindgen-tests/tests/expectations/tests/issue-946.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-946.rs
@@ -2,17 +2,8 @@
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct foo {}
-#[test]
-fn bindgen_test_layout_foo() {
-    assert_eq!(
-        ::std::mem::size_of::<foo>(),
-        0usize,
-        concat!("Size of: ", stringify!(foo)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<foo>(),
-        1usize,
-        concat!("Alignment of ", stringify!(foo)),
-    );
-}
+const _: () = {
+    ["Size of foo"][::std::mem::size_of::<foo>() - 0usize];
+    ["Alignment of foo"][::std::mem::align_of::<foo>() - 1usize];
+};
 pub type bar = foo;

--- a/bindgen-tests/tests/expectations/tests/issue_311.rs
+++ b/bindgen-tests/tests/expectations/tests/issue_311.rs
@@ -13,30 +13,16 @@ pub mod root {
     pub struct jsval_layout__bindgen_ty_1 {
         pub _address: u8,
     }
-    #[test]
-    fn bindgen_test_layout_jsval_layout__bindgen_ty_1() {
-        assert_eq!(
-            ::std::mem::size_of::<jsval_layout__bindgen_ty_1>(),
-            1usize,
-            concat!("Size of: ", stringify!(jsval_layout__bindgen_ty_1)),
-        );
-        assert_eq!(
-            ::std::mem::align_of::<jsval_layout__bindgen_ty_1>(),
-            1usize,
-            concat!("Alignment of ", stringify!(jsval_layout__bindgen_ty_1)),
-        );
-    }
-    #[test]
-    fn bindgen_test_layout_jsval_layout() {
-        assert_eq!(
-            ::std::mem::size_of::<jsval_layout>(),
-            1usize,
-            concat!("Size of: ", stringify!(jsval_layout)),
-        );
-        assert_eq!(
-            ::std::mem::align_of::<jsval_layout>(),
-            1usize,
-            concat!("Alignment of ", stringify!(jsval_layout)),
-        );
-    }
+    const _: () = {
+        [
+            "Size of jsval_layout__bindgen_ty_1",
+        ][::std::mem::size_of::<jsval_layout__bindgen_ty_1>() - 1usize];
+        [
+            "Alignment of jsval_layout__bindgen_ty_1",
+        ][::std::mem::align_of::<jsval_layout__bindgen_ty_1>() - 1usize];
+    };
+    const _: () = {
+        ["Size of jsval_layout"][::std::mem::size_of::<jsval_layout>() - 1usize];
+        ["Alignment of jsval_layout"][::std::mem::align_of::<jsval_layout>() - 1usize];
+    };
 }

--- a/bindgen-tests/tests/expectations/tests/jsval_layout_opaque.rs
+++ b/bindgen-tests/tests/expectations/tests/jsval_layout_opaque.rs
@@ -186,19 +186,14 @@ pub struct jsval_layout__bindgen_ty_1 {
     pub _bitfield_align_1: [u64; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 8usize]>,
 }
-#[test]
-fn bindgen_test_layout_jsval_layout__bindgen_ty_1() {
-    assert_eq!(
-        ::std::mem::size_of::<jsval_layout__bindgen_ty_1>(),
-        8usize,
-        concat!("Size of: ", stringify!(jsval_layout__bindgen_ty_1)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<jsval_layout__bindgen_ty_1>(),
-        8usize,
-        concat!("Alignment of ", stringify!(jsval_layout__bindgen_ty_1)),
-    );
-}
+const _: () = {
+    [
+        "Size of jsval_layout__bindgen_ty_1",
+    ][::std::mem::size_of::<jsval_layout__bindgen_ty_1>() - 8usize];
+    [
+        "Alignment of jsval_layout__bindgen_ty_1",
+    ][::std::mem::align_of::<jsval_layout__bindgen_ty_1>() - 8usize];
+};
 impl Default for jsval_layout__bindgen_ty_1 {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
@@ -270,51 +265,23 @@ pub union jsval_layout__bindgen_ty_2__bindgen_ty_1 {
     pub u32_: u32,
     pub why: JSWhyMagic,
 }
-#[test]
-fn bindgen_test_layout_jsval_layout__bindgen_ty_2__bindgen_ty_1() {
-    const UNINIT: ::std::mem::MaybeUninit<jsval_layout__bindgen_ty_2__bindgen_ty_1> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<jsval_layout__bindgen_ty_2__bindgen_ty_1>(),
-        4usize,
-        concat!("Size of: ", stringify!(jsval_layout__bindgen_ty_2__bindgen_ty_1)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<jsval_layout__bindgen_ty_2__bindgen_ty_1>(),
-        4usize,
-        concat!("Alignment of ", stringify!(jsval_layout__bindgen_ty_2__bindgen_ty_1)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).i32_) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(jsval_layout__bindgen_ty_2__bindgen_ty_1),
-            "::",
-            stringify!(i32_),
-        ),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).u32_) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(jsval_layout__bindgen_ty_2__bindgen_ty_1),
-            "::",
-            stringify!(u32_),
-        ),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).why) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(jsval_layout__bindgen_ty_2__bindgen_ty_1),
-            "::",
-            stringify!(why),
-        ),
-    );
-}
+const _: () = {
+    [
+        "Size of jsval_layout__bindgen_ty_2__bindgen_ty_1",
+    ][::std::mem::size_of::<jsval_layout__bindgen_ty_2__bindgen_ty_1>() - 4usize];
+    [
+        "Alignment of jsval_layout__bindgen_ty_2__bindgen_ty_1",
+    ][::std::mem::align_of::<jsval_layout__bindgen_ty_2__bindgen_ty_1>() - 4usize];
+    [
+        "Offset of field: jsval_layout__bindgen_ty_2__bindgen_ty_1::i32_",
+    ][::std::mem::offset_of!(jsval_layout__bindgen_ty_2__bindgen_ty_1, i32_) - 0usize];
+    [
+        "Offset of field: jsval_layout__bindgen_ty_2__bindgen_ty_1::u32_",
+    ][::std::mem::offset_of!(jsval_layout__bindgen_ty_2__bindgen_ty_1, u32_) - 0usize];
+    [
+        "Offset of field: jsval_layout__bindgen_ty_2__bindgen_ty_1::why",
+    ][::std::mem::offset_of!(jsval_layout__bindgen_ty_2__bindgen_ty_1, why) - 0usize];
+};
 impl Default for jsval_layout__bindgen_ty_2__bindgen_ty_1 {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
@@ -324,31 +291,17 @@ impl Default for jsval_layout__bindgen_ty_2__bindgen_ty_1 {
         }
     }
 }
-#[test]
-fn bindgen_test_layout_jsval_layout__bindgen_ty_2() {
-    const UNINIT: ::std::mem::MaybeUninit<jsval_layout__bindgen_ty_2> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<jsval_layout__bindgen_ty_2>(),
-        4usize,
-        concat!("Size of: ", stringify!(jsval_layout__bindgen_ty_2)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<jsval_layout__bindgen_ty_2>(),
-        4usize,
-        concat!("Alignment of ", stringify!(jsval_layout__bindgen_ty_2)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).payload) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(jsval_layout__bindgen_ty_2),
-            "::",
-            stringify!(payload),
-        ),
-    );
-}
+const _: () = {
+    [
+        "Size of jsval_layout__bindgen_ty_2",
+    ][::std::mem::size_of::<jsval_layout__bindgen_ty_2>() - 4usize];
+    [
+        "Alignment of jsval_layout__bindgen_ty_2",
+    ][::std::mem::align_of::<jsval_layout__bindgen_ty_2>() - 4usize];
+    [
+        "Offset of field: jsval_layout__bindgen_ty_2::payload",
+    ][::std::mem::offset_of!(jsval_layout__bindgen_ty_2, payload) - 0usize];
+};
 impl Default for jsval_layout__bindgen_ty_2 {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
@@ -358,71 +311,31 @@ impl Default for jsval_layout__bindgen_ty_2 {
         }
     }
 }
-#[test]
-fn bindgen_test_layout_jsval_layout() {
-    const UNINIT: ::std::mem::MaybeUninit<jsval_layout> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<jsval_layout>(),
-        8usize,
-        concat!("Size of: ", stringify!(jsval_layout)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<jsval_layout>(),
-        8usize,
-        concat!("Alignment of ", stringify!(jsval_layout)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).asBits) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(jsval_layout), "::", stringify!(asBits)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).debugView) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(jsval_layout),
-            "::",
-            stringify!(debugView),
-        ),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).s) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(jsval_layout), "::", stringify!(s)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).asDouble) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(jsval_layout),
-            "::",
-            stringify!(asDouble),
-        ),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).asPtr) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(jsval_layout), "::", stringify!(asPtr)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).asWord) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(jsval_layout), "::", stringify!(asWord)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).asUIntPtr) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(jsval_layout),
-            "::",
-            stringify!(asUIntPtr),
-        ),
-    );
-}
+const _: () = {
+    ["Size of jsval_layout"][::std::mem::size_of::<jsval_layout>() - 8usize];
+    ["Alignment of jsval_layout"][::std::mem::align_of::<jsval_layout>() - 8usize];
+    [
+        "Offset of field: jsval_layout::asBits",
+    ][::std::mem::offset_of!(jsval_layout, asBits) - 0usize];
+    [
+        "Offset of field: jsval_layout::debugView",
+    ][::std::mem::offset_of!(jsval_layout, debugView) - 0usize];
+    [
+        "Offset of field: jsval_layout::s",
+    ][::std::mem::offset_of!(jsval_layout, s) - 0usize];
+    [
+        "Offset of field: jsval_layout::asDouble",
+    ][::std::mem::offset_of!(jsval_layout, asDouble) - 0usize];
+    [
+        "Offset of field: jsval_layout::asPtr",
+    ][::std::mem::offset_of!(jsval_layout, asPtr) - 0usize];
+    [
+        "Offset of field: jsval_layout::asWord",
+    ][::std::mem::offset_of!(jsval_layout, asWord) - 0usize];
+    [
+        "Offset of field: jsval_layout::asUIntPtr",
+    ][::std::mem::offset_of!(jsval_layout, asUIntPtr) - 0usize];
+};
 impl Default for jsval_layout {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
@@ -437,26 +350,11 @@ impl Default for jsval_layout {
 pub struct Value {
     pub data: jsval_layout,
 }
-#[test]
-fn bindgen_test_layout_Value() {
-    const UNINIT: ::std::mem::MaybeUninit<Value> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<Value>(),
-        8usize,
-        concat!("Size of: ", stringify!(Value)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Value>(),
-        8usize,
-        concat!("Alignment of ", stringify!(Value)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).data) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(Value), "::", stringify!(data)),
-    );
-}
+const _: () = {
+    ["Size of Value"][::std::mem::size_of::<Value>() - 8usize];
+    ["Alignment of Value"][::std::mem::align_of::<Value>() - 8usize];
+    ["Offset of field: Value::data"][::std::mem::offset_of!(Value, data) - 0usize];
+};
 impl Default for Value {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();

--- a/bindgen-tests/tests/expectations/tests/jsval_layout_opaque_1_0.rs
+++ b/bindgen-tests/tests/expectations/tests/jsval_layout_opaque_1_0.rs
@@ -235,12 +235,12 @@ fn bindgen_test_layout_jsval_layout__bindgen_ty_1() {
     assert_eq!(
         ::std::mem::size_of::<jsval_layout__bindgen_ty_1>(),
         8usize,
-        concat!("Size of: ", stringify!(jsval_layout__bindgen_ty_1)),
+        "Size of jsval_layout__bindgen_ty_1",
     );
     assert_eq!(
         ::std::mem::align_of::<jsval_layout__bindgen_ty_1>(),
         8usize,
-        concat!("Alignment of ", stringify!(jsval_layout__bindgen_ty_1)),
+        "Alignment of jsval_layout__bindgen_ty_1",
     );
 }
 impl Clone for jsval_layout__bindgen_ty_1 {
@@ -327,42 +327,27 @@ fn bindgen_test_layout_jsval_layout__bindgen_ty_2__bindgen_ty_1() {
     assert_eq!(
         ::std::mem::size_of::<jsval_layout__bindgen_ty_2__bindgen_ty_1>(),
         4usize,
-        concat!("Size of: ", stringify!(jsval_layout__bindgen_ty_2__bindgen_ty_1)),
+        "Size of jsval_layout__bindgen_ty_2__bindgen_ty_1",
     );
     assert_eq!(
         ::std::mem::align_of::<jsval_layout__bindgen_ty_2__bindgen_ty_1>(),
         4usize,
-        concat!("Alignment of ", stringify!(jsval_layout__bindgen_ty_2__bindgen_ty_1)),
+        "Alignment of jsval_layout__bindgen_ty_2__bindgen_ty_1",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).i32_) as usize - ptr as usize },
         0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(jsval_layout__bindgen_ty_2__bindgen_ty_1),
-            "::",
-            stringify!(i32_),
-        ),
+        "Offset of field: jsval_layout__bindgen_ty_2__bindgen_ty_1::i32_",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).u32_) as usize - ptr as usize },
         0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(jsval_layout__bindgen_ty_2__bindgen_ty_1),
-            "::",
-            stringify!(u32_),
-        ),
+        "Offset of field: jsval_layout__bindgen_ty_2__bindgen_ty_1::u32_",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).why) as usize - ptr as usize },
         0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(jsval_layout__bindgen_ty_2__bindgen_ty_1),
-            "::",
-            stringify!(why),
-        ),
+        "Offset of field: jsval_layout__bindgen_ty_2__bindgen_ty_1::why",
     );
 }
 impl Clone for jsval_layout__bindgen_ty_2__bindgen_ty_1 {
@@ -377,22 +362,17 @@ fn bindgen_test_layout_jsval_layout__bindgen_ty_2() {
     assert_eq!(
         ::std::mem::size_of::<jsval_layout__bindgen_ty_2>(),
         4usize,
-        concat!("Size of: ", stringify!(jsval_layout__bindgen_ty_2)),
+        "Size of jsval_layout__bindgen_ty_2",
     );
     assert_eq!(
         ::std::mem::align_of::<jsval_layout__bindgen_ty_2>(),
         4usize,
-        concat!("Alignment of ", stringify!(jsval_layout__bindgen_ty_2)),
+        "Alignment of jsval_layout__bindgen_ty_2",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).payload) as usize - ptr as usize },
         0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(jsval_layout__bindgen_ty_2),
-            "::",
-            stringify!(payload),
-        ),
+        "Offset of field: jsval_layout__bindgen_ty_2::payload",
     );
 }
 impl Clone for jsval_layout__bindgen_ty_2 {
@@ -404,65 +384,46 @@ impl Clone for jsval_layout__bindgen_ty_2 {
 fn bindgen_test_layout_jsval_layout() {
     const UNINIT: ::std::mem::MaybeUninit<jsval_layout> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<jsval_layout>(),
-        8usize,
-        concat!("Size of: ", stringify!(jsval_layout)),
-    );
+    assert_eq!(::std::mem::size_of::<jsval_layout>(), 8usize, "Size of jsval_layout");
     assert_eq!(
         ::std::mem::align_of::<jsval_layout>(),
         8usize,
-        concat!("Alignment of ", stringify!(jsval_layout)),
+        "Alignment of jsval_layout",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).asBits) as usize - ptr as usize },
         0usize,
-        concat!("Offset of field: ", stringify!(jsval_layout), "::", stringify!(asBits)),
+        "Offset of field: jsval_layout::asBits",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).debugView) as usize - ptr as usize },
         0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(jsval_layout),
-            "::",
-            stringify!(debugView),
-        ),
+        "Offset of field: jsval_layout::debugView",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).s) as usize - ptr as usize },
         0usize,
-        concat!("Offset of field: ", stringify!(jsval_layout), "::", stringify!(s)),
+        "Offset of field: jsval_layout::s",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).asDouble) as usize - ptr as usize },
         0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(jsval_layout),
-            "::",
-            stringify!(asDouble),
-        ),
+        "Offset of field: jsval_layout::asDouble",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).asPtr) as usize - ptr as usize },
         0usize,
-        concat!("Offset of field: ", stringify!(jsval_layout), "::", stringify!(asPtr)),
+        "Offset of field: jsval_layout::asPtr",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).asWord) as usize - ptr as usize },
         0usize,
-        concat!("Offset of field: ", stringify!(jsval_layout), "::", stringify!(asWord)),
+        "Offset of field: jsval_layout::asWord",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).asUIntPtr) as usize - ptr as usize },
         0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(jsval_layout),
-            "::",
-            stringify!(asUIntPtr),
-        ),
+        "Offset of field: jsval_layout::asUIntPtr",
     );
 }
 impl Clone for jsval_layout {
@@ -479,20 +440,12 @@ pub struct Value {
 fn bindgen_test_layout_Value() {
     const UNINIT: ::std::mem::MaybeUninit<Value> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<Value>(),
-        8usize,
-        concat!("Size of: ", stringify!(Value)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Value>(),
-        8usize,
-        concat!("Alignment of ", stringify!(Value)),
-    );
+    assert_eq!(::std::mem::size_of::<Value>(), 8usize, "Size of Value");
+    assert_eq!(::std::mem::align_of::<Value>(), 8usize, "Alignment of Value");
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).data) as usize - ptr as usize },
         0usize,
-        concat!("Offset of field: ", stringify!(Value), "::", stringify!(data)),
+        "Offset of field: Value::data",
     );
 }
 impl Clone for Value {

--- a/bindgen-tests/tests/expectations/tests/layout.rs
+++ b/bindgen-tests/tests/expectations/tests/layout.rs
@@ -5,11 +5,7 @@ pub struct header {
 }
 #[test]
 fn bindgen_test_layout_header() {
-    assert_eq!(
-        ::std::mem::size_of::<header>(),
-        16usize,
-        concat!("Size of: ", stringify!(header)),
-    );
+    assert_eq!(::std::mem::size_of::<header>(), 16usize, "Size of header");
 }
 impl Default for header {
     fn default() -> Self {

--- a/bindgen-tests/tests/expectations/tests/layout_align.rs
+++ b/bindgen-tests/tests/expectations/tests/layout_align.rs
@@ -127,51 +127,25 @@ pub struct rte_kni_fifo {
     ///< The buffer contains mbuf pointers
     pub buffer: __IncompleteArrayField<*mut ::std::os::raw::c_void>,
 }
-#[test]
-fn bindgen_test_layout_rte_kni_fifo() {
-    const UNINIT: ::std::mem::MaybeUninit<rte_kni_fifo> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<rte_kni_fifo>(),
-        16usize,
-        concat!("Size of: ", stringify!(rte_kni_fifo)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<rte_kni_fifo>(),
-        8usize,
-        concat!("Alignment of ", stringify!(rte_kni_fifo)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).write) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(rte_kni_fifo), "::", stringify!(write)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).read) as usize - ptr as usize },
-        4usize,
-        concat!("Offset of field: ", stringify!(rte_kni_fifo), "::", stringify!(read)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).len) as usize - ptr as usize },
-        8usize,
-        concat!("Offset of field: ", stringify!(rte_kni_fifo), "::", stringify!(len)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).elem_size) as usize - ptr as usize },
-        12usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_kni_fifo),
-            "::",
-            stringify!(elem_size),
-        ),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).buffer) as usize - ptr as usize },
-        16usize,
-        concat!("Offset of field: ", stringify!(rte_kni_fifo), "::", stringify!(buffer)),
-    );
-}
+const _: () = {
+    ["Size of rte_kni_fifo"][::std::mem::size_of::<rte_kni_fifo>() - 16usize];
+    ["Alignment of rte_kni_fifo"][::std::mem::align_of::<rte_kni_fifo>() - 8usize];
+    [
+        "Offset of field: rte_kni_fifo::write",
+    ][::std::mem::offset_of!(rte_kni_fifo, write) - 0usize];
+    [
+        "Offset of field: rte_kni_fifo::read",
+    ][::std::mem::offset_of!(rte_kni_fifo, read) - 4usize];
+    [
+        "Offset of field: rte_kni_fifo::len",
+    ][::std::mem::offset_of!(rte_kni_fifo, len) - 8usize];
+    [
+        "Offset of field: rte_kni_fifo::elem_size",
+    ][::std::mem::offset_of!(rte_kni_fifo, elem_size) - 12usize];
+    [
+        "Offset of field: rte_kni_fifo::buffer",
+    ][::std::mem::offset_of!(rte_kni_fifo, buffer) - 16usize];
+};
 impl Default for rte_kni_fifo {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
@@ -191,31 +165,13 @@ pub struct rte_eth_link {
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
     pub __bindgen_padding_0: [u8; 3usize],
 }
-#[test]
-fn bindgen_test_layout_rte_eth_link() {
-    const UNINIT: ::std::mem::MaybeUninit<rte_eth_link> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<rte_eth_link>(),
-        8usize,
-        concat!("Size of: ", stringify!(rte_eth_link)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<rte_eth_link>(),
-        8usize,
-        concat!("Alignment of ", stringify!(rte_eth_link)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).link_speed) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_link),
-            "::",
-            stringify!(link_speed),
-        ),
-    );
-}
+const _: () = {
+    ["Size of rte_eth_link"][::std::mem::size_of::<rte_eth_link>() - 8usize];
+    ["Alignment of rte_eth_link"][::std::mem::align_of::<rte_eth_link>() - 8usize];
+    [
+        "Offset of field: rte_eth_link::link_speed",
+    ][::std::mem::offset_of!(rte_eth_link, link_speed) - 0usize];
+};
 impl rte_eth_link {
     #[inline]
     pub fn link_duplex(&self) -> u16 {

--- a/bindgen-tests/tests/expectations/tests/layout_arp.rs
+++ b/bindgen-tests/tests/expectations/tests/layout_arp.rs
@@ -22,31 +22,13 @@ pub struct ether_addr {
     ///< Addr bytes in tx order
     pub addr_bytes: [u8; 6usize],
 }
-#[test]
-fn bindgen_test_layout_ether_addr() {
-    const UNINIT: ::std::mem::MaybeUninit<ether_addr> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<ether_addr>(),
-        6usize,
-        concat!("Size of: ", stringify!(ether_addr)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<ether_addr>(),
-        1usize,
-        concat!("Alignment of ", stringify!(ether_addr)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).addr_bytes) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(ether_addr),
-            "::",
-            stringify!(addr_bytes),
-        ),
-    );
-}
+const _: () = {
+    ["Size of ether_addr"][::std::mem::size_of::<ether_addr>() - 6usize];
+    ["Alignment of ether_addr"][::std::mem::align_of::<ether_addr>() - 1usize];
+    [
+        "Offset of field: ether_addr::addr_bytes",
+    ][::std::mem::offset_of!(ether_addr, addr_bytes) - 0usize];
+};
 /// ARP header IPv4 payload.
 #[repr(C, packed)]
 #[derive(Debug, Default, Copy, Clone)]
@@ -60,41 +42,22 @@ pub struct arp_ipv4 {
     ///< target IP address
     pub arp_tip: u32,
 }
-#[test]
-fn bindgen_test_layout_arp_ipv4() {
-    const UNINIT: ::std::mem::MaybeUninit<arp_ipv4> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<arp_ipv4>(),
-        20usize,
-        concat!("Size of: ", stringify!(arp_ipv4)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<arp_ipv4>(),
-        1usize,
-        concat!("Alignment of ", stringify!(arp_ipv4)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).arp_sha) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(arp_ipv4), "::", stringify!(arp_sha)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).arp_sip) as usize - ptr as usize },
-        6usize,
-        concat!("Offset of field: ", stringify!(arp_ipv4), "::", stringify!(arp_sip)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).arp_tha) as usize - ptr as usize },
-        10usize,
-        concat!("Offset of field: ", stringify!(arp_ipv4), "::", stringify!(arp_tha)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).arp_tip) as usize - ptr as usize },
-        16usize,
-        concat!("Offset of field: ", stringify!(arp_ipv4), "::", stringify!(arp_tip)),
-    );
-}
+const _: () = {
+    ["Size of arp_ipv4"][::std::mem::size_of::<arp_ipv4>() - 20usize];
+    ["Alignment of arp_ipv4"][::std::mem::align_of::<arp_ipv4>() - 1usize];
+    [
+        "Offset of field: arp_ipv4::arp_sha",
+    ][::std::mem::offset_of!(arp_ipv4, arp_sha) - 0usize];
+    [
+        "Offset of field: arp_ipv4::arp_sip",
+    ][::std::mem::offset_of!(arp_ipv4, arp_sip) - 6usize];
+    [
+        "Offset of field: arp_ipv4::arp_tha",
+    ][::std::mem::offset_of!(arp_ipv4, arp_tha) - 10usize];
+    [
+        "Offset of field: arp_ipv4::arp_tip",
+    ][::std::mem::offset_of!(arp_ipv4, arp_tip) - 16usize];
+};
 /// ARP header.
 #[repr(C, packed)]
 #[derive(Debug, Default, Copy, Clone)]
@@ -106,48 +69,25 @@ pub struct arp_hdr {
     pub arp_op: u16,
     pub arp_data: arp_ipv4,
 }
-#[test]
-fn bindgen_test_layout_arp_hdr() {
-    const UNINIT: ::std::mem::MaybeUninit<arp_hdr> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<arp_hdr>(),
-        28usize,
-        concat!("Size of: ", stringify!(arp_hdr)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<arp_hdr>(),
-        1usize,
-        concat!("Alignment of ", stringify!(arp_hdr)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).arp_hrd) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(arp_hdr), "::", stringify!(arp_hrd)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).arp_pro) as usize - ptr as usize },
-        2usize,
-        concat!("Offset of field: ", stringify!(arp_hdr), "::", stringify!(arp_pro)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).arp_hln) as usize - ptr as usize },
-        4usize,
-        concat!("Offset of field: ", stringify!(arp_hdr), "::", stringify!(arp_hln)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).arp_pln) as usize - ptr as usize },
-        5usize,
-        concat!("Offset of field: ", stringify!(arp_hdr), "::", stringify!(arp_pln)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).arp_op) as usize - ptr as usize },
-        6usize,
-        concat!("Offset of field: ", stringify!(arp_hdr), "::", stringify!(arp_op)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).arp_data) as usize - ptr as usize },
-        8usize,
-        concat!("Offset of field: ", stringify!(arp_hdr), "::", stringify!(arp_data)),
-    );
-}
+const _: () = {
+    ["Size of arp_hdr"][::std::mem::size_of::<arp_hdr>() - 28usize];
+    ["Alignment of arp_hdr"][::std::mem::align_of::<arp_hdr>() - 1usize];
+    [
+        "Offset of field: arp_hdr::arp_hrd",
+    ][::std::mem::offset_of!(arp_hdr, arp_hrd) - 0usize];
+    [
+        "Offset of field: arp_hdr::arp_pro",
+    ][::std::mem::offset_of!(arp_hdr, arp_pro) - 2usize];
+    [
+        "Offset of field: arp_hdr::arp_hln",
+    ][::std::mem::offset_of!(arp_hdr, arp_hln) - 4usize];
+    [
+        "Offset of field: arp_hdr::arp_pln",
+    ][::std::mem::offset_of!(arp_hdr, arp_pln) - 5usize];
+    [
+        "Offset of field: arp_hdr::arp_op",
+    ][::std::mem::offset_of!(arp_hdr, arp_op) - 6usize];
+    [
+        "Offset of field: arp_hdr::arp_data",
+    ][::std::mem::offset_of!(arp_hdr, arp_data) - 8usize];
+};

--- a/bindgen-tests/tests/expectations/tests/layout_array.rs
+++ b/bindgen-tests/tests/expectations/tests/layout_array.rs
@@ -68,62 +68,42 @@ fn bindgen_test_layout_rte_mempool_ops() {
     assert_eq!(
         ::std::mem::size_of::<rte_mempool_ops>(),
         128usize,
-        concat!("Size of: ", stringify!(rte_mempool_ops)),
+        "Size of rte_mempool_ops",
     );
     assert_eq!(
         ::std::mem::align_of::<rte_mempool_ops>(),
         64usize,
-        concat!("Alignment of ", stringify!(rte_mempool_ops)),
+        "Alignment of rte_mempool_ops",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).name) as usize - ptr as usize },
         0usize,
-        concat!("Offset of field: ", stringify!(rte_mempool_ops), "::", stringify!(name)),
+        "Offset of field: rte_mempool_ops::name",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).alloc) as usize - ptr as usize },
         32usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mempool_ops),
-            "::",
-            stringify!(alloc),
-        ),
+        "Offset of field: rte_mempool_ops::alloc",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).free) as usize - ptr as usize },
         40usize,
-        concat!("Offset of field: ", stringify!(rte_mempool_ops), "::", stringify!(free)),
+        "Offset of field: rte_mempool_ops::free",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).enqueue) as usize - ptr as usize },
         48usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mempool_ops),
-            "::",
-            stringify!(enqueue),
-        ),
+        "Offset of field: rte_mempool_ops::enqueue",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).dequeue) as usize - ptr as usize },
         56usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mempool_ops),
-            "::",
-            stringify!(dequeue),
-        ),
+        "Offset of field: rte_mempool_ops::dequeue",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).get_count) as usize - ptr as usize },
         64usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mempool_ops),
-            "::",
-            stringify!(get_count),
-        ),
+        "Offset of field: rte_mempool_ops::get_count",
     );
 }
 impl Default for rte_mempool_ops {
@@ -156,22 +136,17 @@ fn bindgen_test_layout_rte_spinlock_t() {
     assert_eq!(
         ::std::mem::size_of::<rte_spinlock_t>(),
         4usize,
-        concat!("Size of: ", stringify!(rte_spinlock_t)),
+        "Size of rte_spinlock_t",
     );
     assert_eq!(
         ::std::mem::align_of::<rte_spinlock_t>(),
         4usize,
-        concat!("Alignment of ", stringify!(rte_spinlock_t)),
+        "Alignment of rte_spinlock_t",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).locked) as usize - ptr as usize },
         0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_spinlock_t),
-            "::",
-            stringify!(locked),
-        ),
+        "Offset of field: rte_spinlock_t::locked",
     );
 }
 /** Structure storing the table of registered ops structs, each of which contain
@@ -200,42 +175,27 @@ fn bindgen_test_layout_rte_mempool_ops_table() {
     assert_eq!(
         ::std::mem::size_of::<rte_mempool_ops_table>(),
         2112usize,
-        concat!("Size of: ", stringify!(rte_mempool_ops_table)),
+        "Size of rte_mempool_ops_table",
     );
     assert_eq!(
         ::std::mem::align_of::<rte_mempool_ops_table>(),
         64usize,
-        concat!("Alignment of ", stringify!(rte_mempool_ops_table)),
+        "Alignment of rte_mempool_ops_table",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).sl) as usize - ptr as usize },
         0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mempool_ops_table),
-            "::",
-            stringify!(sl),
-        ),
+        "Offset of field: rte_mempool_ops_table::sl",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).num_ops) as usize - ptr as usize },
         4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mempool_ops_table),
-            "::",
-            stringify!(num_ops),
-        ),
+        "Offset of field: rte_mempool_ops_table::num_ops",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).ops) as usize - ptr as usize },
         64usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mempool_ops_table),
-            "::",
-            stringify!(ops),
-        ),
+        "Offset of field: rte_mempool_ops_table::ops",
     );
 }
 impl Default for rte_mempool_ops_table {
@@ -269,22 +229,17 @@ fn bindgen_test_layout_malloc_heap__bindgen_ty_1() {
     assert_eq!(
         ::std::mem::size_of::<malloc_heap__bindgen_ty_1>(),
         8usize,
-        concat!("Size of: ", stringify!(malloc_heap__bindgen_ty_1)),
+        "Size of malloc_heap__bindgen_ty_1",
     );
     assert_eq!(
         ::std::mem::align_of::<malloc_heap__bindgen_ty_1>(),
         8usize,
-        concat!("Alignment of ", stringify!(malloc_heap__bindgen_ty_1)),
+        "Alignment of malloc_heap__bindgen_ty_1",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).lh_first) as usize - ptr as usize },
         0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(malloc_heap__bindgen_ty_1),
-            "::",
-            stringify!(lh_first),
-        ),
+        "Offset of field: malloc_heap__bindgen_ty_1::lh_first",
     );
 }
 impl Default for malloc_heap__bindgen_ty_1 {
@@ -300,50 +255,31 @@ impl Default for malloc_heap__bindgen_ty_1 {
 fn bindgen_test_layout_malloc_heap() {
     const UNINIT: ::std::mem::MaybeUninit<malloc_heap> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<malloc_heap>(),
-        128usize,
-        concat!("Size of: ", stringify!(malloc_heap)),
-    );
+    assert_eq!(::std::mem::size_of::<malloc_heap>(), 128usize, "Size of malloc_heap");
     assert_eq!(
         ::std::mem::align_of::<malloc_heap>(),
         64usize,
-        concat!("Alignment of ", stringify!(malloc_heap)),
+        "Alignment of malloc_heap",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).lock) as usize - ptr as usize },
         0usize,
-        concat!("Offset of field: ", stringify!(malloc_heap), "::", stringify!(lock)),
+        "Offset of field: malloc_heap::lock",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).free_head) as usize - ptr as usize },
         8usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(malloc_heap),
-            "::",
-            stringify!(free_head),
-        ),
+        "Offset of field: malloc_heap::free_head",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).alloc_count) as usize - ptr as usize },
         112usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(malloc_heap),
-            "::",
-            stringify!(alloc_count),
-        ),
+        "Offset of field: malloc_heap::alloc_count",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).total_size) as usize - ptr as usize },
         120usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(malloc_heap),
-            "::",
-            stringify!(total_size),
-        ),
+        "Offset of field: malloc_heap::total_size",
     );
 }
 impl Default for malloc_heap {

--- a/bindgen-tests/tests/expectations/tests/layout_array_too_long.rs
+++ b/bindgen-tests/tests/expectations/tests/layout_array_too_long.rs
@@ -31,30 +31,22 @@ pub struct ip_frag {
 fn bindgen_test_layout_ip_frag() {
     const UNINIT: ::std::mem::MaybeUninit<ip_frag> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<ip_frag>(),
-        16usize,
-        concat!("Size of: ", stringify!(ip_frag)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<ip_frag>(),
-        8usize,
-        concat!("Alignment of ", stringify!(ip_frag)),
-    );
+    assert_eq!(::std::mem::size_of::<ip_frag>(), 16usize, "Size of ip_frag");
+    assert_eq!(::std::mem::align_of::<ip_frag>(), 8usize, "Alignment of ip_frag");
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).ofs) as usize - ptr as usize },
         0usize,
-        concat!("Offset of field: ", stringify!(ip_frag), "::", stringify!(ofs)),
+        "Offset of field: ip_frag::ofs",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).len) as usize - ptr as usize },
         2usize,
-        concat!("Offset of field: ", stringify!(ip_frag), "::", stringify!(len)),
+        "Offset of field: ip_frag::len",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).mb) as usize - ptr as usize },
         8usize,
-        concat!("Offset of field: ", stringify!(ip_frag), "::", stringify!(mb)),
+        "Offset of field: ip_frag::mb",
     );
 }
 impl Default for ip_frag {
@@ -81,30 +73,26 @@ pub struct ip_frag_key {
 fn bindgen_test_layout_ip_frag_key() {
     const UNINIT: ::std::mem::MaybeUninit<ip_frag_key> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<ip_frag_key>(),
-        40usize,
-        concat!("Size of: ", stringify!(ip_frag_key)),
-    );
+    assert_eq!(::std::mem::size_of::<ip_frag_key>(), 40usize, "Size of ip_frag_key");
     assert_eq!(
         ::std::mem::align_of::<ip_frag_key>(),
         8usize,
-        concat!("Alignment of ", stringify!(ip_frag_key)),
+        "Alignment of ip_frag_key",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).src_dst) as usize - ptr as usize },
         0usize,
-        concat!("Offset of field: ", stringify!(ip_frag_key), "::", stringify!(src_dst)),
+        "Offset of field: ip_frag_key::src_dst",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).id) as usize - ptr as usize },
         32usize,
-        concat!("Offset of field: ", stringify!(ip_frag_key), "::", stringify!(id)),
+        "Offset of field: ip_frag_key::id",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).key_len) as usize - ptr as usize },
         36usize,
-        concat!("Offset of field: ", stringify!(ip_frag_key), "::", stringify!(key_len)),
+        "Offset of field: ip_frag_key::key_len",
     );
 }
 /** @internal Fragmented packet to reassemble.
@@ -141,32 +129,22 @@ fn bindgen_test_layout_ip_frag_pkt__bindgen_ty_1() {
     assert_eq!(
         ::std::mem::size_of::<ip_frag_pkt__bindgen_ty_1>(),
         16usize,
-        concat!("Size of: ", stringify!(ip_frag_pkt__bindgen_ty_1)),
+        "Size of ip_frag_pkt__bindgen_ty_1",
     );
     assert_eq!(
         ::std::mem::align_of::<ip_frag_pkt__bindgen_ty_1>(),
         8usize,
-        concat!("Alignment of ", stringify!(ip_frag_pkt__bindgen_ty_1)),
+        "Alignment of ip_frag_pkt__bindgen_ty_1",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).tqe_next) as usize - ptr as usize },
         0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(ip_frag_pkt__bindgen_ty_1),
-            "::",
-            stringify!(tqe_next),
-        ),
+        "Offset of field: ip_frag_pkt__bindgen_ty_1::tqe_next",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).tqe_prev) as usize - ptr as usize },
         8usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(ip_frag_pkt__bindgen_ty_1),
-            "::",
-            stringify!(tqe_prev),
-        ),
+        "Offset of field: ip_frag_pkt__bindgen_ty_1::tqe_prev",
     );
 }
 impl Default for ip_frag_pkt__bindgen_ty_1 {
@@ -182,60 +160,46 @@ impl Default for ip_frag_pkt__bindgen_ty_1 {
 fn bindgen_test_layout_ip_frag_pkt() {
     const UNINIT: ::std::mem::MaybeUninit<ip_frag_pkt> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<ip_frag_pkt>(),
-        192usize,
-        concat!("Size of: ", stringify!(ip_frag_pkt)),
-    );
+    assert_eq!(::std::mem::size_of::<ip_frag_pkt>(), 192usize, "Size of ip_frag_pkt");
     assert_eq!(
         ::std::mem::align_of::<ip_frag_pkt>(),
         64usize,
-        concat!("Alignment of ", stringify!(ip_frag_pkt)),
+        "Alignment of ip_frag_pkt",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).lru) as usize - ptr as usize },
         0usize,
-        concat!("Offset of field: ", stringify!(ip_frag_pkt), "::", stringify!(lru)),
+        "Offset of field: ip_frag_pkt::lru",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).key) as usize - ptr as usize },
         16usize,
-        concat!("Offset of field: ", stringify!(ip_frag_pkt), "::", stringify!(key)),
+        "Offset of field: ip_frag_pkt::key",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).start) as usize - ptr as usize },
         56usize,
-        concat!("Offset of field: ", stringify!(ip_frag_pkt), "::", stringify!(start)),
+        "Offset of field: ip_frag_pkt::start",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).total_size) as usize - ptr as usize },
         64usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(ip_frag_pkt),
-            "::",
-            stringify!(total_size),
-        ),
+        "Offset of field: ip_frag_pkt::total_size",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).frag_size) as usize - ptr as usize },
         68usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(ip_frag_pkt),
-            "::",
-            stringify!(frag_size),
-        ),
+        "Offset of field: ip_frag_pkt::frag_size",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).last_idx) as usize - ptr as usize },
         72usize,
-        concat!("Offset of field: ", stringify!(ip_frag_pkt), "::", stringify!(last_idx)),
+        "Offset of field: ip_frag_pkt::last_idx",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).frags) as usize - ptr as usize },
         80usize,
-        concat!("Offset of field: ", stringify!(ip_frag_pkt), "::", stringify!(frags)),
+        "Offset of field: ip_frag_pkt::frags",
     );
 }
 impl Default for ip_frag_pkt {

--- a/bindgen-tests/tests/expectations/tests/layout_cmdline_token.rs
+++ b/bindgen-tests/tests/expectations/tests/layout_cmdline_token.rs
@@ -7,41 +7,18 @@ pub struct cmdline_token_hdr {
     pub ops: *mut cmdline_token_ops,
     pub offset: ::std::os::raw::c_uint,
 }
-#[test]
-fn bindgen_test_layout_cmdline_token_hdr() {
-    const UNINIT: ::std::mem::MaybeUninit<cmdline_token_hdr> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<cmdline_token_hdr>(),
-        16usize,
-        concat!("Size of: ", stringify!(cmdline_token_hdr)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<cmdline_token_hdr>(),
-        8usize,
-        concat!("Alignment of ", stringify!(cmdline_token_hdr)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).ops) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(cmdline_token_hdr),
-            "::",
-            stringify!(ops),
-        ),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).offset) as usize - ptr as usize },
-        8usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(cmdline_token_hdr),
-            "::",
-            stringify!(offset),
-        ),
-    );
-}
+const _: () = {
+    ["Size of cmdline_token_hdr"][::std::mem::size_of::<cmdline_token_hdr>() - 16usize];
+    [
+        "Alignment of cmdline_token_hdr",
+    ][::std::mem::align_of::<cmdline_token_hdr>() - 8usize];
+    [
+        "Offset of field: cmdline_token_hdr::ops",
+    ][::std::mem::offset_of!(cmdline_token_hdr, ops) - 0usize];
+    [
+        "Offset of field: cmdline_token_hdr::offset",
+    ][::std::mem::offset_of!(cmdline_token_hdr, offset) - 8usize];
+};
 impl Default for cmdline_token_hdr {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
@@ -107,61 +84,24 @@ pub struct cmdline_token_ops {
         ) -> ::std::os::raw::c_int,
     >,
 }
-#[test]
-fn bindgen_test_layout_cmdline_token_ops() {
-    const UNINIT: ::std::mem::MaybeUninit<cmdline_token_ops> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<cmdline_token_ops>(),
-        32usize,
-        concat!("Size of: ", stringify!(cmdline_token_ops)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<cmdline_token_ops>(),
-        8usize,
-        concat!("Alignment of ", stringify!(cmdline_token_ops)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).parse) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(cmdline_token_ops),
-            "::",
-            stringify!(parse),
-        ),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).complete_get_nb) as usize - ptr as usize },
-        8usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(cmdline_token_ops),
-            "::",
-            stringify!(complete_get_nb),
-        ),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).complete_get_elt) as usize - ptr as usize },
-        16usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(cmdline_token_ops),
-            "::",
-            stringify!(complete_get_elt),
-        ),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).get_help) as usize - ptr as usize },
-        24usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(cmdline_token_ops),
-            "::",
-            stringify!(get_help),
-        ),
-    );
-}
+const _: () = {
+    ["Size of cmdline_token_ops"][::std::mem::size_of::<cmdline_token_ops>() - 32usize];
+    [
+        "Alignment of cmdline_token_ops",
+    ][::std::mem::align_of::<cmdline_token_ops>() - 8usize];
+    [
+        "Offset of field: cmdline_token_ops::parse",
+    ][::std::mem::offset_of!(cmdline_token_ops, parse) - 0usize];
+    [
+        "Offset of field: cmdline_token_ops::complete_get_nb",
+    ][::std::mem::offset_of!(cmdline_token_ops, complete_get_nb) - 8usize];
+    [
+        "Offset of field: cmdline_token_ops::complete_get_elt",
+    ][::std::mem::offset_of!(cmdline_token_ops, complete_get_elt) - 16usize];
+    [
+        "Offset of field: cmdline_token_ops::get_help",
+    ][::std::mem::offset_of!(cmdline_token_ops, get_help) - 24usize];
+};
 #[repr(u32)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum cmdline_numtype {
@@ -179,31 +119,17 @@ pub enum cmdline_numtype {
 pub struct cmdline_token_num_data {
     pub type_: cmdline_numtype,
 }
-#[test]
-fn bindgen_test_layout_cmdline_token_num_data() {
-    const UNINIT: ::std::mem::MaybeUninit<cmdline_token_num_data> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<cmdline_token_num_data>(),
-        4usize,
-        concat!("Size of: ", stringify!(cmdline_token_num_data)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<cmdline_token_num_data>(),
-        4usize,
-        concat!("Alignment of ", stringify!(cmdline_token_num_data)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).type_) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(cmdline_token_num_data),
-            "::",
-            stringify!(type_),
-        ),
-    );
-}
+const _: () = {
+    [
+        "Size of cmdline_token_num_data",
+    ][::std::mem::size_of::<cmdline_token_num_data>() - 4usize];
+    [
+        "Alignment of cmdline_token_num_data",
+    ][::std::mem::align_of::<cmdline_token_num_data>() - 4usize];
+    [
+        "Offset of field: cmdline_token_num_data::type_",
+    ][::std::mem::offset_of!(cmdline_token_num_data, type_) - 0usize];
+};
 impl Default for cmdline_token_num_data {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
@@ -219,41 +145,18 @@ pub struct cmdline_token_num {
     pub hdr: cmdline_token_hdr,
     pub num_data: cmdline_token_num_data,
 }
-#[test]
-fn bindgen_test_layout_cmdline_token_num() {
-    const UNINIT: ::std::mem::MaybeUninit<cmdline_token_num> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<cmdline_token_num>(),
-        24usize,
-        concat!("Size of: ", stringify!(cmdline_token_num)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<cmdline_token_num>(),
-        8usize,
-        concat!("Alignment of ", stringify!(cmdline_token_num)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).hdr) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(cmdline_token_num),
-            "::",
-            stringify!(hdr),
-        ),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).num_data) as usize - ptr as usize },
-        16usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(cmdline_token_num),
-            "::",
-            stringify!(num_data),
-        ),
-    );
-}
+const _: () = {
+    ["Size of cmdline_token_num"][::std::mem::size_of::<cmdline_token_num>() - 24usize];
+    [
+        "Alignment of cmdline_token_num",
+    ][::std::mem::align_of::<cmdline_token_num>() - 8usize];
+    [
+        "Offset of field: cmdline_token_num::hdr",
+    ][::std::mem::offset_of!(cmdline_token_num, hdr) - 0usize];
+    [
+        "Offset of field: cmdline_token_num::num_data",
+    ][::std::mem::offset_of!(cmdline_token_num, num_data) - 16usize];
+};
 impl Default for cmdline_token_num {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();

--- a/bindgen-tests/tests/expectations/tests/layout_eth_conf.rs
+++ b/bindgen-tests/tests/expectations/tests/layout_eth_conf.rs
@@ -157,42 +157,27 @@ fn bindgen_test_layout_rte_eth_rxmode() {
     assert_eq!(
         ::std::mem::size_of::<rte_eth_rxmode>(),
         12usize,
-        concat!("Size of: ", stringify!(rte_eth_rxmode)),
+        "Size of rte_eth_rxmode",
     );
     assert_eq!(
         ::std::mem::align_of::<rte_eth_rxmode>(),
         4usize,
-        concat!("Alignment of ", stringify!(rte_eth_rxmode)),
+        "Alignment of rte_eth_rxmode",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).mq_mode) as usize - ptr as usize },
         0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_rxmode),
-            "::",
-            stringify!(mq_mode),
-        ),
+        "Offset of field: rte_eth_rxmode::mq_mode",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).max_rx_pkt_len) as usize - ptr as usize },
         4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_rxmode),
-            "::",
-            stringify!(max_rx_pkt_len),
-        ),
+        "Offset of field: rte_eth_rxmode::max_rx_pkt_len",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).split_hdr_size) as usize - ptr as usize },
         8usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_rxmode),
-            "::",
-            stringify!(split_hdr_size),
-        ),
+        "Offset of field: rte_eth_rxmode::split_hdr_size",
     );
 }
 impl Default for rte_eth_rxmode {
@@ -447,27 +432,22 @@ fn bindgen_test_layout_rte_eth_txmode() {
     assert_eq!(
         ::std::mem::size_of::<rte_eth_txmode>(),
         8usize,
-        concat!("Size of: ", stringify!(rte_eth_txmode)),
+        "Size of rte_eth_txmode",
     );
     assert_eq!(
         ::std::mem::align_of::<rte_eth_txmode>(),
         4usize,
-        concat!("Alignment of ", stringify!(rte_eth_txmode)),
+        "Alignment of rte_eth_txmode",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).mq_mode) as usize - ptr as usize },
         0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_txmode),
-            "::",
-            stringify!(mq_mode),
-        ),
+        "Offset of field: rte_eth_txmode::mq_mode",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).pvid) as usize - ptr as usize },
         4usize,
-        concat!("Offset of field: ", stringify!(rte_eth_txmode), "::", stringify!(pvid)),
+        "Offset of field: rte_eth_txmode::pvid",
     );
 }
 impl Default for rte_eth_txmode {
@@ -588,42 +568,27 @@ fn bindgen_test_layout_rte_eth_rss_conf() {
     assert_eq!(
         ::std::mem::size_of::<rte_eth_rss_conf>(),
         24usize,
-        concat!("Size of: ", stringify!(rte_eth_rss_conf)),
+        "Size of rte_eth_rss_conf",
     );
     assert_eq!(
         ::std::mem::align_of::<rte_eth_rss_conf>(),
         8usize,
-        concat!("Alignment of ", stringify!(rte_eth_rss_conf)),
+        "Alignment of rte_eth_rss_conf",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).rss_key) as usize - ptr as usize },
         0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_rss_conf),
-            "::",
-            stringify!(rss_key),
-        ),
+        "Offset of field: rte_eth_rss_conf::rss_key",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).rss_key_len) as usize - ptr as usize },
         8usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_rss_conf),
-            "::",
-            stringify!(rss_key_len),
-        ),
+        "Offset of field: rte_eth_rss_conf::rss_key_len",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).rss_hf) as usize - ptr as usize },
         16usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_rss_conf),
-            "::",
-            stringify!(rss_hf),
-        ),
+        "Offset of field: rte_eth_rss_conf::rss_hf",
     );
 }
 impl Default for rte_eth_rss_conf {
@@ -698,32 +663,22 @@ fn bindgen_test_layout_rte_eth_vmdq_dcb_conf__bindgen_ty_1() {
     assert_eq!(
         ::std::mem::size_of::<rte_eth_vmdq_dcb_conf__bindgen_ty_1>(),
         16usize,
-        concat!("Size of: ", stringify!(rte_eth_vmdq_dcb_conf__bindgen_ty_1)),
+        "Size of rte_eth_vmdq_dcb_conf__bindgen_ty_1",
     );
     assert_eq!(
         ::std::mem::align_of::<rte_eth_vmdq_dcb_conf__bindgen_ty_1>(),
         8usize,
-        concat!("Alignment of ", stringify!(rte_eth_vmdq_dcb_conf__bindgen_ty_1)),
+        "Alignment of rte_eth_vmdq_dcb_conf__bindgen_ty_1",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).vlan_id) as usize - ptr as usize },
         0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_vmdq_dcb_conf__bindgen_ty_1),
-            "::",
-            stringify!(vlan_id),
-        ),
+        "Offset of field: rte_eth_vmdq_dcb_conf__bindgen_ty_1::vlan_id",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).pools) as usize - ptr as usize },
         8usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_vmdq_dcb_conf__bindgen_ty_1),
-            "::",
-            stringify!(pools),
-        ),
+        "Offset of field: rte_eth_vmdq_dcb_conf__bindgen_ty_1::pools",
     );
 }
 #[test]
@@ -733,74 +688,44 @@ fn bindgen_test_layout_rte_eth_vmdq_dcb_conf() {
     assert_eq!(
         ::std::mem::size_of::<rte_eth_vmdq_dcb_conf>(),
         1040usize,
-        concat!("Size of: ", stringify!(rte_eth_vmdq_dcb_conf)),
+        "Size of rte_eth_vmdq_dcb_conf",
     );
     assert_eq!(
         ::std::mem::align_of::<rte_eth_vmdq_dcb_conf>(),
         8usize,
-        concat!("Alignment of ", stringify!(rte_eth_vmdq_dcb_conf)),
+        "Alignment of rte_eth_vmdq_dcb_conf",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).nb_queue_pools) as usize - ptr as usize },
         0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_vmdq_dcb_conf),
-            "::",
-            stringify!(nb_queue_pools),
-        ),
+        "Offset of field: rte_eth_vmdq_dcb_conf::nb_queue_pools",
     );
     assert_eq!(
         unsafe {
             ::std::ptr::addr_of!((*ptr).enable_default_pool) as usize - ptr as usize
         },
         4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_vmdq_dcb_conf),
-            "::",
-            stringify!(enable_default_pool),
-        ),
+        "Offset of field: rte_eth_vmdq_dcb_conf::enable_default_pool",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).default_pool) as usize - ptr as usize },
         5usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_vmdq_dcb_conf),
-            "::",
-            stringify!(default_pool),
-        ),
+        "Offset of field: rte_eth_vmdq_dcb_conf::default_pool",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).nb_pool_maps) as usize - ptr as usize },
         6usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_vmdq_dcb_conf),
-            "::",
-            stringify!(nb_pool_maps),
-        ),
+        "Offset of field: rte_eth_vmdq_dcb_conf::nb_pool_maps",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).pool_map) as usize - ptr as usize },
         8usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_vmdq_dcb_conf),
-            "::",
-            stringify!(pool_map),
-        ),
+        "Offset of field: rte_eth_vmdq_dcb_conf::pool_map",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).dcb_tc) as usize - ptr as usize },
         1032usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_vmdq_dcb_conf),
-            "::",
-            stringify!(dcb_tc),
-        ),
+        "Offset of field: rte_eth_vmdq_dcb_conf::dcb_tc",
     );
 }
 impl Default for rte_eth_vmdq_dcb_conf {
@@ -827,32 +752,22 @@ fn bindgen_test_layout_rte_eth_dcb_rx_conf() {
     assert_eq!(
         ::std::mem::size_of::<rte_eth_dcb_rx_conf>(),
         12usize,
-        concat!("Size of: ", stringify!(rte_eth_dcb_rx_conf)),
+        "Size of rte_eth_dcb_rx_conf",
     );
     assert_eq!(
         ::std::mem::align_of::<rte_eth_dcb_rx_conf>(),
         4usize,
-        concat!("Alignment of ", stringify!(rte_eth_dcb_rx_conf)),
+        "Alignment of rte_eth_dcb_rx_conf",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).nb_tcs) as usize - ptr as usize },
         0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_dcb_rx_conf),
-            "::",
-            stringify!(nb_tcs),
-        ),
+        "Offset of field: rte_eth_dcb_rx_conf::nb_tcs",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).dcb_tc) as usize - ptr as usize },
         4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_dcb_rx_conf),
-            "::",
-            stringify!(dcb_tc),
-        ),
+        "Offset of field: rte_eth_dcb_rx_conf::dcb_tc",
     );
 }
 impl Default for rte_eth_dcb_rx_conf {
@@ -879,32 +794,22 @@ fn bindgen_test_layout_rte_eth_vmdq_dcb_tx_conf() {
     assert_eq!(
         ::std::mem::size_of::<rte_eth_vmdq_dcb_tx_conf>(),
         12usize,
-        concat!("Size of: ", stringify!(rte_eth_vmdq_dcb_tx_conf)),
+        "Size of rte_eth_vmdq_dcb_tx_conf",
     );
     assert_eq!(
         ::std::mem::align_of::<rte_eth_vmdq_dcb_tx_conf>(),
         4usize,
-        concat!("Alignment of ", stringify!(rte_eth_vmdq_dcb_tx_conf)),
+        "Alignment of rte_eth_vmdq_dcb_tx_conf",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).nb_queue_pools) as usize - ptr as usize },
         0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_vmdq_dcb_tx_conf),
-            "::",
-            stringify!(nb_queue_pools),
-        ),
+        "Offset of field: rte_eth_vmdq_dcb_tx_conf::nb_queue_pools",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).dcb_tc) as usize - ptr as usize },
         4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_vmdq_dcb_tx_conf),
-            "::",
-            stringify!(dcb_tc),
-        ),
+        "Offset of field: rte_eth_vmdq_dcb_tx_conf::dcb_tc",
     );
 }
 impl Default for rte_eth_vmdq_dcb_tx_conf {
@@ -931,32 +836,22 @@ fn bindgen_test_layout_rte_eth_dcb_tx_conf() {
     assert_eq!(
         ::std::mem::size_of::<rte_eth_dcb_tx_conf>(),
         12usize,
-        concat!("Size of: ", stringify!(rte_eth_dcb_tx_conf)),
+        "Size of rte_eth_dcb_tx_conf",
     );
     assert_eq!(
         ::std::mem::align_of::<rte_eth_dcb_tx_conf>(),
         4usize,
-        concat!("Alignment of ", stringify!(rte_eth_dcb_tx_conf)),
+        "Alignment of rte_eth_dcb_tx_conf",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).nb_tcs) as usize - ptr as usize },
         0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_dcb_tx_conf),
-            "::",
-            stringify!(nb_tcs),
-        ),
+        "Offset of field: rte_eth_dcb_tx_conf::nb_tcs",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).dcb_tc) as usize - ptr as usize },
         4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_dcb_tx_conf),
-            "::",
-            stringify!(dcb_tc),
-        ),
+        "Offset of field: rte_eth_dcb_tx_conf::dcb_tc",
     );
 }
 impl Default for rte_eth_dcb_tx_conf {
@@ -981,22 +876,17 @@ fn bindgen_test_layout_rte_eth_vmdq_tx_conf() {
     assert_eq!(
         ::std::mem::size_of::<rte_eth_vmdq_tx_conf>(),
         4usize,
-        concat!("Size of: ", stringify!(rte_eth_vmdq_tx_conf)),
+        "Size of rte_eth_vmdq_tx_conf",
     );
     assert_eq!(
         ::std::mem::align_of::<rte_eth_vmdq_tx_conf>(),
         4usize,
-        concat!("Alignment of ", stringify!(rte_eth_vmdq_tx_conf)),
+        "Alignment of rte_eth_vmdq_tx_conf",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).nb_queue_pools) as usize - ptr as usize },
         0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_vmdq_tx_conf),
-            "::",
-            stringify!(nb_queue_pools),
-        ),
+        "Offset of field: rte_eth_vmdq_tx_conf::nb_queue_pools",
     );
 }
 impl Default for rte_eth_vmdq_tx_conf {
@@ -1041,32 +931,22 @@ fn bindgen_test_layout_rte_eth_vmdq_rx_conf__bindgen_ty_1() {
     assert_eq!(
         ::std::mem::size_of::<rte_eth_vmdq_rx_conf__bindgen_ty_1>(),
         16usize,
-        concat!("Size of: ", stringify!(rte_eth_vmdq_rx_conf__bindgen_ty_1)),
+        "Size of rte_eth_vmdq_rx_conf__bindgen_ty_1",
     );
     assert_eq!(
         ::std::mem::align_of::<rte_eth_vmdq_rx_conf__bindgen_ty_1>(),
         8usize,
-        concat!("Alignment of ", stringify!(rte_eth_vmdq_rx_conf__bindgen_ty_1)),
+        "Alignment of rte_eth_vmdq_rx_conf__bindgen_ty_1",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).vlan_id) as usize - ptr as usize },
         0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_vmdq_rx_conf__bindgen_ty_1),
-            "::",
-            stringify!(vlan_id),
-        ),
+        "Offset of field: rte_eth_vmdq_rx_conf__bindgen_ty_1::vlan_id",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).pools) as usize - ptr as usize },
         8usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_vmdq_rx_conf__bindgen_ty_1),
-            "::",
-            stringify!(pools),
-        ),
+        "Offset of field: rte_eth_vmdq_rx_conf__bindgen_ty_1::pools",
     );
 }
 #[test]
@@ -1076,84 +956,49 @@ fn bindgen_test_layout_rte_eth_vmdq_rx_conf() {
     assert_eq!(
         ::std::mem::size_of::<rte_eth_vmdq_rx_conf>(),
         1040usize,
-        concat!("Size of: ", stringify!(rte_eth_vmdq_rx_conf)),
+        "Size of rte_eth_vmdq_rx_conf",
     );
     assert_eq!(
         ::std::mem::align_of::<rte_eth_vmdq_rx_conf>(),
         8usize,
-        concat!("Alignment of ", stringify!(rte_eth_vmdq_rx_conf)),
+        "Alignment of rte_eth_vmdq_rx_conf",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).nb_queue_pools) as usize - ptr as usize },
         0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_vmdq_rx_conf),
-            "::",
-            stringify!(nb_queue_pools),
-        ),
+        "Offset of field: rte_eth_vmdq_rx_conf::nb_queue_pools",
     );
     assert_eq!(
         unsafe {
             ::std::ptr::addr_of!((*ptr).enable_default_pool) as usize - ptr as usize
         },
         4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_vmdq_rx_conf),
-            "::",
-            stringify!(enable_default_pool),
-        ),
+        "Offset of field: rte_eth_vmdq_rx_conf::enable_default_pool",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).default_pool) as usize - ptr as usize },
         5usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_vmdq_rx_conf),
-            "::",
-            stringify!(default_pool),
-        ),
+        "Offset of field: rte_eth_vmdq_rx_conf::default_pool",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).enable_loop_back) as usize - ptr as usize },
         6usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_vmdq_rx_conf),
-            "::",
-            stringify!(enable_loop_back),
-        ),
+        "Offset of field: rte_eth_vmdq_rx_conf::enable_loop_back",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).nb_pool_maps) as usize - ptr as usize },
         7usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_vmdq_rx_conf),
-            "::",
-            stringify!(nb_pool_maps),
-        ),
+        "Offset of field: rte_eth_vmdq_rx_conf::nb_pool_maps",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).rx_mode) as usize - ptr as usize },
         8usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_vmdq_rx_conf),
-            "::",
-            stringify!(rx_mode),
-        ),
+        "Offset of field: rte_eth_vmdq_rx_conf::rx_mode",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).pool_map) as usize - ptr as usize },
         16usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_vmdq_rx_conf),
-            "::",
-            stringify!(pool_map),
-        ),
+        "Offset of field: rte_eth_vmdq_rx_conf::pool_map",
     );
 }
 impl Default for rte_eth_vmdq_rx_conf {
@@ -1225,62 +1070,37 @@ fn bindgen_test_layout_rte_eth_ipv4_flow() {
     assert_eq!(
         ::std::mem::size_of::<rte_eth_ipv4_flow>(),
         12usize,
-        concat!("Size of: ", stringify!(rte_eth_ipv4_flow)),
+        "Size of rte_eth_ipv4_flow",
     );
     assert_eq!(
         ::std::mem::align_of::<rte_eth_ipv4_flow>(),
         4usize,
-        concat!("Alignment of ", stringify!(rte_eth_ipv4_flow)),
+        "Alignment of rte_eth_ipv4_flow",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).src_ip) as usize - ptr as usize },
         0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_ipv4_flow),
-            "::",
-            stringify!(src_ip),
-        ),
+        "Offset of field: rte_eth_ipv4_flow::src_ip",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).dst_ip) as usize - ptr as usize },
         4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_ipv4_flow),
-            "::",
-            stringify!(dst_ip),
-        ),
+        "Offset of field: rte_eth_ipv4_flow::dst_ip",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).tos) as usize - ptr as usize },
         8usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_ipv4_flow),
-            "::",
-            stringify!(tos),
-        ),
+        "Offset of field: rte_eth_ipv4_flow::tos",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).ttl) as usize - ptr as usize },
         9usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_ipv4_flow),
-            "::",
-            stringify!(ttl),
-        ),
+        "Offset of field: rte_eth_ipv4_flow::ttl",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).proto) as usize - ptr as usize },
         10usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_ipv4_flow),
-            "::",
-            stringify!(proto),
-        ),
+        "Offset of field: rte_eth_ipv4_flow::proto",
     );
 }
 /// A structure used to define the input for IPV6 flow
@@ -1305,57 +1125,37 @@ fn bindgen_test_layout_rte_eth_ipv6_flow() {
     assert_eq!(
         ::std::mem::size_of::<rte_eth_ipv6_flow>(),
         36usize,
-        concat!("Size of: ", stringify!(rte_eth_ipv6_flow)),
+        "Size of rte_eth_ipv6_flow",
     );
     assert_eq!(
         ::std::mem::align_of::<rte_eth_ipv6_flow>(),
         4usize,
-        concat!("Alignment of ", stringify!(rte_eth_ipv6_flow)),
+        "Alignment of rte_eth_ipv6_flow",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).src_ip) as usize - ptr as usize },
         0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_ipv6_flow),
-            "::",
-            stringify!(src_ip),
-        ),
+        "Offset of field: rte_eth_ipv6_flow::src_ip",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).dst_ip) as usize - ptr as usize },
         16usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_ipv6_flow),
-            "::",
-            stringify!(dst_ip),
-        ),
+        "Offset of field: rte_eth_ipv6_flow::dst_ip",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).tc) as usize - ptr as usize },
         32usize,
-        concat!("Offset of field: ", stringify!(rte_eth_ipv6_flow), "::", stringify!(tc)),
+        "Offset of field: rte_eth_ipv6_flow::tc",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).proto) as usize - ptr as usize },
         33usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_ipv6_flow),
-            "::",
-            stringify!(proto),
-        ),
+        "Offset of field: rte_eth_ipv6_flow::proto",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).hop_limits) as usize - ptr as usize },
         34usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_ipv6_flow),
-            "::",
-            stringify!(hop_limits),
-        ),
+        "Offset of field: rte_eth_ipv6_flow::hop_limits",
     );
 }
 /**  A structure used to configure FDIR masks that are used by the device
@@ -1389,94 +1189,54 @@ fn bindgen_test_layout_rte_eth_fdir_masks() {
     assert_eq!(
         ::std::mem::size_of::<rte_eth_fdir_masks>(),
         68usize,
-        concat!("Size of: ", stringify!(rte_eth_fdir_masks)),
+        "Size of rte_eth_fdir_masks",
     );
     assert_eq!(
         ::std::mem::align_of::<rte_eth_fdir_masks>(),
         4usize,
-        concat!("Alignment of ", stringify!(rte_eth_fdir_masks)),
+        "Alignment of rte_eth_fdir_masks",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).vlan_tci_mask) as usize - ptr as usize },
         0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_fdir_masks),
-            "::",
-            stringify!(vlan_tci_mask),
-        ),
+        "Offset of field: rte_eth_fdir_masks::vlan_tci_mask",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).ipv4_mask) as usize - ptr as usize },
         4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_fdir_masks),
-            "::",
-            stringify!(ipv4_mask),
-        ),
+        "Offset of field: rte_eth_fdir_masks::ipv4_mask",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).ipv6_mask) as usize - ptr as usize },
         16usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_fdir_masks),
-            "::",
-            stringify!(ipv6_mask),
-        ),
+        "Offset of field: rte_eth_fdir_masks::ipv6_mask",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).src_port_mask) as usize - ptr as usize },
         52usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_fdir_masks),
-            "::",
-            stringify!(src_port_mask),
-        ),
+        "Offset of field: rte_eth_fdir_masks::src_port_mask",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).dst_port_mask) as usize - ptr as usize },
         54usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_fdir_masks),
-            "::",
-            stringify!(dst_port_mask),
-        ),
+        "Offset of field: rte_eth_fdir_masks::dst_port_mask",
     );
     assert_eq!(
         unsafe {
             ::std::ptr::addr_of!((*ptr).mac_addr_byte_mask) as usize - ptr as usize
         },
         56usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_fdir_masks),
-            "::",
-            stringify!(mac_addr_byte_mask),
-        ),
+        "Offset of field: rte_eth_fdir_masks::mac_addr_byte_mask",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).tunnel_id_mask) as usize - ptr as usize },
         60usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_fdir_masks),
-            "::",
-            stringify!(tunnel_id_mask),
-        ),
+        "Offset of field: rte_eth_fdir_masks::tunnel_id_mask",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).tunnel_type_mask) as usize - ptr as usize },
         64usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_fdir_masks),
-            "::",
-            stringify!(tunnel_type_mask),
-        ),
+        "Offset of field: rte_eth_fdir_masks::tunnel_type_mask",
     );
 }
 #[repr(u32)]
@@ -1506,32 +1266,22 @@ fn bindgen_test_layout_rte_eth_flex_payload_cfg() {
     assert_eq!(
         ::std::mem::size_of::<rte_eth_flex_payload_cfg>(),
         36usize,
-        concat!("Size of: ", stringify!(rte_eth_flex_payload_cfg)),
+        "Size of rte_eth_flex_payload_cfg",
     );
     assert_eq!(
         ::std::mem::align_of::<rte_eth_flex_payload_cfg>(),
         4usize,
-        concat!("Alignment of ", stringify!(rte_eth_flex_payload_cfg)),
+        "Alignment of rte_eth_flex_payload_cfg",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).type_) as usize - ptr as usize },
         0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_flex_payload_cfg),
-            "::",
-            stringify!(type_),
-        ),
+        "Offset of field: rte_eth_flex_payload_cfg::type_",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).src_offset) as usize - ptr as usize },
         4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_flex_payload_cfg),
-            "::",
-            stringify!(src_offset),
-        ),
+        "Offset of field: rte_eth_flex_payload_cfg::src_offset",
     );
 }
 impl Default for rte_eth_flex_payload_cfg {
@@ -1558,32 +1308,22 @@ fn bindgen_test_layout_rte_eth_fdir_flex_mask() {
     assert_eq!(
         ::std::mem::size_of::<rte_eth_fdir_flex_mask>(),
         18usize,
-        concat!("Size of: ", stringify!(rte_eth_fdir_flex_mask)),
+        "Size of rte_eth_fdir_flex_mask",
     );
     assert_eq!(
         ::std::mem::align_of::<rte_eth_fdir_flex_mask>(),
         2usize,
-        concat!("Alignment of ", stringify!(rte_eth_fdir_flex_mask)),
+        "Alignment of rte_eth_fdir_flex_mask",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).flow_type) as usize - ptr as usize },
         0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_fdir_flex_mask),
-            "::",
-            stringify!(flow_type),
-        ),
+        "Offset of field: rte_eth_fdir_flex_mask::flow_type",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).mask) as usize - ptr as usize },
         2usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_fdir_flex_mask),
-            "::",
-            stringify!(mask),
-        ),
+        "Offset of field: rte_eth_fdir_flex_mask::mask",
     );
 }
 /** A structure used to define all flexible payload related setting
@@ -1605,52 +1345,32 @@ fn bindgen_test_layout_rte_eth_fdir_flex_conf() {
     assert_eq!(
         ::std::mem::size_of::<rte_eth_fdir_flex_conf>(),
         688usize,
-        concat!("Size of: ", stringify!(rte_eth_fdir_flex_conf)),
+        "Size of rte_eth_fdir_flex_conf",
     );
     assert_eq!(
         ::std::mem::align_of::<rte_eth_fdir_flex_conf>(),
         4usize,
-        concat!("Alignment of ", stringify!(rte_eth_fdir_flex_conf)),
+        "Alignment of rte_eth_fdir_flex_conf",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).nb_payloads) as usize - ptr as usize },
         0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_fdir_flex_conf),
-            "::",
-            stringify!(nb_payloads),
-        ),
+        "Offset of field: rte_eth_fdir_flex_conf::nb_payloads",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).nb_flexmasks) as usize - ptr as usize },
         2usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_fdir_flex_conf),
-            "::",
-            stringify!(nb_flexmasks),
-        ),
+        "Offset of field: rte_eth_fdir_flex_conf::nb_flexmasks",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).flex_set) as usize - ptr as usize },
         4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_fdir_flex_conf),
-            "::",
-            stringify!(flex_set),
-        ),
+        "Offset of field: rte_eth_fdir_flex_conf::flex_set",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).flex_mask) as usize - ptr as usize },
         292usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_fdir_flex_conf),
-            "::",
-            stringify!(flex_mask),
-        ),
+        "Offset of field: rte_eth_fdir_flex_conf::flex_mask",
     );
 }
 impl Default for rte_eth_fdir_flex_conf {
@@ -1687,57 +1407,42 @@ fn bindgen_test_layout_rte_fdir_conf() {
     assert_eq!(
         ::std::mem::size_of::<rte_fdir_conf>(),
         772usize,
-        concat!("Size of: ", stringify!(rte_fdir_conf)),
+        "Size of rte_fdir_conf",
     );
     assert_eq!(
         ::std::mem::align_of::<rte_fdir_conf>(),
         4usize,
-        concat!("Alignment of ", stringify!(rte_fdir_conf)),
+        "Alignment of rte_fdir_conf",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).mode) as usize - ptr as usize },
         0usize,
-        concat!("Offset of field: ", stringify!(rte_fdir_conf), "::", stringify!(mode)),
+        "Offset of field: rte_fdir_conf::mode",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).pballoc) as usize - ptr as usize },
         4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_fdir_conf),
-            "::",
-            stringify!(pballoc),
-        ),
+        "Offset of field: rte_fdir_conf::pballoc",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).status) as usize - ptr as usize },
         8usize,
-        concat!("Offset of field: ", stringify!(rte_fdir_conf), "::", stringify!(status)),
+        "Offset of field: rte_fdir_conf::status",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).drop_queue) as usize - ptr as usize },
         12usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_fdir_conf),
-            "::",
-            stringify!(drop_queue),
-        ),
+        "Offset of field: rte_fdir_conf::drop_queue",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).mask) as usize - ptr as usize },
         16usize,
-        concat!("Offset of field: ", stringify!(rte_fdir_conf), "::", stringify!(mask)),
+        "Offset of field: rte_fdir_conf::mask",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).flex_conf) as usize - ptr as usize },
         84usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_fdir_conf),
-            "::",
-            stringify!(flex_conf),
-        ),
+        "Offset of field: rte_fdir_conf::flex_conf",
     );
 }
 impl Default for rte_fdir_conf {
@@ -1762,25 +1467,21 @@ pub struct rte_intr_conf {
 fn bindgen_test_layout_rte_intr_conf() {
     const UNINIT: ::std::mem::MaybeUninit<rte_intr_conf> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<rte_intr_conf>(),
-        4usize,
-        concat!("Size of: ", stringify!(rte_intr_conf)),
-    );
+    assert_eq!(::std::mem::size_of::<rte_intr_conf>(), 4usize, "Size of rte_intr_conf");
     assert_eq!(
         ::std::mem::align_of::<rte_intr_conf>(),
         2usize,
-        concat!("Alignment of ", stringify!(rte_intr_conf)),
+        "Alignment of rte_intr_conf",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).lsc) as usize - ptr as usize },
         0usize,
-        concat!("Offset of field: ", stringify!(rte_intr_conf), "::", stringify!(lsc)),
+        "Offset of field: rte_intr_conf::lsc",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).rxq) as usize - ptr as usize },
         2usize,
-        concat!("Offset of field: ", stringify!(rte_intr_conf), "::", stringify!(rxq)),
+        "Offset of field: rte_intr_conf::rxq",
     );
 }
 /** A structure used to configure an Ethernet port.
@@ -1835,52 +1536,32 @@ fn bindgen_test_layout_rte_eth_conf__bindgen_ty_1() {
     assert_eq!(
         ::std::mem::size_of::<rte_eth_conf__bindgen_ty_1>(),
         2120usize,
-        concat!("Size of: ", stringify!(rte_eth_conf__bindgen_ty_1)),
+        "Size of rte_eth_conf__bindgen_ty_1",
     );
     assert_eq!(
         ::std::mem::align_of::<rte_eth_conf__bindgen_ty_1>(),
         8usize,
-        concat!("Alignment of ", stringify!(rte_eth_conf__bindgen_ty_1)),
+        "Alignment of rte_eth_conf__bindgen_ty_1",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).rss_conf) as usize - ptr as usize },
         0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_conf__bindgen_ty_1),
-            "::",
-            stringify!(rss_conf),
-        ),
+        "Offset of field: rte_eth_conf__bindgen_ty_1::rss_conf",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).vmdq_dcb_conf) as usize - ptr as usize },
         24usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_conf__bindgen_ty_1),
-            "::",
-            stringify!(vmdq_dcb_conf),
-        ),
+        "Offset of field: rte_eth_conf__bindgen_ty_1::vmdq_dcb_conf",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).dcb_rx_conf) as usize - ptr as usize },
         1064usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_conf__bindgen_ty_1),
-            "::",
-            stringify!(dcb_rx_conf),
-        ),
+        "Offset of field: rte_eth_conf__bindgen_ty_1::dcb_rx_conf",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).vmdq_rx_conf) as usize - ptr as usize },
         1080usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_conf__bindgen_ty_1),
-            "::",
-            stringify!(vmdq_rx_conf),
-        ),
+        "Offset of field: rte_eth_conf__bindgen_ty_1::vmdq_rx_conf",
     );
 }
 impl Default for rte_eth_conf__bindgen_ty_1 {
@@ -1906,42 +1587,27 @@ fn bindgen_test_layout_rte_eth_conf__bindgen_ty_2() {
     assert_eq!(
         ::std::mem::size_of::<rte_eth_conf__bindgen_ty_2>(),
         12usize,
-        concat!("Size of: ", stringify!(rte_eth_conf__bindgen_ty_2)),
+        "Size of rte_eth_conf__bindgen_ty_2",
     );
     assert_eq!(
         ::std::mem::align_of::<rte_eth_conf__bindgen_ty_2>(),
         4usize,
-        concat!("Alignment of ", stringify!(rte_eth_conf__bindgen_ty_2)),
+        "Alignment of rte_eth_conf__bindgen_ty_2",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).vmdq_dcb_tx_conf) as usize - ptr as usize },
         0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_conf__bindgen_ty_2),
-            "::",
-            stringify!(vmdq_dcb_tx_conf),
-        ),
+        "Offset of field: rte_eth_conf__bindgen_ty_2::vmdq_dcb_tx_conf",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).dcb_tx_conf) as usize - ptr as usize },
         0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_conf__bindgen_ty_2),
-            "::",
-            stringify!(dcb_tx_conf),
-        ),
+        "Offset of field: rte_eth_conf__bindgen_ty_2::dcb_tx_conf",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).vmdq_tx_conf) as usize - ptr as usize },
         0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_conf__bindgen_ty_2),
-            "::",
-            stringify!(vmdq_tx_conf),
-        ),
+        "Offset of field: rte_eth_conf__bindgen_ty_2::vmdq_tx_conf",
     );
 }
 impl Default for rte_eth_conf__bindgen_ty_2 {
@@ -1957,97 +1623,58 @@ impl Default for rte_eth_conf__bindgen_ty_2 {
 fn bindgen_test_layout_rte_eth_conf() {
     const UNINIT: ::std::mem::MaybeUninit<rte_eth_conf> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<rte_eth_conf>(),
-        2944usize,
-        concat!("Size of: ", stringify!(rte_eth_conf)),
-    );
+    assert_eq!(::std::mem::size_of::<rte_eth_conf>(), 2944usize, "Size of rte_eth_conf");
     assert_eq!(
         ::std::mem::align_of::<rte_eth_conf>(),
         8usize,
-        concat!("Alignment of ", stringify!(rte_eth_conf)),
+        "Alignment of rte_eth_conf",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).link_speeds) as usize - ptr as usize },
         0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_conf),
-            "::",
-            stringify!(link_speeds),
-        ),
+        "Offset of field: rte_eth_conf::link_speeds",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).rxmode) as usize - ptr as usize },
         4usize,
-        concat!("Offset of field: ", stringify!(rte_eth_conf), "::", stringify!(rxmode)),
+        "Offset of field: rte_eth_conf::rxmode",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).txmode) as usize - ptr as usize },
         16usize,
-        concat!("Offset of field: ", stringify!(rte_eth_conf), "::", stringify!(txmode)),
+        "Offset of field: rte_eth_conf::txmode",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).lpbk_mode) as usize - ptr as usize },
         24usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_conf),
-            "::",
-            stringify!(lpbk_mode),
-        ),
+        "Offset of field: rte_eth_conf::lpbk_mode",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).rx_adv_conf) as usize - ptr as usize },
         32usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_conf),
-            "::",
-            stringify!(rx_adv_conf),
-        ),
+        "Offset of field: rte_eth_conf::rx_adv_conf",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).tx_adv_conf) as usize - ptr as usize },
         2152usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_conf),
-            "::",
-            stringify!(tx_adv_conf),
-        ),
+        "Offset of field: rte_eth_conf::tx_adv_conf",
     );
     assert_eq!(
         unsafe {
             ::std::ptr::addr_of!((*ptr).dcb_capability_en) as usize - ptr as usize
         },
         2164usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_conf),
-            "::",
-            stringify!(dcb_capability_en),
-        ),
+        "Offset of field: rte_eth_conf::dcb_capability_en",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).fdir_conf) as usize - ptr as usize },
         2168usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_conf),
-            "::",
-            stringify!(fdir_conf),
-        ),
+        "Offset of field: rte_eth_conf::fdir_conf",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).intr_conf) as usize - ptr as usize },
         2940usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_conf),
-            "::",
-            stringify!(intr_conf),
-        ),
+        "Offset of field: rte_eth_conf::intr_conf",
     );
 }
 impl Default for rte_eth_conf {

--- a/bindgen-tests/tests/expectations/tests/layout_eth_conf_1_0.rs
+++ b/bindgen-tests/tests/expectations/tests/layout_eth_conf_1_0.rs
@@ -200,42 +200,27 @@ fn bindgen_test_layout_rte_eth_rxmode() {
     assert_eq!(
         ::std::mem::size_of::<rte_eth_rxmode>(),
         12usize,
-        concat!("Size of: ", stringify!(rte_eth_rxmode)),
+        "Size of rte_eth_rxmode",
     );
     assert_eq!(
         ::std::mem::align_of::<rte_eth_rxmode>(),
         4usize,
-        concat!("Alignment of ", stringify!(rte_eth_rxmode)),
+        "Alignment of rte_eth_rxmode",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).mq_mode) as usize - ptr as usize },
         0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_rxmode),
-            "::",
-            stringify!(mq_mode),
-        ),
+        "Offset of field: rte_eth_rxmode::mq_mode",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).max_rx_pkt_len) as usize - ptr as usize },
         4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_rxmode),
-            "::",
-            stringify!(max_rx_pkt_len),
-        ),
+        "Offset of field: rte_eth_rxmode::max_rx_pkt_len",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).split_hdr_size) as usize - ptr as usize },
         8usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_rxmode),
-            "::",
-            stringify!(split_hdr_size),
-        ),
+        "Offset of field: rte_eth_rxmode::split_hdr_size",
     );
 }
 impl Clone for rte_eth_rxmode {
@@ -495,27 +480,22 @@ fn bindgen_test_layout_rte_eth_txmode() {
     assert_eq!(
         ::std::mem::size_of::<rte_eth_txmode>(),
         8usize,
-        concat!("Size of: ", stringify!(rte_eth_txmode)),
+        "Size of rte_eth_txmode",
     );
     assert_eq!(
         ::std::mem::align_of::<rte_eth_txmode>(),
         4usize,
-        concat!("Alignment of ", stringify!(rte_eth_txmode)),
+        "Alignment of rte_eth_txmode",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).mq_mode) as usize - ptr as usize },
         0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_txmode),
-            "::",
-            stringify!(mq_mode),
-        ),
+        "Offset of field: rte_eth_txmode::mq_mode",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).pvid) as usize - ptr as usize },
         4usize,
-        concat!("Offset of field: ", stringify!(rte_eth_txmode), "::", stringify!(pvid)),
+        "Offset of field: rte_eth_txmode::pvid",
     );
 }
 impl Clone for rte_eth_txmode {
@@ -641,42 +621,27 @@ fn bindgen_test_layout_rte_eth_rss_conf() {
     assert_eq!(
         ::std::mem::size_of::<rte_eth_rss_conf>(),
         24usize,
-        concat!("Size of: ", stringify!(rte_eth_rss_conf)),
+        "Size of rte_eth_rss_conf",
     );
     assert_eq!(
         ::std::mem::align_of::<rte_eth_rss_conf>(),
         8usize,
-        concat!("Alignment of ", stringify!(rte_eth_rss_conf)),
+        "Alignment of rte_eth_rss_conf",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).rss_key) as usize - ptr as usize },
         0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_rss_conf),
-            "::",
-            stringify!(rss_key),
-        ),
+        "Offset of field: rte_eth_rss_conf::rss_key",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).rss_key_len) as usize - ptr as usize },
         8usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_rss_conf),
-            "::",
-            stringify!(rss_key_len),
-        ),
+        "Offset of field: rte_eth_rss_conf::rss_key_len",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).rss_hf) as usize - ptr as usize },
         16usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_rss_conf),
-            "::",
-            stringify!(rss_hf),
-        ),
+        "Offset of field: rte_eth_rss_conf::rss_hf",
     );
 }
 impl Clone for rte_eth_rss_conf {
@@ -756,32 +721,22 @@ fn bindgen_test_layout_rte_eth_vmdq_dcb_conf__bindgen_ty_1() {
     assert_eq!(
         ::std::mem::size_of::<rte_eth_vmdq_dcb_conf__bindgen_ty_1>(),
         16usize,
-        concat!("Size of: ", stringify!(rte_eth_vmdq_dcb_conf__bindgen_ty_1)),
+        "Size of rte_eth_vmdq_dcb_conf__bindgen_ty_1",
     );
     assert_eq!(
         ::std::mem::align_of::<rte_eth_vmdq_dcb_conf__bindgen_ty_1>(),
         8usize,
-        concat!("Alignment of ", stringify!(rte_eth_vmdq_dcb_conf__bindgen_ty_1)),
+        "Alignment of rte_eth_vmdq_dcb_conf__bindgen_ty_1",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).vlan_id) as usize - ptr as usize },
         0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_vmdq_dcb_conf__bindgen_ty_1),
-            "::",
-            stringify!(vlan_id),
-        ),
+        "Offset of field: rte_eth_vmdq_dcb_conf__bindgen_ty_1::vlan_id",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).pools) as usize - ptr as usize },
         8usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_vmdq_dcb_conf__bindgen_ty_1),
-            "::",
-            stringify!(pools),
-        ),
+        "Offset of field: rte_eth_vmdq_dcb_conf__bindgen_ty_1::pools",
     );
 }
 impl Clone for rte_eth_vmdq_dcb_conf__bindgen_ty_1 {
@@ -796,74 +751,44 @@ fn bindgen_test_layout_rte_eth_vmdq_dcb_conf() {
     assert_eq!(
         ::std::mem::size_of::<rte_eth_vmdq_dcb_conf>(),
         1040usize,
-        concat!("Size of: ", stringify!(rte_eth_vmdq_dcb_conf)),
+        "Size of rte_eth_vmdq_dcb_conf",
     );
     assert_eq!(
         ::std::mem::align_of::<rte_eth_vmdq_dcb_conf>(),
         8usize,
-        concat!("Alignment of ", stringify!(rte_eth_vmdq_dcb_conf)),
+        "Alignment of rte_eth_vmdq_dcb_conf",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).nb_queue_pools) as usize - ptr as usize },
         0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_vmdq_dcb_conf),
-            "::",
-            stringify!(nb_queue_pools),
-        ),
+        "Offset of field: rte_eth_vmdq_dcb_conf::nb_queue_pools",
     );
     assert_eq!(
         unsafe {
             ::std::ptr::addr_of!((*ptr).enable_default_pool) as usize - ptr as usize
         },
         4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_vmdq_dcb_conf),
-            "::",
-            stringify!(enable_default_pool),
-        ),
+        "Offset of field: rte_eth_vmdq_dcb_conf::enable_default_pool",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).default_pool) as usize - ptr as usize },
         5usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_vmdq_dcb_conf),
-            "::",
-            stringify!(default_pool),
-        ),
+        "Offset of field: rte_eth_vmdq_dcb_conf::default_pool",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).nb_pool_maps) as usize - ptr as usize },
         6usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_vmdq_dcb_conf),
-            "::",
-            stringify!(nb_pool_maps),
-        ),
+        "Offset of field: rte_eth_vmdq_dcb_conf::nb_pool_maps",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).pool_map) as usize - ptr as usize },
         8usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_vmdq_dcb_conf),
-            "::",
-            stringify!(pool_map),
-        ),
+        "Offset of field: rte_eth_vmdq_dcb_conf::pool_map",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).dcb_tc) as usize - ptr as usize },
         1032usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_vmdq_dcb_conf),
-            "::",
-            stringify!(dcb_tc),
-        ),
+        "Offset of field: rte_eth_vmdq_dcb_conf::dcb_tc",
     );
 }
 impl Clone for rte_eth_vmdq_dcb_conf {
@@ -895,32 +820,22 @@ fn bindgen_test_layout_rte_eth_dcb_rx_conf() {
     assert_eq!(
         ::std::mem::size_of::<rte_eth_dcb_rx_conf>(),
         12usize,
-        concat!("Size of: ", stringify!(rte_eth_dcb_rx_conf)),
+        "Size of rte_eth_dcb_rx_conf",
     );
     assert_eq!(
         ::std::mem::align_of::<rte_eth_dcb_rx_conf>(),
         4usize,
-        concat!("Alignment of ", stringify!(rte_eth_dcb_rx_conf)),
+        "Alignment of rte_eth_dcb_rx_conf",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).nb_tcs) as usize - ptr as usize },
         0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_dcb_rx_conf),
-            "::",
-            stringify!(nb_tcs),
-        ),
+        "Offset of field: rte_eth_dcb_rx_conf::nb_tcs",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).dcb_tc) as usize - ptr as usize },
         4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_dcb_rx_conf),
-            "::",
-            stringify!(dcb_tc),
-        ),
+        "Offset of field: rte_eth_dcb_rx_conf::dcb_tc",
     );
 }
 impl Clone for rte_eth_dcb_rx_conf {
@@ -952,32 +867,22 @@ fn bindgen_test_layout_rte_eth_vmdq_dcb_tx_conf() {
     assert_eq!(
         ::std::mem::size_of::<rte_eth_vmdq_dcb_tx_conf>(),
         12usize,
-        concat!("Size of: ", stringify!(rte_eth_vmdq_dcb_tx_conf)),
+        "Size of rte_eth_vmdq_dcb_tx_conf",
     );
     assert_eq!(
         ::std::mem::align_of::<rte_eth_vmdq_dcb_tx_conf>(),
         4usize,
-        concat!("Alignment of ", stringify!(rte_eth_vmdq_dcb_tx_conf)),
+        "Alignment of rte_eth_vmdq_dcb_tx_conf",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).nb_queue_pools) as usize - ptr as usize },
         0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_vmdq_dcb_tx_conf),
-            "::",
-            stringify!(nb_queue_pools),
-        ),
+        "Offset of field: rte_eth_vmdq_dcb_tx_conf::nb_queue_pools",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).dcb_tc) as usize - ptr as usize },
         4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_vmdq_dcb_tx_conf),
-            "::",
-            stringify!(dcb_tc),
-        ),
+        "Offset of field: rte_eth_vmdq_dcb_tx_conf::dcb_tc",
     );
 }
 impl Clone for rte_eth_vmdq_dcb_tx_conf {
@@ -1009,32 +914,22 @@ fn bindgen_test_layout_rte_eth_dcb_tx_conf() {
     assert_eq!(
         ::std::mem::size_of::<rte_eth_dcb_tx_conf>(),
         12usize,
-        concat!("Size of: ", stringify!(rte_eth_dcb_tx_conf)),
+        "Size of rte_eth_dcb_tx_conf",
     );
     assert_eq!(
         ::std::mem::align_of::<rte_eth_dcb_tx_conf>(),
         4usize,
-        concat!("Alignment of ", stringify!(rte_eth_dcb_tx_conf)),
+        "Alignment of rte_eth_dcb_tx_conf",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).nb_tcs) as usize - ptr as usize },
         0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_dcb_tx_conf),
-            "::",
-            stringify!(nb_tcs),
-        ),
+        "Offset of field: rte_eth_dcb_tx_conf::nb_tcs",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).dcb_tc) as usize - ptr as usize },
         4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_dcb_tx_conf),
-            "::",
-            stringify!(dcb_tc),
-        ),
+        "Offset of field: rte_eth_dcb_tx_conf::dcb_tc",
     );
 }
 impl Clone for rte_eth_dcb_tx_conf {
@@ -1064,22 +959,17 @@ fn bindgen_test_layout_rte_eth_vmdq_tx_conf() {
     assert_eq!(
         ::std::mem::size_of::<rte_eth_vmdq_tx_conf>(),
         4usize,
-        concat!("Size of: ", stringify!(rte_eth_vmdq_tx_conf)),
+        "Size of rte_eth_vmdq_tx_conf",
     );
     assert_eq!(
         ::std::mem::align_of::<rte_eth_vmdq_tx_conf>(),
         4usize,
-        concat!("Alignment of ", stringify!(rte_eth_vmdq_tx_conf)),
+        "Alignment of rte_eth_vmdq_tx_conf",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).nb_queue_pools) as usize - ptr as usize },
         0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_vmdq_tx_conf),
-            "::",
-            stringify!(nb_queue_pools),
-        ),
+        "Offset of field: rte_eth_vmdq_tx_conf::nb_queue_pools",
     );
 }
 impl Clone for rte_eth_vmdq_tx_conf {
@@ -1129,32 +1019,22 @@ fn bindgen_test_layout_rte_eth_vmdq_rx_conf__bindgen_ty_1() {
     assert_eq!(
         ::std::mem::size_of::<rte_eth_vmdq_rx_conf__bindgen_ty_1>(),
         16usize,
-        concat!("Size of: ", stringify!(rte_eth_vmdq_rx_conf__bindgen_ty_1)),
+        "Size of rte_eth_vmdq_rx_conf__bindgen_ty_1",
     );
     assert_eq!(
         ::std::mem::align_of::<rte_eth_vmdq_rx_conf__bindgen_ty_1>(),
         8usize,
-        concat!("Alignment of ", stringify!(rte_eth_vmdq_rx_conf__bindgen_ty_1)),
+        "Alignment of rte_eth_vmdq_rx_conf__bindgen_ty_1",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).vlan_id) as usize - ptr as usize },
         0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_vmdq_rx_conf__bindgen_ty_1),
-            "::",
-            stringify!(vlan_id),
-        ),
+        "Offset of field: rte_eth_vmdq_rx_conf__bindgen_ty_1::vlan_id",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).pools) as usize - ptr as usize },
         8usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_vmdq_rx_conf__bindgen_ty_1),
-            "::",
-            stringify!(pools),
-        ),
+        "Offset of field: rte_eth_vmdq_rx_conf__bindgen_ty_1::pools",
     );
 }
 impl Clone for rte_eth_vmdq_rx_conf__bindgen_ty_1 {
@@ -1169,84 +1049,49 @@ fn bindgen_test_layout_rte_eth_vmdq_rx_conf() {
     assert_eq!(
         ::std::mem::size_of::<rte_eth_vmdq_rx_conf>(),
         1040usize,
-        concat!("Size of: ", stringify!(rte_eth_vmdq_rx_conf)),
+        "Size of rte_eth_vmdq_rx_conf",
     );
     assert_eq!(
         ::std::mem::align_of::<rte_eth_vmdq_rx_conf>(),
         8usize,
-        concat!("Alignment of ", stringify!(rte_eth_vmdq_rx_conf)),
+        "Alignment of rte_eth_vmdq_rx_conf",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).nb_queue_pools) as usize - ptr as usize },
         0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_vmdq_rx_conf),
-            "::",
-            stringify!(nb_queue_pools),
-        ),
+        "Offset of field: rte_eth_vmdq_rx_conf::nb_queue_pools",
     );
     assert_eq!(
         unsafe {
             ::std::ptr::addr_of!((*ptr).enable_default_pool) as usize - ptr as usize
         },
         4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_vmdq_rx_conf),
-            "::",
-            stringify!(enable_default_pool),
-        ),
+        "Offset of field: rte_eth_vmdq_rx_conf::enable_default_pool",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).default_pool) as usize - ptr as usize },
         5usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_vmdq_rx_conf),
-            "::",
-            stringify!(default_pool),
-        ),
+        "Offset of field: rte_eth_vmdq_rx_conf::default_pool",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).enable_loop_back) as usize - ptr as usize },
         6usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_vmdq_rx_conf),
-            "::",
-            stringify!(enable_loop_back),
-        ),
+        "Offset of field: rte_eth_vmdq_rx_conf::enable_loop_back",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).nb_pool_maps) as usize - ptr as usize },
         7usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_vmdq_rx_conf),
-            "::",
-            stringify!(nb_pool_maps),
-        ),
+        "Offset of field: rte_eth_vmdq_rx_conf::nb_pool_maps",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).rx_mode) as usize - ptr as usize },
         8usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_vmdq_rx_conf),
-            "::",
-            stringify!(rx_mode),
-        ),
+        "Offset of field: rte_eth_vmdq_rx_conf::rx_mode",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).pool_map) as usize - ptr as usize },
         16usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_vmdq_rx_conf),
-            "::",
-            stringify!(pool_map),
-        ),
+        "Offset of field: rte_eth_vmdq_rx_conf::pool_map",
     );
 }
 impl Clone for rte_eth_vmdq_rx_conf {
@@ -1323,62 +1168,37 @@ fn bindgen_test_layout_rte_eth_ipv4_flow() {
     assert_eq!(
         ::std::mem::size_of::<rte_eth_ipv4_flow>(),
         12usize,
-        concat!("Size of: ", stringify!(rte_eth_ipv4_flow)),
+        "Size of rte_eth_ipv4_flow",
     );
     assert_eq!(
         ::std::mem::align_of::<rte_eth_ipv4_flow>(),
         4usize,
-        concat!("Alignment of ", stringify!(rte_eth_ipv4_flow)),
+        "Alignment of rte_eth_ipv4_flow",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).src_ip) as usize - ptr as usize },
         0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_ipv4_flow),
-            "::",
-            stringify!(src_ip),
-        ),
+        "Offset of field: rte_eth_ipv4_flow::src_ip",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).dst_ip) as usize - ptr as usize },
         4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_ipv4_flow),
-            "::",
-            stringify!(dst_ip),
-        ),
+        "Offset of field: rte_eth_ipv4_flow::dst_ip",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).tos) as usize - ptr as usize },
         8usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_ipv4_flow),
-            "::",
-            stringify!(tos),
-        ),
+        "Offset of field: rte_eth_ipv4_flow::tos",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).ttl) as usize - ptr as usize },
         9usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_ipv4_flow),
-            "::",
-            stringify!(ttl),
-        ),
+        "Offset of field: rte_eth_ipv4_flow::ttl",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).proto) as usize - ptr as usize },
         10usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_ipv4_flow),
-            "::",
-            stringify!(proto),
-        ),
+        "Offset of field: rte_eth_ipv4_flow::proto",
     );
 }
 impl Clone for rte_eth_ipv4_flow {
@@ -1408,57 +1228,37 @@ fn bindgen_test_layout_rte_eth_ipv6_flow() {
     assert_eq!(
         ::std::mem::size_of::<rte_eth_ipv6_flow>(),
         36usize,
-        concat!("Size of: ", stringify!(rte_eth_ipv6_flow)),
+        "Size of rte_eth_ipv6_flow",
     );
     assert_eq!(
         ::std::mem::align_of::<rte_eth_ipv6_flow>(),
         4usize,
-        concat!("Alignment of ", stringify!(rte_eth_ipv6_flow)),
+        "Alignment of rte_eth_ipv6_flow",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).src_ip) as usize - ptr as usize },
         0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_ipv6_flow),
-            "::",
-            stringify!(src_ip),
-        ),
+        "Offset of field: rte_eth_ipv6_flow::src_ip",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).dst_ip) as usize - ptr as usize },
         16usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_ipv6_flow),
-            "::",
-            stringify!(dst_ip),
-        ),
+        "Offset of field: rte_eth_ipv6_flow::dst_ip",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).tc) as usize - ptr as usize },
         32usize,
-        concat!("Offset of field: ", stringify!(rte_eth_ipv6_flow), "::", stringify!(tc)),
+        "Offset of field: rte_eth_ipv6_flow::tc",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).proto) as usize - ptr as usize },
         33usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_ipv6_flow),
-            "::",
-            stringify!(proto),
-        ),
+        "Offset of field: rte_eth_ipv6_flow::proto",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).hop_limits) as usize - ptr as usize },
         34usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_ipv6_flow),
-            "::",
-            stringify!(hop_limits),
-        ),
+        "Offset of field: rte_eth_ipv6_flow::hop_limits",
     );
 }
 impl Clone for rte_eth_ipv6_flow {
@@ -1497,94 +1297,54 @@ fn bindgen_test_layout_rte_eth_fdir_masks() {
     assert_eq!(
         ::std::mem::size_of::<rte_eth_fdir_masks>(),
         68usize,
-        concat!("Size of: ", stringify!(rte_eth_fdir_masks)),
+        "Size of rte_eth_fdir_masks",
     );
     assert_eq!(
         ::std::mem::align_of::<rte_eth_fdir_masks>(),
         4usize,
-        concat!("Alignment of ", stringify!(rte_eth_fdir_masks)),
+        "Alignment of rte_eth_fdir_masks",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).vlan_tci_mask) as usize - ptr as usize },
         0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_fdir_masks),
-            "::",
-            stringify!(vlan_tci_mask),
-        ),
+        "Offset of field: rte_eth_fdir_masks::vlan_tci_mask",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).ipv4_mask) as usize - ptr as usize },
         4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_fdir_masks),
-            "::",
-            stringify!(ipv4_mask),
-        ),
+        "Offset of field: rte_eth_fdir_masks::ipv4_mask",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).ipv6_mask) as usize - ptr as usize },
         16usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_fdir_masks),
-            "::",
-            stringify!(ipv6_mask),
-        ),
+        "Offset of field: rte_eth_fdir_masks::ipv6_mask",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).src_port_mask) as usize - ptr as usize },
         52usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_fdir_masks),
-            "::",
-            stringify!(src_port_mask),
-        ),
+        "Offset of field: rte_eth_fdir_masks::src_port_mask",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).dst_port_mask) as usize - ptr as usize },
         54usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_fdir_masks),
-            "::",
-            stringify!(dst_port_mask),
-        ),
+        "Offset of field: rte_eth_fdir_masks::dst_port_mask",
     );
     assert_eq!(
         unsafe {
             ::std::ptr::addr_of!((*ptr).mac_addr_byte_mask) as usize - ptr as usize
         },
         56usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_fdir_masks),
-            "::",
-            stringify!(mac_addr_byte_mask),
-        ),
+        "Offset of field: rte_eth_fdir_masks::mac_addr_byte_mask",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).tunnel_id_mask) as usize - ptr as usize },
         60usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_fdir_masks),
-            "::",
-            stringify!(tunnel_id_mask),
-        ),
+        "Offset of field: rte_eth_fdir_masks::tunnel_id_mask",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).tunnel_type_mask) as usize - ptr as usize },
         64usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_fdir_masks),
-            "::",
-            stringify!(tunnel_type_mask),
-        ),
+        "Offset of field: rte_eth_fdir_masks::tunnel_type_mask",
     );
 }
 impl Clone for rte_eth_fdir_masks {
@@ -1619,32 +1379,22 @@ fn bindgen_test_layout_rte_eth_flex_payload_cfg() {
     assert_eq!(
         ::std::mem::size_of::<rte_eth_flex_payload_cfg>(),
         36usize,
-        concat!("Size of: ", stringify!(rte_eth_flex_payload_cfg)),
+        "Size of rte_eth_flex_payload_cfg",
     );
     assert_eq!(
         ::std::mem::align_of::<rte_eth_flex_payload_cfg>(),
         4usize,
-        concat!("Alignment of ", stringify!(rte_eth_flex_payload_cfg)),
+        "Alignment of rte_eth_flex_payload_cfg",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).type_) as usize - ptr as usize },
         0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_flex_payload_cfg),
-            "::",
-            stringify!(type_),
-        ),
+        "Offset of field: rte_eth_flex_payload_cfg::type_",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).src_offset) as usize - ptr as usize },
         4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_flex_payload_cfg),
-            "::",
-            stringify!(src_offset),
-        ),
+        "Offset of field: rte_eth_flex_payload_cfg::src_offset",
     );
 }
 impl Clone for rte_eth_flex_payload_cfg {
@@ -1676,32 +1426,22 @@ fn bindgen_test_layout_rte_eth_fdir_flex_mask() {
     assert_eq!(
         ::std::mem::size_of::<rte_eth_fdir_flex_mask>(),
         18usize,
-        concat!("Size of: ", stringify!(rte_eth_fdir_flex_mask)),
+        "Size of rte_eth_fdir_flex_mask",
     );
     assert_eq!(
         ::std::mem::align_of::<rte_eth_fdir_flex_mask>(),
         2usize,
-        concat!("Alignment of ", stringify!(rte_eth_fdir_flex_mask)),
+        "Alignment of rte_eth_fdir_flex_mask",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).flow_type) as usize - ptr as usize },
         0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_fdir_flex_mask),
-            "::",
-            stringify!(flow_type),
-        ),
+        "Offset of field: rte_eth_fdir_flex_mask::flow_type",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).mask) as usize - ptr as usize },
         2usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_fdir_flex_mask),
-            "::",
-            stringify!(mask),
-        ),
+        "Offset of field: rte_eth_fdir_flex_mask::mask",
     );
 }
 impl Clone for rte_eth_fdir_flex_mask {
@@ -1728,52 +1468,32 @@ fn bindgen_test_layout_rte_eth_fdir_flex_conf() {
     assert_eq!(
         ::std::mem::size_of::<rte_eth_fdir_flex_conf>(),
         688usize,
-        concat!("Size of: ", stringify!(rte_eth_fdir_flex_conf)),
+        "Size of rte_eth_fdir_flex_conf",
     );
     assert_eq!(
         ::std::mem::align_of::<rte_eth_fdir_flex_conf>(),
         4usize,
-        concat!("Alignment of ", stringify!(rte_eth_fdir_flex_conf)),
+        "Alignment of rte_eth_fdir_flex_conf",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).nb_payloads) as usize - ptr as usize },
         0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_fdir_flex_conf),
-            "::",
-            stringify!(nb_payloads),
-        ),
+        "Offset of field: rte_eth_fdir_flex_conf::nb_payloads",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).nb_flexmasks) as usize - ptr as usize },
         2usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_fdir_flex_conf),
-            "::",
-            stringify!(nb_flexmasks),
-        ),
+        "Offset of field: rte_eth_fdir_flex_conf::nb_flexmasks",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).flex_set) as usize - ptr as usize },
         4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_fdir_flex_conf),
-            "::",
-            stringify!(flex_set),
-        ),
+        "Offset of field: rte_eth_fdir_flex_conf::flex_set",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).flex_mask) as usize - ptr as usize },
         292usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_fdir_flex_conf),
-            "::",
-            stringify!(flex_mask),
-        ),
+        "Offset of field: rte_eth_fdir_flex_conf::flex_mask",
     );
 }
 impl Clone for rte_eth_fdir_flex_conf {
@@ -1815,57 +1535,42 @@ fn bindgen_test_layout_rte_fdir_conf() {
     assert_eq!(
         ::std::mem::size_of::<rte_fdir_conf>(),
         772usize,
-        concat!("Size of: ", stringify!(rte_fdir_conf)),
+        "Size of rte_fdir_conf",
     );
     assert_eq!(
         ::std::mem::align_of::<rte_fdir_conf>(),
         4usize,
-        concat!("Alignment of ", stringify!(rte_fdir_conf)),
+        "Alignment of rte_fdir_conf",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).mode) as usize - ptr as usize },
         0usize,
-        concat!("Offset of field: ", stringify!(rte_fdir_conf), "::", stringify!(mode)),
+        "Offset of field: rte_fdir_conf::mode",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).pballoc) as usize - ptr as usize },
         4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_fdir_conf),
-            "::",
-            stringify!(pballoc),
-        ),
+        "Offset of field: rte_fdir_conf::pballoc",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).status) as usize - ptr as usize },
         8usize,
-        concat!("Offset of field: ", stringify!(rte_fdir_conf), "::", stringify!(status)),
+        "Offset of field: rte_fdir_conf::status",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).drop_queue) as usize - ptr as usize },
         12usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_fdir_conf),
-            "::",
-            stringify!(drop_queue),
-        ),
+        "Offset of field: rte_fdir_conf::drop_queue",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).mask) as usize - ptr as usize },
         16usize,
-        concat!("Offset of field: ", stringify!(rte_fdir_conf), "::", stringify!(mask)),
+        "Offset of field: rte_fdir_conf::mask",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).flex_conf) as usize - ptr as usize },
         84usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_fdir_conf),
-            "::",
-            stringify!(flex_conf),
-        ),
+        "Offset of field: rte_fdir_conf::flex_conf",
     );
 }
 impl Clone for rte_fdir_conf {
@@ -1895,25 +1600,21 @@ pub struct rte_intr_conf {
 fn bindgen_test_layout_rte_intr_conf() {
     const UNINIT: ::std::mem::MaybeUninit<rte_intr_conf> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<rte_intr_conf>(),
-        4usize,
-        concat!("Size of: ", stringify!(rte_intr_conf)),
-    );
+    assert_eq!(::std::mem::size_of::<rte_intr_conf>(), 4usize, "Size of rte_intr_conf");
     assert_eq!(
         ::std::mem::align_of::<rte_intr_conf>(),
         2usize,
-        concat!("Alignment of ", stringify!(rte_intr_conf)),
+        "Alignment of rte_intr_conf",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).lsc) as usize - ptr as usize },
         0usize,
-        concat!("Offset of field: ", stringify!(rte_intr_conf), "::", stringify!(lsc)),
+        "Offset of field: rte_intr_conf::lsc",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).rxq) as usize - ptr as usize },
         2usize,
-        concat!("Offset of field: ", stringify!(rte_intr_conf), "::", stringify!(rxq)),
+        "Offset of field: rte_intr_conf::rxq",
     );
 }
 impl Clone for rte_intr_conf {
@@ -1973,52 +1674,32 @@ fn bindgen_test_layout_rte_eth_conf__bindgen_ty_1() {
     assert_eq!(
         ::std::mem::size_of::<rte_eth_conf__bindgen_ty_1>(),
         2120usize,
-        concat!("Size of: ", stringify!(rte_eth_conf__bindgen_ty_1)),
+        "Size of rte_eth_conf__bindgen_ty_1",
     );
     assert_eq!(
         ::std::mem::align_of::<rte_eth_conf__bindgen_ty_1>(),
         8usize,
-        concat!("Alignment of ", stringify!(rte_eth_conf__bindgen_ty_1)),
+        "Alignment of rte_eth_conf__bindgen_ty_1",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).rss_conf) as usize - ptr as usize },
         0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_conf__bindgen_ty_1),
-            "::",
-            stringify!(rss_conf),
-        ),
+        "Offset of field: rte_eth_conf__bindgen_ty_1::rss_conf",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).vmdq_dcb_conf) as usize - ptr as usize },
         24usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_conf__bindgen_ty_1),
-            "::",
-            stringify!(vmdq_dcb_conf),
-        ),
+        "Offset of field: rte_eth_conf__bindgen_ty_1::vmdq_dcb_conf",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).dcb_rx_conf) as usize - ptr as usize },
         1064usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_conf__bindgen_ty_1),
-            "::",
-            stringify!(dcb_rx_conf),
-        ),
+        "Offset of field: rte_eth_conf__bindgen_ty_1::dcb_rx_conf",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).vmdq_rx_conf) as usize - ptr as usize },
         1080usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_conf__bindgen_ty_1),
-            "::",
-            stringify!(vmdq_rx_conf),
-        ),
+        "Offset of field: rte_eth_conf__bindgen_ty_1::vmdq_rx_conf",
     );
 }
 impl Clone for rte_eth_conf__bindgen_ty_1 {
@@ -2050,42 +1731,27 @@ fn bindgen_test_layout_rte_eth_conf__bindgen_ty_2() {
     assert_eq!(
         ::std::mem::size_of::<rte_eth_conf__bindgen_ty_2>(),
         12usize,
-        concat!("Size of: ", stringify!(rte_eth_conf__bindgen_ty_2)),
+        "Size of rte_eth_conf__bindgen_ty_2",
     );
     assert_eq!(
         ::std::mem::align_of::<rte_eth_conf__bindgen_ty_2>(),
         4usize,
-        concat!("Alignment of ", stringify!(rte_eth_conf__bindgen_ty_2)),
+        "Alignment of rte_eth_conf__bindgen_ty_2",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).vmdq_dcb_tx_conf) as usize - ptr as usize },
         0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_conf__bindgen_ty_2),
-            "::",
-            stringify!(vmdq_dcb_tx_conf),
-        ),
+        "Offset of field: rte_eth_conf__bindgen_ty_2::vmdq_dcb_tx_conf",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).dcb_tx_conf) as usize - ptr as usize },
         0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_conf__bindgen_ty_2),
-            "::",
-            stringify!(dcb_tx_conf),
-        ),
+        "Offset of field: rte_eth_conf__bindgen_ty_2::dcb_tx_conf",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).vmdq_tx_conf) as usize - ptr as usize },
         0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_conf__bindgen_ty_2),
-            "::",
-            stringify!(vmdq_tx_conf),
-        ),
+        "Offset of field: rte_eth_conf__bindgen_ty_2::vmdq_tx_conf",
     );
 }
 impl Clone for rte_eth_conf__bindgen_ty_2 {
@@ -2097,97 +1763,58 @@ impl Clone for rte_eth_conf__bindgen_ty_2 {
 fn bindgen_test_layout_rte_eth_conf() {
     const UNINIT: ::std::mem::MaybeUninit<rte_eth_conf> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<rte_eth_conf>(),
-        2944usize,
-        concat!("Size of: ", stringify!(rte_eth_conf)),
-    );
+    assert_eq!(::std::mem::size_of::<rte_eth_conf>(), 2944usize, "Size of rte_eth_conf");
     assert_eq!(
         ::std::mem::align_of::<rte_eth_conf>(),
         8usize,
-        concat!("Alignment of ", stringify!(rte_eth_conf)),
+        "Alignment of rte_eth_conf",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).link_speeds) as usize - ptr as usize },
         0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_conf),
-            "::",
-            stringify!(link_speeds),
-        ),
+        "Offset of field: rte_eth_conf::link_speeds",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).rxmode) as usize - ptr as usize },
         4usize,
-        concat!("Offset of field: ", stringify!(rte_eth_conf), "::", stringify!(rxmode)),
+        "Offset of field: rte_eth_conf::rxmode",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).txmode) as usize - ptr as usize },
         16usize,
-        concat!("Offset of field: ", stringify!(rte_eth_conf), "::", stringify!(txmode)),
+        "Offset of field: rte_eth_conf::txmode",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).lpbk_mode) as usize - ptr as usize },
         24usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_conf),
-            "::",
-            stringify!(lpbk_mode),
-        ),
+        "Offset of field: rte_eth_conf::lpbk_mode",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).rx_adv_conf) as usize - ptr as usize },
         32usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_conf),
-            "::",
-            stringify!(rx_adv_conf),
-        ),
+        "Offset of field: rte_eth_conf::rx_adv_conf",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).tx_adv_conf) as usize - ptr as usize },
         2152usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_conf),
-            "::",
-            stringify!(tx_adv_conf),
-        ),
+        "Offset of field: rte_eth_conf::tx_adv_conf",
     );
     assert_eq!(
         unsafe {
             ::std::ptr::addr_of!((*ptr).dcb_capability_en) as usize - ptr as usize
         },
         2164usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_conf),
-            "::",
-            stringify!(dcb_capability_en),
-        ),
+        "Offset of field: rte_eth_conf::dcb_capability_en",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).fdir_conf) as usize - ptr as usize },
         2168usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_conf),
-            "::",
-            stringify!(fdir_conf),
-        ),
+        "Offset of field: rte_eth_conf::fdir_conf",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).intr_conf) as usize - ptr as usize },
         2940usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_eth_conf),
-            "::",
-            stringify!(intr_conf),
-        ),
+        "Offset of field: rte_eth_conf::intr_conf",
     );
 }
 impl Clone for rte_eth_conf {

--- a/bindgen-tests/tests/expectations/tests/layout_kni_mbuf.rs
+++ b/bindgen-tests/tests/expectations/tests/layout_kni_mbuf.rs
@@ -30,110 +30,81 @@ pub struct rte_kni_mbuf {
 fn bindgen_test_layout_rte_kni_mbuf() {
     const UNINIT: ::std::mem::MaybeUninit<rte_kni_mbuf> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<rte_kni_mbuf>(),
-        128usize,
-        concat!("Size of: ", stringify!(rte_kni_mbuf)),
-    );
+    assert_eq!(::std::mem::size_of::<rte_kni_mbuf>(), 128usize, "Size of rte_kni_mbuf");
     assert_eq!(
         ::std::mem::align_of::<rte_kni_mbuf>(),
         64usize,
-        concat!("Alignment of ", stringify!(rte_kni_mbuf)),
+        "Alignment of rte_kni_mbuf",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).buf_addr) as usize - ptr as usize },
         0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_kni_mbuf),
-            "::",
-            stringify!(buf_addr),
-        ),
+        "Offset of field: rte_kni_mbuf::buf_addr",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).buf_physaddr) as usize - ptr as usize },
         8usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_kni_mbuf),
-            "::",
-            stringify!(buf_physaddr),
-        ),
+        "Offset of field: rte_kni_mbuf::buf_physaddr",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).pad0) as usize - ptr as usize },
         16usize,
-        concat!("Offset of field: ", stringify!(rte_kni_mbuf), "::", stringify!(pad0)),
+        "Offset of field: rte_kni_mbuf::pad0",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).data_off) as usize - ptr as usize },
         18usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_kni_mbuf),
-            "::",
-            stringify!(data_off),
-        ),
+        "Offset of field: rte_kni_mbuf::data_off",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).pad1) as usize - ptr as usize },
         20usize,
-        concat!("Offset of field: ", stringify!(rte_kni_mbuf), "::", stringify!(pad1)),
+        "Offset of field: rte_kni_mbuf::pad1",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).nb_segs) as usize - ptr as usize },
         22usize,
-        concat!("Offset of field: ", stringify!(rte_kni_mbuf), "::", stringify!(nb_segs)),
+        "Offset of field: rte_kni_mbuf::nb_segs",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).pad4) as usize - ptr as usize },
         23usize,
-        concat!("Offset of field: ", stringify!(rte_kni_mbuf), "::", stringify!(pad4)),
+        "Offset of field: rte_kni_mbuf::pad4",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).ol_flags) as usize - ptr as usize },
         24usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_kni_mbuf),
-            "::",
-            stringify!(ol_flags),
-        ),
+        "Offset of field: rte_kni_mbuf::ol_flags",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).pad2) as usize - ptr as usize },
         32usize,
-        concat!("Offset of field: ", stringify!(rte_kni_mbuf), "::", stringify!(pad2)),
+        "Offset of field: rte_kni_mbuf::pad2",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).pkt_len) as usize - ptr as usize },
         36usize,
-        concat!("Offset of field: ", stringify!(rte_kni_mbuf), "::", stringify!(pkt_len)),
+        "Offset of field: rte_kni_mbuf::pkt_len",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).data_len) as usize - ptr as usize },
         40usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_kni_mbuf),
-            "::",
-            stringify!(data_len),
-        ),
+        "Offset of field: rte_kni_mbuf::data_len",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).pad3) as usize - ptr as usize },
         64usize,
-        concat!("Offset of field: ", stringify!(rte_kni_mbuf), "::", stringify!(pad3)),
+        "Offset of field: rte_kni_mbuf::pad3",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).pool) as usize - ptr as usize },
         72usize,
-        concat!("Offset of field: ", stringify!(rte_kni_mbuf), "::", stringify!(pool)),
+        "Offset of field: rte_kni_mbuf::pool",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).next) as usize - ptr as usize },
         80usize,
-        concat!("Offset of field: ", stringify!(rte_kni_mbuf), "::", stringify!(next)),
+        "Offset of field: rte_kni_mbuf::next",
     );
 }
 impl Default for rte_kni_mbuf {

--- a/bindgen-tests/tests/expectations/tests/layout_large_align_field.rs
+++ b/bindgen-tests/tests/expectations/tests/layout_large_align_field.rs
@@ -61,30 +61,22 @@ pub struct ip_frag {
 fn bindgen_test_layout_ip_frag() {
     const UNINIT: ::std::mem::MaybeUninit<ip_frag> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<ip_frag>(),
-        16usize,
-        concat!("Size of: ", stringify!(ip_frag)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<ip_frag>(),
-        8usize,
-        concat!("Alignment of ", stringify!(ip_frag)),
-    );
+    assert_eq!(::std::mem::size_of::<ip_frag>(), 16usize, "Size of ip_frag");
+    assert_eq!(::std::mem::align_of::<ip_frag>(), 8usize, "Alignment of ip_frag");
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).ofs) as usize - ptr as usize },
         0usize,
-        concat!("Offset of field: ", stringify!(ip_frag), "::", stringify!(ofs)),
+        "Offset of field: ip_frag::ofs",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).len) as usize - ptr as usize },
         2usize,
-        concat!("Offset of field: ", stringify!(ip_frag), "::", stringify!(len)),
+        "Offset of field: ip_frag::len",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).mb) as usize - ptr as usize },
         8usize,
-        concat!("Offset of field: ", stringify!(ip_frag), "::", stringify!(mb)),
+        "Offset of field: ip_frag::mb",
     );
 }
 impl Default for ip_frag {
@@ -111,30 +103,26 @@ pub struct ip_frag_key {
 fn bindgen_test_layout_ip_frag_key() {
     const UNINIT: ::std::mem::MaybeUninit<ip_frag_key> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<ip_frag_key>(),
-        40usize,
-        concat!("Size of: ", stringify!(ip_frag_key)),
-    );
+    assert_eq!(::std::mem::size_of::<ip_frag_key>(), 40usize, "Size of ip_frag_key");
     assert_eq!(
         ::std::mem::align_of::<ip_frag_key>(),
         8usize,
-        concat!("Alignment of ", stringify!(ip_frag_key)),
+        "Alignment of ip_frag_key",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).src_dst) as usize - ptr as usize },
         0usize,
-        concat!("Offset of field: ", stringify!(ip_frag_key), "::", stringify!(src_dst)),
+        "Offset of field: ip_frag_key::src_dst",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).id) as usize - ptr as usize },
         32usize,
-        concat!("Offset of field: ", stringify!(ip_frag_key), "::", stringify!(id)),
+        "Offset of field: ip_frag_key::id",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).key_len) as usize - ptr as usize },
         36usize,
-        concat!("Offset of field: ", stringify!(ip_frag_key), "::", stringify!(key_len)),
+        "Offset of field: ip_frag_key::key_len",
     );
 }
 /** @internal Fragmented packet to reassemble.
@@ -171,32 +159,22 @@ fn bindgen_test_layout_ip_frag_pkt__bindgen_ty_1() {
     assert_eq!(
         ::std::mem::size_of::<ip_frag_pkt__bindgen_ty_1>(),
         16usize,
-        concat!("Size of: ", stringify!(ip_frag_pkt__bindgen_ty_1)),
+        "Size of ip_frag_pkt__bindgen_ty_1",
     );
     assert_eq!(
         ::std::mem::align_of::<ip_frag_pkt__bindgen_ty_1>(),
         8usize,
-        concat!("Alignment of ", stringify!(ip_frag_pkt__bindgen_ty_1)),
+        "Alignment of ip_frag_pkt__bindgen_ty_1",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).tqe_next) as usize - ptr as usize },
         0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(ip_frag_pkt__bindgen_ty_1),
-            "::",
-            stringify!(tqe_next),
-        ),
+        "Offset of field: ip_frag_pkt__bindgen_ty_1::tqe_next",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).tqe_prev) as usize - ptr as usize },
         8usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(ip_frag_pkt__bindgen_ty_1),
-            "::",
-            stringify!(tqe_prev),
-        ),
+        "Offset of field: ip_frag_pkt__bindgen_ty_1::tqe_prev",
     );
 }
 impl Default for ip_frag_pkt__bindgen_ty_1 {
@@ -212,60 +190,46 @@ impl Default for ip_frag_pkt__bindgen_ty_1 {
 fn bindgen_test_layout_ip_frag_pkt() {
     const UNINIT: ::std::mem::MaybeUninit<ip_frag_pkt> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<ip_frag_pkt>(),
-        192usize,
-        concat!("Size of: ", stringify!(ip_frag_pkt)),
-    );
+    assert_eq!(::std::mem::size_of::<ip_frag_pkt>(), 192usize, "Size of ip_frag_pkt");
     assert_eq!(
         ::std::mem::align_of::<ip_frag_pkt>(),
         64usize,
-        concat!("Alignment of ", stringify!(ip_frag_pkt)),
+        "Alignment of ip_frag_pkt",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).lru) as usize - ptr as usize },
         0usize,
-        concat!("Offset of field: ", stringify!(ip_frag_pkt), "::", stringify!(lru)),
+        "Offset of field: ip_frag_pkt::lru",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).key) as usize - ptr as usize },
         16usize,
-        concat!("Offset of field: ", stringify!(ip_frag_pkt), "::", stringify!(key)),
+        "Offset of field: ip_frag_pkt::key",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).start) as usize - ptr as usize },
         56usize,
-        concat!("Offset of field: ", stringify!(ip_frag_pkt), "::", stringify!(start)),
+        "Offset of field: ip_frag_pkt::start",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).total_size) as usize - ptr as usize },
         64usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(ip_frag_pkt),
-            "::",
-            stringify!(total_size),
-        ),
+        "Offset of field: ip_frag_pkt::total_size",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).frag_size) as usize - ptr as usize },
         68usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(ip_frag_pkt),
-            "::",
-            stringify!(frag_size),
-        ),
+        "Offset of field: ip_frag_pkt::frag_size",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).last_idx) as usize - ptr as usize },
         72usize,
-        concat!("Offset of field: ", stringify!(ip_frag_pkt), "::", stringify!(last_idx)),
+        "Offset of field: ip_frag_pkt::last_idx",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).frags) as usize - ptr as usize },
         80usize,
-        concat!("Offset of field: ", stringify!(ip_frag_pkt), "::", stringify!(frags)),
+        "Offset of field: ip_frag_pkt::frags",
     );
 }
 impl Default for ip_frag_pkt {
@@ -287,30 +251,21 @@ pub struct ip_pkt_list {
 fn bindgen_test_layout_ip_pkt_list() {
     const UNINIT: ::std::mem::MaybeUninit<ip_pkt_list> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<ip_pkt_list>(),
-        16usize,
-        concat!("Size of: ", stringify!(ip_pkt_list)),
-    );
+    assert_eq!(::std::mem::size_of::<ip_pkt_list>(), 16usize, "Size of ip_pkt_list");
     assert_eq!(
         ::std::mem::align_of::<ip_pkt_list>(),
         8usize,
-        concat!("Alignment of ", stringify!(ip_pkt_list)),
+        "Alignment of ip_pkt_list",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).tqh_first) as usize - ptr as usize },
         0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(ip_pkt_list),
-            "::",
-            stringify!(tqh_first),
-        ),
+        "Offset of field: ip_pkt_list::tqh_first",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).tqh_last) as usize - ptr as usize },
         8usize,
-        concat!("Offset of field: ", stringify!(ip_pkt_list), "::", stringify!(tqh_last)),
+        "Offset of field: ip_pkt_list::tqh_last",
     );
 }
 impl Default for ip_pkt_list {
@@ -347,72 +302,42 @@ fn bindgen_test_layout_ip_frag_tbl_stat() {
     assert_eq!(
         ::std::mem::size_of::<ip_frag_tbl_stat>(),
         64usize,
-        concat!("Size of: ", stringify!(ip_frag_tbl_stat)),
+        "Size of ip_frag_tbl_stat",
     );
     assert_eq!(
         ::std::mem::align_of::<ip_frag_tbl_stat>(),
         64usize,
-        concat!("Alignment of ", stringify!(ip_frag_tbl_stat)),
+        "Alignment of ip_frag_tbl_stat",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).find_num) as usize - ptr as usize },
         0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(ip_frag_tbl_stat),
-            "::",
-            stringify!(find_num),
-        ),
+        "Offset of field: ip_frag_tbl_stat::find_num",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).add_num) as usize - ptr as usize },
         8usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(ip_frag_tbl_stat),
-            "::",
-            stringify!(add_num),
-        ),
+        "Offset of field: ip_frag_tbl_stat::add_num",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).del_num) as usize - ptr as usize },
         16usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(ip_frag_tbl_stat),
-            "::",
-            stringify!(del_num),
-        ),
+        "Offset of field: ip_frag_tbl_stat::del_num",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).reuse_num) as usize - ptr as usize },
         24usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(ip_frag_tbl_stat),
-            "::",
-            stringify!(reuse_num),
-        ),
+        "Offset of field: ip_frag_tbl_stat::reuse_num",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).fail_total) as usize - ptr as usize },
         32usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(ip_frag_tbl_stat),
-            "::",
-            stringify!(fail_total),
-        ),
+        "Offset of field: ip_frag_tbl_stat::fail_total",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).fail_nospace) as usize - ptr as usize },
         40usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(ip_frag_tbl_stat),
-            "::",
-            stringify!(fail_nospace),
-        ),
+        "Offset of field: ip_frag_tbl_stat::fail_nospace",
     );
 }
 impl Default for ip_frag_tbl_stat {
@@ -459,102 +384,67 @@ fn bindgen_test_layout_rte_ip_frag_tbl() {
     assert_eq!(
         ::std::mem::size_of::<rte_ip_frag_tbl>(),
         128usize,
-        concat!("Size of: ", stringify!(rte_ip_frag_tbl)),
+        "Size of rte_ip_frag_tbl",
     );
     assert_eq!(
         ::std::mem::align_of::<rte_ip_frag_tbl>(),
         64usize,
-        concat!("Alignment of ", stringify!(rte_ip_frag_tbl)),
+        "Alignment of rte_ip_frag_tbl",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).max_cycles) as usize - ptr as usize },
         0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_ip_frag_tbl),
-            "::",
-            stringify!(max_cycles),
-        ),
+        "Offset of field: rte_ip_frag_tbl::max_cycles",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).entry_mask) as usize - ptr as usize },
         8usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_ip_frag_tbl),
-            "::",
-            stringify!(entry_mask),
-        ),
+        "Offset of field: rte_ip_frag_tbl::entry_mask",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).max_entries) as usize - ptr as usize },
         12usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_ip_frag_tbl),
-            "::",
-            stringify!(max_entries),
-        ),
+        "Offset of field: rte_ip_frag_tbl::max_entries",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).use_entries) as usize - ptr as usize },
         16usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_ip_frag_tbl),
-            "::",
-            stringify!(use_entries),
-        ),
+        "Offset of field: rte_ip_frag_tbl::use_entries",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).bucket_entries) as usize - ptr as usize },
         20usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_ip_frag_tbl),
-            "::",
-            stringify!(bucket_entries),
-        ),
+        "Offset of field: rte_ip_frag_tbl::bucket_entries",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).nb_entries) as usize - ptr as usize },
         24usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_ip_frag_tbl),
-            "::",
-            stringify!(nb_entries),
-        ),
+        "Offset of field: rte_ip_frag_tbl::nb_entries",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).nb_buckets) as usize - ptr as usize },
         28usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_ip_frag_tbl),
-            "::",
-            stringify!(nb_buckets),
-        ),
+        "Offset of field: rte_ip_frag_tbl::nb_buckets",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).last) as usize - ptr as usize },
         32usize,
-        concat!("Offset of field: ", stringify!(rte_ip_frag_tbl), "::", stringify!(last)),
+        "Offset of field: rte_ip_frag_tbl::last",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).lru) as usize - ptr as usize },
         40usize,
-        concat!("Offset of field: ", stringify!(rte_ip_frag_tbl), "::", stringify!(lru)),
+        "Offset of field: rte_ip_frag_tbl::lru",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).stat) as usize - ptr as usize },
         64usize,
-        concat!("Offset of field: ", stringify!(rte_ip_frag_tbl), "::", stringify!(stat)),
+        "Offset of field: rte_ip_frag_tbl::stat",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).pkt) as usize - ptr as usize },
         128usize,
-        concat!("Offset of field: ", stringify!(rte_ip_frag_tbl), "::", stringify!(pkt)),
+        "Offset of field: rte_ip_frag_tbl::pkt",
     );
 }
 impl Default for rte_ip_frag_tbl {

--- a/bindgen-tests/tests/expectations/tests/layout_mbuf.rs
+++ b/bindgen-tests/tests/expectations/tests/layout_mbuf.rs
@@ -96,26 +96,13 @@ pub struct rte_atomic16_t {
     ///< An internal counter value.
     pub cnt: i16,
 }
-#[test]
-fn bindgen_test_layout_rte_atomic16_t() {
-    const UNINIT: ::std::mem::MaybeUninit<rte_atomic16_t> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<rte_atomic16_t>(),
-        2usize,
-        concat!("Size of: ", stringify!(rte_atomic16_t)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<rte_atomic16_t>(),
-        2usize,
-        concat!("Alignment of ", stringify!(rte_atomic16_t)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).cnt) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(rte_atomic16_t), "::", stringify!(cnt)),
-    );
-}
+const _: () = {
+    ["Size of rte_atomic16_t"][::std::mem::size_of::<rte_atomic16_t>() - 2usize];
+    ["Alignment of rte_atomic16_t"][::std::mem::align_of::<rte_atomic16_t>() - 2usize];
+    [
+        "Offset of field: rte_atomic16_t::cnt",
+    ][::std::mem::offset_of!(rte_atomic16_t, cnt) - 0usize];
+};
 /// The generic rte_mbuf, containing a packet mbuf.
 #[repr(C)]
 #[repr(align(64))]
@@ -177,41 +164,20 @@ pub union rte_mbuf__bindgen_ty_1 {
     ///< Non-atomically accessed refcnt
     pub refcnt: u16,
 }
-#[test]
-fn bindgen_test_layout_rte_mbuf__bindgen_ty_1() {
-    const UNINIT: ::std::mem::MaybeUninit<rte_mbuf__bindgen_ty_1> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<rte_mbuf__bindgen_ty_1>(),
-        2usize,
-        concat!("Size of: ", stringify!(rte_mbuf__bindgen_ty_1)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<rte_mbuf__bindgen_ty_1>(),
-        2usize,
-        concat!("Alignment of ", stringify!(rte_mbuf__bindgen_ty_1)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).refcnt_atomic) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mbuf__bindgen_ty_1),
-            "::",
-            stringify!(refcnt_atomic),
-        ),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).refcnt) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mbuf__bindgen_ty_1),
-            "::",
-            stringify!(refcnt),
-        ),
-    );
-}
+const _: () = {
+    [
+        "Size of rte_mbuf__bindgen_ty_1",
+    ][::std::mem::size_of::<rte_mbuf__bindgen_ty_1>() - 2usize];
+    [
+        "Alignment of rte_mbuf__bindgen_ty_1",
+    ][::std::mem::align_of::<rte_mbuf__bindgen_ty_1>() - 2usize];
+    [
+        "Offset of field: rte_mbuf__bindgen_ty_1::refcnt_atomic",
+    ][::std::mem::offset_of!(rte_mbuf__bindgen_ty_1, refcnt_atomic) - 0usize];
+    [
+        "Offset of field: rte_mbuf__bindgen_ty_1::refcnt",
+    ][::std::mem::offset_of!(rte_mbuf__bindgen_ty_1, refcnt) - 0usize];
+};
 impl Default for rte_mbuf__bindgen_ty_1 {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
@@ -235,19 +201,14 @@ pub struct rte_mbuf__bindgen_ty_2__bindgen_ty_1 {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
 }
-#[test]
-fn bindgen_test_layout_rte_mbuf__bindgen_ty_2__bindgen_ty_1() {
-    assert_eq!(
-        ::std::mem::size_of::<rte_mbuf__bindgen_ty_2__bindgen_ty_1>(),
-        4usize,
-        concat!("Size of: ", stringify!(rte_mbuf__bindgen_ty_2__bindgen_ty_1)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<rte_mbuf__bindgen_ty_2__bindgen_ty_1>(),
-        4usize,
-        concat!("Alignment of ", stringify!(rte_mbuf__bindgen_ty_2__bindgen_ty_1)),
-    );
-}
+const _: () = {
+    [
+        "Size of rte_mbuf__bindgen_ty_2__bindgen_ty_1",
+    ][::std::mem::size_of::<rte_mbuf__bindgen_ty_2__bindgen_ty_1>() - 4usize];
+    [
+        "Alignment of rte_mbuf__bindgen_ty_2__bindgen_ty_1",
+    ][::std::mem::align_of::<rte_mbuf__bindgen_ty_2__bindgen_ty_1>() - 4usize];
+};
 impl rte_mbuf__bindgen_ty_2__bindgen_ty_1 {
     #[inline]
     pub fn l2_type(&self) -> u32 {
@@ -409,31 +370,17 @@ impl rte_mbuf__bindgen_ty_2__bindgen_ty_1 {
         __bindgen_bitfield_unit
     }
 }
-#[test]
-fn bindgen_test_layout_rte_mbuf__bindgen_ty_2() {
-    const UNINIT: ::std::mem::MaybeUninit<rte_mbuf__bindgen_ty_2> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<rte_mbuf__bindgen_ty_2>(),
-        4usize,
-        concat!("Size of: ", stringify!(rte_mbuf__bindgen_ty_2)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<rte_mbuf__bindgen_ty_2>(),
-        4usize,
-        concat!("Alignment of ", stringify!(rte_mbuf__bindgen_ty_2)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).packet_type) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mbuf__bindgen_ty_2),
-            "::",
-            stringify!(packet_type),
-        ),
-    );
-}
+const _: () = {
+    [
+        "Size of rte_mbuf__bindgen_ty_2",
+    ][::std::mem::size_of::<rte_mbuf__bindgen_ty_2>() - 4usize];
+    [
+        "Alignment of rte_mbuf__bindgen_ty_2",
+    ][::std::mem::align_of::<rte_mbuf__bindgen_ty_2>() - 4usize];
+    [
+        "Offset of field: rte_mbuf__bindgen_ty_2::packet_type",
+    ][::std::mem::offset_of!(rte_mbuf__bindgen_ty_2, packet_type) - 0usize];
+};
 impl Default for rte_mbuf__bindgen_ty_2 {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
@@ -473,86 +420,42 @@ pub struct rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1 {
     pub hash: u16,
     pub id: u16,
 }
-#[test]
-fn bindgen_test_layout_rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1() {
-    const UNINIT: ::std::mem::MaybeUninit<
+const _: () = {
+    [
+        "Size of rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1",
+    ][::std::mem::size_of::<
         rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1,
-    > = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<
-            rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1,
-        >(),
-        4usize,
-        concat!(
-            "Size of: ",
-            stringify!(rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1),
-        ),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<
-            rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1,
-        >(),
-        2usize,
-        concat!(
-            "Alignment of ",
-            stringify!(rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1),
-        ),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).hash) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1),
-            "::",
-            stringify!(hash),
-        ),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).id) as usize - ptr as usize },
-        2usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1),
-            "::",
-            stringify!(id),
-        ),
-    );
-}
-#[test]
-fn bindgen_test_layout_rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1() {
-    const UNINIT: ::std::mem::MaybeUninit<
-        rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1,
-    > = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1>(),
-        4usize,
-        concat!(
-            "Size of: ",
-            stringify!(rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1),
-        ),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1>(),
-        4usize,
-        concat!(
-            "Alignment of ",
-            stringify!(rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1),
-        ),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).lo) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1),
-            "::",
-            stringify!(lo),
-        ),
-    );
-}
+    >() - 4usize];
+    [
+        "Alignment of rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1",
+    ][::std::mem::align_of::<
+        rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1,
+    >() - 2usize];
+    [
+        "Offset of field: rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1::hash",
+    ][::std::mem::offset_of!(
+        rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1, hash
+    ) - 0usize];
+    [
+        "Offset of field: rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1::id",
+    ][::std::mem::offset_of!(
+        rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1, id
+    ) - 2usize];
+};
+const _: () = {
+    [
+        "Size of rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1",
+    ][::std::mem::size_of::<rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1>()
+        - 4usize];
+    [
+        "Alignment of rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1",
+    ][::std::mem::align_of::<rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1>()
+        - 4usize];
+    [
+        "Offset of field: rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1::lo",
+    ][::std::mem::offset_of!(rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1, lo)
+        - 0usize];
+};
 impl Default for rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1 {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
@@ -562,31 +465,17 @@ impl Default for rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1 {
         }
     }
 }
-#[test]
-fn bindgen_test_layout_rte_mbuf__bindgen_ty_3__bindgen_ty_1() {
-    const UNINIT: ::std::mem::MaybeUninit<rte_mbuf__bindgen_ty_3__bindgen_ty_1> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<rte_mbuf__bindgen_ty_3__bindgen_ty_1>(),
-        8usize,
-        concat!("Size of: ", stringify!(rte_mbuf__bindgen_ty_3__bindgen_ty_1)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<rte_mbuf__bindgen_ty_3__bindgen_ty_1>(),
-        4usize,
-        concat!("Alignment of ", stringify!(rte_mbuf__bindgen_ty_3__bindgen_ty_1)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).hi) as usize - ptr as usize },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mbuf__bindgen_ty_3__bindgen_ty_1),
-            "::",
-            stringify!(hi),
-        ),
-    );
-}
+const _: () = {
+    [
+        "Size of rte_mbuf__bindgen_ty_3__bindgen_ty_1",
+    ][::std::mem::size_of::<rte_mbuf__bindgen_ty_3__bindgen_ty_1>() - 8usize];
+    [
+        "Alignment of rte_mbuf__bindgen_ty_3__bindgen_ty_1",
+    ][::std::mem::align_of::<rte_mbuf__bindgen_ty_3__bindgen_ty_1>() - 4usize];
+    [
+        "Offset of field: rte_mbuf__bindgen_ty_3__bindgen_ty_1::hi",
+    ][::std::mem::offset_of!(rte_mbuf__bindgen_ty_3__bindgen_ty_1, hi) - 4usize];
+};
 impl Default for rte_mbuf__bindgen_ty_3__bindgen_ty_1 {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
@@ -602,96 +491,40 @@ pub struct rte_mbuf__bindgen_ty_3__bindgen_ty_2 {
     pub lo: u32,
     pub hi: u32,
 }
-#[test]
-fn bindgen_test_layout_rte_mbuf__bindgen_ty_3__bindgen_ty_2() {
-    const UNINIT: ::std::mem::MaybeUninit<rte_mbuf__bindgen_ty_3__bindgen_ty_2> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<rte_mbuf__bindgen_ty_3__bindgen_ty_2>(),
-        8usize,
-        concat!("Size of: ", stringify!(rte_mbuf__bindgen_ty_3__bindgen_ty_2)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<rte_mbuf__bindgen_ty_3__bindgen_ty_2>(),
-        4usize,
-        concat!("Alignment of ", stringify!(rte_mbuf__bindgen_ty_3__bindgen_ty_2)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).lo) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mbuf__bindgen_ty_3__bindgen_ty_2),
-            "::",
-            stringify!(lo),
-        ),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).hi) as usize - ptr as usize },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mbuf__bindgen_ty_3__bindgen_ty_2),
-            "::",
-            stringify!(hi),
-        ),
-    );
-}
-#[test]
-fn bindgen_test_layout_rte_mbuf__bindgen_ty_3() {
-    const UNINIT: ::std::mem::MaybeUninit<rte_mbuf__bindgen_ty_3> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<rte_mbuf__bindgen_ty_3>(),
-        8usize,
-        concat!("Size of: ", stringify!(rte_mbuf__bindgen_ty_3)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<rte_mbuf__bindgen_ty_3>(),
-        4usize,
-        concat!("Alignment of ", stringify!(rte_mbuf__bindgen_ty_3)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).rss) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mbuf__bindgen_ty_3),
-            "::",
-            stringify!(rss),
-        ),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).fdir) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mbuf__bindgen_ty_3),
-            "::",
-            stringify!(fdir),
-        ),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).sched) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mbuf__bindgen_ty_3),
-            "::",
-            stringify!(sched),
-        ),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).usr) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mbuf__bindgen_ty_3),
-            "::",
-            stringify!(usr),
-        ),
-    );
-}
+const _: () = {
+    [
+        "Size of rte_mbuf__bindgen_ty_3__bindgen_ty_2",
+    ][::std::mem::size_of::<rte_mbuf__bindgen_ty_3__bindgen_ty_2>() - 8usize];
+    [
+        "Alignment of rte_mbuf__bindgen_ty_3__bindgen_ty_2",
+    ][::std::mem::align_of::<rte_mbuf__bindgen_ty_3__bindgen_ty_2>() - 4usize];
+    [
+        "Offset of field: rte_mbuf__bindgen_ty_3__bindgen_ty_2::lo",
+    ][::std::mem::offset_of!(rte_mbuf__bindgen_ty_3__bindgen_ty_2, lo) - 0usize];
+    [
+        "Offset of field: rte_mbuf__bindgen_ty_3__bindgen_ty_2::hi",
+    ][::std::mem::offset_of!(rte_mbuf__bindgen_ty_3__bindgen_ty_2, hi) - 4usize];
+};
+const _: () = {
+    [
+        "Size of rte_mbuf__bindgen_ty_3",
+    ][::std::mem::size_of::<rte_mbuf__bindgen_ty_3>() - 8usize];
+    [
+        "Alignment of rte_mbuf__bindgen_ty_3",
+    ][::std::mem::align_of::<rte_mbuf__bindgen_ty_3>() - 4usize];
+    [
+        "Offset of field: rte_mbuf__bindgen_ty_3::rss",
+    ][::std::mem::offset_of!(rte_mbuf__bindgen_ty_3, rss) - 0usize];
+    [
+        "Offset of field: rte_mbuf__bindgen_ty_3::fdir",
+    ][::std::mem::offset_of!(rte_mbuf__bindgen_ty_3, fdir) - 0usize];
+    [
+        "Offset of field: rte_mbuf__bindgen_ty_3::sched",
+    ][::std::mem::offset_of!(rte_mbuf__bindgen_ty_3, sched) - 0usize];
+    [
+        "Offset of field: rte_mbuf__bindgen_ty_3::usr",
+    ][::std::mem::offset_of!(rte_mbuf__bindgen_ty_3, usr) - 0usize];
+};
 impl Default for rte_mbuf__bindgen_ty_3 {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
@@ -709,41 +542,20 @@ pub union rte_mbuf__bindgen_ty_4 {
     ///< Allow 8-byte userdata on 32-bit
     pub udata64: u64,
 }
-#[test]
-fn bindgen_test_layout_rte_mbuf__bindgen_ty_4() {
-    const UNINIT: ::std::mem::MaybeUninit<rte_mbuf__bindgen_ty_4> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<rte_mbuf__bindgen_ty_4>(),
-        8usize,
-        concat!("Size of: ", stringify!(rte_mbuf__bindgen_ty_4)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<rte_mbuf__bindgen_ty_4>(),
-        8usize,
-        concat!("Alignment of ", stringify!(rte_mbuf__bindgen_ty_4)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).userdata) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mbuf__bindgen_ty_4),
-            "::",
-            stringify!(userdata),
-        ),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).udata64) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mbuf__bindgen_ty_4),
-            "::",
-            stringify!(udata64),
-        ),
-    );
-}
+const _: () = {
+    [
+        "Size of rte_mbuf__bindgen_ty_4",
+    ][::std::mem::size_of::<rte_mbuf__bindgen_ty_4>() - 8usize];
+    [
+        "Alignment of rte_mbuf__bindgen_ty_4",
+    ][::std::mem::align_of::<rte_mbuf__bindgen_ty_4>() - 8usize];
+    [
+        "Offset of field: rte_mbuf__bindgen_ty_4::userdata",
+    ][::std::mem::offset_of!(rte_mbuf__bindgen_ty_4, userdata) - 0usize];
+    [
+        "Offset of field: rte_mbuf__bindgen_ty_4::udata64",
+    ][::std::mem::offset_of!(rte_mbuf__bindgen_ty_4, udata64) - 0usize];
+};
 impl Default for rte_mbuf__bindgen_ty_4 {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
@@ -767,19 +579,14 @@ pub struct rte_mbuf__bindgen_ty_5__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 7usize]>,
 }
-#[test]
-fn bindgen_test_layout_rte_mbuf__bindgen_ty_5__bindgen_ty_1() {
-    assert_eq!(
-        ::std::mem::size_of::<rte_mbuf__bindgen_ty_5__bindgen_ty_1>(),
-        8usize,
-        concat!("Size of: ", stringify!(rte_mbuf__bindgen_ty_5__bindgen_ty_1)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<rte_mbuf__bindgen_ty_5__bindgen_ty_1>(),
-        8usize,
-        concat!("Alignment of ", stringify!(rte_mbuf__bindgen_ty_5__bindgen_ty_1)),
-    );
-}
+const _: () = {
+    [
+        "Size of rte_mbuf__bindgen_ty_5__bindgen_ty_1",
+    ][::std::mem::size_of::<rte_mbuf__bindgen_ty_5__bindgen_ty_1>() - 8usize];
+    [
+        "Alignment of rte_mbuf__bindgen_ty_5__bindgen_ty_1",
+    ][::std::mem::align_of::<rte_mbuf__bindgen_ty_5__bindgen_ty_1>() - 8usize];
+};
 impl rte_mbuf__bindgen_ty_5__bindgen_ty_1 {
     #[inline]
     pub fn l2_len(&self) -> u64 {
@@ -918,31 +725,17 @@ impl rte_mbuf__bindgen_ty_5__bindgen_ty_1 {
         __bindgen_bitfield_unit
     }
 }
-#[test]
-fn bindgen_test_layout_rte_mbuf__bindgen_ty_5() {
-    const UNINIT: ::std::mem::MaybeUninit<rte_mbuf__bindgen_ty_5> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<rte_mbuf__bindgen_ty_5>(),
-        8usize,
-        concat!("Size of: ", stringify!(rte_mbuf__bindgen_ty_5)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<rte_mbuf__bindgen_ty_5>(),
-        8usize,
-        concat!("Alignment of ", stringify!(rte_mbuf__bindgen_ty_5)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).tx_offload) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mbuf__bindgen_ty_5),
-            "::",
-            stringify!(tx_offload),
-        ),
-    );
-}
+const _: () = {
+    [
+        "Size of rte_mbuf__bindgen_ty_5",
+    ][::std::mem::size_of::<rte_mbuf__bindgen_ty_5>() - 8usize];
+    [
+        "Alignment of rte_mbuf__bindgen_ty_5",
+    ][::std::mem::align_of::<rte_mbuf__bindgen_ty_5>() - 8usize];
+    [
+        "Offset of field: rte_mbuf__bindgen_ty_5::tx_offload",
+    ][::std::mem::offset_of!(rte_mbuf__bindgen_ty_5, tx_offload) - 0usize];
+};
 impl Default for rte_mbuf__bindgen_ty_5 {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
@@ -952,143 +745,73 @@ impl Default for rte_mbuf__bindgen_ty_5 {
         }
     }
 }
-#[test]
-fn bindgen_test_layout_rte_mbuf() {
-    const UNINIT: ::std::mem::MaybeUninit<rte_mbuf> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<rte_mbuf>(),
-        128usize,
-        concat!("Size of: ", stringify!(rte_mbuf)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<rte_mbuf>(),
-        64usize,
-        concat!("Alignment of ", stringify!(rte_mbuf)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).cacheline0) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(rte_mbuf), "::", stringify!(cacheline0)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).buf_addr) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(rte_mbuf), "::", stringify!(buf_addr)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).buf_physaddr) as usize - ptr as usize },
-        8usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mbuf),
-            "::",
-            stringify!(buf_physaddr),
-        ),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).buf_len) as usize - ptr as usize },
-        16usize,
-        concat!("Offset of field: ", stringify!(rte_mbuf), "::", stringify!(buf_len)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).rearm_data) as usize - ptr as usize },
-        18usize,
-        concat!("Offset of field: ", stringify!(rte_mbuf), "::", stringify!(rearm_data)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).data_off) as usize - ptr as usize },
-        18usize,
-        concat!("Offset of field: ", stringify!(rte_mbuf), "::", stringify!(data_off)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).nb_segs) as usize - ptr as usize },
-        22usize,
-        concat!("Offset of field: ", stringify!(rte_mbuf), "::", stringify!(nb_segs)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).port) as usize - ptr as usize },
-        23usize,
-        concat!("Offset of field: ", stringify!(rte_mbuf), "::", stringify!(port)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).ol_flags) as usize - ptr as usize },
-        24usize,
-        concat!("Offset of field: ", stringify!(rte_mbuf), "::", stringify!(ol_flags)),
-    );
-    assert_eq!(
-        unsafe {
-            ::std::ptr::addr_of!((*ptr).rx_descriptor_fields1) as usize - ptr as usize
-        },
-        32usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mbuf),
-            "::",
-            stringify!(rx_descriptor_fields1),
-        ),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).pkt_len) as usize - ptr as usize },
-        36usize,
-        concat!("Offset of field: ", stringify!(rte_mbuf), "::", stringify!(pkt_len)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).data_len) as usize - ptr as usize },
-        40usize,
-        concat!("Offset of field: ", stringify!(rte_mbuf), "::", stringify!(data_len)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).vlan_tci) as usize - ptr as usize },
-        42usize,
-        concat!("Offset of field: ", stringify!(rte_mbuf), "::", stringify!(vlan_tci)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).hash) as usize - ptr as usize },
-        44usize,
-        concat!("Offset of field: ", stringify!(rte_mbuf), "::", stringify!(hash)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).seqn) as usize - ptr as usize },
-        52usize,
-        concat!("Offset of field: ", stringify!(rte_mbuf), "::", stringify!(seqn)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).vlan_tci_outer) as usize - ptr as usize },
-        56usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mbuf),
-            "::",
-            stringify!(vlan_tci_outer),
-        ),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).cacheline1) as usize - ptr as usize },
-        64usize,
-        concat!("Offset of field: ", stringify!(rte_mbuf), "::", stringify!(cacheline1)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).pool) as usize - ptr as usize },
-        72usize,
-        concat!("Offset of field: ", stringify!(rte_mbuf), "::", stringify!(pool)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).next) as usize - ptr as usize },
-        80usize,
-        concat!("Offset of field: ", stringify!(rte_mbuf), "::", stringify!(next)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).priv_size) as usize - ptr as usize },
-        96usize,
-        concat!("Offset of field: ", stringify!(rte_mbuf), "::", stringify!(priv_size)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).timesync) as usize - ptr as usize },
-        98usize,
-        concat!("Offset of field: ", stringify!(rte_mbuf), "::", stringify!(timesync)),
-    );
-}
+const _: () = {
+    ["Size of rte_mbuf"][::std::mem::size_of::<rte_mbuf>() - 128usize];
+    ["Alignment of rte_mbuf"][::std::mem::align_of::<rte_mbuf>() - 64usize];
+    [
+        "Offset of field: rte_mbuf::cacheline0",
+    ][::std::mem::offset_of!(rte_mbuf, cacheline0) - 0usize];
+    [
+        "Offset of field: rte_mbuf::buf_addr",
+    ][::std::mem::offset_of!(rte_mbuf, buf_addr) - 0usize];
+    [
+        "Offset of field: rte_mbuf::buf_physaddr",
+    ][::std::mem::offset_of!(rte_mbuf, buf_physaddr) - 8usize];
+    [
+        "Offset of field: rte_mbuf::buf_len",
+    ][::std::mem::offset_of!(rte_mbuf, buf_len) - 16usize];
+    [
+        "Offset of field: rte_mbuf::rearm_data",
+    ][::std::mem::offset_of!(rte_mbuf, rearm_data) - 18usize];
+    [
+        "Offset of field: rte_mbuf::data_off",
+    ][::std::mem::offset_of!(rte_mbuf, data_off) - 18usize];
+    [
+        "Offset of field: rte_mbuf::nb_segs",
+    ][::std::mem::offset_of!(rte_mbuf, nb_segs) - 22usize];
+    [
+        "Offset of field: rte_mbuf::port",
+    ][::std::mem::offset_of!(rte_mbuf, port) - 23usize];
+    [
+        "Offset of field: rte_mbuf::ol_flags",
+    ][::std::mem::offset_of!(rte_mbuf, ol_flags) - 24usize];
+    [
+        "Offset of field: rte_mbuf::rx_descriptor_fields1",
+    ][::std::mem::offset_of!(rte_mbuf, rx_descriptor_fields1) - 32usize];
+    [
+        "Offset of field: rte_mbuf::pkt_len",
+    ][::std::mem::offset_of!(rte_mbuf, pkt_len) - 36usize];
+    [
+        "Offset of field: rte_mbuf::data_len",
+    ][::std::mem::offset_of!(rte_mbuf, data_len) - 40usize];
+    [
+        "Offset of field: rte_mbuf::vlan_tci",
+    ][::std::mem::offset_of!(rte_mbuf, vlan_tci) - 42usize];
+    [
+        "Offset of field: rte_mbuf::hash",
+    ][::std::mem::offset_of!(rte_mbuf, hash) - 44usize];
+    [
+        "Offset of field: rte_mbuf::seqn",
+    ][::std::mem::offset_of!(rte_mbuf, seqn) - 52usize];
+    [
+        "Offset of field: rte_mbuf::vlan_tci_outer",
+    ][::std::mem::offset_of!(rte_mbuf, vlan_tci_outer) - 56usize];
+    [
+        "Offset of field: rte_mbuf::cacheline1",
+    ][::std::mem::offset_of!(rte_mbuf, cacheline1) - 64usize];
+    [
+        "Offset of field: rte_mbuf::pool",
+    ][::std::mem::offset_of!(rte_mbuf, pool) - 72usize];
+    [
+        "Offset of field: rte_mbuf::next",
+    ][::std::mem::offset_of!(rte_mbuf, next) - 80usize];
+    [
+        "Offset of field: rte_mbuf::priv_size",
+    ][::std::mem::offset_of!(rte_mbuf, priv_size) - 96usize];
+    [
+        "Offset of field: rte_mbuf::timesync",
+    ][::std::mem::offset_of!(rte_mbuf, timesync) - 98usize];
+};
 impl Default for rte_mbuf {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();

--- a/bindgen-tests/tests/expectations/tests/layout_mbuf_1_0.rs
+++ b/bindgen-tests/tests/expectations/tests/layout_mbuf_1_0.rs
@@ -146,17 +146,17 @@ fn bindgen_test_layout_rte_atomic16_t() {
     assert_eq!(
         ::std::mem::size_of::<rte_atomic16_t>(),
         2usize,
-        concat!("Size of: ", stringify!(rte_atomic16_t)),
+        "Size of rte_atomic16_t",
     );
     assert_eq!(
         ::std::mem::align_of::<rte_atomic16_t>(),
         2usize,
-        concat!("Alignment of ", stringify!(rte_atomic16_t)),
+        "Alignment of rte_atomic16_t",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).cnt) as usize - ptr as usize },
         0usize,
-        concat!("Offset of field: ", stringify!(rte_atomic16_t), "::", stringify!(cnt)),
+        "Offset of field: rte_atomic16_t::cnt",
     );
 }
 impl Clone for rte_atomic16_t {
@@ -233,32 +233,22 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_1() {
     assert_eq!(
         ::std::mem::size_of::<rte_mbuf__bindgen_ty_1>(),
         2usize,
-        concat!("Size of: ", stringify!(rte_mbuf__bindgen_ty_1)),
+        "Size of rte_mbuf__bindgen_ty_1",
     );
     assert_eq!(
         ::std::mem::align_of::<rte_mbuf__bindgen_ty_1>(),
         2usize,
-        concat!("Alignment of ", stringify!(rte_mbuf__bindgen_ty_1)),
+        "Alignment of rte_mbuf__bindgen_ty_1",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).refcnt_atomic) as usize - ptr as usize },
         0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mbuf__bindgen_ty_1),
-            "::",
-            stringify!(refcnt_atomic),
-        ),
+        "Offset of field: rte_mbuf__bindgen_ty_1::refcnt_atomic",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).refcnt) as usize - ptr as usize },
         0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mbuf__bindgen_ty_1),
-            "::",
-            stringify!(refcnt),
-        ),
+        "Offset of field: rte_mbuf__bindgen_ty_1::refcnt",
     );
 }
 impl Clone for rte_mbuf__bindgen_ty_1 {
@@ -286,12 +276,12 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_2__bindgen_ty_1() {
     assert_eq!(
         ::std::mem::size_of::<rte_mbuf__bindgen_ty_2__bindgen_ty_1>(),
         4usize,
-        concat!("Size of: ", stringify!(rte_mbuf__bindgen_ty_2__bindgen_ty_1)),
+        "Size of rte_mbuf__bindgen_ty_2__bindgen_ty_1",
     );
     assert_eq!(
         ::std::mem::align_of::<rte_mbuf__bindgen_ty_2__bindgen_ty_1>(),
         4usize,
-        concat!("Alignment of ", stringify!(rte_mbuf__bindgen_ty_2__bindgen_ty_1)),
+        "Alignment of rte_mbuf__bindgen_ty_2__bindgen_ty_1",
     );
 }
 impl Clone for rte_mbuf__bindgen_ty_2__bindgen_ty_1 {
@@ -467,22 +457,17 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_2() {
     assert_eq!(
         ::std::mem::size_of::<rte_mbuf__bindgen_ty_2>(),
         4usize,
-        concat!("Size of: ", stringify!(rte_mbuf__bindgen_ty_2)),
+        "Size of rte_mbuf__bindgen_ty_2",
     );
     assert_eq!(
         ::std::mem::align_of::<rte_mbuf__bindgen_ty_2>(),
         4usize,
-        concat!("Alignment of ", stringify!(rte_mbuf__bindgen_ty_2)),
+        "Alignment of rte_mbuf__bindgen_ty_2",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).packet_type) as usize - ptr as usize },
         0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mbuf__bindgen_ty_2),
-            "::",
-            stringify!(packet_type),
-        ),
+        "Offset of field: rte_mbuf__bindgen_ty_2::packet_type",
     );
 }
 impl Clone for rte_mbuf__bindgen_ty_2 {
@@ -535,40 +520,24 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindg
             rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1,
         >(),
         4usize,
-        concat!(
-            "Size of: ",
-            stringify!(rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1),
-        ),
+        "Size of rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1",
     );
     assert_eq!(
         ::std::mem::align_of::<
             rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1,
         >(),
         2usize,
-        concat!(
-            "Alignment of ",
-            stringify!(rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1),
-        ),
+        "Alignment of rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).hash) as usize - ptr as usize },
         0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1),
-            "::",
-            stringify!(hash),
-        ),
+        "Offset of field: rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1::hash",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).id) as usize - ptr as usize },
         2usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1),
-            "::",
-            stringify!(id),
-        ),
+        "Offset of field: rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1::id",
     );
 }
 impl Clone for rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1 {
@@ -585,28 +554,17 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1() {
     assert_eq!(
         ::std::mem::size_of::<rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1>(),
         4usize,
-        concat!(
-            "Size of: ",
-            stringify!(rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1),
-        ),
+        "Size of rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1",
     );
     assert_eq!(
         ::std::mem::align_of::<rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1>(),
         4usize,
-        concat!(
-            "Alignment of ",
-            stringify!(rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1),
-        ),
+        "Alignment of rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).lo) as usize - ptr as usize },
         0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1),
-            "::",
-            stringify!(lo),
-        ),
+        "Offset of field: rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1::lo",
     );
 }
 impl Clone for rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1 {
@@ -621,22 +579,17 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_3__bindgen_ty_1() {
     assert_eq!(
         ::std::mem::size_of::<rte_mbuf__bindgen_ty_3__bindgen_ty_1>(),
         8usize,
-        concat!("Size of: ", stringify!(rte_mbuf__bindgen_ty_3__bindgen_ty_1)),
+        "Size of rte_mbuf__bindgen_ty_3__bindgen_ty_1",
     );
     assert_eq!(
         ::std::mem::align_of::<rte_mbuf__bindgen_ty_3__bindgen_ty_1>(),
         4usize,
-        concat!("Alignment of ", stringify!(rte_mbuf__bindgen_ty_3__bindgen_ty_1)),
+        "Alignment of rte_mbuf__bindgen_ty_3__bindgen_ty_1",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).hi) as usize - ptr as usize },
         4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mbuf__bindgen_ty_3__bindgen_ty_1),
-            "::",
-            stringify!(hi),
-        ),
+        "Offset of field: rte_mbuf__bindgen_ty_3__bindgen_ty_1::hi",
     );
 }
 impl Clone for rte_mbuf__bindgen_ty_3__bindgen_ty_1 {
@@ -657,32 +610,22 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_3__bindgen_ty_2() {
     assert_eq!(
         ::std::mem::size_of::<rte_mbuf__bindgen_ty_3__bindgen_ty_2>(),
         8usize,
-        concat!("Size of: ", stringify!(rte_mbuf__bindgen_ty_3__bindgen_ty_2)),
+        "Size of rte_mbuf__bindgen_ty_3__bindgen_ty_2",
     );
     assert_eq!(
         ::std::mem::align_of::<rte_mbuf__bindgen_ty_3__bindgen_ty_2>(),
         4usize,
-        concat!("Alignment of ", stringify!(rte_mbuf__bindgen_ty_3__bindgen_ty_2)),
+        "Alignment of rte_mbuf__bindgen_ty_3__bindgen_ty_2",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).lo) as usize - ptr as usize },
         0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mbuf__bindgen_ty_3__bindgen_ty_2),
-            "::",
-            stringify!(lo),
-        ),
+        "Offset of field: rte_mbuf__bindgen_ty_3__bindgen_ty_2::lo",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).hi) as usize - ptr as usize },
         4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mbuf__bindgen_ty_3__bindgen_ty_2),
-            "::",
-            stringify!(hi),
-        ),
+        "Offset of field: rte_mbuf__bindgen_ty_3__bindgen_ty_2::hi",
     );
 }
 impl Clone for rte_mbuf__bindgen_ty_3__bindgen_ty_2 {
@@ -697,52 +640,32 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_3() {
     assert_eq!(
         ::std::mem::size_of::<rte_mbuf__bindgen_ty_3>(),
         8usize,
-        concat!("Size of: ", stringify!(rte_mbuf__bindgen_ty_3)),
+        "Size of rte_mbuf__bindgen_ty_3",
     );
     assert_eq!(
         ::std::mem::align_of::<rte_mbuf__bindgen_ty_3>(),
         4usize,
-        concat!("Alignment of ", stringify!(rte_mbuf__bindgen_ty_3)),
+        "Alignment of rte_mbuf__bindgen_ty_3",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).rss) as usize - ptr as usize },
         0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mbuf__bindgen_ty_3),
-            "::",
-            stringify!(rss),
-        ),
+        "Offset of field: rte_mbuf__bindgen_ty_3::rss",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).fdir) as usize - ptr as usize },
         0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mbuf__bindgen_ty_3),
-            "::",
-            stringify!(fdir),
-        ),
+        "Offset of field: rte_mbuf__bindgen_ty_3::fdir",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).sched) as usize - ptr as usize },
         0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mbuf__bindgen_ty_3),
-            "::",
-            stringify!(sched),
-        ),
+        "Offset of field: rte_mbuf__bindgen_ty_3::sched",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).usr) as usize - ptr as usize },
         0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mbuf__bindgen_ty_3),
-            "::",
-            stringify!(usr),
-        ),
+        "Offset of field: rte_mbuf__bindgen_ty_3::usr",
     );
 }
 impl Clone for rte_mbuf__bindgen_ty_3 {
@@ -766,32 +689,22 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_4() {
     assert_eq!(
         ::std::mem::size_of::<rte_mbuf__bindgen_ty_4>(),
         8usize,
-        concat!("Size of: ", stringify!(rte_mbuf__bindgen_ty_4)),
+        "Size of rte_mbuf__bindgen_ty_4",
     );
     assert_eq!(
         ::std::mem::align_of::<rte_mbuf__bindgen_ty_4>(),
         8usize,
-        concat!("Alignment of ", stringify!(rte_mbuf__bindgen_ty_4)),
+        "Alignment of rte_mbuf__bindgen_ty_4",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).userdata) as usize - ptr as usize },
         0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mbuf__bindgen_ty_4),
-            "::",
-            stringify!(userdata),
-        ),
+        "Offset of field: rte_mbuf__bindgen_ty_4::userdata",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).udata64) as usize - ptr as usize },
         0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mbuf__bindgen_ty_4),
-            "::",
-            stringify!(udata64),
-        ),
+        "Offset of field: rte_mbuf__bindgen_ty_4::udata64",
     );
 }
 impl Clone for rte_mbuf__bindgen_ty_4 {
@@ -819,12 +732,12 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_5__bindgen_ty_1() {
     assert_eq!(
         ::std::mem::size_of::<rte_mbuf__bindgen_ty_5__bindgen_ty_1>(),
         8usize,
-        concat!("Size of: ", stringify!(rte_mbuf__bindgen_ty_5__bindgen_ty_1)),
+        "Size of rte_mbuf__bindgen_ty_5__bindgen_ty_1",
     );
     assert_eq!(
         ::std::mem::align_of::<rte_mbuf__bindgen_ty_5__bindgen_ty_1>(),
         8usize,
-        concat!("Alignment of ", stringify!(rte_mbuf__bindgen_ty_5__bindgen_ty_1)),
+        "Alignment of rte_mbuf__bindgen_ty_5__bindgen_ty_1",
     );
 }
 impl Clone for rte_mbuf__bindgen_ty_5__bindgen_ty_1 {
@@ -977,22 +890,17 @@ fn bindgen_test_layout_rte_mbuf__bindgen_ty_5() {
     assert_eq!(
         ::std::mem::size_of::<rte_mbuf__bindgen_ty_5>(),
         8usize,
-        concat!("Size of: ", stringify!(rte_mbuf__bindgen_ty_5)),
+        "Size of rte_mbuf__bindgen_ty_5",
     );
     assert_eq!(
         ::std::mem::align_of::<rte_mbuf__bindgen_ty_5>(),
         8usize,
-        concat!("Alignment of ", stringify!(rte_mbuf__bindgen_ty_5)),
+        "Alignment of rte_mbuf__bindgen_ty_5",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).tx_offload) as usize - ptr as usize },
         0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mbuf__bindgen_ty_5),
-            "::",
-            stringify!(tx_offload),
-        ),
+        "Offset of field: rte_mbuf__bindgen_ty_5::tx_offload",
     );
 }
 impl Clone for rte_mbuf__bindgen_ty_5 {
@@ -1004,132 +912,113 @@ impl Clone for rte_mbuf__bindgen_ty_5 {
 fn bindgen_test_layout_rte_mbuf() {
     const UNINIT: ::std::mem::MaybeUninit<rte_mbuf> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<rte_mbuf>(),
-        128usize,
-        concat!("Size of: ", stringify!(rte_mbuf)),
-    );
+    assert_eq!(::std::mem::size_of::<rte_mbuf>(), 128usize, "Size of rte_mbuf");
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).cacheline0) as usize - ptr as usize },
         0usize,
-        concat!("Offset of field: ", stringify!(rte_mbuf), "::", stringify!(cacheline0)),
+        "Offset of field: rte_mbuf::cacheline0",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).buf_addr) as usize - ptr as usize },
         0usize,
-        concat!("Offset of field: ", stringify!(rte_mbuf), "::", stringify!(buf_addr)),
+        "Offset of field: rte_mbuf::buf_addr",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).buf_physaddr) as usize - ptr as usize },
         8usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mbuf),
-            "::",
-            stringify!(buf_physaddr),
-        ),
+        "Offset of field: rte_mbuf::buf_physaddr",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).buf_len) as usize - ptr as usize },
         16usize,
-        concat!("Offset of field: ", stringify!(rte_mbuf), "::", stringify!(buf_len)),
+        "Offset of field: rte_mbuf::buf_len",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).rearm_data) as usize - ptr as usize },
         18usize,
-        concat!("Offset of field: ", stringify!(rte_mbuf), "::", stringify!(rearm_data)),
+        "Offset of field: rte_mbuf::rearm_data",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).data_off) as usize - ptr as usize },
         18usize,
-        concat!("Offset of field: ", stringify!(rte_mbuf), "::", stringify!(data_off)),
+        "Offset of field: rte_mbuf::data_off",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).nb_segs) as usize - ptr as usize },
         22usize,
-        concat!("Offset of field: ", stringify!(rte_mbuf), "::", stringify!(nb_segs)),
+        "Offset of field: rte_mbuf::nb_segs",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).port) as usize - ptr as usize },
         23usize,
-        concat!("Offset of field: ", stringify!(rte_mbuf), "::", stringify!(port)),
+        "Offset of field: rte_mbuf::port",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).ol_flags) as usize - ptr as usize },
         24usize,
-        concat!("Offset of field: ", stringify!(rte_mbuf), "::", stringify!(ol_flags)),
+        "Offset of field: rte_mbuf::ol_flags",
     );
     assert_eq!(
         unsafe {
             ::std::ptr::addr_of!((*ptr).rx_descriptor_fields1) as usize - ptr as usize
         },
         32usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mbuf),
-            "::",
-            stringify!(rx_descriptor_fields1),
-        ),
+        "Offset of field: rte_mbuf::rx_descriptor_fields1",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).pkt_len) as usize - ptr as usize },
         36usize,
-        concat!("Offset of field: ", stringify!(rte_mbuf), "::", stringify!(pkt_len)),
+        "Offset of field: rte_mbuf::pkt_len",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).data_len) as usize - ptr as usize },
         40usize,
-        concat!("Offset of field: ", stringify!(rte_mbuf), "::", stringify!(data_len)),
+        "Offset of field: rte_mbuf::data_len",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).vlan_tci) as usize - ptr as usize },
         42usize,
-        concat!("Offset of field: ", stringify!(rte_mbuf), "::", stringify!(vlan_tci)),
+        "Offset of field: rte_mbuf::vlan_tci",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).hash) as usize - ptr as usize },
         44usize,
-        concat!("Offset of field: ", stringify!(rte_mbuf), "::", stringify!(hash)),
+        "Offset of field: rte_mbuf::hash",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).seqn) as usize - ptr as usize },
         52usize,
-        concat!("Offset of field: ", stringify!(rte_mbuf), "::", stringify!(seqn)),
+        "Offset of field: rte_mbuf::seqn",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).vlan_tci_outer) as usize - ptr as usize },
         56usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(rte_mbuf),
-            "::",
-            stringify!(vlan_tci_outer),
-        ),
+        "Offset of field: rte_mbuf::vlan_tci_outer",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).cacheline1) as usize - ptr as usize },
         64usize,
-        concat!("Offset of field: ", stringify!(rte_mbuf), "::", stringify!(cacheline1)),
+        "Offset of field: rte_mbuf::cacheline1",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).pool) as usize - ptr as usize },
         72usize,
-        concat!("Offset of field: ", stringify!(rte_mbuf), "::", stringify!(pool)),
+        "Offset of field: rte_mbuf::pool",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).next) as usize - ptr as usize },
         80usize,
-        concat!("Offset of field: ", stringify!(rte_mbuf), "::", stringify!(next)),
+        "Offset of field: rte_mbuf::next",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).priv_size) as usize - ptr as usize },
         96usize,
-        concat!("Offset of field: ", stringify!(rte_mbuf), "::", stringify!(priv_size)),
+        "Offset of field: rte_mbuf::priv_size",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).timesync) as usize - ptr as usize },
         98usize,
-        concat!("Offset of field: ", stringify!(rte_mbuf), "::", stringify!(timesync)),
+        "Offset of field: rte_mbuf::timesync",
     );
 }
 impl Default for rte_mbuf {

--- a/bindgen-tests/tests/expectations/tests/libclang-9/constified-enum-module-overflow.rs
+++ b/bindgen-tests/tests/expectations/tests/libclang-9/constified-enum-module-overflow.rs
@@ -15,32 +15,16 @@ pub type C_U = B;
 pub struct A {
     pub u: u8,
 }
-#[test]
-fn bindgen_test_layout_A() {
-    const UNINIT: ::std::mem::MaybeUninit<A> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(::std::mem::size_of::<A>(), 1usize, concat!("Size of: ", stringify!(A)));
-    assert_eq!(
-        ::std::mem::align_of::<A>(),
-        1usize,
-        concat!("Alignment of ", stringify!(A)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).u) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(A), "::", stringify!(u)),
-    );
-}
-#[test]
-fn __bindgen_test_layout_C_open0_A_close0_instantiation() {
-    assert_eq!(
-        ::std::mem::size_of::<C>(),
-        1usize,
-        concat!("Size of template specialization: ", stringify!(C)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<C>(),
-        1usize,
-        concat!("Alignment of template specialization: ", stringify!(C)),
-    );
-}
+const _: () = {
+    ["Size of A"][::std::mem::size_of::<A>() - 1usize];
+    ["Alignment of A"][::std::mem::align_of::<A>() - 1usize];
+    ["Offset of field: A::u"][::std::mem::offset_of!(A, u) - 0usize];
+};
+const _: () = {
+    [
+        "Size of template specialization: C_open0_A_close0",
+    ][::std::mem::size_of::<C>() - 1usize];
+    [
+        "Align of template specialization: C_open0_A_close0",
+    ][::std::mem::align_of::<C>() - 1usize];
+};

--- a/bindgen-tests/tests/expectations/tests/libclang-9/ptr32-has-different-size.rs
+++ b/bindgen-tests/tests/expectations/tests/libclang-9/ptr32-has-different-size.rs
@@ -4,31 +4,13 @@
 pub struct TEST_STRUCT {
     pub ptr_32bit: *mut ::std::os::raw::c_void,
 }
-#[test]
-fn bindgen_test_layout_TEST_STRUCT() {
-    const UNINIT: ::std::mem::MaybeUninit<TEST_STRUCT> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<TEST_STRUCT>(),
-        8usize,
-        concat!("Size of: ", stringify!(TEST_STRUCT)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<TEST_STRUCT>(),
-        8usize,
-        concat!("Alignment of ", stringify!(TEST_STRUCT)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).ptr_32bit) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(TEST_STRUCT),
-            "::",
-            stringify!(ptr_32bit),
-        ),
-    );
-}
+const _: () = {
+    ["Size of TEST_STRUCT"][::std::mem::size_of::<TEST_STRUCT>() - 8usize];
+    ["Alignment of TEST_STRUCT"][::std::mem::align_of::<TEST_STRUCT>() - 8usize];
+    [
+        "Offset of field: TEST_STRUCT::ptr_32bit",
+    ][::std::mem::offset_of!(TEST_STRUCT, ptr_32bit) - 0usize];
+};
 impl Default for TEST_STRUCT {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();

--- a/bindgen-tests/tests/expectations/tests/libclang-9/struct_typedef_ns.rs
+++ b/bindgen-tests/tests/expectations/tests/libclang-9/struct_typedef_ns.rs
@@ -11,31 +11,15 @@ pub mod root {
         pub struct typedef_struct {
             pub foo: ::std::os::raw::c_int,
         }
-        #[test]
-        fn bindgen_test_layout_typedef_struct() {
-            const UNINIT: ::std::mem::MaybeUninit<typedef_struct> = ::std::mem::MaybeUninit::uninit();
-            let ptr = UNINIT.as_ptr();
-            assert_eq!(
-                ::std::mem::size_of::<typedef_struct>(),
-                4usize,
-                concat!("Size of: ", stringify!(typedef_struct)),
-            );
-            assert_eq!(
-                ::std::mem::align_of::<typedef_struct>(),
-                4usize,
-                concat!("Alignment of ", stringify!(typedef_struct)),
-            );
-            assert_eq!(
-                unsafe { ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize },
-                0usize,
-                concat!(
-                    "Offset of field: ",
-                    stringify!(typedef_struct),
-                    "::",
-                    stringify!(foo),
-                ),
-            );
-        }
+        const _: () = {
+            ["Size of typedef_struct"][::std::mem::size_of::<typedef_struct>() - 4usize];
+            [
+                "Alignment of typedef_struct",
+            ][::std::mem::align_of::<typedef_struct>() - 4usize];
+            [
+                "Offset of field: typedef_struct::foo",
+            ][::std::mem::offset_of!(typedef_struct, foo) - 0usize];
+        };
         #[repr(u32)]
         #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
         pub enum typedef_enum {
@@ -50,31 +34,15 @@ pub mod root {
         pub struct _bindgen_ty_1 {
             pub foo: ::std::os::raw::c_int,
         }
-        #[test]
-        fn bindgen_test_layout__bindgen_ty_1() {
-            const UNINIT: ::std::mem::MaybeUninit<_bindgen_ty_1> = ::std::mem::MaybeUninit::uninit();
-            let ptr = UNINIT.as_ptr();
-            assert_eq!(
-                ::std::mem::size_of::<_bindgen_ty_1>(),
-                4usize,
-                concat!("Size of: ", stringify!(_bindgen_ty_1)),
-            );
-            assert_eq!(
-                ::std::mem::align_of::<_bindgen_ty_1>(),
-                4usize,
-                concat!("Alignment of ", stringify!(_bindgen_ty_1)),
-            );
-            assert_eq!(
-                unsafe { ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize },
-                0usize,
-                concat!(
-                    "Offset of field: ",
-                    stringify!(_bindgen_ty_1),
-                    "::",
-                    stringify!(foo),
-                ),
-            );
-        }
+        const _: () = {
+            ["Size of _bindgen_ty_1"][::std::mem::size_of::<_bindgen_ty_1>() - 4usize];
+            [
+                "Alignment of _bindgen_ty_1",
+            ][::std::mem::align_of::<_bindgen_ty_1>() - 4usize];
+            [
+                "Offset of field: _bindgen_ty_1::foo",
+            ][::std::mem::offset_of!(_bindgen_ty_1, foo) - 0usize];
+        };
         pub type typedef_struct = root::_bindgen_mod_id_12::_bindgen_ty_1;
         pub const _bindgen_mod_id_12_BAR: root::_bindgen_mod_id_12::_bindgen_ty_2 = _bindgen_ty_2::BAR;
         #[repr(u32)]

--- a/bindgen-tests/tests/expectations/tests/long_double.rs
+++ b/bindgen-tests/tests/expectations/tests/long_double.rs
@@ -9,19 +9,11 @@ pub struct foo {
 fn bindgen_test_layout_foo() {
     const UNINIT: ::std::mem::MaybeUninit<foo> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<foo>(),
-        16usize,
-        concat!("Size of: ", stringify!(foo)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<foo>(),
-        16usize,
-        concat!("Alignment of ", stringify!(foo)),
-    );
+    assert_eq!(::std::mem::size_of::<foo>(), 16usize, "Size of foo");
+    assert_eq!(::std::mem::align_of::<foo>(), 16usize, "Alignment of foo");
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize },
         0usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar)),
+        "Offset of field: foo::bar",
     );
 }

--- a/bindgen-tests/tests/expectations/tests/mangling-linux32.rs
+++ b/bindgen-tests/tests/expectations/tests/mangling-linux32.rs
@@ -11,16 +11,7 @@ extern "C" {
     #[link_name = "\u{1}_ZN3Foo4sBarE"]
     pub static mut Foo_sBar: bool;
 }
-#[test]
-fn bindgen_test_layout_Foo() {
-    assert_eq!(
-        ::std::mem::size_of::<Foo>(),
-        1usize,
-        concat!("Size of: ", stringify!(Foo)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Foo>(),
-        1usize,
-        concat!("Alignment of ", stringify!(Foo)),
-    );
-}
+const _: () = {
+    ["Size of Foo"][::std::mem::size_of::<Foo>() - 1usize];
+    ["Alignment of Foo"][::std::mem::align_of::<Foo>() - 1usize];
+};

--- a/bindgen-tests/tests/expectations/tests/mangling-linux64.rs
+++ b/bindgen-tests/tests/expectations/tests/mangling-linux64.rs
@@ -11,16 +11,7 @@ extern "C" {
     #[link_name = "\u{1}_ZN3Foo4sBarE"]
     pub static mut Foo_sBar: bool;
 }
-#[test]
-fn bindgen_test_layout_Foo() {
-    assert_eq!(
-        ::std::mem::size_of::<Foo>(),
-        1usize,
-        concat!("Size of: ", stringify!(Foo)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Foo>(),
-        1usize,
-        concat!("Alignment of ", stringify!(Foo)),
-    );
-}
+const _: () = {
+    ["Size of Foo"][::std::mem::size_of::<Foo>() - 1usize];
+    ["Alignment of Foo"][::std::mem::align_of::<Foo>() - 1usize];
+};

--- a/bindgen-tests/tests/expectations/tests/mangling-macos.rs
+++ b/bindgen-tests/tests/expectations/tests/mangling-macos.rs
@@ -11,16 +11,7 @@ extern "C" {
     #[link_name = "\u{1}__ZN3Foo4sBarE"]
     pub static mut Foo_sBar: bool;
 }
-#[test]
-fn bindgen_test_layout_Foo() {
-    assert_eq!(
-        ::std::mem::size_of::<Foo>(),
-        1usize,
-        concat!("Size of: ", stringify!(Foo)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Foo>(),
-        1usize,
-        concat!("Alignment of ", stringify!(Foo)),
-    );
-}
+const _: () = {
+    ["Size of Foo"][::std::mem::size_of::<Foo>() - 1usize];
+    ["Alignment of Foo"][::std::mem::align_of::<Foo>() - 1usize];
+};

--- a/bindgen-tests/tests/expectations/tests/mangling-win32.rs
+++ b/bindgen-tests/tests/expectations/tests/mangling-win32.rs
@@ -11,19 +11,10 @@ extern "C" {
     #[link_name = "\u{1}?sBar@Foo@@2_NA"]
     pub static mut Foo_sBar: bool;
 }
-#[test]
-fn bindgen_test_layout_Foo() {
-    assert_eq!(
-        ::std::mem::size_of::<Foo>(),
-        1usize,
-        concat!("Size of: ", stringify!(Foo)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Foo>(),
-        1usize,
-        concat!("Alignment of ", stringify!(Foo)),
-    );
-}
+const _: () = {
+    ["Size of Foo"][::std::mem::size_of::<Foo>() - 1usize];
+    ["Alignment of Foo"][::std::mem::align_of::<Foo>() - 1usize];
+};
 extern "fastcall" {
     pub fn fast_call_func_no_args() -> ::std::os::raw::c_int;
 }

--- a/bindgen-tests/tests/expectations/tests/mangling-win64.rs
+++ b/bindgen-tests/tests/expectations/tests/mangling-win64.rs
@@ -11,16 +11,7 @@ extern "C" {
     #[link_name = "\u{1}?sBar@Foo@@2_NA"]
     pub static mut Foo_sBar: bool;
 }
-#[test]
-fn bindgen_test_layout_Foo() {
-    assert_eq!(
-        ::std::mem::size_of::<Foo>(),
-        1usize,
-        concat!("Size of: ", stringify!(Foo)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Foo>(),
-        1usize,
-        concat!("Alignment of ", stringify!(Foo)),
-    );
-}
+const _: () = {
+    ["Size of Foo"][::std::mem::size_of::<Foo>() - 1usize];
+    ["Alignment of Foo"][::std::mem::align_of::<Foo>() - 1usize];
+};

--- a/bindgen-tests/tests/expectations/tests/merge-extern-blocks.rs
+++ b/bindgen-tests/tests/expectations/tests/merge-extern-blocks.rs
@@ -8,26 +8,11 @@ pub mod root {
     pub struct Point {
         pub x: ::std::os::raw::c_int,
     }
-    #[test]
-    fn bindgen_test_layout_Point() {
-        const UNINIT: ::std::mem::MaybeUninit<Point> = ::std::mem::MaybeUninit::uninit();
-        let ptr = UNINIT.as_ptr();
-        assert_eq!(
-            ::std::mem::size_of::<Point>(),
-            4usize,
-            concat!("Size of: ", stringify!(Point)),
-        );
-        assert_eq!(
-            ::std::mem::align_of::<Point>(),
-            4usize,
-            concat!("Alignment of ", stringify!(Point)),
-        );
-        assert_eq!(
-            unsafe { ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize },
-            0usize,
-            concat!("Offset of field: ", stringify!(Point), "::", stringify!(x)),
-        );
-    }
+    const _: () = {
+        ["Size of Point"][::std::mem::size_of::<Point>() - 4usize];
+        ["Alignment of Point"][::std::mem::align_of::<Point>() - 4usize];
+        ["Offset of field: Point::x"][::std::mem::offset_of!(Point, x) - 0usize];
+    };
     pub mod ns {
         #[allow(unused_imports)]
         use self::super::super::root;
@@ -36,26 +21,11 @@ pub mod root {
         pub struct Point {
             pub x: ::std::os::raw::c_int,
         }
-        #[test]
-        fn bindgen_test_layout_Point() {
-            const UNINIT: ::std::mem::MaybeUninit<Point> = ::std::mem::MaybeUninit::uninit();
-            let ptr = UNINIT.as_ptr();
-            assert_eq!(
-                ::std::mem::size_of::<Point>(),
-                4usize,
-                concat!("Size of: ", stringify!(Point)),
-            );
-            assert_eq!(
-                ::std::mem::align_of::<Point>(),
-                4usize,
-                concat!("Alignment of ", stringify!(Point)),
-            );
-            assert_eq!(
-                unsafe { ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize },
-                0usize,
-                concat!("Offset of field: ", stringify!(Point), "::", stringify!(x)),
-            );
-        }
+        const _: () = {
+            ["Size of Point"][::std::mem::size_of::<Point>() - 4usize];
+            ["Alignment of Point"][::std::mem::align_of::<Point>() - 4usize];
+            ["Offset of field: Point::x"][::std::mem::offset_of!(Point, x) - 0usize];
+        };
         extern "C" {
             #[link_name = "\u{1}_ZN2ns3fooEv"]
             pub fn foo() -> ::std::os::raw::c_int;

--- a/bindgen-tests/tests/expectations/tests/method-mangling.rs
+++ b/bindgen-tests/tests/expectations/tests/method-mangling.rs
@@ -4,19 +4,10 @@
 pub struct Foo {
     pub _address: u8,
 }
-#[test]
-fn bindgen_test_layout_Foo() {
-    assert_eq!(
-        ::std::mem::size_of::<Foo>(),
-        1usize,
-        concat!("Size of: ", stringify!(Foo)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Foo>(),
-        1usize,
-        concat!("Alignment of ", stringify!(Foo)),
-    );
-}
+const _: () = {
+    ["Size of Foo"][::std::mem::size_of::<Foo>() - 1usize];
+    ["Alignment of Foo"][::std::mem::align_of::<Foo>() - 1usize];
+};
 extern "C" {
     #[link_name = "\u{1}_ZN3Foo4typeEv"]
     pub fn Foo_type(this: *mut Foo) -> ::std::os::raw::c_int;

--- a/bindgen-tests/tests/expectations/tests/module-allowlisted.rs
+++ b/bindgen-tests/tests/expectations/tests/module-allowlisted.rs
@@ -8,17 +8,8 @@ pub mod root {
     pub struct Test {
         pub _address: u8,
     }
-    #[test]
-    fn bindgen_test_layout_Test() {
-        assert_eq!(
-            ::std::mem::size_of::<Test>(),
-            1usize,
-            concat!("Size of: ", stringify!(Test)),
-        );
-        assert_eq!(
-            ::std::mem::align_of::<Test>(),
-            1usize,
-            concat!("Alignment of ", stringify!(Test)),
-        );
-    }
+    const _: () = {
+        ["Size of Test"][::std::mem::size_of::<Test>() - 1usize];
+        ["Alignment of Test"][::std::mem::align_of::<Test>() - 1usize];
+    };
 }

--- a/bindgen-tests/tests/expectations/tests/msvc-no-usr.rs
+++ b/bindgen-tests/tests/expectations/tests/msvc-no-usr.rs
@@ -4,19 +4,8 @@
 pub struct A {
     pub foo: usize,
 }
-#[test]
-fn bindgen_test_layout_A() {
-    const UNINIT: ::std::mem::MaybeUninit<A> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(::std::mem::size_of::<A>(), 8usize, concat!("Size of: ", stringify!(A)));
-    assert_eq!(
-        ::std::mem::align_of::<A>(),
-        8usize,
-        concat!("Alignment of ", stringify!(A)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(A), "::", stringify!(foo)),
-    );
-}
+const _: () = {
+    ["Size of A"][::std::mem::size_of::<A>() - 8usize];
+    ["Alignment of A"][::std::mem::align_of::<A>() - 8usize];
+    ["Offset of field: A::foo"][::std::mem::offset_of!(A, foo) - 0usize];
+};

--- a/bindgen-tests/tests/expectations/tests/multiple-inherit-empty-correct-layout.rs
+++ b/bindgen-tests/tests/expectations/tests/multiple-inherit-empty-correct-layout.rs
@@ -4,52 +4,25 @@
 pub struct Foo {
     pub _address: u8,
 }
-#[test]
-fn bindgen_test_layout_Foo() {
-    assert_eq!(
-        ::std::mem::size_of::<Foo>(),
-        1usize,
-        concat!("Size of: ", stringify!(Foo)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Foo>(),
-        1usize,
-        concat!("Alignment of ", stringify!(Foo)),
-    );
-}
+const _: () = {
+    ["Size of Foo"][::std::mem::size_of::<Foo>() - 1usize];
+    ["Alignment of Foo"][::std::mem::align_of::<Foo>() - 1usize];
+};
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct Bar {
     pub _address: u8,
 }
-#[test]
-fn bindgen_test_layout_Bar() {
-    assert_eq!(
-        ::std::mem::size_of::<Bar>(),
-        1usize,
-        concat!("Size of: ", stringify!(Bar)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Bar>(),
-        1usize,
-        concat!("Alignment of ", stringify!(Bar)),
-    );
-}
+const _: () = {
+    ["Size of Bar"][::std::mem::size_of::<Bar>() - 1usize];
+    ["Alignment of Bar"][::std::mem::align_of::<Bar>() - 1usize];
+};
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct Baz {
     pub _address: u8,
 }
-#[test]
-fn bindgen_test_layout_Baz() {
-    assert_eq!(
-        ::std::mem::size_of::<Baz>(),
-        1usize,
-        concat!("Size of: ", stringify!(Baz)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Baz>(),
-        1usize,
-        concat!("Alignment of ", stringify!(Baz)),
-    );
-}
+const _: () = {
+    ["Size of Baz"][::std::mem::size_of::<Baz>() - 1usize];
+    ["Alignment of Baz"][::std::mem::align_of::<Baz>() - 1usize];
+};

--- a/bindgen-tests/tests/expectations/tests/mutable.rs
+++ b/bindgen-tests/tests/expectations/tests/mutable.rs
@@ -5,79 +5,38 @@ pub struct C {
     pub m_member: ::std::os::raw::c_int,
     pub m_other: ::std::os::raw::c_int,
 }
-#[test]
-fn bindgen_test_layout_C() {
-    const UNINIT: ::std::mem::MaybeUninit<C> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(::std::mem::size_of::<C>(), 8usize, concat!("Size of: ", stringify!(C)));
-    assert_eq!(
-        ::std::mem::align_of::<C>(),
-        4usize,
-        concat!("Alignment of ", stringify!(C)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).m_member) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(C), "::", stringify!(m_member)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).m_other) as usize - ptr as usize },
-        4usize,
-        concat!("Offset of field: ", stringify!(C), "::", stringify!(m_other)),
-    );
-}
+const _: () = {
+    ["Size of C"][::std::mem::size_of::<C>() - 8usize];
+    ["Alignment of C"][::std::mem::align_of::<C>() - 4usize];
+    ["Offset of field: C::m_member"][::std::mem::offset_of!(C, m_member) - 0usize];
+    ["Offset of field: C::m_other"][::std::mem::offset_of!(C, m_other) - 4usize];
+};
 #[repr(C)]
 #[derive(Debug, Default)]
 pub struct NonCopiable {
     pub m_member: ::std::os::raw::c_int,
 }
-#[test]
-fn bindgen_test_layout_NonCopiable() {
-    const UNINIT: ::std::mem::MaybeUninit<NonCopiable> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<NonCopiable>(),
-        4usize,
-        concat!("Size of: ", stringify!(NonCopiable)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<NonCopiable>(),
-        4usize,
-        concat!("Alignment of ", stringify!(NonCopiable)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).m_member) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(NonCopiable), "::", stringify!(m_member)),
-    );
-}
+const _: () = {
+    ["Size of NonCopiable"][::std::mem::size_of::<NonCopiable>() - 4usize];
+    ["Alignment of NonCopiable"][::std::mem::align_of::<NonCopiable>() - 4usize];
+    [
+        "Offset of field: NonCopiable::m_member",
+    ][::std::mem::offset_of!(NonCopiable, m_member) - 0usize];
+};
 #[repr(C)]
 #[derive(Debug, Default)]
 pub struct NonCopiableWithNonCopiableMutableMember {
     pub m_member: NonCopiable,
 }
-#[test]
-fn bindgen_test_layout_NonCopiableWithNonCopiableMutableMember() {
-    const UNINIT: ::std::mem::MaybeUninit<NonCopiableWithNonCopiableMutableMember> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<NonCopiableWithNonCopiableMutableMember>(),
-        4usize,
-        concat!("Size of: ", stringify!(NonCopiableWithNonCopiableMutableMember)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<NonCopiableWithNonCopiableMutableMember>(),
-        4usize,
-        concat!("Alignment of ", stringify!(NonCopiableWithNonCopiableMutableMember)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).m_member) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(NonCopiableWithNonCopiableMutableMember),
-            "::",
-            stringify!(m_member),
-        ),
-    );
-}
+const _: () = {
+    [
+        "Size of NonCopiableWithNonCopiableMutableMember",
+    ][::std::mem::size_of::<NonCopiableWithNonCopiableMutableMember>() - 4usize];
+    [
+        "Alignment of NonCopiableWithNonCopiableMutableMember",
+    ][::std::mem::align_of::<NonCopiableWithNonCopiableMutableMember>() - 4usize];
+    [
+        "Offset of field: NonCopiableWithNonCopiableMutableMember::m_member",
+    ][::std::mem::offset_of!(NonCopiableWithNonCopiableMutableMember, m_member)
+        - 0usize];
+};

--- a/bindgen-tests/tests/expectations/tests/namespace.rs
+++ b/bindgen-tests/tests/expectations/tests/namespace.rs
@@ -25,26 +25,11 @@ pub mod root {
         pub struct A {
             pub b: root::whatever::whatever_int_t,
         }
-        #[test]
-        fn bindgen_test_layout_A() {
-            const UNINIT: ::std::mem::MaybeUninit<A> = ::std::mem::MaybeUninit::uninit();
-            let ptr = UNINIT.as_ptr();
-            assert_eq!(
-                ::std::mem::size_of::<A>(),
-                4usize,
-                concat!("Size of: ", stringify!(A)),
-            );
-            assert_eq!(
-                ::std::mem::align_of::<A>(),
-                4usize,
-                concat!("Alignment of ", stringify!(A)),
-            );
-            assert_eq!(
-                unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
-                0usize,
-                concat!("Offset of field: ", stringify!(A), "::", stringify!(b)),
-            );
-        }
+        const _: () = {
+            ["Size of A"][::std::mem::size_of::<A>() - 4usize];
+            ["Alignment of A"][::std::mem::align_of::<A>() - 4usize];
+            ["Offset of field: A::b"][::std::mem::offset_of!(A, b) - 0usize];
+        };
     }
     #[repr(C)]
     #[derive(Debug)]

--- a/bindgen-tests/tests/expectations/tests/nested.rs
+++ b/bindgen-tests/tests/expectations/tests/nested.rs
@@ -4,26 +4,11 @@
 pub struct Calc {
     pub w: ::std::os::raw::c_int,
 }
-#[test]
-fn bindgen_test_layout_Calc() {
-    const UNINIT: ::std::mem::MaybeUninit<Calc> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<Calc>(),
-        4usize,
-        concat!("Size of: ", stringify!(Calc)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Calc>(),
-        4usize,
-        concat!("Alignment of ", stringify!(Calc)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).w) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(Calc), "::", stringify!(w)),
-    );
-}
+const _: () = {
+    ["Size of Calc"][::std::mem::size_of::<Calc>() - 4usize];
+    ["Alignment of Calc"][::std::mem::align_of::<Calc>() - 4usize];
+    ["Offset of field: Calc::w"][::std::mem::offset_of!(Calc, w) - 0usize];
+};
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct Test {
@@ -40,54 +25,25 @@ pub struct Test_Size {
 pub struct Test_Size_Dimension {
     pub _base: Calc,
 }
-#[test]
-fn bindgen_test_layout_Test_Size_Dimension() {
-    assert_eq!(
-        ::std::mem::size_of::<Test_Size_Dimension>(),
-        4usize,
-        concat!("Size of: ", stringify!(Test_Size_Dimension)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Test_Size_Dimension>(),
-        4usize,
-        concat!("Alignment of ", stringify!(Test_Size_Dimension)),
-    );
-}
-#[test]
-fn bindgen_test_layout_Test_Size() {
-    const UNINIT: ::std::mem::MaybeUninit<Test_Size> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<Test_Size>(),
-        8usize,
-        concat!("Size of: ", stringify!(Test_Size)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Test_Size>(),
-        4usize,
-        concat!("Alignment of ", stringify!(Test_Size)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).mWidth) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(Test_Size), "::", stringify!(mWidth)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).mHeight) as usize - ptr as usize },
-        4usize,
-        concat!("Offset of field: ", stringify!(Test_Size), "::", stringify!(mHeight)),
-    );
-}
-#[test]
-fn bindgen_test_layout_Test() {
-    assert_eq!(
-        ::std::mem::size_of::<Test>(),
-        1usize,
-        concat!("Size of: ", stringify!(Test)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Test>(),
-        1usize,
-        concat!("Alignment of ", stringify!(Test)),
-    );
-}
+const _: () = {
+    [
+        "Size of Test_Size_Dimension",
+    ][::std::mem::size_of::<Test_Size_Dimension>() - 4usize];
+    [
+        "Alignment of Test_Size_Dimension",
+    ][::std::mem::align_of::<Test_Size_Dimension>() - 4usize];
+};
+const _: () = {
+    ["Size of Test_Size"][::std::mem::size_of::<Test_Size>() - 8usize];
+    ["Alignment of Test_Size"][::std::mem::align_of::<Test_Size>() - 4usize];
+    [
+        "Offset of field: Test_Size::mWidth",
+    ][::std::mem::offset_of!(Test_Size, mWidth) - 0usize];
+    [
+        "Offset of field: Test_Size::mHeight",
+    ][::std::mem::offset_of!(Test_Size, mHeight) - 4usize];
+};
+const _: () = {
+    ["Size of Test"][::std::mem::size_of::<Test>() - 1usize];
+    ["Alignment of Test"][::std::mem::align_of::<Test>() - 1usize];
+};

--- a/bindgen-tests/tests/expectations/tests/nested_vtable.rs
+++ b/bindgen-tests/tests/expectations/tests/nested_vtable.rs
@@ -10,19 +10,10 @@ pub struct nsISupports__bindgen_vtable {
 pub struct nsISupports {
     pub vtable_: *const nsISupports__bindgen_vtable,
 }
-#[test]
-fn bindgen_test_layout_nsISupports() {
-    assert_eq!(
-        ::std::mem::size_of::<nsISupports>(),
-        8usize,
-        concat!("Size of: ", stringify!(nsISupports)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<nsISupports>(),
-        8usize,
-        concat!("Alignment of ", stringify!(nsISupports)),
-    );
-}
+const _: () = {
+    ["Size of nsISupports"][::std::mem::size_of::<nsISupports>() - 8usize];
+    ["Alignment of nsISupports"][::std::mem::align_of::<nsISupports>() - 8usize];
+};
 impl Default for nsISupports {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
@@ -43,19 +34,10 @@ extern "C" {
 pub struct nsIRunnable {
     pub _base: nsISupports,
 }
-#[test]
-fn bindgen_test_layout_nsIRunnable() {
-    assert_eq!(
-        ::std::mem::size_of::<nsIRunnable>(),
-        8usize,
-        concat!("Size of: ", stringify!(nsIRunnable)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<nsIRunnable>(),
-        8usize,
-        concat!("Alignment of ", stringify!(nsIRunnable)),
-    );
-}
+const _: () = {
+    ["Size of nsIRunnable"][::std::mem::size_of::<nsIRunnable>() - 8usize];
+    ["Alignment of nsIRunnable"][::std::mem::align_of::<nsIRunnable>() - 8usize];
+};
 impl Default for nsIRunnable {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
@@ -70,19 +52,10 @@ impl Default for nsIRunnable {
 pub struct Runnable {
     pub _base: nsIRunnable,
 }
-#[test]
-fn bindgen_test_layout_Runnable() {
-    assert_eq!(
-        ::std::mem::size_of::<Runnable>(),
-        8usize,
-        concat!("Size of: ", stringify!(Runnable)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Runnable>(),
-        8usize,
-        concat!("Alignment of ", stringify!(Runnable)),
-    );
-}
+const _: () = {
+    ["Size of Runnable"][::std::mem::size_of::<Runnable>() - 8usize];
+    ["Alignment of Runnable"][::std::mem::align_of::<Runnable>() - 8usize];
+};
 impl Default for Runnable {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();

--- a/bindgen-tests/tests/expectations/tests/nested_within_namespace.rs
+++ b/bindgen-tests/tests/expectations/tests/nested_within_namespace.rs
@@ -16,70 +16,27 @@ pub mod root {
         pub struct Bar_Baz {
             pub foo: ::std::os::raw::c_int,
         }
-        #[test]
-        fn bindgen_test_layout_Bar_Baz() {
-            const UNINIT: ::std::mem::MaybeUninit<Bar_Baz> = ::std::mem::MaybeUninit::uninit();
-            let ptr = UNINIT.as_ptr();
-            assert_eq!(
-                ::std::mem::size_of::<Bar_Baz>(),
-                4usize,
-                concat!("Size of: ", stringify!(Bar_Baz)),
-            );
-            assert_eq!(
-                ::std::mem::align_of::<Bar_Baz>(),
-                4usize,
-                concat!("Alignment of ", stringify!(Bar_Baz)),
-            );
-            assert_eq!(
-                unsafe { ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize },
-                0usize,
-                concat!("Offset of field: ", stringify!(Bar_Baz), "::", stringify!(foo)),
-            );
-        }
-        #[test]
-        fn bindgen_test_layout_Bar() {
-            const UNINIT: ::std::mem::MaybeUninit<Bar> = ::std::mem::MaybeUninit::uninit();
-            let ptr = UNINIT.as_ptr();
-            assert_eq!(
-                ::std::mem::size_of::<Bar>(),
-                4usize,
-                concat!("Size of: ", stringify!(Bar)),
-            );
-            assert_eq!(
-                ::std::mem::align_of::<Bar>(),
-                4usize,
-                concat!("Alignment of ", stringify!(Bar)),
-            );
-            assert_eq!(
-                unsafe { ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize },
-                0usize,
-                concat!("Offset of field: ", stringify!(Bar), "::", stringify!(foo)),
-            );
-        }
+        const _: () = {
+            ["Size of Bar_Baz"][::std::mem::size_of::<Bar_Baz>() - 4usize];
+            ["Alignment of Bar_Baz"][::std::mem::align_of::<Bar_Baz>() - 4usize];
+            [
+                "Offset of field: Bar_Baz::foo",
+            ][::std::mem::offset_of!(Bar_Baz, foo) - 0usize];
+        };
+        const _: () = {
+            ["Size of Bar"][::std::mem::size_of::<Bar>() - 4usize];
+            ["Alignment of Bar"][::std::mem::align_of::<Bar>() - 4usize];
+            ["Offset of field: Bar::foo"][::std::mem::offset_of!(Bar, foo) - 0usize];
+        };
         #[repr(C)]
         #[derive(Debug, Default, Copy, Clone)]
         pub struct Baz {
             pub baz: ::std::os::raw::c_int,
         }
-        #[test]
-        fn bindgen_test_layout_Baz() {
-            const UNINIT: ::std::mem::MaybeUninit<Baz> = ::std::mem::MaybeUninit::uninit();
-            let ptr = UNINIT.as_ptr();
-            assert_eq!(
-                ::std::mem::size_of::<Baz>(),
-                4usize,
-                concat!("Size of: ", stringify!(Baz)),
-            );
-            assert_eq!(
-                ::std::mem::align_of::<Baz>(),
-                4usize,
-                concat!("Alignment of ", stringify!(Baz)),
-            );
-            assert_eq!(
-                unsafe { ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize },
-                0usize,
-                concat!("Offset of field: ", stringify!(Baz), "::", stringify!(baz)),
-            );
-        }
+        const _: () = {
+            ["Size of Baz"][::std::mem::size_of::<Baz>() - 4usize];
+            ["Alignment of Baz"][::std::mem::align_of::<Baz>() - 4usize];
+            ["Offset of field: Baz::baz"][::std::mem::offset_of!(Baz, baz) - 0usize];
+        };
     }
 }

--- a/bindgen-tests/tests/expectations/tests/no-comments.rs
+++ b/bindgen-tests/tests/expectations/tests/no-comments.rs
@@ -4,23 +4,8 @@
 pub struct Foo {
     pub s: ::std::os::raw::c_int,
 }
-#[test]
-fn bindgen_test_layout_Foo() {
-    const UNINIT: ::std::mem::MaybeUninit<Foo> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<Foo>(),
-        4usize,
-        concat!("Size of: ", stringify!(Foo)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Foo>(),
-        4usize,
-        concat!("Alignment of ", stringify!(Foo)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).s) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(Foo), "::", stringify!(s)),
-    );
-}
+const _: () = {
+    ["Size of Foo"][::std::mem::size_of::<Foo>() - 4usize];
+    ["Alignment of Foo"][::std::mem::align_of::<Foo>() - 4usize];
+    ["Offset of field: Foo::s"][::std::mem::offset_of!(Foo, s) - 0usize];
+};

--- a/bindgen-tests/tests/expectations/tests/no-derive-debug.rs
+++ b/bindgen-tests/tests/expectations/tests/no-derive-debug.rs
@@ -12,31 +12,12 @@ pub struct bar {
     pub foo: foo,
     pub baz: ::std::os::raw::c_int,
 }
-#[test]
-fn bindgen_test_layout_bar() {
-    const UNINIT: ::std::mem::MaybeUninit<bar> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<bar>(),
-        8usize,
-        concat!("Size of: ", stringify!(bar)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<bar>(),
-        4usize,
-        concat!("Alignment of ", stringify!(bar)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(bar), "::", stringify!(foo)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize },
-        4usize,
-        concat!("Offset of field: ", stringify!(bar), "::", stringify!(baz)),
-    );
-}
+const _: () = {
+    ["Size of bar"][::std::mem::size_of::<bar>() - 8usize];
+    ["Alignment of bar"][::std::mem::align_of::<bar>() - 4usize];
+    ["Offset of field: bar::foo"][::std::mem::offset_of!(bar, foo) - 0usize];
+    ["Offset of field: bar::baz"][::std::mem::offset_of!(bar, baz) - 4usize];
+};
 impl Default for bar {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();

--- a/bindgen-tests/tests/expectations/tests/no-derive-default.rs
+++ b/bindgen-tests/tests/expectations/tests/no-derive-default.rs
@@ -12,28 +12,9 @@ pub struct bar {
     pub foo: foo,
     pub baz: ::std::os::raw::c_int,
 }
-#[test]
-fn bindgen_test_layout_bar() {
-    const UNINIT: ::std::mem::MaybeUninit<bar> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<bar>(),
-        8usize,
-        concat!("Size of: ", stringify!(bar)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<bar>(),
-        4usize,
-        concat!("Alignment of ", stringify!(bar)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(bar), "::", stringify!(foo)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize },
-        4usize,
-        concat!("Offset of field: ", stringify!(bar), "::", stringify!(baz)),
-    );
-}
+const _: () = {
+    ["Size of bar"][::std::mem::size_of::<bar>() - 8usize];
+    ["Alignment of bar"][::std::mem::align_of::<bar>() - 4usize];
+    ["Offset of field: bar::foo"][::std::mem::offset_of!(bar, foo) - 0usize];
+    ["Offset of field: bar::baz"][::std::mem::offset_of!(bar, baz) - 4usize];
+};

--- a/bindgen-tests/tests/expectations/tests/no-hash-allowlisted.rs
+++ b/bindgen-tests/tests/expectations/tests/no-hash-allowlisted.rs
@@ -4,23 +4,8 @@
 pub struct NoHash {
     pub i: ::std::os::raw::c_int,
 }
-#[test]
-fn bindgen_test_layout_NoHash() {
-    const UNINIT: ::std::mem::MaybeUninit<NoHash> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<NoHash>(),
-        4usize,
-        concat!("Size of: ", stringify!(NoHash)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<NoHash>(),
-        4usize,
-        concat!("Alignment of ", stringify!(NoHash)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).i) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(NoHash), "::", stringify!(i)),
-    );
-}
+const _: () = {
+    ["Size of NoHash"][::std::mem::size_of::<NoHash>() - 4usize];
+    ["Alignment of NoHash"][::std::mem::align_of::<NoHash>() - 4usize];
+    ["Offset of field: NoHash::i"][::std::mem::offset_of!(NoHash, i) - 0usize];
+};

--- a/bindgen-tests/tests/expectations/tests/no-hash-opaque.rs
+++ b/bindgen-tests/tests/expectations/tests/no-hash-opaque.rs
@@ -5,16 +5,7 @@
 pub struct NoHash {
     pub _bindgen_opaque_blob: u32,
 }
-#[test]
-fn bindgen_test_layout_NoHash() {
-    assert_eq!(
-        ::std::mem::size_of::<NoHash>(),
-        4usize,
-        concat!("Size of: ", stringify!(NoHash)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<NoHash>(),
-        4usize,
-        concat!("Alignment of ", stringify!(NoHash)),
-    );
-}
+const _: () = {
+    ["Size of NoHash"][::std::mem::size_of::<NoHash>() - 4usize];
+    ["Alignment of NoHash"][::std::mem::align_of::<NoHash>() - 4usize];
+};

--- a/bindgen-tests/tests/expectations/tests/no-partialeq-allowlisted.rs
+++ b/bindgen-tests/tests/expectations/tests/no-partialeq-allowlisted.rs
@@ -4,23 +4,8 @@
 pub struct NoPartialEq {
     pub i: ::std::os::raw::c_int,
 }
-#[test]
-fn bindgen_test_layout_NoPartialEq() {
-    const UNINIT: ::std::mem::MaybeUninit<NoPartialEq> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<NoPartialEq>(),
-        4usize,
-        concat!("Size of: ", stringify!(NoPartialEq)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<NoPartialEq>(),
-        4usize,
-        concat!("Alignment of ", stringify!(NoPartialEq)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).i) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(NoPartialEq), "::", stringify!(i)),
-    );
-}
+const _: () = {
+    ["Size of NoPartialEq"][::std::mem::size_of::<NoPartialEq>() - 4usize];
+    ["Alignment of NoPartialEq"][::std::mem::align_of::<NoPartialEq>() - 4usize];
+    ["Offset of field: NoPartialEq::i"][::std::mem::offset_of!(NoPartialEq, i) - 0usize];
+};

--- a/bindgen-tests/tests/expectations/tests/no-partialeq-opaque.rs
+++ b/bindgen-tests/tests/expectations/tests/no-partialeq-opaque.rs
@@ -5,16 +5,7 @@
 pub struct NoPartialEq {
     pub _bindgen_opaque_blob: u32,
 }
-#[test]
-fn bindgen_test_layout_NoPartialEq() {
-    assert_eq!(
-        ::std::mem::size_of::<NoPartialEq>(),
-        4usize,
-        concat!("Size of: ", stringify!(NoPartialEq)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<NoPartialEq>(),
-        4usize,
-        concat!("Alignment of ", stringify!(NoPartialEq)),
-    );
-}
+const _: () = {
+    ["Size of NoPartialEq"][::std::mem::size_of::<NoPartialEq>() - 4usize];
+    ["Alignment of NoPartialEq"][::std::mem::align_of::<NoPartialEq>() - 4usize];
+};

--- a/bindgen-tests/tests/expectations/tests/no-recursive-allowlisting.rs
+++ b/bindgen-tests/tests/expectations/tests/no-recursive-allowlisting.rs
@@ -5,26 +5,11 @@ pub enum Bar {}
 pub struct Foo {
     pub baz: *mut Bar,
 }
-#[test]
-fn bindgen_test_layout_Foo() {
-    const UNINIT: ::std::mem::MaybeUninit<Foo> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<Foo>(),
-        8usize,
-        concat!("Size of: ", stringify!(Foo)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Foo>(),
-        8usize,
-        concat!("Alignment of ", stringify!(Foo)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(Foo), "::", stringify!(baz)),
-    );
-}
+const _: () = {
+    ["Size of Foo"][::std::mem::size_of::<Foo>() - 8usize];
+    ["Alignment of Foo"][::std::mem::align_of::<Foo>() - 8usize];
+    ["Offset of field: Foo::baz"][::std::mem::offset_of!(Foo, baz) - 0usize];
+};
 impl Default for Foo {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();

--- a/bindgen-tests/tests/expectations/tests/no-std.rs
+++ b/bindgen-tests/tests/expectations/tests/no-std.rs
@@ -11,36 +11,13 @@ pub struct foo {
     pub b: libc::c_int,
     pub bar: *mut libc::c_void,
 }
-#[test]
-fn bindgen_test_layout_foo() {
-    const UNINIT: ::core::mem::MaybeUninit<foo> = ::core::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::core::mem::size_of::<foo>(),
-        16usize,
-        concat!("Size of: ", stringify!(foo)),
-    );
-    assert_eq!(
-        ::core::mem::align_of::<foo>(),
-        8usize,
-        concat!("Alignment of ", stringify!(foo)),
-    );
-    assert_eq!(
-        unsafe { ::core::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(a)),
-    );
-    assert_eq!(
-        unsafe { ::core::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
-        4usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(b)),
-    );
-    assert_eq!(
-        unsafe { ::core::ptr::addr_of!((*ptr).bar) as usize - ptr as usize },
-        8usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar)),
-    );
-}
+const _: () = {
+    ["Size of foo"][::core::mem::size_of::<foo>() - 16usize];
+    ["Alignment of foo"][::core::mem::align_of::<foo>() - 8usize];
+    ["Offset of field: foo::a"][::core::mem::offset_of!(foo, a) - 0usize];
+    ["Offset of field: foo::b"][::core::mem::offset_of!(foo, b) - 4usize];
+    ["Offset of field: foo::bar"][::core::mem::offset_of!(foo, bar) - 8usize];
+};
 impl Default for foo {
     fn default() -> Self {
         let mut s = ::core::mem::MaybeUninit::<Self>::uninit();

--- a/bindgen-tests/tests/expectations/tests/no_copy_allowlisted.rs
+++ b/bindgen-tests/tests/expectations/tests/no_copy_allowlisted.rs
@@ -4,23 +4,8 @@
 pub struct NoCopy {
     pub i: ::std::os::raw::c_int,
 }
-#[test]
-fn bindgen_test_layout_NoCopy() {
-    const UNINIT: ::std::mem::MaybeUninit<NoCopy> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<NoCopy>(),
-        4usize,
-        concat!("Size of: ", stringify!(NoCopy)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<NoCopy>(),
-        4usize,
-        concat!("Alignment of ", stringify!(NoCopy)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).i) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(NoCopy), "::", stringify!(i)),
-    );
-}
+const _: () = {
+    ["Size of NoCopy"][::std::mem::size_of::<NoCopy>() - 4usize];
+    ["Alignment of NoCopy"][::std::mem::align_of::<NoCopy>() - 4usize];
+    ["Offset of field: NoCopy::i"][::std::mem::offset_of!(NoCopy, i) - 0usize];
+};

--- a/bindgen-tests/tests/expectations/tests/no_copy_opaque.rs
+++ b/bindgen-tests/tests/expectations/tests/no_copy_opaque.rs
@@ -5,16 +5,7 @@
 pub struct NoCopy {
     pub _bindgen_opaque_blob: u32,
 }
-#[test]
-fn bindgen_test_layout_NoCopy() {
-    assert_eq!(
-        ::std::mem::size_of::<NoCopy>(),
-        4usize,
-        concat!("Size of: ", stringify!(NoCopy)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<NoCopy>(),
-        4usize,
-        concat!("Alignment of ", stringify!(NoCopy)),
-    );
-}
+const _: () = {
+    ["Size of NoCopy"][::std::mem::size_of::<NoCopy>() - 4usize];
+    ["Alignment of NoCopy"][::std::mem::align_of::<NoCopy>() - 4usize];
+};

--- a/bindgen-tests/tests/expectations/tests/no_debug_allowlisted.rs
+++ b/bindgen-tests/tests/expectations/tests/no_debug_allowlisted.rs
@@ -4,23 +4,8 @@
 pub struct NoDebug {
     pub i: ::std::os::raw::c_int,
 }
-#[test]
-fn bindgen_test_layout_NoDebug() {
-    const UNINIT: ::std::mem::MaybeUninit<NoDebug> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<NoDebug>(),
-        4usize,
-        concat!("Size of: ", stringify!(NoDebug)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<NoDebug>(),
-        4usize,
-        concat!("Alignment of ", stringify!(NoDebug)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).i) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(NoDebug), "::", stringify!(i)),
-    );
-}
+const _: () = {
+    ["Size of NoDebug"][::std::mem::size_of::<NoDebug>() - 4usize];
+    ["Alignment of NoDebug"][::std::mem::align_of::<NoDebug>() - 4usize];
+    ["Offset of field: NoDebug::i"][::std::mem::offset_of!(NoDebug, i) - 0usize];
+};

--- a/bindgen-tests/tests/expectations/tests/no_debug_opaque.rs
+++ b/bindgen-tests/tests/expectations/tests/no_debug_opaque.rs
@@ -5,16 +5,7 @@
 pub struct NoDebug {
     pub _bindgen_opaque_blob: u32,
 }
-#[test]
-fn bindgen_test_layout_NoDebug() {
-    assert_eq!(
-        ::std::mem::size_of::<NoDebug>(),
-        4usize,
-        concat!("Size of: ", stringify!(NoDebug)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<NoDebug>(),
-        4usize,
-        concat!("Alignment of ", stringify!(NoDebug)),
-    );
-}
+const _: () = {
+    ["Size of NoDebug"][::std::mem::size_of::<NoDebug>() - 4usize];
+    ["Alignment of NoDebug"][::std::mem::align_of::<NoDebug>() - 4usize];
+};

--- a/bindgen-tests/tests/expectations/tests/no_default_allowlisted.rs
+++ b/bindgen-tests/tests/expectations/tests/no_default_allowlisted.rs
@@ -4,23 +4,8 @@
 pub struct NoDefault {
     pub i: ::std::os::raw::c_int,
 }
-#[test]
-fn bindgen_test_layout_NoDefault() {
-    const UNINIT: ::std::mem::MaybeUninit<NoDefault> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<NoDefault>(),
-        4usize,
-        concat!("Size of: ", stringify!(NoDefault)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<NoDefault>(),
-        4usize,
-        concat!("Alignment of ", stringify!(NoDefault)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).i) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(NoDefault), "::", stringify!(i)),
-    );
-}
+const _: () = {
+    ["Size of NoDefault"][::std::mem::size_of::<NoDefault>() - 4usize];
+    ["Alignment of NoDefault"][::std::mem::align_of::<NoDefault>() - 4usize];
+    ["Offset of field: NoDefault::i"][::std::mem::offset_of!(NoDefault, i) - 0usize];
+};

--- a/bindgen-tests/tests/expectations/tests/no_default_opaque.rs
+++ b/bindgen-tests/tests/expectations/tests/no_default_opaque.rs
@@ -5,16 +5,7 @@
 pub struct NoDefault {
     pub _bindgen_opaque_blob: u32,
 }
-#[test]
-fn bindgen_test_layout_NoDefault() {
-    assert_eq!(
-        ::std::mem::size_of::<NoDefault>(),
-        4usize,
-        concat!("Size of: ", stringify!(NoDefault)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<NoDefault>(),
-        4usize,
-        concat!("Alignment of ", stringify!(NoDefault)),
-    );
-}
+const _: () = {
+    ["Size of NoDefault"][::std::mem::size_of::<NoDefault>() - 4usize];
+    ["Alignment of NoDefault"][::std::mem::align_of::<NoDefault>() - 4usize];
+};

--- a/bindgen-tests/tests/expectations/tests/no_size_t_is_usize.rs
+++ b/bindgen-tests/tests/expectations/tests/no_size_t_is_usize.rs
@@ -8,32 +8,13 @@ pub struct A {
     pub offset: ssize_t,
     pub next: *mut A,
 }
-#[test]
-fn bindgen_test_layout_A() {
-    const UNINIT: ::std::mem::MaybeUninit<A> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(::std::mem::size_of::<A>(), 24usize, concat!("Size of: ", stringify!(A)));
-    assert_eq!(
-        ::std::mem::align_of::<A>(),
-        8usize,
-        concat!("Alignment of ", stringify!(A)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).len) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(A), "::", stringify!(len)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).offset) as usize - ptr as usize },
-        8usize,
-        concat!("Offset of field: ", stringify!(A), "::", stringify!(offset)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).next) as usize - ptr as usize },
-        16usize,
-        concat!("Offset of field: ", stringify!(A), "::", stringify!(next)),
-    );
-}
+const _: () = {
+    ["Size of A"][::std::mem::size_of::<A>() - 24usize];
+    ["Alignment of A"][::std::mem::align_of::<A>() - 8usize];
+    ["Offset of field: A::len"][::std::mem::offset_of!(A, len) - 0usize];
+    ["Offset of field: A::offset"][::std::mem::offset_of!(A, offset) - 8usize];
+    ["Offset of field: A::next"][::std::mem::offset_of!(A, next) - 16usize];
+};
 impl Default for A {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();

--- a/bindgen-tests/tests/expectations/tests/non-type-params.rs
+++ b/bindgen-tests/tests/expectations/tests/non-type-params.rs
@@ -8,48 +8,16 @@ pub struct UsesArray {
     pub array_bool_8: [u8; 8usize],
     pub array_int_4: ArrayInt4,
 }
-#[test]
-fn bindgen_test_layout_UsesArray() {
-    const UNINIT: ::std::mem::MaybeUninit<UsesArray> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<UsesArray>(),
-        40usize,
-        concat!("Size of: ", stringify!(UsesArray)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<UsesArray>(),
-        4usize,
-        concat!("Alignment of ", stringify!(UsesArray)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).array_char_16) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(UsesArray),
-            "::",
-            stringify!(array_char_16),
-        ),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).array_bool_8) as usize - ptr as usize },
-        16usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(UsesArray),
-            "::",
-            stringify!(array_bool_8),
-        ),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).array_int_4) as usize - ptr as usize },
-        24usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(UsesArray),
-            "::",
-            stringify!(array_int_4),
-        ),
-    );
-}
+const _: () = {
+    ["Size of UsesArray"][::std::mem::size_of::<UsesArray>() - 40usize];
+    ["Alignment of UsesArray"][::std::mem::align_of::<UsesArray>() - 4usize];
+    [
+        "Offset of field: UsesArray::array_char_16",
+    ][::std::mem::offset_of!(UsesArray, array_char_16) - 0usize];
+    [
+        "Offset of field: UsesArray::array_bool_8",
+    ][::std::mem::offset_of!(UsesArray, array_bool_8) - 16usize];
+    [
+        "Offset of field: UsesArray::array_int_4",
+    ][::std::mem::offset_of!(UsesArray, array_int_4) - 24usize];
+};

--- a/bindgen-tests/tests/expectations/tests/objc_interface_type.rs
+++ b/bindgen-tests/tests/expectations/tests/objc_interface_type.rs
@@ -25,26 +25,11 @@ pub trait IFoo: Sized + std::ops::Deref {}
 pub struct FooStruct {
     pub foo: Foo,
 }
-#[test]
-fn bindgen_test_layout_FooStruct() {
-    const UNINIT: ::std::mem::MaybeUninit<FooStruct> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<FooStruct>(),
-        8usize,
-        concat!("Size of: ", stringify!(FooStruct)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<FooStruct>(),
-        8usize,
-        concat!("Alignment of ", stringify!(FooStruct)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(FooStruct), "::", stringify!(foo)),
-    );
-}
+const _: () = {
+    ["Size of FooStruct"][::std::mem::size_of::<FooStruct>() - 8usize];
+    ["Alignment of FooStruct"][::std::mem::align_of::<FooStruct>() - 8usize];
+    ["Offset of field: FooStruct::foo"][::std::mem::offset_of!(FooStruct, foo) - 0usize];
+};
 impl Default for FooStruct {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();

--- a/bindgen-tests/tests/expectations/tests/only_bitfields.rs
+++ b/bindgen-tests/tests/expectations/tests/only_bitfields.rs
@@ -89,15 +89,10 @@ pub struct C {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
 }
-#[test]
-fn bindgen_test_layout_C() {
-    assert_eq!(::std::mem::size_of::<C>(), 1usize, concat!("Size of: ", stringify!(C)));
-    assert_eq!(
-        ::std::mem::align_of::<C>(),
-        1usize,
-        concat!("Alignment of ", stringify!(C)),
-    );
-}
+const _: () = {
+    ["Size of C"][::std::mem::size_of::<C>() - 1usize];
+    ["Alignment of C"][::std::mem::align_of::<C>() - 1usize];
+};
 impl C {
     #[inline]
     pub fn a(&self) -> bool {

--- a/bindgen-tests/tests/expectations/tests/opaque-template-inst-member-2.rs
+++ b/bindgen-tests/tests/expectations/tests/opaque-template-inst-member-2.rs
@@ -13,41 +13,20 @@ pub struct ContainsOpaqueTemplate {
     pub mBlah: u32,
     pub mBaz: ::std::os::raw::c_int,
 }
-#[test]
-fn bindgen_test_layout_ContainsOpaqueTemplate() {
-    const UNINIT: ::std::mem::MaybeUninit<ContainsOpaqueTemplate> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<ContainsOpaqueTemplate>(),
-        8usize,
-        concat!("Size of: ", stringify!(ContainsOpaqueTemplate)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<ContainsOpaqueTemplate>(),
-        4usize,
-        concat!("Alignment of ", stringify!(ContainsOpaqueTemplate)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).mBlah) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(ContainsOpaqueTemplate),
-            "::",
-            stringify!(mBlah),
-        ),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).mBaz) as usize - ptr as usize },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(ContainsOpaqueTemplate),
-            "::",
-            stringify!(mBaz),
-        ),
-    );
-}
+const _: () = {
+    [
+        "Size of ContainsOpaqueTemplate",
+    ][::std::mem::size_of::<ContainsOpaqueTemplate>() - 8usize];
+    [
+        "Alignment of ContainsOpaqueTemplate",
+    ][::std::mem::align_of::<ContainsOpaqueTemplate>() - 4usize];
+    [
+        "Offset of field: ContainsOpaqueTemplate::mBlah",
+    ][::std::mem::offset_of!(ContainsOpaqueTemplate, mBlah) - 0usize];
+    [
+        "Offset of field: ContainsOpaqueTemplate::mBaz",
+    ][::std::mem::offset_of!(ContainsOpaqueTemplate, mBaz) - 4usize];
+};
 /// Should also derive Debug/Hash/PartialEq.
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -55,31 +34,17 @@ pub struct InheritsOpaqueTemplate {
     pub _base: u8,
     pub wow: *mut ::std::os::raw::c_char,
 }
-#[test]
-fn bindgen_test_layout_InheritsOpaqueTemplate() {
-    const UNINIT: ::std::mem::MaybeUninit<InheritsOpaqueTemplate> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<InheritsOpaqueTemplate>(),
-        16usize,
-        concat!("Size of: ", stringify!(InheritsOpaqueTemplate)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<InheritsOpaqueTemplate>(),
-        8usize,
-        concat!("Alignment of ", stringify!(InheritsOpaqueTemplate)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).wow) as usize - ptr as usize },
-        8usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(InheritsOpaqueTemplate),
-            "::",
-            stringify!(wow),
-        ),
-    );
-}
+const _: () = {
+    [
+        "Size of InheritsOpaqueTemplate",
+    ][::std::mem::size_of::<InheritsOpaqueTemplate>() - 16usize];
+    [
+        "Alignment of InheritsOpaqueTemplate",
+    ][::std::mem::align_of::<InheritsOpaqueTemplate>() - 8usize];
+    [
+        "Offset of field: InheritsOpaqueTemplate::wow",
+    ][::std::mem::offset_of!(InheritsOpaqueTemplate, wow) - 8usize];
+};
 impl Default for InheritsOpaqueTemplate {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();

--- a/bindgen-tests/tests/expectations/tests/opaque-template-inst-member.rs
+++ b/bindgen-tests/tests/expectations/tests/opaque-template-inst-member.rs
@@ -18,32 +18,22 @@ fn bindgen_test_layout_ContainsOpaqueTemplate() {
     assert_eq!(
         ::std::mem::size_of::<ContainsOpaqueTemplate>(),
         408usize,
-        concat!("Size of: ", stringify!(ContainsOpaqueTemplate)),
+        "Size of ContainsOpaqueTemplate",
     );
     assert_eq!(
         ::std::mem::align_of::<ContainsOpaqueTemplate>(),
         4usize,
-        concat!("Alignment of ", stringify!(ContainsOpaqueTemplate)),
+        "Alignment of ContainsOpaqueTemplate",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).mBlah) as usize - ptr as usize },
         0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(ContainsOpaqueTemplate),
-            "::",
-            stringify!(mBlah),
-        ),
+        "Offset of field: ContainsOpaqueTemplate::mBlah",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).mBaz) as usize - ptr as usize },
         404usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(ContainsOpaqueTemplate),
-            "::",
-            stringify!(mBaz),
-        ),
+        "Offset of field: ContainsOpaqueTemplate::mBaz",
     );
 }
 impl Default for ContainsOpaqueTemplate {
@@ -74,22 +64,17 @@ fn bindgen_test_layout_InheritsOpaqueTemplate() {
     assert_eq!(
         ::std::mem::size_of::<InheritsOpaqueTemplate>(),
         416usize,
-        concat!("Size of: ", stringify!(InheritsOpaqueTemplate)),
+        "Size of InheritsOpaqueTemplate",
     );
     assert_eq!(
         ::std::mem::align_of::<InheritsOpaqueTemplate>(),
         8usize,
-        concat!("Alignment of ", stringify!(InheritsOpaqueTemplate)),
+        "Alignment of InheritsOpaqueTemplate",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).wow) as usize - ptr as usize },
         408usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(InheritsOpaqueTemplate),
-            "::",
-            stringify!(wow),
-        ),
+        "Offset of field: InheritsOpaqueTemplate::wow",
     );
 }
 impl Default for InheritsOpaqueTemplate {

--- a/bindgen-tests/tests/expectations/tests/opaque-template-instantiation-namespaced.rs
+++ b/bindgen-tests/tests/expectations/tests/opaque-template-instantiation-namespaced.rs
@@ -26,83 +26,37 @@ pub mod root {
         pub struct Foo {
             pub c: ::std::os::raw::c_char,
         }
-        #[test]
-        fn bindgen_test_layout_Foo() {
-            const UNINIT: ::std::mem::MaybeUninit<Foo> = ::std::mem::MaybeUninit::uninit();
-            let ptr = UNINIT.as_ptr();
-            assert_eq!(
-                ::std::mem::size_of::<Foo>(),
-                1usize,
-                concat!("Size of: ", stringify!(Foo)),
-            );
-            assert_eq!(
-                ::std::mem::align_of::<Foo>(),
-                1usize,
-                concat!("Alignment of ", stringify!(Foo)),
-            );
-            assert_eq!(
-                unsafe { ::std::ptr::addr_of!((*ptr).c) as usize - ptr as usize },
-                0usize,
-                concat!("Offset of field: ", stringify!(Foo), "::", stringify!(c)),
-            );
-        }
+        const _: () = {
+            ["Size of Foo"][::std::mem::size_of::<Foo>() - 1usize];
+            ["Alignment of Foo"][::std::mem::align_of::<Foo>() - 1usize];
+            ["Offset of field: Foo::c"][::std::mem::offset_of!(Foo, c) - 0usize];
+        };
         #[repr(C)]
         #[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
         pub struct Bar {
             pub i: ::std::os::raw::c_int,
         }
-        #[test]
-        fn bindgen_test_layout_Bar() {
-            const UNINIT: ::std::mem::MaybeUninit<Bar> = ::std::mem::MaybeUninit::uninit();
-            let ptr = UNINIT.as_ptr();
-            assert_eq!(
-                ::std::mem::size_of::<Bar>(),
-                4usize,
-                concat!("Size of: ", stringify!(Bar)),
-            );
-            assert_eq!(
-                ::std::mem::align_of::<Bar>(),
-                4usize,
-                concat!("Alignment of ", stringify!(Bar)),
-            );
-            assert_eq!(
-                unsafe { ::std::ptr::addr_of!((*ptr).i) as usize - ptr as usize },
-                0usize,
-                concat!("Offset of field: ", stringify!(Bar), "::", stringify!(i)),
-            );
-        }
+        const _: () = {
+            ["Size of Bar"][::std::mem::size_of::<Bar>() - 4usize];
+            ["Alignment of Bar"][::std::mem::align_of::<Bar>() - 4usize];
+            ["Offset of field: Bar::i"][::std::mem::offset_of!(Bar, i) - 0usize];
+        };
         #[repr(C)]
         #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
         pub struct ContainsInstantiation {
             pub not_opaque: root::zoidberg::Template<root::zoidberg::Foo>,
         }
-        #[test]
-        fn bindgen_test_layout_ContainsInstantiation() {
-            const UNINIT: ::std::mem::MaybeUninit<ContainsInstantiation> = ::std::mem::MaybeUninit::uninit();
-            let ptr = UNINIT.as_ptr();
-            assert_eq!(
-                ::std::mem::size_of::<ContainsInstantiation>(),
-                1usize,
-                concat!("Size of: ", stringify!(ContainsInstantiation)),
-            );
-            assert_eq!(
-                ::std::mem::align_of::<ContainsInstantiation>(),
-                1usize,
-                concat!("Alignment of ", stringify!(ContainsInstantiation)),
-            );
-            assert_eq!(
-                unsafe {
-                    ::std::ptr::addr_of!((*ptr).not_opaque) as usize - ptr as usize
-                },
-                0usize,
-                concat!(
-                    "Offset of field: ",
-                    stringify!(ContainsInstantiation),
-                    "::",
-                    stringify!(not_opaque),
-                ),
-            );
-        }
+        const _: () = {
+            [
+                "Size of ContainsInstantiation",
+            ][::std::mem::size_of::<ContainsInstantiation>() - 1usize];
+            [
+                "Alignment of ContainsInstantiation",
+            ][::std::mem::align_of::<ContainsInstantiation>() - 1usize];
+            [
+                "Offset of field: ContainsInstantiation::not_opaque",
+            ][::std::mem::offset_of!(ContainsInstantiation, not_opaque) - 0usize];
+        };
         impl Default for ContainsInstantiation {
             fn default() -> Self {
                 let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
@@ -117,49 +71,26 @@ pub mod root {
         pub struct ContainsOpaqueInstantiation {
             pub opaque: u32,
         }
-        #[test]
-        fn bindgen_test_layout_ContainsOpaqueInstantiation() {
-            const UNINIT: ::std::mem::MaybeUninit<ContainsOpaqueInstantiation> = ::std::mem::MaybeUninit::uninit();
-            let ptr = UNINIT.as_ptr();
-            assert_eq!(
-                ::std::mem::size_of::<ContainsOpaqueInstantiation>(),
-                4usize,
-                concat!("Size of: ", stringify!(ContainsOpaqueInstantiation)),
-            );
-            assert_eq!(
-                ::std::mem::align_of::<ContainsOpaqueInstantiation>(),
-                4usize,
-                concat!("Alignment of ", stringify!(ContainsOpaqueInstantiation)),
-            );
-            assert_eq!(
-                unsafe { ::std::ptr::addr_of!((*ptr).opaque) as usize - ptr as usize },
-                0usize,
-                concat!(
-                    "Offset of field: ",
-                    stringify!(ContainsOpaqueInstantiation),
-                    "::",
-                    stringify!(opaque),
-                ),
-            );
-        }
+        const _: () = {
+            [
+                "Size of ContainsOpaqueInstantiation",
+            ][::std::mem::size_of::<ContainsOpaqueInstantiation>() - 4usize];
+            [
+                "Alignment of ContainsOpaqueInstantiation",
+            ][::std::mem::align_of::<ContainsOpaqueInstantiation>() - 4usize];
+            [
+                "Offset of field: ContainsOpaqueInstantiation::opaque",
+            ][::std::mem::offset_of!(ContainsOpaqueInstantiation, opaque) - 0usize];
+        };
     }
-    #[test]
-    fn __bindgen_test_layout_Template_open0_Foo_close0_instantiation() {
-        assert_eq!(
-            ::std::mem::size_of::<root::zoidberg::Template<root::zoidberg::Foo>>(),
-            1usize,
-            concat!(
-                "Size of template specialization: ",
-                stringify!(root::zoidberg::Template < root::zoidberg::Foo >),
-            ),
-        );
-        assert_eq!(
-            ::std::mem::align_of::<root::zoidberg::Template<root::zoidberg::Foo>>(),
-            1usize,
-            concat!(
-                "Alignment of template specialization: ",
-                stringify!(root::zoidberg::Template < root::zoidberg::Foo >),
-            ),
-        );
-    }
+    const _: () = {
+        [
+            "Size of template specialization: Template_open0_Foo_close0",
+        ][::std::mem::size_of::<root::zoidberg::Template<root::zoidberg::Foo>>()
+            - 1usize];
+        [
+            "Align of template specialization: Template_open0_Foo_close0",
+        ][::std::mem::align_of::<root::zoidberg::Template<root::zoidberg::Foo>>()
+            - 1usize];
+    };
 }

--- a/bindgen-tests/tests/expectations/tests/opaque-template-instantiation.rs
+++ b/bindgen-tests/tests/expectations/tests/opaque-template-instantiation.rs
@@ -19,31 +19,17 @@ impl<T> Default for Template<T> {
 pub struct ContainsInstantiation {
     pub not_opaque: Template<::std::os::raw::c_char>,
 }
-#[test]
-fn bindgen_test_layout_ContainsInstantiation() {
-    const UNINIT: ::std::mem::MaybeUninit<ContainsInstantiation> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<ContainsInstantiation>(),
-        1usize,
-        concat!("Size of: ", stringify!(ContainsInstantiation)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<ContainsInstantiation>(),
-        1usize,
-        concat!("Alignment of ", stringify!(ContainsInstantiation)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).not_opaque) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(ContainsInstantiation),
-            "::",
-            stringify!(not_opaque),
-        ),
-    );
-}
+const _: () = {
+    [
+        "Size of ContainsInstantiation",
+    ][::std::mem::size_of::<ContainsInstantiation>() - 1usize];
+    [
+        "Alignment of ContainsInstantiation",
+    ][::std::mem::align_of::<ContainsInstantiation>() - 1usize];
+    [
+        "Offset of field: ContainsInstantiation::not_opaque",
+    ][::std::mem::offset_of!(ContainsInstantiation, not_opaque) - 0usize];
+};
 impl Default for ContainsInstantiation {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
@@ -58,47 +44,22 @@ impl Default for ContainsInstantiation {
 pub struct ContainsOpaqueInstantiation {
     pub opaque: u32,
 }
-#[test]
-fn bindgen_test_layout_ContainsOpaqueInstantiation() {
-    const UNINIT: ::std::mem::MaybeUninit<ContainsOpaqueInstantiation> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<ContainsOpaqueInstantiation>(),
-        4usize,
-        concat!("Size of: ", stringify!(ContainsOpaqueInstantiation)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<ContainsOpaqueInstantiation>(),
-        4usize,
-        concat!("Alignment of ", stringify!(ContainsOpaqueInstantiation)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).opaque) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(ContainsOpaqueInstantiation),
-            "::",
-            stringify!(opaque),
-        ),
-    );
-}
-#[test]
-fn __bindgen_test_layout_Template_open0_char_close0_instantiation() {
-    assert_eq!(
-        ::std::mem::size_of::<Template<::std::os::raw::c_char>>(),
-        1usize,
-        concat!(
-            "Size of template specialization: ",
-            stringify!(Template < ::std::os::raw::c_char >),
-        ),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Template<::std::os::raw::c_char>>(),
-        1usize,
-        concat!(
-            "Alignment of template specialization: ",
-            stringify!(Template < ::std::os::raw::c_char >),
-        ),
-    );
-}
+const _: () = {
+    [
+        "Size of ContainsOpaqueInstantiation",
+    ][::std::mem::size_of::<ContainsOpaqueInstantiation>() - 4usize];
+    [
+        "Alignment of ContainsOpaqueInstantiation",
+    ][::std::mem::align_of::<ContainsOpaqueInstantiation>() - 4usize];
+    [
+        "Offset of field: ContainsOpaqueInstantiation::opaque",
+    ][::std::mem::offset_of!(ContainsOpaqueInstantiation, opaque) - 0usize];
+};
+const _: () = {
+    [
+        "Size of template specialization: Template_open0_char_close0",
+    ][::std::mem::size_of::<Template<::std::os::raw::c_char>>() - 1usize];
+    [
+        "Align of template specialization: Template_open0_char_close0",
+    ][::std::mem::align_of::<Template<::std::os::raw::c_char>>() - 1usize];
+};

--- a/bindgen-tests/tests/expectations/tests/opaque-tracing.rs
+++ b/bindgen-tests/tests/expectations/tests/opaque-tracing.rs
@@ -9,16 +9,7 @@ extern "C" {
 pub struct Container {
     pub _bindgen_opaque_blob: [u32; 2usize],
 }
-#[test]
-fn bindgen_test_layout_Container() {
-    assert_eq!(
-        ::std::mem::size_of::<Container>(),
-        8usize,
-        concat!("Size of: ", stringify!(Container)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Container>(),
-        4usize,
-        concat!("Alignment of ", stringify!(Container)),
-    );
-}
+const _: () = {
+    ["Size of Container"][::std::mem::size_of::<Container>() - 8usize];
+    ["Alignment of Container"][::std::mem::align_of::<Container>() - 4usize];
+};

--- a/bindgen-tests/tests/expectations/tests/opaque_in_struct.rs
+++ b/bindgen-tests/tests/expectations/tests/opaque_in_struct.rs
@@ -6,41 +6,19 @@
 pub struct opaque {
     pub _bindgen_opaque_blob: u32,
 }
-#[test]
-fn bindgen_test_layout_opaque() {
-    assert_eq!(
-        ::std::mem::size_of::<opaque>(),
-        4usize,
-        concat!("Size of: ", stringify!(opaque)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<opaque>(),
-        4usize,
-        concat!("Alignment of ", stringify!(opaque)),
-    );
-}
+const _: () = {
+    ["Size of opaque"][::std::mem::size_of::<opaque>() - 4usize];
+    ["Alignment of opaque"][::std::mem::align_of::<opaque>() - 4usize];
+};
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct container {
     pub contained: opaque,
 }
-#[test]
-fn bindgen_test_layout_container() {
-    const UNINIT: ::std::mem::MaybeUninit<container> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<container>(),
-        4usize,
-        concat!("Size of: ", stringify!(container)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<container>(),
-        4usize,
-        concat!("Alignment of ", stringify!(container)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).contained) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(container), "::", stringify!(contained)),
-    );
-}
+const _: () = {
+    ["Size of container"][::std::mem::size_of::<container>() - 4usize];
+    ["Alignment of container"][::std::mem::align_of::<container>() - 4usize];
+    [
+        "Offset of field: container::contained",
+    ][::std::mem::offset_of!(container, contained) - 0usize];
+};

--- a/bindgen-tests/tests/expectations/tests/opaque_pointer.rs
+++ b/bindgen-tests/tests/expectations/tests/opaque_pointer.rs
@@ -6,19 +6,10 @@
 pub struct OtherOpaque {
     pub _bindgen_opaque_blob: u32,
 }
-#[test]
-fn bindgen_test_layout_OtherOpaque() {
-    assert_eq!(
-        ::std::mem::size_of::<OtherOpaque>(),
-        4usize,
-        concat!("Size of: ", stringify!(OtherOpaque)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<OtherOpaque>(),
-        4usize,
-        concat!("Alignment of ", stringify!(OtherOpaque)),
-    );
-}
+const _: () = {
+    ["Size of OtherOpaque"][::std::mem::size_of::<OtherOpaque>() - 4usize];
+    ["Alignment of OtherOpaque"][::std::mem::align_of::<OtherOpaque>() - 4usize];
+};
 /// <div rustbindgen opaque></div>
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
@@ -32,41 +23,19 @@ pub struct WithOpaquePtr {
     pub other: u32,
     pub t: OtherOpaque,
 }
-#[test]
-fn bindgen_test_layout_WithOpaquePtr() {
-    const UNINIT: ::std::mem::MaybeUninit<WithOpaquePtr> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<WithOpaquePtr>(),
-        16usize,
-        concat!("Size of: ", stringify!(WithOpaquePtr)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<WithOpaquePtr>(),
-        8usize,
-        concat!("Alignment of ", stringify!(WithOpaquePtr)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).whatever) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(WithOpaquePtr),
-            "::",
-            stringify!(whatever),
-        ),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).other) as usize - ptr as usize },
-        8usize,
-        concat!("Offset of field: ", stringify!(WithOpaquePtr), "::", stringify!(other)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).t) as usize - ptr as usize },
-        12usize,
-        concat!("Offset of field: ", stringify!(WithOpaquePtr), "::", stringify!(t)),
-    );
-}
+const _: () = {
+    ["Size of WithOpaquePtr"][::std::mem::size_of::<WithOpaquePtr>() - 16usize];
+    ["Alignment of WithOpaquePtr"][::std::mem::align_of::<WithOpaquePtr>() - 8usize];
+    [
+        "Offset of field: WithOpaquePtr::whatever",
+    ][::std::mem::offset_of!(WithOpaquePtr, whatever) - 0usize];
+    [
+        "Offset of field: WithOpaquePtr::other",
+    ][::std::mem::offset_of!(WithOpaquePtr, other) - 8usize];
+    [
+        "Offset of field: WithOpaquePtr::t",
+    ][::std::mem::offset_of!(WithOpaquePtr, t) - 12usize];
+};
 impl Default for WithOpaquePtr {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();

--- a/bindgen-tests/tests/expectations/tests/packed-bitfield.rs
+++ b/bindgen-tests/tests/expectations/tests/packed-bitfield.rs
@@ -89,19 +89,10 @@ pub struct Date {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 3usize]>,
 }
-#[test]
-fn bindgen_test_layout_Date() {
-    assert_eq!(
-        ::std::mem::size_of::<Date>(),
-        3usize,
-        concat!("Size of: ", stringify!(Date)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Date>(),
-        1usize,
-        concat!("Alignment of ", stringify!(Date)),
-    );
-}
+const _: () = {
+    ["Size of Date"][::std::mem::size_of::<Date>() - 3usize];
+    ["Alignment of Date"][::std::mem::align_of::<Date>() - 1usize];
+};
 impl Date {
     #[inline]
     pub fn day(&self) -> ::std::os::raw::c_uchar {

--- a/bindgen-tests/tests/expectations/tests/packed-n-with-padding.rs
+++ b/bindgen-tests/tests/expectations/tests/packed-n-with-padding.rs
@@ -7,38 +7,11 @@ pub struct Packed {
     pub c: ::std::os::raw::c_char,
     pub d: ::std::os::raw::c_int,
 }
-#[test]
-fn bindgen_test_layout_Packed() {
-    const UNINIT: ::std::mem::MaybeUninit<Packed> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<Packed>(),
-        10usize,
-        concat!("Size of: ", stringify!(Packed)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Packed>(),
-        2usize,
-        concat!("Alignment of ", stringify!(Packed)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(Packed), "::", stringify!(a)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
-        2usize,
-        concat!("Offset of field: ", stringify!(Packed), "::", stringify!(b)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).c) as usize - ptr as usize },
-        4usize,
-        concat!("Offset of field: ", stringify!(Packed), "::", stringify!(c)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize },
-        6usize,
-        concat!("Offset of field: ", stringify!(Packed), "::", stringify!(d)),
-    );
-}
+const _: () = {
+    ["Size of Packed"][::std::mem::size_of::<Packed>() - 10usize];
+    ["Alignment of Packed"][::std::mem::align_of::<Packed>() - 2usize];
+    ["Offset of field: Packed::a"][::std::mem::offset_of!(Packed, a) - 0usize];
+    ["Offset of field: Packed::b"][::std::mem::offset_of!(Packed, b) - 2usize];
+    ["Offset of field: Packed::c"][::std::mem::offset_of!(Packed, c) - 4usize];
+    ["Offset of field: Packed::d"][::std::mem::offset_of!(Packed, d) - 6usize];
+};

--- a/bindgen-tests/tests/expectations/tests/packed-vtable.rs
+++ b/bindgen-tests/tests/expectations/tests/packed-vtable.rs
@@ -8,15 +8,11 @@ pub struct PackedVtable {
 }
 #[test]
 fn bindgen_test_layout_PackedVtable() {
-    assert_eq!(
-        ::std::mem::size_of::<PackedVtable>(),
-        8usize,
-        concat!("Size of: ", stringify!(PackedVtable)),
-    );
+    assert_eq!(::std::mem::size_of::<PackedVtable>(), 8usize, "Size of PackedVtable");
     assert_eq!(
         ::std::mem::align_of::<PackedVtable>(),
         1usize,
-        concat!("Alignment of ", stringify!(PackedVtable)),
+        "Alignment of PackedVtable",
     );
 }
 impl Default for PackedVtable {

--- a/bindgen-tests/tests/expectations/tests/parm-union.rs
+++ b/bindgen-tests/tests/expectations/tests/parm-union.rs
@@ -4,19 +4,10 @@
 pub struct Struct {
     pub _address: u8,
 }
-#[test]
-fn bindgen_test_layout_Struct() {
-    assert_eq!(
-        ::std::mem::size_of::<Struct>(),
-        1usize,
-        concat!("Size of: ", stringify!(Struct)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Struct>(),
-        1usize,
-        concat!("Alignment of ", stringify!(Struct)),
-    );
-}
+const _: () = {
+    ["Size of Struct"][::std::mem::size_of::<Struct>() - 1usize];
+    ["Alignment of Struct"][::std::mem::align_of::<Struct>() - 1usize];
+};
 extern "C" {
     #[link_name = "\u{1}_ZN6Struct8FunctionER5Union"]
     pub fn Struct_Function(this: *mut Struct, arg1: *mut Union);

--- a/bindgen-tests/tests/expectations/tests/partial-specialization-and-inheritance.rs
+++ b/bindgen-tests/tests/expectations/tests/partial-specialization-and-inheritance.rs
@@ -18,16 +18,7 @@ extern "C" {
     #[link_name = "\u{1}_ZN5Usage13static_memberE"]
     pub static mut Usage_static_member: [u32; 2usize];
 }
-#[test]
-fn bindgen_test_layout_Usage() {
-    assert_eq!(
-        ::std::mem::size_of::<Usage>(),
-        1usize,
-        concat!("Size of: ", stringify!(Usage)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Usage>(),
-        1usize,
-        concat!("Alignment of ", stringify!(Usage)),
-    );
-}
+const _: () = {
+    ["Size of Usage"][::std::mem::size_of::<Usage>() - 1usize];
+    ["Alignment of Usage"][::std::mem::align_of::<Usage>() - 1usize];
+};

--- a/bindgen-tests/tests/expectations/tests/private.rs
+++ b/bindgen-tests/tests/expectations/tests/private.rs
@@ -6,41 +6,16 @@ pub struct HasPrivate {
     /// <div rustbindgen private></div>
     mIsPrivate: ::std::os::raw::c_int,
 }
-#[test]
-fn bindgen_test_layout_HasPrivate() {
-    const UNINIT: ::std::mem::MaybeUninit<HasPrivate> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<HasPrivate>(),
-        8usize,
-        concat!("Size of: ", stringify!(HasPrivate)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<HasPrivate>(),
-        4usize,
-        concat!("Alignment of ", stringify!(HasPrivate)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).mNotPrivate) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(HasPrivate),
-            "::",
-            stringify!(mNotPrivate),
-        ),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).mIsPrivate) as usize - ptr as usize },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(HasPrivate),
-            "::",
-            stringify!(mIsPrivate),
-        ),
-    );
-}
+const _: () = {
+    ["Size of HasPrivate"][::std::mem::size_of::<HasPrivate>() - 8usize];
+    ["Alignment of HasPrivate"][::std::mem::align_of::<HasPrivate>() - 4usize];
+    [
+        "Offset of field: HasPrivate::mNotPrivate",
+    ][::std::mem::offset_of!(HasPrivate, mNotPrivate) - 0usize];
+    [
+        "Offset of field: HasPrivate::mIsPrivate",
+    ][::std::mem::offset_of!(HasPrivate, mIsPrivate) - 4usize];
+};
 /// <div rustbindgen private></div>
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
@@ -48,41 +23,16 @@ pub struct VeryPrivate {
     mIsPrivate: ::std::os::raw::c_int,
     mIsAlsoPrivate: ::std::os::raw::c_int,
 }
-#[test]
-fn bindgen_test_layout_VeryPrivate() {
-    const UNINIT: ::std::mem::MaybeUninit<VeryPrivate> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<VeryPrivate>(),
-        8usize,
-        concat!("Size of: ", stringify!(VeryPrivate)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<VeryPrivate>(),
-        4usize,
-        concat!("Alignment of ", stringify!(VeryPrivate)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).mIsPrivate) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(VeryPrivate),
-            "::",
-            stringify!(mIsPrivate),
-        ),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).mIsAlsoPrivate) as usize - ptr as usize },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(VeryPrivate),
-            "::",
-            stringify!(mIsAlsoPrivate),
-        ),
-    );
-}
+const _: () = {
+    ["Size of VeryPrivate"][::std::mem::size_of::<VeryPrivate>() - 8usize];
+    ["Alignment of VeryPrivate"][::std::mem::align_of::<VeryPrivate>() - 4usize];
+    [
+        "Offset of field: VeryPrivate::mIsPrivate",
+    ][::std::mem::offset_of!(VeryPrivate, mIsPrivate) - 0usize];
+    [
+        "Offset of field: VeryPrivate::mIsAlsoPrivate",
+    ][::std::mem::offset_of!(VeryPrivate, mIsAlsoPrivate) - 4usize];
+};
 /// <div rustbindgen private></div>
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
@@ -91,38 +41,15 @@ pub struct ContradictPrivate {
     pub mNotPrivate: ::std::os::raw::c_int,
     mIsPrivate: ::std::os::raw::c_int,
 }
-#[test]
-fn bindgen_test_layout_ContradictPrivate() {
-    const UNINIT: ::std::mem::MaybeUninit<ContradictPrivate> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<ContradictPrivate>(),
-        8usize,
-        concat!("Size of: ", stringify!(ContradictPrivate)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<ContradictPrivate>(),
-        4usize,
-        concat!("Alignment of ", stringify!(ContradictPrivate)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).mNotPrivate) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(ContradictPrivate),
-            "::",
-            stringify!(mNotPrivate),
-        ),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).mIsPrivate) as usize - ptr as usize },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(ContradictPrivate),
-            "::",
-            stringify!(mIsPrivate),
-        ),
-    );
-}
+const _: () = {
+    ["Size of ContradictPrivate"][::std::mem::size_of::<ContradictPrivate>() - 8usize];
+    [
+        "Alignment of ContradictPrivate",
+    ][::std::mem::align_of::<ContradictPrivate>() - 4usize];
+    [
+        "Offset of field: ContradictPrivate::mNotPrivate",
+    ][::std::mem::offset_of!(ContradictPrivate, mNotPrivate) - 0usize];
+    [
+        "Offset of field: ContradictPrivate::mIsPrivate",
+    ][::std::mem::offset_of!(ContradictPrivate, mIsPrivate) - 4usize];
+};

--- a/bindgen-tests/tests/expectations/tests/private_fields.rs
+++ b/bindgen-tests/tests/expectations/tests/private_fields.rs
@@ -89,31 +89,12 @@ pub struct PubPriv {
     pub x: ::std::os::raw::c_int,
     y: ::std::os::raw::c_int,
 }
-#[test]
-fn bindgen_test_layout_PubPriv() {
-    const UNINIT: ::std::mem::MaybeUninit<PubPriv> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<PubPriv>(),
-        8usize,
-        concat!("Size of: ", stringify!(PubPriv)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<PubPriv>(),
-        4usize,
-        concat!("Alignment of ", stringify!(PubPriv)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(PubPriv), "::", stringify!(x)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).y) as usize - ptr as usize },
-        4usize,
-        concat!("Offset of field: ", stringify!(PubPriv), "::", stringify!(y)),
-    );
-}
+const _: () = {
+    ["Size of PubPriv"][::std::mem::size_of::<PubPriv>() - 8usize];
+    ["Alignment of PubPriv"][::std::mem::align_of::<PubPriv>() - 4usize];
+    ["Offset of field: PubPriv::x"][::std::mem::offset_of!(PubPriv, x) - 0usize];
+    ["Offset of field: PubPriv::y"][::std::mem::offset_of!(PubPriv, y) - 4usize];
+};
 #[repr(C)]
 #[repr(align(4))]
 #[derive(Debug, Default, Copy, Clone)]
@@ -122,19 +103,12 @@ pub struct PrivateBitFields {
     _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
     pub __bindgen_padding_0: [u8; 3usize],
 }
-#[test]
-fn bindgen_test_layout_PrivateBitFields() {
-    assert_eq!(
-        ::std::mem::size_of::<PrivateBitFields>(),
-        4usize,
-        concat!("Size of: ", stringify!(PrivateBitFields)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<PrivateBitFields>(),
-        4usize,
-        concat!("Alignment of ", stringify!(PrivateBitFields)),
-    );
-}
+const _: () = {
+    ["Size of PrivateBitFields"][::std::mem::size_of::<PrivateBitFields>() - 4usize];
+    [
+        "Alignment of PrivateBitFields",
+    ][::std::mem::align_of::<PrivateBitFields>() - 4usize];
+};
 impl PrivateBitFields {
     #[inline]
     fn a(&self) -> ::std::os::raw::c_uint {
@@ -193,19 +167,10 @@ pub struct PublicBitFields {
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
     pub __bindgen_padding_0: [u8; 3usize],
 }
-#[test]
-fn bindgen_test_layout_PublicBitFields() {
-    assert_eq!(
-        ::std::mem::size_of::<PublicBitFields>(),
-        4usize,
-        concat!("Size of: ", stringify!(PublicBitFields)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<PublicBitFields>(),
-        4usize,
-        concat!("Alignment of ", stringify!(PublicBitFields)),
-    );
-}
+const _: () = {
+    ["Size of PublicBitFields"][::std::mem::size_of::<PublicBitFields>() - 4usize];
+    ["Alignment of PublicBitFields"][::std::mem::align_of::<PublicBitFields>() - 4usize];
+};
 impl PublicBitFields {
     #[inline]
     pub fn a(&self) -> ::std::os::raw::c_uint {
@@ -264,19 +229,10 @@ pub struct MixedBitFields {
     _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
     pub __bindgen_padding_0: [u8; 3usize],
 }
-#[test]
-fn bindgen_test_layout_MixedBitFields() {
-    assert_eq!(
-        ::std::mem::size_of::<MixedBitFields>(),
-        4usize,
-        concat!("Size of: ", stringify!(MixedBitFields)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<MixedBitFields>(),
-        4usize,
-        concat!("Alignment of ", stringify!(MixedBitFields)),
-    );
-}
+const _: () = {
+    ["Size of MixedBitFields"][::std::mem::size_of::<MixedBitFields>() - 4usize];
+    ["Alignment of MixedBitFields"][::std::mem::align_of::<MixedBitFields>() - 4usize];
+};
 impl MixedBitFields {
     #[inline]
     fn a(&self) -> ::std::os::raw::c_uint {
@@ -332,62 +288,33 @@ impl MixedBitFields {
 pub struct Base {
     pub member: ::std::os::raw::c_int,
 }
-#[test]
-fn bindgen_test_layout_Base() {
-    const UNINIT: ::std::mem::MaybeUninit<Base> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<Base>(),
-        4usize,
-        concat!("Size of: ", stringify!(Base)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Base>(),
-        4usize,
-        concat!("Alignment of ", stringify!(Base)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).member) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(Base), "::", stringify!(member)),
-    );
-}
+const _: () = {
+    ["Size of Base"][::std::mem::size_of::<Base>() - 4usize];
+    ["Alignment of Base"][::std::mem::align_of::<Base>() - 4usize];
+    ["Offset of field: Base::member"][::std::mem::offset_of!(Base, member) - 0usize];
+};
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct InheritsPrivately {
     _base: Base,
 }
-#[test]
-fn bindgen_test_layout_InheritsPrivately() {
-    assert_eq!(
-        ::std::mem::size_of::<InheritsPrivately>(),
-        4usize,
-        concat!("Size of: ", stringify!(InheritsPrivately)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<InheritsPrivately>(),
-        4usize,
-        concat!("Alignment of ", stringify!(InheritsPrivately)),
-    );
-}
+const _: () = {
+    ["Size of InheritsPrivately"][::std::mem::size_of::<InheritsPrivately>() - 4usize];
+    [
+        "Alignment of InheritsPrivately",
+    ][::std::mem::align_of::<InheritsPrivately>() - 4usize];
+};
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct InheritsPublically {
     pub _base: Base,
 }
-#[test]
-fn bindgen_test_layout_InheritsPublically() {
-    assert_eq!(
-        ::std::mem::size_of::<InheritsPublically>(),
-        4usize,
-        concat!("Size of: ", stringify!(InheritsPublically)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<InheritsPublically>(),
-        4usize,
-        concat!("Alignment of ", stringify!(InheritsPublically)),
-    );
-}
+const _: () = {
+    ["Size of InheritsPublically"][::std::mem::size_of::<InheritsPublically>() - 4usize];
+    [
+        "Alignment of InheritsPublically",
+    ][::std::mem::align_of::<InheritsPublically>() - 4usize];
+};
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct WithAnonStruct {
@@ -399,74 +326,37 @@ pub struct WithAnonStruct {
 pub struct WithAnonStruct__bindgen_ty_1 {
     pub a: ::std::os::raw::c_int,
 }
-#[test]
-fn bindgen_test_layout_WithAnonStruct__bindgen_ty_1() {
-    const UNINIT: ::std::mem::MaybeUninit<WithAnonStruct__bindgen_ty_1> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<WithAnonStruct__bindgen_ty_1>(),
-        4usize,
-        concat!("Size of: ", stringify!(WithAnonStruct__bindgen_ty_1)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<WithAnonStruct__bindgen_ty_1>(),
-        4usize,
-        concat!("Alignment of ", stringify!(WithAnonStruct__bindgen_ty_1)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(WithAnonStruct__bindgen_ty_1),
-            "::",
-            stringify!(a),
-        ),
-    );
-}
+const _: () = {
+    [
+        "Size of WithAnonStruct__bindgen_ty_1",
+    ][::std::mem::size_of::<WithAnonStruct__bindgen_ty_1>() - 4usize];
+    [
+        "Alignment of WithAnonStruct__bindgen_ty_1",
+    ][::std::mem::align_of::<WithAnonStruct__bindgen_ty_1>() - 4usize];
+    [
+        "Offset of field: WithAnonStruct__bindgen_ty_1::a",
+    ][::std::mem::offset_of!(WithAnonStruct__bindgen_ty_1, a) - 0usize];
+};
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct WithAnonStruct__bindgen_ty_2 {
     pub b: ::std::os::raw::c_int,
 }
-#[test]
-fn bindgen_test_layout_WithAnonStruct__bindgen_ty_2() {
-    const UNINIT: ::std::mem::MaybeUninit<WithAnonStruct__bindgen_ty_2> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<WithAnonStruct__bindgen_ty_2>(),
-        4usize,
-        concat!("Size of: ", stringify!(WithAnonStruct__bindgen_ty_2)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<WithAnonStruct__bindgen_ty_2>(),
-        4usize,
-        concat!("Alignment of ", stringify!(WithAnonStruct__bindgen_ty_2)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(WithAnonStruct__bindgen_ty_2),
-            "::",
-            stringify!(b),
-        ),
-    );
-}
-#[test]
-fn bindgen_test_layout_WithAnonStruct() {
-    assert_eq!(
-        ::std::mem::size_of::<WithAnonStruct>(),
-        8usize,
-        concat!("Size of: ", stringify!(WithAnonStruct)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<WithAnonStruct>(),
-        4usize,
-        concat!("Alignment of ", stringify!(WithAnonStruct)),
-    );
-}
+const _: () = {
+    [
+        "Size of WithAnonStruct__bindgen_ty_2",
+    ][::std::mem::size_of::<WithAnonStruct__bindgen_ty_2>() - 4usize];
+    [
+        "Alignment of WithAnonStruct__bindgen_ty_2",
+    ][::std::mem::align_of::<WithAnonStruct__bindgen_ty_2>() - 4usize];
+    [
+        "Offset of field: WithAnonStruct__bindgen_ty_2::b",
+    ][::std::mem::offset_of!(WithAnonStruct__bindgen_ty_2, b) - 0usize];
+};
+const _: () = {
+    ["Size of WithAnonStruct"][::std::mem::size_of::<WithAnonStruct>() - 8usize];
+    ["Alignment of WithAnonStruct"][::std::mem::align_of::<WithAnonStruct>() - 4usize];
+};
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct WithAnonUnion {
@@ -477,19 +367,14 @@ pub struct WithAnonUnion {
 pub union WithAnonUnion__bindgen_ty_1 {
     pub _address: u8,
 }
-#[test]
-fn bindgen_test_layout_WithAnonUnion__bindgen_ty_1() {
-    assert_eq!(
-        ::std::mem::size_of::<WithAnonUnion__bindgen_ty_1>(),
-        1usize,
-        concat!("Size of: ", stringify!(WithAnonUnion__bindgen_ty_1)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<WithAnonUnion__bindgen_ty_1>(),
-        1usize,
-        concat!("Alignment of ", stringify!(WithAnonUnion__bindgen_ty_1)),
-    );
-}
+const _: () = {
+    [
+        "Size of WithAnonUnion__bindgen_ty_1",
+    ][::std::mem::size_of::<WithAnonUnion__bindgen_ty_1>() - 1usize];
+    [
+        "Alignment of WithAnonUnion__bindgen_ty_1",
+    ][::std::mem::align_of::<WithAnonUnion__bindgen_ty_1>() - 1usize];
+};
 impl Default for WithAnonUnion__bindgen_ty_1 {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
@@ -499,19 +384,10 @@ impl Default for WithAnonUnion__bindgen_ty_1 {
         }
     }
 }
-#[test]
-fn bindgen_test_layout_WithAnonUnion() {
-    assert_eq!(
-        ::std::mem::size_of::<WithAnonUnion>(),
-        1usize,
-        concat!("Size of: ", stringify!(WithAnonUnion)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<WithAnonUnion>(),
-        1usize,
-        concat!("Alignment of ", stringify!(WithAnonUnion)),
-    );
-}
+const _: () = {
+    ["Size of WithAnonUnion"][::std::mem::size_of::<WithAnonUnion>() - 1usize];
+    ["Alignment of WithAnonUnion"][::std::mem::align_of::<WithAnonUnion>() - 1usize];
+};
 impl Default for WithAnonUnion {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
@@ -532,36 +408,15 @@ pub struct Override {
     _bitfield_1: __BindgenBitfieldUnit<[u8; 2usize]>,
     pub __bindgen_padding_0: u16,
 }
-#[test]
-fn bindgen_test_layout_Override() {
-    const UNINIT: ::std::mem::MaybeUninit<Override> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<Override>(),
-        16usize,
-        concat!("Size of: ", stringify!(Override)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Override>(),
-        4usize,
-        concat!("Alignment of ", stringify!(Override)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(Override), "::", stringify!(a)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
-        4usize,
-        concat!("Offset of field: ", stringify!(Override), "::", stringify!(b)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).private_c) as usize - ptr as usize },
-        8usize,
-        concat!("Offset of field: ", stringify!(Override), "::", stringify!(private_c)),
-    );
-}
+const _: () = {
+    ["Size of Override"][::std::mem::size_of::<Override>() - 16usize];
+    ["Alignment of Override"][::std::mem::align_of::<Override>() - 4usize];
+    ["Offset of field: Override::a"][::std::mem::offset_of!(Override, a) - 0usize];
+    ["Offset of field: Override::b"][::std::mem::offset_of!(Override, b) - 4usize];
+    [
+        "Offset of field: Override::private_c",
+    ][::std::mem::offset_of!(Override, private_c) - 8usize];
+};
 impl Override {
     #[inline]
     pub fn bf_a(&self) -> ::std::os::raw::c_uint {

--- a/bindgen-tests/tests/expectations/tests/ptr32-has-different-size.rs
+++ b/bindgen-tests/tests/expectations/tests/ptr32-has-different-size.rs
@@ -4,31 +4,13 @@
 pub struct TEST_STRUCT {
     pub ptr_32bit: u32,
 }
-#[test]
-fn bindgen_test_layout_TEST_STRUCT() {
-    const UNINIT: ::std::mem::MaybeUninit<TEST_STRUCT> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<TEST_STRUCT>(),
-        4usize,
-        concat!("Size of: ", stringify!(TEST_STRUCT)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<TEST_STRUCT>(),
-        4usize,
-        concat!("Alignment of ", stringify!(TEST_STRUCT)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).ptr_32bit) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(TEST_STRUCT),
-            "::",
-            stringify!(ptr_32bit),
-        ),
-    );
-}
+const _: () = {
+    ["Size of TEST_STRUCT"][::std::mem::size_of::<TEST_STRUCT>() - 4usize];
+    ["Alignment of TEST_STRUCT"][::std::mem::align_of::<TEST_STRUCT>() - 4usize];
+    [
+        "Offset of field: TEST_STRUCT::ptr_32bit",
+    ][::std::mem::offset_of!(TEST_STRUCT, ptr_32bit) - 0usize];
+};
 impl Default for TEST_STRUCT {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();

--- a/bindgen-tests/tests/expectations/tests/public-dtor.rs
+++ b/bindgen-tests/tests/expectations/tests/public-dtor.rs
@@ -4,19 +4,10 @@
 pub struct cv_Foo {
     pub _address: u8,
 }
-#[test]
-fn bindgen_test_layout_cv_Foo() {
-    assert_eq!(
-        ::std::mem::size_of::<cv_Foo>(),
-        1usize,
-        concat!("Size of: ", stringify!(cv_Foo)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<cv_Foo>(),
-        1usize,
-        concat!("Alignment of ", stringify!(cv_Foo)),
-    );
-}
+const _: () = {
+    ["Size of cv_Foo"][::std::mem::size_of::<cv_Foo>() - 1usize];
+    ["Alignment of cv_Foo"][::std::mem::align_of::<cv_Foo>() - 1usize];
+};
 extern "C" {
     #[link_name = "\u{1}_ZN2cv3FooD1Ev"]
     pub fn cv_Foo_Foo_destructor(this: *mut cv_Foo);
@@ -32,16 +23,7 @@ impl cv_Foo {
 pub struct cv_Bar {
     pub _address: u8,
 }
-#[test]
-fn bindgen_test_layout_cv_Bar() {
-    assert_eq!(
-        ::std::mem::size_of::<cv_Bar>(),
-        1usize,
-        concat!("Size of: ", stringify!(cv_Bar)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<cv_Bar>(),
-        1usize,
-        concat!("Alignment of ", stringify!(cv_Bar)),
-    );
-}
+const _: () = {
+    ["Size of cv_Bar"][::std::mem::size_of::<cv_Bar>() - 1usize];
+    ["Alignment of cv_Bar"][::std::mem::align_of::<cv_Bar>() - 1usize];
+};

--- a/bindgen-tests/tests/expectations/tests/redundant-packed-and-align.rs
+++ b/bindgen-tests/tests/expectations/tests/redundant-packed-and-align.rs
@@ -90,31 +90,18 @@ pub struct redundant_packed {
     pub a: u32,
     pub b: u32,
 }
-#[test]
-fn bindgen_test_layout_redundant_packed() {
-    const UNINIT: ::std::mem::MaybeUninit<redundant_packed> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<redundant_packed>(),
-        8usize,
-        concat!("Size of: ", stringify!(redundant_packed)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<redundant_packed>(),
-        8usize,
-        concat!("Alignment of ", stringify!(redundant_packed)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(redundant_packed), "::", stringify!(a)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
-        4usize,
-        concat!("Offset of field: ", stringify!(redundant_packed), "::", stringify!(b)),
-    );
-}
+const _: () = {
+    ["Size of redundant_packed"][::std::mem::size_of::<redundant_packed>() - 8usize];
+    [
+        "Alignment of redundant_packed",
+    ][::std::mem::align_of::<redundant_packed>() - 8usize];
+    [
+        "Offset of field: redundant_packed::a",
+    ][::std::mem::offset_of!(redundant_packed, a) - 0usize];
+    [
+        "Offset of field: redundant_packed::b",
+    ][::std::mem::offset_of!(redundant_packed, b) - 4usize];
+};
 #[repr(C)]
 #[repr(align(8))]
 #[derive(Debug, Default, Copy, Clone)]
@@ -124,41 +111,20 @@ pub struct redundant_packed_bitfield {
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
     pub c: u32,
 }
-#[test]
-fn bindgen_test_layout_redundant_packed_bitfield() {
-    const UNINIT: ::std::mem::MaybeUninit<redundant_packed_bitfield> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<redundant_packed_bitfield>(),
-        8usize,
-        concat!("Size of: ", stringify!(redundant_packed_bitfield)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<redundant_packed_bitfield>(),
-        8usize,
-        concat!("Alignment of ", stringify!(redundant_packed_bitfield)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(redundant_packed_bitfield),
-            "::",
-            stringify!(a),
-        ),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).c) as usize - ptr as usize },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(redundant_packed_bitfield),
-            "::",
-            stringify!(c),
-        ),
-    );
-}
+const _: () = {
+    [
+        "Size of redundant_packed_bitfield",
+    ][::std::mem::size_of::<redundant_packed_bitfield>() - 8usize];
+    [
+        "Alignment of redundant_packed_bitfield",
+    ][::std::mem::align_of::<redundant_packed_bitfield>() - 8usize];
+    [
+        "Offset of field: redundant_packed_bitfield::a",
+    ][::std::mem::offset_of!(redundant_packed_bitfield, a) - 0usize];
+    [
+        "Offset of field: redundant_packed_bitfield::c",
+    ][::std::mem::offset_of!(redundant_packed_bitfield, c) - 4usize];
+};
 impl redundant_packed_bitfield {
     #[inline]
     pub fn b0(&self) -> u8 {
@@ -213,41 +179,20 @@ pub union redundant_packed_union {
     pub a: u64,
     pub b: u32,
 }
-#[test]
-fn bindgen_test_layout_redundant_packed_union() {
-    const UNINIT: ::std::mem::MaybeUninit<redundant_packed_union> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<redundant_packed_union>(),
-        16usize,
-        concat!("Size of: ", stringify!(redundant_packed_union)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<redundant_packed_union>(),
-        16usize,
-        concat!("Alignment of ", stringify!(redundant_packed_union)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(redundant_packed_union),
-            "::",
-            stringify!(a),
-        ),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(redundant_packed_union),
-            "::",
-            stringify!(b),
-        ),
-    );
-}
+const _: () = {
+    [
+        "Size of redundant_packed_union",
+    ][::std::mem::size_of::<redundant_packed_union>() - 16usize];
+    [
+        "Alignment of redundant_packed_union",
+    ][::std::mem::align_of::<redundant_packed_union>() - 16usize];
+    [
+        "Offset of field: redundant_packed_union::a",
+    ][::std::mem::offset_of!(redundant_packed_union, a) - 0usize];
+    [
+        "Offset of field: redundant_packed_union::b",
+    ][::std::mem::offset_of!(redundant_packed_union, b) - 0usize];
+};
 impl Default for redundant_packed_union {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
@@ -263,26 +208,11 @@ impl Default for redundant_packed_union {
 pub struct inner {
     pub a: u8,
 }
-#[test]
-fn bindgen_test_layout_inner() {
-    const UNINIT: ::std::mem::MaybeUninit<inner> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<inner>(),
-        2usize,
-        concat!("Size of: ", stringify!(inner)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<inner>(),
-        2usize,
-        concat!("Alignment of ", stringify!(inner)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(inner), "::", stringify!(a)),
-    );
-}
+const _: () = {
+    ["Size of inner"][::std::mem::size_of::<inner>() - 2usize];
+    ["Alignment of inner"][::std::mem::align_of::<inner>() - 2usize];
+    ["Offset of field: inner::a"][::std::mem::offset_of!(inner, a) - 0usize];
+};
 #[repr(C)]
 #[repr(align(8))]
 #[derive(Debug, Default, Copy, Clone)]
@@ -290,41 +220,20 @@ pub struct outer_redundant_packed {
     pub a: [inner; 2usize],
     pub b: u32,
 }
-#[test]
-fn bindgen_test_layout_outer_redundant_packed() {
-    const UNINIT: ::std::mem::MaybeUninit<outer_redundant_packed> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<outer_redundant_packed>(),
-        8usize,
-        concat!("Size of: ", stringify!(outer_redundant_packed)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<outer_redundant_packed>(),
-        8usize,
-        concat!("Alignment of ", stringify!(outer_redundant_packed)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(outer_redundant_packed),
-            "::",
-            stringify!(a),
-        ),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
-        4usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(outer_redundant_packed),
-            "::",
-            stringify!(b),
-        ),
-    );
-}
+const _: () = {
+    [
+        "Size of outer_redundant_packed",
+    ][::std::mem::size_of::<outer_redundant_packed>() - 8usize];
+    [
+        "Alignment of outer_redundant_packed",
+    ][::std::mem::align_of::<outer_redundant_packed>() - 8usize];
+    [
+        "Offset of field: outer_redundant_packed::a",
+    ][::std::mem::offset_of!(outer_redundant_packed, a) - 0usize];
+    [
+        "Offset of field: outer_redundant_packed::b",
+    ][::std::mem::offset_of!(outer_redundant_packed, b) - 4usize];
+};
 #[repr(C)]
 #[repr(align(4))]
 #[derive(Debug, Default, Copy, Clone)]
@@ -332,38 +241,17 @@ pub struct redundant_pragma_packed {
     pub a: u8,
     pub b: u16,
 }
-#[test]
-fn bindgen_test_layout_redundant_pragma_packed() {
-    const UNINIT: ::std::mem::MaybeUninit<redundant_pragma_packed> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<redundant_pragma_packed>(),
-        4usize,
-        concat!("Size of: ", stringify!(redundant_pragma_packed)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<redundant_pragma_packed>(),
-        4usize,
-        concat!("Alignment of ", stringify!(redundant_pragma_packed)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(redundant_pragma_packed),
-            "::",
-            stringify!(a),
-        ),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
-        2usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(redundant_pragma_packed),
-            "::",
-            stringify!(b),
-        ),
-    );
-}
+const _: () = {
+    [
+        "Size of redundant_pragma_packed",
+    ][::std::mem::size_of::<redundant_pragma_packed>() - 4usize];
+    [
+        "Alignment of redundant_pragma_packed",
+    ][::std::mem::align_of::<redundant_pragma_packed>() - 4usize];
+    [
+        "Offset of field: redundant_pragma_packed::a",
+    ][::std::mem::offset_of!(redundant_pragma_packed, a) - 0usize];
+    [
+        "Offset of field: redundant_pragma_packed::b",
+    ][::std::mem::offset_of!(redundant_pragma_packed, b) - 2usize];
+};

--- a/bindgen-tests/tests/expectations/tests/ref_argument_array.rs
+++ b/bindgen-tests/tests/expectations/tests/ref_argument_array.rs
@@ -12,19 +12,10 @@ pub struct nsID__bindgen_vtable {
 pub struct nsID {
     pub vtable_: *const nsID__bindgen_vtable,
 }
-#[test]
-fn bindgen_test_layout_nsID() {
-    assert_eq!(
-        ::std::mem::size_of::<nsID>(),
-        8usize,
-        concat!("Size of: ", stringify!(nsID)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<nsID>(),
-        8usize,
-        concat!("Alignment of ", stringify!(nsID)),
-    );
-}
+const _: () = {
+    ["Size of nsID"][::std::mem::size_of::<nsID>() - 8usize];
+    ["Alignment of nsID"][::std::mem::align_of::<nsID>() - 8usize];
+};
 impl Default for nsID {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();

--- a/bindgen-tests/tests/expectations/tests/reparented_replacement.rs
+++ b/bindgen-tests/tests/expectations/tests/reparented_replacement.rs
@@ -12,26 +12,11 @@ pub mod root {
         pub struct Bar {
             pub bazz: ::std::os::raw::c_int,
         }
-        #[test]
-        fn bindgen_test_layout_Bar() {
-            const UNINIT: ::std::mem::MaybeUninit<Bar> = ::std::mem::MaybeUninit::uninit();
-            let ptr = UNINIT.as_ptr();
-            assert_eq!(
-                ::std::mem::size_of::<Bar>(),
-                4usize,
-                concat!("Size of: ", stringify!(Bar)),
-            );
-            assert_eq!(
-                ::std::mem::align_of::<Bar>(),
-                4usize,
-                concat!("Alignment of ", stringify!(Bar)),
-            );
-            assert_eq!(
-                unsafe { ::std::ptr::addr_of!((*ptr).bazz) as usize - ptr as usize },
-                0usize,
-                concat!("Offset of field: ", stringify!(Bar), "::", stringify!(bazz)),
-            );
-        }
+        const _: () = {
+            ["Size of Bar"][::std::mem::size_of::<Bar>() - 4usize];
+            ["Alignment of Bar"][::std::mem::align_of::<Bar>() - 4usize];
+            ["Offset of field: Bar::bazz"][::std::mem::offset_of!(Bar, bazz) - 0usize];
+        };
     }
     pub type ReferencesBar = root::foo::Bar;
 }

--- a/bindgen-tests/tests/expectations/tests/replace_use.rs
+++ b/bindgen-tests/tests/expectations/tests/replace_use.rs
@@ -10,36 +10,16 @@ pub struct nsTArray {
 pub struct Test {
     pub a: nsTArray,
 }
-#[test]
-fn bindgen_test_layout_Test() {
-    const UNINIT: ::std::mem::MaybeUninit<Test> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<Test>(),
-        4usize,
-        concat!("Size of: ", stringify!(Test)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Test>(),
-        4usize,
-        concat!("Alignment of ", stringify!(Test)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(Test), "::", stringify!(a)),
-    );
-}
-#[test]
-fn __bindgen_test_layout_nsTArray_open0_long_close0_instantiation() {
-    assert_eq!(
-        ::std::mem::size_of::<nsTArray>(),
-        4usize,
-        concat!("Size of template specialization: ", stringify!(nsTArray)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<nsTArray>(),
-        4usize,
-        concat!("Alignment of template specialization: ", stringify!(nsTArray)),
-    );
-}
+const _: () = {
+    ["Size of Test"][::std::mem::size_of::<Test>() - 4usize];
+    ["Alignment of Test"][::std::mem::align_of::<Test>() - 4usize];
+    ["Offset of field: Test::a"][::std::mem::offset_of!(Test, a) - 0usize];
+};
+const _: () = {
+    [
+        "Size of template specialization: nsTArray_open0_long_close0",
+    ][::std::mem::size_of::<nsTArray>() - 4usize];
+    [
+        "Align of template specialization: nsTArray_open0_long_close0",
+    ][::std::mem::align_of::<nsTArray>() - 4usize];
+};

--- a/bindgen-tests/tests/expectations/tests/repr-align.rs
+++ b/bindgen-tests/tests/expectations/tests/repr-align.rs
@@ -11,21 +11,17 @@ pub struct a {
 fn bindgen_test_layout_a() {
     const UNINIT: ::std::mem::MaybeUninit<a> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
-    assert_eq!(::std::mem::size_of::<a>(), 8usize, concat!("Size of: ", stringify!(a)));
-    assert_eq!(
-        ::std::mem::align_of::<a>(),
-        8usize,
-        concat!("Alignment of ", stringify!(a)),
-    );
+    assert_eq!(::std::mem::size_of::<a>(), 8usize, "Size of a");
+    assert_eq!(::std::mem::align_of::<a>(), 8usize, "Alignment of a");
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
         0usize,
-        concat!("Offset of field: ", stringify!(a), "::", stringify!(b)),
+        "Offset of field: a::b",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).c) as usize - ptr as usize },
         4usize,
-        concat!("Offset of field: ", stringify!(a), "::", stringify!(c)),
+        "Offset of field: a::c",
     );
 }
 #[repr(C)]
@@ -39,20 +35,16 @@ pub struct b {
 fn bindgen_test_layout_b() {
     const UNINIT: ::std::mem::MaybeUninit<b> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
-    assert_eq!(::std::mem::size_of::<b>(), 8usize, concat!("Size of: ", stringify!(b)));
-    assert_eq!(
-        ::std::mem::align_of::<b>(),
-        8usize,
-        concat!("Alignment of ", stringify!(b)),
-    );
+    assert_eq!(::std::mem::size_of::<b>(), 8usize, "Size of b");
+    assert_eq!(::std::mem::align_of::<b>(), 8usize, "Alignment of b");
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
         0usize,
-        concat!("Offset of field: ", stringify!(b), "::", stringify!(b)),
+        "Offset of field: b::b",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).c) as usize - ptr as usize },
         4usize,
-        concat!("Offset of field: ", stringify!(b), "::", stringify!(c)),
+        "Offset of field: b::c",
     );
 }

--- a/bindgen-tests/tests/expectations/tests/same_struct_name_in_different_namespaces.rs
+++ b/bindgen-tests/tests/expectations/tests/same_struct_name_in_different_namespaces.rs
@@ -10,28 +10,13 @@ pub struct JS_shadow_Zone {
     pub x: ::std::os::raw::c_int,
     pub y: ::std::os::raw::c_int,
 }
-#[test]
-fn bindgen_test_layout_JS_shadow_Zone() {
-    const UNINIT: ::std::mem::MaybeUninit<JS_shadow_Zone> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<JS_shadow_Zone>(),
-        8usize,
-        concat!("Size of: ", stringify!(JS_shadow_Zone)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<JS_shadow_Zone>(),
-        4usize,
-        concat!("Alignment of ", stringify!(JS_shadow_Zone)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(JS_shadow_Zone), "::", stringify!(x)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).y) as usize - ptr as usize },
-        4usize,
-        concat!("Offset of field: ", stringify!(JS_shadow_Zone), "::", stringify!(y)),
-    );
-}
+const _: () = {
+    ["Size of JS_shadow_Zone"][::std::mem::size_of::<JS_shadow_Zone>() - 8usize];
+    ["Alignment of JS_shadow_Zone"][::std::mem::align_of::<JS_shadow_Zone>() - 4usize];
+    [
+        "Offset of field: JS_shadow_Zone::x",
+    ][::std::mem::offset_of!(JS_shadow_Zone, x) - 0usize];
+    [
+        "Offset of field: JS_shadow_Zone::y",
+    ][::std::mem::offset_of!(JS_shadow_Zone, y) - 4usize];
+};

--- a/bindgen-tests/tests/expectations/tests/sentry-defined-multiple-times.rs
+++ b/bindgen-tests/tests/expectations/tests/sentry-defined-multiple-times.rs
@@ -21,85 +21,44 @@ pub mod root {
         pub struct sentry {
             pub i_am_plain_sentry: bool,
         }
-        #[test]
-        fn bindgen_test_layout_sentry() {
-            const UNINIT: ::std::mem::MaybeUninit<sentry> = ::std::mem::MaybeUninit::uninit();
-            let ptr = UNINIT.as_ptr();
-            assert_eq!(
-                ::std::mem::size_of::<sentry>(),
-                1usize,
-                concat!("Size of: ", stringify!(sentry)),
-            );
-            assert_eq!(
-                ::std::mem::align_of::<sentry>(),
-                1usize,
-                concat!("Alignment of ", stringify!(sentry)),
-            );
-            assert_eq!(
-                unsafe {
-                    ::std::ptr::addr_of!((*ptr).i_am_plain_sentry) as usize
-                        - ptr as usize
-                },
-                0usize,
-                concat!(
-                    "Offset of field: ",
-                    stringify!(sentry),
-                    "::",
-                    stringify!(i_am_plain_sentry),
-                ),
-            );
-        }
+        const _: () = {
+            ["Size of sentry"][::std::mem::size_of::<sentry>() - 1usize];
+            ["Alignment of sentry"][::std::mem::align_of::<sentry>() - 1usize];
+            [
+                "Offset of field: sentry::i_am_plain_sentry",
+            ][::std::mem::offset_of!(sentry, i_am_plain_sentry) - 0usize];
+        };
         #[repr(C)]
         #[derive(Debug, Default, Copy, Clone)]
         pub struct NotTemplateWrapper {
             pub _address: u8,
         }
-        #[test]
-        fn bindgen_test_layout_NotTemplateWrapper() {
-            assert_eq!(
-                ::std::mem::size_of::<NotTemplateWrapper>(),
-                1usize,
-                concat!("Size of: ", stringify!(NotTemplateWrapper)),
-            );
-            assert_eq!(
-                ::std::mem::align_of::<NotTemplateWrapper>(),
-                1usize,
-                concat!("Alignment of ", stringify!(NotTemplateWrapper)),
-            );
-        }
+        const _: () = {
+            [
+                "Size of NotTemplateWrapper",
+            ][::std::mem::size_of::<NotTemplateWrapper>() - 1usize];
+            [
+                "Alignment of NotTemplateWrapper",
+            ][::std::mem::align_of::<NotTemplateWrapper>() - 1usize];
+        };
         #[repr(C)]
         #[derive(Debug, Default, Copy, Clone)]
         pub struct NotTemplateWrapper_sentry {
             pub i_am_not_template_wrapper_sentry: ::std::os::raw::c_char,
         }
-        #[test]
-        fn bindgen_test_layout_NotTemplateWrapper_sentry() {
-            const UNINIT: ::std::mem::MaybeUninit<NotTemplateWrapper_sentry> = ::std::mem::MaybeUninit::uninit();
-            let ptr = UNINIT.as_ptr();
-            assert_eq!(
-                ::std::mem::size_of::<NotTemplateWrapper_sentry>(),
-                1usize,
-                concat!("Size of: ", stringify!(NotTemplateWrapper_sentry)),
-            );
-            assert_eq!(
-                ::std::mem::align_of::<NotTemplateWrapper_sentry>(),
-                1usize,
-                concat!("Alignment of ", stringify!(NotTemplateWrapper_sentry)),
-            );
-            assert_eq!(
-                unsafe {
-                    ::std::ptr::addr_of!((*ptr).i_am_not_template_wrapper_sentry)
-                        as usize - ptr as usize
-                },
-                0usize,
-                concat!(
-                    "Offset of field: ",
-                    stringify!(NotTemplateWrapper_sentry),
-                    "::",
-                    stringify!(i_am_not_template_wrapper_sentry),
-                ),
-            );
-        }
+        const _: () = {
+            [
+                "Size of NotTemplateWrapper_sentry",
+            ][::std::mem::size_of::<NotTemplateWrapper_sentry>() - 1usize];
+            [
+                "Alignment of NotTemplateWrapper_sentry",
+            ][::std::mem::align_of::<NotTemplateWrapper_sentry>() - 1usize];
+            [
+                "Offset of field: NotTemplateWrapper_sentry::i_am_not_template_wrapper_sentry",
+            ][::std::mem::offset_of!(
+                NotTemplateWrapper_sentry, i_am_not_template_wrapper_sentry
+            ) - 0usize];
+        };
         #[repr(C)]
         #[derive(Debug, Default, Copy, Clone)]
         pub struct InlineNotTemplateWrapper {
@@ -110,47 +69,27 @@ pub mod root {
         pub struct InlineNotTemplateWrapper_sentry {
             pub i_am_inline_not_template_wrapper_sentry: bool,
         }
-        #[test]
-        fn bindgen_test_layout_InlineNotTemplateWrapper_sentry() {
-            const UNINIT: ::std::mem::MaybeUninit<InlineNotTemplateWrapper_sentry> = ::std::mem::MaybeUninit::uninit();
-            let ptr = UNINIT.as_ptr();
-            assert_eq!(
-                ::std::mem::size_of::<InlineNotTemplateWrapper_sentry>(),
-                1usize,
-                concat!("Size of: ", stringify!(InlineNotTemplateWrapper_sentry)),
-            );
-            assert_eq!(
-                ::std::mem::align_of::<InlineNotTemplateWrapper_sentry>(),
-                1usize,
-                concat!("Alignment of ", stringify!(InlineNotTemplateWrapper_sentry)),
-            );
-            assert_eq!(
-                unsafe {
-                    ::std::ptr::addr_of!((*ptr).i_am_inline_not_template_wrapper_sentry)
-                        as usize - ptr as usize
-                },
-                0usize,
-                concat!(
-                    "Offset of field: ",
-                    stringify!(InlineNotTemplateWrapper_sentry),
-                    "::",
-                    stringify!(i_am_inline_not_template_wrapper_sentry),
-                ),
-            );
-        }
-        #[test]
-        fn bindgen_test_layout_InlineNotTemplateWrapper() {
-            assert_eq!(
-                ::std::mem::size_of::<InlineNotTemplateWrapper>(),
-                1usize,
-                concat!("Size of: ", stringify!(InlineNotTemplateWrapper)),
-            );
-            assert_eq!(
-                ::std::mem::align_of::<InlineNotTemplateWrapper>(),
-                1usize,
-                concat!("Alignment of ", stringify!(InlineNotTemplateWrapper)),
-            );
-        }
+        const _: () = {
+            [
+                "Size of InlineNotTemplateWrapper_sentry",
+            ][::std::mem::size_of::<InlineNotTemplateWrapper_sentry>() - 1usize];
+            [
+                "Alignment of InlineNotTemplateWrapper_sentry",
+            ][::std::mem::align_of::<InlineNotTemplateWrapper_sentry>() - 1usize];
+            [
+                "Offset of field: InlineNotTemplateWrapper_sentry::i_am_inline_not_template_wrapper_sentry",
+            ][::std::mem::offset_of!(
+                InlineNotTemplateWrapper_sentry, i_am_inline_not_template_wrapper_sentry
+            ) - 0usize];
+        };
+        const _: () = {
+            [
+                "Size of InlineNotTemplateWrapper",
+            ][::std::mem::size_of::<InlineNotTemplateWrapper>() - 1usize];
+            [
+                "Alignment of InlineNotTemplateWrapper",
+            ][::std::mem::align_of::<InlineNotTemplateWrapper>() - 1usize];
+        };
         #[repr(C)]
         #[derive(Debug, Default, Copy, Clone)]
         pub struct InlineTemplateWrapper {
@@ -171,76 +110,42 @@ pub mod root {
         pub struct OuterDoubleWrapper_InnerDoubleWrapper {
             pub _address: u8,
         }
-        #[test]
-        fn bindgen_test_layout_OuterDoubleWrapper_InnerDoubleWrapper() {
-            assert_eq!(
-                ::std::mem::size_of::<OuterDoubleWrapper_InnerDoubleWrapper>(),
-                1usize,
-                concat!("Size of: ", stringify!(OuterDoubleWrapper_InnerDoubleWrapper)),
-            );
-            assert_eq!(
-                ::std::mem::align_of::<OuterDoubleWrapper_InnerDoubleWrapper>(),
-                1usize,
-                concat!(
-                    "Alignment of ",
-                    stringify!(OuterDoubleWrapper_InnerDoubleWrapper),
-                ),
-            );
-        }
-        #[test]
-        fn bindgen_test_layout_OuterDoubleWrapper() {
-            assert_eq!(
-                ::std::mem::size_of::<OuterDoubleWrapper>(),
-                1usize,
-                concat!("Size of: ", stringify!(OuterDoubleWrapper)),
-            );
-            assert_eq!(
-                ::std::mem::align_of::<OuterDoubleWrapper>(),
-                1usize,
-                concat!("Alignment of ", stringify!(OuterDoubleWrapper)),
-            );
-        }
+        const _: () = {
+            [
+                "Size of OuterDoubleWrapper_InnerDoubleWrapper",
+            ][::std::mem::size_of::<OuterDoubleWrapper_InnerDoubleWrapper>() - 1usize];
+            [
+                "Alignment of OuterDoubleWrapper_InnerDoubleWrapper",
+            ][::std::mem::align_of::<OuterDoubleWrapper_InnerDoubleWrapper>() - 1usize];
+        };
+        const _: () = {
+            [
+                "Size of OuterDoubleWrapper",
+            ][::std::mem::size_of::<OuterDoubleWrapper>() - 1usize];
+            [
+                "Alignment of OuterDoubleWrapper",
+            ][::std::mem::align_of::<OuterDoubleWrapper>() - 1usize];
+        };
         #[repr(C)]
         #[derive(Debug, Default, Copy, Clone)]
         pub struct OuterDoubleWrapper_InnerDoubleWrapper_sentry {
             pub i_am_double_wrapper_sentry: ::std::os::raw::c_int,
         }
-        #[test]
-        fn bindgen_test_layout_OuterDoubleWrapper_InnerDoubleWrapper_sentry() {
-            const UNINIT: ::std::mem::MaybeUninit<
-                OuterDoubleWrapper_InnerDoubleWrapper_sentry,
-            > = ::std::mem::MaybeUninit::uninit();
-            let ptr = UNINIT.as_ptr();
-            assert_eq!(
-                ::std::mem::size_of::<OuterDoubleWrapper_InnerDoubleWrapper_sentry>(),
-                4usize,
-                concat!(
-                    "Size of: ",
-                    stringify!(OuterDoubleWrapper_InnerDoubleWrapper_sentry),
-                ),
-            );
-            assert_eq!(
-                ::std::mem::align_of::<OuterDoubleWrapper_InnerDoubleWrapper_sentry>(),
-                4usize,
-                concat!(
-                    "Alignment of ",
-                    stringify!(OuterDoubleWrapper_InnerDoubleWrapper_sentry),
-                ),
-            );
-            assert_eq!(
-                unsafe {
-                    ::std::ptr::addr_of!((*ptr).i_am_double_wrapper_sentry) as usize
-                        - ptr as usize
-                },
-                0usize,
-                concat!(
-                    "Offset of field: ",
-                    stringify!(OuterDoubleWrapper_InnerDoubleWrapper_sentry),
-                    "::",
-                    stringify!(i_am_double_wrapper_sentry),
-                ),
-            );
-        }
+        const _: () = {
+            [
+                "Size of OuterDoubleWrapper_InnerDoubleWrapper_sentry",
+            ][::std::mem::size_of::<OuterDoubleWrapper_InnerDoubleWrapper_sentry>()
+                - 4usize];
+            [
+                "Alignment of OuterDoubleWrapper_InnerDoubleWrapper_sentry",
+            ][::std::mem::align_of::<OuterDoubleWrapper_InnerDoubleWrapper_sentry>()
+                - 4usize];
+            [
+                "Offset of field: OuterDoubleWrapper_InnerDoubleWrapper_sentry::i_am_double_wrapper_sentry",
+            ][::std::mem::offset_of!(
+                OuterDoubleWrapper_InnerDoubleWrapper_sentry, i_am_double_wrapper_sentry
+            ) - 0usize];
+        };
         #[repr(C)]
         #[derive(Debug, Default, Copy, Clone)]
         pub struct OuterDoubleInlineWrapper {
@@ -256,82 +161,42 @@ pub mod root {
         pub struct OuterDoubleInlineWrapper_InnerDoubleInlineWrapper_sentry {
             pub i_am_double_wrapper_inline_sentry: ::std::os::raw::c_int,
         }
-        #[test]
-        fn bindgen_test_layout_OuterDoubleInlineWrapper_InnerDoubleInlineWrapper_sentry() {
-            const UNINIT: ::std::mem::MaybeUninit<
+        const _: () = {
+            [
+                "Size of OuterDoubleInlineWrapper_InnerDoubleInlineWrapper_sentry",
+            ][::std::mem::size_of::<
                 OuterDoubleInlineWrapper_InnerDoubleInlineWrapper_sentry,
-            > = ::std::mem::MaybeUninit::uninit();
-            let ptr = UNINIT.as_ptr();
-            assert_eq!(
-                ::std::mem::size_of::<
-                    OuterDoubleInlineWrapper_InnerDoubleInlineWrapper_sentry,
-                >(),
-                4usize,
-                concat!(
-                    "Size of: ",
-                    stringify!(OuterDoubleInlineWrapper_InnerDoubleInlineWrapper_sentry),
-                ),
-            );
-            assert_eq!(
-                ::std::mem::align_of::<
-                    OuterDoubleInlineWrapper_InnerDoubleInlineWrapper_sentry,
-                >(),
-                4usize,
-                concat!(
-                    "Alignment of ",
-                    stringify!(OuterDoubleInlineWrapper_InnerDoubleInlineWrapper_sentry),
-                ),
-            );
-            assert_eq!(
-                unsafe {
-                    ::std::ptr::addr_of!((*ptr).i_am_double_wrapper_inline_sentry)
-                        as usize - ptr as usize
-                },
-                0usize,
-                concat!(
-                    "Offset of field: ",
-                    stringify!(OuterDoubleInlineWrapper_InnerDoubleInlineWrapper_sentry),
-                    "::",
-                    stringify!(i_am_double_wrapper_inline_sentry),
-                ),
-            );
-        }
-        #[test]
-        fn bindgen_test_layout_OuterDoubleInlineWrapper_InnerDoubleInlineWrapper() {
-            assert_eq!(
-                ::std::mem::size_of::<
-                    OuterDoubleInlineWrapper_InnerDoubleInlineWrapper,
-                >(),
-                1usize,
-                concat!(
-                    "Size of: ",
-                    stringify!(OuterDoubleInlineWrapper_InnerDoubleInlineWrapper),
-                ),
-            );
-            assert_eq!(
-                ::std::mem::align_of::<
-                    OuterDoubleInlineWrapper_InnerDoubleInlineWrapper,
-                >(),
-                1usize,
-                concat!(
-                    "Alignment of ",
-                    stringify!(OuterDoubleInlineWrapper_InnerDoubleInlineWrapper),
-                ),
-            );
-        }
-        #[test]
-        fn bindgen_test_layout_OuterDoubleInlineWrapper() {
-            assert_eq!(
-                ::std::mem::size_of::<OuterDoubleInlineWrapper>(),
-                1usize,
-                concat!("Size of: ", stringify!(OuterDoubleInlineWrapper)),
-            );
-            assert_eq!(
-                ::std::mem::align_of::<OuterDoubleInlineWrapper>(),
-                1usize,
-                concat!("Alignment of ", stringify!(OuterDoubleInlineWrapper)),
-            );
-        }
+            >() - 4usize];
+            [
+                "Alignment of OuterDoubleInlineWrapper_InnerDoubleInlineWrapper_sentry",
+            ][::std::mem::align_of::<
+                OuterDoubleInlineWrapper_InnerDoubleInlineWrapper_sentry,
+            >() - 4usize];
+            [
+                "Offset of field: OuterDoubleInlineWrapper_InnerDoubleInlineWrapper_sentry::i_am_double_wrapper_inline_sentry",
+            ][::std::mem::offset_of!(
+                OuterDoubleInlineWrapper_InnerDoubleInlineWrapper_sentry,
+                i_am_double_wrapper_inline_sentry
+            ) - 0usize];
+        };
+        const _: () = {
+            [
+                "Size of OuterDoubleInlineWrapper_InnerDoubleInlineWrapper",
+            ][::std::mem::size_of::<OuterDoubleInlineWrapper_InnerDoubleInlineWrapper>()
+                - 1usize];
+            [
+                "Alignment of OuterDoubleInlineWrapper_InnerDoubleInlineWrapper",
+            ][::std::mem::align_of::<OuterDoubleInlineWrapper_InnerDoubleInlineWrapper>()
+                - 1usize];
+        };
+        const _: () = {
+            [
+                "Size of OuterDoubleInlineWrapper",
+            ][::std::mem::size_of::<OuterDoubleInlineWrapper>() - 1usize];
+            [
+                "Alignment of OuterDoubleInlineWrapper",
+            ][::std::mem::align_of::<OuterDoubleInlineWrapper>() - 1usize];
+        };
     }
     #[repr(C)]
     #[derive(Debug, Default, Copy, Clone)]
@@ -348,32 +213,11 @@ pub mod root {
     pub struct sentry {
         pub i_am_outside_namespace_sentry: ::std::os::raw::c_int,
     }
-    #[test]
-    fn bindgen_test_layout_sentry() {
-        const UNINIT: ::std::mem::MaybeUninit<sentry> = ::std::mem::MaybeUninit::uninit();
-        let ptr = UNINIT.as_ptr();
-        assert_eq!(
-            ::std::mem::size_of::<sentry>(),
-            4usize,
-            concat!("Size of: ", stringify!(sentry)),
-        );
-        assert_eq!(
-            ::std::mem::align_of::<sentry>(),
-            4usize,
-            concat!("Alignment of ", stringify!(sentry)),
-        );
-        assert_eq!(
-            unsafe {
-                ::std::ptr::addr_of!((*ptr).i_am_outside_namespace_sentry) as usize
-                    - ptr as usize
-            },
-            0usize,
-            concat!(
-                "Offset of field: ",
-                stringify!(sentry),
-                "::",
-                stringify!(i_am_outside_namespace_sentry),
-            ),
-        );
-    }
+    const _: () = {
+        ["Size of sentry"][::std::mem::size_of::<sentry>() - 4usize];
+        ["Alignment of sentry"][::std::mem::align_of::<sentry>() - 4usize];
+        [
+            "Offset of field: sentry::i_am_outside_namespace_sentry",
+        ][::std::mem::offset_of!(sentry, i_am_outside_namespace_sentry) - 0usize];
+    };
 }

--- a/bindgen-tests/tests/expectations/tests/size_t_template.rs
+++ b/bindgen-tests/tests/expectations/tests/size_t_template.rs
@@ -4,19 +4,8 @@
 pub struct C {
     pub arr: [u32; 3usize],
 }
-#[test]
-fn bindgen_test_layout_C() {
-    const UNINIT: ::std::mem::MaybeUninit<C> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(::std::mem::size_of::<C>(), 12usize, concat!("Size of: ", stringify!(C)));
-    assert_eq!(
-        ::std::mem::align_of::<C>(),
-        4usize,
-        concat!("Alignment of ", stringify!(C)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).arr) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(C), "::", stringify!(arr)),
-    );
-}
+const _: () = {
+    ["Size of C"][::std::mem::size_of::<C>() - 12usize];
+    ["Alignment of C"][::std::mem::align_of::<C>() - 4usize];
+    ["Offset of field: C::arr"][::std::mem::offset_of!(C, arr) - 0usize];
+};

--- a/bindgen-tests/tests/expectations/tests/sorted_items.rs
+++ b/bindgen-tests/tests/expectations/tests/sorted_items.rs
@@ -14,57 +14,19 @@ pub mod root {
         pub a: root::number,
         pub b: root::number,
     }
+    const _: () = {
+        ["Size of Point"][::std::mem::size_of::<Point>() - 8usize];
+        ["Alignment of Point"][::std::mem::align_of::<Point>() - 4usize];
+        ["Offset of field: Point::x"][::std::mem::offset_of!(Point, x) - 0usize];
+        ["Offset of field: Point::y"][::std::mem::offset_of!(Point, y) - 4usize];
+    };
+    const _: () = {
+        ["Size of Angle"][::std::mem::size_of::<Angle>() - 8usize];
+        ["Alignment of Angle"][::std::mem::align_of::<Angle>() - 4usize];
+        ["Offset of field: Angle::a"][::std::mem::offset_of!(Angle, a) - 0usize];
+        ["Offset of field: Angle::b"][::std::mem::offset_of!(Angle, b) - 4usize];
+    };
     pub const NUMBER: root::number = 42;
-    #[test]
-    fn bindgen_test_layout_Point() {
-        const UNINIT: ::std::mem::MaybeUninit<Point> = ::std::mem::MaybeUninit::uninit();
-        let ptr = UNINIT.as_ptr();
-        assert_eq!(
-            ::std::mem::size_of::<Point>(),
-            8usize,
-            concat!("Size of: ", stringify!(Point)),
-        );
-        assert_eq!(
-            ::std::mem::align_of::<Point>(),
-            4usize,
-            concat!("Alignment of ", stringify!(Point)),
-        );
-        assert_eq!(
-            unsafe { ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize },
-            0usize,
-            concat!("Offset of field: ", stringify!(Point), "::", stringify!(x)),
-        );
-        assert_eq!(
-            unsafe { ::std::ptr::addr_of!((*ptr).y) as usize - ptr as usize },
-            4usize,
-            concat!("Offset of field: ", stringify!(Point), "::", stringify!(y)),
-        );
-    }
-    #[test]
-    fn bindgen_test_layout_Angle() {
-        const UNINIT: ::std::mem::MaybeUninit<Angle> = ::std::mem::MaybeUninit::uninit();
-        let ptr = UNINIT.as_ptr();
-        assert_eq!(
-            ::std::mem::size_of::<Angle>(),
-            8usize,
-            concat!("Size of: ", stringify!(Angle)),
-        );
-        assert_eq!(
-            ::std::mem::align_of::<Angle>(),
-            4usize,
-            concat!("Alignment of ", stringify!(Angle)),
-        );
-        assert_eq!(
-            unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
-            0usize,
-            concat!("Offset of field: ", stringify!(Angle), "::", stringify!(a)),
-        );
-        assert_eq!(
-            unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
-            4usize,
-            concat!("Offset of field: ", stringify!(Angle), "::", stringify!(b)),
-        );
-    }
     pub mod ns {
         pub type number = ::std::os::raw::c_int;
         #[repr(C)]
@@ -79,57 +41,19 @@ pub mod root {
             pub a: root::ns::number,
             pub b: root::ns::number,
         }
+        const _: () = {
+            ["Size of Point"][::std::mem::size_of::<Point>() - 8usize];
+            ["Alignment of Point"][::std::mem::align_of::<Point>() - 4usize];
+            ["Offset of field: Point::x"][::std::mem::offset_of!(Point, x) - 0usize];
+            ["Offset of field: Point::y"][::std::mem::offset_of!(Point, y) - 4usize];
+        };
+        const _: () = {
+            ["Size of Angle"][::std::mem::size_of::<Angle>() - 8usize];
+            ["Alignment of Angle"][::std::mem::align_of::<Angle>() - 4usize];
+            ["Offset of field: Angle::a"][::std::mem::offset_of!(Angle, a) - 0usize];
+            ["Offset of field: Angle::b"][::std::mem::offset_of!(Angle, b) - 4usize];
+        };
         pub const NUMBER: root::ns::number = 42;
-        #[test]
-        fn bindgen_test_layout_Point() {
-            const UNINIT: ::std::mem::MaybeUninit<Point> = ::std::mem::MaybeUninit::uninit();
-            let ptr = UNINIT.as_ptr();
-            assert_eq!(
-                ::std::mem::size_of::<Point>(),
-                8usize,
-                concat!("Size of: ", stringify!(Point)),
-            );
-            assert_eq!(
-                ::std::mem::align_of::<Point>(),
-                4usize,
-                concat!("Alignment of ", stringify!(Point)),
-            );
-            assert_eq!(
-                unsafe { ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize },
-                0usize,
-                concat!("Offset of field: ", stringify!(Point), "::", stringify!(x)),
-            );
-            assert_eq!(
-                unsafe { ::std::ptr::addr_of!((*ptr).y) as usize - ptr as usize },
-                4usize,
-                concat!("Offset of field: ", stringify!(Point), "::", stringify!(y)),
-            );
-        }
-        #[test]
-        fn bindgen_test_layout_Angle() {
-            const UNINIT: ::std::mem::MaybeUninit<Angle> = ::std::mem::MaybeUninit::uninit();
-            let ptr = UNINIT.as_ptr();
-            assert_eq!(
-                ::std::mem::size_of::<Angle>(),
-                8usize,
-                concat!("Size of: ", stringify!(Angle)),
-            );
-            assert_eq!(
-                ::std::mem::align_of::<Angle>(),
-                4usize,
-                concat!("Alignment of ", stringify!(Angle)),
-            );
-            assert_eq!(
-                unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
-                0usize,
-                concat!("Offset of field: ", stringify!(Angle), "::", stringify!(a)),
-            );
-            assert_eq!(
-                unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
-                4usize,
-                concat!("Offset of field: ", stringify!(Angle), "::", stringify!(b)),
-            );
-        }
         #[allow(unused_imports)]
         use self::super::super::root;
         extern "C" {

--- a/bindgen-tests/tests/expectations/tests/stdint_typedef.rs
+++ b/bindgen-tests/tests/expectations/tests/stdint_typedef.rs
@@ -7,23 +7,8 @@ extern "C" {
 pub struct Struct {
     pub field: u64,
 }
-#[test]
-fn bindgen_test_layout_Struct() {
-    const UNINIT: ::std::mem::MaybeUninit<Struct> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<Struct>(),
-        8usize,
-        concat!("Size of: ", stringify!(Struct)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Struct>(),
-        8usize,
-        concat!("Alignment of ", stringify!(Struct)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).field) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(Struct), "::", stringify!(field)),
-    );
-}
+const _: () = {
+    ["Size of Struct"][::std::mem::size_of::<Struct>() - 8usize];
+    ["Alignment of Struct"][::std::mem::align_of::<Struct>() - 8usize];
+    ["Offset of field: Struct::field"][::std::mem::offset_of!(Struct, field) - 0usize];
+};

--- a/bindgen-tests/tests/expectations/tests/struct_containing_forward_declared_struct.rs
+++ b/bindgen-tests/tests/expectations/tests/struct_containing_forward_declared_struct.rs
@@ -4,22 +4,11 @@
 pub struct a {
     pub val_a: *mut b,
 }
-#[test]
-fn bindgen_test_layout_a() {
-    const UNINIT: ::std::mem::MaybeUninit<a> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(::std::mem::size_of::<a>(), 8usize, concat!("Size of: ", stringify!(a)));
-    assert_eq!(
-        ::std::mem::align_of::<a>(),
-        8usize,
-        concat!("Alignment of ", stringify!(a)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).val_a) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(a), "::", stringify!(val_a)),
-    );
-}
+const _: () = {
+    ["Size of a"][::std::mem::size_of::<a>() - 8usize];
+    ["Alignment of a"][::std::mem::align_of::<a>() - 8usize];
+    ["Offset of field: a::val_a"][::std::mem::offset_of!(a, val_a) - 0usize];
+};
 impl Default for a {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
@@ -34,19 +23,8 @@ impl Default for a {
 pub struct b {
     pub val_b: ::std::os::raw::c_int,
 }
-#[test]
-fn bindgen_test_layout_b() {
-    const UNINIT: ::std::mem::MaybeUninit<b> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(::std::mem::size_of::<b>(), 4usize, concat!("Size of: ", stringify!(b)));
-    assert_eq!(
-        ::std::mem::align_of::<b>(),
-        4usize,
-        concat!("Alignment of ", stringify!(b)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).val_b) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(b), "::", stringify!(val_b)),
-    );
-}
+const _: () = {
+    ["Size of b"][::std::mem::size_of::<b>() - 4usize];
+    ["Alignment of b"][::std::mem::align_of::<b>() - 4usize];
+    ["Offset of field: b::val_b"][::std::mem::offset_of!(b, val_b) - 0usize];
+};

--- a/bindgen-tests/tests/expectations/tests/struct_typedef.rs
+++ b/bindgen-tests/tests/expectations/tests/struct_typedef.rs
@@ -4,61 +4,29 @@
 pub struct typedef_named_struct {
     pub has_name: bool,
 }
-#[test]
-fn bindgen_test_layout_typedef_named_struct() {
-    const UNINIT: ::std::mem::MaybeUninit<typedef_named_struct> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<typedef_named_struct>(),
-        1usize,
-        concat!("Size of: ", stringify!(typedef_named_struct)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<typedef_named_struct>(),
-        1usize,
-        concat!("Alignment of ", stringify!(typedef_named_struct)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).has_name) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(typedef_named_struct),
-            "::",
-            stringify!(has_name),
-        ),
-    );
-}
+const _: () = {
+    [
+        "Size of typedef_named_struct",
+    ][::std::mem::size_of::<typedef_named_struct>() - 1usize];
+    [
+        "Alignment of typedef_named_struct",
+    ][::std::mem::align_of::<typedef_named_struct>() - 1usize];
+    [
+        "Offset of field: typedef_named_struct::has_name",
+    ][::std::mem::offset_of!(typedef_named_struct, has_name) - 0usize];
+};
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct _bindgen_ty_1 {
     pub no_name: *mut ::std::os::raw::c_void,
 }
-#[test]
-fn bindgen_test_layout__bindgen_ty_1() {
-    const UNINIT: ::std::mem::MaybeUninit<_bindgen_ty_1> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<_bindgen_ty_1>(),
-        8usize,
-        concat!("Size of: ", stringify!(_bindgen_ty_1)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<_bindgen_ty_1>(),
-        8usize,
-        concat!("Alignment of ", stringify!(_bindgen_ty_1)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).no_name) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(_bindgen_ty_1),
-            "::",
-            stringify!(no_name),
-        ),
-    );
-}
+const _: () = {
+    ["Size of _bindgen_ty_1"][::std::mem::size_of::<_bindgen_ty_1>() - 8usize];
+    ["Alignment of _bindgen_ty_1"][::std::mem::align_of::<_bindgen_ty_1>() - 8usize];
+    [
+        "Offset of field: _bindgen_ty_1::no_name",
+    ][::std::mem::offset_of!(_bindgen_ty_1, no_name) - 0usize];
+};
 impl Default for _bindgen_ty_1 {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();

--- a/bindgen-tests/tests/expectations/tests/struct_typedef_ns.rs
+++ b/bindgen-tests/tests/expectations/tests/struct_typedef_ns.rs
@@ -11,31 +11,15 @@ pub mod root {
         pub struct typedef_struct {
             pub foo: ::std::os::raw::c_int,
         }
-        #[test]
-        fn bindgen_test_layout_typedef_struct() {
-            const UNINIT: ::std::mem::MaybeUninit<typedef_struct> = ::std::mem::MaybeUninit::uninit();
-            let ptr = UNINIT.as_ptr();
-            assert_eq!(
-                ::std::mem::size_of::<typedef_struct>(),
-                4usize,
-                concat!("Size of: ", stringify!(typedef_struct)),
-            );
-            assert_eq!(
-                ::std::mem::align_of::<typedef_struct>(),
-                4usize,
-                concat!("Alignment of ", stringify!(typedef_struct)),
-            );
-            assert_eq!(
-                unsafe { ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize },
-                0usize,
-                concat!(
-                    "Offset of field: ",
-                    stringify!(typedef_struct),
-                    "::",
-                    stringify!(foo),
-                ),
-            );
-        }
+        const _: () = {
+            ["Size of typedef_struct"][::std::mem::size_of::<typedef_struct>() - 4usize];
+            [
+                "Alignment of typedef_struct",
+            ][::std::mem::align_of::<typedef_struct>() - 4usize];
+            [
+                "Offset of field: typedef_struct::foo",
+            ][::std::mem::offset_of!(typedef_struct, foo) - 0usize];
+        };
         #[repr(u32)]
         #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
         pub enum typedef_enum {
@@ -50,31 +34,15 @@ pub mod root {
         pub struct typedef_struct {
             pub foo: ::std::os::raw::c_int,
         }
-        #[test]
-        fn bindgen_test_layout_typedef_struct() {
-            const UNINIT: ::std::mem::MaybeUninit<typedef_struct> = ::std::mem::MaybeUninit::uninit();
-            let ptr = UNINIT.as_ptr();
-            assert_eq!(
-                ::std::mem::size_of::<typedef_struct>(),
-                4usize,
-                concat!("Size of: ", stringify!(typedef_struct)),
-            );
-            assert_eq!(
-                ::std::mem::align_of::<typedef_struct>(),
-                4usize,
-                concat!("Alignment of ", stringify!(typedef_struct)),
-            );
-            assert_eq!(
-                unsafe { ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize },
-                0usize,
-                concat!(
-                    "Offset of field: ",
-                    stringify!(typedef_struct),
-                    "::",
-                    stringify!(foo),
-                ),
-            );
-        }
+        const _: () = {
+            ["Size of typedef_struct"][::std::mem::size_of::<typedef_struct>() - 4usize];
+            [
+                "Alignment of typedef_struct",
+            ][::std::mem::align_of::<typedef_struct>() - 4usize];
+            [
+                "Offset of field: typedef_struct::foo",
+            ][::std::mem::offset_of!(typedef_struct, foo) - 0usize];
+        };
         #[repr(u32)]
         #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
         pub enum typedef_enum {

--- a/bindgen-tests/tests/expectations/tests/struct_with_anon_struct.rs
+++ b/bindgen-tests/tests/expectations/tests/struct_with_anon_struct.rs
@@ -10,48 +10,20 @@ pub struct foo__bindgen_ty_1 {
     pub a: ::std::os::raw::c_int,
     pub b: ::std::os::raw::c_int,
 }
-#[test]
-fn bindgen_test_layout_foo__bindgen_ty_1() {
-    const UNINIT: ::std::mem::MaybeUninit<foo__bindgen_ty_1> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<foo__bindgen_ty_1>(),
-        8usize,
-        concat!("Size of: ", stringify!(foo__bindgen_ty_1)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<foo__bindgen_ty_1>(),
-        4usize,
-        concat!("Alignment of ", stringify!(foo__bindgen_ty_1)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(foo__bindgen_ty_1), "::", stringify!(a)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
-        4usize,
-        concat!("Offset of field: ", stringify!(foo__bindgen_ty_1), "::", stringify!(b)),
-    );
-}
-#[test]
-fn bindgen_test_layout_foo() {
-    const UNINIT: ::std::mem::MaybeUninit<foo> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<foo>(),
-        8usize,
-        concat!("Size of: ", stringify!(foo)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<foo>(),
-        4usize,
-        concat!("Alignment of ", stringify!(foo)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar)),
-    );
-}
+const _: () = {
+    ["Size of foo__bindgen_ty_1"][::std::mem::size_of::<foo__bindgen_ty_1>() - 8usize];
+    [
+        "Alignment of foo__bindgen_ty_1",
+    ][::std::mem::align_of::<foo__bindgen_ty_1>() - 4usize];
+    [
+        "Offset of field: foo__bindgen_ty_1::a",
+    ][::std::mem::offset_of!(foo__bindgen_ty_1, a) - 0usize];
+    [
+        "Offset of field: foo__bindgen_ty_1::b",
+    ][::std::mem::offset_of!(foo__bindgen_ty_1, b) - 4usize];
+};
+const _: () = {
+    ["Size of foo"][::std::mem::size_of::<foo>() - 8usize];
+    ["Alignment of foo"][::std::mem::align_of::<foo>() - 4usize];
+    ["Offset of field: foo::bar"][::std::mem::offset_of!(foo, bar) - 0usize];
+};

--- a/bindgen-tests/tests/expectations/tests/struct_with_anon_struct_array.rs
+++ b/bindgen-tests/tests/expectations/tests/struct_with_anon_struct_array.rs
@@ -11,84 +11,39 @@ pub struct foo__bindgen_ty_1 {
     pub a: ::std::os::raw::c_int,
     pub b: ::std::os::raw::c_int,
 }
-#[test]
-fn bindgen_test_layout_foo__bindgen_ty_1() {
-    const UNINIT: ::std::mem::MaybeUninit<foo__bindgen_ty_1> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<foo__bindgen_ty_1>(),
-        8usize,
-        concat!("Size of: ", stringify!(foo__bindgen_ty_1)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<foo__bindgen_ty_1>(),
-        4usize,
-        concat!("Alignment of ", stringify!(foo__bindgen_ty_1)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(foo__bindgen_ty_1), "::", stringify!(a)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
-        4usize,
-        concat!("Offset of field: ", stringify!(foo__bindgen_ty_1), "::", stringify!(b)),
-    );
-}
+const _: () = {
+    ["Size of foo__bindgen_ty_1"][::std::mem::size_of::<foo__bindgen_ty_1>() - 8usize];
+    [
+        "Alignment of foo__bindgen_ty_1",
+    ][::std::mem::align_of::<foo__bindgen_ty_1>() - 4usize];
+    [
+        "Offset of field: foo__bindgen_ty_1::a",
+    ][::std::mem::offset_of!(foo__bindgen_ty_1, a) - 0usize];
+    [
+        "Offset of field: foo__bindgen_ty_1::b",
+    ][::std::mem::offset_of!(foo__bindgen_ty_1, b) - 4usize];
+};
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct foo__bindgen_ty_2 {
     pub a: ::std::os::raw::c_int,
     pub b: ::std::os::raw::c_int,
 }
-#[test]
-fn bindgen_test_layout_foo__bindgen_ty_2() {
-    const UNINIT: ::std::mem::MaybeUninit<foo__bindgen_ty_2> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<foo__bindgen_ty_2>(),
-        8usize,
-        concat!("Size of: ", stringify!(foo__bindgen_ty_2)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<foo__bindgen_ty_2>(),
-        4usize,
-        concat!("Alignment of ", stringify!(foo__bindgen_ty_2)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(foo__bindgen_ty_2), "::", stringify!(a)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
-        4usize,
-        concat!("Offset of field: ", stringify!(foo__bindgen_ty_2), "::", stringify!(b)),
-    );
-}
-#[test]
-fn bindgen_test_layout_foo() {
-    const UNINIT: ::std::mem::MaybeUninit<foo> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<foo>(),
-        208usize,
-        concat!("Size of: ", stringify!(foo)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<foo>(),
-        4usize,
-        concat!("Alignment of ", stringify!(foo)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize },
-        16usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(baz)),
-    );
-}
+const _: () = {
+    ["Size of foo__bindgen_ty_2"][::std::mem::size_of::<foo__bindgen_ty_2>() - 8usize];
+    [
+        "Alignment of foo__bindgen_ty_2",
+    ][::std::mem::align_of::<foo__bindgen_ty_2>() - 4usize];
+    [
+        "Offset of field: foo__bindgen_ty_2::a",
+    ][::std::mem::offset_of!(foo__bindgen_ty_2, a) - 0usize];
+    [
+        "Offset of field: foo__bindgen_ty_2::b",
+    ][::std::mem::offset_of!(foo__bindgen_ty_2, b) - 4usize];
+};
+const _: () = {
+    ["Size of foo"][::std::mem::size_of::<foo>() - 208usize];
+    ["Alignment of foo"][::std::mem::align_of::<foo>() - 4usize];
+    ["Offset of field: foo::bar"][::std::mem::offset_of!(foo, bar) - 0usize];
+    ["Offset of field: foo::baz"][::std::mem::offset_of!(foo, baz) - 16usize];
+};

--- a/bindgen-tests/tests/expectations/tests/struct_with_anon_struct_pointer.rs
+++ b/bindgen-tests/tests/expectations/tests/struct_with_anon_struct_pointer.rs
@@ -10,51 +10,23 @@ pub struct foo__bindgen_ty_1 {
     pub a: ::std::os::raw::c_int,
     pub b: ::std::os::raw::c_int,
 }
-#[test]
-fn bindgen_test_layout_foo__bindgen_ty_1() {
-    const UNINIT: ::std::mem::MaybeUninit<foo__bindgen_ty_1> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<foo__bindgen_ty_1>(),
-        8usize,
-        concat!("Size of: ", stringify!(foo__bindgen_ty_1)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<foo__bindgen_ty_1>(),
-        4usize,
-        concat!("Alignment of ", stringify!(foo__bindgen_ty_1)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(foo__bindgen_ty_1), "::", stringify!(a)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
-        4usize,
-        concat!("Offset of field: ", stringify!(foo__bindgen_ty_1), "::", stringify!(b)),
-    );
-}
-#[test]
-fn bindgen_test_layout_foo() {
-    const UNINIT: ::std::mem::MaybeUninit<foo> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<foo>(),
-        8usize,
-        concat!("Size of: ", stringify!(foo)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<foo>(),
-        8usize,
-        concat!("Alignment of ", stringify!(foo)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar)),
-    );
-}
+const _: () = {
+    ["Size of foo__bindgen_ty_1"][::std::mem::size_of::<foo__bindgen_ty_1>() - 8usize];
+    [
+        "Alignment of foo__bindgen_ty_1",
+    ][::std::mem::align_of::<foo__bindgen_ty_1>() - 4usize];
+    [
+        "Offset of field: foo__bindgen_ty_1::a",
+    ][::std::mem::offset_of!(foo__bindgen_ty_1, a) - 0usize];
+    [
+        "Offset of field: foo__bindgen_ty_1::b",
+    ][::std::mem::offset_of!(foo__bindgen_ty_1, b) - 4usize];
+};
+const _: () = {
+    ["Size of foo"][::std::mem::size_of::<foo>() - 8usize];
+    ["Alignment of foo"][::std::mem::align_of::<foo>() - 8usize];
+    ["Offset of field: foo::bar"][::std::mem::offset_of!(foo, bar) - 0usize];
+};
 impl Default for foo {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();

--- a/bindgen-tests/tests/expectations/tests/struct_with_anon_union.rs
+++ b/bindgen-tests/tests/expectations/tests/struct_with_anon_union.rs
@@ -10,31 +10,18 @@ pub union foo__bindgen_ty_1 {
     pub a: ::std::os::raw::c_uint,
     pub b: ::std::os::raw::c_ushort,
 }
-#[test]
-fn bindgen_test_layout_foo__bindgen_ty_1() {
-    const UNINIT: ::std::mem::MaybeUninit<foo__bindgen_ty_1> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<foo__bindgen_ty_1>(),
-        4usize,
-        concat!("Size of: ", stringify!(foo__bindgen_ty_1)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<foo__bindgen_ty_1>(),
-        4usize,
-        concat!("Alignment of ", stringify!(foo__bindgen_ty_1)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(foo__bindgen_ty_1), "::", stringify!(a)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(foo__bindgen_ty_1), "::", stringify!(b)),
-    );
-}
+const _: () = {
+    ["Size of foo__bindgen_ty_1"][::std::mem::size_of::<foo__bindgen_ty_1>() - 4usize];
+    [
+        "Alignment of foo__bindgen_ty_1",
+    ][::std::mem::align_of::<foo__bindgen_ty_1>() - 4usize];
+    [
+        "Offset of field: foo__bindgen_ty_1::a",
+    ][::std::mem::offset_of!(foo__bindgen_ty_1, a) - 0usize];
+    [
+        "Offset of field: foo__bindgen_ty_1::b",
+    ][::std::mem::offset_of!(foo__bindgen_ty_1, b) - 0usize];
+};
 impl Default for foo__bindgen_ty_1 {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
@@ -44,26 +31,11 @@ impl Default for foo__bindgen_ty_1 {
         }
     }
 }
-#[test]
-fn bindgen_test_layout_foo() {
-    const UNINIT: ::std::mem::MaybeUninit<foo> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<foo>(),
-        4usize,
-        concat!("Size of: ", stringify!(foo)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<foo>(),
-        4usize,
-        concat!("Alignment of ", stringify!(foo)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar)),
-    );
-}
+const _: () = {
+    ["Size of foo"][::std::mem::size_of::<foo>() - 4usize];
+    ["Alignment of foo"][::std::mem::align_of::<foo>() - 4usize];
+    ["Offset of field: foo::bar"][::std::mem::offset_of!(foo, bar) - 0usize];
+};
 impl Default for foo {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();

--- a/bindgen-tests/tests/expectations/tests/struct_with_anon_union_1_0.rs
+++ b/bindgen-tests/tests/expectations/tests/struct_with_anon_union_1_0.rs
@@ -61,22 +61,22 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
     assert_eq!(
         ::std::mem::size_of::<foo__bindgen_ty_1>(),
         4usize,
-        concat!("Size of: ", stringify!(foo__bindgen_ty_1)),
+        "Size of foo__bindgen_ty_1",
     );
     assert_eq!(
         ::std::mem::align_of::<foo__bindgen_ty_1>(),
         4usize,
-        concat!("Alignment of ", stringify!(foo__bindgen_ty_1)),
+        "Alignment of foo__bindgen_ty_1",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
         0usize,
-        concat!("Offset of field: ", stringify!(foo__bindgen_ty_1), "::", stringify!(a)),
+        "Offset of field: foo__bindgen_ty_1::a",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
         0usize,
-        concat!("Offset of field: ", stringify!(foo__bindgen_ty_1), "::", stringify!(b)),
+        "Offset of field: foo__bindgen_ty_1::b",
     );
 }
 impl Clone for foo__bindgen_ty_1 {
@@ -88,20 +88,12 @@ impl Clone for foo__bindgen_ty_1 {
 fn bindgen_test_layout_foo() {
     const UNINIT: ::std::mem::MaybeUninit<foo> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<foo>(),
-        4usize,
-        concat!("Size of: ", stringify!(foo)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<foo>(),
-        4usize,
-        concat!("Alignment of ", stringify!(foo)),
-    );
+    assert_eq!(::std::mem::size_of::<foo>(), 4usize, "Size of foo");
+    assert_eq!(::std::mem::align_of::<foo>(), 4usize, "Alignment of foo");
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize },
         0usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar)),
+        "Offset of field: foo::bar",
     );
 }
 impl Clone for foo {

--- a/bindgen-tests/tests/expectations/tests/struct_with_anon_unnamed_struct.rs
+++ b/bindgen-tests/tests/expectations/tests/struct_with_anon_unnamed_struct.rs
@@ -10,41 +10,19 @@ pub struct foo__bindgen_ty_1 {
     pub a: ::std::os::raw::c_uint,
     pub b: ::std::os::raw::c_uint,
 }
-#[test]
-fn bindgen_test_layout_foo__bindgen_ty_1() {
-    const UNINIT: ::std::mem::MaybeUninit<foo__bindgen_ty_1> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<foo__bindgen_ty_1>(),
-        8usize,
-        concat!("Size of: ", stringify!(foo__bindgen_ty_1)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<foo__bindgen_ty_1>(),
-        4usize,
-        concat!("Alignment of ", stringify!(foo__bindgen_ty_1)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(foo__bindgen_ty_1), "::", stringify!(a)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
-        4usize,
-        concat!("Offset of field: ", stringify!(foo__bindgen_ty_1), "::", stringify!(b)),
-    );
-}
-#[test]
-fn bindgen_test_layout_foo() {
-    assert_eq!(
-        ::std::mem::size_of::<foo>(),
-        8usize,
-        concat!("Size of: ", stringify!(foo)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<foo>(),
-        4usize,
-        concat!("Alignment of ", stringify!(foo)),
-    );
-}
+const _: () = {
+    ["Size of foo__bindgen_ty_1"][::std::mem::size_of::<foo__bindgen_ty_1>() - 8usize];
+    [
+        "Alignment of foo__bindgen_ty_1",
+    ][::std::mem::align_of::<foo__bindgen_ty_1>() - 4usize];
+    [
+        "Offset of field: foo__bindgen_ty_1::a",
+    ][::std::mem::offset_of!(foo__bindgen_ty_1, a) - 0usize];
+    [
+        "Offset of field: foo__bindgen_ty_1::b",
+    ][::std::mem::offset_of!(foo__bindgen_ty_1, b) - 4usize];
+};
+const _: () = {
+    ["Size of foo"][::std::mem::size_of::<foo>() - 8usize];
+    ["Alignment of foo"][::std::mem::align_of::<foo>() - 4usize];
+};

--- a/bindgen-tests/tests/expectations/tests/struct_with_anon_unnamed_union.rs
+++ b/bindgen-tests/tests/expectations/tests/struct_with_anon_unnamed_union.rs
@@ -10,31 +10,18 @@ pub union foo__bindgen_ty_1 {
     pub a: ::std::os::raw::c_uint,
     pub b: ::std::os::raw::c_ushort,
 }
-#[test]
-fn bindgen_test_layout_foo__bindgen_ty_1() {
-    const UNINIT: ::std::mem::MaybeUninit<foo__bindgen_ty_1> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<foo__bindgen_ty_1>(),
-        4usize,
-        concat!("Size of: ", stringify!(foo__bindgen_ty_1)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<foo__bindgen_ty_1>(),
-        4usize,
-        concat!("Alignment of ", stringify!(foo__bindgen_ty_1)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(foo__bindgen_ty_1), "::", stringify!(a)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(foo__bindgen_ty_1), "::", stringify!(b)),
-    );
-}
+const _: () = {
+    ["Size of foo__bindgen_ty_1"][::std::mem::size_of::<foo__bindgen_ty_1>() - 4usize];
+    [
+        "Alignment of foo__bindgen_ty_1",
+    ][::std::mem::align_of::<foo__bindgen_ty_1>() - 4usize];
+    [
+        "Offset of field: foo__bindgen_ty_1::a",
+    ][::std::mem::offset_of!(foo__bindgen_ty_1, a) - 0usize];
+    [
+        "Offset of field: foo__bindgen_ty_1::b",
+    ][::std::mem::offset_of!(foo__bindgen_ty_1, b) - 0usize];
+};
 impl Default for foo__bindgen_ty_1 {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
@@ -44,19 +31,10 @@ impl Default for foo__bindgen_ty_1 {
         }
     }
 }
-#[test]
-fn bindgen_test_layout_foo() {
-    assert_eq!(
-        ::std::mem::size_of::<foo>(),
-        4usize,
-        concat!("Size of: ", stringify!(foo)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<foo>(),
-        4usize,
-        concat!("Alignment of ", stringify!(foo)),
-    );
-}
+const _: () = {
+    ["Size of foo"][::std::mem::size_of::<foo>() - 4usize];
+    ["Alignment of foo"][::std::mem::align_of::<foo>() - 4usize];
+};
 impl Default for foo {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();

--- a/bindgen-tests/tests/expectations/tests/struct_with_anon_unnamed_union_1_0.rs
+++ b/bindgen-tests/tests/expectations/tests/struct_with_anon_unnamed_union_1_0.rs
@@ -61,22 +61,22 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
     assert_eq!(
         ::std::mem::size_of::<foo__bindgen_ty_1>(),
         4usize,
-        concat!("Size of: ", stringify!(foo__bindgen_ty_1)),
+        "Size of foo__bindgen_ty_1",
     );
     assert_eq!(
         ::std::mem::align_of::<foo__bindgen_ty_1>(),
         4usize,
-        concat!("Alignment of ", stringify!(foo__bindgen_ty_1)),
+        "Alignment of foo__bindgen_ty_1",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
         0usize,
-        concat!("Offset of field: ", stringify!(foo__bindgen_ty_1), "::", stringify!(a)),
+        "Offset of field: foo__bindgen_ty_1::a",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
         0usize,
-        concat!("Offset of field: ", stringify!(foo__bindgen_ty_1), "::", stringify!(b)),
+        "Offset of field: foo__bindgen_ty_1::b",
     );
 }
 impl Clone for foo__bindgen_ty_1 {
@@ -86,16 +86,8 @@ impl Clone for foo__bindgen_ty_1 {
 }
 #[test]
 fn bindgen_test_layout_foo() {
-    assert_eq!(
-        ::std::mem::size_of::<foo>(),
-        4usize,
-        concat!("Size of: ", stringify!(foo)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<foo>(),
-        4usize,
-        concat!("Alignment of ", stringify!(foo)),
-    );
+    assert_eq!(::std::mem::size_of::<foo>(), 4usize, "Size of foo");
+    assert_eq!(::std::mem::align_of::<foo>(), 4usize, "Alignment of foo");
 }
 impl Clone for foo {
     fn clone(&self) -> Self {

--- a/bindgen-tests/tests/expectations/tests/struct_with_bitfields.rs
+++ b/bindgen-tests/tests/expectations/tests/struct_with_bitfields.rs
@@ -92,26 +92,11 @@ pub struct bitfield {
     pub _bitfield_align_2: [u32; 0],
     pub _bitfield_2: __BindgenBitfieldUnit<[u8; 8usize]>,
 }
-#[test]
-fn bindgen_test_layout_bitfield() {
-    const UNINIT: ::std::mem::MaybeUninit<bitfield> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<bitfield>(),
-        16usize,
-        concat!("Size of: ", stringify!(bitfield)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<bitfield>(),
-        4usize,
-        concat!("Alignment of ", stringify!(bitfield)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).e) as usize - ptr as usize },
-        4usize,
-        concat!("Offset of field: ", stringify!(bitfield), "::", stringify!(e)),
-    );
-}
+const _: () = {
+    ["Size of bitfield"][::std::mem::size_of::<bitfield>() - 16usize];
+    ["Alignment of bitfield"][::std::mem::align_of::<bitfield>() - 4usize];
+    ["Offset of field: bitfield::e"][::std::mem::offset_of!(bitfield, e) - 4usize];
+};
 impl bitfield {
     #[inline]
     pub fn a(&self) -> ::std::os::raw::c_ushort {

--- a/bindgen-tests/tests/expectations/tests/struct_with_derive_debug.rs
+++ b/bindgen-tests/tests/expectations/tests/struct_with_derive_debug.rs
@@ -8,20 +8,16 @@ pub struct LittleArray {
 fn bindgen_test_layout_LittleArray() {
     const UNINIT: ::std::mem::MaybeUninit<LittleArray> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<LittleArray>(),
-        128usize,
-        concat!("Size of: ", stringify!(LittleArray)),
-    );
+    assert_eq!(::std::mem::size_of::<LittleArray>(), 128usize, "Size of LittleArray");
     assert_eq!(
         ::std::mem::align_of::<LittleArray>(),
         4usize,
-        concat!("Alignment of ", stringify!(LittleArray)),
+        "Alignment of LittleArray",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
         0usize,
-        concat!("Offset of field: ", stringify!(LittleArray), "::", stringify!(a)),
+        "Offset of field: LittleArray::a",
     );
 }
 #[repr(C)]
@@ -33,20 +29,12 @@ pub struct BigArray {
 fn bindgen_test_layout_BigArray() {
     const UNINIT: ::std::mem::MaybeUninit<BigArray> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<BigArray>(),
-        132usize,
-        concat!("Size of: ", stringify!(BigArray)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<BigArray>(),
-        4usize,
-        concat!("Alignment of ", stringify!(BigArray)),
-    );
+    assert_eq!(::std::mem::size_of::<BigArray>(), 132usize, "Size of BigArray");
+    assert_eq!(::std::mem::align_of::<BigArray>(), 4usize, "Alignment of BigArray");
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
         0usize,
-        concat!("Offset of field: ", stringify!(BigArray), "::", stringify!(a)),
+        "Offset of field: BigArray::a",
     );
 }
 impl Default for BigArray {
@@ -70,17 +58,17 @@ fn bindgen_test_layout_WithLittleArray() {
     assert_eq!(
         ::std::mem::size_of::<WithLittleArray>(),
         128usize,
-        concat!("Size of: ", stringify!(WithLittleArray)),
+        "Size of WithLittleArray",
     );
     assert_eq!(
         ::std::mem::align_of::<WithLittleArray>(),
         4usize,
-        concat!("Alignment of ", stringify!(WithLittleArray)),
+        "Alignment of WithLittleArray",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
         0usize,
-        concat!("Offset of field: ", stringify!(WithLittleArray), "::", stringify!(a)),
+        "Offset of field: WithLittleArray::a",
     );
 }
 #[repr(C)]
@@ -92,20 +80,16 @@ pub struct WithBigArray {
 fn bindgen_test_layout_WithBigArray() {
     const UNINIT: ::std::mem::MaybeUninit<WithBigArray> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<WithBigArray>(),
-        132usize,
-        concat!("Size of: ", stringify!(WithBigArray)),
-    );
+    assert_eq!(::std::mem::size_of::<WithBigArray>(), 132usize, "Size of WithBigArray");
     assert_eq!(
         ::std::mem::align_of::<WithBigArray>(),
         4usize,
-        concat!("Alignment of ", stringify!(WithBigArray)),
+        "Alignment of WithBigArray",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
         0usize,
-        concat!("Offset of field: ", stringify!(WithBigArray), "::", stringify!(a)),
+        "Offset of field: WithBigArray::a",
     );
 }
 impl Default for WithBigArray {

--- a/bindgen-tests/tests/expectations/tests/struct_with_large_array.rs
+++ b/bindgen-tests/tests/expectations/tests/struct_with_large_array.rs
@@ -8,16 +8,12 @@ pub struct S {
 fn bindgen_test_layout_S() {
     const UNINIT: ::std::mem::MaybeUninit<S> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
-    assert_eq!(::std::mem::size_of::<S>(), 33usize, concat!("Size of: ", stringify!(S)));
-    assert_eq!(
-        ::std::mem::align_of::<S>(),
-        1usize,
-        concat!("Alignment of ", stringify!(S)),
-    );
+    assert_eq!(::std::mem::size_of::<S>(), 33usize, "Size of S");
+    assert_eq!(::std::mem::align_of::<S>(), 1usize, "Alignment of S");
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).large_array) as usize - ptr as usize },
         0usize,
-        concat!("Offset of field: ", stringify!(S), "::", stringify!(large_array)),
+        "Offset of field: S::large_array",
     );
 }
 impl Default for S {

--- a/bindgen-tests/tests/expectations/tests/struct_with_nesting.rs
+++ b/bindgen-tests/tests/expectations/tests/struct_with_nesting.rs
@@ -18,41 +18,20 @@ pub struct foo__bindgen_ty_1__bindgen_ty_1 {
     pub c1: ::std::os::raw::c_ushort,
     pub c2: ::std::os::raw::c_ushort,
 }
-#[test]
-fn bindgen_test_layout_foo__bindgen_ty_1__bindgen_ty_1() {
-    const UNINIT: ::std::mem::MaybeUninit<foo__bindgen_ty_1__bindgen_ty_1> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<foo__bindgen_ty_1__bindgen_ty_1>(),
-        4usize,
-        concat!("Size of: ", stringify!(foo__bindgen_ty_1__bindgen_ty_1)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<foo__bindgen_ty_1__bindgen_ty_1>(),
-        2usize,
-        concat!("Alignment of ", stringify!(foo__bindgen_ty_1__bindgen_ty_1)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).c1) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(foo__bindgen_ty_1__bindgen_ty_1),
-            "::",
-            stringify!(c1),
-        ),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).c2) as usize - ptr as usize },
-        2usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(foo__bindgen_ty_1__bindgen_ty_1),
-            "::",
-            stringify!(c2),
-        ),
-    );
-}
+const _: () = {
+    [
+        "Size of foo__bindgen_ty_1__bindgen_ty_1",
+    ][::std::mem::size_of::<foo__bindgen_ty_1__bindgen_ty_1>() - 4usize];
+    [
+        "Alignment of foo__bindgen_ty_1__bindgen_ty_1",
+    ][::std::mem::align_of::<foo__bindgen_ty_1__bindgen_ty_1>() - 2usize];
+    [
+        "Offset of field: foo__bindgen_ty_1__bindgen_ty_1::c1",
+    ][::std::mem::offset_of!(foo__bindgen_ty_1__bindgen_ty_1, c1) - 0usize];
+    [
+        "Offset of field: foo__bindgen_ty_1__bindgen_ty_1::c2",
+    ][::std::mem::offset_of!(foo__bindgen_ty_1__bindgen_ty_1, c2) - 2usize];
+};
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct foo__bindgen_ty_1__bindgen_ty_2 {
@@ -61,81 +40,35 @@ pub struct foo__bindgen_ty_1__bindgen_ty_2 {
     pub d3: ::std::os::raw::c_uchar,
     pub d4: ::std::os::raw::c_uchar,
 }
-#[test]
-fn bindgen_test_layout_foo__bindgen_ty_1__bindgen_ty_2() {
-    const UNINIT: ::std::mem::MaybeUninit<foo__bindgen_ty_1__bindgen_ty_2> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<foo__bindgen_ty_1__bindgen_ty_2>(),
-        4usize,
-        concat!("Size of: ", stringify!(foo__bindgen_ty_1__bindgen_ty_2)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<foo__bindgen_ty_1__bindgen_ty_2>(),
-        1usize,
-        concat!("Alignment of ", stringify!(foo__bindgen_ty_1__bindgen_ty_2)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).d1) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(foo__bindgen_ty_1__bindgen_ty_2),
-            "::",
-            stringify!(d1),
-        ),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).d2) as usize - ptr as usize },
-        1usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(foo__bindgen_ty_1__bindgen_ty_2),
-            "::",
-            stringify!(d2),
-        ),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).d3) as usize - ptr as usize },
-        2usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(foo__bindgen_ty_1__bindgen_ty_2),
-            "::",
-            stringify!(d3),
-        ),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).d4) as usize - ptr as usize },
-        3usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(foo__bindgen_ty_1__bindgen_ty_2),
-            "::",
-            stringify!(d4),
-        ),
-    );
-}
-#[test]
-fn bindgen_test_layout_foo__bindgen_ty_1() {
-    const UNINIT: ::std::mem::MaybeUninit<foo__bindgen_ty_1> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<foo__bindgen_ty_1>(),
-        4usize,
-        concat!("Size of: ", stringify!(foo__bindgen_ty_1)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<foo__bindgen_ty_1>(),
-        4usize,
-        concat!("Alignment of ", stringify!(foo__bindgen_ty_1)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(foo__bindgen_ty_1), "::", stringify!(b)),
-    );
-}
+const _: () = {
+    [
+        "Size of foo__bindgen_ty_1__bindgen_ty_2",
+    ][::std::mem::size_of::<foo__bindgen_ty_1__bindgen_ty_2>() - 4usize];
+    [
+        "Alignment of foo__bindgen_ty_1__bindgen_ty_2",
+    ][::std::mem::align_of::<foo__bindgen_ty_1__bindgen_ty_2>() - 1usize];
+    [
+        "Offset of field: foo__bindgen_ty_1__bindgen_ty_2::d1",
+    ][::std::mem::offset_of!(foo__bindgen_ty_1__bindgen_ty_2, d1) - 0usize];
+    [
+        "Offset of field: foo__bindgen_ty_1__bindgen_ty_2::d2",
+    ][::std::mem::offset_of!(foo__bindgen_ty_1__bindgen_ty_2, d2) - 1usize];
+    [
+        "Offset of field: foo__bindgen_ty_1__bindgen_ty_2::d3",
+    ][::std::mem::offset_of!(foo__bindgen_ty_1__bindgen_ty_2, d3) - 2usize];
+    [
+        "Offset of field: foo__bindgen_ty_1__bindgen_ty_2::d4",
+    ][::std::mem::offset_of!(foo__bindgen_ty_1__bindgen_ty_2, d4) - 3usize];
+};
+const _: () = {
+    ["Size of foo__bindgen_ty_1"][::std::mem::size_of::<foo__bindgen_ty_1>() - 4usize];
+    [
+        "Alignment of foo__bindgen_ty_1",
+    ][::std::mem::align_of::<foo__bindgen_ty_1>() - 4usize];
+    [
+        "Offset of field: foo__bindgen_ty_1::b",
+    ][::std::mem::offset_of!(foo__bindgen_ty_1, b) - 0usize];
+};
 impl Default for foo__bindgen_ty_1 {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
@@ -145,26 +78,11 @@ impl Default for foo__bindgen_ty_1 {
         }
     }
 }
-#[test]
-fn bindgen_test_layout_foo() {
-    const UNINIT: ::std::mem::MaybeUninit<foo> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<foo>(),
-        8usize,
-        concat!("Size of: ", stringify!(foo)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<foo>(),
-        4usize,
-        concat!("Alignment of ", stringify!(foo)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(a)),
-    );
-}
+const _: () = {
+    ["Size of foo"][::std::mem::size_of::<foo>() - 8usize];
+    ["Alignment of foo"][::std::mem::align_of::<foo>() - 4usize];
+    ["Offset of field: foo::a"][::std::mem::offset_of!(foo, a) - 0usize];
+};
 impl Default for foo {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();

--- a/bindgen-tests/tests/expectations/tests/struct_with_nesting_1_0.rs
+++ b/bindgen-tests/tests/expectations/tests/struct_with_nesting_1_0.rs
@@ -69,32 +69,22 @@ fn bindgen_test_layout_foo__bindgen_ty_1__bindgen_ty_1() {
     assert_eq!(
         ::std::mem::size_of::<foo__bindgen_ty_1__bindgen_ty_1>(),
         4usize,
-        concat!("Size of: ", stringify!(foo__bindgen_ty_1__bindgen_ty_1)),
+        "Size of foo__bindgen_ty_1__bindgen_ty_1",
     );
     assert_eq!(
         ::std::mem::align_of::<foo__bindgen_ty_1__bindgen_ty_1>(),
         2usize,
-        concat!("Alignment of ", stringify!(foo__bindgen_ty_1__bindgen_ty_1)),
+        "Alignment of foo__bindgen_ty_1__bindgen_ty_1",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).c1) as usize - ptr as usize },
         0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(foo__bindgen_ty_1__bindgen_ty_1),
-            "::",
-            stringify!(c1),
-        ),
+        "Offset of field: foo__bindgen_ty_1__bindgen_ty_1::c1",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).c2) as usize - ptr as usize },
         2usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(foo__bindgen_ty_1__bindgen_ty_1),
-            "::",
-            stringify!(c2),
-        ),
+        "Offset of field: foo__bindgen_ty_1__bindgen_ty_1::c2",
     );
 }
 impl Clone for foo__bindgen_ty_1__bindgen_ty_1 {
@@ -117,52 +107,32 @@ fn bindgen_test_layout_foo__bindgen_ty_1__bindgen_ty_2() {
     assert_eq!(
         ::std::mem::size_of::<foo__bindgen_ty_1__bindgen_ty_2>(),
         4usize,
-        concat!("Size of: ", stringify!(foo__bindgen_ty_1__bindgen_ty_2)),
+        "Size of foo__bindgen_ty_1__bindgen_ty_2",
     );
     assert_eq!(
         ::std::mem::align_of::<foo__bindgen_ty_1__bindgen_ty_2>(),
         1usize,
-        concat!("Alignment of ", stringify!(foo__bindgen_ty_1__bindgen_ty_2)),
+        "Alignment of foo__bindgen_ty_1__bindgen_ty_2",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).d1) as usize - ptr as usize },
         0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(foo__bindgen_ty_1__bindgen_ty_2),
-            "::",
-            stringify!(d1),
-        ),
+        "Offset of field: foo__bindgen_ty_1__bindgen_ty_2::d1",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).d2) as usize - ptr as usize },
         1usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(foo__bindgen_ty_1__bindgen_ty_2),
-            "::",
-            stringify!(d2),
-        ),
+        "Offset of field: foo__bindgen_ty_1__bindgen_ty_2::d2",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).d3) as usize - ptr as usize },
         2usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(foo__bindgen_ty_1__bindgen_ty_2),
-            "::",
-            stringify!(d3),
-        ),
+        "Offset of field: foo__bindgen_ty_1__bindgen_ty_2::d3",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).d4) as usize - ptr as usize },
         3usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(foo__bindgen_ty_1__bindgen_ty_2),
-            "::",
-            stringify!(d4),
-        ),
+        "Offset of field: foo__bindgen_ty_1__bindgen_ty_2::d4",
     );
 }
 impl Clone for foo__bindgen_ty_1__bindgen_ty_2 {
@@ -177,17 +147,17 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
     assert_eq!(
         ::std::mem::size_of::<foo__bindgen_ty_1>(),
         4usize,
-        concat!("Size of: ", stringify!(foo__bindgen_ty_1)),
+        "Size of foo__bindgen_ty_1",
     );
     assert_eq!(
         ::std::mem::align_of::<foo__bindgen_ty_1>(),
         4usize,
-        concat!("Alignment of ", stringify!(foo__bindgen_ty_1)),
+        "Alignment of foo__bindgen_ty_1",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
         0usize,
-        concat!("Offset of field: ", stringify!(foo__bindgen_ty_1), "::", stringify!(b)),
+        "Offset of field: foo__bindgen_ty_1::b",
     );
 }
 impl Clone for foo__bindgen_ty_1 {
@@ -199,20 +169,12 @@ impl Clone for foo__bindgen_ty_1 {
 fn bindgen_test_layout_foo() {
     const UNINIT: ::std::mem::MaybeUninit<foo> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<foo>(),
-        8usize,
-        concat!("Size of: ", stringify!(foo)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<foo>(),
-        4usize,
-        concat!("Alignment of ", stringify!(foo)),
-    );
+    assert_eq!(::std::mem::size_of::<foo>(), 8usize, "Size of foo");
+    assert_eq!(::std::mem::align_of::<foo>(), 4usize, "Alignment of foo");
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
         0usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(a)),
+        "Offset of field: foo::a",
     );
 }
 impl Clone for foo {

--- a/bindgen-tests/tests/expectations/tests/struct_with_packing.rs
+++ b/bindgen-tests/tests/expectations/tests/struct_with_packing.rs
@@ -5,24 +5,9 @@ pub struct a {
     pub b: ::std::os::raw::c_char,
     pub c: ::std::os::raw::c_short,
 }
-#[test]
-fn bindgen_test_layout_a() {
-    const UNINIT: ::std::mem::MaybeUninit<a> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(::std::mem::size_of::<a>(), 3usize, concat!("Size of: ", stringify!(a)));
-    assert_eq!(
-        ::std::mem::align_of::<a>(),
-        1usize,
-        concat!("Alignment of ", stringify!(a)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(a), "::", stringify!(b)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).c) as usize - ptr as usize },
-        1usize,
-        concat!("Offset of field: ", stringify!(a), "::", stringify!(c)),
-    );
-}
+const _: () = {
+    ["Size of a"][::std::mem::size_of::<a>() - 3usize];
+    ["Alignment of a"][::std::mem::align_of::<a>() - 1usize];
+    ["Offset of field: a::b"][::std::mem::offset_of!(a, b) - 0usize];
+    ["Offset of field: a::c"][::std::mem::offset_of!(a, c) - 1usize];
+};

--- a/bindgen-tests/tests/expectations/tests/struct_with_struct.rs
+++ b/bindgen-tests/tests/expectations/tests/struct_with_struct.rs
@@ -10,48 +10,20 @@ pub struct foo__bindgen_ty_1 {
     pub x: ::std::os::raw::c_uint,
     pub y: ::std::os::raw::c_uint,
 }
-#[test]
-fn bindgen_test_layout_foo__bindgen_ty_1() {
-    const UNINIT: ::std::mem::MaybeUninit<foo__bindgen_ty_1> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<foo__bindgen_ty_1>(),
-        8usize,
-        concat!("Size of: ", stringify!(foo__bindgen_ty_1)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<foo__bindgen_ty_1>(),
-        4usize,
-        concat!("Alignment of ", stringify!(foo__bindgen_ty_1)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(foo__bindgen_ty_1), "::", stringify!(x)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).y) as usize - ptr as usize },
-        4usize,
-        concat!("Offset of field: ", stringify!(foo__bindgen_ty_1), "::", stringify!(y)),
-    );
-}
-#[test]
-fn bindgen_test_layout_foo() {
-    const UNINIT: ::std::mem::MaybeUninit<foo> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<foo>(),
-        8usize,
-        concat!("Size of: ", stringify!(foo)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<foo>(),
-        4usize,
-        concat!("Alignment of ", stringify!(foo)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar)),
-    );
-}
+const _: () = {
+    ["Size of foo__bindgen_ty_1"][::std::mem::size_of::<foo__bindgen_ty_1>() - 8usize];
+    [
+        "Alignment of foo__bindgen_ty_1",
+    ][::std::mem::align_of::<foo__bindgen_ty_1>() - 4usize];
+    [
+        "Offset of field: foo__bindgen_ty_1::x",
+    ][::std::mem::offset_of!(foo__bindgen_ty_1, x) - 0usize];
+    [
+        "Offset of field: foo__bindgen_ty_1::y",
+    ][::std::mem::offset_of!(foo__bindgen_ty_1, y) - 4usize];
+};
+const _: () = {
+    ["Size of foo"][::std::mem::size_of::<foo>() - 8usize];
+    ["Alignment of foo"][::std::mem::align_of::<foo>() - 4usize];
+    ["Offset of field: foo::bar"][::std::mem::offset_of!(foo, bar) - 0usize];
+};

--- a/bindgen-tests/tests/expectations/tests/template.rs
+++ b/bindgen-tests/tests/expectations/tests/template.rs
@@ -60,108 +60,36 @@ pub struct C {
     pub mArrayRef: B<*mut [::std::os::raw::c_int; 1usize]>,
     pub mBConstArray: B<[::std::os::raw::c_int; 1usize]>,
 }
-#[test]
-fn bindgen_test_layout_C() {
-    const UNINIT: ::std::mem::MaybeUninit<C> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<C>(),
-        104usize,
-        concat!("Size of: ", stringify!(C)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<C>(),
-        8usize,
-        concat!("Alignment of ", stringify!(C)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).mB) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(C), "::", stringify!(mB)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).mBConstPtr) as usize - ptr as usize },
-        8usize,
-        concat!("Offset of field: ", stringify!(C), "::", stringify!(mBConstPtr)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).mBConstStructPtr) as usize - ptr as usize },
-        16usize,
-        concat!("Offset of field: ", stringify!(C), "::", stringify!(mBConstStructPtr)),
-    );
-    assert_eq!(
-        unsafe {
-            ::std::ptr::addr_of!((*ptr).mBConstStructPtrArray) as usize - ptr as usize
-        },
-        24usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(C),
-            "::",
-            stringify!(mBConstStructPtrArray),
-        ),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).mBConst) as usize - ptr as usize },
-        32usize,
-        concat!("Offset of field: ", stringify!(C), "::", stringify!(mBConst)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).mBVolatile) as usize - ptr as usize },
-        36usize,
-        concat!("Offset of field: ", stringify!(C), "::", stringify!(mBVolatile)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).mBConstBool) as usize - ptr as usize },
-        40usize,
-        concat!("Offset of field: ", stringify!(C), "::", stringify!(mBConstBool)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).mBConstChar) as usize - ptr as usize },
-        42usize,
-        concat!("Offset of field: ", stringify!(C), "::", stringify!(mBConstChar)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).mBArray) as usize - ptr as usize },
-        44usize,
-        concat!("Offset of field: ", stringify!(C), "::", stringify!(mBArray)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).mBPtrArray) as usize - ptr as usize },
-        48usize,
-        concat!("Offset of field: ", stringify!(C), "::", stringify!(mBPtrArray)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).mBArrayPtr) as usize - ptr as usize },
-        56usize,
-        concat!("Offset of field: ", stringify!(C), "::", stringify!(mBArrayPtr)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).mBRef) as usize - ptr as usize },
-        64usize,
-        concat!("Offset of field: ", stringify!(C), "::", stringify!(mBRef)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).mBConstRef) as usize - ptr as usize },
-        72usize,
-        concat!("Offset of field: ", stringify!(C), "::", stringify!(mBConstRef)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).mPtrRef) as usize - ptr as usize },
-        80usize,
-        concat!("Offset of field: ", stringify!(C), "::", stringify!(mPtrRef)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).mArrayRef) as usize - ptr as usize },
-        88usize,
-        concat!("Offset of field: ", stringify!(C), "::", stringify!(mArrayRef)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).mBConstArray) as usize - ptr as usize },
-        96usize,
-        concat!("Offset of field: ", stringify!(C), "::", stringify!(mBConstArray)),
-    );
-}
+const _: () = {
+    ["Size of C"][::std::mem::size_of::<C>() - 104usize];
+    ["Alignment of C"][::std::mem::align_of::<C>() - 8usize];
+    ["Offset of field: C::mB"][::std::mem::offset_of!(C, mB) - 0usize];
+    ["Offset of field: C::mBConstPtr"][::std::mem::offset_of!(C, mBConstPtr) - 8usize];
+    [
+        "Offset of field: C::mBConstStructPtr",
+    ][::std::mem::offset_of!(C, mBConstStructPtr) - 16usize];
+    [
+        "Offset of field: C::mBConstStructPtrArray",
+    ][::std::mem::offset_of!(C, mBConstStructPtrArray) - 24usize];
+    ["Offset of field: C::mBConst"][::std::mem::offset_of!(C, mBConst) - 32usize];
+    ["Offset of field: C::mBVolatile"][::std::mem::offset_of!(C, mBVolatile) - 36usize];
+    [
+        "Offset of field: C::mBConstBool",
+    ][::std::mem::offset_of!(C, mBConstBool) - 40usize];
+    [
+        "Offset of field: C::mBConstChar",
+    ][::std::mem::offset_of!(C, mBConstChar) - 42usize];
+    ["Offset of field: C::mBArray"][::std::mem::offset_of!(C, mBArray) - 44usize];
+    ["Offset of field: C::mBPtrArray"][::std::mem::offset_of!(C, mBPtrArray) - 48usize];
+    ["Offset of field: C::mBArrayPtr"][::std::mem::offset_of!(C, mBArrayPtr) - 56usize];
+    ["Offset of field: C::mBRef"][::std::mem::offset_of!(C, mBRef) - 64usize];
+    ["Offset of field: C::mBConstRef"][::std::mem::offset_of!(C, mBConstRef) - 72usize];
+    ["Offset of field: C::mPtrRef"][::std::mem::offset_of!(C, mPtrRef) - 80usize];
+    ["Offset of field: C::mArrayRef"][::std::mem::offset_of!(C, mArrayRef) - 88usize];
+    [
+        "Offset of field: C::mBConstArray",
+    ][::std::mem::offset_of!(C, mBConstArray) - 96usize];
+};
 impl Default for C {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
@@ -224,26 +152,13 @@ impl<T> Default for Rooted<T> {
 pub struct RootedContainer {
     pub root: Rooted<*mut ::std::os::raw::c_void>,
 }
-#[test]
-fn bindgen_test_layout_RootedContainer() {
-    const UNINIT: ::std::mem::MaybeUninit<RootedContainer> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<RootedContainer>(),
-        24usize,
-        concat!("Size of: ", stringify!(RootedContainer)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<RootedContainer>(),
-        8usize,
-        concat!("Alignment of ", stringify!(RootedContainer)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).root) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(RootedContainer), "::", stringify!(root)),
-    );
-}
+const _: () = {
+    ["Size of RootedContainer"][::std::mem::size_of::<RootedContainer>() - 24usize];
+    ["Alignment of RootedContainer"][::std::mem::align_of::<RootedContainer>() - 8usize];
+    [
+        "Offset of field: RootedContainer::root",
+    ][::std::mem::offset_of!(RootedContainer, root) - 0usize];
+};
 impl Default for RootedContainer {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
@@ -274,31 +189,15 @@ impl<T> Default for WithDtor<T> {
 pub struct PODButContainsDtor {
     pub member: WithDtorIntFwd,
 }
-#[test]
-fn bindgen_test_layout_PODButContainsDtor() {
-    const UNINIT: ::std::mem::MaybeUninit<PODButContainsDtor> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<PODButContainsDtor>(),
-        4usize,
-        concat!("Size of: ", stringify!(PODButContainsDtor)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<PODButContainsDtor>(),
-        4usize,
-        concat!("Alignment of ", stringify!(PODButContainsDtor)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).member) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(PODButContainsDtor),
-            "::",
-            stringify!(member),
-        ),
-    );
-}
+const _: () = {
+    ["Size of PODButContainsDtor"][::std::mem::size_of::<PODButContainsDtor>() - 4usize];
+    [
+        "Alignment of PODButContainsDtor",
+    ][::std::mem::align_of::<PODButContainsDtor>() - 4usize];
+    [
+        "Offset of field: PODButContainsDtor::member",
+    ][::std::mem::offset_of!(PODButContainsDtor, member) - 0usize];
+};
 impl Default for PODButContainsDtor {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
@@ -319,26 +218,13 @@ pub struct Opaque {
 pub struct POD {
     pub opaque_member: u32,
 }
-#[test]
-fn bindgen_test_layout_POD() {
-    const UNINIT: ::std::mem::MaybeUninit<POD> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<POD>(),
-        4usize,
-        concat!("Size of: ", stringify!(POD)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<POD>(),
-        4usize,
-        concat!("Alignment of ", stringify!(POD)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).opaque_member) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(POD), "::", stringify!(opaque_member)),
-    );
-}
+const _: () = {
+    ["Size of POD"][::std::mem::size_of::<POD>() - 4usize];
+    ["Alignment of POD"][::std::mem::align_of::<POD>() - 4usize];
+    [
+        "Offset of field: POD::opaque_member",
+    ][::std::mem::offset_of!(POD, opaque_member) - 0usize];
+};
 /// <div rustbindgen replaces="NestedReplaced"></div>
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -407,19 +293,10 @@ impl<T> Default for Incomplete<T> {
 pub struct Untemplated {
     pub _address: u8,
 }
-#[test]
-fn bindgen_test_layout_Untemplated() {
-    assert_eq!(
-        ::std::mem::size_of::<Untemplated>(),
-        1usize,
-        concat!("Size of: ", stringify!(Untemplated)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Untemplated>(),
-        1usize,
-        concat!("Alignment of ", stringify!(Untemplated)),
-    );
-}
+const _: () = {
+    ["Size of Untemplated"][::std::mem::size_of::<Untemplated>() - 1usize];
+    ["Alignment of Untemplated"][::std::mem::align_of::<Untemplated>() - 1usize];
+};
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct Templated {
@@ -493,390 +370,171 @@ impl<T> Default for ReplacedWithoutDestructorFwd<T> {
         }
     }
 }
-#[test]
-fn __bindgen_test_layout_Foo_open0_int_int_close0_instantiation() {
-    assert_eq!(
-        ::std::mem::size_of::<Foo<::std::os::raw::c_int>>(),
-        24usize,
-        concat!(
-            "Size of template specialization: ",
-            stringify!(Foo < ::std::os::raw::c_int >),
-        ),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Foo<::std::os::raw::c_int>>(),
-        8usize,
-        concat!(
-            "Alignment of template specialization: ",
-            stringify!(Foo < ::std::os::raw::c_int >),
-        ),
-    );
-}
-#[test]
-fn __bindgen_test_layout_B_open0_unsigned_int_close0_instantiation() {
-    assert_eq!(
-        ::std::mem::size_of::<B<::std::os::raw::c_uint>>(),
-        4usize,
-        concat!(
-            "Size of template specialization: ",
-            stringify!(B < ::std::os::raw::c_uint >),
-        ),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<B<::std::os::raw::c_uint>>(),
-        4usize,
-        concat!(
-            "Alignment of template specialization: ",
-            stringify!(B < ::std::os::raw::c_uint >),
-        ),
-    );
-}
-#[test]
-fn __bindgen_test_layout_B_open0_ptr_const_int_close0_instantiation() {
-    assert_eq!(
-        ::std::mem::size_of::<B<*const ::std::os::raw::c_int>>(),
-        8usize,
-        concat!(
-            "Size of template specialization: ",
-            stringify!(B < * const ::std::os::raw::c_int >),
-        ),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<B<*const ::std::os::raw::c_int>>(),
-        8usize,
-        concat!(
-            "Alignment of template specialization: ",
-            stringify!(B < * const ::std::os::raw::c_int >),
-        ),
-    );
-}
-#[test]
-fn __bindgen_test_layout_B_open0_ptr_const_mozilla__Foo_close0_instantiation() {
-    assert_eq!(
-        ::std::mem::size_of::<B<*const mozilla_Foo>>(),
-        8usize,
-        concat!(
-            "Size of template specialization: ",
-            stringify!(B < * const mozilla_Foo >),
-        ),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<B<*const mozilla_Foo>>(),
-        8usize,
-        concat!(
-            "Alignment of template specialization: ",
-            stringify!(B < * const mozilla_Foo >),
-        ),
-    );
-}
-#[test]
-fn __bindgen_test_layout_B_open0_array1_ptr_const_mozilla__Foo_close0_instantiation() {
-    assert_eq!(
-        ::std::mem::size_of::<B<[*const mozilla_Foo; 1usize]>>(),
-        8usize,
-        concat!(
-            "Size of template specialization: ",
-            stringify!(B < [* const mozilla_Foo; 1usize] >),
-        ),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<B<[*const mozilla_Foo; 1usize]>>(),
-        8usize,
-        concat!(
-            "Alignment of template specialization: ",
-            stringify!(B < [* const mozilla_Foo; 1usize] >),
-        ),
-    );
-}
-#[test]
-fn __bindgen_test_layout_B_open0_const_int_close0_instantiation() {
-    assert_eq!(
-        ::std::mem::size_of::<B<::std::os::raw::c_int>>(),
-        4usize,
-        concat!(
-            "Size of template specialization: ",
-            stringify!(B < ::std::os::raw::c_int >),
-        ),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<B<::std::os::raw::c_int>>(),
-        4usize,
-        concat!(
-            "Alignment of template specialization: ",
-            stringify!(B < ::std::os::raw::c_int >),
-        ),
-    );
-}
-#[test]
-fn __bindgen_test_layout_B_open0_volatile_int_close0_instantiation() {
-    assert_eq!(
-        ::std::mem::size_of::<B<::std::os::raw::c_int>>(),
-        4usize,
-        concat!(
-            "Size of template specialization: ",
-            stringify!(B < ::std::os::raw::c_int >),
-        ),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<B<::std::os::raw::c_int>>(),
-        4usize,
-        concat!(
-            "Alignment of template specialization: ",
-            stringify!(B < ::std::os::raw::c_int >),
-        ),
-    );
-}
-#[test]
-fn __bindgen_test_layout_B_open0_const_bool_close0_instantiation() {
-    assert_eq!(
-        ::std::mem::size_of::<B<bool>>(),
-        1usize,
-        concat!("Size of template specialization: ", stringify!(B < bool >)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<B<bool>>(),
-        1usize,
-        concat!("Alignment of template specialization: ", stringify!(B < bool >)),
-    );
-}
-#[test]
-fn __bindgen_test_layout_B_open0_const_char16_t_close0_instantiation() {
-    assert_eq!(
-        ::std::mem::size_of::<B<u16>>(),
-        2usize,
-        concat!("Size of template specialization: ", stringify!(B < u16 >)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<B<u16>>(),
-        2usize,
-        concat!("Alignment of template specialization: ", stringify!(B < u16 >)),
-    );
-}
-#[test]
-fn __bindgen_test_layout_B_open0_array1_int_close0_instantiation() {
-    assert_eq!(
-        ::std::mem::size_of::<B<[::std::os::raw::c_int; 1usize]>>(),
-        4usize,
-        concat!(
-            "Size of template specialization: ",
-            stringify!(B < [::std::os::raw::c_int; 1usize] >),
-        ),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<B<[::std::os::raw::c_int; 1usize]>>(),
-        4usize,
-        concat!(
-            "Alignment of template specialization: ",
-            stringify!(B < [::std::os::raw::c_int; 1usize] >),
-        ),
-    );
-}
-#[test]
-fn __bindgen_test_layout_B_open0_array1_ptr_int_close0_instantiation() {
-    assert_eq!(
-        ::std::mem::size_of::<B<[*mut ::std::os::raw::c_int; 1usize]>>(),
-        8usize,
-        concat!(
-            "Size of template specialization: ",
-            stringify!(B < [* mut ::std::os::raw::c_int; 1usize] >),
-        ),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<B<[*mut ::std::os::raw::c_int; 1usize]>>(),
-        8usize,
-        concat!(
-            "Alignment of template specialization: ",
-            stringify!(B < [* mut ::std::os::raw::c_int; 1usize] >),
-        ),
-    );
-}
-#[test]
-fn __bindgen_test_layout_B_open0_ptr_array1_int_close0_instantiation() {
-    assert_eq!(
-        ::std::mem::size_of::<B<*mut [::std::os::raw::c_int; 1usize]>>(),
-        8usize,
-        concat!(
-            "Size of template specialization: ",
-            stringify!(B < * mut [::std::os::raw::c_int; 1usize] >),
-        ),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<B<*mut [::std::os::raw::c_int; 1usize]>>(),
-        8usize,
-        concat!(
-            "Alignment of template specialization: ",
-            stringify!(B < * mut [::std::os::raw::c_int; 1usize] >),
-        ),
-    );
-}
-#[test]
-fn __bindgen_test_layout_B_open0_ref_int_close0_instantiation() {
-    assert_eq!(
-        ::std::mem::size_of::<B<*mut ::std::os::raw::c_int>>(),
-        8usize,
-        concat!(
-            "Size of template specialization: ",
-            stringify!(B < * mut ::std::os::raw::c_int >),
-        ),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<B<*mut ::std::os::raw::c_int>>(),
-        8usize,
-        concat!(
-            "Alignment of template specialization: ",
-            stringify!(B < * mut ::std::os::raw::c_int >),
-        ),
-    );
-}
-#[test]
-fn __bindgen_test_layout_B_open0_ref_const_int_close0_instantiation() {
-    assert_eq!(
-        ::std::mem::size_of::<B<*const ::std::os::raw::c_int>>(),
-        8usize,
-        concat!(
-            "Size of template specialization: ",
-            stringify!(B < * const ::std::os::raw::c_int >),
-        ),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<B<*const ::std::os::raw::c_int>>(),
-        8usize,
-        concat!(
-            "Alignment of template specialization: ",
-            stringify!(B < * const ::std::os::raw::c_int >),
-        ),
-    );
-}
-#[test]
-fn __bindgen_test_layout_B_open0_ref_ptr_int_close0_instantiation() {
-    assert_eq!(
-        ::std::mem::size_of::<B<*mut *mut ::std::os::raw::c_int>>(),
-        8usize,
-        concat!(
-            "Size of template specialization: ",
-            stringify!(B < * mut * mut ::std::os::raw::c_int >),
-        ),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<B<*mut *mut ::std::os::raw::c_int>>(),
-        8usize,
-        concat!(
-            "Alignment of template specialization: ",
-            stringify!(B < * mut * mut ::std::os::raw::c_int >),
-        ),
-    );
-}
-#[test]
-fn __bindgen_test_layout_B_open0_ref_array1_int_close0_instantiation() {
-    assert_eq!(
-        ::std::mem::size_of::<B<*mut [::std::os::raw::c_int; 1usize]>>(),
-        8usize,
-        concat!(
-            "Size of template specialization: ",
-            stringify!(B < * mut [::std::os::raw::c_int; 1usize] >),
-        ),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<B<*mut [::std::os::raw::c_int; 1usize]>>(),
-        8usize,
-        concat!(
-            "Alignment of template specialization: ",
-            stringify!(B < * mut [::std::os::raw::c_int; 1usize] >),
-        ),
-    );
-}
-#[test]
-fn __bindgen_test_layout_B_open0_array1_const_int_close0_instantiation() {
-    assert_eq!(
-        ::std::mem::size_of::<B<[::std::os::raw::c_int; 1usize]>>(),
-        4usize,
-        concat!(
-            "Size of template specialization: ",
-            stringify!(B < [::std::os::raw::c_int; 1usize] >),
-        ),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<B<[::std::os::raw::c_int; 1usize]>>(),
-        4usize,
-        concat!(
-            "Alignment of template specialization: ",
-            stringify!(B < [::std::os::raw::c_int; 1usize] >),
-        ),
-    );
-}
-#[test]
-fn __bindgen_test_layout_Foo_open0_int_int_close0_instantiation_1() {
-    assert_eq!(
-        ::std::mem::size_of::<Foo<::std::os::raw::c_int>>(),
-        24usize,
-        concat!(
-            "Size of template specialization: ",
-            stringify!(Foo < ::std::os::raw::c_int >),
-        ),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Foo<::std::os::raw::c_int>>(),
-        8usize,
-        concat!(
-            "Alignment of template specialization: ",
-            stringify!(Foo < ::std::os::raw::c_int >),
-        ),
-    );
-}
-#[test]
-fn __bindgen_test_layout_Rooted_open0_ptr_void_close0_instantiation() {
-    assert_eq!(
-        ::std::mem::size_of::<Rooted<*mut ::std::os::raw::c_void>>(),
-        24usize,
-        concat!(
-            "Size of template specialization: ",
-            stringify!(Rooted < * mut ::std::os::raw::c_void >),
-        ),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Rooted<*mut ::std::os::raw::c_void>>(),
-        8usize,
-        concat!(
-            "Alignment of template specialization: ",
-            stringify!(Rooted < * mut ::std::os::raw::c_void >),
-        ),
-    );
-}
-#[test]
-fn __bindgen_test_layout_Rooted_open0_ptr_void_close0_instantiation_1() {
-    assert_eq!(
-        ::std::mem::size_of::<Rooted<*mut ::std::os::raw::c_void>>(),
-        24usize,
-        concat!(
-            "Size of template specialization: ",
-            stringify!(Rooted < * mut ::std::os::raw::c_void >),
-        ),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Rooted<*mut ::std::os::raw::c_void>>(),
-        8usize,
-        concat!(
-            "Alignment of template specialization: ",
-            stringify!(Rooted < * mut ::std::os::raw::c_void >),
-        ),
-    );
-}
-#[test]
-fn __bindgen_test_layout_WithDtor_open0_int_close0_instantiation() {
-    assert_eq!(
-        ::std::mem::size_of::<WithDtor<::std::os::raw::c_int>>(),
-        4usize,
-        concat!(
-            "Size of template specialization: ",
-            stringify!(WithDtor < ::std::os::raw::c_int >),
-        ),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<WithDtor<::std::os::raw::c_int>>(),
-        4usize,
-        concat!(
-            "Alignment of template specialization: ",
-            stringify!(WithDtor < ::std::os::raw::c_int >),
-        ),
-    );
-}
+const _: () = {
+    [
+        "Size of template specialization: Foo_open0_int_int_close0",
+    ][::std::mem::size_of::<Foo<::std::os::raw::c_int>>() - 24usize];
+    [
+        "Align of template specialization: Foo_open0_int_int_close0",
+    ][::std::mem::align_of::<Foo<::std::os::raw::c_int>>() - 8usize];
+};
+const _: () = {
+    [
+        "Size of template specialization: B_open0_unsigned_int_close0",
+    ][::std::mem::size_of::<B<::std::os::raw::c_uint>>() - 4usize];
+    [
+        "Align of template specialization: B_open0_unsigned_int_close0",
+    ][::std::mem::align_of::<B<::std::os::raw::c_uint>>() - 4usize];
+};
+const _: () = {
+    [
+        "Size of template specialization: B_open0_ptr_const_int_close0",
+    ][::std::mem::size_of::<B<*const ::std::os::raw::c_int>>() - 8usize];
+    [
+        "Align of template specialization: B_open0_ptr_const_int_close0",
+    ][::std::mem::align_of::<B<*const ::std::os::raw::c_int>>() - 8usize];
+};
+const _: () = {
+    [
+        "Size of template specialization: B_open0_ptr_const_mozilla__Foo_close0",
+    ][::std::mem::size_of::<B<*const mozilla_Foo>>() - 8usize];
+    [
+        "Align of template specialization: B_open0_ptr_const_mozilla__Foo_close0",
+    ][::std::mem::align_of::<B<*const mozilla_Foo>>() - 8usize];
+};
+const _: () = {
+    [
+        "Size of template specialization: B_open0_array1_ptr_const_mozilla__Foo_close0",
+    ][::std::mem::size_of::<B<[*const mozilla_Foo; 1usize]>>() - 8usize];
+    [
+        "Align of template specialization: B_open0_array1_ptr_const_mozilla__Foo_close0",
+    ][::std::mem::align_of::<B<[*const mozilla_Foo; 1usize]>>() - 8usize];
+};
+const _: () = {
+    [
+        "Size of template specialization: B_open0_const_int_close0",
+    ][::std::mem::size_of::<B<::std::os::raw::c_int>>() - 4usize];
+    [
+        "Align of template specialization: B_open0_const_int_close0",
+    ][::std::mem::align_of::<B<::std::os::raw::c_int>>() - 4usize];
+};
+const _: () = {
+    [
+        "Size of template specialization: B_open0_volatile_int_close0",
+    ][::std::mem::size_of::<B<::std::os::raw::c_int>>() - 4usize];
+    [
+        "Align of template specialization: B_open0_volatile_int_close0",
+    ][::std::mem::align_of::<B<::std::os::raw::c_int>>() - 4usize];
+};
+const _: () = {
+    [
+        "Size of template specialization: B_open0_const_bool_close0",
+    ][::std::mem::size_of::<B<bool>>() - 1usize];
+    [
+        "Align of template specialization: B_open0_const_bool_close0",
+    ][::std::mem::align_of::<B<bool>>() - 1usize];
+};
+const _: () = {
+    [
+        "Size of template specialization: B_open0_const_char16_t_close0",
+    ][::std::mem::size_of::<B<u16>>() - 2usize];
+    [
+        "Align of template specialization: B_open0_const_char16_t_close0",
+    ][::std::mem::align_of::<B<u16>>() - 2usize];
+};
+const _: () = {
+    [
+        "Size of template specialization: B_open0_array1_int_close0",
+    ][::std::mem::size_of::<B<[::std::os::raw::c_int; 1usize]>>() - 4usize];
+    [
+        "Align of template specialization: B_open0_array1_int_close0",
+    ][::std::mem::align_of::<B<[::std::os::raw::c_int; 1usize]>>() - 4usize];
+};
+const _: () = {
+    [
+        "Size of template specialization: B_open0_array1_ptr_int_close0",
+    ][::std::mem::size_of::<B<[*mut ::std::os::raw::c_int; 1usize]>>() - 8usize];
+    [
+        "Align of template specialization: B_open0_array1_ptr_int_close0",
+    ][::std::mem::align_of::<B<[*mut ::std::os::raw::c_int; 1usize]>>() - 8usize];
+};
+const _: () = {
+    [
+        "Size of template specialization: B_open0_ptr_array1_int_close0",
+    ][::std::mem::size_of::<B<*mut [::std::os::raw::c_int; 1usize]>>() - 8usize];
+    [
+        "Align of template specialization: B_open0_ptr_array1_int_close0",
+    ][::std::mem::align_of::<B<*mut [::std::os::raw::c_int; 1usize]>>() - 8usize];
+};
+const _: () = {
+    [
+        "Size of template specialization: B_open0_ref_int_close0",
+    ][::std::mem::size_of::<B<*mut ::std::os::raw::c_int>>() - 8usize];
+    [
+        "Align of template specialization: B_open0_ref_int_close0",
+    ][::std::mem::align_of::<B<*mut ::std::os::raw::c_int>>() - 8usize];
+};
+const _: () = {
+    [
+        "Size of template specialization: B_open0_ref_const_int_close0",
+    ][::std::mem::size_of::<B<*const ::std::os::raw::c_int>>() - 8usize];
+    [
+        "Align of template specialization: B_open0_ref_const_int_close0",
+    ][::std::mem::align_of::<B<*const ::std::os::raw::c_int>>() - 8usize];
+};
+const _: () = {
+    [
+        "Size of template specialization: B_open0_ref_ptr_int_close0",
+    ][::std::mem::size_of::<B<*mut *mut ::std::os::raw::c_int>>() - 8usize];
+    [
+        "Align of template specialization: B_open0_ref_ptr_int_close0",
+    ][::std::mem::align_of::<B<*mut *mut ::std::os::raw::c_int>>() - 8usize];
+};
+const _: () = {
+    [
+        "Size of template specialization: B_open0_ref_array1_int_close0",
+    ][::std::mem::size_of::<B<*mut [::std::os::raw::c_int; 1usize]>>() - 8usize];
+    [
+        "Align of template specialization: B_open0_ref_array1_int_close0",
+    ][::std::mem::align_of::<B<*mut [::std::os::raw::c_int; 1usize]>>() - 8usize];
+};
+const _: () = {
+    [
+        "Size of template specialization: B_open0_array1_const_int_close0",
+    ][::std::mem::size_of::<B<[::std::os::raw::c_int; 1usize]>>() - 4usize];
+    [
+        "Align of template specialization: B_open0_array1_const_int_close0",
+    ][::std::mem::align_of::<B<[::std::os::raw::c_int; 1usize]>>() - 4usize];
+};
+const _: () = {
+    [
+        "Size of template specialization: Foo_open0_int_int_close0",
+    ][::std::mem::size_of::<Foo<::std::os::raw::c_int>>() - 24usize];
+    [
+        "Align of template specialization: Foo_open0_int_int_close0",
+    ][::std::mem::align_of::<Foo<::std::os::raw::c_int>>() - 8usize];
+};
+const _: () = {
+    [
+        "Size of template specialization: Rooted_open0_ptr_void_close0",
+    ][::std::mem::size_of::<Rooted<*mut ::std::os::raw::c_void>>() - 24usize];
+    [
+        "Align of template specialization: Rooted_open0_ptr_void_close0",
+    ][::std::mem::align_of::<Rooted<*mut ::std::os::raw::c_void>>() - 8usize];
+};
+const _: () = {
+    [
+        "Size of template specialization: Rooted_open0_ptr_void_close0",
+    ][::std::mem::size_of::<Rooted<*mut ::std::os::raw::c_void>>() - 24usize];
+    [
+        "Align of template specialization: Rooted_open0_ptr_void_close0",
+    ][::std::mem::align_of::<Rooted<*mut ::std::os::raw::c_void>>() - 8usize];
+};
+const _: () = {
+    [
+        "Size of template specialization: WithDtor_open0_int_close0",
+    ][::std::mem::size_of::<WithDtor<::std::os::raw::c_int>>() - 4usize];
+    [
+        "Align of template specialization: WithDtor_open0_int_close0",
+    ][::std::mem::align_of::<WithDtor<::std::os::raw::c_int>>() - 4usize];
+};

--- a/bindgen-tests/tests/expectations/tests/template_instantiation_with_fn_local_type.rs
+++ b/bindgen-tests/tests/expectations/tests/template_instantiation_with_fn_local_type.rs
@@ -8,83 +8,46 @@ extern "C" {
     #[link_name = "\u{1}_Z1fv"]
     pub fn f();
 }
-#[test]
-fn __bindgen_test_layout_Foo_open0_Bar_close0_instantiation() {
-    assert_eq!(
-        ::std::mem::size_of::<Foo>(),
-        1usize,
-        concat!("Size of template specialization: ", stringify!(Foo)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Foo>(),
-        1usize,
-        concat!("Alignment of template specialization: ", stringify!(Foo)),
-    );
-}
+const _: () = {
+    [
+        "Size of template specialization: Foo_open0_Bar_close0",
+    ][::std::mem::size_of::<Foo>() - 1usize];
+    [
+        "Align of template specialization: Foo_open0_Bar_close0",
+    ][::std::mem::align_of::<Foo>() - 1usize];
+};
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct Baz {
     pub _address: u8,
 }
-#[test]
-fn bindgen_test_layout_Baz() {
-    assert_eq!(
-        ::std::mem::size_of::<Baz>(),
-        1usize,
-        concat!("Size of: ", stringify!(Baz)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Baz>(),
-        1usize,
-        concat!("Alignment of ", stringify!(Baz)),
-    );
-}
-#[test]
-fn __bindgen_test_layout_Foo_open0_Boo_close0_instantiation() {
-    assert_eq!(
-        ::std::mem::size_of::<Foo>(),
-        1usize,
-        concat!("Size of template specialization: ", stringify!(Foo)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Foo>(),
-        1usize,
-        concat!("Alignment of template specialization: ", stringify!(Foo)),
-    );
-}
+const _: () = {
+    ["Size of Baz"][::std::mem::size_of::<Baz>() - 1usize];
+    ["Alignment of Baz"][::std::mem::align_of::<Baz>() - 1usize];
+};
+const _: () = {
+    [
+        "Size of template specialization: Foo_open0_Boo_close0",
+    ][::std::mem::size_of::<Foo>() - 1usize];
+    [
+        "Align of template specialization: Foo_open0_Boo_close0",
+    ][::std::mem::align_of::<Foo>() - 1usize];
+};
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct Bar {
     pub _address: u8,
 }
-#[test]
-fn bindgen_test_layout_Bar() {
-    assert_eq!(
-        ::std::mem::size_of::<Bar>(),
-        1usize,
-        concat!("Size of: ", stringify!(Bar)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Bar>(),
-        1usize,
-        concat!("Alignment of ", stringify!(Bar)),
-    );
-}
+const _: () = {
+    ["Size of Bar"][::std::mem::size_of::<Bar>() - 1usize];
+    ["Alignment of Bar"][::std::mem::align_of::<Bar>() - 1usize];
+};
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct Boo {
     pub _address: u8,
 }
-#[test]
-fn bindgen_test_layout_Boo() {
-    assert_eq!(
-        ::std::mem::size_of::<Boo>(),
-        1usize,
-        concat!("Size of: ", stringify!(Boo)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Boo>(),
-        1usize,
-        concat!("Alignment of ", stringify!(Boo)),
-    );
-}
+const _: () = {
+    ["Size of Boo"][::std::mem::size_of::<Boo>() - 1usize];
+    ["Alignment of Boo"][::std::mem::align_of::<Boo>() - 1usize];
+};

--- a/bindgen-tests/tests/expectations/tests/test_mixed_header_and_header_contents.rs
+++ b/bindgen-tests/tests/expectations/tests/test_mixed_header_and_header_contents.rs
@@ -31,84 +31,19 @@ pub struct Test {
     pub Ccu: UChar,
     pub Ccd: SChar,
 }
-#[test]
-fn bindgen_test_layout_Test() {
-    const UNINIT: ::std::mem::MaybeUninit<Test> =
-        ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<Test>(),
-        12usize,
-        concat!("Size of: ", stringify!(Test))
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Test>(),
-        1usize,
-        concat!("Alignment of ", stringify!(Test))
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).ch) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(Test), "::", stringify!(ch))
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).u) as usize - ptr as usize },
-        1usize,
-        concat!("Offset of field: ", stringify!(Test), "::", stringify!(u))
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize },
-        2usize,
-        concat!("Offset of field: ", stringify!(Test), "::", stringify!(d))
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).cch) as usize - ptr as usize },
-        3usize,
-        concat!("Offset of field: ", stringify!(Test), "::", stringify!(cch))
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).cu) as usize - ptr as usize },
-        4usize,
-        concat!("Offset of field: ", stringify!(Test), "::", stringify!(cu))
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).cd) as usize - ptr as usize },
-        5usize,
-        concat!("Offset of field: ", stringify!(Test), "::", stringify!(cd))
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).Cch) as usize - ptr as usize },
-        6usize,
-        concat!("Offset of field: ", stringify!(Test), "::", stringify!(Cch))
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).Cu) as usize - ptr as usize },
-        7usize,
-        concat!("Offset of field: ", stringify!(Test), "::", stringify!(Cu))
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).Cd) as usize - ptr as usize },
-        8usize,
-        concat!("Offset of field: ", stringify!(Test), "::", stringify!(Cd))
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).Ccch) as usize - ptr as usize },
-        9usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(Test),
-            "::",
-            stringify!(Ccch)
-        )
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).Ccu) as usize - ptr as usize },
-        10usize,
-        concat!("Offset of field: ", stringify!(Test), "::", stringify!(Ccu))
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).Ccd) as usize - ptr as usize },
-        11usize,
-        concat!("Offset of field: ", stringify!(Test), "::", stringify!(Ccd))
-    );
-}
+const _: () = {
+    ["Size of Test"][::std::mem::size_of::<Test>() - 12usize];
+    ["Alignment of Test"][::std::mem::align_of::<Test>() - 1usize];
+    ["Offset of field: Test::ch"][::std::mem::offset_of!(Test, ch) - 0usize];
+    ["Offset of field: Test::u"][::std::mem::offset_of!(Test, u) - 1usize];
+    ["Offset of field: Test::d"][::std::mem::offset_of!(Test, d) - 2usize];
+    ["Offset of field: Test::cch"][::std::mem::offset_of!(Test, cch) - 3usize];
+    ["Offset of field: Test::cu"][::std::mem::offset_of!(Test, cu) - 4usize];
+    ["Offset of field: Test::cd"][::std::mem::offset_of!(Test, cd) - 5usize];
+    ["Offset of field: Test::Cch"][::std::mem::offset_of!(Test, Cch) - 6usize];
+    ["Offset of field: Test::Cu"][::std::mem::offset_of!(Test, Cu) - 7usize];
+    ["Offset of field: Test::Cd"][::std::mem::offset_of!(Test, Cd) - 8usize];
+    ["Offset of field: Test::Ccch"][::std::mem::offset_of!(Test, Ccch) - 9usize];
+    ["Offset of field: Test::Ccu"][::std::mem::offset_of!(Test, Ccu) - 10usize];
+    ["Offset of field: Test::Ccd"][::std::mem::offset_of!(Test, Ccd) - 11usize];
+};

--- a/bindgen-tests/tests/expectations/tests/test_multiple_header_calls_in_builder.rs
+++ b/bindgen-tests/tests/expectations/tests/test_multiple_header_calls_in_builder.rs
@@ -25,84 +25,19 @@ pub struct Test {
     pub Ccu: UChar,
     pub Ccd: SChar,
 }
-#[test]
-fn bindgen_test_layout_Test() {
-    const UNINIT: ::std::mem::MaybeUninit<Test> =
-        ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<Test>(),
-        12usize,
-        concat!("Size of: ", stringify!(Test))
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Test>(),
-        1usize,
-        concat!("Alignment of ", stringify!(Test))
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).ch) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(Test), "::", stringify!(ch))
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).u) as usize - ptr as usize },
-        1usize,
-        concat!("Offset of field: ", stringify!(Test), "::", stringify!(u))
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).d) as usize - ptr as usize },
-        2usize,
-        concat!("Offset of field: ", stringify!(Test), "::", stringify!(d))
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).cch) as usize - ptr as usize },
-        3usize,
-        concat!("Offset of field: ", stringify!(Test), "::", stringify!(cch))
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).cu) as usize - ptr as usize },
-        4usize,
-        concat!("Offset of field: ", stringify!(Test), "::", stringify!(cu))
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).cd) as usize - ptr as usize },
-        5usize,
-        concat!("Offset of field: ", stringify!(Test), "::", stringify!(cd))
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).Cch) as usize - ptr as usize },
-        6usize,
-        concat!("Offset of field: ", stringify!(Test), "::", stringify!(Cch))
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).Cu) as usize - ptr as usize },
-        7usize,
-        concat!("Offset of field: ", stringify!(Test), "::", stringify!(Cu))
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).Cd) as usize - ptr as usize },
-        8usize,
-        concat!("Offset of field: ", stringify!(Test), "::", stringify!(Cd))
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).Ccch) as usize - ptr as usize },
-        9usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(Test),
-            "::",
-            stringify!(Ccch)
-        )
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).Ccu) as usize - ptr as usize },
-        10usize,
-        concat!("Offset of field: ", stringify!(Test), "::", stringify!(Ccu))
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).Ccd) as usize - ptr as usize },
-        11usize,
-        concat!("Offset of field: ", stringify!(Test), "::", stringify!(Ccd))
-    );
-}
+const _: () = {
+    ["Size of Test"][::std::mem::size_of::<Test>() - 12usize];
+    ["Alignment of Test"][::std::mem::align_of::<Test>() - 1usize];
+    ["Offset of field: Test::ch"][::std::mem::offset_of!(Test, ch) - 0usize];
+    ["Offset of field: Test::u"][::std::mem::offset_of!(Test, u) - 1usize];
+    ["Offset of field: Test::d"][::std::mem::offset_of!(Test, d) - 2usize];
+    ["Offset of field: Test::cch"][::std::mem::offset_of!(Test, cch) - 3usize];
+    ["Offset of field: Test::cu"][::std::mem::offset_of!(Test, cu) - 4usize];
+    ["Offset of field: Test::cd"][::std::mem::offset_of!(Test, cd) - 5usize];
+    ["Offset of field: Test::Cch"][::std::mem::offset_of!(Test, Cch) - 6usize];
+    ["Offset of field: Test::Cu"][::std::mem::offset_of!(Test, Cu) - 7usize];
+    ["Offset of field: Test::Cd"][::std::mem::offset_of!(Test, Cd) - 8usize];
+    ["Offset of field: Test::Ccch"][::std::mem::offset_of!(Test, Ccch) - 9usize];
+    ["Offset of field: Test::Ccu"][::std::mem::offset_of!(Test, Ccu) - 10usize];
+    ["Offset of field: Test::Ccd"][::std::mem::offset_of!(Test, Ccd) - 11usize];
+};

--- a/bindgen-tests/tests/expectations/tests/timex.rs
+++ b/bindgen-tests/tests/expectations/tests/timex.rs
@@ -90,26 +90,11 @@ pub struct timex {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 44usize]>,
 }
-#[test]
-fn bindgen_test_layout_timex() {
-    const UNINIT: ::std::mem::MaybeUninit<timex> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<timex>(),
-        48usize,
-        concat!("Size of: ", stringify!(timex)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<timex>(),
-        4usize,
-        concat!("Alignment of ", stringify!(timex)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).tai) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(timex), "::", stringify!(tai)),
-    );
-}
+const _: () = {
+    ["Size of timex"][::std::mem::size_of::<timex>() - 48usize];
+    ["Alignment of timex"][::std::mem::align_of::<timex>() - 4usize];
+    ["Offset of field: timex::tai"][::std::mem::offset_of!(timex, tai) - 0usize];
+};
 impl Default for timex {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
@@ -126,26 +111,13 @@ pub struct timex_named {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 44usize]>,
 }
-#[test]
-fn bindgen_test_layout_timex_named() {
-    const UNINIT: ::std::mem::MaybeUninit<timex_named> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<timex_named>(),
-        48usize,
-        concat!("Size of: ", stringify!(timex_named)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<timex_named>(),
-        4usize,
-        concat!("Alignment of ", stringify!(timex_named)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).tai) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(timex_named), "::", stringify!(tai)),
-    );
-}
+const _: () = {
+    ["Size of timex_named"][::std::mem::size_of::<timex_named>() - 48usize];
+    ["Alignment of timex_named"][::std::mem::align_of::<timex_named>() - 4usize];
+    [
+        "Offset of field: timex_named::tai",
+    ][::std::mem::offset_of!(timex_named, tai) - 0usize];
+};
 impl Default for timex_named {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();

--- a/bindgen-tests/tests/expectations/tests/transform-op.rs
+++ b/bindgen-tests/tests/expectations/tests/transform-op.rs
@@ -219,12 +219,12 @@ fn __bindgen_test_layout_StylePoint_open0_float_close0_instantiation() {
     assert_eq!(
         ::std::mem::size_of::<StylePoint<f32>>(),
         8usize,
-        concat!("Size of template specialization: ", stringify!(StylePoint < f32 >)),
+        "Size of template specialization: StylePoint_open0_float_close0",
     );
     assert_eq!(
         ::std::mem::align_of::<StylePoint<f32>>(),
         4usize,
-        concat!("Alignment of template specialization: ", stringify!(StylePoint < f32 >)),
+        "Align of template specialization: StylePoint_open0_float_close0",
     );
 }
 #[test]
@@ -232,11 +232,11 @@ fn __bindgen_test_layout_StylePoint_open0_float_close0_instantiation_1() {
     assert_eq!(
         ::std::mem::size_of::<StylePoint<f32>>(),
         8usize,
-        concat!("Size of template specialization: ", stringify!(StylePoint < f32 >)),
+        "Size of template specialization: StylePoint_open0_float_close0",
     );
     assert_eq!(
         ::std::mem::align_of::<StylePoint<f32>>(),
         4usize,
-        concat!("Alignment of template specialization: ", stringify!(StylePoint < f32 >)),
+        "Align of template specialization: StylePoint_open0_float_close0",
     );
 }

--- a/bindgen-tests/tests/expectations/tests/type-referenced-by-allowlisted-function.rs
+++ b/bindgen-tests/tests/expectations/tests/type-referenced-by-allowlisted-function.rs
@@ -4,26 +4,13 @@
 pub struct dl_phdr_info {
     pub x: ::std::os::raw::c_int,
 }
-#[test]
-fn bindgen_test_layout_dl_phdr_info() {
-    const UNINIT: ::std::mem::MaybeUninit<dl_phdr_info> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<dl_phdr_info>(),
-        4usize,
-        concat!("Size of: ", stringify!(dl_phdr_info)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<dl_phdr_info>(),
-        4usize,
-        concat!("Alignment of ", stringify!(dl_phdr_info)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(dl_phdr_info), "::", stringify!(x)),
-    );
-}
+const _: () = {
+    ["Size of dl_phdr_info"][::std::mem::size_of::<dl_phdr_info>() - 4usize];
+    ["Alignment of dl_phdr_info"][::std::mem::align_of::<dl_phdr_info>() - 4usize];
+    [
+        "Offset of field: dl_phdr_info::x",
+    ][::std::mem::offset_of!(dl_phdr_info, x) - 0usize];
+};
 extern "C" {
     pub fn dl_iterate_phdr(arg1: *mut dl_phdr_info) -> ::std::os::raw::c_int;
 }

--- a/bindgen-tests/tests/expectations/tests/type_alias_template_specialized.rs
+++ b/bindgen-tests/tests/expectations/tests/type_alias_template_specialized.rs
@@ -4,26 +4,11 @@
 pub struct Rooted {
     pub ptr: MaybeWrapped<::std::os::raw::c_int>,
 }
-#[test]
-fn bindgen_test_layout_Rooted() {
-    const UNINIT: ::std::mem::MaybeUninit<Rooted> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<Rooted>(),
-        4usize,
-        concat!("Size of: ", stringify!(Rooted)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Rooted>(),
-        4usize,
-        concat!("Alignment of ", stringify!(Rooted)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).ptr) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(Rooted), "::", stringify!(ptr)),
-    );
-}
+const _: () = {
+    ["Size of Rooted"][::std::mem::size_of::<Rooted>() - 4usize];
+    ["Alignment of Rooted"][::std::mem::align_of::<Rooted>() - 4usize];
+    ["Offset of field: Rooted::ptr"][::std::mem::offset_of!(Rooted, ptr) - 0usize];
+};
 impl Default for Rooted {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
@@ -35,22 +20,11 @@ impl Default for Rooted {
 }
 /// <div rustbindgen replaces="MaybeWrapped"></div>
 pub type MaybeWrapped<a> = a;
-#[test]
-fn __bindgen_test_layout_MaybeWrapped_open0_int_close0_instantiation() {
-    assert_eq!(
-        ::std::mem::size_of::<MaybeWrapped<::std::os::raw::c_int>>(),
-        4usize,
-        concat!(
-            "Size of template specialization: ",
-            stringify!(MaybeWrapped < ::std::os::raw::c_int >),
-        ),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<MaybeWrapped<::std::os::raw::c_int>>(),
-        4usize,
-        concat!(
-            "Alignment of template specialization: ",
-            stringify!(MaybeWrapped < ::std::os::raw::c_int >),
-        ),
-    );
-}
+const _: () = {
+    [
+        "Size of template specialization: MaybeWrapped_open0_int_close0",
+    ][::std::mem::size_of::<MaybeWrapped<::std::os::raw::c_int>>() - 4usize];
+    [
+        "Align of template specialization: MaybeWrapped_open0_int_close0",
+    ][::std::mem::align_of::<MaybeWrapped<::std::os::raw::c_int>>() - 4usize];
+};

--- a/bindgen-tests/tests/expectations/tests/typedef-pointer-overlap.rs
+++ b/bindgen-tests/tests/expectations/tests/typedef-pointer-overlap.rs
@@ -4,52 +4,22 @@
 pub struct foo {
     pub inner: ::std::os::raw::c_char,
 }
-#[test]
-fn bindgen_test_layout_foo() {
-    const UNINIT: ::std::mem::MaybeUninit<foo> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<foo>(),
-        1usize,
-        concat!("Size of: ", stringify!(foo)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<foo>(),
-        1usize,
-        concat!("Alignment of ", stringify!(foo)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).inner) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(inner)),
-    );
-}
+const _: () = {
+    ["Size of foo"][::std::mem::size_of::<foo>() - 1usize];
+    ["Alignment of foo"][::std::mem::align_of::<foo>() - 1usize];
+    ["Offset of field: foo::inner"][::std::mem::offset_of!(foo, inner) - 0usize];
+};
 pub type foo_ptr = *const foo;
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct bar {
     pub inner: ::std::os::raw::c_char,
 }
-#[test]
-fn bindgen_test_layout_bar() {
-    const UNINIT: ::std::mem::MaybeUninit<bar> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<bar>(),
-        1usize,
-        concat!("Size of: ", stringify!(bar)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<bar>(),
-        1usize,
-        concat!("Alignment of ", stringify!(bar)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).inner) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(bar), "::", stringify!(inner)),
-    );
-}
+const _: () = {
+    ["Size of bar"][::std::mem::size_of::<bar>() - 1usize];
+    ["Alignment of bar"][::std::mem::align_of::<bar>() - 1usize];
+    ["Offset of field: bar::inner"][::std::mem::offset_of!(bar, inner) - 0usize];
+};
 pub type bar_ptr = *mut bar;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -62,26 +32,13 @@ pub type baz_ptr = *mut baz;
 pub union cat {
     pub standard_issue: ::std::os::raw::c_int,
 }
-#[test]
-fn bindgen_test_layout_cat() {
-    const UNINIT: ::std::mem::MaybeUninit<cat> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<cat>(),
-        4usize,
-        concat!("Size of: ", stringify!(cat)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<cat>(),
-        4usize,
-        concat!("Alignment of ", stringify!(cat)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).standard_issue) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(cat), "::", stringify!(standard_issue)),
-    );
-}
+const _: () = {
+    ["Size of cat"][::std::mem::size_of::<cat>() - 4usize];
+    ["Alignment of cat"][::std::mem::align_of::<cat>() - 4usize];
+    [
+        "Offset of field: cat::standard_issue",
+    ][::std::mem::offset_of!(cat, standard_issue) - 0usize];
+};
 impl Default for cat {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();

--- a/bindgen-tests/tests/expectations/tests/typeref.rs
+++ b/bindgen-tests/tests/expectations/tests/typeref.rs
@@ -4,49 +4,28 @@
 pub struct mozilla_FragmentOrURL {
     pub mIsLocalRef: bool,
 }
-#[test]
-fn bindgen_test_layout_mozilla_FragmentOrURL() {
-    const UNINIT: ::std::mem::MaybeUninit<mozilla_FragmentOrURL> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<mozilla_FragmentOrURL>(),
-        1usize,
-        concat!("Size of: ", stringify!(mozilla_FragmentOrURL)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<mozilla_FragmentOrURL>(),
-        1usize,
-        concat!("Alignment of ", stringify!(mozilla_FragmentOrURL)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).mIsLocalRef) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(mozilla_FragmentOrURL),
-            "::",
-            stringify!(mIsLocalRef),
-        ),
-    );
-}
+const _: () = {
+    [
+        "Size of mozilla_FragmentOrURL",
+    ][::std::mem::size_of::<mozilla_FragmentOrURL>() - 1usize];
+    [
+        "Alignment of mozilla_FragmentOrURL",
+    ][::std::mem::align_of::<mozilla_FragmentOrURL>() - 1usize];
+    [
+        "Offset of field: mozilla_FragmentOrURL::mIsLocalRef",
+    ][::std::mem::offset_of!(mozilla_FragmentOrURL, mIsLocalRef) - 0usize];
+};
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct mozilla_Position {
     pub _address: u8,
 }
-#[test]
-fn bindgen_test_layout_mozilla_Position() {
-    assert_eq!(
-        ::std::mem::size_of::<mozilla_Position>(),
-        1usize,
-        concat!("Size of: ", stringify!(mozilla_Position)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<mozilla_Position>(),
-        1usize,
-        concat!("Alignment of ", stringify!(mozilla_Position)),
-    );
-}
+const _: () = {
+    ["Size of mozilla_Position"][::std::mem::size_of::<mozilla_Position>() - 1usize];
+    [
+        "Alignment of mozilla_Position",
+    ][::std::mem::align_of::<mozilla_Position>() - 1usize];
+};
 #[repr(C)]
 pub struct mozilla_StyleShapeSource {
     pub __bindgen_anon_1: mozilla_StyleShapeSource__bindgen_ty_1,
@@ -79,26 +58,11 @@ impl Default for mozilla_StyleShapeSource {
 pub struct Bar {
     pub mFoo: *mut nsFoo,
 }
-#[test]
-fn bindgen_test_layout_Bar() {
-    const UNINIT: ::std::mem::MaybeUninit<Bar> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<Bar>(),
-        8usize,
-        concat!("Size of: ", stringify!(Bar)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Bar>(),
-        8usize,
-        concat!("Alignment of ", stringify!(Bar)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).mFoo) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(Bar), "::", stringify!(mFoo)),
-    );
-}
+const _: () = {
+    ["Size of Bar"][::std::mem::size_of::<Bar>() - 8usize];
+    ["Alignment of Bar"][::std::mem::align_of::<Bar>() - 8usize];
+    ["Offset of field: Bar::mFoo"][::std::mem::offset_of!(Bar, mFoo) - 0usize];
+};
 impl Default for Bar {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
@@ -112,26 +76,11 @@ impl Default for Bar {
 pub struct nsFoo {
     pub mBar: mozilla_StyleShapeSource,
 }
-#[test]
-fn bindgen_test_layout_nsFoo() {
-    const UNINIT: ::std::mem::MaybeUninit<nsFoo> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<nsFoo>(),
-        8usize,
-        concat!("Size of: ", stringify!(nsFoo)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<nsFoo>(),
-        8usize,
-        concat!("Alignment of ", stringify!(nsFoo)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).mBar) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(nsFoo), "::", stringify!(mBar)),
-    );
-}
+const _: () = {
+    ["Size of nsFoo"][::std::mem::size_of::<nsFoo>() - 8usize];
+    ["Alignment of nsFoo"][::std::mem::align_of::<nsFoo>() - 8usize];
+    ["Offset of field: nsFoo::mBar"][::std::mem::offset_of!(nsFoo, mBar) - 0usize];
+};
 impl Default for nsFoo {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
@@ -141,22 +90,11 @@ impl Default for nsFoo {
         }
     }
 }
-#[test]
-fn __bindgen_test_layout_mozilla_StyleShapeSource_open0_int_close0_instantiation() {
-    assert_eq!(
-        ::std::mem::size_of::<mozilla_StyleShapeSource>(),
-        8usize,
-        concat!(
-            "Size of template specialization: ",
-            stringify!(mozilla_StyleShapeSource),
-        ),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<mozilla_StyleShapeSource>(),
-        8usize,
-        concat!(
-            "Alignment of template specialization: ",
-            stringify!(mozilla_StyleShapeSource),
-        ),
-    );
-}
+const _: () = {
+    [
+        "Size of template specialization: mozilla_StyleShapeSource_open0_int_close0",
+    ][::std::mem::size_of::<mozilla_StyleShapeSource>() - 8usize];
+    [
+        "Align of template specialization: mozilla_StyleShapeSource_open0_int_close0",
+    ][::std::mem::align_of::<mozilla_StyleShapeSource>() - 8usize];
+};

--- a/bindgen-tests/tests/expectations/tests/typeref_1_0.rs
+++ b/bindgen-tests/tests/expectations/tests/typeref_1_0.rs
@@ -54,22 +54,17 @@ fn bindgen_test_layout_mozilla_FragmentOrURL() {
     assert_eq!(
         ::std::mem::size_of::<mozilla_FragmentOrURL>(),
         1usize,
-        concat!("Size of: ", stringify!(mozilla_FragmentOrURL)),
+        "Size of mozilla_FragmentOrURL",
     );
     assert_eq!(
         ::std::mem::align_of::<mozilla_FragmentOrURL>(),
         1usize,
-        concat!("Alignment of ", stringify!(mozilla_FragmentOrURL)),
+        "Alignment of mozilla_FragmentOrURL",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).mIsLocalRef) as usize - ptr as usize },
         0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(mozilla_FragmentOrURL),
-            "::",
-            stringify!(mIsLocalRef),
-        ),
+        "Offset of field: mozilla_FragmentOrURL::mIsLocalRef",
     );
 }
 impl Clone for mozilla_FragmentOrURL {
@@ -87,12 +82,12 @@ fn bindgen_test_layout_mozilla_Position() {
     assert_eq!(
         ::std::mem::size_of::<mozilla_Position>(),
         1usize,
-        concat!("Size of: ", stringify!(mozilla_Position)),
+        "Size of mozilla_Position",
     );
     assert_eq!(
         ::std::mem::align_of::<mozilla_Position>(),
         1usize,
-        concat!("Alignment of ", stringify!(mozilla_Position)),
+        "Alignment of mozilla_Position",
     );
 }
 impl Clone for mozilla_Position {
@@ -121,20 +116,12 @@ pub struct Bar {
 fn bindgen_test_layout_Bar() {
     const UNINIT: ::std::mem::MaybeUninit<Bar> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<Bar>(),
-        8usize,
-        concat!("Size of: ", stringify!(Bar)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Bar>(),
-        8usize,
-        concat!("Alignment of ", stringify!(Bar)),
-    );
+    assert_eq!(::std::mem::size_of::<Bar>(), 8usize, "Size of Bar");
+    assert_eq!(::std::mem::align_of::<Bar>(), 8usize, "Alignment of Bar");
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).mFoo) as usize - ptr as usize },
         0usize,
-        concat!("Offset of field: ", stringify!(Bar), "::", stringify!(mFoo)),
+        "Offset of field: Bar::mFoo",
     );
 }
 impl Clone for Bar {
@@ -160,20 +147,12 @@ pub struct nsFoo {
 fn bindgen_test_layout_nsFoo() {
     const UNINIT: ::std::mem::MaybeUninit<nsFoo> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<nsFoo>(),
-        8usize,
-        concat!("Size of: ", stringify!(nsFoo)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<nsFoo>(),
-        8usize,
-        concat!("Alignment of ", stringify!(nsFoo)),
-    );
+    assert_eq!(::std::mem::size_of::<nsFoo>(), 8usize, "Size of nsFoo");
+    assert_eq!(::std::mem::align_of::<nsFoo>(), 8usize, "Alignment of nsFoo");
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).mBar) as usize - ptr as usize },
         0usize,
-        concat!("Offset of field: ", stringify!(nsFoo), "::", stringify!(mBar)),
+        "Offset of field: nsFoo::mBar",
     );
 }
 impl Clone for nsFoo {
@@ -186,17 +165,11 @@ fn __bindgen_test_layout_mozilla_StyleShapeSource_open0_int_close0_instantiation
     assert_eq!(
         ::std::mem::size_of::<mozilla_StyleShapeSource>(),
         8usize,
-        concat!(
-            "Size of template specialization: ",
-            stringify!(mozilla_StyleShapeSource),
-        ),
+        "Size of template specialization: mozilla_StyleShapeSource_open0_int_close0",
     );
     assert_eq!(
         ::std::mem::align_of::<mozilla_StyleShapeSource>(),
         8usize,
-        concat!(
-            "Alignment of template specialization: ",
-            stringify!(mozilla_StyleShapeSource),
-        ),
+        "Align of template specialization: mozilla_StyleShapeSource_open0_int_close0",
     );
 }

--- a/bindgen-tests/tests/expectations/tests/underscore.rs
+++ b/bindgen-tests/tests/expectations/tests/underscore.rs
@@ -5,23 +5,8 @@ pub const __: ::std::os::raw::c_int = 10;
 pub struct ptr_t {
     pub __: [::std::os::raw::c_uchar; 8usize],
 }
-#[test]
-fn bindgen_test_layout_ptr_t() {
-    const UNINIT: ::std::mem::MaybeUninit<ptr_t> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<ptr_t>(),
-        8usize,
-        concat!("Size of: ", stringify!(ptr_t)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<ptr_t>(),
-        1usize,
-        concat!("Alignment of ", stringify!(ptr_t)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).__) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(ptr_t), "::", stringify!(__)),
-    );
-}
+const _: () = {
+    ["Size of ptr_t"][::std::mem::size_of::<ptr_t>() - 8usize];
+    ["Alignment of ptr_t"][::std::mem::align_of::<ptr_t>() - 1usize];
+    ["Offset of field: ptr_t::__"][::std::mem::offset_of!(ptr_t, __) - 0usize];
+};

--- a/bindgen-tests/tests/expectations/tests/union-align.rs
+++ b/bindgen-tests/tests/expectations/tests/union-align.rs
@@ -9,20 +9,12 @@ pub union Bar {
 fn bindgen_test_layout_Bar() {
     const UNINIT: ::std::mem::MaybeUninit<Bar> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<Bar>(),
-        16usize,
-        concat!("Size of: ", stringify!(Bar)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Bar>(),
-        16usize,
-        concat!("Alignment of ", stringify!(Bar)),
-    );
+    assert_eq!(::std::mem::size_of::<Bar>(), 16usize, "Size of Bar");
+    assert_eq!(::std::mem::align_of::<Bar>(), 16usize, "Alignment of Bar");
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize },
         0usize,
-        concat!("Offset of field: ", stringify!(Bar), "::", stringify!(foo)),
+        "Offset of field: Bar::foo",
     );
 }
 impl Default for Bar {
@@ -44,20 +36,12 @@ pub union Baz {
 fn bindgen_test_layout_Baz() {
     const UNINIT: ::std::mem::MaybeUninit<Baz> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<Baz>(),
-        16usize,
-        concat!("Size of: ", stringify!(Baz)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Baz>(),
-        16usize,
-        concat!("Alignment of ", stringify!(Baz)),
-    );
+    assert_eq!(::std::mem::size_of::<Baz>(), 16usize, "Size of Baz");
+    assert_eq!(::std::mem::align_of::<Baz>(), 16usize, "Alignment of Baz");
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize },
         0usize,
-        concat!("Offset of field: ", stringify!(Baz), "::", stringify!(bar)),
+        "Offset of field: Baz::bar",
     );
 }
 impl Default for Baz {

--- a/bindgen-tests/tests/expectations/tests/union-in-ns.rs
+++ b/bindgen-tests/tests/expectations/tests/union-in-ns.rs
@@ -8,26 +8,11 @@ pub mod root {
     pub union bar {
         pub baz: ::std::os::raw::c_int,
     }
-    #[test]
-    fn bindgen_test_layout_bar() {
-        const UNINIT: ::std::mem::MaybeUninit<bar> = ::std::mem::MaybeUninit::uninit();
-        let ptr = UNINIT.as_ptr();
-        assert_eq!(
-            ::std::mem::size_of::<bar>(),
-            4usize,
-            concat!("Size of: ", stringify!(bar)),
-        );
-        assert_eq!(
-            ::std::mem::align_of::<bar>(),
-            4usize,
-            concat!("Alignment of ", stringify!(bar)),
-        );
-        assert_eq!(
-            unsafe { ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize },
-            0usize,
-            concat!("Offset of field: ", stringify!(bar), "::", stringify!(baz)),
-        );
-    }
+    const _: () = {
+        ["Size of bar"][::std::mem::size_of::<bar>() - 4usize];
+        ["Alignment of bar"][::std::mem::align_of::<bar>() - 4usize];
+        ["Offset of field: bar::baz"][::std::mem::offset_of!(bar, baz) - 0usize];
+    };
     impl Default for bar {
         fn default() -> Self {
             let mut s = ::std::mem::MaybeUninit::<Self>::uninit();

--- a/bindgen-tests/tests/expectations/tests/union-in-ns_1_0.rs
+++ b/bindgen-tests/tests/expectations/tests/union-in-ns_1_0.rs
@@ -56,20 +56,12 @@ pub mod root {
     fn bindgen_test_layout_bar() {
         const UNINIT: ::std::mem::MaybeUninit<bar> = ::std::mem::MaybeUninit::uninit();
         let ptr = UNINIT.as_ptr();
-        assert_eq!(
-            ::std::mem::size_of::<bar>(),
-            4usize,
-            concat!("Size of: ", stringify!(bar)),
-        );
-        assert_eq!(
-            ::std::mem::align_of::<bar>(),
-            4usize,
-            concat!("Alignment of ", stringify!(bar)),
-        );
+        assert_eq!(::std::mem::size_of::<bar>(), 4usize, "Size of bar");
+        assert_eq!(::std::mem::align_of::<bar>(), 4usize, "Alignment of bar");
         assert_eq!(
             unsafe { ::std::ptr::addr_of!((*ptr).baz) as usize - ptr as usize },
             0usize,
-            concat!("Offset of field: ", stringify!(bar), "::", stringify!(baz)),
+            "Offset of field: bar::baz",
         );
     }
     impl Clone for bar {

--- a/bindgen-tests/tests/expectations/tests/union_bitfield.rs
+++ b/bindgen-tests/tests/expectations/tests/union_bitfield.rs
@@ -90,19 +90,10 @@ pub union U4 {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
 }
-#[test]
-fn bindgen_test_layout_U4() {
-    assert_eq!(
-        ::std::mem::size_of::<U4>(),
-        4usize,
-        concat!("Size of: ", stringify!(U4)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<U4>(),
-        4usize,
-        concat!("Alignment of ", stringify!(U4)),
-    );
-}
+const _: () = {
+    ["Size of U4"][::std::mem::size_of::<U4>() - 4usize];
+    ["Alignment of U4"][::std::mem::align_of::<U4>() - 4usize];
+};
 impl Default for U4 {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
@@ -147,15 +138,10 @@ pub union B {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
 }
-#[test]
-fn bindgen_test_layout_B() {
-    assert_eq!(::std::mem::size_of::<B>(), 4usize, concat!("Size of: ", stringify!(B)));
-    assert_eq!(
-        ::std::mem::align_of::<B>(),
-        4usize,
-        concat!("Alignment of ", stringify!(B)),
-    );
-}
+const _: () = {
+    ["Size of B"][::std::mem::size_of::<B>() - 4usize];
+    ["Alignment of B"][::std::mem::align_of::<B>() - 4usize];
+};
 impl Default for B {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();

--- a/bindgen-tests/tests/expectations/tests/union_bitfield_1_0.rs
+++ b/bindgen-tests/tests/expectations/tests/union_bitfield_1_0.rs
@@ -135,16 +135,8 @@ pub struct U4 {
 }
 #[test]
 fn bindgen_test_layout_U4() {
-    assert_eq!(
-        ::std::mem::size_of::<U4>(),
-        4usize,
-        concat!("Size of: ", stringify!(U4)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<U4>(),
-        4usize,
-        concat!("Alignment of ", stringify!(U4)),
-    );
+    assert_eq!(::std::mem::size_of::<U4>(), 4usize, "Size of U4");
+    assert_eq!(::std::mem::align_of::<U4>(), 4usize, "Alignment of U4");
 }
 impl Clone for U4 {
     fn clone(&self) -> Self {
@@ -191,12 +183,8 @@ pub struct B {
 }
 #[test]
 fn bindgen_test_layout_B() {
-    assert_eq!(::std::mem::size_of::<B>(), 4usize, concat!("Size of: ", stringify!(B)));
-    assert_eq!(
-        ::std::mem::align_of::<B>(),
-        4usize,
-        concat!("Alignment of ", stringify!(B)),
-    );
+    assert_eq!(::std::mem::size_of::<B>(), 4usize, "Size of B");
+    assert_eq!(::std::mem::align_of::<B>(), 4usize, "Alignment of B");
 }
 impl Clone for B {
     fn clone(&self) -> Self {
@@ -269,7 +257,7 @@ fn bindgen_test_layout_HasBigBitfield() {
     assert_eq!(
         ::std::mem::size_of::<HasBigBitfield>(),
         16usize,
-        concat!("Size of: ", stringify!(HasBigBitfield)),
+        "Size of HasBigBitfield",
     );
 }
 impl Clone for HasBigBitfield {

--- a/bindgen-tests/tests/expectations/tests/union_dtor.rs
+++ b/bindgen-tests/tests/expectations/tests/union_dtor.rs
@@ -4,31 +4,16 @@ pub union UnionWithDtor {
     pub mFoo: ::std::os::raw::c_int,
     pub mBar: *mut ::std::os::raw::c_void,
 }
-#[test]
-fn bindgen_test_layout_UnionWithDtor() {
-    const UNINIT: ::std::mem::MaybeUninit<UnionWithDtor> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<UnionWithDtor>(),
-        8usize,
-        concat!("Size of: ", stringify!(UnionWithDtor)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<UnionWithDtor>(),
-        8usize,
-        concat!("Alignment of ", stringify!(UnionWithDtor)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).mFoo) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(UnionWithDtor), "::", stringify!(mFoo)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).mBar) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(UnionWithDtor), "::", stringify!(mBar)),
-    );
-}
+const _: () = {
+    ["Size of UnionWithDtor"][::std::mem::size_of::<UnionWithDtor>() - 8usize];
+    ["Alignment of UnionWithDtor"][::std::mem::align_of::<UnionWithDtor>() - 8usize];
+    [
+        "Offset of field: UnionWithDtor::mFoo",
+    ][::std::mem::offset_of!(UnionWithDtor, mFoo) - 0usize];
+    [
+        "Offset of field: UnionWithDtor::mBar",
+    ][::std::mem::offset_of!(UnionWithDtor, mBar) - 0usize];
+};
 extern "C" {
     #[link_name = "\u{1}_ZN13UnionWithDtorD1Ev"]
     pub fn UnionWithDtor_UnionWithDtor_destructor(this: *mut UnionWithDtor);

--- a/bindgen-tests/tests/expectations/tests/union_dtor_1_0.rs
+++ b/bindgen-tests/tests/expectations/tests/union_dtor_1_0.rs
@@ -53,25 +53,21 @@ pub struct UnionWithDtor {
 fn bindgen_test_layout_UnionWithDtor() {
     const UNINIT: ::std::mem::MaybeUninit<UnionWithDtor> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<UnionWithDtor>(),
-        8usize,
-        concat!("Size of: ", stringify!(UnionWithDtor)),
-    );
+    assert_eq!(::std::mem::size_of::<UnionWithDtor>(), 8usize, "Size of UnionWithDtor");
     assert_eq!(
         ::std::mem::align_of::<UnionWithDtor>(),
         8usize,
-        concat!("Alignment of ", stringify!(UnionWithDtor)),
+        "Alignment of UnionWithDtor",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).mFoo) as usize - ptr as usize },
         0usize,
-        concat!("Offset of field: ", stringify!(UnionWithDtor), "::", stringify!(mFoo)),
+        "Offset of field: UnionWithDtor::mFoo",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).mBar) as usize - ptr as usize },
         0usize,
-        concat!("Offset of field: ", stringify!(UnionWithDtor), "::", stringify!(mBar)),
+        "Offset of field: UnionWithDtor::mBar",
     );
 }
 extern "C" {

--- a/bindgen-tests/tests/expectations/tests/union_fields.rs
+++ b/bindgen-tests/tests/expectations/tests/union_fields.rs
@@ -6,41 +6,19 @@ pub union nsStyleUnion {
     pub mFloat: f32,
     pub mPointer: *mut ::std::os::raw::c_void,
 }
-#[test]
-fn bindgen_test_layout_nsStyleUnion() {
-    const UNINIT: ::std::mem::MaybeUninit<nsStyleUnion> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<nsStyleUnion>(),
-        8usize,
-        concat!("Size of: ", stringify!(nsStyleUnion)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<nsStyleUnion>(),
-        8usize,
-        concat!("Alignment of ", stringify!(nsStyleUnion)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).mInt) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(nsStyleUnion), "::", stringify!(mInt)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).mFloat) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(nsStyleUnion), "::", stringify!(mFloat)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).mPointer) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(nsStyleUnion),
-            "::",
-            stringify!(mPointer),
-        ),
-    );
-}
+const _: () = {
+    ["Size of nsStyleUnion"][::std::mem::size_of::<nsStyleUnion>() - 8usize];
+    ["Alignment of nsStyleUnion"][::std::mem::align_of::<nsStyleUnion>() - 8usize];
+    [
+        "Offset of field: nsStyleUnion::mInt",
+    ][::std::mem::offset_of!(nsStyleUnion, mInt) - 0usize];
+    [
+        "Offset of field: nsStyleUnion::mFloat",
+    ][::std::mem::offset_of!(nsStyleUnion, mFloat) - 0usize];
+    [
+        "Offset of field: nsStyleUnion::mPointer",
+    ][::std::mem::offset_of!(nsStyleUnion, mPointer) - 0usize];
+};
 impl Default for nsStyleUnion {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();

--- a/bindgen-tests/tests/expectations/tests/union_fields_1_0.rs
+++ b/bindgen-tests/tests/expectations/tests/union_fields_1_0.rs
@@ -54,35 +54,26 @@ pub struct nsStyleUnion {
 fn bindgen_test_layout_nsStyleUnion() {
     const UNINIT: ::std::mem::MaybeUninit<nsStyleUnion> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<nsStyleUnion>(),
-        8usize,
-        concat!("Size of: ", stringify!(nsStyleUnion)),
-    );
+    assert_eq!(::std::mem::size_of::<nsStyleUnion>(), 8usize, "Size of nsStyleUnion");
     assert_eq!(
         ::std::mem::align_of::<nsStyleUnion>(),
         8usize,
-        concat!("Alignment of ", stringify!(nsStyleUnion)),
+        "Alignment of nsStyleUnion",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).mInt) as usize - ptr as usize },
         0usize,
-        concat!("Offset of field: ", stringify!(nsStyleUnion), "::", stringify!(mInt)),
+        "Offset of field: nsStyleUnion::mInt",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).mFloat) as usize - ptr as usize },
         0usize,
-        concat!("Offset of field: ", stringify!(nsStyleUnion), "::", stringify!(mFloat)),
+        "Offset of field: nsStyleUnion::mFloat",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).mPointer) as usize - ptr as usize },
         0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(nsStyleUnion),
-            "::",
-            stringify!(mPointer),
-        ),
+        "Offset of field: nsStyleUnion::mPointer",
     );
 }
 impl Clone for nsStyleUnion {

--- a/bindgen-tests/tests/expectations/tests/union_with_anon_struct.rs
+++ b/bindgen-tests/tests/expectations/tests/union_with_anon_struct.rs
@@ -10,51 +10,23 @@ pub struct foo__bindgen_ty_1 {
     pub a: ::std::os::raw::c_uint,
     pub b: ::std::os::raw::c_uint,
 }
-#[test]
-fn bindgen_test_layout_foo__bindgen_ty_1() {
-    const UNINIT: ::std::mem::MaybeUninit<foo__bindgen_ty_1> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<foo__bindgen_ty_1>(),
-        8usize,
-        concat!("Size of: ", stringify!(foo__bindgen_ty_1)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<foo__bindgen_ty_1>(),
-        4usize,
-        concat!("Alignment of ", stringify!(foo__bindgen_ty_1)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(foo__bindgen_ty_1), "::", stringify!(a)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
-        4usize,
-        concat!("Offset of field: ", stringify!(foo__bindgen_ty_1), "::", stringify!(b)),
-    );
-}
-#[test]
-fn bindgen_test_layout_foo() {
-    const UNINIT: ::std::mem::MaybeUninit<foo> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<foo>(),
-        8usize,
-        concat!("Size of: ", stringify!(foo)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<foo>(),
-        4usize,
-        concat!("Alignment of ", stringify!(foo)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar)),
-    );
-}
+const _: () = {
+    ["Size of foo__bindgen_ty_1"][::std::mem::size_of::<foo__bindgen_ty_1>() - 8usize];
+    [
+        "Alignment of foo__bindgen_ty_1",
+    ][::std::mem::align_of::<foo__bindgen_ty_1>() - 4usize];
+    [
+        "Offset of field: foo__bindgen_ty_1::a",
+    ][::std::mem::offset_of!(foo__bindgen_ty_1, a) - 0usize];
+    [
+        "Offset of field: foo__bindgen_ty_1::b",
+    ][::std::mem::offset_of!(foo__bindgen_ty_1, b) - 4usize];
+};
+const _: () = {
+    ["Size of foo"][::std::mem::size_of::<foo>() - 8usize];
+    ["Alignment of foo"][::std::mem::align_of::<foo>() - 4usize];
+    ["Offset of field: foo::bar"][::std::mem::offset_of!(foo, bar) - 0usize];
+};
 impl Default for foo {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();

--- a/bindgen-tests/tests/expectations/tests/union_with_anon_struct_1_0.rs
+++ b/bindgen-tests/tests/expectations/tests/union_with_anon_struct_1_0.rs
@@ -61,22 +61,22 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
     assert_eq!(
         ::std::mem::size_of::<foo__bindgen_ty_1>(),
         8usize,
-        concat!("Size of: ", stringify!(foo__bindgen_ty_1)),
+        "Size of foo__bindgen_ty_1",
     );
     assert_eq!(
         ::std::mem::align_of::<foo__bindgen_ty_1>(),
         4usize,
-        concat!("Alignment of ", stringify!(foo__bindgen_ty_1)),
+        "Alignment of foo__bindgen_ty_1",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
         0usize,
-        concat!("Offset of field: ", stringify!(foo__bindgen_ty_1), "::", stringify!(a)),
+        "Offset of field: foo__bindgen_ty_1::a",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
         4usize,
-        concat!("Offset of field: ", stringify!(foo__bindgen_ty_1), "::", stringify!(b)),
+        "Offset of field: foo__bindgen_ty_1::b",
     );
 }
 impl Clone for foo__bindgen_ty_1 {
@@ -88,20 +88,12 @@ impl Clone for foo__bindgen_ty_1 {
 fn bindgen_test_layout_foo() {
     const UNINIT: ::std::mem::MaybeUninit<foo> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<foo>(),
-        8usize,
-        concat!("Size of: ", stringify!(foo)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<foo>(),
-        4usize,
-        concat!("Alignment of ", stringify!(foo)),
-    );
+    assert_eq!(::std::mem::size_of::<foo>(), 8usize, "Size of foo");
+    assert_eq!(::std::mem::align_of::<foo>(), 4usize, "Alignment of foo");
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize },
         0usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar)),
+        "Offset of field: foo::bar",
     );
 }
 impl Clone for foo {

--- a/bindgen-tests/tests/expectations/tests/union_with_anon_struct_bitfield.rs
+++ b/bindgen-tests/tests/expectations/tests/union_with_anon_struct_bitfield.rs
@@ -95,19 +95,12 @@ pub struct foo__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
 }
-#[test]
-fn bindgen_test_layout_foo__bindgen_ty_1() {
-    assert_eq!(
-        ::std::mem::size_of::<foo__bindgen_ty_1>(),
-        4usize,
-        concat!("Size of: ", stringify!(foo__bindgen_ty_1)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<foo__bindgen_ty_1>(),
-        4usize,
-        concat!("Alignment of ", stringify!(foo__bindgen_ty_1)),
-    );
-}
+const _: () = {
+    ["Size of foo__bindgen_ty_1"][::std::mem::size_of::<foo__bindgen_ty_1>() - 4usize];
+    [
+        "Alignment of foo__bindgen_ty_1",
+    ][::std::mem::align_of::<foo__bindgen_ty_1>() - 4usize];
+};
 impl foo__bindgen_ty_1 {
     #[inline]
     pub fn b(&self) -> ::std::os::raw::c_int {
@@ -158,26 +151,11 @@ impl foo__bindgen_ty_1 {
         __bindgen_bitfield_unit
     }
 }
-#[test]
-fn bindgen_test_layout_foo() {
-    const UNINIT: ::std::mem::MaybeUninit<foo> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<foo>(),
-        4usize,
-        concat!("Size of: ", stringify!(foo)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<foo>(),
-        4usize,
-        concat!("Alignment of ", stringify!(foo)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(a)),
-    );
-}
+const _: () = {
+    ["Size of foo"][::std::mem::size_of::<foo>() - 4usize];
+    ["Alignment of foo"][::std::mem::align_of::<foo>() - 4usize];
+    ["Offset of field: foo::a"][::std::mem::offset_of!(foo, a) - 0usize];
+};
 impl Default for foo {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();

--- a/bindgen-tests/tests/expectations/tests/union_with_anon_struct_bitfield_1_0.rs
+++ b/bindgen-tests/tests/expectations/tests/union_with_anon_struct_bitfield_1_0.rs
@@ -144,12 +144,12 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
     assert_eq!(
         ::std::mem::size_of::<foo__bindgen_ty_1>(),
         4usize,
-        concat!("Size of: ", stringify!(foo__bindgen_ty_1)),
+        "Size of foo__bindgen_ty_1",
     );
     assert_eq!(
         ::std::mem::align_of::<foo__bindgen_ty_1>(),
         4usize,
-        concat!("Alignment of ", stringify!(foo__bindgen_ty_1)),
+        "Alignment of foo__bindgen_ty_1",
     );
 }
 impl Clone for foo__bindgen_ty_1 {
@@ -211,20 +211,12 @@ impl foo__bindgen_ty_1 {
 fn bindgen_test_layout_foo() {
     const UNINIT: ::std::mem::MaybeUninit<foo> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<foo>(),
-        4usize,
-        concat!("Size of: ", stringify!(foo)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<foo>(),
-        4usize,
-        concat!("Alignment of ", stringify!(foo)),
-    );
+    assert_eq!(::std::mem::size_of::<foo>(), 4usize, "Size of foo");
+    assert_eq!(::std::mem::align_of::<foo>(), 4usize, "Alignment of foo");
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
         0usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(a)),
+        "Offset of field: foo::a",
     );
 }
 impl Clone for foo {

--- a/bindgen-tests/tests/expectations/tests/union_with_anon_union.rs
+++ b/bindgen-tests/tests/expectations/tests/union_with_anon_union.rs
@@ -10,31 +10,18 @@ pub union foo__bindgen_ty_1 {
     pub a: ::std::os::raw::c_uint,
     pub b: ::std::os::raw::c_ushort,
 }
-#[test]
-fn bindgen_test_layout_foo__bindgen_ty_1() {
-    const UNINIT: ::std::mem::MaybeUninit<foo__bindgen_ty_1> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<foo__bindgen_ty_1>(),
-        4usize,
-        concat!("Size of: ", stringify!(foo__bindgen_ty_1)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<foo__bindgen_ty_1>(),
-        4usize,
-        concat!("Alignment of ", stringify!(foo__bindgen_ty_1)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(foo__bindgen_ty_1), "::", stringify!(a)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(foo__bindgen_ty_1), "::", stringify!(b)),
-    );
-}
+const _: () = {
+    ["Size of foo__bindgen_ty_1"][::std::mem::size_of::<foo__bindgen_ty_1>() - 4usize];
+    [
+        "Alignment of foo__bindgen_ty_1",
+    ][::std::mem::align_of::<foo__bindgen_ty_1>() - 4usize];
+    [
+        "Offset of field: foo__bindgen_ty_1::a",
+    ][::std::mem::offset_of!(foo__bindgen_ty_1, a) - 0usize];
+    [
+        "Offset of field: foo__bindgen_ty_1::b",
+    ][::std::mem::offset_of!(foo__bindgen_ty_1, b) - 0usize];
+};
 impl Default for foo__bindgen_ty_1 {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
@@ -44,26 +31,11 @@ impl Default for foo__bindgen_ty_1 {
         }
     }
 }
-#[test]
-fn bindgen_test_layout_foo() {
-    const UNINIT: ::std::mem::MaybeUninit<foo> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<foo>(),
-        4usize,
-        concat!("Size of: ", stringify!(foo)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<foo>(),
-        4usize,
-        concat!("Alignment of ", stringify!(foo)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar)),
-    );
-}
+const _: () = {
+    ["Size of foo"][::std::mem::size_of::<foo>() - 4usize];
+    ["Alignment of foo"][::std::mem::align_of::<foo>() - 4usize];
+    ["Offset of field: foo::bar"][::std::mem::offset_of!(foo, bar) - 0usize];
+};
 impl Default for foo {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();

--- a/bindgen-tests/tests/expectations/tests/union_with_anon_union_1_0.rs
+++ b/bindgen-tests/tests/expectations/tests/union_with_anon_union_1_0.rs
@@ -62,22 +62,22 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
     assert_eq!(
         ::std::mem::size_of::<foo__bindgen_ty_1>(),
         4usize,
-        concat!("Size of: ", stringify!(foo__bindgen_ty_1)),
+        "Size of foo__bindgen_ty_1",
     );
     assert_eq!(
         ::std::mem::align_of::<foo__bindgen_ty_1>(),
         4usize,
-        concat!("Alignment of ", stringify!(foo__bindgen_ty_1)),
+        "Alignment of foo__bindgen_ty_1",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
         0usize,
-        concat!("Offset of field: ", stringify!(foo__bindgen_ty_1), "::", stringify!(a)),
+        "Offset of field: foo__bindgen_ty_1::a",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
         0usize,
-        concat!("Offset of field: ", stringify!(foo__bindgen_ty_1), "::", stringify!(b)),
+        "Offset of field: foo__bindgen_ty_1::b",
     );
 }
 impl Clone for foo__bindgen_ty_1 {
@@ -89,20 +89,12 @@ impl Clone for foo__bindgen_ty_1 {
 fn bindgen_test_layout_foo() {
     const UNINIT: ::std::mem::MaybeUninit<foo> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<foo>(),
-        4usize,
-        concat!("Size of: ", stringify!(foo)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<foo>(),
-        4usize,
-        concat!("Alignment of ", stringify!(foo)),
-    );
+    assert_eq!(::std::mem::size_of::<foo>(), 4usize, "Size of foo");
+    assert_eq!(::std::mem::align_of::<foo>(), 4usize, "Alignment of foo");
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize },
         0usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar)),
+        "Offset of field: foo::bar",
     );
 }
 impl Clone for foo {

--- a/bindgen-tests/tests/expectations/tests/union_with_anon_unnamed_struct.rs
+++ b/bindgen-tests/tests/expectations/tests/union_with_anon_unnamed_struct.rs
@@ -13,81 +13,31 @@ pub struct pixel__bindgen_ty_1 {
     pub b: ::std::os::raw::c_uchar,
     pub a: ::std::os::raw::c_uchar,
 }
-#[test]
-fn bindgen_test_layout_pixel__bindgen_ty_1() {
-    const UNINIT: ::std::mem::MaybeUninit<pixel__bindgen_ty_1> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<pixel__bindgen_ty_1>(),
-        4usize,
-        concat!("Size of: ", stringify!(pixel__bindgen_ty_1)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<pixel__bindgen_ty_1>(),
-        1usize,
-        concat!("Alignment of ", stringify!(pixel__bindgen_ty_1)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).r) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(pixel__bindgen_ty_1),
-            "::",
-            stringify!(r),
-        ),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).g) as usize - ptr as usize },
-        1usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(pixel__bindgen_ty_1),
-            "::",
-            stringify!(g),
-        ),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
-        2usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(pixel__bindgen_ty_1),
-            "::",
-            stringify!(b),
-        ),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
-        3usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(pixel__bindgen_ty_1),
-            "::",
-            stringify!(a),
-        ),
-    );
-}
-#[test]
-fn bindgen_test_layout_pixel() {
-    const UNINIT: ::std::mem::MaybeUninit<pixel> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<pixel>(),
-        4usize,
-        concat!("Size of: ", stringify!(pixel)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<pixel>(),
-        4usize,
-        concat!("Alignment of ", stringify!(pixel)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).rgba) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(pixel), "::", stringify!(rgba)),
-    );
-}
+const _: () = {
+    [
+        "Size of pixel__bindgen_ty_1",
+    ][::std::mem::size_of::<pixel__bindgen_ty_1>() - 4usize];
+    [
+        "Alignment of pixel__bindgen_ty_1",
+    ][::std::mem::align_of::<pixel__bindgen_ty_1>() - 1usize];
+    [
+        "Offset of field: pixel__bindgen_ty_1::r",
+    ][::std::mem::offset_of!(pixel__bindgen_ty_1, r) - 0usize];
+    [
+        "Offset of field: pixel__bindgen_ty_1::g",
+    ][::std::mem::offset_of!(pixel__bindgen_ty_1, g) - 1usize];
+    [
+        "Offset of field: pixel__bindgen_ty_1::b",
+    ][::std::mem::offset_of!(pixel__bindgen_ty_1, b) - 2usize];
+    [
+        "Offset of field: pixel__bindgen_ty_1::a",
+    ][::std::mem::offset_of!(pixel__bindgen_ty_1, a) - 3usize];
+};
+const _: () = {
+    ["Size of pixel"][::std::mem::size_of::<pixel>() - 4usize];
+    ["Alignment of pixel"][::std::mem::align_of::<pixel>() - 4usize];
+    ["Offset of field: pixel::rgba"][::std::mem::offset_of!(pixel, rgba) - 0usize];
+};
 impl Default for pixel {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();

--- a/bindgen-tests/tests/expectations/tests/union_with_anon_unnamed_struct_1_0.rs
+++ b/bindgen-tests/tests/expectations/tests/union_with_anon_unnamed_struct_1_0.rs
@@ -64,52 +64,32 @@ fn bindgen_test_layout_pixel__bindgen_ty_1() {
     assert_eq!(
         ::std::mem::size_of::<pixel__bindgen_ty_1>(),
         4usize,
-        concat!("Size of: ", stringify!(pixel__bindgen_ty_1)),
+        "Size of pixel__bindgen_ty_1",
     );
     assert_eq!(
         ::std::mem::align_of::<pixel__bindgen_ty_1>(),
         1usize,
-        concat!("Alignment of ", stringify!(pixel__bindgen_ty_1)),
+        "Alignment of pixel__bindgen_ty_1",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).r) as usize - ptr as usize },
         0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(pixel__bindgen_ty_1),
-            "::",
-            stringify!(r),
-        ),
+        "Offset of field: pixel__bindgen_ty_1::r",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).g) as usize - ptr as usize },
         1usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(pixel__bindgen_ty_1),
-            "::",
-            stringify!(g),
-        ),
+        "Offset of field: pixel__bindgen_ty_1::g",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
         2usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(pixel__bindgen_ty_1),
-            "::",
-            stringify!(b),
-        ),
+        "Offset of field: pixel__bindgen_ty_1::b",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
         3usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(pixel__bindgen_ty_1),
-            "::",
-            stringify!(a),
-        ),
+        "Offset of field: pixel__bindgen_ty_1::a",
     );
 }
 impl Clone for pixel__bindgen_ty_1 {
@@ -121,20 +101,12 @@ impl Clone for pixel__bindgen_ty_1 {
 fn bindgen_test_layout_pixel() {
     const UNINIT: ::std::mem::MaybeUninit<pixel> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<pixel>(),
-        4usize,
-        concat!("Size of: ", stringify!(pixel)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<pixel>(),
-        4usize,
-        concat!("Alignment of ", stringify!(pixel)),
-    );
+    assert_eq!(::std::mem::size_of::<pixel>(), 4usize, "Size of pixel");
+    assert_eq!(::std::mem::align_of::<pixel>(), 4usize, "Alignment of pixel");
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).rgba) as usize - ptr as usize },
         0usize,
-        concat!("Offset of field: ", stringify!(pixel), "::", stringify!(rgba)),
+        "Offset of field: pixel::rgba",
     );
 }
 impl Clone for pixel {

--- a/bindgen-tests/tests/expectations/tests/union_with_anon_unnamed_union.rs
+++ b/bindgen-tests/tests/expectations/tests/union_with_anon_unnamed_union.rs
@@ -11,31 +11,18 @@ pub union foo__bindgen_ty_1 {
     pub b: ::std::os::raw::c_ushort,
     pub c: ::std::os::raw::c_uchar,
 }
-#[test]
-fn bindgen_test_layout_foo__bindgen_ty_1() {
-    const UNINIT: ::std::mem::MaybeUninit<foo__bindgen_ty_1> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<foo__bindgen_ty_1>(),
-        2usize,
-        concat!("Size of: ", stringify!(foo__bindgen_ty_1)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<foo__bindgen_ty_1>(),
-        2usize,
-        concat!("Alignment of ", stringify!(foo__bindgen_ty_1)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(foo__bindgen_ty_1), "::", stringify!(b)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).c) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(foo__bindgen_ty_1), "::", stringify!(c)),
-    );
-}
+const _: () = {
+    ["Size of foo__bindgen_ty_1"][::std::mem::size_of::<foo__bindgen_ty_1>() - 2usize];
+    [
+        "Alignment of foo__bindgen_ty_1",
+    ][::std::mem::align_of::<foo__bindgen_ty_1>() - 2usize];
+    [
+        "Offset of field: foo__bindgen_ty_1::b",
+    ][::std::mem::offset_of!(foo__bindgen_ty_1, b) - 0usize];
+    [
+        "Offset of field: foo__bindgen_ty_1::c",
+    ][::std::mem::offset_of!(foo__bindgen_ty_1, c) - 0usize];
+};
 impl Default for foo__bindgen_ty_1 {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
@@ -45,26 +32,11 @@ impl Default for foo__bindgen_ty_1 {
         }
     }
 }
-#[test]
-fn bindgen_test_layout_foo() {
-    const UNINIT: ::std::mem::MaybeUninit<foo> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<foo>(),
-        4usize,
-        concat!("Size of: ", stringify!(foo)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<foo>(),
-        4usize,
-        concat!("Alignment of ", stringify!(foo)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(a)),
-    );
-}
+const _: () = {
+    ["Size of foo"][::std::mem::size_of::<foo>() - 4usize];
+    ["Alignment of foo"][::std::mem::align_of::<foo>() - 4usize];
+    ["Offset of field: foo::a"][::std::mem::offset_of!(foo, a) - 0usize];
+};
 impl Default for foo {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();

--- a/bindgen-tests/tests/expectations/tests/union_with_anon_unnamed_union_1_0.rs
+++ b/bindgen-tests/tests/expectations/tests/union_with_anon_unnamed_union_1_0.rs
@@ -63,22 +63,22 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
     assert_eq!(
         ::std::mem::size_of::<foo__bindgen_ty_1>(),
         2usize,
-        concat!("Size of: ", stringify!(foo__bindgen_ty_1)),
+        "Size of foo__bindgen_ty_1",
     );
     assert_eq!(
         ::std::mem::align_of::<foo__bindgen_ty_1>(),
         2usize,
-        concat!("Alignment of ", stringify!(foo__bindgen_ty_1)),
+        "Alignment of foo__bindgen_ty_1",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
         0usize,
-        concat!("Offset of field: ", stringify!(foo__bindgen_ty_1), "::", stringify!(b)),
+        "Offset of field: foo__bindgen_ty_1::b",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).c) as usize - ptr as usize },
         0usize,
-        concat!("Offset of field: ", stringify!(foo__bindgen_ty_1), "::", stringify!(c)),
+        "Offset of field: foo__bindgen_ty_1::c",
     );
 }
 impl Clone for foo__bindgen_ty_1 {
@@ -90,20 +90,12 @@ impl Clone for foo__bindgen_ty_1 {
 fn bindgen_test_layout_foo() {
     const UNINIT: ::std::mem::MaybeUninit<foo> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<foo>(),
-        4usize,
-        concat!("Size of: ", stringify!(foo)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<foo>(),
-        4usize,
-        concat!("Alignment of ", stringify!(foo)),
-    );
+    assert_eq!(::std::mem::size_of::<foo>(), 4usize, "Size of foo");
+    assert_eq!(::std::mem::align_of::<foo>(), 4usize, "Alignment of foo");
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
         0usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(a)),
+        "Offset of field: foo::a",
     );
 }
 impl Clone for foo {

--- a/bindgen-tests/tests/expectations/tests/union_with_big_member.rs
+++ b/bindgen-tests/tests/expectations/tests/union_with_big_member.rs
@@ -5,31 +5,16 @@ pub union WithBigArray {
     pub a: ::std::os::raw::c_int,
     pub b: [::std::os::raw::c_int; 33usize],
 }
-#[test]
-fn bindgen_test_layout_WithBigArray() {
-    const UNINIT: ::std::mem::MaybeUninit<WithBigArray> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<WithBigArray>(),
-        132usize,
-        concat!("Size of: ", stringify!(WithBigArray)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<WithBigArray>(),
-        4usize,
-        concat!("Alignment of ", stringify!(WithBigArray)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(WithBigArray), "::", stringify!(a)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(WithBigArray), "::", stringify!(b)),
-    );
-}
+const _: () = {
+    ["Size of WithBigArray"][::std::mem::size_of::<WithBigArray>() - 132usize];
+    ["Alignment of WithBigArray"][::std::mem::align_of::<WithBigArray>() - 4usize];
+    [
+        "Offset of field: WithBigArray::a",
+    ][::std::mem::offset_of!(WithBigArray, a) - 0usize];
+    [
+        "Offset of field: WithBigArray::b",
+    ][::std::mem::offset_of!(WithBigArray, b) - 0usize];
+};
 impl Default for WithBigArray {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
@@ -45,31 +30,16 @@ pub union WithBigArray2 {
     pub a: ::std::os::raw::c_int,
     pub b: [::std::os::raw::c_char; 33usize],
 }
-#[test]
-fn bindgen_test_layout_WithBigArray2() {
-    const UNINIT: ::std::mem::MaybeUninit<WithBigArray2> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<WithBigArray2>(),
-        36usize,
-        concat!("Size of: ", stringify!(WithBigArray2)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<WithBigArray2>(),
-        4usize,
-        concat!("Alignment of ", stringify!(WithBigArray2)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(WithBigArray2), "::", stringify!(a)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(WithBigArray2), "::", stringify!(b)),
-    );
-}
+const _: () = {
+    ["Size of WithBigArray2"][::std::mem::size_of::<WithBigArray2>() - 36usize];
+    ["Alignment of WithBigArray2"][::std::mem::align_of::<WithBigArray2>() - 4usize];
+    [
+        "Offset of field: WithBigArray2::a",
+    ][::std::mem::offset_of!(WithBigArray2, a) - 0usize];
+    [
+        "Offset of field: WithBigArray2::b",
+    ][::std::mem::offset_of!(WithBigArray2, b) - 0usize];
+};
 impl Default for WithBigArray2 {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
@@ -85,31 +55,16 @@ pub union WithBigMember {
     pub a: ::std::os::raw::c_int,
     pub b: WithBigArray,
 }
-#[test]
-fn bindgen_test_layout_WithBigMember() {
-    const UNINIT: ::std::mem::MaybeUninit<WithBigMember> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<WithBigMember>(),
-        132usize,
-        concat!("Size of: ", stringify!(WithBigMember)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<WithBigMember>(),
-        4usize,
-        concat!("Alignment of ", stringify!(WithBigMember)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(WithBigMember), "::", stringify!(a)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(WithBigMember), "::", stringify!(b)),
-    );
-}
+const _: () = {
+    ["Size of WithBigMember"][::std::mem::size_of::<WithBigMember>() - 132usize];
+    ["Alignment of WithBigMember"][::std::mem::align_of::<WithBigMember>() - 4usize];
+    [
+        "Offset of field: WithBigMember::a",
+    ][::std::mem::offset_of!(WithBigMember, a) - 0usize];
+    [
+        "Offset of field: WithBigMember::b",
+    ][::std::mem::offset_of!(WithBigMember, b) - 0usize];
+};
 impl Default for WithBigMember {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();

--- a/bindgen-tests/tests/expectations/tests/union_with_big_member_1_0.rs
+++ b/bindgen-tests/tests/expectations/tests/union_with_big_member_1_0.rs
@@ -53,25 +53,21 @@ pub struct WithBigArray {
 fn bindgen_test_layout_WithBigArray() {
     const UNINIT: ::std::mem::MaybeUninit<WithBigArray> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<WithBigArray>(),
-        132usize,
-        concat!("Size of: ", stringify!(WithBigArray)),
-    );
+    assert_eq!(::std::mem::size_of::<WithBigArray>(), 132usize, "Size of WithBigArray");
     assert_eq!(
         ::std::mem::align_of::<WithBigArray>(),
         4usize,
-        concat!("Alignment of ", stringify!(WithBigArray)),
+        "Alignment of WithBigArray",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
         0usize,
-        concat!("Offset of field: ", stringify!(WithBigArray), "::", stringify!(a)),
+        "Offset of field: WithBigArray::a",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
         0usize,
-        concat!("Offset of field: ", stringify!(WithBigArray), "::", stringify!(b)),
+        "Offset of field: WithBigArray::b",
     );
 }
 impl Clone for WithBigArray {
@@ -99,25 +95,21 @@ pub struct WithBigArray2 {
 fn bindgen_test_layout_WithBigArray2() {
     const UNINIT: ::std::mem::MaybeUninit<WithBigArray2> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<WithBigArray2>(),
-        36usize,
-        concat!("Size of: ", stringify!(WithBigArray2)),
-    );
+    assert_eq!(::std::mem::size_of::<WithBigArray2>(), 36usize, "Size of WithBigArray2");
     assert_eq!(
         ::std::mem::align_of::<WithBigArray2>(),
         4usize,
-        concat!("Alignment of ", stringify!(WithBigArray2)),
+        "Alignment of WithBigArray2",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
         0usize,
-        concat!("Offset of field: ", stringify!(WithBigArray2), "::", stringify!(a)),
+        "Offset of field: WithBigArray2::a",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
         0usize,
-        concat!("Offset of field: ", stringify!(WithBigArray2), "::", stringify!(b)),
+        "Offset of field: WithBigArray2::b",
     );
 }
 impl Clone for WithBigArray2 {
@@ -139,22 +131,22 @@ fn bindgen_test_layout_WithBigMember() {
     assert_eq!(
         ::std::mem::size_of::<WithBigMember>(),
         132usize,
-        concat!("Size of: ", stringify!(WithBigMember)),
+        "Size of WithBigMember",
     );
     assert_eq!(
         ::std::mem::align_of::<WithBigMember>(),
         4usize,
-        concat!("Alignment of ", stringify!(WithBigMember)),
+        "Alignment of WithBigMember",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
         0usize,
-        concat!("Offset of field: ", stringify!(WithBigMember), "::", stringify!(a)),
+        "Offset of field: WithBigMember::a",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
         0usize,
-        concat!("Offset of field: ", stringify!(WithBigMember), "::", stringify!(b)),
+        "Offset of field: WithBigMember::b",
     );
 }
 impl Clone for WithBigMember {

--- a/bindgen-tests/tests/expectations/tests/union_with_nesting.rs
+++ b/bindgen-tests/tests/expectations/tests/union_with_nesting.rs
@@ -17,41 +17,20 @@ pub union foo__bindgen_ty_1__bindgen_ty_1 {
     pub b1: ::std::os::raw::c_ushort,
     pub b2: ::std::os::raw::c_ushort,
 }
-#[test]
-fn bindgen_test_layout_foo__bindgen_ty_1__bindgen_ty_1() {
-    const UNINIT: ::std::mem::MaybeUninit<foo__bindgen_ty_1__bindgen_ty_1> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<foo__bindgen_ty_1__bindgen_ty_1>(),
-        2usize,
-        concat!("Size of: ", stringify!(foo__bindgen_ty_1__bindgen_ty_1)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<foo__bindgen_ty_1__bindgen_ty_1>(),
-        2usize,
-        concat!("Alignment of ", stringify!(foo__bindgen_ty_1__bindgen_ty_1)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).b1) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(foo__bindgen_ty_1__bindgen_ty_1),
-            "::",
-            stringify!(b1),
-        ),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).b2) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(foo__bindgen_ty_1__bindgen_ty_1),
-            "::",
-            stringify!(b2),
-        ),
-    );
-}
+const _: () = {
+    [
+        "Size of foo__bindgen_ty_1__bindgen_ty_1",
+    ][::std::mem::size_of::<foo__bindgen_ty_1__bindgen_ty_1>() - 2usize];
+    [
+        "Alignment of foo__bindgen_ty_1__bindgen_ty_1",
+    ][::std::mem::align_of::<foo__bindgen_ty_1__bindgen_ty_1>() - 2usize];
+    [
+        "Offset of field: foo__bindgen_ty_1__bindgen_ty_1::b1",
+    ][::std::mem::offset_of!(foo__bindgen_ty_1__bindgen_ty_1, b1) - 0usize];
+    [
+        "Offset of field: foo__bindgen_ty_1__bindgen_ty_1::b2",
+    ][::std::mem::offset_of!(foo__bindgen_ty_1__bindgen_ty_1, b2) - 0usize];
+};
 impl Default for foo__bindgen_ty_1__bindgen_ty_1 {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
@@ -67,41 +46,20 @@ pub union foo__bindgen_ty_1__bindgen_ty_2 {
     pub c1: ::std::os::raw::c_ushort,
     pub c2: ::std::os::raw::c_ushort,
 }
-#[test]
-fn bindgen_test_layout_foo__bindgen_ty_1__bindgen_ty_2() {
-    const UNINIT: ::std::mem::MaybeUninit<foo__bindgen_ty_1__bindgen_ty_2> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<foo__bindgen_ty_1__bindgen_ty_2>(),
-        2usize,
-        concat!("Size of: ", stringify!(foo__bindgen_ty_1__bindgen_ty_2)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<foo__bindgen_ty_1__bindgen_ty_2>(),
-        2usize,
-        concat!("Alignment of ", stringify!(foo__bindgen_ty_1__bindgen_ty_2)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).c1) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(foo__bindgen_ty_1__bindgen_ty_2),
-            "::",
-            stringify!(c1),
-        ),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).c2) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(foo__bindgen_ty_1__bindgen_ty_2),
-            "::",
-            stringify!(c2),
-        ),
-    );
-}
+const _: () = {
+    [
+        "Size of foo__bindgen_ty_1__bindgen_ty_2",
+    ][::std::mem::size_of::<foo__bindgen_ty_1__bindgen_ty_2>() - 2usize];
+    [
+        "Alignment of foo__bindgen_ty_1__bindgen_ty_2",
+    ][::std::mem::align_of::<foo__bindgen_ty_1__bindgen_ty_2>() - 2usize];
+    [
+        "Offset of field: foo__bindgen_ty_1__bindgen_ty_2::c1",
+    ][::std::mem::offset_of!(foo__bindgen_ty_1__bindgen_ty_2, c1) - 0usize];
+    [
+        "Offset of field: foo__bindgen_ty_1__bindgen_ty_2::c2",
+    ][::std::mem::offset_of!(foo__bindgen_ty_1__bindgen_ty_2, c2) - 0usize];
+};
 impl Default for foo__bindgen_ty_1__bindgen_ty_2 {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
@@ -111,19 +69,12 @@ impl Default for foo__bindgen_ty_1__bindgen_ty_2 {
         }
     }
 }
-#[test]
-fn bindgen_test_layout_foo__bindgen_ty_1() {
-    assert_eq!(
-        ::std::mem::size_of::<foo__bindgen_ty_1>(),
-        4usize,
-        concat!("Size of: ", stringify!(foo__bindgen_ty_1)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<foo__bindgen_ty_1>(),
-        2usize,
-        concat!("Alignment of ", stringify!(foo__bindgen_ty_1)),
-    );
-}
+const _: () = {
+    ["Size of foo__bindgen_ty_1"][::std::mem::size_of::<foo__bindgen_ty_1>() - 4usize];
+    [
+        "Alignment of foo__bindgen_ty_1",
+    ][::std::mem::align_of::<foo__bindgen_ty_1>() - 2usize];
+};
 impl Default for foo__bindgen_ty_1 {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
@@ -133,26 +84,11 @@ impl Default for foo__bindgen_ty_1 {
         }
     }
 }
-#[test]
-fn bindgen_test_layout_foo() {
-    const UNINIT: ::std::mem::MaybeUninit<foo> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<foo>(),
-        4usize,
-        concat!("Size of: ", stringify!(foo)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<foo>(),
-        4usize,
-        concat!("Alignment of ", stringify!(foo)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(a)),
-    );
-}
+const _: () = {
+    ["Size of foo"][::std::mem::size_of::<foo>() - 4usize];
+    ["Alignment of foo"][::std::mem::align_of::<foo>() - 4usize];
+    ["Offset of field: foo::a"][::std::mem::offset_of!(foo, a) - 0usize];
+};
 impl Default for foo {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();

--- a/bindgen-tests/tests/expectations/tests/union_with_nesting_1_0.rs
+++ b/bindgen-tests/tests/expectations/tests/union_with_nesting_1_0.rs
@@ -69,32 +69,22 @@ fn bindgen_test_layout_foo__bindgen_ty_1__bindgen_ty_1() {
     assert_eq!(
         ::std::mem::size_of::<foo__bindgen_ty_1__bindgen_ty_1>(),
         2usize,
-        concat!("Size of: ", stringify!(foo__bindgen_ty_1__bindgen_ty_1)),
+        "Size of foo__bindgen_ty_1__bindgen_ty_1",
     );
     assert_eq!(
         ::std::mem::align_of::<foo__bindgen_ty_1__bindgen_ty_1>(),
         2usize,
-        concat!("Alignment of ", stringify!(foo__bindgen_ty_1__bindgen_ty_1)),
+        "Alignment of foo__bindgen_ty_1__bindgen_ty_1",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).b1) as usize - ptr as usize },
         0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(foo__bindgen_ty_1__bindgen_ty_1),
-            "::",
-            stringify!(b1),
-        ),
+        "Offset of field: foo__bindgen_ty_1__bindgen_ty_1::b1",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).b2) as usize - ptr as usize },
         0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(foo__bindgen_ty_1__bindgen_ty_1),
-            "::",
-            stringify!(b2),
-        ),
+        "Offset of field: foo__bindgen_ty_1__bindgen_ty_1::b2",
     );
 }
 impl Clone for foo__bindgen_ty_1__bindgen_ty_1 {
@@ -116,32 +106,22 @@ fn bindgen_test_layout_foo__bindgen_ty_1__bindgen_ty_2() {
     assert_eq!(
         ::std::mem::size_of::<foo__bindgen_ty_1__bindgen_ty_2>(),
         2usize,
-        concat!("Size of: ", stringify!(foo__bindgen_ty_1__bindgen_ty_2)),
+        "Size of foo__bindgen_ty_1__bindgen_ty_2",
     );
     assert_eq!(
         ::std::mem::align_of::<foo__bindgen_ty_1__bindgen_ty_2>(),
         2usize,
-        concat!("Alignment of ", stringify!(foo__bindgen_ty_1__bindgen_ty_2)),
+        "Alignment of foo__bindgen_ty_1__bindgen_ty_2",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).c1) as usize - ptr as usize },
         0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(foo__bindgen_ty_1__bindgen_ty_2),
-            "::",
-            stringify!(c1),
-        ),
+        "Offset of field: foo__bindgen_ty_1__bindgen_ty_2::c1",
     );
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).c2) as usize - ptr as usize },
         0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(foo__bindgen_ty_1__bindgen_ty_2),
-            "::",
-            stringify!(c2),
-        ),
+        "Offset of field: foo__bindgen_ty_1__bindgen_ty_2::c2",
     );
 }
 impl Clone for foo__bindgen_ty_1__bindgen_ty_2 {
@@ -154,12 +134,12 @@ fn bindgen_test_layout_foo__bindgen_ty_1() {
     assert_eq!(
         ::std::mem::size_of::<foo__bindgen_ty_1>(),
         4usize,
-        concat!("Size of: ", stringify!(foo__bindgen_ty_1)),
+        "Size of foo__bindgen_ty_1",
     );
     assert_eq!(
         ::std::mem::align_of::<foo__bindgen_ty_1>(),
         2usize,
-        concat!("Alignment of ", stringify!(foo__bindgen_ty_1)),
+        "Alignment of foo__bindgen_ty_1",
     );
 }
 impl Clone for foo__bindgen_ty_1 {
@@ -171,20 +151,12 @@ impl Clone for foo__bindgen_ty_1 {
 fn bindgen_test_layout_foo() {
     const UNINIT: ::std::mem::MaybeUninit<foo> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<foo>(),
-        4usize,
-        concat!("Size of: ", stringify!(foo)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<foo>(),
-        4usize,
-        concat!("Alignment of ", stringify!(foo)),
-    );
+    assert_eq!(::std::mem::size_of::<foo>(), 4usize, "Size of foo");
+    assert_eq!(::std::mem::align_of::<foo>(), 4usize, "Alignment of foo");
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
         0usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(a)),
+        "Offset of field: foo::a",
     );
 }
 impl Clone for foo {

--- a/bindgen-tests/tests/expectations/tests/union_with_non_copy_member.rs
+++ b/bindgen-tests/tests/expectations/tests/union_with_non_copy_member.rs
@@ -47,67 +47,33 @@ impl<T> ::std::cmp::Eq for __BindgenUnionField<T> {}
 pub struct NonCopyType {
     pub foo: ::std::os::raw::c_int,
 }
-#[test]
-fn bindgen_test_layout_NonCopyType() {
-    const UNINIT: ::std::mem::MaybeUninit<NonCopyType> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<NonCopyType>(),
-        4usize,
-        concat!("Size of: ", stringify!(NonCopyType)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<NonCopyType>(),
-        4usize,
-        concat!("Alignment of ", stringify!(NonCopyType)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).foo) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(NonCopyType), "::", stringify!(foo)),
-    );
-}
+const _: () = {
+    ["Size of NonCopyType"][::std::mem::size_of::<NonCopyType>() - 4usize];
+    ["Alignment of NonCopyType"][::std::mem::align_of::<NonCopyType>() - 4usize];
+    [
+        "Offset of field: NonCopyType::foo",
+    ][::std::mem::offset_of!(NonCopyType, foo) - 0usize];
+};
 #[repr(C)]
 pub struct WithBindgenGeneratedWrapper {
     pub non_copy_type: __BindgenUnionField<NonCopyType>,
     pub bar: __BindgenUnionField<::std::os::raw::c_int>,
     pub bindgen_union_field: u32,
 }
-#[test]
-fn bindgen_test_layout_WithBindgenGeneratedWrapper() {
-    const UNINIT: ::std::mem::MaybeUninit<WithBindgenGeneratedWrapper> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<WithBindgenGeneratedWrapper>(),
-        4usize,
-        concat!("Size of: ", stringify!(WithBindgenGeneratedWrapper)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<WithBindgenGeneratedWrapper>(),
-        4usize,
-        concat!("Alignment of ", stringify!(WithBindgenGeneratedWrapper)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).non_copy_type) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(WithBindgenGeneratedWrapper),
-            "::",
-            stringify!(non_copy_type),
-        ),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(WithBindgenGeneratedWrapper),
-            "::",
-            stringify!(bar),
-        ),
-    );
-}
+const _: () = {
+    [
+        "Size of WithBindgenGeneratedWrapper",
+    ][::std::mem::size_of::<WithBindgenGeneratedWrapper>() - 4usize];
+    [
+        "Alignment of WithBindgenGeneratedWrapper",
+    ][::std::mem::align_of::<WithBindgenGeneratedWrapper>() - 4usize];
+    [
+        "Offset of field: WithBindgenGeneratedWrapper::non_copy_type",
+    ][::std::mem::offset_of!(WithBindgenGeneratedWrapper, non_copy_type) - 0usize];
+    [
+        "Offset of field: WithBindgenGeneratedWrapper::bar",
+    ][::std::mem::offset_of!(WithBindgenGeneratedWrapper, bar) - 0usize];
+};
 impl Default for WithBindgenGeneratedWrapper {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
@@ -122,36 +88,18 @@ pub union WithManuallyDrop {
     pub non_copy_type: ::std::mem::ManuallyDrop<NonCopyType>,
     pub bar: ::std::mem::ManuallyDrop<::std::os::raw::c_int>,
 }
-#[test]
-fn bindgen_test_layout_WithManuallyDrop() {
-    const UNINIT: ::std::mem::MaybeUninit<WithManuallyDrop> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<WithManuallyDrop>(),
-        4usize,
-        concat!("Size of: ", stringify!(WithManuallyDrop)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<WithManuallyDrop>(),
-        4usize,
-        concat!("Alignment of ", stringify!(WithManuallyDrop)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).non_copy_type) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(WithManuallyDrop),
-            "::",
-            stringify!(non_copy_type),
-        ),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(WithManuallyDrop), "::", stringify!(bar)),
-    );
-}
+const _: () = {
+    ["Size of WithManuallyDrop"][::std::mem::size_of::<WithManuallyDrop>() - 4usize];
+    [
+        "Alignment of WithManuallyDrop",
+    ][::std::mem::align_of::<WithManuallyDrop>() - 4usize];
+    [
+        "Offset of field: WithManuallyDrop::non_copy_type",
+    ][::std::mem::offset_of!(WithManuallyDrop, non_copy_type) - 0usize];
+    [
+        "Offset of field: WithManuallyDrop::bar",
+    ][::std::mem::offset_of!(WithManuallyDrop, bar) - 0usize];
+};
 impl Default for WithManuallyDrop {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
@@ -167,41 +115,18 @@ pub struct WithDefaultWrapper {
     pub bar: __BindgenUnionField<::std::os::raw::c_int>,
     pub bindgen_union_field: u32,
 }
-#[test]
-fn bindgen_test_layout_WithDefaultWrapper() {
-    const UNINIT: ::std::mem::MaybeUninit<WithDefaultWrapper> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<WithDefaultWrapper>(),
-        4usize,
-        concat!("Size of: ", stringify!(WithDefaultWrapper)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<WithDefaultWrapper>(),
-        4usize,
-        concat!("Alignment of ", stringify!(WithDefaultWrapper)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).non_copy_type) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(WithDefaultWrapper),
-            "::",
-            stringify!(non_copy_type),
-        ),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).bar) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(WithDefaultWrapper),
-            "::",
-            stringify!(bar),
-        ),
-    );
-}
+const _: () = {
+    ["Size of WithDefaultWrapper"][::std::mem::size_of::<WithDefaultWrapper>() - 4usize];
+    [
+        "Alignment of WithDefaultWrapper",
+    ][::std::mem::align_of::<WithDefaultWrapper>() - 4usize];
+    [
+        "Offset of field: WithDefaultWrapper::non_copy_type",
+    ][::std::mem::offset_of!(WithDefaultWrapper, non_copy_type) - 0usize];
+    [
+        "Offset of field: WithDefaultWrapper::bar",
+    ][::std::mem::offset_of!(WithDefaultWrapper, bar) - 0usize];
+};
 impl Default for WithDefaultWrapper {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();

--- a/bindgen-tests/tests/expectations/tests/unknown_attr.rs
+++ b/bindgen-tests/tests/expectations/tests/unknown_attr.rs
@@ -7,42 +7,13 @@ pub struct max_align_t {
     pub __bindgen_padding_0: u64,
     pub __clang_max_align_nonce2: ::std::os::raw::c_longlong,
 }
-#[test]
-fn bindgen_test_layout_max_align_t() {
-    const UNINIT: ::std::mem::MaybeUninit<max_align_t> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<max_align_t>(),
-        32usize,
-        concat!("Size of: ", stringify!(max_align_t)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<max_align_t>(),
-        16usize,
-        concat!("Alignment of ", stringify!(max_align_t)),
-    );
-    assert_eq!(
-        unsafe {
-            ::std::ptr::addr_of!((*ptr).__clang_max_align_nonce1) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(max_align_t),
-            "::",
-            stringify!(__clang_max_align_nonce1),
-        ),
-    );
-    assert_eq!(
-        unsafe {
-            ::std::ptr::addr_of!((*ptr).__clang_max_align_nonce2) as usize - ptr as usize
-        },
-        16usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(max_align_t),
-            "::",
-            stringify!(__clang_max_align_nonce2),
-        ),
-    );
-}
+const _: () = {
+    ["Size of max_align_t"][::std::mem::size_of::<max_align_t>() - 32usize];
+    ["Alignment of max_align_t"][::std::mem::align_of::<max_align_t>() - 16usize];
+    [
+        "Offset of field: max_align_t::__clang_max_align_nonce1",
+    ][::std::mem::offset_of!(max_align_t, __clang_max_align_nonce1) - 0usize];
+    [
+        "Offset of field: max_align_t::__clang_max_align_nonce2",
+    ][::std::mem::offset_of!(max_align_t, __clang_max_align_nonce2) - 16usize];
+};

--- a/bindgen-tests/tests/expectations/tests/unsorted-items.rs
+++ b/bindgen-tests/tests/expectations/tests/unsorted-items.rs
@@ -12,62 +12,24 @@ pub struct Point {
     pub x: number,
     pub y: number,
 }
-#[test]
-fn bindgen_test_layout_Point() {
-    const UNINIT: ::std::mem::MaybeUninit<Point> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<Point>(),
-        8usize,
-        concat!("Size of: ", stringify!(Point)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Point>(),
-        4usize,
-        concat!("Alignment of ", stringify!(Point)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(Point), "::", stringify!(x)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).y) as usize - ptr as usize },
-        4usize,
-        concat!("Offset of field: ", stringify!(Point), "::", stringify!(y)),
-    );
-}
+const _: () = {
+    ["Size of Point"][::std::mem::size_of::<Point>() - 8usize];
+    ["Alignment of Point"][::std::mem::align_of::<Point>() - 4usize];
+    ["Offset of field: Point::x"][::std::mem::offset_of!(Point, x) - 0usize];
+    ["Offset of field: Point::y"][::std::mem::offset_of!(Point, y) - 4usize];
+};
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct Angle {
     pub a: number,
     pub b: number,
 }
-#[test]
-fn bindgen_test_layout_Angle() {
-    const UNINIT: ::std::mem::MaybeUninit<Angle> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<Angle>(),
-        8usize,
-        concat!("Size of: ", stringify!(Angle)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Angle>(),
-        4usize,
-        concat!("Alignment of ", stringify!(Angle)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(Angle), "::", stringify!(a)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
-        4usize,
-        concat!("Offset of field: ", stringify!(Angle), "::", stringify!(b)),
-    );
-}
+const _: () = {
+    ["Size of Angle"][::std::mem::size_of::<Angle>() - 8usize];
+    ["Alignment of Angle"][::std::mem::align_of::<Angle>() - 4usize];
+    ["Offset of field: Angle::a"][::std::mem::offset_of!(Angle, a) - 0usize];
+    ["Offset of field: Angle::b"][::std::mem::offset_of!(Angle, b) - 4usize];
+};
 extern "C" {
     pub fn baz(point: Point) -> ::std::os::raw::c_int;
 }

--- a/bindgen-tests/tests/expectations/tests/use-core.rs
+++ b/bindgen-tests/tests/expectations/tests/use-core.rs
@@ -8,36 +8,13 @@ pub struct foo {
     pub b: ::core::ffi::c_int,
     pub bar: *mut ::core::ffi::c_void,
 }
-#[test]
-fn bindgen_test_layout_foo() {
-    const UNINIT: ::core::mem::MaybeUninit<foo> = ::core::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::core::mem::size_of::<foo>(),
-        16usize,
-        concat!("Size of: ", stringify!(foo)),
-    );
-    assert_eq!(
-        ::core::mem::align_of::<foo>(),
-        8usize,
-        concat!("Alignment of ", stringify!(foo)),
-    );
-    assert_eq!(
-        unsafe { ::core::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(a)),
-    );
-    assert_eq!(
-        unsafe { ::core::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
-        4usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(b)),
-    );
-    assert_eq!(
-        unsafe { ::core::ptr::addr_of!((*ptr).bar) as usize - ptr as usize },
-        8usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar)),
-    );
-}
+const _: () = {
+    ["Size of foo"][::core::mem::size_of::<foo>() - 16usize];
+    ["Alignment of foo"][::core::mem::align_of::<foo>() - 8usize];
+    ["Offset of field: foo::a"][::core::mem::offset_of!(foo, a) - 0usize];
+    ["Offset of field: foo::b"][::core::mem::offset_of!(foo, b) - 4usize];
+    ["Offset of field: foo::bar"][::core::mem::offset_of!(foo, bar) - 8usize];
+};
 impl Default for foo {
     fn default() -> Self {
         let mut s = ::core::mem::MaybeUninit::<Self>::uninit();
@@ -53,31 +30,16 @@ pub union _bindgen_ty_1 {
     pub bar: ::core::ffi::c_int,
     pub baz: ::core::ffi::c_long,
 }
-#[test]
-fn bindgen_test_layout__bindgen_ty_1() {
-    const UNINIT: ::core::mem::MaybeUninit<_bindgen_ty_1> = ::core::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::core::mem::size_of::<_bindgen_ty_1>(),
-        8usize,
-        concat!("Size of: ", stringify!(_bindgen_ty_1)),
-    );
-    assert_eq!(
-        ::core::mem::align_of::<_bindgen_ty_1>(),
-        8usize,
-        concat!("Alignment of ", stringify!(_bindgen_ty_1)),
-    );
-    assert_eq!(
-        unsafe { ::core::ptr::addr_of!((*ptr).bar) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(_bindgen_ty_1), "::", stringify!(bar)),
-    );
-    assert_eq!(
-        unsafe { ::core::ptr::addr_of!((*ptr).baz) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(_bindgen_ty_1), "::", stringify!(baz)),
-    );
-}
+const _: () = {
+    ["Size of _bindgen_ty_1"][::core::mem::size_of::<_bindgen_ty_1>() - 8usize];
+    ["Alignment of _bindgen_ty_1"][::core::mem::align_of::<_bindgen_ty_1>() - 8usize];
+    [
+        "Offset of field: _bindgen_ty_1::bar",
+    ][::core::mem::offset_of!(_bindgen_ty_1, bar) - 0usize];
+    [
+        "Offset of field: _bindgen_ty_1::baz",
+    ][::core::mem::offset_of!(_bindgen_ty_1, baz) - 0usize];
+};
 impl Default for _bindgen_ty_1 {
     fn default() -> Self {
         let mut s = ::core::mem::MaybeUninit::<Self>::uninit();

--- a/bindgen-tests/tests/expectations/tests/use-core_1_0.rs
+++ b/bindgen-tests/tests/expectations/tests/use-core_1_0.rs
@@ -54,30 +54,22 @@ pub struct foo {
 fn bindgen_test_layout_foo() {
     const UNINIT: ::core::mem::MaybeUninit<foo> = ::core::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::core::mem::size_of::<foo>(),
-        16usize,
-        concat!("Size of: ", stringify!(foo)),
-    );
-    assert_eq!(
-        ::core::mem::align_of::<foo>(),
-        8usize,
-        concat!("Alignment of ", stringify!(foo)),
-    );
+    assert_eq!(::core::mem::size_of::<foo>(), 16usize, "Size of foo");
+    assert_eq!(::core::mem::align_of::<foo>(), 8usize, "Alignment of foo");
     assert_eq!(
         unsafe { ::core::ptr::addr_of!((*ptr).a) as usize - ptr as usize },
         0usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(a)),
+        "Offset of field: foo::a",
     );
     assert_eq!(
         unsafe { ::core::ptr::addr_of!((*ptr).b) as usize - ptr as usize },
         4usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(b)),
+        "Offset of field: foo::b",
     );
     assert_eq!(
         unsafe { ::core::ptr::addr_of!((*ptr).bar) as usize - ptr as usize },
         8usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(bar)),
+        "Offset of field: foo::bar",
     );
 }
 impl Clone for foo {
@@ -105,25 +97,21 @@ pub struct _bindgen_ty_1 {
 fn bindgen_test_layout__bindgen_ty_1() {
     const UNINIT: ::core::mem::MaybeUninit<_bindgen_ty_1> = ::core::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::core::mem::size_of::<_bindgen_ty_1>(),
-        8usize,
-        concat!("Size of: ", stringify!(_bindgen_ty_1)),
-    );
+    assert_eq!(::core::mem::size_of::<_bindgen_ty_1>(), 8usize, "Size of _bindgen_ty_1");
     assert_eq!(
         ::core::mem::align_of::<_bindgen_ty_1>(),
         8usize,
-        concat!("Alignment of ", stringify!(_bindgen_ty_1)),
+        "Alignment of _bindgen_ty_1",
     );
     assert_eq!(
         unsafe { ::core::ptr::addr_of!((*ptr).bar) as usize - ptr as usize },
         0usize,
-        concat!("Offset of field: ", stringify!(_bindgen_ty_1), "::", stringify!(bar)),
+        "Offset of field: _bindgen_ty_1::bar",
     );
     assert_eq!(
         unsafe { ::core::ptr::addr_of!((*ptr).baz) as usize - ptr as usize },
         0usize,
-        concat!("Offset of field: ", stringify!(_bindgen_ty_1), "::", stringify!(baz)),
+        "Offset of field: _bindgen_ty_1::baz",
     );
 }
 impl Clone for _bindgen_ty_1 {

--- a/bindgen-tests/tests/expectations/tests/var-tracing.rs
+++ b/bindgen-tests/tests/expectations/tests/var-tracing.rs
@@ -4,26 +4,11 @@
 pub struct Bar {
     pub m_baz: ::std::os::raw::c_int,
 }
-#[test]
-fn bindgen_test_layout_Bar() {
-    const UNINIT: ::std::mem::MaybeUninit<Bar> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<Bar>(),
-        4usize,
-        concat!("Size of: ", stringify!(Bar)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Bar>(),
-        4usize,
-        concat!("Alignment of ", stringify!(Bar)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).m_baz) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(Bar), "::", stringify!(m_baz)),
-    );
-}
+const _: () = {
+    ["Size of Bar"][::std::mem::size_of::<Bar>() - 4usize];
+    ["Alignment of Bar"][::std::mem::align_of::<Bar>() - 4usize];
+    ["Offset of field: Bar::m_baz"][::std::mem::offset_of!(Bar, m_baz) - 0usize];
+};
 extern "C" {
     #[link_name = "\u{1}_ZN3BarC1Ei"]
     pub fn Bar_Bar(this: *mut Bar, baz: ::std::os::raw::c_int);
@@ -45,16 +30,7 @@ extern "C" {
     #[link_name = "\u{1}_ZN3Baz3FOOE"]
     pub static Baz_FOO: [Bar; 0usize];
 }
-#[test]
-fn bindgen_test_layout_Baz() {
-    assert_eq!(
-        ::std::mem::size_of::<Baz>(),
-        1usize,
-        concat!("Size of: ", stringify!(Baz)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Baz>(),
-        1usize,
-        concat!("Alignment of ", stringify!(Baz)),
-    );
-}
+const _: () = {
+    ["Size of Baz"][::std::mem::size_of::<Baz>() - 1usize];
+    ["Alignment of Baz"][::std::mem::align_of::<Baz>() - 1usize];
+};

--- a/bindgen-tests/tests/expectations/tests/variadic-method.rs
+++ b/bindgen-tests/tests/expectations/tests/variadic-method.rs
@@ -8,19 +8,10 @@ extern "C" {
 pub struct Bar {
     pub _address: u8,
 }
-#[test]
-fn bindgen_test_layout_Bar() {
-    assert_eq!(
-        ::std::mem::size_of::<Bar>(),
-        1usize,
-        concat!("Size of: ", stringify!(Bar)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Bar>(),
-        1usize,
-        concat!("Alignment of ", stringify!(Bar)),
-    );
-}
+const _: () = {
+    ["Size of Bar"][::std::mem::size_of::<Bar>() - 1usize];
+    ["Alignment of Bar"][::std::mem::align_of::<Bar>() - 1usize];
+};
 extern "C" {
     #[link_name = "\u{1}_ZN3Bar3fooEPKcz"]
     pub fn Bar_foo(this: *mut Bar, fmt: *const ::std::os::raw::c_char, ...);

--- a/bindgen-tests/tests/expectations/tests/vector.rs
+++ b/bindgen-tests/tests/expectations/tests/vector.rs
@@ -4,26 +4,11 @@
 pub struct foo {
     pub mMember: [::std::os::raw::c_longlong; 1usize],
 }
-#[test]
-fn bindgen_test_layout_foo() {
-    const UNINIT: ::std::mem::MaybeUninit<foo> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<foo>(),
-        8usize,
-        concat!("Size of: ", stringify!(foo)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<foo>(),
-        8usize,
-        concat!("Alignment of ", stringify!(foo)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).mMember) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(foo), "::", stringify!(mMember)),
-    );
-}
+const _: () = {
+    ["Size of foo"][::std::mem::size_of::<foo>() - 8usize];
+    ["Alignment of foo"][::std::mem::align_of::<foo>() - 8usize];
+    ["Offset of field: foo::mMember"][::std::mem::offset_of!(foo, mMember) - 0usize];
+};
 pub type __m128 = [f32; 4usize];
 pub type __m128d = [f64; 2usize];
 pub type __m128i = [::std::os::raw::c_longlong; 2usize];

--- a/bindgen-tests/tests/expectations/tests/virtual_dtor.rs
+++ b/bindgen-tests/tests/expectations/tests/virtual_dtor.rs
@@ -6,19 +6,10 @@ pub struct nsSlots__bindgen_vtable(::std::os::raw::c_void);
 pub struct nsSlots {
     pub vtable_: *const nsSlots__bindgen_vtable,
 }
-#[test]
-fn bindgen_test_layout_nsSlots() {
-    assert_eq!(
-        ::std::mem::size_of::<nsSlots>(),
-        8usize,
-        concat!("Size of: ", stringify!(nsSlots)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<nsSlots>(),
-        8usize,
-        concat!("Alignment of ", stringify!(nsSlots)),
-    );
-}
+const _: () = {
+    ["Size of nsSlots"][::std::mem::size_of::<nsSlots>() - 8usize];
+    ["Alignment of nsSlots"][::std::mem::align_of::<nsSlots>() - 8usize];
+};
 impl Default for nsSlots {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();

--- a/bindgen-tests/tests/expectations/tests/virtual_interface.rs
+++ b/bindgen-tests/tests/expectations/tests/virtual_interface.rs
@@ -12,19 +12,12 @@ pub struct PureVirtualIFace__bindgen_vtable {
 pub struct PureVirtualIFace {
     pub vtable_: *const PureVirtualIFace__bindgen_vtable,
 }
-#[test]
-fn bindgen_test_layout_PureVirtualIFace() {
-    assert_eq!(
-        ::std::mem::size_of::<PureVirtualIFace>(),
-        8usize,
-        concat!("Size of: ", stringify!(PureVirtualIFace)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<PureVirtualIFace>(),
-        8usize,
-        concat!("Alignment of ", stringify!(PureVirtualIFace)),
-    );
-}
+const _: () = {
+    ["Size of PureVirtualIFace"][::std::mem::size_of::<PureVirtualIFace>() - 8usize];
+    [
+        "Alignment of PureVirtualIFace",
+    ][::std::mem::align_of::<PureVirtualIFace>() - 8usize];
+};
 impl Default for PureVirtualIFace {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
@@ -43,19 +36,12 @@ pub struct AnotherInterface__bindgen_vtable {
 pub struct AnotherInterface {
     pub vtable_: *const AnotherInterface__bindgen_vtable,
 }
-#[test]
-fn bindgen_test_layout_AnotherInterface() {
-    assert_eq!(
-        ::std::mem::size_of::<AnotherInterface>(),
-        8usize,
-        concat!("Size of: ", stringify!(AnotherInterface)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<AnotherInterface>(),
-        8usize,
-        concat!("Alignment of ", stringify!(AnotherInterface)),
-    );
-}
+const _: () = {
+    ["Size of AnotherInterface"][::std::mem::size_of::<AnotherInterface>() - 8usize];
+    [
+        "Alignment of AnotherInterface",
+    ][::std::mem::align_of::<AnotherInterface>() - 8usize];
+};
 impl Default for AnotherInterface {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
@@ -70,19 +56,10 @@ impl Default for AnotherInterface {
 pub struct Implementation {
     pub _base: PureVirtualIFace,
 }
-#[test]
-fn bindgen_test_layout_Implementation() {
-    assert_eq!(
-        ::std::mem::size_of::<Implementation>(),
-        8usize,
-        concat!("Size of: ", stringify!(Implementation)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Implementation>(),
-        8usize,
-        concat!("Alignment of ", stringify!(Implementation)),
-    );
-}
+const _: () = {
+    ["Size of Implementation"][::std::mem::size_of::<Implementation>() - 8usize];
+    ["Alignment of Implementation"][::std::mem::align_of::<Implementation>() - 8usize];
+};
 impl Default for Implementation {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
@@ -98,19 +75,10 @@ pub struct DoubleImpl {
     pub _base: PureVirtualIFace,
     pub _base_1: AnotherInterface,
 }
-#[test]
-fn bindgen_test_layout_DoubleImpl() {
-    assert_eq!(
-        ::std::mem::size_of::<DoubleImpl>(),
-        16usize,
-        concat!("Size of: ", stringify!(DoubleImpl)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<DoubleImpl>(),
-        8usize,
-        concat!("Alignment of ", stringify!(DoubleImpl)),
-    );
-}
+const _: () = {
+    ["Size of DoubleImpl"][::std::mem::size_of::<DoubleImpl>() - 16usize];
+    ["Alignment of DoubleImpl"][::std::mem::align_of::<DoubleImpl>() - 8usize];
+};
 impl Default for DoubleImpl {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();

--- a/bindgen-tests/tests/expectations/tests/virtual_overloaded.rs
+++ b/bindgen-tests/tests/expectations/tests/virtual_overloaded.rs
@@ -9,15 +9,10 @@ pub struct C__bindgen_vtable {
 pub struct C {
     pub vtable_: *const C__bindgen_vtable,
 }
-#[test]
-fn bindgen_test_layout_C() {
-    assert_eq!(::std::mem::size_of::<C>(), 8usize, concat!("Size of: ", stringify!(C)));
-    assert_eq!(
-        ::std::mem::align_of::<C>(),
-        8usize,
-        concat!("Alignment of ", stringify!(C)),
-    );
-}
+const _: () = {
+    ["Size of C"][::std::mem::size_of::<C>() - 8usize];
+    ["Alignment of C"][::std::mem::align_of::<C>() - 8usize];
+};
 impl Default for C {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();

--- a/bindgen-tests/tests/expectations/tests/vtable_recursive_sig.rs
+++ b/bindgen-tests/tests/expectations/tests/vtable_recursive_sig.rs
@@ -8,19 +8,10 @@ pub struct Base__bindgen_vtable {
 pub struct Base {
     pub vtable_: *const Base__bindgen_vtable,
 }
-#[test]
-fn bindgen_test_layout_Base() {
-    assert_eq!(
-        ::std::mem::size_of::<Base>(),
-        8usize,
-        concat!("Size of: ", stringify!(Base)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Base>(),
-        8usize,
-        concat!("Alignment of ", stringify!(Base)),
-    );
-}
+const _: () = {
+    ["Size of Base"][::std::mem::size_of::<Base>() - 8usize];
+    ["Alignment of Base"][::std::mem::align_of::<Base>() - 8usize];
+};
 impl Default for Base {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
@@ -39,19 +30,10 @@ extern "C" {
 pub struct Derived {
     pub _base: Base,
 }
-#[test]
-fn bindgen_test_layout_Derived() {
-    assert_eq!(
-        ::std::mem::size_of::<Derived>(),
-        8usize,
-        concat!("Size of: ", stringify!(Derived)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Derived>(),
-        8usize,
-        concat!("Alignment of ", stringify!(Derived)),
-    );
-}
+const _: () = {
+    ["Size of Derived"][::std::mem::size_of::<Derived>() - 8usize];
+    ["Alignment of Derived"][::std::mem::align_of::<Derived>() - 8usize];
+};
 impl Default for Derived {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();

--- a/bindgen-tests/tests/expectations/tests/wasm-constructor-returns.rs
+++ b/bindgen-tests/tests/expectations/tests/wasm-constructor-returns.rs
@@ -4,19 +4,10 @@
 pub struct Foo {
     pub _address: u8,
 }
-#[test]
-fn bindgen_test_layout_Foo() {
-    assert_eq!(
-        ::std::mem::size_of::<Foo>(),
-        1usize,
-        concat!("Size of: ", stringify!(Foo)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Foo>(),
-        1usize,
-        concat!("Alignment of ", stringify!(Foo)),
-    );
-}
+const _: () = {
+    ["Size of Foo"][::std::mem::size_of::<Foo>() - 1usize];
+    ["Alignment of Foo"][::std::mem::align_of::<Foo>() - 1usize];
+};
 extern "C" {
     #[link_name = "\u{1}_ZN3FooC1Ei"]
     pub fn Foo_Foo(

--- a/bindgen-tests/tests/expectations/tests/weird_bitfields.rs
+++ b/bindgen-tests/tests/expectations/tests/weird_bitfields.rs
@@ -111,118 +111,46 @@ pub struct Weird {
     pub _bitfield_2: __BindgenBitfieldUnit<[u8; 2usize]>,
     pub __bindgen_padding_0: [u8; 3usize],
 }
-#[test]
-fn bindgen_test_layout_Weird() {
-    const UNINIT: ::std::mem::MaybeUninit<Weird> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<Weird>(),
-        24usize,
-        concat!("Size of: ", stringify!(Weird)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Weird>(),
-        4usize,
-        concat!("Alignment of ", stringify!(Weird)),
-    );
-    assert_eq!(
-        unsafe {
-            ::std::ptr::addr_of!((*ptr).mStrokeDasharrayLength) as usize - ptr as usize
-        },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(Weird),
-            "::",
-            stringify!(mStrokeDasharrayLength),
-        ),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).mClipRule) as usize - ptr as usize },
-        8usize,
-        concat!("Offset of field: ", stringify!(Weird), "::", stringify!(mClipRule)),
-    );
-    assert_eq!(
-        unsafe {
-            ::std::ptr::addr_of!((*ptr).mColorInterpolation) as usize - ptr as usize
-        },
-        9usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(Weird),
-            "::",
-            stringify!(mColorInterpolation),
-        ),
-    );
-    assert_eq!(
-        unsafe {
-            ::std::ptr::addr_of!((*ptr).mColorInterpolationFilters) as usize
-                - ptr as usize
-        },
-        10usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(Weird),
-            "::",
-            stringify!(mColorInterpolationFilters),
-        ),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).mFillRule) as usize - ptr as usize },
-        11usize,
-        concat!("Offset of field: ", stringify!(Weird), "::", stringify!(mFillRule)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).mImageRendering) as usize - ptr as usize },
-        12usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(Weird),
-            "::",
-            stringify!(mImageRendering),
-        ),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).mPaintOrder) as usize - ptr as usize },
-        13usize,
-        concat!("Offset of field: ", stringify!(Weird), "::", stringify!(mPaintOrder)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).mShapeRendering) as usize - ptr as usize },
-        14usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(Weird),
-            "::",
-            stringify!(mShapeRendering),
-        ),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).mStrokeLinecap) as usize - ptr as usize },
-        15usize,
-        concat!("Offset of field: ", stringify!(Weird), "::", stringify!(mStrokeLinecap)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).mStrokeLinejoin) as usize - ptr as usize },
-        16usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(Weird),
-            "::",
-            stringify!(mStrokeLinejoin),
-        ),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).mTextAnchor) as usize - ptr as usize },
-        17usize,
-        concat!("Offset of field: ", stringify!(Weird), "::", stringify!(mTextAnchor)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).mTextRendering) as usize - ptr as usize },
-        18usize,
-        concat!("Offset of field: ", stringify!(Weird), "::", stringify!(mTextRendering)),
-    );
-}
+const _: () = {
+    ["Size of Weird"][::std::mem::size_of::<Weird>() - 24usize];
+    ["Alignment of Weird"][::std::mem::align_of::<Weird>() - 4usize];
+    [
+        "Offset of field: Weird::mStrokeDasharrayLength",
+    ][::std::mem::offset_of!(Weird, mStrokeDasharrayLength) - 0usize];
+    [
+        "Offset of field: Weird::mClipRule",
+    ][::std::mem::offset_of!(Weird, mClipRule) - 8usize];
+    [
+        "Offset of field: Weird::mColorInterpolation",
+    ][::std::mem::offset_of!(Weird, mColorInterpolation) - 9usize];
+    [
+        "Offset of field: Weird::mColorInterpolationFilters",
+    ][::std::mem::offset_of!(Weird, mColorInterpolationFilters) - 10usize];
+    [
+        "Offset of field: Weird::mFillRule",
+    ][::std::mem::offset_of!(Weird, mFillRule) - 11usize];
+    [
+        "Offset of field: Weird::mImageRendering",
+    ][::std::mem::offset_of!(Weird, mImageRendering) - 12usize];
+    [
+        "Offset of field: Weird::mPaintOrder",
+    ][::std::mem::offset_of!(Weird, mPaintOrder) - 13usize];
+    [
+        "Offset of field: Weird::mShapeRendering",
+    ][::std::mem::offset_of!(Weird, mShapeRendering) - 14usize];
+    [
+        "Offset of field: Weird::mStrokeLinecap",
+    ][::std::mem::offset_of!(Weird, mStrokeLinecap) - 15usize];
+    [
+        "Offset of field: Weird::mStrokeLinejoin",
+    ][::std::mem::offset_of!(Weird, mStrokeLinejoin) - 16usize];
+    [
+        "Offset of field: Weird::mTextAnchor",
+    ][::std::mem::offset_of!(Weird, mTextAnchor) - 17usize];
+    [
+        "Offset of field: Weird::mTextRendering",
+    ][::std::mem::offset_of!(Weird, mTextRendering) - 18usize];
+};
 impl Default for Weird {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();

--- a/bindgen-tests/tests/expectations/tests/what_is_going_on.rs
+++ b/bindgen-tests/tests/expectations/tests/what_is_going_on.rs
@@ -4,19 +4,10 @@
 pub struct UnknownUnits {
     pub _address: u8,
 }
-#[test]
-fn bindgen_test_layout_UnknownUnits() {
-    assert_eq!(
-        ::std::mem::size_of::<UnknownUnits>(),
-        1usize,
-        concat!("Size of: ", stringify!(UnknownUnits)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<UnknownUnits>(),
-        1usize,
-        concat!("Alignment of ", stringify!(UnknownUnits)),
-    );
-}
+const _: () = {
+    ["Size of UnknownUnits"][::std::mem::size_of::<UnknownUnits>() - 1usize];
+    ["Alignment of UnknownUnits"][::std::mem::align_of::<UnknownUnits>() - 1usize];
+};
 pub type Float = f32;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]

--- a/bindgen-tests/tests/expectations/tests/win32-dtors.rs
+++ b/bindgen-tests/tests/expectations/tests/win32-dtors.rs
@@ -8,20 +8,12 @@ pub struct CppObj {
 fn bindgen_test_layout_CppObj() {
     const UNINIT: ::std::mem::MaybeUninit<CppObj> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<CppObj>(),
-        4usize,
-        concat!("Size of: ", stringify!(CppObj)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<CppObj>(),
-        4usize,
-        concat!("Alignment of ", stringify!(CppObj)),
-    );
+    assert_eq!(::std::mem::size_of::<CppObj>(), 4usize, "Size of CppObj");
+    assert_eq!(::std::mem::align_of::<CppObj>(), 4usize, "Alignment of CppObj");
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize },
         0usize,
-        concat!("Offset of field: ", stringify!(CppObj), "::", stringify!(x)),
+        "Offset of field: CppObj::x",
     );
 }
 extern "C" {
@@ -56,20 +48,12 @@ pub struct CppObj2 {
 fn bindgen_test_layout_CppObj2() {
     const UNINIT: ::std::mem::MaybeUninit<CppObj2> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<CppObj2>(),
-        16usize,
-        concat!("Size of: ", stringify!(CppObj2)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<CppObj2>(),
-        8usize,
-        concat!("Alignment of ", stringify!(CppObj2)),
-    );
+    assert_eq!(::std::mem::size_of::<CppObj2>(), 16usize, "Size of CppObj2");
+    assert_eq!(::std::mem::align_of::<CppObj2>(), 8usize, "Alignment of CppObj2");
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize },
         8usize,
-        concat!("Offset of field: ", stringify!(CppObj2), "::", stringify!(x)),
+        "Offset of field: CppObj2::x",
     );
 }
 extern "C" {
@@ -107,20 +91,12 @@ pub struct CppObj3 {
 fn bindgen_test_layout_CppObj3() {
     const UNINIT: ::std::mem::MaybeUninit<CppObj3> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<CppObj3>(),
-        24usize,
-        concat!("Size of: ", stringify!(CppObj3)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<CppObj3>(),
-        8usize,
-        concat!("Alignment of ", stringify!(CppObj3)),
-    );
+    assert_eq!(::std::mem::size_of::<CppObj3>(), 24usize, "Size of CppObj3");
+    assert_eq!(::std::mem::align_of::<CppObj3>(), 8usize, "Alignment of CppObj3");
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize },
         16usize,
-        concat!("Offset of field: ", stringify!(CppObj3), "::", stringify!(x)),
+        "Offset of field: CppObj3::x",
     );
 }
 extern "C" {
@@ -158,20 +134,12 @@ pub struct CppObj4 {
 fn bindgen_test_layout_CppObj4() {
     const UNINIT: ::std::mem::MaybeUninit<CppObj4> = ::std::mem::MaybeUninit::uninit();
     let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<CppObj4>(),
-        24usize,
-        concat!("Size of: ", stringify!(CppObj4)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<CppObj4>(),
-        8usize,
-        concat!("Alignment of ", stringify!(CppObj4)),
-    );
+    assert_eq!(::std::mem::size_of::<CppObj4>(), 24usize, "Size of CppObj4");
+    assert_eq!(::std::mem::align_of::<CppObj4>(), 8usize, "Alignment of CppObj4");
     assert_eq!(
         unsafe { ::std::ptr::addr_of!((*ptr).x) as usize - ptr as usize },
         16usize,
-        concat!("Offset of field: ", stringify!(CppObj4), "::", stringify!(x)),
+        "Offset of field: CppObj4::x",
     );
 }
 extern "C" {

--- a/bindgen-tests/tests/expectations/tests/win32-thiscall_1_0.rs
+++ b/bindgen-tests/tests/expectations/tests/win32-thiscall_1_0.rs
@@ -6,16 +6,8 @@ pub struct Foo {
 }
 #[test]
 fn bindgen_test_layout_Foo() {
-    assert_eq!(
-        ::std::mem::size_of::<Foo>(),
-        1usize,
-        concat!("Size of: ", stringify!(Foo)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Foo>(),
-        1usize,
-        concat!("Alignment of ", stringify!(Foo)),
-    );
+    assert_eq!(::std::mem::size_of::<Foo>(), 1usize, "Size of Foo");
+    assert_eq!(::std::mem::align_of::<Foo>(), 1usize, "Alignment of Foo");
 }
 impl Clone for Foo {
     fn clone(&self) -> Self {

--- a/bindgen-tests/tests/expectations/tests/win32-thiscall_1_73.rs
+++ b/bindgen-tests/tests/expectations/tests/win32-thiscall_1_73.rs
@@ -7,16 +7,8 @@ pub struct Foo {
 }
 #[test]
 fn bindgen_test_layout_Foo() {
-    assert_eq!(
-        ::std::mem::size_of::<Foo>(),
-        1usize,
-        concat!("Size of: ", stringify!(Foo)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Foo>(),
-        1usize,
-        concat!("Alignment of ", stringify!(Foo)),
-    );
+    assert_eq!(::std::mem::size_of::<Foo>(), 1usize, "Size of Foo");
+    assert_eq!(::std::mem::align_of::<Foo>(), 1usize, "Alignment of Foo");
 }
 extern "thiscall" {
     #[link_name = "\u{1}?test@Foo@@QAEXXZ"]

--- a/bindgen-tests/tests/expectations/tests/win32-thiscall_nightly.rs
+++ b/bindgen-tests/tests/expectations/tests/win32-thiscall_nightly.rs
@@ -6,19 +6,10 @@
 pub struct Foo {
     pub _address: u8,
 }
-#[test]
-fn bindgen_test_layout_Foo() {
-    assert_eq!(
-        ::std::mem::size_of::<Foo>(),
-        1usize,
-        concat!("Size of: ", stringify!(Foo)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<Foo>(),
-        1usize,
-        concat!("Alignment of ", stringify!(Foo)),
-    );
-}
+const _: () = {
+    ["Size of Foo"][::std::mem::size_of::<Foo>() - 1usize];
+    ["Alignment of Foo"][::std::mem::align_of::<Foo>() - 1usize];
+};
 extern "thiscall" {
     #[link_name = "\u{1}?test@Foo@@QAEXXZ"]
     pub fn Foo_test(this: *mut Foo);

--- a/bindgen-tests/tests/expectations/tests/zero-size-array-align.rs
+++ b/bindgen-tests/tests/expectations/tests/zero-size-array-align.rs
@@ -36,33 +36,14 @@ pub struct dm_deps {
     pub filler: ::std::os::raw::c_uint,
     pub device: __IncompleteArrayField<::std::os::raw::c_ulonglong>,
 }
-#[test]
-fn bindgen_test_layout_dm_deps() {
-    const UNINIT: ::std::mem::MaybeUninit<dm_deps> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<dm_deps>(),
-        8usize,
-        concat!("Size of: ", stringify!(dm_deps)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<dm_deps>(),
-        8usize,
-        concat!("Alignment of ", stringify!(dm_deps)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).count) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(dm_deps), "::", stringify!(count)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).filler) as usize - ptr as usize },
-        4usize,
-        concat!("Offset of field: ", stringify!(dm_deps), "::", stringify!(filler)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).device) as usize - ptr as usize },
-        8usize,
-        concat!("Offset of field: ", stringify!(dm_deps), "::", stringify!(device)),
-    );
-}
+const _: () = {
+    ["Size of dm_deps"][::std::mem::size_of::<dm_deps>() - 8usize];
+    ["Alignment of dm_deps"][::std::mem::align_of::<dm_deps>() - 8usize];
+    ["Offset of field: dm_deps::count"][::std::mem::offset_of!(dm_deps, count) - 0usize];
+    [
+        "Offset of field: dm_deps::filler",
+    ][::std::mem::offset_of!(dm_deps, filler) - 4usize];
+    [
+        "Offset of field: dm_deps::device",
+    ][::std::mem::offset_of!(dm_deps, device) - 8usize];
+};

--- a/bindgen-tests/tests/expectations/tests/zero-sized-array.rs
+++ b/bindgen-tests/tests/expectations/tests/zero-sized-array.rs
@@ -35,57 +35,30 @@ impl<T> ::std::fmt::Debug for __IncompleteArrayField<T> {
 pub struct ZeroSizedArray {
     pub arr: __IncompleteArrayField<::std::os::raw::c_char>,
 }
-#[test]
-fn bindgen_test_layout_ZeroSizedArray() {
-    const UNINIT: ::std::mem::MaybeUninit<ZeroSizedArray> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<ZeroSizedArray>(),
-        0usize,
-        concat!("Size of: ", stringify!(ZeroSizedArray)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<ZeroSizedArray>(),
-        1usize,
-        concat!("Alignment of ", stringify!(ZeroSizedArray)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).arr) as usize - ptr as usize },
-        0usize,
-        concat!("Offset of field: ", stringify!(ZeroSizedArray), "::", stringify!(arr)),
-    );
-}
+const _: () = {
+    ["Size of ZeroSizedArray"][::std::mem::size_of::<ZeroSizedArray>() - 0usize];
+    ["Alignment of ZeroSizedArray"][::std::mem::align_of::<ZeroSizedArray>() - 1usize];
+    [
+        "Offset of field: ZeroSizedArray::arr",
+    ][::std::mem::offset_of!(ZeroSizedArray, arr) - 0usize];
+};
 /// And nor should this get an `_address` field.
 #[repr(C)]
 #[derive(Debug, Default)]
 pub struct ContainsZeroSizedArray {
     pub zsa: ZeroSizedArray,
 }
-#[test]
-fn bindgen_test_layout_ContainsZeroSizedArray() {
-    const UNINIT: ::std::mem::MaybeUninit<ContainsZeroSizedArray> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<ContainsZeroSizedArray>(),
-        0usize,
-        concat!("Size of: ", stringify!(ContainsZeroSizedArray)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<ContainsZeroSizedArray>(),
-        1usize,
-        concat!("Alignment of ", stringify!(ContainsZeroSizedArray)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).zsa) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(ContainsZeroSizedArray),
-            "::",
-            stringify!(zsa),
-        ),
-    );
-}
+const _: () = {
+    [
+        "Size of ContainsZeroSizedArray",
+    ][::std::mem::size_of::<ContainsZeroSizedArray>() - 0usize];
+    [
+        "Alignment of ContainsZeroSizedArray",
+    ][::std::mem::align_of::<ContainsZeroSizedArray>() - 1usize];
+    [
+        "Offset of field: ContainsZeroSizedArray::zsa",
+    ][::std::mem::offset_of!(ContainsZeroSizedArray, zsa) - 0usize];
+};
 /** Inheriting from ZeroSizedArray shouldn't cause an `_address` to be inserted
  either.*/
 #[repr(C)]
@@ -93,78 +66,45 @@ fn bindgen_test_layout_ContainsZeroSizedArray() {
 pub struct InheritsZeroSizedArray {
     pub _base: ZeroSizedArray,
 }
-#[test]
-fn bindgen_test_layout_InheritsZeroSizedArray() {
-    assert_eq!(
-        ::std::mem::size_of::<InheritsZeroSizedArray>(),
-        0usize,
-        concat!("Size of: ", stringify!(InheritsZeroSizedArray)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<InheritsZeroSizedArray>(),
-        1usize,
-        concat!("Alignment of ", stringify!(InheritsZeroSizedArray)),
-    );
-}
+const _: () = {
+    [
+        "Size of InheritsZeroSizedArray",
+    ][::std::mem::size_of::<InheritsZeroSizedArray>() - 0usize];
+    [
+        "Alignment of InheritsZeroSizedArray",
+    ][::std::mem::align_of::<InheritsZeroSizedArray>() - 1usize];
+};
 /// And this should not get an `_address` field either.
 #[repr(C)]
 #[derive(Debug, Default)]
 pub struct DynamicallySizedArray {
     pub arr: __IncompleteArrayField<::std::os::raw::c_char>,
 }
-#[test]
-fn bindgen_test_layout_DynamicallySizedArray() {
-    const UNINIT: ::std::mem::MaybeUninit<DynamicallySizedArray> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<DynamicallySizedArray>(),
-        0usize,
-        concat!("Size of: ", stringify!(DynamicallySizedArray)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<DynamicallySizedArray>(),
-        1usize,
-        concat!("Alignment of ", stringify!(DynamicallySizedArray)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).arr) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(DynamicallySizedArray),
-            "::",
-            stringify!(arr),
-        ),
-    );
-}
+const _: () = {
+    [
+        "Size of DynamicallySizedArray",
+    ][::std::mem::size_of::<DynamicallySizedArray>() - 0usize];
+    [
+        "Alignment of DynamicallySizedArray",
+    ][::std::mem::align_of::<DynamicallySizedArray>() - 1usize];
+    [
+        "Offset of field: DynamicallySizedArray::arr",
+    ][::std::mem::offset_of!(DynamicallySizedArray, arr) - 0usize];
+};
 /// No `_address` field here either.
 #[repr(C)]
 #[derive(Debug, Default)]
 pub struct ContainsDynamicallySizedArray {
     pub dsa: DynamicallySizedArray,
 }
-#[test]
-fn bindgen_test_layout_ContainsDynamicallySizedArray() {
-    const UNINIT: ::std::mem::MaybeUninit<ContainsDynamicallySizedArray> = ::std::mem::MaybeUninit::uninit();
-    let ptr = UNINIT.as_ptr();
-    assert_eq!(
-        ::std::mem::size_of::<ContainsDynamicallySizedArray>(),
-        0usize,
-        concat!("Size of: ", stringify!(ContainsDynamicallySizedArray)),
-    );
-    assert_eq!(
-        ::std::mem::align_of::<ContainsDynamicallySizedArray>(),
-        1usize,
-        concat!("Alignment of ", stringify!(ContainsDynamicallySizedArray)),
-    );
-    assert_eq!(
-        unsafe { ::std::ptr::addr_of!((*ptr).dsa) as usize - ptr as usize },
-        0usize,
-        concat!(
-            "Offset of field: ",
-            stringify!(ContainsDynamicallySizedArray),
-            "::",
-            stringify!(dsa),
-        ),
-    );
-}
+const _: () = {
+    [
+        "Size of ContainsDynamicallySizedArray",
+    ][::std::mem::size_of::<ContainsDynamicallySizedArray>() - 0usize];
+    [
+        "Alignment of ContainsDynamicallySizedArray",
+    ][::std::mem::align_of::<ContainsDynamicallySizedArray>() - 1usize];
+    [
+        "Offset of field: ContainsDynamicallySizedArray::dsa",
+    ][::std::mem::offset_of!(ContainsDynamicallySizedArray, dsa) - 0usize];
+};

--- a/bindgen/features.rs
+++ b/bindgen/features.rs
@@ -97,6 +97,7 @@ define_rust_targets! {
     Nightly => {
         vectorcall_abi,
     },
+    Stable_1_77(77) => { offset_of: #106655 },
     Stable_1_73(73) => { thiscall_abi: #42202 },
     Stable_1_71(71) => { c_unwind_abi: #106075 },
     Stable_1_68(68) => { abi_efiapi: #105795 },


### PR DESCRIPTION
This commit emits layout tests as compile-time assertions, rather than as unit tests. This allows them to be run in situations where running unit tests is unfeasible, i.e. cross-compiled code and nostd targets.

Fixes #2786. @ojeda - I noticed you tagged the feature request for Rust-for-Linux.