### PR TITLE
Remove which dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,7 +40,6 @@ dependencies = [
  "rustc-hash",
  "shlex",
  "syn 2.0.18",
- "which",
 ]
 
 [[package]]
@@ -660,17 +659,6 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
-
-[[package]]
-name = "which"
-version = "4.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2441c784c52b289a054b7201fc93253e288f094e2f4be9058343127c4226a269"
-dependencies = [
- "either",
- "libc",
- "once_cell",
-]
 
 [[package]]
 name = "winapi"

--- a/bindgen-cli/Cargo.toml
+++ b/bindgen-cli/Cargo.toml
@@ -28,12 +28,10 @@ log = { version = "0.4", optional = true }
 shlex = "1"
 
 [features]
-default = ["logging", "runtime", "which-rustfmt"]
+default = ["logging", "runtime"]
 logging = ["bindgen/logging", "dep:env_logger", "dep:log"]
 static = ["bindgen/static"]
 runtime = ["bindgen/runtime"]
-# Dynamically discover a `rustfmt` binary using the `which` crate
-which-rustfmt = ["bindgen/which-rustfmt"]
 prettyplease = ["bindgen/prettyplease"]
 
 ## The following features are for internal use and they shouldn't be used if

--- a/bindgen-tests/Cargo.toml
+++ b/bindgen-tests/Cargo.toml
@@ -19,7 +19,6 @@ owo-colors = "3.5.0"
 logging = ["bindgen/logging"]
 static = ["bindgen/static"]
 runtime = ["bindgen/runtime"]
-which-rustfmt = ["bindgen/which-rustfmt"]
 
 __testing_only_extra_assertions = ["bindgen/__testing_only_extra_assertions"]
 __testing_only_libclang_9 = ["bindgen/__testing_only_libclang_9"]

--- a/bindgen/Cargo.toml
+++ b/bindgen/Cargo.toml
@@ -40,15 +40,14 @@ regex = { version = "1.5.3", default-features = false, features = ["std", "unico
 rustc-hash = "1.0.1"
 shlex = "1"
 syn = { version = "2.0", features = ["full", "extra-traits", "visit-mut"] }
-which = { version = "4.2.1", optional = true, default-features = false }
 
 [features]
-default = ["logging", "prettyplease", "runtime", "which-rustfmt"]
+default = ["logging", "prettyplease", "runtime"]
 logging = ["dep:log"]
 static = ["clang-sys/static"]
 runtime = ["clang-sys/runtime"]
-# Dynamically discover a `rustfmt` binary using the `which` crate
-which-rustfmt = ["dep:which"]
+# This feature is no longer used for anything and should be removed in bindgen 0.70
+which-rustfmt = []
 experimental = ["dep:annotate-snippets"]
 
 ## The following features are for internal use and they shouldn't be used if

--- a/bindgen/lib.rs
+++ b/bindgen/lib.rs
@@ -983,14 +983,6 @@ impl Bindings {
         if let Ok(rustfmt) = env::var("RUSTFMT") {
             return Ok(Cow::Owned(rustfmt.into()));
         }
-        #[cfg(feature = "which-rustfmt")]
-        match which::which("rustfmt") {
-            Ok(p) => Ok(Cow::Owned(p)),
-            Err(e) => {
-                Err(io::Error::new(io::ErrorKind::Other, format!("{}", e)))
-            }
-        }
-        #[cfg(not(feature = "which-rustfmt"))]
         // No rustfmt binary was specified, so assume that the binary is called
         // "rustfmt" and that it is in the user's PATH.
         Ok(Cow::Owned("rustfmt".into()))


### PR DESCRIPTION
The which dependency was introduced alongside the ability for bindgen to call rustfmt: https://github.com/rust-lang/rust-bindgen/pull/905

Theres been some dancing around the need for this dependency, with a feature added to disable it back in 2019 https://github.com/rust-lang/rust-bindgen/pull/1615

But I dont believe its actually required at all and in this PR I propose that we can just remove it entirely.

My understanding is that `which` will check the PATH for any binaries matching the passed name.
However if we were to just attempt to execute that name directly the OS would perform the exact same operation, checking the PATH for any binaries matching the name.
So we should just directly execute `rustfmt`, unless its overridden by the `RUSTFMT` env var.

If my understanding is incorrect, lets instead document why which is needed.