### PR TITLE
Switch to single precompiled header in macro fallback

### DIFF
--- a/bindgen-tests/tests/expectations/tests/libclang-9/macro_fallback_non_system_dir.rs
+++ b/bindgen-tests/tests/expectations/tests/libclang-9/macro_fallback_non_system_dir.rs
@@ -1,0 +1,1 @@
+pub const NEGATIVE: i32 = -1;

--- a/bindgen-tests/tests/expectations/tests/test_macro_fallback_non_system_dir.rs
+++ b/bindgen-tests/tests/expectations/tests/test_macro_fallback_non_system_dir.rs
@@ -1,0 +1,6 @@
+pub const CONST: u32 = 5;
+pub const OTHER_CONST: u32 = 6;
+pub const LARGE_CONST: u32 = 1536;
+pub const THE_CONST: u32 = 28;
+pub const MY_CONST: u32 = 69;
+pub const NEGATIVE: i32 = -1;

--- a/bindgen-tests/tests/headers/issue-753.h
+++ b/bindgen-tests/tests/headers/issue-753.h
@@ -1,7 +1,12 @@
 // bindgen-flags: --clang-macro-fallback
 
+#ifndef ISSUE_753_H
+#define ISSUE_753_H
+
 #define UINT32_C(c) c ## U
 
 #define CONST UINT32_C(5)
 #define OTHER_CONST UINT32_C(6)
 #define LARGE_CONST UINT32_C(6 << 8)
+
+#endif

--- a/bindgen-tests/tests/macro_fallback_test_headers/another_header.h
+++ b/bindgen-tests/tests/macro_fallback_test_headers/another_header.h
@@ -1,0 +1,10 @@
+#ifndef ANOTHER_HEADER_H
+#define ANOTHER_HEADER_H
+
+#include <issue-753.h>
+
+#define SHOULD_NOT_GENERATE UINT64_C(~0)
+#define MY_CONST UINT32_C(69)
+#define NEGATIVE ~0
+
+#endif

--- a/bindgen-tests/tests/macro_fallback_test_headers/one_header.h
+++ b/bindgen-tests/tests/macro_fallback_test_headers/one_header.h
@@ -1,0 +1,8 @@
+#ifndef ONE_HEADER_H
+#define ONE_HEADER_H
+
+#include <issue-753.h>
+
+#define THE_CONST UINT32_C(28)
+
+#endif

--- a/bindgen/clang.rs
+++ b/bindgen/clang.rs
@@ -1908,7 +1908,8 @@ impl Drop for TranslationUnit {
 /// Translation unit used for macro fallback parsing
 pub(crate) struct FallbackTranslationUnit {
     file_path: String,
-    pch_paths: Vec<String>,
+    header_path: String,
+    pch_path: String,
     idx: Box<Index>,
     tu: TranslationUnit,
 }
@@ -1923,7 +1924,8 @@ impl FallbackTranslationUnit {
     /// Create a new fallback translation unit
     pub(crate) fn new(
         file: String,
-        pch_paths: Vec<String>,
+        header_path: String,
+        pch_path: String,
         c_args: &[Box<str>],
     ) -> Option<Self> {
         // Create empty file
@@ -1944,7 +1946,8 @@ impl FallbackTranslationUnit {
         )?;
         Some(FallbackTranslationUnit {
             file_path: file,
-            pch_paths,
+            header_path,
+            pch_path,
             tu: f_translation_unit,
             idx: f_index,
         })
@@ -1982,9 +1985,8 @@ impl FallbackTranslationUnit {
 impl Drop for FallbackTranslationUnit {
     fn drop(&mut self) {
         let _ = std::fs::remove_file(&self.file_path);
-        for pch in self.pch_paths.iter() {
-            let _ = std::fs::remove_file(pch);
-        }
+        let _ = std::fs::remove_file(&self.header_path);
+        let _ = std::fs::remove_file(&self.pch_path);
     }
 }
 


### PR DESCRIPTION
Fix for issue reported [here](https://github.com/rust-lang/rust-bindgen/pull/2779#issuecomment-2081376090).

@SeleDreams Could you also confirm that this resolves your problem?