### PR TITLE
Only trigger the publish workflow manually

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,10 +1,8 @@
-# This is triggered after the Release workflow successfully completes its run
-on:
-  workflow_run:
-    workflows:
-      - Release
-    types:
-      - completed
+# To trigger this:
+# - go to Actions > Publish
+# - click the Run Workflow dropdown in the top-right
+name: Publish
+on: workflow_dispatch
 env:
   CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 jobs:


### PR DESCRIPTION
This workflow has been running several times after a release has already happened.

I'm putting it on manual mode until we figure out how to fix the release process.
