### PR TITLE
Remove lazy_static and lazycell dependencies

### DIFF
--- a/.github/workflows/bindgen.yml
+++ b/.github/workflows/bindgen.yml
@@ -50,20 +50,20 @@ jobs:
         with:
           # MSRV below is documented in Cargo.toml and README.md, please update those if you
           # change this.
-          toolchain: 1.60.0
+          toolchain: 1.70.0
 
       - name: Test lib with msrv
-        run: cargo +1.60.0 test --package bindgen
+        run: cargo +1.70.0 test --package bindgen
 
       - name: Install msrv for cli
         uses: dtolnay/rust-toolchain@master
         with:
           # MSRV below is documented in Cargo.toml and README.md, please update those if you
           # change this.
-          toolchain: 1.64.0
+          toolchain: 1.70.0
 
       - name: Test cli with msrv
-        run: cargo +1.64.0 build --package bindgen-cli
+        run: cargo +1.70.0 build --package bindgen-cli
 
   minimal:
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,8 +30,6 @@ dependencies = [
  "cexpr",
  "clang-sys",
  "itertools",
- "lazy_static",
- "lazycell",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -312,12 +310,6 @@ name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
-
-[[package]]
-name = "lazycell"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -306,12 +306,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lazy_static"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
-
-[[package]]
 name = "libc"
 version = "0.2.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -465,7 +459,6 @@ name = "quickchecking"
 version = "0.0.0"
 dependencies = [
  "clap",
- "lazy_static",
  "quickcheck",
  "tempfile",
 ]

--- a/README.md
+++ b/README.md
@@ -39,9 +39,9 @@ extern "C" {
 
 ## MSRV
 
-The `bindgen` minimum supported Rust version is **1.60.0**.
+The `bindgen` minimum supported Rust version is **1.70.0**.
 
-The `bindgen-cli` minimum supported Rust version is **1.64.0**.
+The `bindgen-cli` minimum supported Rust version is **1.70.0**.
 
 No MSRV bump policy has been established yet, so MSRV may increase in any release.
 

--- a/bindgen-cli/Cargo.toml
+++ b/bindgen-cli/Cargo.toml
@@ -13,7 +13,7 @@ documentation = "https://docs.rs/bindgen"
 homepage = "https://rust-lang.github.io/rust-bindgen/"
 version = "0.69.4"
 edition = "2018"
-rust-version = "1.64.0"
+rust-version = "1.70.0"
 
 [[bin]]
 path = "main.rs"

--- a/bindgen-tests/tests/quickchecking/Cargo.toml
+++ b/bindgen-tests/tests/quickchecking/Cargo.toml
@@ -3,7 +3,7 @@ name = "quickchecking"
 description = "Bindgen property tests with quickcheck. Generate random valid C code and pass it to the csmith/predicate.py script"
 version = "0.0.0"
 publish = false
-rust-version = "1.64"
+rust-version = "1.70"
 edition = "2018"
 
 [lib]

--- a/bindgen-tests/tests/quickchecking/Cargo.toml
+++ b/bindgen-tests/tests/quickchecking/Cargo.toml
@@ -16,7 +16,6 @@ path = "src/bin.rs"
 
 [dependencies]
 clap = "4"
-lazy_static = "1.0"
 quickcheck = "1.0"
 tempfile = "3"
 

--- a/bindgen-tests/tests/quickchecking/src/lib.rs
+++ b/bindgen-tests/tests/quickchecking/src/lib.rs
@@ -14,10 +14,7 @@
 //!     println!("{}", header);
 //! }
 //! ```
-//!
 #![deny(missing_docs)]
-#[macro_use]
-extern crate lazy_static;
 
 use quickcheck::{Gen, QuickCheck, TestResult};
 use std::error::Error;
@@ -38,10 +35,7 @@ struct Context {
 }
 
 // Initialize global context.
-lazy_static! {
-    static ref CONTEXT: Mutex<Context> =
-        Mutex::new(Context { output_path: None });
-}
+static CONTEXT: Mutex<Context> = Mutex::new(Context { output_path: None });
 
 // Passes fuzzed header to the `csmith-fuzzing/predicate.py` script, returns
 // output of the associated command.

--- a/bindgen/Cargo.toml
+++ b/bindgen/Cargo.toml
@@ -18,7 +18,7 @@ version = "0.69.4"
 edition = "2018"
 build = "build.rs"
 # If you change this, also update README.md and msrv in .github/workflows/bindgen.yml
-rust-version = "1.60.0"
+rust-version = "1.70.0"
 
 [lib]
 name = "bindgen"
@@ -30,8 +30,6 @@ bitflags = "2.2.1"
 cexpr = "0.6"
 clang-sys = { version = "1", features = ["clang_6_0"] }
 itertools = { version = ">=0.10,<0.13", default-features = false }
-lazy_static = "1"
-lazycell = "1"
 log = { version = "0.4", optional = true }
 prettyplease = { version = "0.2.7", optional = true, features = ["verbatim"] }
 proc-macro2 = { version = "1", default-features = false }

--- a/bindgen/callbacks.rs
+++ b/bindgen/callbacks.rs
@@ -7,19 +7,14 @@ pub use crate::ir::int::IntKind;
 use std::fmt;
 
 /// An enum to allow ignoring parsing of macros.
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Default)]
 pub enum MacroParsingBehavior {
     /// Ignore the macro, generating no code for it, or anything that depends on
     /// it.
     Ignore,
     /// The default behavior bindgen would have otherwise.
+    #[default]
     Default,
-}
-
-impl Default for MacroParsingBehavior {
-    fn default() -> Self {
-        MacroParsingBehavior::Default
-    }
 }
 
 /// A trait to allow configuring different kinds of types in different

