### PR TITLE
Add support for custom attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -235,6 +235,7 @@
 - Add option to use DST structs for flexible arrays (--flexarray-dst, #2772).
 - Add option to dynamically load variables (#2812).
 - Add option in CLI to use rustified non-exhaustive enums (--rustified-non-exhaustive-enum, #2847).
+- Add support for custom attributes (--with-attribute-custom, #2866)
 ## Changed
 - Remove which and lazy-static dependencies (#2809, #2817).
 - Generate compile-time layout tests (#2787).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,6 +49,7 @@ dependencies = [
  "clap_complete",
  "env_logger 0.10.0",
  "log",
+ "proc-macro2",
  "shlex",
 ]
 
@@ -69,6 +70,7 @@ dependencies = [
  "clap_complete",
  "owo-colors",
  "prettyplease",
+ "proc-macro2",
  "shlex",
  "similar",
  "syn 2.0.18",

--- a/bindgen-cli/Cargo.toml
+++ b/bindgen-cli/Cargo.toml
@@ -25,6 +25,7 @@ clap = { version = "4", features = ["derive"] }
 clap_complete = "4"
 env_logger = { version = "0.10.0", optional = true }
 log = { version = "0.4", optional = true }
+proc-macro2 = { version = "1", default-features = false }
 shlex = "1"
 
 [features]

--- a/bindgen-integration/build.rs
+++ b/bindgen-integration/build.rs
@@ -133,6 +133,18 @@ impl ParseCallbacks for MacroCallback {
             vec![]
         }
     }
+
+    // Test the "custom attributes" capability.
+    fn add_attributes(
+        &self,
+        info: &bindgen::callbacks::AttributeInfo<'_>,
+    ) -> Vec<String> {
+        if info.name == "Test" {
+            vec!["#[cfg_attr(test, derive(PartialOrd))]".into()]
+        } else {
+            vec![]
+        }
+    }
 }
 
 impl Drop for MacroCallback {

--- a/bindgen-integration/src/lib.rs
+++ b/bindgen-integration/src/lib.rs
@@ -298,6 +298,15 @@ fn test_custom_derive() {
 }
 
 #[test]
+fn test_custom_attributes() {
+    // The `add_attributes` callback should have added `#[cfg_attr(test, derive(PartialOrd))])`
+    // to the `Test` struct. If it didn't, this will fail to compile.
+    let test1 = unsafe { bindings::Test::new(5) };
+    let test2 = unsafe { bindings::Test::new(6) };
+    assert!(test1 < test2);
+}
+
+#[test]
 fn test_wrap_static_fns() {
     // GH-1090: https://github.com/rust-lang/rust-bindgen/issues/1090
     unsafe {

--- a/bindgen-tests/Cargo.toml
+++ b/bindgen-tests/Cargo.toml
@@ -10,6 +10,7 @@ clap = { version = "4", features = ["derive"] }
 clap_complete = "4"
 shlex = "1"
 prettyplease = { version = "0.2.7", features = ["verbatim"] }
+proc-macro2 = { version = "1", default-features = false }
 syn = { version = "2.0" }
 tempfile = "3"
 similar = { version = "2.2.1", features = ["inline"] }

--- a/bindgen-tests/tests/expectations/tests/attribute-custom-cli.rs
+++ b/bindgen-tests/tests/expectations/tests/attribute-custom-cli.rs
@@ -1,0 +1,48 @@
+#![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
+#[repr(C)]
+#[doc(hidden)]
+#[derive(Default)]
+pub struct foo_struct {
+    pub inner: ::std::os::raw::c_int,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of foo_struct"][::std::mem::size_of::<foo_struct>() - 4usize];
+    ["Alignment of foo_struct"][::std::mem::align_of::<foo_struct>() - 4usize];
+    [
+        "Offset of field: foo_struct::inner",
+    ][::std::mem::offset_of!(foo_struct, inner) - 0usize];
+};
+#[repr(u32)]
+#[cfg_attr(test, derive(PartialOrd, Copy))]
+#[derive(Clone, Hash, PartialEq, Eq)]
+pub enum foo_enum {
+    inner = 0,
+}
+#[repr(C)]
+#[doc(hidden)]
+#[derive(Clone)]
+#[derive(Copy)]
+pub union foo_union {
+    pub fst: ::std::mem::ManuallyDrop<::std::os::raw::c_int>,
+    pub snd: ::std::mem::ManuallyDrop<f32>,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of foo_union"][::std::mem::size_of::<foo_union>() - 4usize];
+    ["Alignment of foo_union"][::std::mem::align_of::<foo_union>() - 4usize];
+    ["Offset of field: foo_union::fst"][::std::mem::offset_of!(foo_union, fst) - 0usize];
+    ["Offset of field: foo_union::snd"][::std::mem::offset_of!(foo_union, snd) - 0usize];
+};
+#[repr(C)]
+pub struct non_matching {
+    pub inner: ::std::os::raw::c_int,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of non_matching"][::std::mem::size_of::<non_matching>() - 4usize];
+    ["Alignment of non_matching"][::std::mem::align_of::<non_matching>() - 4usize];
+    [
+        "Offset of field: non_matching::inner",
+    ][::std::mem::offset_of!(non_matching, inner) - 0usize];
+};

--- a/bindgen-tests/tests/expectations/tests/attribute-custom.rs
+++ b/bindgen-tests/tests/expectations/tests/attribute-custom.rs
@@ -1,0 +1,22 @@
+#![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
+/// <div rustbindgen attribute="#[derive(Debug)]"></div>
+#[repr(C)]
+#[derive(Debug)]
+pub struct my_type {
+    pub a: ::std::os::raw::c_int,
+}
+/** <div rustbindgen attribute="#[derive(Debug)]"></div>
+ <div rustbindgen attribute="#[derive(Clone)]"></div>*/
+#[repr(C)]
+#[derive(Debug)]
+#[derive(Clone)]
+pub struct my_type2 {
+    pub a: ::std::os::raw::c_uint,
+}
+/// <div rustbindgen attribute="#[derive(Debug)]" attribute="#[derive(Clone)]"></div>
+#[repr(C)]
+#[derive(Debug)]
+#[derive(Clone)]
+pub struct my_type3 {
+    pub a: ::std::os::raw::c_ulong,
+}

--- a/bindgen-tests/tests/headers/attribute-custom-cli.h
+++ b/bindgen-tests/tests/headers/attribute-custom-cli.h
@@ -1,0 +1,14 @@
+// bindgen-flags: --default-enum-style rust --default-non-copy-union-style manually_drop --no-default=".*" --no-hash=".*" --no-partialeq=".*" --no-debug=".*" --no-copy=".*" --with-attribute-custom="foo_[^e].*=#[doc(hidden)]" --with-attribute-custom-struct="foo.*=#[derive(Default)]" --with-attribute-custom-enum="foo.*=#[cfg_attr(test, derive(PartialOrd, Copy))]" --with-attribute-custom-union="foo.*=#[derive(Clone)],#[derive(Copy)]"
+struct foo_struct {
+    int inner;
+};
+enum foo_enum {
+    inner = 0
+};
+union foo_union {
+    int fst;
+    float snd;
+};
+struct non_matching {
+    int inner;
+};

--- a/bindgen-tests/tests/headers/attribute-custom.h
+++ b/bindgen-tests/tests/headers/attribute-custom.h
@@ -1,0 +1,28 @@
+// bindgen-flags: --no-derive-debug --no-derive-copy --no-derive-default --default-enum-style rust --no-layout-tests
+
+/** <div rustbindgen attribute="#[derive(Debug)]"></div> */
+struct my_type;
+
+/** <div rustbindgen attribute="#[derive(Clone)]"></div> */
+struct my_type;
+
+struct my_type {
+    int a;
+};
+
+/**
+ * <div rustbindgen attribute="#[derive(Debug)]"></div>
+ * <div rustbindgen attribute="#[derive(Clone)]"></div>
+ */
+struct my_type2;
+
+struct my_type2 {
+    unsigned a;
+};
+
+/**
+ * <div rustbindgen attribute="#[derive(Debug)]" attribute="#[derive(Clone)]"></div>
+ */
+struct my_type3 {
+    unsigned long a;
+};

--- a/bindgen/callbacks.rs
+++ b/bindgen/callbacks.rs
@@ -129,6 +129,14 @@ pub trait ParseCallbacks: fmt::Debug {
         vec![]
     }
 
+    /// Provide a list of custom attributes.
+    ///
+    /// If no additional attributes are wanted, this function should return an
+    /// empty `Vec`.
+    fn add_attributes(&self, _info: &AttributeInfo<'_>) -> Vec<String> {
+        vec![]
+    }
+
     /// Process a source code comment.
     fn process_comment(&self, _comment: &str) -> Option<String> {
         None
@@ -161,6 +169,17 @@ pub trait ParseCallbacks: fmt::Debug {
 #[derive(Debug)]
 #[non_exhaustive]
 pub struct DeriveInfo<'a> {
+    /// The name of the type.
+    pub name: &'a str,
+    /// The kind of the type.
+    pub kind: TypeKind,
+}
+
+/// Relevant information about a type to which new attributes will be added using
+/// [`ParseCallbacks::add_attributes`].
+#[derive(Debug)]
+#[non_exhaustive]
+pub struct AttributeInfo<'a> {
     /// The name of the type.
     pub name: &'a str,
     /// The kind of the type.

--- a/bindgen/ir/annotations.rs
+++ b/bindgen/ir/annotations.rs
@@ -102,6 +102,8 @@ pub(crate) struct Annotations {
     constify_enum_variant: bool,
     /// List of explicit derives for this type.
     derives: Vec<String>,
+    /// List of explicit attributes for this type.
+    attributes: Vec<String>,
 }
 
 fn parse_accessor(s: &str) -> FieldAccessorKind {
@@ -169,6 +171,11 @@ impl Annotations {
         &self.derives
     }
 
+    /// The list of attributes that have been specified in this annotation.
+    pub(crate) fn attributes(&self) -> &[String] {
+        &self.attributes
+    }
+
     /// Should we avoid implementing the `Copy` trait?
     pub(crate) fn disallow_copy(&self) -> bool {
         self.disallow_copy
@@ -223,6 +230,7 @@ impl Annotations {
                         )
                     }
                     "derive" => self.derives.push(attr.value),
+                    "attribute" => self.attributes.push(attr.value),
                     "private" => {
                         self.visibility_kind = if attr.value != "false" {
                             Some(FieldVisibilityKind::Private)


### PR DESCRIPTION
This adds support for custom attributes:

- `ParseCallbacks::add_attributes(&self, info: &AttributeInfo<'_>) -> Vec<TokenStream>`
- `--with-attribute-custom <CUSTOM>`
- `--with-attribute-custom-struct <CUSTOM>`
- `--with-attribute-custom-enum <CUSTOM>`
- `--with-attribute-custom-union <CUSTOM>`

The implementation is very similar to the custom derives functionality. One thing I am not sure about is returning `Vec<TokenStream>` instead of `Vec<String>`, but that seemed natural to me.

Fixes https://github.com/rust-lang/rust-bindgen/issues/2520