### PR TITLE
Log item for which layout retrieval fails

### DIFF
--- a/bindgen/codegen/mod.rs
+++ b/bindgen/codegen/mod.rs
@@ -2216,7 +2216,9 @@ impl CodeGenerator for CompInfo {
         } else if is_union && !forward_decl {
             // TODO(emilio): It'd be nice to unify this with the struct path
             // above somehow.
-            let layout = layout.expect("Unable to get layout information?");
+            let layout = layout.unwrap_or_else(|| {
+                panic!("Unable to get layout information for item\n{:#?}", item)
+            });
             if struct_layout.requires_explicit_align(layout) {
                 explicit_align = Some(layout.align);
             }


### PR DESCRIPTION
Related https://github.com/rust-lang/rust-bindgen/issues/1768, https://github.com/ghpr-asia/wsdf/issues/18

I think this would at least make analyzing this failure easier and based on the wsdf issue it seems that in some cases including another file also helps fixing this.