### PR TITLE
Add prettyplease feature to bindgen-cli

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -207,6 +207,8 @@
 - Add target mappings for riscv64imac and riscv32imafc.
 ## Removed
 ## Fixed
+- Fix `--formatter=prettyplease` not working in `bindgen-cli` by adding `prettyplease` feature and
+  enabling it by default for `bindgen-cli` (#2789) .
 ## Security
 
 # 0.69.4 (2024-02-04)

--- a/bindgen-cli/Cargo.toml
+++ b/bindgen-cli/Cargo.toml
@@ -20,7 +20,7 @@ path = "main.rs"
 name = "bindgen"
 
 [dependencies]
-bindgen = { path = "../bindgen", version = "=0.69.4",  default-features = false, features = ["__cli", "experimental"] }
+bindgen = { path = "../bindgen", version = "=0.69.4",  default-features = false, features = ["__cli", "experimental", "prettyplease"] }
 clap = { version = "4", features = ["derive"] }
 clap_complete = "4"
 env_logger = { version = "0.10.0", optional = true }
@@ -34,6 +34,7 @@ static = ["bindgen/static"]
 runtime = ["bindgen/runtime"]
 # Dynamically discover a `rustfmt` binary using the `which` crate
 which-rustfmt = ["bindgen/which-rustfmt"]
+prettyplease = ["bindgen/prettyplease"]
 
 ## The following features are for internal use and they shouldn't be used if
 ## you're not hacking on bindgen


### PR DESCRIPTION
The bindgen documentation explictly mentions being able to use `--formatter=prettyplease`, but currently the prettyplease feature has no way to be enabled.
Enable it by default, since the documentation also doesn't mention needing to cargo install with a feature.

Documentation: https://rust-lang.github.io/rust-bindgen/code-formatting.html