### PR TITLE
Added non-exhaustive enums to the CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -207,6 +207,7 @@
 - Add a complex macro fallback API (#2779).
 - Add option to use DST structs for flexible arrays (--flexarray-dst, #2772).
 - Add option to dynamically load variables (#2812).
+- Add option in CLI to use rustified non-exhaustive enums (--rustified-non-exhaustive-enum, #2847).
 ## Changed
 - Remove which and lazy-static dependencies (#2809, #2817).
 - Generate compile-time layout tests (#2787).

--- a/bindgen-cli/options.rs
+++ b/bindgen-cli/options.rs
@@ -114,6 +114,9 @@ struct BindgenCommand {
     /// Mark any enum whose name matches REGEX as a Rust enum.
     #[arg(long, value_name = "REGEX")]
     rustified_enum: Vec<String>,
+    /// Mark any enum whose name matches REGEX as a non-exhaustive Rust enum.
+    #[arg(long, value_name = "REGEX")]
+    rustified_non_exhaustive_enum: Vec<String>,
     /// Mark any enum whose name matches REGEX as a series of constants.
     #[arg(long, value_name = "REGEX")]
     constified_enum: Vec<String>,
@@ -469,6 +472,7 @@ where
         newtype_enum,
         newtype_global_enum,
         rustified_enum,
+        rustified_non_exhaustive_enum,
         constified_enum,
         constified_enum_module,
         default_macro_constant_type,
@@ -633,6 +637,10 @@ where
 
     for regex in rustified_enum {
         builder = builder.rustified_enum(regex);
+    }
+
+    for regex in rustified_non_exhaustive_enum {
+        builder = builder.rustified_non_exhaustive_enum(regex);
     }
 
     for regex in constified_enum {
@@ -1081,8 +1089,8 @@ where
             &self,
             info: &bindgen::callbacks::DeriveInfo<'_>,
         ) -> Vec<String> {
-            if self.kind.map(|kind| kind == info.kind).unwrap_or(true) &&
-                self.regex_set.matches(info.name)
+            if self.kind.map(|kind| kind == info.kind).unwrap_or(true)
+                && self.regex_set.matches(info.name)
             {
                 return self.derives.clone();
             }

--- a/bindgen-cli/options.rs
+++ b/bindgen-cli/options.rs
@@ -1089,8 +1089,8 @@ where
             &self,
             info: &bindgen::callbacks::DeriveInfo<'_>,
         ) -> Vec<String> {
-            if self.kind.map(|kind| kind == info.kind).unwrap_or(true)
-                && self.regex_set.matches(info.name)
+            if self.kind.map(|kind| kind == info.kind).unwrap_or(true) &&
+                self.regex_set.matches(info.name)
             {
                 return self.derives.clone();
             }

--- a/bindgen/lib.rs
+++ b/bindgen/lib.rs
@@ -87,10 +87,10 @@ pub const DEFAULT_ANON_FIELDS_PREFIX: &str = "__bindgen_anon_";
 const DEFAULT_NON_EXTERN_FNS_SUFFIX: &str = "__extern";
 
 fn file_is_cpp(name_file: &str) -> bool {
-    name_file.ends_with(".hpp")
-        || name_file.ends_with(".hxx")
-        || name_file.ends_with(".hh")
-        || name_file.ends_with(".h++")
+    name_file.ends_with(".hpp") ||
+        name_file.ends_with(".hxx") ||
+        name_file.ends_with(".hh") ||
+        name_file.ends_with(".h++")
 }
 
 fn args_are_cpp(clang_args: &[Box<str>]) -> bool {
@@ -799,8 +799,8 @@ impl Bindings {
                             return false;
                         }
 
-                        if arg.starts_with("-I")
-                            || arg.starts_with("--include-directory=")
+                        if arg.starts_with("-I") ||
+                            arg.starts_with("--include-directory=")
                         {
                             return false;
                         }
@@ -827,8 +827,8 @@ impl Bindings {
             debug!("Found clang: {:?}", clang);
 
             // Whether we are working with C or C++ inputs.
-            let is_cpp = args_are_cpp(&options.clang_args)
-                || options.input_headers.iter().any(|h| file_is_cpp(h));
+            let is_cpp = args_are_cpp(&options.clang_args) ||
+                options.input_headers.iter().any(|h| file_is_cpp(h));
 
             let search_paths = if is_cpp {
                 clang.cpp_search_paths

--- a/bindgen/lib.rs
+++ b/bindgen/lib.rs
@@ -237,7 +237,7 @@ impl std::fmt::Display for Formatter {
 /// 2. [`bitfield_enum()`](#method.bitfield_enum)
 /// 3. [`newtype_enum()`](#method.newtype_enum)
 /// 4. [`rustified_enum()`](#method.rustified_enum)
-/// 4. [`rustified_non_exhaustive_enum()`](#method.rustified_non_exhaustive_enum)
+/// 5. [`rustified_non_exhaustive_enum()`](#method.rustified_non_exhaustive_enum)
 ///
 /// For each C enum, bindgen tries to match the pattern in the following order:
 ///

--- a/bindgen/lib.rs
+++ b/bindgen/lib.rs
@@ -87,10 +87,10 @@ pub const DEFAULT_ANON_FIELDS_PREFIX: &str = "__bindgen_anon_";
 const DEFAULT_NON_EXTERN_FNS_SUFFIX: &str = "__extern";
 
 fn file_is_cpp(name_file: &str) -> bool {
-    name_file.ends_with(".hpp") ||
-        name_file.ends_with(".hxx") ||
-        name_file.ends_with(".hh") ||
-        name_file.ends_with(".h++")
+    name_file.ends_with(".hpp")
+        || name_file.ends_with(".hxx")
+        || name_file.ends_with(".hh")
+        || name_file.ends_with(".h++")
 }
 
 fn args_are_cpp(clang_args: &[Box<str>]) -> bool {
@@ -237,6 +237,7 @@ impl std::fmt::Display for Formatter {
 /// 2. [`bitfield_enum()`](#method.bitfield_enum)
 /// 3. [`newtype_enum()`](#method.newtype_enum)
 /// 4. [`rustified_enum()`](#method.rustified_enum)
+/// 4. [`rustified_non_exhaustive_enum()`](#method.rustified_non_exhaustive_enum)
 ///
 /// For each C enum, bindgen tries to match the pattern in the following order:
 ///
@@ -798,8 +799,8 @@ impl Bindings {
                             return false;
                         }
 
-                        if arg.starts_with("-I") ||
-                            arg.starts_with("--include-directory=")
+                        if arg.starts_with("-I")
+                            || arg.starts_with("--include-directory=")
                         {
                             return false;
                         }
@@ -826,8 +827,8 @@ impl Bindings {
             debug!("Found clang: {:?}", clang);
 
             // Whether we are working with C or C++ inputs.
-            let is_cpp = args_are_cpp(&options.clang_args) ||
-                options.input_headers.iter().any(|h| file_is_cpp(h));
+            let is_cpp = args_are_cpp(&options.clang_args)
+                || options.input_headers.iter().any(|h| file_is_cpp(h));
 
             let search_paths = if is_cpp {
                 clang.cpp_search_paths


### PR DESCRIPTION
Currently the CLI allows for all other enum builder options except for non-exhaustive rustified enums. This PR fixes the omission.

Solves #2846 