### PR TITLE
Use clang_getFileLocation instead of clang_getSpellingLocation

### DIFF
--- a/bindgen/clang.rs
+++ b/bindgen/clang.rs
@@ -1610,7 +1610,7 @@ impl SourceLocation {
             let mut line = 0;
             let mut col = 0;
             let mut off = 0;
-            clang_getSpellingLocation(
+            clang_getFileLocation(
                 self.x, &mut file, &mut line, &mut col, &mut off,
             );
             (File { x: file }, line as usize, col as usize, off as usize)


### PR DESCRIPTION
Both had the same behavior... until https://github.com/llvm/llvm-project/commit/2e770edd8ce13f48402f1d93e5fb982d8a2ebe64 which fixed getSpellingLocation, but bindgen looks like it actually expects the getFileLocation result.