### PR TITLE
Update flex-array implementation to work with Rust 1.80

### DIFF
--- a/bindgen-tests/tests/expectations/tests/flexarray.rs
+++ b/bindgen-tests/tests/expectations/tests/flexarray.rs
@@ -50,7 +50,10 @@ const _: () = {
 impl flexarray<[::std::os::raw::c_int]> {
     pub fn layout(len: usize) -> ::std::alloc::Layout {
         unsafe {
-            let p: *const Self = ::std::ptr::from_raw_parts(::std::ptr::null(), len);
+            let p: *const Self = ::std::ptr::from_raw_parts(
+                ::std::ptr::null::<()>(),
+                len,
+            );
             ::std::alloc::Layout::for_value_raw(p)
         }
     }
@@ -136,7 +139,10 @@ const _: () = {
 impl flexarray_zero<[::std::os::raw::c_int]> {
     pub fn layout(len: usize) -> ::std::alloc::Layout {
         unsafe {
-            let p: *const Self = ::std::ptr::from_raw_parts(::std::ptr::null(), len);
+            let p: *const Self = ::std::ptr::from_raw_parts(
+                ::std::ptr::null::<()>(),
+                len,
+            );
             ::std::alloc::Layout::for_value_raw(p)
         }
     }
@@ -220,7 +226,10 @@ pub struct flexarray_template<T, FAM: ?Sized = [T; 0]> {
 impl<T> flexarray_template<T, [T]> {
     pub fn layout(len: usize) -> ::std::alloc::Layout {
         unsafe {
-            let p: *const Self = ::std::ptr::from_raw_parts(::std::ptr::null(), len);
+            let p: *const Self = ::std::ptr::from_raw_parts(
+                ::std::ptr::null::<()>(),
+                len,
+            );
             ::std::alloc::Layout::for_value_raw(p)
         }
     }
@@ -344,7 +353,10 @@ const _: () = {
 impl flexarray_bogus_zero_fam<[::std::os::raw::c_char]> {
     pub fn layout(len: usize) -> ::std::alloc::Layout {
         unsafe {
-            let p: *const Self = ::std::ptr::from_raw_parts(::std::ptr::null(), len);
+            let p: *const Self = ::std::ptr::from_raw_parts(
+                ::std::ptr::null::<()>(),
+                len,
+            );
             ::std::alloc::Layout::for_value_raw(p)
         }
     }
@@ -450,7 +462,10 @@ const _: () = {
 impl flexarray_align<[::std::os::raw::c_int]> {
     pub fn layout(len: usize) -> ::std::alloc::Layout {
         unsafe {
-            let p: *const Self = ::std::ptr::from_raw_parts(::std::ptr::null(), len);
+            let p: *const Self = ::std::ptr::from_raw_parts(
+                ::std::ptr::null::<()>(),
+                len,
+            );
             ::std::alloc::Layout::for_value_raw(p)
         }
     }

--- a/bindgen/codegen/mod.rs
+++ b/bindgen/codegen/mod.rs
@@ -2723,7 +2723,7 @@ impl CompInfo {
                 pub fn layout(len: usize) -> ::#prefix::alloc::Layout {
                     // SAFETY: Null pointers are OK if we don't deref them
                     unsafe {
-                        let p: *const Self = ::#prefix::ptr::from_raw_parts(::#prefix::ptr::null(), len);
+                        let p: *const Self = ::#prefix::ptr::from_raw_parts(::#prefix::ptr::null::<()>(), len);
                         ::#prefix::alloc::Layout::for_value_raw(p)
                     }
                 }


### PR DESCRIPTION
The signature of `core::ptr::from_raw_parts` is different between Rust 1.79 and Rust 1.80, causing an ambiguity in the code previously produced by bindgen.

- https://doc.rust-lang.org/1.79.0/core/ptr/fn.from_raw_parts.html
- https://doc.rust-lang.org/1.80.0/core/ptr/fn.from_raw_parts.html

```diff
- pub fn from_raw_parts<T: ?Sized>(
+ pub const fn from_raw_parts<T: ?Sized>(
-     data_pointer: *const (),
+     data_pointer: *const impl Thin,
      metadata: <T as Pointee>::Metadata,
  ) -> *const T
```

```console
error[E0283]: type annotations needed
   --> lib.rs:317:62
    |
317 |             let p: *const Self = ::core::ptr::from_raw_parts(::core::ptr::null(), len);
    |                                  --------------------------- ^^^^^^^^^^^^^^^^^ cannot infer type of the type parameter `T` declared on the function `null`
    |                                  |
    |                                  required by a bound introduced by this call
    |
    = note: cannot satisfy `_: Thin`
help: consider specifying the generic argument
    |
317 |             let p: *const Self = ::core::ptr::from_raw_parts(::core::ptr::null::<T>(), len);
    |                                                                               +++++
```