### PR TITLE
feat: add dynamic loading of variable

### DIFF
--- a/bindgen-tests/tests/expectations/tests/dynamic_loading_variable_required.rs
+++ b/bindgen-tests/tests/expectations/tests/dynamic_loading_variable_required.rs
@@ -1,0 +1,32 @@
+#![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
+pub struct TestLib {
+    __library: ::libloading::Library,
+    pub foo: *mut ::std::os::raw::c_int,
+    pub baz: *mut *mut ::std::os::raw::c_int,
+}
+impl TestLib {
+    pub unsafe fn new<P>(path: P) -> Result<Self, ::libloading::Error>
+    where
+        P: AsRef<::std::ffi::OsStr>,
+    {
+        let library = ::libloading::Library::new(path)?;
+        Self::from_library(library)
+    }
+    pub unsafe fn from_library<L>(library: L) -> Result<Self, ::libloading::Error>
+    where
+        L: Into<::libloading::Library>,
+    {
+        let __library = library.into();
+        let foo = __library.get::<*mut ::std::os::raw::c_int>(b"foo\0").map(|sym| *sym)?;
+        let baz = __library
+            .get::<*mut *mut ::std::os::raw::c_int>(b"baz\0")
+            .map(|sym| *sym)?;
+        Ok(TestLib { __library, foo, baz })
+    }
+    pub unsafe fn foo(&self) -> *mut ::std::os::raw::c_int {
+        self.foo
+    }
+    pub unsafe fn baz(&self) -> *mut *mut ::std::os::raw::c_int {
+        self.baz
+    }
+}

--- a/bindgen-tests/tests/expectations/tests/dynamic_loading_variable_simple.rs
+++ b/bindgen-tests/tests/expectations/tests/dynamic_loading_variable_simple.rs
@@ -1,0 +1,32 @@
+#![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
+pub struct TestLib {
+    __library: ::libloading::Library,
+    pub foo: Result<*mut ::std::os::raw::c_int, ::libloading::Error>,
+    pub baz: Result<*mut *mut ::std::os::raw::c_int, ::libloading::Error>,
+}
+impl TestLib {
+    pub unsafe fn new<P>(path: P) -> Result<Self, ::libloading::Error>
+    where
+        P: AsRef<::std::ffi::OsStr>,
+    {
+        let library = ::libloading::Library::new(path)?;
+        Self::from_library(library)
+    }
+    pub unsafe fn from_library<L>(library: L) -> Result<Self, ::libloading::Error>
+    where
+        L: Into<::libloading::Library>,
+    {
+        let __library = library.into();
+        let foo = __library.get::<*mut ::std::os::raw::c_int>(b"foo\0").map(|sym| *sym);
+        let baz = __library
+            .get::<*mut *mut ::std::os::raw::c_int>(b"baz\0")
+            .map(|sym| *sym);
+        Ok(TestLib { __library, foo, baz })
+    }
+    pub unsafe fn foo(&self) -> *mut ::std::os::raw::c_int {
+        *self.foo.as_ref().expect("Expected variable, got error.")
+    }
+    pub unsafe fn baz(&self) -> *mut *mut ::std::os::raw::c_int {
+        *self.baz.as_ref().expect("Expected variable, got error.")
+    }
+}

--- a/bindgen-tests/tests/expectations/tests/dynamic_loading_variable_with_allowlist.rs
+++ b/bindgen-tests/tests/expectations/tests/dynamic_loading_variable_with_allowlist.rs
@@ -1,0 +1,30 @@
+#![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
+pub struct TestLib {
+    __library: ::libloading::Library,
+    pub foo: Result<*mut ::std::os::raw::c_int, ::libloading::Error>,
+    pub bar: Result<*mut ::std::os::raw::c_int, ::libloading::Error>,
+}
+impl TestLib {
+    pub unsafe fn new<P>(path: P) -> Result<Self, ::libloading::Error>
+    where
+        P: AsRef<::std::ffi::OsStr>,
+    {
+        let library = ::libloading::Library::new(path)?;
+        Self::from_library(library)
+    }
+    pub unsafe fn from_library<L>(library: L) -> Result<Self, ::libloading::Error>
+    where
+        L: Into<::libloading::Library>,
+    {
+        let __library = library.into();
+        let foo = __library.get::<*mut ::std::os::raw::c_int>(b"foo\0").map(|sym| *sym);
+        let bar = __library.get::<*mut ::std::os::raw::c_int>(b"bar\0").map(|sym| *sym);
+        Ok(TestLib { __library, foo, bar })
+    }
+    pub unsafe fn foo(&self) -> *mut ::std::os::raw::c_int {
+        *self.foo.as_ref().expect("Expected variable, got error.")
+    }
+    pub unsafe fn bar(&self) -> *mut ::std::os::raw::c_int {
+        *self.bar.as_ref().expect("Expected variable, got error.")
+    }
+}

