### PR TITLE
Add tracking issue number for `"vectorcall"` ABI feature

### DIFF
--- a/bindgen/features.rs
+++ b/bindgen/features.rs
@@ -95,7 +95,7 @@ macro_rules! define_rust_targets {
 // not stable.
 define_rust_targets! {
     Nightly => {
-        vectorcall_abi,
+        vectorcall_abi: #124485,
         ptr_metadata: #81513,
         layout_for_ptr: #69835,
     },


### PR DESCRIPTION
The `"vectorcall"` ABI now has a tracking issue at rust-lang/rust#124485.