### PR TITLE
Allow itertools 0.13, bump Cargo.lock to it

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -298,9 +298,9 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]

--- a/bindgen/Cargo.toml
+++ b/bindgen/Cargo.toml
@@ -29,7 +29,7 @@ annotate-snippets = { version = "0.9.1", features = ["color"], optional = true }
 bitflags = "2.2.1"
 cexpr = "0.6"
 clang-sys = { version = "1", features = ["clang_6_0"] }
-itertools = { version = ">=0.10,<0.13", default-features = false }
+itertools = { version = ">=0.10,<0.14", default-features = false }
 log = { version = "0.4", optional = true }
 prettyplease = { version = "0.2.7", optional = true, features = ["verbatim"] }
 proc-macro2 = { version = "1", default-features = false }


### PR DESCRIPTION
In the vein of https://github.com/rust-lang/rust-bindgen/pull/2745, just in the other direction.

Changes: https://github.com/rust-itertools/itertools/blob/master/CHANGELOG.md#0130