### PR TITLE
ci: Add Rust for Linux

### DIFF
--- a/.github/workflows/bindgen.yml
+++ b/.github/workflows/bindgen.yml
@@ -227,6 +227,7 @@ jobs:
           BINDGEN_FEATURE_RUNTIME: ${{matrix.feature_runtime}}
           BINDGEN_FEATURE_EXTRA_ASSERTS: ${{matrix.feature_extra_asserts}}
           BINDGEN_NO_DEFAULT_FEATURES: ${{matrix.no_default_features}}
+          BINDGEN_RUST_FOR_LINUX_TEST: ${{matrix.os == 'ubuntu-latest' && matrix.llvm_version == '16.0' && matrix.feature_extra_asserts == 0 && 1 || 0}}
         run: ./ci/test.sh
 
   check-cfg:

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -118,3 +118,79 @@ assert_no_diff
 
 # Run the integration tests
 (cd bindgen-integration && cargo test $CARGO_ARGS)
+
+if [ "$BINDGEN_RUST_FOR_LINUX_TEST" == "1" ]; then
+  # Run the Rust for Linux test
+  #
+  # This is intended to be an end-to-end test that runs what Linux kernel
+  # developers/users would do. It is a quick, build-only test of the Rust code
+  # in the Linux kernel.
+
+  # Put LLVM binaries in the path for `LLVM=1`. The LLVM `bin` directory should
+  # go first since there are others in the Ubuntu image.
+  export PATH="${LLVM_DIRECTORY}/bin:${PATH}"
+
+  # Kernel build dependency: `bindgen-cli`, which is under test.
+  #
+  # Using `cargo build` (and adding the two common profiles to the `$PATH`) so
+  # that we can use `$CARGO_ARGS` as is, since `cargo install` does not support
+  # `--release`. `--target-dir` is used to isolate from other possible tests.
+  # A cleaner alternative is using `--out-dir`, but it is unstable.
+  (cd bindgen-cli && cargo build --target-dir ${HOME}/.bindgen $CARGO_ARGS)
+  export PATH="${HOME}/.bindgen/release:${HOME}/.bindgen/debug:${PATH}"
+
+  # Kernel build dependency: `libelf-dev`.
+  sudo apt-get update
+  sudo apt-get install libelf-dev
+
+  # Kernel build dependency: the Rust standard library sources.
+  #
+  # `rustup` is used here to install the `rust-src` component (instead of using
+  # `actions-rs/toolchain`'s `components` option in the workflow step) since we
+  # only need it for this test, and anyway the action installs `rustup`.
+  rustup component add rust-src
+
+  # Ideally this should be updated from time to time (e.g. every kernel `-rc1`),
+  # and each update should only contain this change.
+  #
+  # Both commit hashes and tags are supported.
+  LINUX_VERSION=c13320499ba0efd93174ef6462ae8a7a2933f6e7
+
+  # Download Linux at a specific commit
+  mkdir -p linux
+  git -C linux init
+  git -C linux remote add origin https://github.com/torvalds/linux.git
+  git -C linux fetch --depth 1 origin ${LINUX_VERSION}
+  git -C linux checkout FETCH_HEAD
+
+  # Configure Rust for Linux
+  cat <<EOF > linux/kernel/configs/rfl-for-bindgen-ci.config
+# CONFIG_WERROR is not set
+
+CONFIG_RUST=y
+
+CONFIG_SAMPLES=y
+CONFIG_SAMPLES_RUST=y
+
+CONFIG_SAMPLE_RUST_MINIMAL=m
+CONFIG_SAMPLE_RUST_PRINT=y
+
+CONFIG_RUST_PHYLIB_ABSTRACTIONS=y
+CONFIG_AX88796B_PHY=y
+CONFIG_AX88796B_RUST_PHY=y
+
+CONFIG_KUNIT=y
+CONFIG_RUST_KERNEL_DOCTESTS=y
+EOF
+
+  make -C linux LLVM=1 -j$(($(nproc) + 1)) \
+      rustavailable \
+      defconfig \
+      rfl-for-bindgen-ci.config
+
+  # Build Rust for Linux
+  make -C linux LLVM=1 -j$(($(nproc) + 1)) \
+      samples/rust/rust_minimal.o \
+      samples/rust/rust_print.o \
+      drivers/net/phy/ax88796b_rust.o
+fi


### PR DESCRIPTION
Rust for Linux, so far, has pinned the Rust compiler and `bindgen` versions. The kernel is looking into expanding that support to several versions, i.e. establishing a minimum supported version, so that the kernel can start to be more easily built. In particular, it should be possible to build the kernel using the tools provided directly by Linux distributions. In order to help achieve that goal, the Rust project has added the kernel to its Rust pre-merge CI.

This commit does the same for `bindgen`. In particular, it adds a quick, build-only test of the Rust code in the kernel as an extra step in the `test` workflow.

This is intended to be an end-to-end test that runs what kernel developers/users would do. In particular, it is useful to catch certain issues that go beyond the C header comparisons. For instance, it would have been able to catch an issue like the `--version` option unexpectedly requiring a header in 0.69.0 (fixed in 0.69.1) [1].

It would also have detected another issue present in 0.66.0 and 0.66.1: a panic handling certain C headers with string literals containing an interior NUL [2]. While the kernel is not really a stable test, and such an issue would still require that a proper test is added, it is nevertheless a good test case of non-trivial C headers that may trigger edge cases like that.

Of course, `bindgen` may need to disable the test for different reasons, i.e. there is no expectation to block any urgent/important PR, and the kernel can also call `bindgen` differently depending on the version, i.e. we are happy to adjust on our side too. Even if it gets disabled often, we would still be in a better situation than not having the test at all.

The Linux version (hash or tag) should ideally be updated from time to time (e.g. every kernel `-rc1`), and each update should only contain that change.

Link: https://github.com/rust-lang/rust-bindgen/pull/2678 [1]
Link: https://github.com/rust-lang/rust-bindgen/pull/2567 [2]