--- a/bindgen/clang.rs
+++ b/bindgen/clang.rs
@@ -14,8 +14,8 @@ use std::fs::OpenOptions;
 use std::hash::Hash;
 use std::hash::Hasher;
 use std::os::raw::{c_char, c_int, c_longlong, c_uint, c_ulong, c_ulonglong};
-use std::{mem, ptr, slice};
 use std::sync::OnceLock;
+use std::{mem, ptr, slice};
 
 /// Type representing a clang attribute.
 ///

--- a/bindgen/codegen/mod.rs
+++ b/bindgen/codegen/mod.rs
@@ -2608,7 +2608,7 @@ impl CodeGenerator for CompInfo {
                 ctx,
                 &canonical_ident,
                 flex_inner_ty,
-                &*generic_param_names,
+                &generic_param_names,
                 &impl_generics_labels,
             ));
         }
@@ -3010,7 +3010,7 @@ impl Method {
 }
 
 /// A helper type that represents different enum variations.
-#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug, Default)]
 pub enum EnumVariation {
     /// The code for this enum will use a Rust enum. Note that creating this in unsafe code
     /// (including FFI) with an invalid value will invoke undefined behaviour, whether or not
@@ -3027,6 +3027,7 @@ pub enum EnumVariation {
         is_global: bool,
     },
     /// The code for this enum will use consts
+    #[default]
     Consts,
     /// The code for this enum will use a module containing consts
     ModuleConsts,
@@ -3041,12 +3042,6 @@ impl EnumVariation {
     /// true.
     fn is_const(&self) -> bool {
         matches!(*self, EnumVariation::Consts | EnumVariation::ModuleConsts)
-    }
-}
-
-impl Default for EnumVariation {
-    fn default() -> EnumVariation {
-        EnumVariation::Consts
     }
 }
 
@@ -3757,11 +3752,12 @@ impl CodeGenerator for Enum {
 }
 
 /// Enum for the default type of macro constants.
-#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug, Default)]
 pub enum MacroTypeVariation {
     /// Use i32 or i64
     Signed,
     /// Use u32 or u64
+    #[default]
     Unsigned,
 }
 
@@ -3772,12 +3768,6 @@ impl fmt::Display for MacroTypeVariation {
             Self::Unsigned => "unsigned",
         };
         s.fmt(f)
-    }
-}
-
-impl Default for MacroTypeVariation {
-    fn default() -> MacroTypeVariation {
-        MacroTypeVariation::Unsigned
     }
 }
 
@@ -3801,9 +3791,10 @@ impl std::str::FromStr for MacroTypeVariation {
 }
 
 /// Enum for how aliases should be translated.
-#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug, Default)]
 pub enum AliasVariation {
     /// Convert to regular Rust alias
+    #[default]
     TypeAlias,
     /// Create a new type by wrapping the old type in a struct and using #[repr(transparent)]
     NewType,
@@ -3820,12 +3811,6 @@ impl fmt::Display for AliasVariation {
         };
 
         s.fmt(f)
-    }
-}
-
-impl Default for AliasVariation {
-    fn default() -> AliasVariation {
-        AliasVariation::TypeAlias
     }
 }
 

--- a/bindgen/ir/analysis/has_vtable.rs
+++ b/bindgen/ir/analysis/has_vtable.rs
@@ -9,9 +9,10 @@ use std::cmp;
 use std::ops;
 
 /// The result of the `HasVtableAnalysis` for an individual item.
