### PR TITLE
Remove legacy integer methods

### DIFF
--- a/bindgen/clang.rs
+++ b/bindgen/clang.rs
@@ -2355,7 +2355,7 @@ impl EvalResult {
 
         if unsafe { clang_EvalResult_isUnsignedInt(self.x) } != 0 {
             let value = unsafe { clang_EvalResult_getAsUnsigned(self.x) };
-            if value > i64::max_value() as c_ulonglong {
+            if value > i64::MAX as c_ulonglong {
                 return None;
             }
 
@@ -2363,10 +2363,10 @@ impl EvalResult {
         }
 
         let value = unsafe { clang_EvalResult_getAsLongLong(self.x) };
-        if value > i64::max_value() as c_longlong {
+        if value > i64::MAX as c_longlong {
             return None;
         }
-        if value < i64::min_value() as c_longlong {
+        if value < i64::MIN as c_longlong {
             return None;
         }
         #[allow(clippy::unnecessary_cast)]

--- a/bindgen/codegen/mod.rs
+++ b/bindgen/codegen/mod.rs
@@ -2608,7 +2608,7 @@ impl CodeGenerator for CompInfo {
                 ctx,
                 &canonical_ident,
                 flex_inner_ty,
-                &*generic_param_names,
+                &generic_param_names,
                 &impl_generics_labels,
             ));
         }

--- a/bindgen/ir/var.rs
+++ b/bindgen/ir/var.rs
@@ -129,27 +129,23 @@ fn default_macro_constant_type(ctx: &BindgenContext, value: i64) -> IntKind {
         ctx.options().default_macro_constant_type ==
             MacroTypeVariation::Signed
     {
-        if value < i32::min_value() as i64 || value > i32::max_value() as i64 {
+        if value < i32::MIN as i64 || value > i32::MAX as i64 {
             IntKind::I64
         } else if !ctx.options().fit_macro_constants ||
-            value < i16::min_value() as i64 ||
-            value > i16::max_value() as i64
+            value < i16::MIN as i64 ||
+            value > i16::MAX as i64
         {
             IntKind::I32
-        } else if value < i8::min_value() as i64 ||
-            value > i8::max_value() as i64
-        {
+        } else if value < i8::MIN as i64 || value > i8::MAX as i64 {
             IntKind::I16
         } else {
             IntKind::I8
         }
-    } else if value > u32::max_value() as i64 {
+    } else if value > u32::MAX as i64 {
         IntKind::U64
-    } else if !ctx.options().fit_macro_constants ||
-        value > u16::max_value() as i64
-    {
+    } else if !ctx.options().fit_macro_constants || value > u16::MAX as i64 {
         IntKind::U32
-    } else if value > u8::max_value() as i64 {
+    } else if value > u8::MAX as i64 {
         IntKind::U16
     } else {
         IntKind::U8
@@ -243,7 +239,7 @@ impl ClangSubItemParser for Var {
                                 c as u8
                             }
                             CChar::Raw(c) => {
-                                assert!(c <= ::std::u8::MAX as u64);
+                                assert!(c <= u8::MAX as u64);
                                 c as u8
                             }
                         };


### PR DESCRIPTION
This is coming up as a new Clippy lint (https://rust-lang.github.io/rust-clippy/master/index.html#/legacy_numeric_constants) on CI runs. The constants in question have been stable for ages (since 1.43).