--- a/bindgen-tests/tests/headers/dynamic_loading_variable_required.h
+++ b/bindgen-tests/tests/headers/dynamic_loading_variable_required.h
@@ -1,0 +1,4 @@
+// bindgen-flags: --dynamic-loading TestLib --dynamic-link-require-all
+
+int foo;
+int *baz;

--- a/bindgen-tests/tests/headers/dynamic_loading_variable_simple.h
+++ b/bindgen-tests/tests/headers/dynamic_loading_variable_simple.h
@@ -1,0 +1,4 @@
+// bindgen-flags: --dynamic-loading TestLib
+
+int foo;
+int *baz;

--- a/bindgen-tests/tests/headers/dynamic_loading_variable_with_allowlist.hpp
+++ b/bindgen-tests/tests/headers/dynamic_loading_variable_with_allowlist.hpp
@@ -1,0 +1,5 @@
+// bindgen-flags: --dynamic-loading TestLib --allowlist-var foo --allowlist-var bar
+
+int foo;
+int bar;
+int baz; // should not be allowed

--- a/bindgen/codegen/dyngen.rs
+++ b/bindgen/codegen/dyngen.rs
@@ -1,7 +1,7 @@
 use crate::codegen;
 use crate::ir::context::BindgenContext;
 use crate::ir::function::ClangAbi;
-use proc_macro2::Ident;
+use proc_macro2::{Ident, TokenStream};
 
 /// Used to build the output tokens for dynamic bindings.
 #[derive(Default)]
@@ -122,7 +122,7 @@ impl DynamicItems {
     }
 
     #[allow(clippy::too_many_arguments)]
-    pub(crate) fn push(
+    pub(crate) fn push_func(
         &mut self,
         ident: Ident,
         abi: ClangAbi,
@@ -189,6 +189,49 @@ impl DynamicItems {
         } else {
             quote! {
                 let #ident = #library_get.map(|sym| *sym);
+            }
+        });
+
+        self.init_fields.push(quote! {
+            #ident
+        });
+    }
+
+    pub fn push_var(
+        &mut self,
+        ident: Ident,
+        ty: TokenStream,
+        is_required: bool,
+    ) {
+        let member = if is_required {
+            quote! { *mut #ty }
+        } else {
+            quote! { Result<*mut #ty, ::libloading::Error> }
+        };
+
+        self.struct_members.push(quote! {
+            pub #ident: #member,
+        });
+
+        let deref = if is_required {
+            quote! { self.#ident }
+        } else {
+            quote! { *self.#ident.as_ref().expect("Expected variable, got error.") }
+        };
+        self.struct_implementation.push(quote! {
+            pub unsafe fn #ident (&self) -> *mut #ty {
+                #deref
+            }
+        });
+
+        let ident_str = codegen::helpers::ast_ty::cstr_expr(ident.to_string());
+        self.constructor_inits.push(if is_required {
+            quote! {
+                let #ident = __library.get::<*mut #ty>(#ident_str).map(|sym| *sym)?;
+            }
+        } else {
+            quote! {
+                let #ident = __library.get::<*mut #ty>(#ident_str).map(|sym| *sym);
             }
         });
 


### PR DESCRIPTION
It's just a rebase of #2114 , since the original pull requests are closed, I thought might just rebase and create a new one for reviewing, @emilio.

Supporting for dynamic loading can be a useful feature when one need to found library in a dynamic way(i.e. choose between libraries with compatible ABI), and supporting loading static variable is a important feature in this feature.