-#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Default)]
 pub(crate) enum HasVtableResult {
     /// The item does not have a vtable pointer.
+    #[default]
     No,
 
     /// The item has a vtable and the actual vtable pointer is within this item.
@@ -20,12 +21,6 @@ pub(crate) enum HasVtableResult {
     /// The item has a vtable, but the actual vtable pointer is in a base
     /// member.
     BaseHasVtable,
-}
-
-impl Default for HasVtableResult {
-    fn default() -> Self {
-        HasVtableResult::No
-    }
 }
 
 impl HasVtableResult {

--- a/bindgen/ir/analysis/mod.rs
+++ b/bindgen/ir/analysis/mod.rs
@@ -125,20 +125,15 @@ pub(crate) trait MonotoneFramework: Sized + fmt::Debug {
 
 /// Whether an analysis's `constrain` function modified the incremental results
 /// or not.
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Default)]
 pub(crate) enum ConstrainResult {
     /// The incremental results were updated, and the fix-point computation
     /// should continue.
     Changed,
 
     /// The incremental results were not updated.
+    #[default]
     Same,
-}
-
-impl Default for ConstrainResult {
-    fn default() -> Self {
-        ConstrainResult::Same
-    }
 }
 
 impl ops::BitOr for ConstrainResult {

--- a/bindgen/ir/analysis/sizedness.rs
+++ b/bindgen/ir/analysis/sizedness.rs
@@ -24,13 +24,14 @@ use std::{cmp, ops};
 ///
 /// We initially assume that all types are `ZeroSized` and then update our
 /// understanding as we learn more about each type.
-#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Default)]
 pub(crate) enum SizednessResult {
     /// The type is zero-sized.
     ///
     /// This means that if it is a C++ type, and is not being used as a base
     /// member, then we must add an `_address` byte to enforce the
     /// unique-address-per-distinct-object-instance rule.
+    #[default]
     ZeroSized,
 
     /// Whether this type is zero-sized or not depends on whether a type
@@ -60,12 +61,6 @@ pub(crate) enum SizednessResult {
     /// it might contain an incomplete array or some other dynamically sized
     /// type.
     NonZeroSized,
-}
-
-impl Default for SizednessResult {
-    fn default() -> Self {
-        SizednessResult::ZeroSized
-    }
 }
 
 impl SizednessResult {

--- a/bindgen/ir/annotations.rs
+++ b/bindgen/ir/annotations.rs
@@ -9,13 +9,14 @@ use std::str::FromStr;
 use crate::clang;
 
 /// What kind of visibility modifier should be used for a struct or field?
-#[derive(Copy, PartialEq, Eq, PartialOrd, Ord, Clone, Debug)]
+#[derive(Copy, PartialEq, Eq, PartialOrd, Ord, Clone, Debug, Default)]
 pub enum FieldVisibilityKind {
     /// Fields are marked as private, i.e., struct Foo {bar: bool}
     Private,
     /// Fields are marked as crate public, i.e., struct Foo {pub(crate) bar: bool}
     PublicCrate,
     /// Fields are marked as public, i.e., struct Foo {pub bar: bool}
+    #[default]
     Public,
 }
 
@@ -41,12 +42,6 @@ impl std::fmt::Display for FieldVisibilityKind {
         };
 
         s.fmt(f)
-    }
-}
-
-impl Default for FieldVisibilityKind {
-    fn default() -> Self {
-        FieldVisibilityKind::Public
     }
 }
 

--- a/bindgen/ir/derive.rs
+++ b/bindgen/ir/derive.rs
@@ -92,9 +92,10 @@ pub(crate) trait CanDeriveOrd {
 ///
 /// Initially we assume that we can derive trait for all types and then
 /// update our understanding as we learn more about each type.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Default)]
 pub enum CanDerive {
     /// Yes, we can derive automatically.
+    #[default]
     Yes,
 
     /// The only thing that stops us from automatically deriving is that
@@ -105,12 +106,6 @@ pub enum CanDerive {
 
     /// No, we cannot.
     No,
-}
-
-impl Default for CanDerive {
-    fn default() -> CanDerive {
-        CanDerive::Yes
-    }
 }
 
 impl CanDerive {

--- a/bindgen/ir/item.rs
+++ b/bindgen/ir/item.rs
@@ -1807,8 +1807,9 @@ impl Item {
             spelling: &str,
         ) -> bool {
             static ANON_TYPE_PARAM_RE: OnceLock<regex::Regex> = OnceLock::new();
-            let anon_type_param_re = ANON_TYPE_PARAM_RE.get_or_init(||
-                    regex::Regex::new(r"^type\-parameter\-\d+\-\d+$").unwrap());
+            let anon_type_param_re = ANON_TYPE_PARAM_RE.get_or_init(|| {
+                regex::Regex::new(r"^type\-parameter\-\d+\-\d+$").unwrap()
+            });
 
             if refd.kind() != clang_sys::CXCursor_TemplateTypeParameter {
                 return false;

--- a/bindgen/ir/item.rs
+++ b/bindgen/ir/item.rs
@@ -20,13 +20,12 @@ use super::ty::{Type, TypeKind};
 use crate::clang;
 use crate::parse::{ClangSubItemParser, ParseError, ParseResult};
 
-use lazycell::LazyCell;
-
-use std::cell::Cell;
+use std::cell::{Cell, OnceCell};
 use std::collections::BTreeSet;
 use std::fmt::Write;
 use std::io;
 use std::iter;
+use std::sync::OnceLock;
 
 /// A trait to get the canonical name from an item.
 ///
@@ -380,7 +379,7 @@ pub(crate) struct Item {
     ///
     /// Note that only structs, unions, and enums get a local type ID. In any
     /// case this is an implementation detail.
-    local_id: LazyCell<usize>,
+    local_id: OnceCell<usize>,
 
     /// The next local ID to use for a child or template instantiation.
     next_child_local_id: Cell<usize>,
@@ -389,11 +388,11 @@ pub(crate) struct Item {
     ///
     /// This is a fairly used operation during codegen so this makes bindgen
     /// considerably faster in those cases.
-    canonical_name: LazyCell<String>,
+    canonical_name: OnceCell<String>,
 
     /// The path to use for allowlisting and other name-based checks, as
     /// returned by `path_for_allowlisting`, lazily constructed.
-    path_for_allowlisting: LazyCell<Vec<String>>,
+    path_for_allowlisting: OnceCell<Vec<String>>,
 
     /// A doc comment over the item, if any.
     comment: Option<String>,
@@ -431,10 +430,10 @@ impl Item {
         debug_assert!(id != parent_id || kind.is_module());
         Item {
             id,
-            local_id: LazyCell::new(),
+            local_id: OnceCell::new(),
             next_child_local_id: Cell::new(1),
-            canonical_name: LazyCell::new(),
-            path_for_allowlisting: LazyCell::new(),
+            canonical_name: OnceCell::new(),
+            path_for_allowlisting: OnceCell::new(),
             parent_id,
             comment,
             annotations: annotations.unwrap_or_default(),
@@ -535,7 +534,7 @@ impl Item {
     /// below this item's lexical scope, meaning that this can be useful for
     /// generating relatively stable identifiers within a scope.
     pub(crate) fn local_id(&self, ctx: &BindgenContext) -> usize {
-        *self.local_id.borrow_with(|| {
+        *self.local_id.get_or_init(|| {
             let parent = ctx.resolve_item(self.parent_id);
             parent.next_child_local_id()
         })
@@ -1037,7 +1036,7 @@ impl Item {
         ctx: &BindgenContext,
     ) -> &Vec<String> {
         self.path_for_allowlisting
-            .borrow_with(|| self.compute_path(ctx, UserMangled::No))
+            .get_or_init(|| self.compute_path(ctx, UserMangled::No))
     }
 
     fn compute_path(
@@ -1807,10 +1806,9 @@ impl Item {
             refd: &clang::Cursor,
             spelling: &str,
         ) -> bool {
-            lazy_static! {
-                static ref ANON_TYPE_PARAM_RE: regex::Regex =
-                    regex::Regex::new(r"^type\-parameter\-\d+\-\d+$").unwrap();
-            }
+            static ANON_TYPE_PARAM_RE: OnceLock<regex::Regex> = OnceLock::new();
+            let anon_type_param_re = ANON_TYPE_PARAM_RE.get_or_init(||
+                    regex::Regex::new(r"^type\-parameter\-\d+\-\d+$").unwrap());
 
             if refd.kind() != clang_sys::CXCursor_TemplateTypeParameter {
                 return false;
@@ -1819,7 +1817,7 @@ impl Item {
             let refd_spelling = refd.spelling();
             refd_spelling == spelling ||
                 // Allow for anonymous template parameters.
-                (refd_spelling.is_empty() && ANON_TYPE_PARAM_RE.is_match(spelling.as_ref()))
+                (refd_spelling.is_empty() && anon_type_param_re.is_match(spelling.as_ref()))
         }
 
         let definition = if is_template_with_spelling(&location, &ty_spelling) {
@@ -1909,7 +1907,7 @@ impl ItemCanonicalName for Item {
             "You're not supposed to call this yet"
         );
         self.canonical_name
-            .borrow_with(|| {
+            .get_or_init(|| {
                 let in_namespace = ctx.options().enable_cxx_namespaces ||
                     ctx.options().disable_name_namespacing;
 


### PR DESCRIPTION
This functionality was moved into the standard library, with a slightly different API, in Rust 1.70 (June 2023). As this was nearly a year ago now I think this is a reasonable MSRV bump. (The change to quickchecking makes use of `Mutex::new` now being const.)