### PR TITLE
Print CLI errors to stderr instead of stdout

### DIFF
--- a/bindgen-cli/main.rs
+++ b/bindgen-cli/main.rs
@@ -38,7 +38,7 @@ pub fn main() {
                 if verbose {
                     print_verbose_err()
                 }
-                println!("{}", info);
+                eprintln!("{}", info);
             }));
 
             let bindings =
@@ -49,21 +49,21 @@ pub fn main() {
             bindings.write(output).expect("Unable to write output");
         }
         Err(error) => {
-            println!("{}", error);
+            eprintln!("{}", error);
             std::process::exit(1);
         }
     };
 }
 
 fn print_verbose_err() {
-    println!("Bindgen unexpectedly panicked");
-    println!(
+    eprintln!("Bindgen unexpectedly panicked");
+    eprintln!(
         "This may be caused by one of the known-unsupported \
          things (https://rust-lang.github.io/rust-bindgen/cpp.html), \
          please modify the bindgen flags to work around it as \
          described in https://rust-lang.github.io/rust-bindgen/cpp.html"
     );
-    println!(
+    eprintln!(
         "Otherwise, please file an issue at \
          https://github.com/rust-lang/rust-bindgen/issues/new"
     );


### PR DESCRIPTION
This prevents them of sneaking into output files instead of being displayed when manually generating bindings by redirecting stdout.

Similar to #1031, the CLI should print to stderr too.