### PR TITLE
Add `FieldInfo::field_type_name`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -238,6 +238,7 @@
 - Add option to use DST structs for flexible arrays (--flexarray-dst, #2772).
 - Add option to dynamically load variables (#2812).
 - Add option in CLI to use rustified non-exhaustive enums (--rustified-non-exhaustive-enum, #2847).
+- Add field_type_name to FieldInfo.
 ## Changed
 - Remove which and lazy-static dependencies (#2809, #2817).
 - Generate compile-time layout tests (#2787).

--- a/bindgen/callbacks.rs
+++ b/bindgen/callbacks.rs
@@ -280,4 +280,6 @@ pub struct FieldInfo<'a> {
     pub type_name: &'a str,
     /// The name of the field.
     pub field_name: &'a str,
+    /// The name of the type of the field.
+    pub field_type_name: Option<&'a str>,
 }

--- a/bindgen/codegen/mod.rs
+++ b/bindgen/codegen/mod.rs
@@ -1544,6 +1544,7 @@ impl FieldCodegen<'_> for FieldData {
                 cb.field_visibility(FieldInfo {
                     type_name: &parent_item.canonical_name(ctx),
                     field_name,
+                    field_type_name: field_ty.name(),
                 })
             }),
             self.annotations(),
@@ -1949,6 +1950,7 @@ impl<'a> FieldCodegen<'a> for Bitfield {
 
         let bitfield_ty_item = ctx.resolve_item(self.ty());
         let bitfield_ty = bitfield_ty_item.expect_type();
+        let bitfield_ty_ident = bitfield_ty.name();
 
         let bitfield_ty_layout = bitfield_ty
             .layout(ctx)
@@ -1973,6 +1975,7 @@ impl<'a> FieldCodegen<'a> for Bitfield {
                 cb.field_visibility(FieldInfo {
                     type_name: &parent_item.canonical_name(ctx),
                     field_name,
+                    field_type_name: bitfield_ty_ident,
                 })
             })
         });

--- a/bindgen/codegen/mod.rs
+++ b/bindgen/codegen/mod.rs
@@ -1118,6 +1118,9 @@ impl CodeGenerator for Type {
                                 cb.field_visibility(FieldInfo {
                                     type_name: &item.canonical_name(ctx),
                                     field_name: "0",
+                                    field_type_name: inner_item
+                                        .expect_type()
+                                        .name(),
                                 })
                             })
                             .unwrap_or(ctx.options().default_visibility);


### PR DESCRIPTION
In my case, I want to make a field private and wrap it behind an accessor function that makes the field `unsafe` to access. I need the field's type in order to make this decision correctly. In some cases a type name is not available and I am fine with that.