### PR TITLE
Add Dockerfiles to run bindgen-tests with many clang versions

### DIFF
--- a/.github/workflows/bindgen-tests.yml
+++ b/.github/workflows/bindgen-tests.yml
@@ -1,0 +1,33 @@
+name: bindgen-tests with different versions of clang
+
+on:
+  push:
+    branches:
+      - "**"
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        llvm_version: [13, 14, 15, 16, 17, 18]
+
+    steps:
+      - uses: actions/checkout@v4
+        name: Checkout code
+
+      - name: Build Clang Docker Image
+        run: |
+          docker build ./dockerfiles/ -f dockerfiles/Dockerfile-clang -t clang:${{ matrix.llvm_version }}-ubuntu --build-arg LLVM_VERSION=${{ matrix.llvm_version }}
+
+      - name: Build Bindgen Docker Image
+        run: |
+          docker build . -f dockerfiles/Dockerfile-bindgen -t bindgen:clang-${{ matrix.llvm_version }}-ubuntu --build-arg LLVM_VERSION=${{ matrix.llvm_version }}
+
+      - name: Run Tests in Docker Container
+        run: |
+          docker run bindgen:clang-${{ matrix.llvm_version }}-ubuntu

--- a/dockerfiles/Dockerfile-bindgen
+++ b/dockerfiles/Dockerfile-bindgen
@@ -1,0 +1,10 @@
+ARG	LLVM_VERSION=13
+
+FROM clang:${LLVM_VERSION}-ubuntu
+
+RUN	curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain nightly
+
+COPY	.	/project
+WORKDIR	/project
+
+CMD	["/root/.cargo/bin/cargo", "test", "-p", "bindgen-tests", "--features", "__testing_only_extra_assertions"]

--- a/dockerfiles/Dockerfile-clang
+++ b/dockerfiles/Dockerfile-clang
@@ -1,0 +1,16 @@
+FROM ubuntu:jammy
+
+ENV	DEBIAN_FRONTEND	noninteractive
+
+ARG	LLVM_VERSION=13
+
+RUN	apt-get update && apt-get install -y \
+	wget \
+	curl \
+	gnupg \
+	build-essential \
+	&& wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor | tee /usr/share/keyrings/llvm-archive-keyring.gpg > /dev/null \
+	&& echo "deb [signed-by=/usr/share/keyrings/llvm-archive-keyring.gpg] https://apt.llvm.org/jammy/ llvm-toolchain-jammy-${LLVM_VERSION} main" > /etc/apt/sources.list.d/llvm.list \
+	&& apt-get update && apt-get install -y \
+	clang-${LLVM_VERSION} \
+	libclang-${LLVM_VERSION}-dev

--- a/dockerfiles/README.md
+++ b/dockerfiles/README.md
@@ -1,0 +1,31 @@
+# Dockerfiles for running cargo test on bindgen-tests
+
+## Dockerfile-clang
+
+LLVM_VERSION can be [13, 18] and correspond to the packages at [apt.llvm.org](https://apt.llvm.org/) for Ubuntu 22.04
+
+From the `rust-bingen` repo,
+
+```
+docker build dockerfiles -f dockerfiles/Dockerfile-clang -t clang:14-ubuntu --build-arg LLVM_VERSION=14
+```
+
+## Dockerfile-bindgen
+
+From the `rust-bindgen` repo,
+
+```
+docker build . -f dockerfiles/Dockerfile-bindgen -t bindgen:clang-14-ubuntu --build-arg LLVM_VERSION=14
+```
+
+## Make changes to the repo happen in the docker container
+
+```
+docker run -v .:/project bindgen:clang-14-ubuntu
+```
+
+To pass an environment variable to the container
+
+```
+docker run -v .:/project -e BINDGEN_OVERWRITE_EXPECTED=1 bindgen:clang-14-ubuntu
+```


### PR DESCRIPTION
As mentioned in #2638, this contains Dockerfiles to run bindgen-tests against clang versions 13-18 using Ubuntu 22.04

The included dockerfiles/README.md explains the usage of the Dockerfiles.

@pvdrz Let me know what you think.