### PR TITLE
Simplify Rust to Clang target conversion

### DIFF
--- a/bindgen/lib.rs
+++ b/bindgen/lib.rs
@@ -686,45 +686,31 @@ pub(crate) const HOST_TARGET: &str =
 // Some architecture triplets are different between rust and libclang, see #1211
 // and duplicates.
 fn rust_to_clang_target(rust_target: &str) -> Box<str> {
-    if rust_target.starts_with("aarch64-apple-") {
-        let mut clang_target = "arm64-apple-".to_owned();
-        clang_target
-            .push_str(rust_target.strip_prefix("aarch64-apple-").unwrap());
-        return clang_target.into();
-    } else if rust_target.starts_with("riscv64gc-") {
-        let mut clang_target = "riscv64-".to_owned();
-        clang_target.push_str(rust_target.strip_prefix("riscv64gc-").unwrap());
-        return clang_target.into();
-    } else if rust_target.starts_with("riscv64imac-") {
-        let mut clang_target = "riscv64-".to_owned();
-        clang_target
-            .push_str(rust_target.strip_prefix("riscv64imac-").unwrap());
-        return clang_target.into();
-    } else if rust_target.ends_with("-espidf") {
-        let mut clang_target =
-            rust_target.strip_suffix("-espidf").unwrap().to_owned();
-        clang_target.push_str("-elf");
-        if clang_target.starts_with("riscv32imc-") {
-            clang_target = "riscv32-".to_owned() +
-                clang_target.strip_prefix("riscv32imc-").unwrap();
-        }
-        return clang_target.into();
-    } else if rust_target.starts_with("riscv32imc-") {
-        let mut clang_target = "riscv32-".to_owned();
-        clang_target.push_str(rust_target.strip_prefix("riscv32imc-").unwrap());
-        return clang_target.into();
-    } else if rust_target.starts_with("riscv32imac-") {
-        let mut clang_target = "riscv32-".to_owned();
-        clang_target
-            .push_str(rust_target.strip_prefix("riscv32imac-").unwrap());
-        return clang_target.into();
-    } else if rust_target.starts_with("riscv32imafc-") {
-        let mut clang_target = "riscv32-".to_owned();
-        clang_target
-            .push_str(rust_target.strip_prefix("riscv32imafc-").unwrap());
-        return clang_target.into();
+    const TRIPLE_HYPHENS_MESSAGE: &str = "Target triple should contain hyphens";
+
+    let mut clang_target = rust_target.to_owned();
+
+    if clang_target.starts_with("riscv32") {
+        let idx = clang_target.find('-').expect(TRIPLE_HYPHENS_MESSAGE);
+
+        clang_target.replace_range(..idx, "riscv32");
+    } else if clang_target.starts_with("riscv64") {
+        let idx = clang_target.find('-').expect(TRIPLE_HYPHENS_MESSAGE);
+
+        clang_target.replace_range(..idx, "riscv64");
+    } else if clang_target.starts_with("aarch64-apple-") {
+        let idx = clang_target.find('-').expect(TRIPLE_HYPHENS_MESSAGE);
+
+        clang_target.replace_range(..idx, "arm64");
     }
-    rust_target.into()
+
+    if clang_target.ends_with("-espidf") {
+        let idx = clang_target.rfind('-').expect(TRIPLE_HYPHENS_MESSAGE);
+
+        clang_target.replace_range((idx + 1).., "elf");
+    }
+
+    clang_target.into()
 }
 
 /// Returns the effective target, and whether it was explicitly specified on the
@@ -1381,6 +1367,10 @@ fn test_rust_to_clang_target_riscv() {
     );
     assert_eq!(
         rust_to_clang_target("riscv32imafc-unknown-none-elf").as_ref(),
+        "riscv32-unknown-none-elf"
+    );
+    assert_eq!(
+        rust_to_clang_target("riscv32i-unknown-none-elf").as_ref(),
         "riscv32-unknown-none-elf"
     );
 }


### PR DESCRIPTION
This change simplifies/generalizes the rust to clang target conversion and allows more targets to work. (e.g. `riscv32i-unknown-none-elf`)

Let me know if I'm missing something!