### PR TITLE
Add `#[clippy::allow]` attribute to `const` layout tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -212,6 +212,7 @@
 ## Changed
 ## Removed
 ## Fixed
+- Fix regression where the `const` layout tests were triggering the `unnecessary_operation` and `identity_op` clippy warnings.
 ## Security
 
 # 0.70.0 (2024-08-16)

--- a/bindgen-tests/tests/expectations/tests/16-byte-alignment.rs
+++ b/bindgen-tests/tests/expectations/tests/16-byte-alignment.rs
@@ -18,6 +18,7 @@ pub struct rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1 {
     pub dport: u16,
     pub sport: u16,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     [
         "Size of rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1",
@@ -34,6 +35,7 @@ const _: () = {
     ][::std::mem::offset_of!(rte_ipv4_tuple__bindgen_ty_1__bindgen_ty_1, sport)
         - 2usize];
 };
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     [
         "Size of rte_ipv4_tuple__bindgen_ty_1",
@@ -54,6 +56,7 @@ impl Default for rte_ipv4_tuple__bindgen_ty_1 {
         }
     }
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of rte_ipv4_tuple"][::std::mem::size_of::<rte_ipv4_tuple>() - 12usize];
     ["Alignment of rte_ipv4_tuple"][::std::mem::align_of::<rte_ipv4_tuple>() - 4usize];
@@ -92,6 +95,7 @@ pub struct rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1 {
     pub dport: u16,
     pub sport: u16,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     [
         "Size of rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1",
@@ -108,6 +112,7 @@ const _: () = {
     ][::std::mem::offset_of!(rte_ipv6_tuple__bindgen_ty_1__bindgen_ty_1, sport)
         - 2usize];
 };
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     [
         "Size of rte_ipv6_tuple__bindgen_ty_1",
@@ -128,6 +133,7 @@ impl Default for rte_ipv6_tuple__bindgen_ty_1 {
         }
     }
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of rte_ipv6_tuple"][::std::mem::size_of::<rte_ipv6_tuple>() - 36usize];
     ["Alignment of rte_ipv6_tuple"][::std::mem::align_of::<rte_ipv6_tuple>() - 4usize];
@@ -154,6 +160,7 @@ pub union rte_thash_tuple {
     pub v4: rte_ipv4_tuple,
     pub v6: rte_ipv6_tuple,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of rte_thash_tuple"][::std::mem::size_of::<rte_thash_tuple>() - 48usize];
     [

--- a/bindgen-tests/tests/expectations/tests/accessors.rs
+++ b/bindgen-tests/tests/expectations/tests/accessors.rs
@@ -10,6 +10,7 @@ pub struct SomeAccessors {
     /// <div rustbindgen accessor="immutable"></div>
     pub mImmutableAccessor: ::std::os::raw::c_int,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of SomeAccessors"][::std::mem::size_of::<SomeAccessors>() - 16usize];
     ["Alignment of SomeAccessors"][::std::mem::align_of::<SomeAccessors>() - 4usize];
@@ -55,6 +56,7 @@ pub struct AllAccessors {
     pub mBothAccessors: ::std::os::raw::c_int,
     pub mAlsoBothAccessors: ::std::os::raw::c_int,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of AllAccessors"][::std::mem::size_of::<AllAccessors>() - 8usize];
     ["Alignment of AllAccessors"][::std::mem::align_of::<AllAccessors>() - 4usize];
@@ -90,6 +92,7 @@ pub struct AllUnsafeAccessors {
     pub mBothAccessors: ::std::os::raw::c_int,
     pub mAlsoBothAccessors: ::std::os::raw::c_int,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of AllUnsafeAccessors"][::std::mem::size_of::<AllUnsafeAccessors>() - 8usize];
     [
@@ -132,6 +135,7 @@ pub struct ContradictAccessors {
     /// <div rustbindgen accessor="immutable"></div>
     pub mImmutableAccessor: ::std::os::raw::c_int,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     [
         "Size of ContradictAccessors",
@@ -180,6 +184,7 @@ impl ContradictAccessors {
 pub struct Replaced {
     pub mAccessor: ::std::os::raw::c_int,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of Replaced"][::std::mem::size_of::<Replaced>() - 4usize];
     ["Alignment of Replaced"][::std::mem::align_of::<Replaced>() - 4usize];
@@ -203,6 +208,7 @@ impl Replaced {
 pub struct Wrapper {
     pub mReplaced: Replaced,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of Wrapper"][::std::mem::size_of::<Wrapper>() - 4usize];
     ["Alignment of Wrapper"][::std::mem::align_of::<Wrapper>() - 4usize];

--- a/bindgen-tests/tests/expectations/tests/allowlist-file.rs
+++ b/bindgen-tests/tests/expectations/tests/allowlist-file.rs
@@ -12,6 +12,7 @@ extern "C" {
 pub struct someClass {
     pub _address: u8,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of someClass"][::std::mem::size_of::<someClass>() - 1usize];
     ["Alignment of someClass"][::std::mem::align_of::<someClass>() - 1usize];
@@ -38,6 +39,7 @@ extern "C" {
 pub struct StructWithAllowlistedDefinition {
     pub other: *mut StructWithAllowlistedFwdDecl,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     [
         "Size of StructWithAllowlistedDefinition",
@@ -63,6 +65,7 @@ impl Default for StructWithAllowlistedDefinition {
 pub struct StructWithAllowlistedFwdDecl {
     pub b: ::std::os::raw::c_int,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     [
         "Size of StructWithAllowlistedFwdDecl",
@@ -79,6 +82,7 @@ const _: () = {
 pub struct AllowlistMe {
     pub foo: ::std::os::raw::c_int,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of AllowlistMe"][::std::mem::size_of::<AllowlistMe>() - 4usize];
     ["Alignment of AllowlistMe"][::std::mem::align_of::<AllowlistMe>() - 4usize];

--- a/bindgen-tests/tests/expectations/tests/allowlist-namespaces-basic.rs
+++ b/bindgen-tests/tests/expectations/tests/allowlist-namespaces-basic.rs
@@ -14,6 +14,7 @@ pub mod root {
             pub struct Helper {
                 pub _address: u8,
             }
+            #[allow(clippy::unnecessary_operation, clippy::identity_op)]
             const _: () = {
                 ["Size of Helper"][::std::mem::size_of::<Helper>() - 1usize];
                 ["Alignment of Helper"][::std::mem::align_of::<Helper>() - 1usize];

--- a/bindgen-tests/tests/expectations/tests/allowlist-namespaces.rs
+++ b/bindgen-tests/tests/expectations/tests/allowlist-namespaces.rs
@@ -14,6 +14,7 @@ pub mod root {
             pub struct Helper {
                 pub _address: u8,
             }
+            #[allow(clippy::unnecessary_operation, clippy::identity_op)]
             const _: () = {
                 ["Size of Helper"][::std::mem::size_of::<Helper>() - 1usize];
                 ["Alignment of Helper"][::std::mem::align_of::<Helper>() - 1usize];
@@ -24,6 +25,7 @@ pub mod root {
         pub struct Test {
             pub helper: root::outer::inner::Helper,
         }
+        #[allow(clippy::unnecessary_operation, clippy::identity_op)]
         const _: () = {
             ["Size of Test"][::std::mem::size_of::<Test>() - 1usize];
             ["Alignment of Test"][::std::mem::align_of::<Test>() - 1usize];

--- a/bindgen-tests/tests/expectations/tests/allowlist_item.rs
+++ b/bindgen-tests/tests/expectations/tests/allowlist_item.rs
@@ -5,6 +5,7 @@ pub const FooDefault: u32 = 0;
 pub struct Foo {
     pub field: ::std::os::raw::c_int,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of Foo"][::std::mem::size_of::<Foo>() - 4usize];
     ["Alignment of Foo"][::std::mem::align_of::<Foo>() - 4usize];

--- a/bindgen-tests/tests/expectations/tests/allowlisted-item-references-no-hash.rs
+++ b/bindgen-tests/tests/expectations/tests/allowlisted-item-references-no-hash.rs
@@ -4,6 +4,7 @@
 pub struct NoHash {
     pub _address: u8,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of NoHash"][::std::mem::size_of::<NoHash>() - 1usize];
     ["Alignment of NoHash"][::std::mem::align_of::<NoHash>() - 1usize];
@@ -13,6 +14,7 @@ const _: () = {
 pub struct AllowlistMe {
     pub a: NoHash,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of AllowlistMe"][::std::mem::size_of::<AllowlistMe>() - 1usize];
     ["Alignment of AllowlistMe"][::std::mem::align_of::<AllowlistMe>() - 1usize];

--- a/bindgen-tests/tests/expectations/tests/allowlisted-item-references-no-partialeq.rs
+++ b/bindgen-tests/tests/expectations/tests/allowlisted-item-references-no-partialeq.rs
@@ -4,6 +4,7 @@
 pub struct NoPartialEq {
     pub _address: u8,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of NoPartialEq"][::std::mem::size_of::<NoPartialEq>() - 1usize];
     ["Alignment of NoPartialEq"][::std::mem::align_of::<NoPartialEq>() - 1usize];
@@ -13,6 +14,7 @@ const _: () = {
 pub struct AllowlistMe {
     pub a: NoPartialEq,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of AllowlistMe"][::std::mem::size_of::<AllowlistMe>() - 1usize];
     ["Alignment of AllowlistMe"][::std::mem::align_of::<AllowlistMe>() - 1usize];

--- a/bindgen-tests/tests/expectations/tests/allowlisted_item_references_no_copy.rs
+++ b/bindgen-tests/tests/expectations/tests/allowlisted_item_references_no_copy.rs
@@ -4,6 +4,7 @@
 pub struct NoCopy {
     pub _address: u8,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of NoCopy"][::std::mem::size_of::<NoCopy>() - 1usize];
     ["Alignment of NoCopy"][::std::mem::align_of::<NoCopy>() - 1usize];
@@ -13,6 +14,7 @@ const _: () = {
 pub struct AllowlistMe {
     pub a: NoCopy,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of AllowlistMe"][::std::mem::size_of::<AllowlistMe>() - 1usize];
     ["Alignment of AllowlistMe"][::std::mem::align_of::<AllowlistMe>() - 1usize];

--- a/bindgen-tests/tests/expectations/tests/annotation_hide.rs
+++ b/bindgen-tests/tests/expectations/tests/annotation_hide.rs
@@ -6,6 +6,7 @@
 pub struct D {
     pub _bindgen_opaque_blob: u32,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of D"][::std::mem::size_of::<D>() - 4usize];
     ["Alignment of D"][::std::mem::align_of::<D>() - 4usize];
@@ -15,6 +16,7 @@ const _: () = {
 pub struct NotAnnotated {
     pub f: ::std::os::raw::c_int,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of NotAnnotated"][::std::mem::size_of::<NotAnnotated>() - 4usize];
     ["Alignment of NotAnnotated"][::std::mem::align_of::<NotAnnotated>() - 4usize];

--- a/bindgen-tests/tests/expectations/tests/anon-fields-prefix.rs
+++ b/bindgen-tests/tests/expectations/tests/anon-fields-prefix.rs
@@ -13,6 +13,7 @@ pub struct color__bindgen_ty_1 {
     pub g: ::std::os::raw::c_uchar,
     pub b: ::std::os::raw::c_uchar,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     [
         "Size of color__bindgen_ty_1",
@@ -37,6 +38,7 @@ pub struct color__bindgen_ty_2 {
     pub u: ::std::os::raw::c_uchar,
     pub v: ::std::os::raw::c_uchar,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     [
         "Size of color__bindgen_ty_2",
@@ -54,6 +56,7 @@ const _: () = {
         "Offset of field: color__bindgen_ty_2::v",
     ][::std::mem::offset_of!(color__bindgen_ty_2, v) - 2usize];
 };
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of color"][::std::mem::size_of::<color>() - 3usize];
     ["Alignment of color"][::std::mem::align_of::<color>() - 1usize];

--- a/bindgen-tests/tests/expectations/tests/anon_enum.rs
+++ b/bindgen-tests/tests/expectations/tests/anon_enum.rs
@@ -11,6 +11,7 @@ pub const Test_T_NONE: Test__bindgen_ty_1 = Test__bindgen_ty_1::T_NONE;
 pub enum Test__bindgen_ty_1 {
     T_NONE = 0,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of Test"][::std::mem::size_of::<Test>() - 8usize];
     ["Alignment of Test"][::std::mem::align_of::<Test>() - 4usize];

--- a/bindgen-tests/tests/expectations/tests/anon_enum_trait.rs
+++ b/bindgen-tests/tests/expectations/tests/anon_enum_trait.rs
@@ -30,6 +30,7 @@ pub const Foo_Baz: Foo__bindgen_ty_1 = Foo__bindgen_ty_1::Bar;
 pub enum Foo__bindgen_ty_1 {
     Bar = 0,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of Foo"][::std::mem::size_of::<Foo>() - 1usize];
     ["Alignment of Foo"][::std::mem::align_of::<Foo>() - 1usize];

--- a/bindgen-tests/tests/expectations/tests/anon_struct_in_union.rs
+++ b/bindgen-tests/tests/expectations/tests/anon_struct_in_union.rs
@@ -14,6 +14,7 @@ pub union s__bindgen_ty_1 {
 pub struct s__bindgen_ty_1_inner {
     pub b: ::std::os::raw::c_int,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     [
         "Size of s__bindgen_ty_1_inner",
@@ -25,6 +26,7 @@ const _: () = {
         "Offset of field: s__bindgen_ty_1_inner::b",
     ][::std::mem::offset_of!(s__bindgen_ty_1_inner, b) - 0usize];
 };
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of s__bindgen_ty_1"][::std::mem::size_of::<s__bindgen_ty_1>() - 4usize];
     ["Alignment of s__bindgen_ty_1"][::std::mem::align_of::<s__bindgen_ty_1>() - 4usize];
@@ -41,6 +43,7 @@ impl Default for s__bindgen_ty_1 {
         }
     }
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of s"][::std::mem::size_of::<s>() - 4usize];
     ["Alignment of s"][::std::mem::align_of::<s>() - 4usize];

--- a/bindgen-tests/tests/expectations/tests/anon_union.rs
+++ b/bindgen-tests/tests/expectations/tests/anon_union.rs
@@ -51,6 +51,7 @@ impl Default for TErrorResult {
 pub struct ErrorResult {
     pub _base: TErrorResult,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of ErrorResult"][::std::mem::size_of::<ErrorResult>() - 24usize];
     ["Alignment of ErrorResult"][::std::mem::align_of::<ErrorResult>() - 8usize];
@@ -64,6 +65,7 @@ impl Default for ErrorResult {
         }
     }
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     [
         "Size of template specialization: TErrorResult_open0_int_close0",

--- a/bindgen-tests/tests/expectations/tests/array-of-zero-sized-types.rs
+++ b/bindgen-tests/tests/expectations/tests/array-of-zero-sized-types.rs
@@ -5,6 +5,7 @@
 pub struct Empty {
     pub _address: u8,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of Empty"][::std::mem::size_of::<Empty>() - 1usize];
     ["Alignment of Empty"][::std::mem::align_of::<Empty>() - 1usize];
@@ -16,6 +17,7 @@ const _: () = {
 pub struct HasArrayOfEmpty {
     pub empties: [Empty; 10usize],
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of HasArrayOfEmpty"][::std::mem::size_of::<HasArrayOfEmpty>() - 10usize];
     ["Alignment of HasArrayOfEmpty"][::std::mem::align_of::<HasArrayOfEmpty>() - 1usize];

--- a/bindgen-tests/tests/expectations/tests/attribute_warn_unused_result_pre_1_27.rs
+++ b/bindgen-tests/tests/expectations/tests/attribute_warn_unused_result_pre_1_27.rs
@@ -4,6 +4,7 @@
 pub struct Foo {
     pub _address: u8,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of Foo"][::std::mem::size_of::<Foo>() - 1usize];
     ["Alignment of Foo"][::std::mem::align_of::<Foo>() - 1usize];

--- a/bindgen-tests/tests/expectations/tests/auto.rs
+++ b/bindgen-tests/tests/expectations/tests/auto.rs
@@ -5,6 +5,7 @@ pub struct Foo {
     pub _address: u8,
 }
 pub const Foo_kFoo: bool = true;
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of Foo"][::std::mem::size_of::<Foo>() - 1usize];
     ["Alignment of Foo"][::std::mem::align_of::<Foo>() - 1usize];

--- a/bindgen-tests/tests/expectations/tests/base-to-derived.rs
+++ b/bindgen-tests/tests/expectations/tests/base-to-derived.rs
@@ -4,6 +4,7 @@
 pub struct false_type {
     pub _address: u8,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of false_type"][::std::mem::size_of::<false_type>() - 1usize];
     ["Alignment of false_type"][::std::mem::align_of::<false_type>() - 1usize];

--- a/bindgen-tests/tests/expectations/tests/bitfield-32bit-overflow.rs
+++ b/bindgen-tests/tests/expectations/tests/bitfield-32bit-overflow.rs
@@ -89,6 +89,7 @@ pub struct MuchBitfield {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 5usize]>,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of MuchBitfield"][::std::mem::size_of::<MuchBitfield>() - 5usize];
     ["Alignment of MuchBitfield"][::std::mem::align_of::<MuchBitfield>() - 1usize];

--- a/bindgen-tests/tests/expectations/tests/bitfield-enum-basic.rs
+++ b/bindgen-tests/tests/expectations/tests/bitfield-enum-basic.rs
@@ -148,6 +148,7 @@ impl ::std::ops::BitAndAssign for Dummy__bindgen_ty_1 {
 #[repr(transparent)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct Dummy__bindgen_ty_1(pub ::std::os::raw::c_uint);
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of Dummy"][::std::mem::size_of::<Dummy>() - 1usize];
     ["Alignment of Dummy"][::std::mem::align_of::<Dummy>() - 1usize];

--- a/bindgen-tests/tests/expectations/tests/bitfield-large.rs
+++ b/bindgen-tests/tests/expectations/tests/bitfield-large.rs
@@ -90,6 +90,7 @@ pub struct HasBigBitfield {
     pub _bitfield_align_1: [u64; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 16usize]>,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of HasBigBitfield"][::std::mem::size_of::<HasBigBitfield>() - 16usize];
     ["Alignment of HasBigBitfield"][::std::mem::align_of::<HasBigBitfield>() - 16usize];
@@ -128,6 +129,7 @@ pub struct HasTwoBigBitfields {
     pub _bitfield_align_1: [u64; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 16usize]>,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     [
         "Size of HasTwoBigBitfields",

--- a/bindgen-tests/tests/expectations/tests/bitfield-linux-32.rs
+++ b/bindgen-tests/tests/expectations/tests/bitfield-linux-32.rs
@@ -90,6 +90,7 @@ pub struct Test {
     pub _bitfield_align_1: [u64; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 8usize]>,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of Test"][::std::mem::size_of::<Test>() - 16usize];
     ["Alignment of Test"][::std::mem::align_of::<Test>() - 4usize];

--- a/bindgen-tests/tests/expectations/tests/bitfield-method-same-name.rs
+++ b/bindgen-tests/tests/expectations/tests/bitfield-method-same-name.rs
@@ -89,6 +89,7 @@ pub struct Foo {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of Foo"][::std::mem::size_of::<Foo>() - 1usize];
     ["Alignment of Foo"][::std::mem::align_of::<Foo>() - 1usize];

--- a/bindgen-tests/tests/expectations/tests/bitfield_align.rs
+++ b/bindgen-tests/tests/expectations/tests/bitfield_align.rs
@@ -92,6 +92,7 @@ pub struct A {
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 2usize]>,
     pub y: ::std::os::raw::c_uchar,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of A"][::std::mem::size_of::<A>() - 4usize];
     ["Alignment of A"][::std::mem::align_of::<A>() - 4usize];
@@ -322,6 +323,7 @@ pub struct B {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of B"][::std::mem::size_of::<B>() - 4usize];
     ["Alignment of B"][::std::mem::align_of::<B>() - 4usize];
@@ -384,6 +386,7 @@ pub struct C {
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
     pub baz: ::std::os::raw::c_uint,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of C"][::std::mem::size_of::<C>() - 8usize];
     ["Alignment of C"][::std::mem::align_of::<C>() - 4usize];
@@ -448,6 +451,7 @@ pub struct Date1 {
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 3usize]>,
     pub __bindgen_padding_0: u8,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of Date1"][::std::mem::size_of::<Date1>() - 4usize];
     ["Alignment of Date1"][::std::mem::align_of::<Date1>() - 2usize];
@@ -551,6 +555,7 @@ pub struct Date2 {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of Date2"][::std::mem::size_of::<Date2>() - 4usize];
     ["Alignment of Date2"][::std::mem::align_of::<Date2>() - 2usize];
@@ -676,6 +681,7 @@ pub struct Date3 {
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 3usize]>,
     pub byte: ::std::os::raw::c_uchar,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of Date3"][::std::mem::size_of::<Date3>() - 4usize];
     ["Alignment of Date3"][::std::mem::align_of::<Date3>() - 2usize];

--- a/bindgen-tests/tests/expectations/tests/bitfield_align_2.rs
+++ b/bindgen-tests/tests/expectations/tests/bitfield_align_2.rs
@@ -98,6 +98,7 @@ pub struct TaggedPtr {
     pub _bitfield_align_1: [u64; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 8usize]>,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of TaggedPtr"][::std::mem::size_of::<TaggedPtr>() - 8usize];
     ["Alignment of TaggedPtr"][::std::mem::align_of::<TaggedPtr>() - 8usize];

--- a/bindgen-tests/tests/expectations/tests/bitfield_large_overflow.rs
+++ b/bindgen-tests/tests/expectations/tests/bitfield_large_overflow.rs
@@ -5,6 +5,7 @@
 pub struct _bindgen_ty_1 {
     pub _bindgen_opaque_blob: [u64; 10usize],
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of _bindgen_ty_1"][::std::mem::size_of::<_bindgen_ty_1>() - 80usize];
     ["Alignment of _bindgen_ty_1"][::std::mem::align_of::<_bindgen_ty_1>() - 8usize];

--- a/bindgen-tests/tests/expectations/tests/bitfield_method_mangling.rs
+++ b/bindgen-tests/tests/expectations/tests/bitfield_method_mangling.rs
@@ -89,6 +89,7 @@ pub struct mach_msg_type_descriptor_t {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     [
         "Size of mach_msg_type_descriptor_t",

--- a/bindgen-tests/tests/expectations/tests/bitfield_pragma_packed.rs
+++ b/bindgen-tests/tests/expectations/tests/bitfield_pragma_packed.rs
@@ -89,6 +89,7 @@ pub struct Struct {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of Struct"][::std::mem::size_of::<Struct>() - 4usize];
     ["Alignment of Struct"][::std::mem::align_of::<Struct>() - 1usize];
@@ -212,6 +213,7 @@ pub struct Inner {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of Inner"][::std::mem::size_of::<Inner>() - 4usize];
     ["Alignment of Inner"][::std::mem::align_of::<Inner>() - 2usize];
@@ -271,6 +273,7 @@ impl Inner {
 pub struct Outer {
     pub inner: Inner,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of Outer"][::std::mem::size_of::<Outer>() - 4usize];
     ["Alignment of Outer"][::std::mem::align_of::<Outer>() - 1usize];

--- a/bindgen-tests/tests/expectations/tests/blocklist-and-impl-debug.rs
+++ b/bindgen-tests/tests/expectations/tests/blocklist-and-impl-debug.rs
@@ -5,6 +5,7 @@ pub struct BlocklistMe(u8);
 pub struct ShouldManuallyImplDebug {
     pub a: BlocklistMe,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     [
         "Size of ShouldManuallyImplDebug",

--- a/bindgen-tests/tests/expectations/tests/blocklist-file.rs
+++ b/bindgen-tests/tests/expectations/tests/blocklist-file.rs
@@ -6,6 +6,7 @@ pub struct SizedIntegers {
     pub y: u16,
     pub z: u32,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of SizedIntegers"][::std::mem::size_of::<SizedIntegers>() - 8usize];
     ["Alignment of SizedIntegers"][::std::mem::align_of::<SizedIntegers>() - 4usize];
@@ -24,6 +25,7 @@ const _: () = {
 pub struct StructWithBlocklistedFwdDecl {
     pub b: u8,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     [
         "Size of StructWithBlocklistedFwdDecl",

--- a/bindgen-tests/tests/expectations/tests/blocklist-function.rs
+++ b/bindgen-tests/tests/expectations/tests/blocklist-function.rs
@@ -20,6 +20,7 @@ pub mod root {
     pub struct C {
         pub _address: u8,
     }
+    #[allow(clippy::unnecessary_operation, clippy::identity_op)]
     const _: () = {
         ["Size of C"][::std::mem::size_of::<C>() - 1usize];
         ["Alignment of C"][::std::mem::align_of::<C>() - 1usize];

--- a/bindgen-tests/tests/expectations/tests/blocklist-methods.rs
+++ b/bindgen-tests/tests/expectations/tests/blocklist-methods.rs
@@ -4,6 +4,7 @@
 pub struct Foo {
     pub _address: u8,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of Foo"][::std::mem::size_of::<Foo>() - 1usize];
     ["Alignment of Foo"][::std::mem::align_of::<Foo>() - 1usize];

--- a/bindgen-tests/tests/expectations/tests/blocklist_bitfield_unit.rs
+++ b/bindgen-tests/tests/expectations/tests/blocklist_bitfield_unit.rs
@@ -10,6 +10,7 @@ pub struct C {
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
     pub baz: ::std::os::raw::c_uint,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of C"][::std::mem::size_of::<C>() - 8usize];
     ["Alignment of C"][::std::mem::align_of::<C>() - 4usize];

--- a/bindgen-tests/tests/expectations/tests/blocks-signature.rs
+++ b/bindgen-tests/tests/expectations/tests/blocks-signature.rs
@@ -28,6 +28,7 @@ pub struct contains_block_pointers {
     pub val: contains_block_pointers__bindgen_ty_id_61,
     pub ptr_val: *mut _bindgen_ty_id_68,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     [
         "Size of contains_block_pointers",

--- a/bindgen-tests/tests/expectations/tests/blocks.rs
+++ b/bindgen-tests/tests/expectations/tests/blocks.rs
@@ -27,6 +27,7 @@ pub struct contains_block_pointers {
     pub val: *mut ::std::os::raw::c_void,
     pub ptr_val: *mut *mut ::std::os::raw::c_void,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     [
         "Size of contains_block_pointers",

--- a/bindgen-tests/tests/expectations/tests/bug-1529681.rs
+++ b/bindgen-tests/tests/expectations/tests/bug-1529681.rs
@@ -4,6 +4,7 @@
 pub struct BrowsingContext {
     pub _address: u8,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of BrowsingContext"][::std::mem::size_of::<BrowsingContext>() - 1usize];
     ["Alignment of BrowsingContext"][::std::mem::align_of::<BrowsingContext>() - 1usize];

--- a/bindgen-tests/tests/expectations/tests/c-empty-layout.rs
+++ b/bindgen-tests/tests/expectations/tests/c-empty-layout.rs
@@ -2,6 +2,7 @@
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct Foo {}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of Foo"][::std::mem::size_of::<Foo>() - 0usize];
     ["Alignment of Foo"][::std::mem::align_of::<Foo>() - 1usize];

--- a/bindgen-tests/tests/expectations/tests/c_naming.rs
+++ b/bindgen-tests/tests/expectations/tests/c_naming.rs
@@ -4,6 +4,7 @@
 pub struct struct_a {
     pub a: ::std::os::raw::c_int,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of struct_a"][::std::mem::size_of::<struct_a>() - 4usize];
     ["Alignment of struct_a"][::std::mem::align_of::<struct_a>() - 4usize];
@@ -16,6 +17,7 @@ pub union union_b {
     pub a: ::std::os::raw::c_int,
     pub b: ::std::os::raw::c_int,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of union_b"][::std::mem::size_of::<union_b>() - 4usize];
     ["Alignment of union_b"][::std::mem::align_of::<union_b>() - 4usize];

--- a/bindgen-tests/tests/expectations/tests/call-conv-field.rs
+++ b/bindgen-tests/tests/expectations/tests/call-conv-field.rs
@@ -10,6 +10,7 @@ pub struct JNINativeInterface_ {
     >,
     pub __hack: ::std::os::raw::c_ulonglong,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     [
         "Size of JNINativeInterface_",

--- a/bindgen-tests/tests/expectations/tests/canonical-types.rs
+++ b/bindgen-tests/tests/expectations/tests/canonical-types.rs
@@ -76,6 +76,7 @@ impl Default for ClassC_ClassCInnerCRTP {
 pub struct ClassD {
     pub _address: u8,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of ClassD"][::std::mem::size_of::<ClassD>() - 1usize];
     ["Alignment of ClassD"][::std::mem::align_of::<ClassD>() - 1usize];
@@ -89,6 +90,7 @@ impl Default for ClassD {
         }
     }
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     [
         "Size of template specialization: ClassB_open0_ClassD_ClassCInnerCRTP_close0",
@@ -102,6 +104,7 @@ const _: () = {
 pub struct ClassCInnerCRTP {
     pub _address: u8,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of ClassCInnerCRTP"][::std::mem::size_of::<ClassCInnerCRTP>() - 1usize];
     ["Alignment of ClassCInnerCRTP"][::std::mem::align_of::<ClassCInnerCRTP>() - 1usize];
@@ -115,6 +118,7 @@ impl Default for ClassCInnerCRTP {
         }
     }
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     [
         "Size of template specialization: ClassB_open0_ClassCInnerCRTP_ClassAInner_close0",
@@ -128,6 +132,7 @@ const _: () = {
 pub struct ClassAInner {
     pub x: *mut ClassCInnerA,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of ClassAInner"][::std::mem::size_of::<ClassAInner>() - 8usize];
     ["Alignment of ClassAInner"][::std::mem::align_of::<ClassAInner>() - 8usize];
@@ -147,6 +152,7 @@ impl Default for ClassAInner {
 pub struct ClassCInnerA {
     pub member: *mut ClassCInnerB,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of ClassCInnerA"][::std::mem::size_of::<ClassCInnerA>() - 8usize];
     ["Alignment of ClassCInnerA"][::std::mem::align_of::<ClassCInnerA>() - 8usize];
@@ -168,6 +174,7 @@ impl Default for ClassCInnerA {
 pub struct ClassCInnerB {
     pub cache: *mut ClassCInnerA,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of ClassCInnerB"][::std::mem::size_of::<ClassCInnerB>() - 8usize];
     ["Alignment of ClassCInnerB"][::std::mem::align_of::<ClassCInnerB>() - 8usize];

--- a/bindgen-tests/tests/expectations/tests/canonical_path_without_namespacing.rs
+++ b/bindgen-tests/tests/expectations/tests/canonical_path_without_namespacing.rs
@@ -4,6 +4,7 @@
 pub struct Bar {
     pub _address: u8,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of Bar"][::std::mem::size_of::<Bar>() - 1usize];
     ["Alignment of Bar"][::std::mem::align_of::<Bar>() - 1usize];

--- a/bindgen-tests/tests/expectations/tests/char.rs
+++ b/bindgen-tests/tests/expectations/tests/char.rs
@@ -18,6 +18,7 @@ pub struct Test {
     pub Ccu: UChar,
     pub Ccd: SChar,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of Test"][::std::mem::size_of::<Test>() - 12usize];
     ["Alignment of Test"][::std::mem::align_of::<Test>() - 1usize];

--- a/bindgen-tests/tests/expectations/tests/class_nested.rs
+++ b/bindgen-tests/tests/expectations/tests/class_nested.rs
@@ -9,6 +9,7 @@ pub struct A {
 pub struct A_B {
     pub member_b: ::std::os::raw::c_int,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of A_B"][::std::mem::size_of::<A_B>() - 4usize];
     ["Alignment of A_B"][::std::mem::align_of::<A_B>() - 4usize];
@@ -29,6 +30,7 @@ impl<T> Default for A_D<T> {
         }
     }
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of A"][::std::mem::size_of::<A>() - 4usize];
     ["Alignment of A"][::std::mem::align_of::<A>() - 4usize];
@@ -39,6 +41,7 @@ const _: () = {
 pub struct A_C {
     pub baz: ::std::os::raw::c_int,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of A_C"][::std::mem::size_of::<A_C>() - 4usize];
     ["Alignment of A_C"][::std::mem::align_of::<A_C>() - 4usize];
@@ -47,6 +50,7 @@ const _: () = {
 extern "C" {
     pub static mut var: A_B;
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     [
         "Size of template specialization: A_D_open0_int_close0",
@@ -63,6 +67,7 @@ extern "C" {
 pub struct D {
     pub member: A_B,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of D"][::std::mem::size_of::<D>() - 4usize];
     ["Alignment of D"][::std::mem::align_of::<D>() - 4usize];

--- a/bindgen-tests/tests/expectations/tests/class_no_members.rs
+++ b/bindgen-tests/tests/expectations/tests/class_no_members.rs
@@ -4,6 +4,7 @@
 pub struct whatever {
     pub _address: u8,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of whatever"][::std::mem::size_of::<whatever>() - 1usize];
     ["Alignment of whatever"][::std::mem::align_of::<whatever>() - 1usize];
@@ -13,6 +14,7 @@ const _: () = {
 pub struct whatever_child {
     pub _address: u8,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of whatever_child"][::std::mem::size_of::<whatever_child>() - 1usize];
     ["Alignment of whatever_child"][::std::mem::align_of::<whatever_child>() - 1usize];
@@ -22,6 +24,7 @@ const _: () = {
 pub struct whatever_child_with_member {
     pub m_member: ::std::os::raw::c_int,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     [
         "Size of whatever_child_with_member",

--- a/bindgen-tests/tests/expectations/tests/class_static.rs
+++ b/bindgen-tests/tests/expectations/tests/class_static.rs
@@ -12,6 +12,7 @@ extern "C" {
     #[link_name = "\u{1}_ZN7MyClass26example_check_no_collisionE"]
     pub static mut MyClass_example_check_no_collision: *const ::std::os::raw::c_int;
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of MyClass"][::std::mem::size_of::<MyClass>() - 1usize];
     ["Alignment of MyClass"][::std::mem::align_of::<MyClass>() - 1usize];

--- a/bindgen-tests/tests/expectations/tests/class_static_const.rs
+++ b/bindgen-tests/tests/expectations/tests/class_static_const.rs
@@ -7,6 +7,7 @@ pub struct A {
 pub const A_a: ::std::os::raw::c_int = 0;
 pub const A_b: i32 = 63;
 pub const A_c: u32 = 255;
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of A"][::std::mem::size_of::<A>() - 1usize];
     ["Alignment of A"][::std::mem::align_of::<A>() - 1usize];

--- a/bindgen-tests/tests/expectations/tests/class_use_as.rs
+++ b/bindgen-tests/tests/expectations/tests/class_use_as.rs
@@ -5,6 +5,7 @@
 pub struct whatever {
     pub replacement: ::std::os::raw::c_int,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of whatever"][::std::mem::size_of::<whatever>() - 4usize];
     ["Alignment of whatever"][::std::mem::align_of::<whatever>() - 4usize];
@@ -17,6 +18,7 @@ const _: () = {
 pub struct container {
     pub c: whatever,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of container"][::std::mem::size_of::<container>() - 4usize];
     ["Alignment of container"][::std::mem::align_of::<container>() - 4usize];

--- a/bindgen-tests/tests/expectations/tests/class_with_dtor.rs
+++ b/bindgen-tests/tests/expectations/tests/class_with_dtor.rs
@@ -20,6 +20,7 @@ pub type HandleValue = HandleWithDtor<::std::os::raw::c_int>;
 pub struct WithoutDtor {
     pub shouldBeWithDtor: HandleValue,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of WithoutDtor"][::std::mem::size_of::<WithoutDtor>() - 8usize];
     ["Alignment of WithoutDtor"][::std::mem::align_of::<WithoutDtor>() - 8usize];
@@ -36,6 +37,7 @@ impl Default for WithoutDtor {
         }
     }
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     [
         "Size of template specialization: HandleWithDtor_open0_int_close0",

--- a/bindgen-tests/tests/expectations/tests/class_with_inner_struct.rs
+++ b/bindgen-tests/tests/expectations/tests/class_with_inner_struct.rs
@@ -12,6 +12,7 @@ pub struct A_Segment {
     pub begin: ::std::os::raw::c_int,
     pub end: ::std::os::raw::c_int,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of A_Segment"][::std::mem::size_of::<A_Segment>() - 8usize];
     ["Alignment of A_Segment"][::std::mem::align_of::<A_Segment>() - 4usize];
@@ -25,6 +26,7 @@ const _: () = {
 pub union A__bindgen_ty_1 {
     pub f: ::std::os::raw::c_int,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of A__bindgen_ty_1"][::std::mem::size_of::<A__bindgen_ty_1>() - 4usize];
     ["Alignment of A__bindgen_ty_1"][::std::mem::align_of::<A__bindgen_ty_1>() - 4usize];
@@ -46,6 +48,7 @@ impl Default for A__bindgen_ty_1 {
 pub union A__bindgen_ty_2 {
     pub d: ::std::os::raw::c_int,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of A__bindgen_ty_2"][::std::mem::size_of::<A__bindgen_ty_2>() - 4usize];
     ["Alignment of A__bindgen_ty_2"][::std::mem::align_of::<A__bindgen_ty_2>() - 4usize];
@@ -62,6 +65,7 @@ impl Default for A__bindgen_ty_2 {
         }
     }
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of A"][::std::mem::size_of::<A>() - 12usize];
     ["Alignment of A"][::std::mem::align_of::<A>() - 4usize];
@@ -88,6 +92,7 @@ pub struct B_Segment {
     pub begin: ::std::os::raw::c_int,
     pub end: ::std::os::raw::c_int,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of B_Segment"][::std::mem::size_of::<B_Segment>() - 8usize];
     ["Alignment of B_Segment"][::std::mem::align_of::<B_Segment>() - 4usize];
@@ -96,6 +101,7 @@ const _: () = {
     ][::std::mem::offset_of!(B_Segment, begin) - 0usize];
     ["Offset of field: B_Segment::end"][::std::mem::offset_of!(B_Segment, end) - 4usize];
 };
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of B"][::std::mem::size_of::<B>() - 4usize];
     ["Alignment of B"][::std::mem::align_of::<B>() - 4usize];
@@ -129,6 +135,7 @@ pub struct C__bindgen_ty_1__bindgen_ty_1 {
     pub mX2: f32,
     pub mY2: f32,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     [
         "Size of C__bindgen_ty_1__bindgen_ty_1",
@@ -155,6 +162,7 @@ pub struct C__bindgen_ty_1__bindgen_ty_2 {
     pub mStepSyntax: StepSyntax,
     pub mSteps: ::std::os::raw::c_uint,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     [
         "Size of C__bindgen_ty_1__bindgen_ty_2",
@@ -178,6 +186,7 @@ impl Default for C__bindgen_ty_1__bindgen_ty_2 {
         }
     }
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of C__bindgen_ty_1"][::std::mem::size_of::<C__bindgen_ty_1>() - 16usize];
     ["Alignment of C__bindgen_ty_1"][::std::mem::align_of::<C__bindgen_ty_1>() - 4usize];
@@ -200,6 +209,7 @@ pub struct C_Segment {
     pub begin: ::std::os::raw::c_int,
     pub end: ::std::os::raw::c_int,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of C_Segment"][::std::mem::size_of::<C_Segment>() - 8usize];
     ["Alignment of C_Segment"][::std::mem::align_of::<C_Segment>() - 4usize];
@@ -208,6 +218,7 @@ const _: () = {
     ][::std::mem::offset_of!(C_Segment, begin) - 0usize];
     ["Offset of field: C_Segment::end"][::std::mem::offset_of!(C_Segment, end) - 4usize];
 };
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of C"][::std::mem::size_of::<C>() - 20usize];
     ["Alignment of C"][::std::mem::align_of::<C>() - 4usize];

--- a/bindgen-tests/tests/expectations/tests/class_with_typedef.rs
+++ b/bindgen-tests/tests/expectations/tests/class_with_typedef.rs
@@ -11,6 +11,7 @@ pub struct C {
 }
 pub type C_MyInt = ::std::os::raw::c_int;
 pub type C_Lookup = *const ::std::os::raw::c_char;
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of C"][::std::mem::size_of::<C>() - 72usize];
     ["Alignment of C"][::std::mem::align_of::<C>() - 8usize];
@@ -69,6 +70,7 @@ pub struct D {
     pub _base: C,
     pub ptr: *mut C_MyInt,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of D"][::std::mem::size_of::<D>() - 80usize];
     ["Alignment of D"][::std::mem::align_of::<D>() - 8usize];

--- a/bindgen-tests/tests/expectations/tests/comment-indent.rs
+++ b/bindgen-tests/tests/expectations/tests/comment-indent.rs
@@ -19,10 +19,12 @@ pub mod root {
     pub struct Foo_Bar {
         pub _address: u8,
     }
+    #[allow(clippy::unnecessary_operation, clippy::identity_op)]
     const _: () = {
         ["Size of Foo_Bar"][::std::mem::size_of::<Foo_Bar>() - 1usize];
         ["Alignment of Foo_Bar"][::std::mem::align_of::<Foo_Bar>() - 1usize];
     };
+    #[allow(clippy::unnecessary_operation, clippy::identity_op)]
     const _: () = {
         ["Size of Foo"][::std::mem::size_of::<Foo>() - 1usize];
         ["Alignment of Foo"][::std::mem::align_of::<Foo>() - 1usize];
@@ -44,6 +46,7 @@ pub mod root {
  +------+          +-------+*/
             pub member: ::std::os::raw::c_int,
         }
+        #[allow(clippy::unnecessary_operation, clippy::identity_op)]
         const _: () = {
             ["Size of Baz"][::std::mem::size_of::<Baz>() - 4usize];
             ["Alignment of Baz"][::std::mem::align_of::<Baz>() - 4usize];
@@ -59,6 +62,7 @@ pub mod root {
         pub struct InInlineNS {
             pub _address: u8,
         }
+        #[allow(clippy::unnecessary_operation, clippy::identity_op)]
         const _: () = {
             ["Size of InInlineNS"][::std::mem::size_of::<InInlineNS>() - 1usize];
             ["Alignment of InInlineNS"][::std::mem::align_of::<InInlineNS>() - 1usize];
@@ -68,6 +72,7 @@ pub mod root {
         pub struct Bazz {
             pub _address: u8,
         }
+        #[allow(clippy::unnecessary_operation, clippy::identity_op)]
         const _: () = {
             ["Size of Bazz"][::std::mem::size_of::<Bazz>() - 1usize];
             ["Alignment of Bazz"][::std::mem::align_of::<Bazz>() - 1usize];

--- a/bindgen-tests/tests/expectations/tests/complex.rs
+++ b/bindgen-tests/tests/expectations/tests/complex.rs
@@ -10,6 +10,7 @@ pub struct __BindgenComplex<T> {
 pub struct TestDouble {
     pub mMember: __BindgenComplex<f64>,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of TestDouble"][::std::mem::size_of::<TestDouble>() - 16usize];
     ["Alignment of TestDouble"][::std::mem::align_of::<TestDouble>() - 8usize];
@@ -22,6 +23,7 @@ const _: () = {
 pub struct TestDoublePtr {
     pub mMember: *mut __BindgenComplex<f64>,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of TestDoublePtr"][::std::mem::size_of::<TestDoublePtr>() - 8usize];
     ["Alignment of TestDoublePtr"][::std::mem::align_of::<TestDoublePtr>() - 8usize];
@@ -43,6 +45,7 @@ impl Default for TestDoublePtr {
 pub struct TestFloat {
     pub mMember: __BindgenComplex<f32>,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of TestFloat"][::std::mem::size_of::<TestFloat>() - 8usize];
     ["Alignment of TestFloat"][::std::mem::align_of::<TestFloat>() - 4usize];
@@ -55,6 +58,7 @@ const _: () = {
 pub struct TestFloatPtr {
     pub mMember: *mut __BindgenComplex<f32>,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of TestFloatPtr"][::std::mem::size_of::<TestFloatPtr>() - 8usize];
     ["Alignment of TestFloatPtr"][::std::mem::align_of::<TestFloatPtr>() - 8usize];

--- a/bindgen-tests/tests/expectations/tests/const-const-mut-ptr.rs
+++ b/bindgen-tests/tests/expectations/tests/const-const-mut-ptr.rs
@@ -4,6 +4,7 @@
 pub struct foo {
     pub bar: *const *const *mut *const ::std::os::raw::c_int,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of foo"][::std::mem::size_of::<foo>() - 8usize];
     ["Alignment of foo"][::std::mem::align_of::<foo>() - 8usize];

--- a/bindgen-tests/tests/expectations/tests/const_array_typedef.rs
+++ b/bindgen-tests/tests/expectations/tests/const_array_typedef.rs
@@ -4,6 +4,7 @@
 pub struct strct {
     pub field: ::std::os::raw::c_int,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of strct"][::std::mem::size_of::<strct>() - 4usize];
     ["Alignment of strct"][::std::mem::align_of::<strct>() - 4usize];

--- a/bindgen-tests/tests/expectations/tests/const_bool.rs
+++ b/bindgen-tests/tests/expectations/tests/const_bool.rs
@@ -6,6 +6,7 @@ pub struct A {
     pub _address: u8,
 }
 pub const A_k: bool = false;
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of A"][::std::mem::size_of::<A>() - 1usize];
     ["Alignment of A"][::std::mem::align_of::<A>() - 1usize];

--- a/bindgen-tests/tests/expectations/tests/const_enum_unnamed.rs
+++ b/bindgen-tests/tests/expectations/tests/const_enum_unnamed.rs
@@ -18,6 +18,7 @@ pub const Foo_FOO_BAR: Foo__bindgen_ty_1 = Foo__bindgen_ty_1::FOO_BAR;
 pub enum Foo__bindgen_ty_1 {
     FOO_BAR = 10,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of Foo"][::std::mem::size_of::<Foo>() - 1usize];
     ["Alignment of Foo"][::std::mem::align_of::<Foo>() - 1usize];

--- a/bindgen-tests/tests/expectations/tests/constified-enum-module-overflow.rs
+++ b/bindgen-tests/tests/expectations/tests/constified-enum-module-overflow.rs
@@ -15,11 +15,13 @@ pub type C_U = B;
 pub struct A {
     pub u: B,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of A"][::std::mem::size_of::<A>() - 1usize];
     ["Alignment of A"][::std::mem::align_of::<A>() - 1usize];
     ["Offset of field: A::u"][::std::mem::offset_of!(A, u) - 0usize];
 };
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     [
         "Size of template specialization: C_open0_A_close0",
@@ -28,6 +30,7 @@ const _: () = {
         "Align of template specialization: C_open0_A_close0",
     ][::std::mem::align_of::<C>() - 1usize];
 };
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     [
         "Size of template specialization: B_open0_A_close0",

--- a/bindgen-tests/tests/expectations/tests/constify-all-enums.rs
+++ b/bindgen-tests/tests/expectations/tests/constify-all-enums.rs
@@ -8,6 +8,7 @@ pub type foo = ::std::os::raw::c_uint;
 pub struct bar {
     pub this_should_work: foo,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of bar"][::std::mem::size_of::<bar>() - 4usize];
     ["Alignment of bar"][::std::mem::align_of::<bar>() - 4usize];

--- a/bindgen-tests/tests/expectations/tests/constify-module-enums-basic.rs
+++ b/bindgen-tests/tests/expectations/tests/constify-module-enums-basic.rs
@@ -12,6 +12,7 @@ pub use self::foo_alias1 as foo_alias2;
 pub struct bar {
     pub this_should_work: foo::Type,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of bar"][::std::mem::size_of::<bar>() - 4usize];
     ["Alignment of bar"][::std::mem::align_of::<bar>() - 4usize];

--- a/bindgen-tests/tests/expectations/tests/constify-module-enums-namespace.rs
+++ b/bindgen-tests/tests/expectations/tests/constify-module-enums-namespace.rs
@@ -24,6 +24,7 @@ pub mod root {
             pub struct bar {
                 pub this_should_work: root::ns1::ns2::foo::Type,
             }
+            #[allow(clippy::unnecessary_operation, clippy::identity_op)]
             const _: () = {
                 ["Size of bar"][::std::mem::size_of::<bar>() - 4usize];
                 ["Alignment of bar"][::std::mem::align_of::<bar>() - 4usize];

--- a/bindgen-tests/tests/expectations/tests/constify-module-enums-shadow-name.rs
+++ b/bindgen-tests/tests/expectations/tests/constify-module-enums-shadow-name.rs
@@ -11,6 +11,7 @@ pub mod foo {
 pub struct bar {
     pub member: foo::Type,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of bar"][::std::mem::size_of::<bar>() - 4usize];
     ["Alignment of bar"][::std::mem::align_of::<bar>() - 4usize];

--- a/bindgen-tests/tests/expectations/tests/constify-module-enums-simple-alias.rs
+++ b/bindgen-tests/tests/expectations/tests/constify-module-enums-simple-alias.rs
@@ -20,6 +20,7 @@ pub struct Bar {
     pub baz_ptr3: *mut Foo_alias2,
     pub baz_ptr4: *mut Foo_alias3,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of Bar"][::std::mem::size_of::<Bar>() - 48usize];
     ["Alignment of Bar"][::std::mem::align_of::<Bar>() - 8usize];

--- a/bindgen-tests/tests/expectations/tests/constify-module-enums-simple-nonamespace.rs
+++ b/bindgen-tests/tests/expectations/tests/constify-module-enums-simple-nonamespace.rs
@@ -10,6 +10,7 @@ pub struct Bar {
     pub baz1: one_Foo::Type,
     pub baz2: *mut one_Foo::Type,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of Bar"][::std::mem::size_of::<Bar>() - 16usize];
     ["Alignment of Bar"][::std::mem::align_of::<Bar>() - 8usize];

--- a/bindgen-tests/tests/expectations/tests/constify-module-enums-types.rs
+++ b/bindgen-tests/tests/expectations/tests/constify-module-enums-types.rs
@@ -45,6 +45,7 @@ pub struct bar {
     pub member9: anon_enum_alias2,
     pub member10: anon_enum_alias3,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of bar"][::std::mem::size_of::<bar>() - 48usize];
     ["Alignment of bar"][::std::mem::align_of::<bar>() - 8usize];
@@ -73,6 +74,7 @@ impl Default for bar {
 pub struct Baz {
     pub member1: ns2_Foo::Type,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of Baz"][::std::mem::size_of::<Baz>() - 4usize];
     ["Alignment of Baz"][::std::mem::align_of::<Baz>() - 4usize];
@@ -97,6 +99,7 @@ pub mod one_Foo {
 pub struct Bar {
     pub baz: *mut one_Foo::Type,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of Bar"][::std::mem::size_of::<Bar>() - 8usize];
     ["Alignment of Bar"][::std::mem::align_of::<Bar>() - 8usize];

--- a/bindgen-tests/tests/expectations/tests/constructor-tp.rs
+++ b/bindgen-tests/tests/expectations/tests/constructor-tp.rs
@@ -9,6 +9,7 @@ pub struct Foo {
 pub struct Bar {
     pub _address: u8,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of Bar"][::std::mem::size_of::<Bar>() - 1usize];
     ["Alignment of Bar"][::std::mem::align_of::<Bar>() - 1usize];

--- a/bindgen-tests/tests/expectations/tests/constructors.rs
+++ b/bindgen-tests/tests/expectations/tests/constructors.rs
@@ -4,6 +4,7 @@
 pub struct TestOverload {
     pub _address: u8,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of TestOverload"][::std::mem::size_of::<TestOverload>() - 1usize];
     ["Alignment of TestOverload"][::std::mem::align_of::<TestOverload>() - 1usize];
@@ -38,6 +39,7 @@ impl TestOverload {
 pub struct TestPublicNoArgs {
     pub _address: u8,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of TestPublicNoArgs"][::std::mem::size_of::<TestPublicNoArgs>() - 1usize];
     [

--- a/bindgen-tests/tests/expectations/tests/contains-vs-inherits-zero-sized.rs
+++ b/bindgen-tests/tests/expectations/tests/contains-vs-inherits-zero-sized.rs
@@ -5,6 +5,7 @@
 pub struct Empty {
     pub _address: u8,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of Empty"][::std::mem::size_of::<Empty>() - 1usize];
     ["Alignment of Empty"][::std::mem::align_of::<Empty>() - 1usize];
@@ -16,6 +17,7 @@ const _: () = {
 pub struct Inherits {
     pub b: bool,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of Inherits"][::std::mem::size_of::<Inherits>() - 1usize];
     ["Alignment of Inherits"][::std::mem::align_of::<Inherits>() - 1usize];
@@ -29,6 +31,7 @@ pub struct Contains {
     pub empty: Empty,
     pub b: bool,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of Contains"][::std::mem::size_of::<Contains>() - 2usize];
     ["Alignment of Contains"][::std::mem::align_of::<Contains>() - 1usize];

--- a/bindgen-tests/tests/expectations/tests/convert-floats.rs
+++ b/bindgen-tests/tests/expectations/tests/convert-floats.rs
@@ -15,6 +15,7 @@ pub struct foo {
     pub complexFloat: __BindgenComplex<::std::os::raw::c_float>,
     pub complexDouble: __BindgenComplex<::std::os::raw::c_double>,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of foo"][::std::mem::size_of::<foo>() - 48usize];
     ["Alignment of foo"][::std::mem::align_of::<foo>() - 8usize];

--- a/bindgen-tests/tests/expectations/tests/cpp-empty-layout.rs
+++ b/bindgen-tests/tests/expectations/tests/cpp-empty-layout.rs
@@ -4,6 +4,7 @@
 pub struct Foo {
     pub _address: u8,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of Foo"][::std::mem::size_of::<Foo>() - 1usize];
     ["Alignment of Foo"][::std::mem::align_of::<Foo>() - 1usize];

--- a/bindgen-tests/tests/expectations/tests/crtp.rs
+++ b/bindgen-tests/tests/expectations/tests/crtp.rs
@@ -9,6 +9,7 @@ pub struct Base {
 pub struct Derived {
     pub _address: u8,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of Derived"][::std::mem::size_of::<Derived>() - 1usize];
     ["Alignment of Derived"][::std::mem::align_of::<Derived>() - 1usize];
@@ -23,6 +24,7 @@ pub struct BaseWithDestructor {
 pub struct DerivedFromBaseWithDestructor {
     pub _address: u8,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     [
         "Size of DerivedFromBaseWithDestructor",
@@ -31,6 +33,7 @@ const _: () = {
         "Alignment of DerivedFromBaseWithDestructor",
     ][::std::mem::align_of::<DerivedFromBaseWithDestructor>() - 1usize];
 };
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     [
         "Size of template specialization: Base_open0_Derived_close0",
@@ -39,6 +42,7 @@ const _: () = {
         "Align of template specialization: Base_open0_Derived_close0",
     ][::std::mem::align_of::<Base>() - 1usize];
 };
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     [
         "Size of template specialization: BaseWithDestructor_open0_DerivedFromBaseWithDestructor_close0",

--- a/bindgen-tests/tests/expectations/tests/ctypes-prefix-path.rs
+++ b/bindgen-tests/tests/expectations/tests/ctypes-prefix-path.rs
@@ -13,6 +13,7 @@ pub struct foo {
     pub b: libc::foo::c_int,
     pub bar: *mut libc::foo::c_void,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of foo"][::core::mem::size_of::<foo>() - 16usize];
     ["Alignment of foo"][::core::mem::align_of::<foo>() - 8usize];

--- a/bindgen-tests/tests/expectations/tests/default-template-parameter.rs
+++ b/bindgen-tests/tests/expectations/tests/default-template-parameter.rs
@@ -16,6 +16,7 @@ impl<T, U> Default for Foo<T, U> {
         }
     }
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     [
         "Size of template specialization: Foo_open0_bool__int_close0",

--- a/bindgen-tests/tests/expectations/tests/deleted-function.rs
+++ b/bindgen-tests/tests/expectations/tests/deleted-function.rs
@@ -4,6 +4,7 @@
 pub struct A {
     pub _address: u8,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of A"][::std::mem::size_of::<A>() - 1usize];
     ["Alignment of A"][::std::mem::align_of::<A>() - 1usize];
@@ -31,6 +32,7 @@ impl A {
 pub struct B {
     pub _address: u8,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of B"][::std::mem::size_of::<B>() - 1usize];
     ["Alignment of B"][::std::mem::align_of::<B>() - 1usize];
@@ -40,6 +42,7 @@ const _: () = {
 pub struct C {
     pub _address: u8,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of C"][::std::mem::size_of::<C>() - 1usize];
     ["Alignment of C"][::std::mem::align_of::<C>() - 1usize];

--- a/bindgen-tests/tests/expectations/tests/derive-custom-cli.rs
+++ b/bindgen-tests/tests/expectations/tests/derive-custom-cli.rs
@@ -4,6 +4,7 @@
 pub struct foo_struct {
     pub inner: ::std::os::raw::c_int,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of foo_struct"][::std::mem::size_of::<foo_struct>() - 4usize];
     ["Alignment of foo_struct"][::std::mem::align_of::<foo_struct>() - 4usize];
@@ -22,6 +23,7 @@ pub union foo_union {
     pub fst: ::std::mem::ManuallyDrop<::std::os::raw::c_int>,
     pub snd: ::std::mem::ManuallyDrop<f32>,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of foo_union"][::std::mem::size_of::<foo_union>() - 4usize];
     ["Alignment of foo_union"][::std::mem::align_of::<foo_union>() - 4usize];
@@ -32,6 +34,7 @@ const _: () = {
 pub struct non_matching {
     pub inner: ::std::os::raw::c_int,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of non_matching"][::std::mem::size_of::<non_matching>() - 4usize];
     ["Alignment of non_matching"][::std::mem::align_of::<non_matching>() - 4usize];

--- a/bindgen-tests/tests/expectations/tests/derive-debug-mangle-name.rs
+++ b/bindgen-tests/tests/expectations/tests/derive-debug-mangle-name.rs
@@ -12,6 +12,7 @@ pub union perf_event_attr__bindgen_ty_1 {
     pub b: ::std::os::raw::c_int,
     pub c: ::std::os::raw::c_int,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     [
         "Size of perf_event_attr__bindgen_ty_1",
@@ -40,6 +41,7 @@ impl ::std::fmt::Debug for perf_event_attr__bindgen_ty_1 {
         write!(f, "perf_event_attr__bindgen_ty_1 {{ union }}")
     }
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of perf_event_attr"][::std::mem::size_of::<perf_event_attr>() - 12usize];
     ["Alignment of perf_event_attr"][::std::mem::align_of::<perf_event_attr>() - 4usize];

--- a/bindgen-tests/tests/expectations/tests/derive-default-and-blocklist.rs
+++ b/bindgen-tests/tests/expectations/tests/derive-default-and-blocklist.rs
@@ -6,6 +6,7 @@ pub struct BlocklistMe(u8);
 pub struct ShouldNotDeriveDefault {
     pub a: BlocklistMe,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     [
         "Size of ShouldNotDeriveDefault",

--- a/bindgen-tests/tests/expectations/tests/derive-fn-ptr.rs
+++ b/bindgen-tests/tests/expectations/tests/derive-fn-ptr.rs
@@ -24,6 +24,7 @@ pub type my_fun_t = ::std::option::Option<
 pub struct Foo {
     pub callback: my_fun_t,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of Foo"][::std::mem::size_of::<Foo>() - 8usize];
     ["Alignment of Foo"][::std::mem::align_of::<Foo>() - 8usize];
@@ -50,6 +51,7 @@ pub type my_fun2_t = ::std::option::Option<
 pub struct Bar {
     pub callback: my_fun2_t,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of Bar"][::std::mem::size_of::<Bar>() - 8usize];
     ["Alignment of Bar"][::std::mem::align_of::<Bar>() - 8usize];

--- a/bindgen-tests/tests/expectations/tests/derive-hash-and-blocklist.rs
+++ b/bindgen-tests/tests/expectations/tests/derive-hash-and-blocklist.rs
@@ -5,6 +5,7 @@ pub struct BlocklistMe(u8);
 pub struct ShouldNotDeriveHash {
     pub a: BlocklistMe,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     [
         "Size of ShouldNotDeriveHash",

--- a/bindgen-tests/tests/expectations/tests/derive-hash-blocklisting.rs
+++ b/bindgen-tests/tests/expectations/tests/derive-hash-blocklisting.rs
@@ -11,6 +11,7 @@ pub struct Blocklisted<T> {
 pub struct AllowlistedOne {
     pub a: Blocklisted<::std::os::raw::c_int>,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of AllowlistedOne"][::std::mem::size_of::<AllowlistedOne>() - 4usize];
     ["Alignment of AllowlistedOne"][::std::mem::align_of::<AllowlistedOne>() - 4usize];
@@ -32,6 +33,7 @@ impl Default for AllowlistedOne {
 pub struct AllowlistedTwo {
     pub b: Blocklisted<f32>,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of AllowlistedTwo"][::std::mem::size_of::<AllowlistedTwo>() - 4usize];
     ["Alignment of AllowlistedTwo"][::std::mem::align_of::<AllowlistedTwo>() - 4usize];

--- a/bindgen-tests/tests/expectations/tests/derive-hash-struct-with-anon-struct-float.rs
+++ b/bindgen-tests/tests/expectations/tests/derive-hash-struct-with-anon-struct-float.rs
@@ -11,6 +11,7 @@ pub struct foo__bindgen_ty_1 {
     pub a: f32,
     pub b: f32,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of foo__bindgen_ty_1"][::std::mem::size_of::<foo__bindgen_ty_1>() - 8usize];
     [
@@ -23,6 +24,7 @@ const _: () = {
         "Offset of field: foo__bindgen_ty_1::b",
     ][::std::mem::offset_of!(foo__bindgen_ty_1, b) - 4usize];
 };
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of foo"][::std::mem::size_of::<foo>() - 8usize];
     ["Alignment of foo"][::std::mem::align_of::<foo>() - 4usize];

--- a/bindgen-tests/tests/expectations/tests/derive-hash-struct-with-float-array.rs
+++ b/bindgen-tests/tests/expectations/tests/derive-hash-struct-with-float-array.rs
@@ -5,6 +5,7 @@
 pub struct foo {
     pub bar: [f32; 3usize],
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of foo"][::std::mem::size_of::<foo>() - 12usize];
     ["Alignment of foo"][::std::mem::align_of::<foo>() - 4usize];

--- a/bindgen-tests/tests/expectations/tests/derive-hash-struct-with-incomplete-array.rs
+++ b/bindgen-tests/tests/expectations/tests/derive-hash-struct-with-incomplete-array.rs
@@ -35,6 +35,7 @@ pub struct test {
     pub a: ::std::os::raw::c_int,
     pub zero_length_array: __IncompleteArrayField<::std::os::raw::c_char>,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of test"][::std::mem::size_of::<test>() - 4usize];
     ["Alignment of test"][::std::mem::align_of::<test>() - 4usize];
@@ -49,6 +50,7 @@ pub struct test2 {
     pub a: ::std::os::raw::c_int,
     pub incomplete_array: __IncompleteArrayField<::std::os::raw::c_char>,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of test2"][::std::mem::size_of::<test2>() - 4usize];
     ["Alignment of test2"][::std::mem::align_of::<test2>() - 4usize];
@@ -64,6 +66,7 @@ pub struct test3 {
     pub zero_length_array: __IncompleteArrayField<::std::os::raw::c_char>,
     pub incomplete_array: __IncompleteArrayField<::std::os::raw::c_char>,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of test3"][::std::mem::size_of::<test3>() - 4usize];
     ["Alignment of test3"][::std::mem::align_of::<test3>() - 4usize];

--- a/bindgen-tests/tests/expectations/tests/derive-hash-struct-with-pointer.rs
+++ b/bindgen-tests/tests/expectations/tests/derive-hash-struct-with-pointer.rs
@@ -5,6 +5,7 @@
 pub struct ConstPtrMutObj {
     pub bar: *mut ::std::os::raw::c_int,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of ConstPtrMutObj"][::std::mem::size_of::<ConstPtrMutObj>() - 8usize];
     ["Alignment of ConstPtrMutObj"][::std::mem::align_of::<ConstPtrMutObj>() - 8usize];
@@ -26,6 +27,7 @@ impl Default for ConstPtrMutObj {
 pub struct MutPtrMutObj {
     pub bar: *mut ::std::os::raw::c_int,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of MutPtrMutObj"][::std::mem::size_of::<MutPtrMutObj>() - 8usize];
     ["Alignment of MutPtrMutObj"][::std::mem::align_of::<MutPtrMutObj>() - 8usize];
@@ -47,6 +49,7 @@ impl Default for MutPtrMutObj {
 pub struct MutPtrConstObj {
     pub bar: *const ::std::os::raw::c_int,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of MutPtrConstObj"][::std::mem::size_of::<MutPtrConstObj>() - 8usize];
     ["Alignment of MutPtrConstObj"][::std::mem::align_of::<MutPtrConstObj>() - 8usize];
@@ -68,6 +71,7 @@ impl Default for MutPtrConstObj {
 pub struct ConstPtrConstObj {
     pub bar: *const ::std::os::raw::c_int,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of ConstPtrConstObj"][::std::mem::size_of::<ConstPtrConstObj>() - 8usize];
     [

--- a/bindgen-tests/tests/expectations/tests/derive-hash-template-inst-float.rs
+++ b/bindgen-tests/tests/expectations/tests/derive-hash-template-inst-float.rs
@@ -21,6 +21,7 @@ impl<T> Default for foo<T> {
 pub struct IntStr {
     pub a: foo<::std::os::raw::c_int>,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of IntStr"][::std::mem::size_of::<IntStr>() - 4usize];
     ["Alignment of IntStr"][::std::mem::align_of::<IntStr>() - 4usize];
@@ -41,6 +42,7 @@ impl Default for IntStr {
 pub struct FloatStr {
     pub a: foo<f32>,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of FloatStr"][::std::mem::size_of::<FloatStr>() - 4usize];
     ["Alignment of FloatStr"][::std::mem::align_of::<FloatStr>() - 4usize];
@@ -55,6 +57,7 @@ impl Default for FloatStr {
         }
     }
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     [
         "Size of template specialization: foo_open0_int_close0",
@@ -63,6 +66,7 @@ const _: () = {
         "Align of template specialization: foo_open0_int_close0",
     ][::std::mem::align_of::<foo<::std::os::raw::c_int>>() - 4usize];
 };
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     [
         "Size of template specialization: foo_open0_float_close0",

--- a/bindgen-tests/tests/expectations/tests/derive-partialeq-and-blocklist.rs
+++ b/bindgen-tests/tests/expectations/tests/derive-partialeq-and-blocklist.rs
@@ -6,6 +6,7 @@ pub struct BlocklistMe(u8);
 pub struct ShouldNotDerivePartialEq {
     pub a: BlocklistMe,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     [
         "Size of ShouldNotDerivePartialEq",

--- a/bindgen-tests/tests/expectations/tests/derive-partialeq-anonfield.rs
+++ b/bindgen-tests/tests/expectations/tests/derive-partialeq-anonfield.rs
@@ -11,6 +11,7 @@ pub struct rte_mbuf {
 pub struct rte_mbuf__bindgen_ty_1 {
     pub bindgen_union_field: [u8; 0usize],
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     [
         "Size of rte_mbuf__bindgen_ty_1",
@@ -28,6 +29,7 @@ impl Default for rte_mbuf__bindgen_ty_1 {
         }
     }
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of rte_mbuf"][::std::mem::size_of::<rte_mbuf>() - 0usize];
     ["Alignment of rte_mbuf"][::std::mem::align_of::<rte_mbuf>() - 64usize];

--- a/bindgen-tests/tests/expectations/tests/derive-partialeq-pointer.rs
+++ b/bindgen-tests/tests/expectations/tests/derive-partialeq-pointer.rs
@@ -4,6 +4,7 @@
 pub struct Bar {
     pub b: *mut a,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of Bar"][::std::mem::size_of::<Bar>() - 8usize];
     ["Alignment of Bar"][::std::mem::align_of::<Bar>() - 8usize];
@@ -28,6 +29,7 @@ pub struct c {
 pub union c__bindgen_ty_1 {
     pub _address: u8,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of c__bindgen_ty_1"][::std::mem::size_of::<c__bindgen_ty_1>() - 1usize];
     ["Alignment of c__bindgen_ty_1"][::std::mem::align_of::<c__bindgen_ty_1>() - 1usize];
@@ -41,6 +43,7 @@ impl Default for c__bindgen_ty_1 {
         }
     }
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of c"][::std::mem::size_of::<c>() - 1usize];
     ["Alignment of c"][::std::mem::align_of::<c>() - 1usize];
@@ -59,6 +62,7 @@ impl Default for c {
 pub struct a {
     pub d: c,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of a"][::std::mem::size_of::<a>() - 1usize];
     ["Alignment of a"][::std::mem::align_of::<a>() - 1usize];

--- a/bindgen-tests/tests/expectations/tests/derive-partialeq-union.rs
+++ b/bindgen-tests/tests/expectations/tests/derive-partialeq-union.rs
@@ -6,6 +6,7 @@ pub union ShouldNotDerivePartialEq {
     pub a: ::std::os::raw::c_char,
     pub b: ::std::os::raw::c_int,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     [
         "Size of ShouldNotDerivePartialEq",

--- a/bindgen-tests/tests/expectations/tests/disable-nested-struct-naming.rs
+++ b/bindgen-tests/tests/expectations/tests/disable-nested-struct-naming.rs
@@ -27,11 +27,13 @@ pub struct bar1__bindgen_ty_1__bindgen_ty_1 {
 pub struct bar4 {
     pub x4: ::std::os::raw::c_int,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of bar4"][::std::mem::size_of::<bar4>() - 4usize];
     ["Alignment of bar4"][::std::mem::align_of::<bar4>() - 4usize];
     ["Offset of field: bar4::x4"][::std::mem::offset_of!(bar4, x4) - 0usize];
 };
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     [
         "Size of bar1__bindgen_ty_1__bindgen_ty_1",
@@ -46,6 +48,7 @@ const _: () = {
         "Offset of field: bar1__bindgen_ty_1__bindgen_ty_1::b4",
     ][::std::mem::offset_of!(bar1__bindgen_ty_1__bindgen_ty_1, b4) - 4usize];
 };
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     [
         "Size of bar1__bindgen_ty_1",
@@ -60,12 +63,14 @@ const _: () = {
         "Offset of field: bar1__bindgen_ty_1::b3",
     ][::std::mem::offset_of!(bar1__bindgen_ty_1, b3) - 4usize];
 };
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of bar1"][::std::mem::size_of::<bar1>() - 16usize];
     ["Alignment of bar1"][::std::mem::align_of::<bar1>() - 4usize];
     ["Offset of field: bar1::x1"][::std::mem::offset_of!(bar1, x1) - 0usize];
     ["Offset of field: bar1::b2"][::std::mem::offset_of!(bar1, b2) - 4usize];
 };
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of foo"][::std::mem::size_of::<foo>() - 16usize];
     ["Alignment of foo"][::std::mem::align_of::<foo>() - 4usize];
@@ -86,11 +91,13 @@ pub struct _bindgen_ty_1__bindgen_ty_1 {
 pub struct baz {
     pub x: ::std::os::raw::c_int,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of baz"][::std::mem::size_of::<baz>() - 4usize];
     ["Alignment of baz"][::std::mem::align_of::<baz>() - 4usize];
     ["Offset of field: baz::x"][::std::mem::offset_of!(baz, x) - 0usize];
 };
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     [
         "Size of _bindgen_ty_1__bindgen_ty_1",
@@ -102,6 +109,7 @@ const _: () = {
         "Offset of field: _bindgen_ty_1__bindgen_ty_1::b",
     ][::std::mem::offset_of!(_bindgen_ty_1__bindgen_ty_1, b) - 0usize];
 };
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of _bindgen_ty_1"][::std::mem::size_of::<_bindgen_ty_1>() - 4usize];
     ["Alignment of _bindgen_ty_1"][::std::mem::align_of::<_bindgen_ty_1>() - 4usize];

--- a/bindgen-tests/tests/expectations/tests/disable-untagged-union.rs
+++ b/bindgen-tests/tests/expectations/tests/disable-untagged-union.rs
@@ -49,6 +49,7 @@ pub struct Foo {
     pub baz: __BindgenUnionField<::std::os::raw::c_uint>,
     pub bindgen_union_field: u32,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of Foo"][::std::mem::size_of::<Foo>() - 4usize];
     ["Alignment of Foo"][::std::mem::align_of::<Foo>() - 4usize];

--- a/bindgen-tests/tests/expectations/tests/do-not-derive-copy.rs
+++ b/bindgen-tests/tests/expectations/tests/do-not-derive-copy.rs
@@ -4,6 +4,7 @@
 pub struct WouldBeCopyButWeAreNotDerivingCopy {
     pub x: ::std::os::raw::c_int,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     [
         "Size of WouldBeCopyButWeAreNotDerivingCopy",

--- a/bindgen-tests/tests/expectations/tests/doggo-or-null.rs
+++ b/bindgen-tests/tests/expectations/tests/doggo-or-null.rs
@@ -4,6 +4,7 @@
 pub struct Doggo {
     pub x: ::std::os::raw::c_int,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of Doggo"][::std::mem::size_of::<Doggo>() - 4usize];
     ["Alignment of Doggo"][::std::mem::align_of::<Doggo>() - 4usize];
@@ -14,6 +15,7 @@ const _: () = {
 pub struct Null {
     pub _address: u8,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of Null"][::std::mem::size_of::<Null>() - 1usize];
     ["Alignment of Null"][::std::mem::align_of::<Null>() - 1usize];
@@ -30,6 +32,7 @@ const _: () = {
 pub union DoggoOrNull {
     pub _bindgen_opaque_blob: u32,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of DoggoOrNull"][::std::mem::size_of::<DoggoOrNull>() - 4usize];
     ["Alignment of DoggoOrNull"][::std::mem::align_of::<DoggoOrNull>() - 4usize];

--- a/bindgen-tests/tests/expectations/tests/duplicated-definition-count.rs
+++ b/bindgen-tests/tests/expectations/tests/duplicated-definition-count.rs
@@ -4,6 +4,7 @@
 pub struct BitStream {
     pub _address: u8,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of BitStream"][::std::mem::size_of::<BitStream>() - 1usize];
     ["Alignment of BitStream"][::std::mem::align_of::<BitStream>() - 1usize];

--- a/bindgen-tests/tests/expectations/tests/duplicated-namespaces-definitions.rs
+++ b/bindgen-tests/tests/expectations/tests/duplicated-namespaces-definitions.rs
@@ -12,6 +12,7 @@ pub mod root {
             pub foo: ::std::os::raw::c_int,
             pub baz: bool,
         }
+        #[allow(clippy::unnecessary_operation, clippy::identity_op)]
         const _: () = {
             ["Size of Bar"][::std::mem::size_of::<Bar>() - 8usize];
             ["Alignment of Bar"][::std::mem::align_of::<Bar>() - 4usize];
@@ -27,6 +28,7 @@ pub mod root {
         pub struct Foo {
             pub ptr: *mut root::foo::Bar,
         }
+        #[allow(clippy::unnecessary_operation, clippy::identity_op)]
         const _: () = {
             ["Size of Foo"][::std::mem::size_of::<Foo>() - 8usize];
             ["Alignment of Foo"][::std::mem::align_of::<Foo>() - 8usize];

--- a/bindgen-tests/tests/expectations/tests/dynamic_loading_with_blocklist.rs
+++ b/bindgen-tests/tests/expectations/tests/dynamic_loading_with_blocklist.rs
@@ -4,6 +4,7 @@
 pub struct X {
     pub _x: ::std::os::raw::c_int,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of X"][::std::mem::size_of::<X>() - 4usize];
     ["Alignment of X"][::std::mem::align_of::<X>() - 4usize];

--- a/bindgen-tests/tests/expectations/tests/dynamic_loading_with_class.rs
+++ b/bindgen-tests/tests/expectations/tests/dynamic_loading_with_class.rs
@@ -4,6 +4,7 @@
 pub struct A {
     pub _x: ::std::os::raw::c_int,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of A"][::std::mem::size_of::<A>() - 4usize];
     ["Alignment of A"][::std::mem::align_of::<A>() - 4usize];

--- a/bindgen-tests/tests/expectations/tests/enum-default-bitfield.rs
+++ b/bindgen-tests/tests/expectations/tests/enum-default-bitfield.rs
@@ -35,6 +35,7 @@ impl ::std::ops::BitAndAssign for foo__bindgen_ty_1 {
 #[repr(transparent)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct foo__bindgen_ty_1(pub ::std::os::raw::c_uint);
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of foo"][::std::mem::size_of::<foo>() - 4usize];
     ["Alignment of foo"][::std::mem::align_of::<foo>() - 4usize];

--- a/bindgen-tests/tests/expectations/tests/enum-default-consts.rs
+++ b/bindgen-tests/tests/expectations/tests/enum-default-consts.rs
@@ -7,6 +7,7 @@ pub struct foo {
 pub const foo_FOO_A: foo__bindgen_ty_1 = 0;
 pub const foo_FOO_B: foo__bindgen_ty_1 = 1;
 pub type foo__bindgen_ty_1 = ::std::os::raw::c_uint;
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of foo"][::std::mem::size_of::<foo>() - 4usize];
     ["Alignment of foo"][::std::mem::align_of::<foo>() - 4usize];

--- a/bindgen-tests/tests/expectations/tests/enum-default-module.rs
+++ b/bindgen-tests/tests/expectations/tests/enum-default-module.rs
@@ -9,6 +9,7 @@ pub mod foo__bindgen_ty_1 {
     pub const FOO_A: Type = 0;
     pub const FOO_B: Type = 1;
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of foo"][::std::mem::size_of::<foo>() - 4usize];
     ["Alignment of foo"][::std::mem::align_of::<foo>() - 4usize];

--- a/bindgen-tests/tests/expectations/tests/enum-default-rust.rs
+++ b/bindgen-tests/tests/expectations/tests/enum-default-rust.rs
@@ -12,6 +12,7 @@ pub enum foo__bindgen_ty_1 {
     FOO_A = 0,
     FOO_B = 1,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of foo"][::std::mem::size_of::<foo>() - 4usize];
     ["Alignment of foo"][::std::mem::align_of::<foo>() - 4usize];

--- a/bindgen-tests/tests/expectations/tests/enum-no-debug-rust.rs
+++ b/bindgen-tests/tests/expectations/tests/enum-no-debug-rust.rs
@@ -12,6 +12,7 @@ pub enum foo__bindgen_ty_1 {
     FOO_A = 0,
     FOO_B = 1,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of foo"][::std::mem::size_of::<foo>() - 4usize];
     ["Alignment of foo"][::std::mem::align_of::<foo>() - 4usize];

--- a/bindgen-tests/tests/expectations/tests/enum.rs
+++ b/bindgen-tests/tests/expectations/tests/enum.rs
@@ -7,6 +7,7 @@ pub struct foo {
 pub const foo_FOO_A: foo__bindgen_ty_1 = 0;
 pub const foo_FOO_B: foo__bindgen_ty_1 = 1;
 pub type foo__bindgen_ty_1 = ::std::os::raw::c_uint;
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of foo"][::std::mem::size_of::<foo>() - 4usize];
     ["Alignment of foo"][::std::mem::align_of::<foo>() - 4usize];

--- a/bindgen-tests/tests/expectations/tests/enum_and_vtable_mangling.rs
+++ b/bindgen-tests/tests/expectations/tests/enum_and_vtable_mangling.rs
@@ -17,6 +17,7 @@ pub struct C {
     pub vtable_: *const C__bindgen_vtable,
     pub i: ::std::os::raw::c_int,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of C"][::std::mem::size_of::<C>() - 16usize];
     ["Alignment of C"][::std::mem::align_of::<C>() - 8usize];

--- a/bindgen-tests/tests/expectations/tests/explicit-padding.rs
+++ b/bindgen-tests/tests/expectations/tests/explicit-padding.rs
@@ -8,6 +8,7 @@ pub struct pad_me {
     pub third: u16,
     pub __bindgen_padding_1: [u8; 2usize],
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of pad_me"][::std::mem::size_of::<pad_me>() - 12usize];
     ["Alignment of pad_me"][::std::mem::align_of::<pad_me>() - 4usize];
@@ -22,6 +23,7 @@ pub union dont_pad_me {
     pub second: u32,
     pub third: u16,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of dont_pad_me"][::std::mem::size_of::<dont_pad_me>() - 4usize];
     ["Alignment of dont_pad_me"][::std::mem::align_of::<dont_pad_me>() - 4usize];

--- a/bindgen-tests/tests/expectations/tests/field-visibility-callback.rs
+++ b/bindgen-tests/tests/expectations/tests/field-visibility-callback.rs
@@ -92,6 +92,7 @@ pub struct my_struct {
     _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
     __bindgen_padding_0: [u8; 3usize],
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of my_struct"][::std::mem::size_of::<my_struct>() - 12usize];
     ["Alignment of my_struct"][::std::mem::align_of::<my_struct>() - 4usize];

--- a/bindgen-tests/tests/expectations/tests/field-visibility.rs
+++ b/bindgen-tests/tests/expectations/tests/field-visibility.rs
@@ -91,6 +91,7 @@ pub struct my_struct1 {
     _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
     __bindgen_padding_0: [u8; 3usize],
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of my_struct1"][::std::mem::size_of::<my_struct1>() - 4usize];
     ["Alignment of my_struct1"][::std::mem::align_of::<my_struct1>() - 4usize];
@@ -130,6 +131,7 @@ pub struct my_struct2 {
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
     pub __bindgen_padding_0: [u8; 3usize],
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of my_struct2"][::std::mem::size_of::<my_struct2>() - 4usize];
     ["Alignment of my_struct2"][::std::mem::align_of::<my_struct2>() - 4usize];

--- a/bindgen-tests/tests/expectations/tests/flexarray.rs
+++ b/bindgen-tests/tests/expectations/tests/flexarray.rs
@@ -37,6 +37,7 @@ pub struct flexarray<FAM: ?Sized = [::std::os::raw::c_int; 0]> {
     pub count: ::std::os::raw::c_int,
     pub data: FAM,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of flexarray"][::std::mem::size_of::<flexarray>() - 4usize];
     ["Alignment of flexarray"][::std::mem::align_of::<flexarray>() - 4usize];
@@ -126,6 +127,7 @@ pub struct flexarray_zero<FAM: ?Sized = [::std::os::raw::c_int; 0]> {
     pub count: ::std::os::raw::c_int,
     pub data: FAM,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of flexarray_zero"][::std::mem::size_of::<flexarray_zero>() - 4usize];
     ["Alignment of flexarray_zero"][::std::mem::align_of::<flexarray_zero>() - 4usize];
@@ -310,6 +312,7 @@ impl<T> Default for flexarray_template<T, [T; 0]> {
 pub struct flexarray_ref {
     pub things: *mut flexarray,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of flexarray_ref"][::std::mem::size_of::<flexarray_ref>() - 8usize];
     ["Alignment of flexarray_ref"][::std::mem::align_of::<flexarray_ref>() - 8usize];
@@ -333,6 +336,7 @@ pub struct flexarray_bogus_zero_fam<FAM: ?Sized = [::std::os::raw::c_char; 0]> {
     pub data1: __IncompleteArrayField<::std::os::raw::c_int>,
     pub data2: FAM,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     [
         "Size of flexarray_bogus_zero_fam",
@@ -447,6 +451,7 @@ pub struct flexarray_align<FAM: ?Sized = [::std::os::raw::c_int; 0]> {
     pub count: ::std::os::raw::c_int,
     pub data: FAM,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of flexarray_align"][::std::mem::size_of::<flexarray_align>() - 128usize];
     [

--- a/bindgen-tests/tests/expectations/tests/float16.rs
+++ b/bindgen-tests/tests/expectations/tests/float16.rs
@@ -10,6 +10,7 @@ extern "C" {
 pub struct Test__Float16 {
     pub f: __BindgenFloat16,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of Test__Float16"][::std::mem::size_of::<Test__Float16>() - 2usize];
     ["Alignment of Test__Float16"][::std::mem::align_of::<Test__Float16>() - 2usize];
@@ -22,6 +23,7 @@ const _: () = {
 pub struct Test__Float16Ref {
     pub f: *mut __BindgenFloat16,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of Test__Float16Ref"][::std::mem::size_of::<Test__Float16Ref>() - 8usize];
     [

--- a/bindgen-tests/tests/expectations/tests/forward-declaration-autoptr.rs
+++ b/bindgen-tests/tests/expectations/tests/forward-declaration-autoptr.rs
@@ -24,6 +24,7 @@ impl<T> Default for RefPtr<T> {
 pub struct Bar {
     pub m_member: RefPtr<Foo>,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of Bar"][::std::mem::size_of::<Bar>() - 8usize];
     ["Alignment of Bar"][::std::mem::align_of::<Bar>() - 8usize];
@@ -38,6 +39,7 @@ impl Default for Bar {
         }
     }
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     [
         "Size of template specialization: RefPtr_open0_Foo_close0",

--- a/bindgen-tests/tests/expectations/tests/forward_declared_complex_types.rs
+++ b/bindgen-tests/tests/expectations/tests/forward_declared_complex_types.rs
@@ -4,6 +4,7 @@
 pub struct Foo_empty {
     pub _address: u8,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of Foo_empty"][::std::mem::size_of::<Foo_empty>() - 1usize];
     ["Alignment of Foo_empty"][::std::mem::align_of::<Foo_empty>() - 1usize];
@@ -18,6 +19,7 @@ pub struct Foo {
 pub struct Bar {
     pub f: *mut Foo,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of Bar"][::std::mem::size_of::<Bar>() - 8usize];
     ["Alignment of Bar"][::std::mem::align_of::<Bar>() - 8usize];

--- a/bindgen-tests/tests/expectations/tests/forward_declared_struct.rs
+++ b/bindgen-tests/tests/expectations/tests/forward_declared_struct.rs
@@ -4,6 +4,7 @@
 pub struct a {
     pub b: ::std::os::raw::c_int,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of a"][::std::mem::size_of::<a>() - 4usize];
     ["Alignment of a"][::std::mem::align_of::<a>() - 4usize];
@@ -14,6 +15,7 @@ const _: () = {
 pub struct c {
     pub d: ::std::os::raw::c_int,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of c"][::std::mem::size_of::<c>() - 4usize];
     ["Alignment of c"][::std::mem::align_of::<c>() - 4usize];

--- a/bindgen-tests/tests/expectations/tests/func_ptr_in_struct.rs
+++ b/bindgen-tests/tests/expectations/tests/func_ptr_in_struct.rs
@@ -11,6 +11,7 @@ pub struct Foo {
         unsafe extern "C" fn(x: ::std::os::raw::c_int, y: ::std::os::raw::c_int) -> baz,
     >,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of Foo"][::std::mem::size_of::<Foo>() - 8usize];
     ["Alignment of Foo"][::std::mem::align_of::<Foo>() - 8usize];

--- a/bindgen-tests/tests/expectations/tests/func_return_must_use.rs
+++ b/bindgen-tests/tests/expectations/tests/func_return_must_use.rs
@@ -28,6 +28,7 @@ extern "C" {
 #[derive(Debug, Default, Copy, Clone)]
 #[must_use]
 pub struct AnnotatedStruct {}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of AnnotatedStruct"][::std::mem::size_of::<AnnotatedStruct>() - 0usize];
     ["Alignment of AnnotatedStruct"][::std::mem::align_of::<AnnotatedStruct>() - 1usize];
@@ -39,6 +40,7 @@ extern "C" {
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct PlainStruct {}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of PlainStruct"][::std::mem::size_of::<PlainStruct>() - 0usize];
     ["Alignment of PlainStruct"][::std::mem::align_of::<PlainStruct>() - 1usize];

--- a/bindgen-tests/tests/expectations/tests/gen-constructors-neg.rs
+++ b/bindgen-tests/tests/expectations/tests/gen-constructors-neg.rs
@@ -4,6 +4,7 @@
 pub struct Foo {
     pub _address: u8,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of Foo"][::std::mem::size_of::<Foo>() - 1usize];
     ["Alignment of Foo"][::std::mem::align_of::<Foo>() - 1usize];

--- a/bindgen-tests/tests/expectations/tests/gen-constructors.rs
+++ b/bindgen-tests/tests/expectations/tests/gen-constructors.rs
@@ -4,6 +4,7 @@
 pub struct Foo {
     pub _address: u8,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of Foo"][::std::mem::size_of::<Foo>() - 1usize];
     ["Alignment of Foo"][::std::mem::align_of::<Foo>() - 1usize];

--- a/bindgen-tests/tests/expectations/tests/gen-destructors-neg.rs
+++ b/bindgen-tests/tests/expectations/tests/gen-destructors-neg.rs
@@ -4,6 +4,7 @@
 pub struct Foo {
     pub bar: ::std::os::raw::c_int,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of Foo"][::std::mem::size_of::<Foo>() - 4usize];
     ["Alignment of Foo"][::std::mem::align_of::<Foo>() - 4usize];

--- a/bindgen-tests/tests/expectations/tests/gen-destructors.rs
+++ b/bindgen-tests/tests/expectations/tests/gen-destructors.rs
@@ -4,6 +4,7 @@
 pub struct Foo {
     pub bar: ::std::os::raw::c_int,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of Foo"][::std::mem::size_of::<Foo>() - 4usize];
     ["Alignment of Foo"][::std::mem::align_of::<Foo>() - 4usize];

--- a/bindgen-tests/tests/expectations/tests/generate-inline.rs
+++ b/bindgen-tests/tests/expectations/tests/generate-inline.rs
@@ -4,6 +4,7 @@
 pub struct Foo {
     pub _address: u8,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of Foo"][::std::mem::size_of::<Foo>() - 1usize];
     ["Alignment of Foo"][::std::mem::align_of::<Foo>() - 1usize];

--- a/bindgen-tests/tests/expectations/tests/incomplete-array-padding.rs
+++ b/bindgen-tests/tests/expectations/tests/incomplete-array-padding.rs
@@ -120,6 +120,7 @@ pub struct foo {
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
     pub b: __IncompleteArrayField<*mut ::std::os::raw::c_void>,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of foo"][::std::mem::size_of::<foo>() - 8usize];
     ["Alignment of foo"][::std::mem::align_of::<foo>() - 8usize];

--- a/bindgen-tests/tests/expectations/tests/inherit-from-template-instantiation-with-vtable.rs
+++ b/bindgen-tests/tests/expectations/tests/inherit-from-template-instantiation-with-vtable.rs
@@ -24,6 +24,7 @@ impl<T> Default for BaseWithVtable<T> {
 pub struct DerivedWithNoVirtualMethods {
     pub _base: BaseWithVtable<*mut ::std::os::raw::c_char>,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     [
         "Size of DerivedWithNoVirtualMethods",
@@ -47,6 +48,7 @@ impl Default for DerivedWithNoVirtualMethods {
 pub struct DerivedWithVirtualMethods {
     pub _base: BaseWithVtable<*mut ::std::os::raw::c_char>,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     [
         "Size of DerivedWithVirtualMethods",
@@ -89,6 +91,7 @@ pub struct DerivedWithVtable {
     pub vtable_: *const DerivedWithVtable__bindgen_vtable,
     pub _base: BaseWithoutVtable<*mut ::std::os::raw::c_char>,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of DerivedWithVtable"][::std::mem::size_of::<DerivedWithVtable>() - 16usize];
     [
@@ -110,6 +113,7 @@ impl Default for DerivedWithVtable {
 pub struct DerivedWithoutVtable {
     pub _base: BaseWithoutVtable<*mut ::std::os::raw::c_char>,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     [
         "Size of DerivedWithoutVtable",
@@ -127,6 +131,7 @@ impl Default for DerivedWithoutVtable {
         }
     }
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     [
         "Size of template specialization: BaseWithVtable_open0_ptr_char_close0",
@@ -135,6 +140,7 @@ const _: () = {
         "Align of template specialization: BaseWithVtable_open0_ptr_char_close0",
     ][::std::mem::align_of::<BaseWithVtable<*mut ::std::os::raw::c_char>>() - 8usize];
 };
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     [
         "Size of template specialization: BaseWithVtable_open0_ptr_char_close0",
@@ -143,6 +149,7 @@ const _: () = {
         "Align of template specialization: BaseWithVtable_open0_ptr_char_close0",
     ][::std::mem::align_of::<BaseWithVtable<*mut ::std::os::raw::c_char>>() - 8usize];
 };
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     [
         "Size of template specialization: BaseWithoutVtable_open0_ptr_char_close0",
@@ -151,6 +158,7 @@ const _: () = {
         "Align of template specialization: BaseWithoutVtable_open0_ptr_char_close0",
     ][::std::mem::align_of::<BaseWithoutVtable<*mut ::std::os::raw::c_char>>() - 8usize];
 };
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     [
         "Size of template specialization: BaseWithoutVtable_open0_ptr_char_close0",

--- a/bindgen-tests/tests/expectations/tests/inherit_multiple_interfaces.rs
+++ b/bindgen-tests/tests/expectations/tests/inherit_multiple_interfaces.rs
@@ -7,6 +7,7 @@ pub struct A {
     pub vtable_: *const A__bindgen_vtable,
     pub member: ::std::os::raw::c_int,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of A"][::std::mem::size_of::<A>() - 16usize];
     ["Alignment of A"][::std::mem::align_of::<A>() - 8usize];
@@ -29,6 +30,7 @@ pub struct B {
     pub vtable_: *const B__bindgen_vtable,
     pub member2: *mut ::std::os::raw::c_void,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of B"][::std::mem::size_of::<B>() - 16usize];
     ["Alignment of B"][::std::mem::align_of::<B>() - 8usize];
@@ -50,6 +52,7 @@ pub struct C {
     pub _base_1: B,
     pub member3: f32,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of C"][::std::mem::size_of::<C>() - 40usize];
     ["Alignment of C"][::std::mem::align_of::<C>() - 8usize];

--- a/bindgen-tests/tests/expectations/tests/inherit_typedef.rs
+++ b/bindgen-tests/tests/expectations/tests/inherit_typedef.rs
@@ -4,6 +4,7 @@
 pub struct Foo {
     pub _address: u8,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of Foo"][::std::mem::size_of::<Foo>() - 1usize];
     ["Alignment of Foo"][::std::mem::align_of::<Foo>() - 1usize];
@@ -14,6 +15,7 @@ pub type TypedefedFoo = Foo;
 pub struct Bar {
     pub _address: u8,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of Bar"][::std::mem::size_of::<Bar>() - 1usize];
     ["Alignment of Bar"][::std::mem::align_of::<Bar>() - 1usize];

--- a/bindgen-tests/tests/expectations/tests/inline_namespace.rs
+++ b/bindgen-tests/tests/expectations/tests/inline_namespace.rs
@@ -13,6 +13,7 @@ pub mod root {
     pub struct Bar {
         pub baz: root::foo::Ty,
     }
+    #[allow(clippy::unnecessary_operation, clippy::identity_op)]
     const _: () = {
         ["Size of Bar"][::std::mem::size_of::<Bar>() - 4usize];
         ["Alignment of Bar"][::std::mem::align_of::<Bar>() - 4usize];

--- a/bindgen-tests/tests/expectations/tests/inline_namespace_conservative.rs
+++ b/bindgen-tests/tests/expectations/tests/inline_namespace_conservative.rs
@@ -18,6 +18,7 @@ pub mod root {
     pub struct Bar {
         pub baz: root::foo::bar::Ty,
     }
+    #[allow(clippy::unnecessary_operation, clippy::identity_op)]
     const _: () = {
         ["Size of Bar"][::std::mem::size_of::<Bar>() - 4usize];
         ["Alignment of Bar"][::std::mem::align_of::<Bar>() - 4usize];

--- a/bindgen-tests/tests/expectations/tests/inner_const.rs
+++ b/bindgen-tests/tests/expectations/tests/inner_const.rs
@@ -12,6 +12,7 @@ extern "C" {
     #[link_name = "\u{1}_ZN3Foo8whateverE"]
     pub static mut Foo_whatever: Foo;
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of Foo"][::std::mem::size_of::<Foo>() - 4usize];
     ["Alignment of Foo"][::std::mem::align_of::<Foo>() - 4usize];

--- a/bindgen-tests/tests/expectations/tests/inner_template_self.rs
+++ b/bindgen-tests/tests/expectations/tests/inner_template_self.rs
@@ -19,6 +19,7 @@ impl Default for LinkedList {
 pub struct InstantiateIt {
     pub m_list: LinkedList,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of InstantiateIt"][::std::mem::size_of::<InstantiateIt>() - 16usize];
     ["Alignment of InstantiateIt"][::std::mem::align_of::<InstantiateIt>() - 8usize];
@@ -35,6 +36,7 @@ impl Default for InstantiateIt {
         }
     }
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     [
         "Size of template specialization: LinkedList_open0_int_close0",

--- a/bindgen-tests/tests/expectations/tests/issue-1034.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-1034.rs
@@ -89,6 +89,7 @@ pub struct S2 {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 2usize]>,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of S2"][::std::mem::size_of::<S2>() - 2usize];
     ["Alignment of S2"][::std::mem::align_of::<S2>() - 1usize];

--- a/bindgen-tests/tests/expectations/tests/issue-1076-unnamed-bitfield-alignment.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-1076-unnamed-bitfield-alignment.rs
@@ -89,6 +89,7 @@ pub struct S1 {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 3usize]>,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of S1"][::std::mem::size_of::<S1>() - 3usize];
     ["Alignment of S1"][::std::mem::align_of::<S1>() - 1usize];

--- a/bindgen-tests/tests/expectations/tests/issue-1118-using-forward-decl.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-1118-using-forward-decl.rs
@@ -5,6 +5,7 @@ pub type c = nsTArray;
 pub struct nsTArray_base {
     pub d: *mut ::std::os::raw::c_int,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of nsTArray_base"][::std::mem::size_of::<nsTArray_base>() - 8usize];
     ["Alignment of nsTArray_base"][::std::mem::align_of::<nsTArray_base>() - 8usize];
@@ -40,6 +41,7 @@ impl Default for nsTArray {
 pub struct nsIContent {
     pub foo: nsTArray,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of nsIContent"][::std::mem::size_of::<nsIContent>() - 8usize];
     ["Alignment of nsIContent"][::std::mem::align_of::<nsIContent>() - 8usize];
@@ -60,6 +62,7 @@ extern "C" {
     #[link_name = "\u{1}_Z35Gecko_GetAnonymousContentForElementv"]
     pub fn Gecko_GetAnonymousContentForElement() -> *mut nsTArray;
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     [
         "Size of template specialization: nsTArray_open0_ptr_nsIContent_close0",
@@ -68,6 +71,7 @@ const _: () = {
         "Align of template specialization: nsTArray_open0_ptr_nsIContent_close0",
     ][::std::mem::align_of::<nsTArray>() - 8usize];
 };
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     [
         "Size of template specialization: nsTArray_open0_ptr_nsIContent_close0",

--- a/bindgen-tests/tests/expectations/tests/issue-1197-pure-virtual-stuff.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-1197-pure-virtual-stuff.rs
@@ -6,6 +6,7 @@ pub struct Foo__bindgen_vtable(::std::os::raw::c_void);
 pub struct Foo {
     pub vtable_: *const Foo__bindgen_vtable,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of Foo"][::std::mem::size_of::<Foo>() - 8usize];
     ["Alignment of Foo"][::std::mem::align_of::<Foo>() - 8usize];

--- a/bindgen-tests/tests/expectations/tests/issue-1216-variadic-member.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-1216-variadic-member.rs
@@ -14,6 +14,7 @@ pub struct Foo {
         ),
     >,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of Foo"][::std::mem::size_of::<Foo>() - 8usize];
     ["Alignment of Foo"][::std::mem::align_of::<Foo>() - 8usize];

--- a/bindgen-tests/tests/expectations/tests/issue-1281.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-1281.rs
@@ -9,11 +9,13 @@ pub struct bar {
 pub struct foo {
     pub foo: ::std::os::raw::c_int,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of foo"][::std::mem::size_of::<foo>() - 4usize];
     ["Alignment of foo"][::std::mem::align_of::<foo>() - 4usize];
     ["Offset of field: foo::foo"][::std::mem::offset_of!(foo, foo) - 0usize];
 };
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of bar"][::std::mem::size_of::<bar>() - 4usize];
     ["Alignment of bar"][::std::mem::align_of::<bar>() - 4usize];
@@ -25,6 +27,7 @@ pub type bar_t = bar;
 pub struct baz {
     pub f: foo,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of baz"][::std::mem::size_of::<baz>() - 4usize];
     ["Alignment of baz"][::std::mem::align_of::<baz>() - 4usize];

--- a/bindgen-tests/tests/expectations/tests/issue-1285.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-1285.rs
@@ -10,6 +10,7 @@ pub union foo__bindgen_ty_1 {
     pub a: ::std::os::raw::c_uint,
     pub b: ::std::os::raw::c_ushort,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of foo__bindgen_ty_1"][::std::mem::size_of::<foo__bindgen_ty_1>() - 4usize];
     [
@@ -31,6 +32,7 @@ impl Default for foo__bindgen_ty_1 {
         }
     }
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of foo"][::std::mem::size_of::<foo>() - 4usize];
     ["Alignment of foo"][::std::mem::align_of::<foo>() - 4usize];

--- a/bindgen-tests/tests/expectations/tests/issue-1382-rust-primitive-types.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-1382-rust-primitive-types.rs
@@ -25,6 +25,7 @@ pub struct Foo {
     pub f32_: ::std::os::raw::c_int,
     pub f64_: ::std::os::raw::c_int,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of Foo"][::std::mem::size_of::<Foo>() - 56usize];
     ["Alignment of Foo"][::std::mem::align_of::<Foo>() - 4usize];

--- a/bindgen-tests/tests/expectations/tests/issue-1443.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-1443.rs
@@ -10,6 +10,7 @@ pub struct Bar {
     pub f: *const Foo,
     pub m: ::std::os::raw::c_uint,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of Bar"][::std::mem::size_of::<Bar>() - 16usize];
     ["Alignment of Bar"][::std::mem::align_of::<Bar>() - 8usize];
@@ -31,6 +32,7 @@ pub struct Baz {
     pub f: *mut Foo,
     pub m: ::std::os::raw::c_uint,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of Baz"][::std::mem::size_of::<Baz>() - 16usize];
     ["Alignment of Baz"][::std::mem::align_of::<Baz>() - 8usize];
@@ -52,6 +54,7 @@ pub struct Tar {
     pub f: *const Foo,
     pub m: ::std::os::raw::c_uint,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of Tar"][::std::mem::size_of::<Tar>() - 16usize];
     ["Alignment of Tar"][::std::mem::align_of::<Tar>() - 8usize];
@@ -73,6 +76,7 @@ pub struct Taz {
     pub f: *mut Foo,
     pub m: ::std::os::raw::c_uint,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of Taz"][::std::mem::size_of::<Taz>() - 16usize];
     ["Alignment of Taz"][::std::mem::align_of::<Taz>() - 8usize];

--- a/bindgen-tests/tests/expectations/tests/issue-1454.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-1454.rs
@@ -7,6 +7,7 @@ pub struct extern_type;
 pub struct local_type {
     pub inner: extern_type,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of local_type"][::std::mem::size_of::<local_type>() - 0usize];
     ["Alignment of local_type"][::std::mem::align_of::<local_type>() - 1usize];

--- a/bindgen-tests/tests/expectations/tests/issue-1498.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-1498.rs
@@ -24,6 +24,7 @@ pub union rte_memseg__bindgen_ty_1 {
     ///< Makes sure addr is always 64 bits
     pub addr_64: u64,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     [
         "Size of rte_memseg__bindgen_ty_1",
@@ -47,6 +48,7 @@ impl Default for rte_memseg__bindgen_ty_1 {
         }
     }
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of rte_memseg"][::std::mem::size_of::<rte_memseg>() - 44usize];
     ["Alignment of rte_memseg"][::std::mem::align_of::<rte_memseg>() - 1usize];

--- a/bindgen-tests/tests/expectations/tests/issue-1947.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-1947.rs
@@ -96,6 +96,7 @@ pub struct V56AMDY {
     pub _bitfield_2: __BindgenBitfieldUnit<[u8; 3usize]>,
     pub _rB_: U8,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of V56AMDY"][::std::mem::size_of::<V56AMDY>() - 8usize];
     ["Alignment of V56AMDY"][::std::mem::align_of::<V56AMDY>() - 2usize];

--- a/bindgen-tests/tests/expectations/tests/issue-1977-larger-arrays.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-1977-larger-arrays.rs
@@ -4,6 +4,7 @@
 pub struct S {
     pub large_array: [::std::os::raw::c_char; 33usize],
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of S"][::std::mem::size_of::<S>() - 33usize];
     ["Alignment of S"][::std::mem::align_of::<S>() - 1usize];

--- a/bindgen-tests/tests/expectations/tests/issue-1995.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-1995.rs
@@ -11,6 +11,7 @@ pub const FOO: ::std::os::raw::c_int = 1;
 pub struct Bar {
     pub baz: ::std::os::raw::c_int,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of Bar"][::std::mem::size_of::<Bar>() - 4usize];
     ["Alignment of Bar"][::std::mem::align_of::<Bar>() - 4usize];

--- a/bindgen-tests/tests/expectations/tests/issue-2019.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-2019.rs
@@ -4,6 +4,7 @@
 pub struct A {
     pub a: ::std::os::raw::c_int,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of A"][::std::mem::size_of::<A>() - 4usize];
     ["Alignment of A"][::std::mem::align_of::<A>() - 4usize];
@@ -24,6 +25,7 @@ impl A {
 pub struct B {
     pub b: ::std::os::raw::c_int,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of B"][::std::mem::size_of::<B>() - 4usize];
     ["Alignment of B"][::std::mem::align_of::<B>() - 4usize];

--- a/bindgen-tests/tests/expectations/tests/issue-2556.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-2556.rs
@@ -9,6 +9,7 @@ pub mod root {
         pub width: ::std::os::raw::c_int,
         pub height: ::std::os::raw::c_int,
     }
+    #[allow(clippy::unnecessary_operation, clippy::identity_op)]
     const _: () = {
         ["Size of nsSize"][::std::mem::size_of::<nsSize>() - 8usize];
         ["Alignment of nsSize"][::std::mem::align_of::<nsSize>() - 4usize];

--- a/bindgen-tests/tests/expectations/tests/issue-2695.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-2695.rs
@@ -8,6 +8,7 @@ pub struct Test {
     pub c: ::std::os::raw::c_char,
     pub __bindgen_padding_0: u8,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of Test"][::std::mem::size_of::<Test>() - 12usize];
     ["Alignment of Test"][::std::mem::align_of::<Test>() - 2usize];

--- a/bindgen-tests/tests/expectations/tests/issue-410.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-410.rs
@@ -11,6 +11,7 @@ pub mod root {
         pub struct Value {
             pub _address: u8,
         }
+        #[allow(clippy::unnecessary_operation, clippy::identity_op)]
         const _: () = {
             ["Size of Value"][::std::mem::size_of::<Value>() - 1usize];
             ["Alignment of Value"][::std::mem::align_of::<Value>() - 1usize];

--- a/bindgen-tests/tests/expectations/tests/issue-447.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-447.rs
@@ -14,6 +14,7 @@ pub mod root {
             pub struct GuardObjectNotifier {
                 pub _address: u8,
             }
+            #[allow(clippy::unnecessary_operation, clippy::identity_op)]
             const _: () = {
                 [
                     "Size of GuardObjectNotifier",
@@ -29,6 +30,7 @@ pub mod root {
     pub struct JSAutoCompartment {
         pub _address: u8,
     }
+    #[allow(clippy::unnecessary_operation, clippy::identity_op)]
     const _: () = {
         [
             "Size of JSAutoCompartment",

--- a/bindgen-tests/tests/expectations/tests/issue-537.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-537.rs
@@ -6,6 +6,7 @@
 pub struct AlignedToOne {
     pub i: ::std::os::raw::c_int,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of AlignedToOne"][::std::mem::size_of::<AlignedToOne>() - 4usize];
     ["Alignment of AlignedToOne"][::std::mem::align_of::<AlignedToOne>() - 1usize];
@@ -20,6 +21,7 @@ const _: () = {
 pub struct AlignedToTwo {
     pub i: ::std::os::raw::c_int,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of AlignedToTwo"][::std::mem::size_of::<AlignedToTwo>() - 4usize];
     ["Alignment of AlignedToTwo"][::std::mem::align_of::<AlignedToTwo>() - 2usize];
@@ -36,6 +38,7 @@ pub struct PackedToOne {
     pub x: ::std::os::raw::c_int,
     pub y: ::std::os::raw::c_int,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of PackedToOne"][::std::mem::size_of::<PackedToOne>() - 8usize];
     ["Alignment of PackedToOne"][::std::mem::align_of::<PackedToOne>() - 1usize];
@@ -51,6 +54,7 @@ pub struct PackedToTwo {
     pub x: ::std::os::raw::c_int,
     pub y: ::std::os::raw::c_int,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of PackedToTwo"][::std::mem::size_of::<PackedToTwo>() - 8usize];
     ["Alignment of PackedToTwo"][::std::mem::align_of::<PackedToTwo>() - 2usize];

--- a/bindgen-tests/tests/expectations/tests/issue-569-non-type-template-params-causing-layout-test-failures.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-569-non-type-template-params-causing-layout-test-failures.rs
@@ -27,6 +27,7 @@ impl Default for JS_Base {
 pub struct JS_AutoIdVector {
     pub _base: JS_Base,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of JS_AutoIdVector"][::std::mem::size_of::<JS_AutoIdVector>() - 1usize];
     ["Alignment of JS_AutoIdVector"][::std::mem::align_of::<JS_AutoIdVector>() - 1usize];
@@ -40,6 +41,7 @@ impl Default for JS_AutoIdVector {
         }
     }
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     [
         "Size of template specialization: JS_Base_open0_int_close0",

--- a/bindgen-tests/tests/expectations/tests/issue-573-layout-test-failures.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-573-layout-test-failures.rs
@@ -9,6 +9,7 @@ pub struct Outer {
 pub struct AutoIdVector {
     pub ar: Outer,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of AutoIdVector"][::std::mem::size_of::<AutoIdVector>() - 1usize];
     ["Alignment of AutoIdVector"][::std::mem::align_of::<AutoIdVector>() - 1usize];
@@ -16,6 +17,7 @@ const _: () = {
         "Offset of field: AutoIdVector::ar",
     ][::std::mem::offset_of!(AutoIdVector, ar) - 0usize];
 };
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     [
         "Size of template specialization: Outer_open0_int_close0",

--- a/bindgen-tests/tests/expectations/tests/issue-574-assertion-failure-in-codegen.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-574-assertion-failure-in-codegen.rs
@@ -9,6 +9,7 @@ pub struct a {
 pub struct _bindgen_ty_1 {
     pub ar: a,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of _bindgen_ty_1"][::std::mem::size_of::<_bindgen_ty_1>() - 1usize];
     ["Alignment of _bindgen_ty_1"][::std::mem::align_of::<_bindgen_ty_1>() - 1usize];
@@ -19,6 +20,7 @@ const _: () = {
 extern "C" {
     pub static mut AutoIdVector: _bindgen_ty_1;
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     [
         "Size of template specialization: a_open0_int_close0",

--- a/bindgen-tests/tests/expectations/tests/issue-584-stylo-template-analysis-panic.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-584-stylo-template-analysis-panic.rs
@@ -6,6 +6,7 @@ pub struct A {
     pub _address: u8,
 }
 pub type A_a = b;
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of A"][::std::mem::size_of::<A>() - 1usize];
     ["Alignment of A"][::std::mem::align_of::<A>() - 1usize];
@@ -33,6 +34,7 @@ pub struct f {
 pub struct g {
     pub h: f,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of g"][::std::mem::size_of::<g>() - 1usize];
     ["Alignment of g"][::std::mem::align_of::<g>() - 1usize];
@@ -51,6 +53,7 @@ impl Default for g {
 pub struct b {
     pub _base: g,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of b"][::std::mem::size_of::<b>() - 1usize];
     ["Alignment of b"][::std::mem::align_of::<b>() - 1usize];
@@ -68,6 +71,7 @@ extern "C" {
     #[link_name = "\u{1}_Z25Servo_Element_GetSnapshotv"]
     pub fn Servo_Element_GetSnapshot() -> A;
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     [
         "Size of template specialization: f_open0_e_open1_int_close1_close0",

--- a/bindgen-tests/tests/expectations/tests/issue-639-typedef-anon-field.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-639-typedef-anon-field.rs
@@ -9,11 +9,13 @@ pub struct Foo {
 pub struct Foo_Bar {
     pub abc: ::std::os::raw::c_int,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of Foo_Bar"][::std::mem::size_of::<Foo_Bar>() - 4usize];
     ["Alignment of Foo_Bar"][::std::mem::align_of::<Foo_Bar>() - 4usize];
     ["Offset of field: Foo_Bar::abc"][::std::mem::offset_of!(Foo_Bar, abc) - 0usize];
 };
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of Foo"][::std::mem::size_of::<Foo>() - 4usize];
     ["Alignment of Foo"][::std::mem::align_of::<Foo>() - 4usize];
@@ -29,11 +31,13 @@ pub struct Baz {
 pub struct Baz_Bar {
     pub abc: ::std::os::raw::c_int,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of Baz_Bar"][::std::mem::size_of::<Baz_Bar>() - 4usize];
     ["Alignment of Baz_Bar"][::std::mem::align_of::<Baz_Bar>() - 4usize];
     ["Offset of field: Baz_Bar::abc"][::std::mem::offset_of!(Baz_Bar, abc) - 0usize];
 };
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of Baz"][::std::mem::size_of::<Baz>() - 1usize];
     ["Alignment of Baz"][::std::mem::align_of::<Baz>() - 1usize];

--- a/bindgen-tests/tests/expectations/tests/issue-643-inner-struct.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-643-inner-struct.rs
@@ -42,6 +42,7 @@ pub struct rte_ring {
 pub struct rte_ring_prod {
     pub watermark: ::std::os::raw::c_uint,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of rte_ring_prod"][::std::mem::size_of::<rte_ring_prod>() - 4usize];
     ["Alignment of rte_ring_prod"][::std::mem::align_of::<rte_ring_prod>() - 4usize];
@@ -54,6 +55,7 @@ const _: () = {
 pub struct rte_ring_cons {
     pub sc_dequeue: ::std::os::raw::c_uint,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of rte_ring_cons"][::std::mem::size_of::<rte_ring_cons>() - 4usize];
     ["Alignment of rte_ring_cons"][::std::mem::align_of::<rte_ring_cons>() - 4usize];
@@ -61,6 +63,7 @@ const _: () = {
         "Offset of field: rte_ring_cons::sc_dequeue",
     ][::std::mem::offset_of!(rte_ring_cons, sc_dequeue) - 0usize];
 };
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of rte_ring"][::std::mem::size_of::<rte_ring>() - 16usize];
     ["Alignment of rte_ring"][::std::mem::align_of::<rte_ring>() - 8usize];

--- a/bindgen-tests/tests/expectations/tests/issue-674-1.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-674-1.rs
@@ -18,6 +18,7 @@ pub mod root {
     pub struct CapturingContentInfo {
         pub a: u8,
     }
+    #[allow(clippy::unnecessary_operation, clippy::identity_op)]
     const _: () = {
         [
             "Size of CapturingContentInfo",

--- a/bindgen-tests/tests/expectations/tests/issue-674-2.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-674-2.rs
@@ -18,6 +18,7 @@ pub mod root {
     pub struct c {
         pub b: u8,
     }
+    #[allow(clippy::unnecessary_operation, clippy::identity_op)]
     const _: () = {
         ["Size of c"][::std::mem::size_of::<c>() - 1usize];
         ["Alignment of c"][::std::mem::align_of::<c>() - 1usize];
@@ -28,6 +29,7 @@ pub mod root {
     pub struct B {
         pub a: root::c,
     }
+    #[allow(clippy::unnecessary_operation, clippy::identity_op)]
     const _: () = {
         ["Size of B"][::std::mem::size_of::<B>() - 1usize];
         ["Alignment of B"][::std::mem::align_of::<B>() - 1usize];
@@ -38,6 +40,7 @@ pub mod root {
     pub struct StaticRefPtr {
         pub _address: u8,
     }
+    #[allow(clippy::unnecessary_operation, clippy::identity_op)]
     const _: () = {
         [
             "Size of template specialization: StaticRefPtr_open0_B_close0",

--- a/bindgen-tests/tests/expectations/tests/issue-674-3.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-674-3.rs
@@ -14,6 +14,7 @@ pub mod root {
     pub struct a {
         pub b: u8,
     }
+    #[allow(clippy::unnecessary_operation, clippy::identity_op)]
     const _: () = {
         ["Size of a"][::std::mem::size_of::<a>() - 1usize];
         ["Alignment of a"][::std::mem::align_of::<a>() - 1usize];
@@ -24,6 +25,7 @@ pub mod root {
     pub struct nsCSSValue {
         pub c: root::a,
     }
+    #[allow(clippy::unnecessary_operation, clippy::identity_op)]
     const _: () = {
         ["Size of nsCSSValue"][::std::mem::size_of::<nsCSSValue>() - 1usize];
         ["Alignment of nsCSSValue"][::std::mem::align_of::<nsCSSValue>() - 1usize];

--- a/bindgen-tests/tests/expectations/tests/issue-691-template-parameter-virtual.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-691-template-parameter-virtual.rs
@@ -6,6 +6,7 @@ pub struct VirtualMethods__bindgen_vtable {}
 pub struct VirtualMethods {
     pub vtable_: *const VirtualMethods__bindgen_vtable,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of VirtualMethods"][::std::mem::size_of::<VirtualMethods>() - 8usize];
     ["Alignment of VirtualMethods"][::std::mem::align_of::<VirtualMethods>() - 8usize];
@@ -29,6 +30,7 @@ pub struct Set {
 pub struct ServoElementSnapshotTable {
     pub _base: Set,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     [
         "Size of ServoElementSnapshotTable",
@@ -46,6 +48,7 @@ impl Default for ServoElementSnapshotTable {
         }
     }
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     [
         "Size of template specialization: Set_open0_VirtualMethods_close0",

--- a/bindgen-tests/tests/expectations/tests/issue-739-pointer-wide-bitfield.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-739-pointer-wide-bitfield.rs
@@ -90,6 +90,7 @@ pub struct Foo {
     pub _bitfield_align_1: [u64; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 32usize]>,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of Foo"][::std::mem::size_of::<Foo>() - 32usize];
     ["Alignment of Foo"][::std::mem::align_of::<Foo>() - 8usize];

--- a/bindgen-tests/tests/expectations/tests/issue-769-bad-instantiation-test.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-769-bad-instantiation-test.rs
@@ -19,6 +19,7 @@ pub mod root {
         }
     }
     pub type AutoValueVector_Alias = ::std::os::raw::c_int;
+    #[allow(clippy::unnecessary_operation, clippy::identity_op)]
     const _: () = {
         [
             "Size of template specialization: Rooted_open0_int_close0",
@@ -27,6 +28,7 @@ pub mod root {
             "Align of template specialization: Rooted_open0_int_close0",
         ][::std::mem::align_of::<root::Rooted<::std::os::raw::c_int>>() - 4usize];
     };
+    #[allow(clippy::unnecessary_operation, clippy::identity_op)]
     const _: () = {
         [
             "Size of template specialization: Rooted_open0_AutoValueVector_Alias_close0",

--- a/bindgen-tests/tests/expectations/tests/issue-801-opaque-sloppiness.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-801-opaque-sloppiness.rs
@@ -10,6 +10,7 @@ pub struct A {
 pub struct B {
     pub _bindgen_opaque_blob: u8,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of B"][::std::mem::size_of::<B>() - 1usize];
     ["Alignment of B"][::std::mem::align_of::<B>() - 1usize];
@@ -23,6 +24,7 @@ extern "C" {
 pub struct C {
     pub b: B,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of C"][::std::mem::size_of::<C>() - 1usize];
     ["Alignment of C"][::std::mem::align_of::<C>() - 1usize];

--- a/bindgen-tests/tests/expectations/tests/issue-807-opaque-types-methods-being-generated.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-807-opaque-types-methods-being-generated.rs
@@ -4,6 +4,7 @@
 pub struct Pupper {
     pub _address: u8,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of Pupper"][::std::mem::size_of::<Pupper>() - 1usize];
     ["Alignment of Pupper"][::std::mem::align_of::<Pupper>() - 1usize];
@@ -13,6 +14,7 @@ const _: () = {
 pub struct Doggo {
     pub _address: u8,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of Doggo"][::std::mem::size_of::<Doggo>() - 1usize];
     ["Alignment of Doggo"][::std::mem::align_of::<Doggo>() - 1usize];
@@ -22,6 +24,7 @@ const _: () = {
 pub struct SuchWow {
     pub _address: u8,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of SuchWow"][::std::mem::size_of::<SuchWow>() - 1usize];
     ["Alignment of SuchWow"][::std::mem::align_of::<SuchWow>() - 1usize];
@@ -32,6 +35,7 @@ const _: () = {
 pub struct Opaque {
     pub _bindgen_opaque_blob: u8,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of Opaque"][::std::mem::size_of::<Opaque>() - 1usize];
     ["Alignment of Opaque"][::std::mem::align_of::<Opaque>() - 1usize];
@@ -65,6 +69,7 @@ extern "C" {
 pub struct Allowlisted {
     pub some_member: Opaque,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of Allowlisted"][::std::mem::size_of::<Allowlisted>() - 1usize];
     ["Alignment of Allowlisted"][::std::mem::align_of::<Allowlisted>() - 1usize];

--- a/bindgen-tests/tests/expectations/tests/issue-816.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-816.rs
@@ -90,6 +90,7 @@ pub struct capabilities {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 16usize]>,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of capabilities"][::std::mem::size_of::<capabilities>() - 16usize];
     ["Alignment of capabilities"][::std::mem::align_of::<capabilities>() - 4usize];

--- a/bindgen-tests/tests/expectations/tests/issue-826-generating-methods-when-asked-not-to.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-826-generating-methods-when-asked-not-to.rs
@@ -4,6 +4,7 @@
 pub struct Foo {
     pub _address: u8,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of Foo"][::std::mem::size_of::<Foo>() - 1usize];
     ["Alignment of Foo"][::std::mem::align_of::<Foo>() - 1usize];

--- a/bindgen-tests/tests/expectations/tests/issue-834.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-834.rs
@@ -4,6 +4,7 @@
 pub struct U {
     pub _address: u8,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of U"][::std::mem::size_of::<U>() - 1usize];
     ["Alignment of U"][::std::mem::align_of::<U>() - 1usize];

--- a/bindgen-tests/tests/expectations/tests/issue-888-enum-var-decl-jump.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-888-enum-var-decl-jump.rs
@@ -15,6 +15,7 @@ pub mod root {
             #[link_name = "\u{1}_ZN6Halide4Type1bE"]
             pub static mut Type_b: root::a;
         }
+        #[allow(clippy::unnecessary_operation, clippy::identity_op)]
         const _: () = {
             ["Size of Type"][::std::mem::size_of::<Type>() - 1usize];
             ["Alignment of Type"][::std::mem::align_of::<Type>() - 1usize];

--- a/bindgen-tests/tests/expectations/tests/issue-944-derive-copy-and-blocklisting.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-944-derive-copy-and-blocklisting.rs
@@ -5,6 +5,7 @@ pub struct BlocklistMe(u8);
 pub struct ShouldNotBeCopy {
     pub a: BlocklistMe,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of ShouldNotBeCopy"][::std::mem::size_of::<ShouldNotBeCopy>() - 1usize];
     ["Alignment of ShouldNotBeCopy"][::std::mem::align_of::<ShouldNotBeCopy>() - 1usize];

--- a/bindgen-tests/tests/expectations/tests/issue-946.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-946.rs
@@ -2,6 +2,7 @@
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct foo {}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of foo"][::std::mem::size_of::<foo>() - 0usize];
     ["Alignment of foo"][::std::mem::align_of::<foo>() - 1usize];

--- a/bindgen-tests/tests/expectations/tests/issue_311.rs
+++ b/bindgen-tests/tests/expectations/tests/issue_311.rs
@@ -13,6 +13,7 @@ pub mod root {
     pub struct jsval_layout__bindgen_ty_1 {
         pub _address: u8,
     }
+    #[allow(clippy::unnecessary_operation, clippy::identity_op)]
     const _: () = {
         [
             "Size of jsval_layout__bindgen_ty_1",
@@ -21,6 +22,7 @@ pub mod root {
             "Alignment of jsval_layout__bindgen_ty_1",
         ][::std::mem::align_of::<jsval_layout__bindgen_ty_1>() - 1usize];
     };
+    #[allow(clippy::unnecessary_operation, clippy::identity_op)]
     const _: () = {
         ["Size of jsval_layout"][::std::mem::size_of::<jsval_layout>() - 1usize];
         ["Alignment of jsval_layout"][::std::mem::align_of::<jsval_layout>() - 1usize];

--- a/bindgen-tests/tests/expectations/tests/jsval_layout_opaque.rs
+++ b/bindgen-tests/tests/expectations/tests/jsval_layout_opaque.rs
@@ -186,6 +186,7 @@ pub struct jsval_layout__bindgen_ty_1 {
     pub _bitfield_align_1: [u64; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 8usize]>,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     [
         "Size of jsval_layout__bindgen_ty_1",
@@ -265,6 +266,7 @@ pub union jsval_layout__bindgen_ty_2__bindgen_ty_1 {
     pub u32_: u32,
     pub why: JSWhyMagic,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     [
         "Size of jsval_layout__bindgen_ty_2__bindgen_ty_1",
@@ -291,6 +293,7 @@ impl Default for jsval_layout__bindgen_ty_2__bindgen_ty_1 {
         }
     }
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     [
         "Size of jsval_layout__bindgen_ty_2",
@@ -311,6 +314,7 @@ impl Default for jsval_layout__bindgen_ty_2 {
         }
     }
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of jsval_layout"][::std::mem::size_of::<jsval_layout>() - 8usize];
     ["Alignment of jsval_layout"][::std::mem::align_of::<jsval_layout>() - 8usize];
@@ -350,6 +354,7 @@ impl Default for jsval_layout {
 pub struct Value {
     pub data: jsval_layout,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of Value"][::std::mem::size_of::<Value>() - 8usize];
     ["Alignment of Value"][::std::mem::align_of::<Value>() - 8usize];

--- a/bindgen-tests/tests/expectations/tests/layout_align.rs
+++ b/bindgen-tests/tests/expectations/tests/layout_align.rs
@@ -127,6 +127,7 @@ pub struct rte_kni_fifo {
     ///< The buffer contains mbuf pointers
     pub buffer: __IncompleteArrayField<*mut ::std::os::raw::c_void>,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of rte_kni_fifo"][::std::mem::size_of::<rte_kni_fifo>() - 16usize];
     ["Alignment of rte_kni_fifo"][::std::mem::align_of::<rte_kni_fifo>() - 8usize];
@@ -165,6 +166,7 @@ pub struct rte_eth_link {
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
     pub __bindgen_padding_0: [u8; 3usize],
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of rte_eth_link"][::std::mem::size_of::<rte_eth_link>() - 8usize];
     ["Alignment of rte_eth_link"][::std::mem::align_of::<rte_eth_link>() - 8usize];

--- a/bindgen-tests/tests/expectations/tests/layout_arp.rs
+++ b/bindgen-tests/tests/expectations/tests/layout_arp.rs
@@ -22,6 +22,7 @@ pub struct ether_addr {
     ///< Addr bytes in tx order
     pub addr_bytes: [u8; 6usize],
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of ether_addr"][::std::mem::size_of::<ether_addr>() - 6usize];
     ["Alignment of ether_addr"][::std::mem::align_of::<ether_addr>() - 1usize];
@@ -42,6 +43,7 @@ pub struct arp_ipv4 {
     ///< target IP address
     pub arp_tip: u32,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of arp_ipv4"][::std::mem::size_of::<arp_ipv4>() - 20usize];
     ["Alignment of arp_ipv4"][::std::mem::align_of::<arp_ipv4>() - 1usize];
@@ -69,6 +71,7 @@ pub struct arp_hdr {
     pub arp_op: u16,
     pub arp_data: arp_ipv4,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of arp_hdr"][::std::mem::size_of::<arp_hdr>() - 28usize];
     ["Alignment of arp_hdr"][::std::mem::align_of::<arp_hdr>() - 1usize];

--- a/bindgen-tests/tests/expectations/tests/layout_cmdline_token.rs
+++ b/bindgen-tests/tests/expectations/tests/layout_cmdline_token.rs
@@ -7,6 +7,7 @@ pub struct cmdline_token_hdr {
     pub ops: *mut cmdline_token_ops,
     pub offset: ::std::os::raw::c_uint,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of cmdline_token_hdr"][::std::mem::size_of::<cmdline_token_hdr>() - 16usize];
     [
@@ -84,6 +85,7 @@ pub struct cmdline_token_ops {
         ) -> ::std::os::raw::c_int,
     >,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of cmdline_token_ops"][::std::mem::size_of::<cmdline_token_ops>() - 32usize];
     [
@@ -119,6 +121,7 @@ pub enum cmdline_numtype {
 pub struct cmdline_token_num_data {
     pub type_: cmdline_numtype,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     [
         "Size of cmdline_token_num_data",
@@ -145,6 +148,7 @@ pub struct cmdline_token_num {
     pub hdr: cmdline_token_hdr,
     pub num_data: cmdline_token_num_data,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of cmdline_token_num"][::std::mem::size_of::<cmdline_token_num>() - 24usize];
     [

--- a/bindgen-tests/tests/expectations/tests/layout_mbuf.rs
+++ b/bindgen-tests/tests/expectations/tests/layout_mbuf.rs
@@ -96,6 +96,7 @@ pub struct rte_atomic16_t {
     ///< An internal counter value.
     pub cnt: i16,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of rte_atomic16_t"][::std::mem::size_of::<rte_atomic16_t>() - 2usize];
     ["Alignment of rte_atomic16_t"][::std::mem::align_of::<rte_atomic16_t>() - 2usize];
@@ -164,6 +165,7 @@ pub union rte_mbuf__bindgen_ty_1 {
     ///< Non-atomically accessed refcnt
     pub refcnt: u16,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     [
         "Size of rte_mbuf__bindgen_ty_1",
@@ -201,6 +203,7 @@ pub struct rte_mbuf__bindgen_ty_2__bindgen_ty_1 {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     [
         "Size of rte_mbuf__bindgen_ty_2__bindgen_ty_1",
@@ -370,6 +373,7 @@ impl rte_mbuf__bindgen_ty_2__bindgen_ty_1 {
         __bindgen_bitfield_unit
     }
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     [
         "Size of rte_mbuf__bindgen_ty_2",
@@ -420,6 +424,7 @@ pub struct rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1 {
     pub hash: u16,
     pub id: u16,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     [
         "Size of rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1",
@@ -442,6 +447,7 @@ const _: () = {
         rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1__bindgen_ty_1, id
     ) - 2usize];
 };
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     [
         "Size of rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1",
@@ -465,6 +471,7 @@ impl Default for rte_mbuf__bindgen_ty_3__bindgen_ty_1__bindgen_ty_1 {
         }
     }
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     [
         "Size of rte_mbuf__bindgen_ty_3__bindgen_ty_1",
@@ -491,6 +498,7 @@ pub struct rte_mbuf__bindgen_ty_3__bindgen_ty_2 {
     pub lo: u32,
     pub hi: u32,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     [
         "Size of rte_mbuf__bindgen_ty_3__bindgen_ty_2",
@@ -505,6 +513,7 @@ const _: () = {
         "Offset of field: rte_mbuf__bindgen_ty_3__bindgen_ty_2::hi",
     ][::std::mem::offset_of!(rte_mbuf__bindgen_ty_3__bindgen_ty_2, hi) - 4usize];
 };
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     [
         "Size of rte_mbuf__bindgen_ty_3",
@@ -542,6 +551,7 @@ pub union rte_mbuf__bindgen_ty_4 {
     ///< Allow 8-byte userdata on 32-bit
     pub udata64: u64,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     [
         "Size of rte_mbuf__bindgen_ty_4",
@@ -579,6 +589,7 @@ pub struct rte_mbuf__bindgen_ty_5__bindgen_ty_1 {
     pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 7usize]>,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     [
         "Size of rte_mbuf__bindgen_ty_5__bindgen_ty_1",
@@ -725,6 +736,7 @@ impl rte_mbuf__bindgen_ty_5__bindgen_ty_1 {
         __bindgen_bitfield_unit
     }
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     [
         "Size of rte_mbuf__bindgen_ty_5",
@@ -745,6 +757,7 @@ impl Default for rte_mbuf__bindgen_ty_5 {
         }
     }
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of rte_mbuf"][::std::mem::size_of::<rte_mbuf>() - 128usize];
     ["Alignment of rte_mbuf"][::std::mem::align_of::<rte_mbuf>() - 64usize];

--- a/bindgen-tests/tests/expectations/tests/libclang-9/constified-enum-module-overflow.rs
+++ b/bindgen-tests/tests/expectations/tests/libclang-9/constified-enum-module-overflow.rs
@@ -15,11 +15,13 @@ pub type C_U = B;
 pub struct A {
     pub u: u8,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of A"][::std::mem::size_of::<A>() - 1usize];
     ["Alignment of A"][::std::mem::align_of::<A>() - 1usize];
     ["Offset of field: A::u"][::std::mem::offset_of!(A, u) - 0usize];
 };
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     [
         "Size of template specialization: C_open0_A_close0",

--- a/bindgen-tests/tests/expectations/tests/libclang-9/ptr32-has-different-size.rs
+++ b/bindgen-tests/tests/expectations/tests/libclang-9/ptr32-has-different-size.rs
@@ -4,6 +4,7 @@
 pub struct TEST_STRUCT {
     pub ptr_32bit: *mut ::std::os::raw::c_void,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of TEST_STRUCT"][::std::mem::size_of::<TEST_STRUCT>() - 8usize];
     ["Alignment of TEST_STRUCT"][::std::mem::align_of::<TEST_STRUCT>() - 8usize];

--- a/bindgen-tests/tests/expectations/tests/libclang-9/struct_typedef_ns.rs
+++ b/bindgen-tests/tests/expectations/tests/libclang-9/struct_typedef_ns.rs
@@ -11,6 +11,7 @@ pub mod root {
         pub struct typedef_struct {
             pub foo: ::std::os::raw::c_int,
         }
+        #[allow(clippy::unnecessary_operation, clippy::identity_op)]
         const _: () = {
             ["Size of typedef_struct"][::std::mem::size_of::<typedef_struct>() - 4usize];
             [
@@ -34,6 +35,7 @@ pub mod root {
         pub struct _bindgen_ty_1 {
             pub foo: ::std::os::raw::c_int,
         }
+        #[allow(clippy::unnecessary_operation, clippy::identity_op)]
         const _: () = {
             ["Size of _bindgen_ty_1"][::std::mem::size_of::<_bindgen_ty_1>() - 4usize];
             [

--- a/bindgen-tests/tests/expectations/tests/mangling-linux32.rs
+++ b/bindgen-tests/tests/expectations/tests/mangling-linux32.rs
@@ -11,6 +11,7 @@ extern "C" {
     #[link_name = "\u{1}_ZN3Foo4sBarE"]
     pub static mut Foo_sBar: bool;
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of Foo"][::std::mem::size_of::<Foo>() - 1usize];
     ["Alignment of Foo"][::std::mem::align_of::<Foo>() - 1usize];

--- a/bindgen-tests/tests/expectations/tests/mangling-linux64.rs
+++ b/bindgen-tests/tests/expectations/tests/mangling-linux64.rs
@@ -11,6 +11,7 @@ extern "C" {
     #[link_name = "\u{1}_ZN3Foo4sBarE"]
     pub static mut Foo_sBar: bool;
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of Foo"][::std::mem::size_of::<Foo>() - 1usize];
     ["Alignment of Foo"][::std::mem::align_of::<Foo>() - 1usize];

--- a/bindgen-tests/tests/expectations/tests/mangling-macos.rs
+++ b/bindgen-tests/tests/expectations/tests/mangling-macos.rs
@@ -11,6 +11,7 @@ extern "C" {
     #[link_name = "\u{1}__ZN3Foo4sBarE"]
     pub static mut Foo_sBar: bool;
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of Foo"][::std::mem::size_of::<Foo>() - 1usize];
     ["Alignment of Foo"][::std::mem::align_of::<Foo>() - 1usize];

--- a/bindgen-tests/tests/expectations/tests/mangling-win32.rs
+++ b/bindgen-tests/tests/expectations/tests/mangling-win32.rs
@@ -11,6 +11,7 @@ extern "C" {
     #[link_name = "\u{1}?sBar@Foo@@2_NA"]
     pub static mut Foo_sBar: bool;
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of Foo"][::std::mem::size_of::<Foo>() - 1usize];
     ["Alignment of Foo"][::std::mem::align_of::<Foo>() - 1usize];

--- a/bindgen-tests/tests/expectations/tests/mangling-win64.rs
+++ b/bindgen-tests/tests/expectations/tests/mangling-win64.rs
@@ -11,6 +11,7 @@ extern "C" {
     #[link_name = "\u{1}?sBar@Foo@@2_NA"]
     pub static mut Foo_sBar: bool;
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of Foo"][::std::mem::size_of::<Foo>() - 1usize];
     ["Alignment of Foo"][::std::mem::align_of::<Foo>() - 1usize];

--- a/bindgen-tests/tests/expectations/tests/merge-extern-blocks.rs
+++ b/bindgen-tests/tests/expectations/tests/merge-extern-blocks.rs
@@ -8,6 +8,7 @@ pub mod root {
     pub struct Point {
         pub x: ::std::os::raw::c_int,
     }
+    #[allow(clippy::unnecessary_operation, clippy::identity_op)]
     const _: () = {
         ["Size of Point"][::std::mem::size_of::<Point>() - 4usize];
         ["Alignment of Point"][::std::mem::align_of::<Point>() - 4usize];
@@ -21,6 +22,7 @@ pub mod root {
         pub struct Point {
             pub x: ::std::os::raw::c_int,
         }
+        #[allow(clippy::unnecessary_operation, clippy::identity_op)]
         const _: () = {
             ["Size of Point"][::std::mem::size_of::<Point>() - 4usize];
             ["Alignment of Point"][::std::mem::align_of::<Point>() - 4usize];

--- a/bindgen-tests/tests/expectations/tests/method-mangling.rs
+++ b/bindgen-tests/tests/expectations/tests/method-mangling.rs
@@ -4,6 +4,7 @@
 pub struct Foo {
     pub _address: u8,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of Foo"][::std::mem::size_of::<Foo>() - 1usize];
     ["Alignment of Foo"][::std::mem::align_of::<Foo>() - 1usize];

--- a/bindgen-tests/tests/expectations/tests/module-allowlisted.rs
+++ b/bindgen-tests/tests/expectations/tests/module-allowlisted.rs
@@ -8,6 +8,7 @@ pub mod root {
     pub struct Test {
         pub _address: u8,
     }
+    #[allow(clippy::unnecessary_operation, clippy::identity_op)]
     const _: () = {
         ["Size of Test"][::std::mem::size_of::<Test>() - 1usize];
         ["Alignment of Test"][::std::mem::align_of::<Test>() - 1usize];

--- a/bindgen-tests/tests/expectations/tests/msvc-no-usr.rs
+++ b/bindgen-tests/tests/expectations/tests/msvc-no-usr.rs
@@ -4,6 +4,7 @@
 pub struct A {
     pub foo: usize,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of A"][::std::mem::size_of::<A>() - 8usize];
     ["Alignment of A"][::std::mem::align_of::<A>() - 8usize];

--- a/bindgen-tests/tests/expectations/tests/multiple-inherit-empty-correct-layout.rs
+++ b/bindgen-tests/tests/expectations/tests/multiple-inherit-empty-correct-layout.rs
@@ -4,6 +4,7 @@
 pub struct Foo {
     pub _address: u8,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of Foo"][::std::mem::size_of::<Foo>() - 1usize];
     ["Alignment of Foo"][::std::mem::align_of::<Foo>() - 1usize];
@@ -13,6 +14,7 @@ const _: () = {
 pub struct Bar {
     pub _address: u8,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of Bar"][::std::mem::size_of::<Bar>() - 1usize];
     ["Alignment of Bar"][::std::mem::align_of::<Bar>() - 1usize];
@@ -22,6 +24,7 @@ const _: () = {
 pub struct Baz {
     pub _address: u8,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of Baz"][::std::mem::size_of::<Baz>() - 1usize];
     ["Alignment of Baz"][::std::mem::align_of::<Baz>() - 1usize];

--- a/bindgen-tests/tests/expectations/tests/mutable.rs
+++ b/bindgen-tests/tests/expectations/tests/mutable.rs
@@ -5,6 +5,7 @@ pub struct C {
     pub m_member: ::std::os::raw::c_int,
     pub m_other: ::std::os::raw::c_int,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of C"][::std::mem::size_of::<C>() - 8usize];
     ["Alignment of C"][::std::mem::align_of::<C>() - 4usize];
@@ -16,6 +17,7 @@ const _: () = {
 pub struct NonCopiable {
     pub m_member: ::std::os::raw::c_int,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of NonCopiable"][::std::mem::size_of::<NonCopiable>() - 4usize];
     ["Alignment of NonCopiable"][::std::mem::align_of::<NonCopiable>() - 4usize];
@@ -28,6 +30,7 @@ const _: () = {
 pub struct NonCopiableWithNonCopiableMutableMember {
     pub m_member: NonCopiable,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     [
         "Size of NonCopiableWithNonCopiableMutableMember",

--- a/bindgen-tests/tests/expectations/tests/namespace.rs
+++ b/bindgen-tests/tests/expectations/tests/namespace.rs
@@ -25,6 +25,7 @@ pub mod root {
         pub struct A {
             pub b: root::whatever::whatever_int_t,
         }
+        #[allow(clippy::unnecessary_operation, clippy::identity_op)]
         const _: () = {
             ["Size of A"][::std::mem::size_of::<A>() - 4usize];
             ["Alignment of A"][::std::mem::align_of::<A>() - 4usize];

--- a/bindgen-tests/tests/expectations/tests/nested.rs
+++ b/bindgen-tests/tests/expectations/tests/nested.rs
@@ -4,6 +4,7 @@
 pub struct Calc {
     pub w: ::std::os::raw::c_int,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of Calc"][::std::mem::size_of::<Calc>() - 4usize];
     ["Alignment of Calc"][::std::mem::align_of::<Calc>() - 4usize];
@@ -25,6 +26,7 @@ pub struct Test_Size {
 pub struct Test_Size_Dimension {
     pub _base: Calc,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     [
         "Size of Test_Size_Dimension",
@@ -33,6 +35,7 @@ const _: () = {
         "Alignment of Test_Size_Dimension",
     ][::std::mem::align_of::<Test_Size_Dimension>() - 4usize];
 };
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of Test_Size"][::std::mem::size_of::<Test_Size>() - 8usize];
     ["Alignment of Test_Size"][::std::mem::align_of::<Test_Size>() - 4usize];
@@ -43,6 +46,7 @@ const _: () = {
         "Offset of field: Test_Size::mHeight",
     ][::std::mem::offset_of!(Test_Size, mHeight) - 4usize];
 };
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of Test"][::std::mem::size_of::<Test>() - 1usize];
     ["Alignment of Test"][::std::mem::align_of::<Test>() - 1usize];

--- a/bindgen-tests/tests/expectations/tests/nested_vtable.rs
+++ b/bindgen-tests/tests/expectations/tests/nested_vtable.rs
@@ -10,6 +10,7 @@ pub struct nsISupports__bindgen_vtable {
 pub struct nsISupports {
     pub vtable_: *const nsISupports__bindgen_vtable,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of nsISupports"][::std::mem::size_of::<nsISupports>() - 8usize];
     ["Alignment of nsISupports"][::std::mem::align_of::<nsISupports>() - 8usize];
@@ -34,6 +35,7 @@ extern "C" {
 pub struct nsIRunnable {
     pub _base: nsISupports,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of nsIRunnable"][::std::mem::size_of::<nsIRunnable>() - 8usize];
     ["Alignment of nsIRunnable"][::std::mem::align_of::<nsIRunnable>() - 8usize];
@@ -52,6 +54,7 @@ impl Default for nsIRunnable {
 pub struct Runnable {
     pub _base: nsIRunnable,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of Runnable"][::std::mem::size_of::<Runnable>() - 8usize];
     ["Alignment of Runnable"][::std::mem::align_of::<Runnable>() - 8usize];

--- a/bindgen-tests/tests/expectations/tests/nested_within_namespace.rs
+++ b/bindgen-tests/tests/expectations/tests/nested_within_namespace.rs
@@ -16,6 +16,7 @@ pub mod root {
         pub struct Bar_Baz {
             pub foo: ::std::os::raw::c_int,
         }
+        #[allow(clippy::unnecessary_operation, clippy::identity_op)]
         const _: () = {
             ["Size of Bar_Baz"][::std::mem::size_of::<Bar_Baz>() - 4usize];
             ["Alignment of Bar_Baz"][::std::mem::align_of::<Bar_Baz>() - 4usize];
@@ -23,6 +24,7 @@ pub mod root {
                 "Offset of field: Bar_Baz::foo",
             ][::std::mem::offset_of!(Bar_Baz, foo) - 0usize];
         };
+        #[allow(clippy::unnecessary_operation, clippy::identity_op)]
         const _: () = {
             ["Size of Bar"][::std::mem::size_of::<Bar>() - 4usize];
             ["Alignment of Bar"][::std::mem::align_of::<Bar>() - 4usize];
@@ -33,6 +35,7 @@ pub mod root {
         pub struct Baz {
             pub baz: ::std::os::raw::c_int,
         }
+        #[allow(clippy::unnecessary_operation, clippy::identity_op)]
         const _: () = {
             ["Size of Baz"][::std::mem::size_of::<Baz>() - 4usize];
             ["Alignment of Baz"][::std::mem::align_of::<Baz>() - 4usize];

--- a/bindgen-tests/tests/expectations/tests/no-comments.rs
+++ b/bindgen-tests/tests/expectations/tests/no-comments.rs
@@ -4,6 +4,7 @@
 pub struct Foo {
     pub s: ::std::os::raw::c_int,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of Foo"][::std::mem::size_of::<Foo>() - 4usize];
     ["Alignment of Foo"][::std::mem::align_of::<Foo>() - 4usize];

--- a/bindgen-tests/tests/expectations/tests/no-derive-debug.rs
+++ b/bindgen-tests/tests/expectations/tests/no-derive-debug.rs
@@ -12,6 +12,7 @@ pub struct bar {
     pub foo: foo,
     pub baz: ::std::os::raw::c_int,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of bar"][::std::mem::size_of::<bar>() - 8usize];
     ["Alignment of bar"][::std::mem::align_of::<bar>() - 4usize];

--- a/bindgen-tests/tests/expectations/tests/no-derive-default.rs
+++ b/bindgen-tests/tests/expectations/tests/no-derive-default.rs
@@ -12,6 +12,7 @@ pub struct bar {
     pub foo: foo,
     pub baz: ::std::os::raw::c_int,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of bar"][::std::mem::size_of::<bar>() - 8usize];
     ["Alignment of bar"][::std::mem::align_of::<bar>() - 4usize];

--- a/bindgen-tests/tests/expectations/tests/no-hash-allowlisted.rs
+++ b/bindgen-tests/tests/expectations/tests/no-hash-allowlisted.rs
@@ -4,6 +4,7 @@
 pub struct NoHash {
     pub i: ::std::os::raw::c_int,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of NoHash"][::std::mem::size_of::<NoHash>() - 4usize];
     ["Alignment of NoHash"][::std::mem::align_of::<NoHash>() - 4usize];

--- a/bindgen-tests/tests/expectations/tests/no-hash-opaque.rs
+++ b/bindgen-tests/tests/expectations/tests/no-hash-opaque.rs
@@ -5,6 +5,7 @@
 pub struct NoHash {
     pub _bindgen_opaque_blob: u32,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of NoHash"][::std::mem::size_of::<NoHash>() - 4usize];
     ["Alignment of NoHash"][::std::mem::align_of::<NoHash>() - 4usize];

--- a/bindgen-tests/tests/expectations/tests/no-partialeq-allowlisted.rs
+++ b/bindgen-tests/tests/expectations/tests/no-partialeq-allowlisted.rs
@@ -4,6 +4,7 @@
 pub struct NoPartialEq {
     pub i: ::std::os::raw::c_int,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of NoPartialEq"][::std::mem::size_of::<NoPartialEq>() - 4usize];
     ["Alignment of NoPartialEq"][::std::mem::align_of::<NoPartialEq>() - 4usize];

--- a/bindgen-tests/tests/expectations/tests/no-partialeq-opaque.rs
+++ b/bindgen-tests/tests/expectations/tests/no-partialeq-opaque.rs
@@ -5,6 +5,7 @@
 pub struct NoPartialEq {
     pub _bindgen_opaque_blob: u32,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of NoPartialEq"][::std::mem::size_of::<NoPartialEq>() - 4usize];
     ["Alignment of NoPartialEq"][::std::mem::align_of::<NoPartialEq>() - 4usize];

--- a/bindgen-tests/tests/expectations/tests/no-recursive-allowlisting.rs
+++ b/bindgen-tests/tests/expectations/tests/no-recursive-allowlisting.rs
@@ -5,6 +5,7 @@ pub enum Bar {}
 pub struct Foo {
     pub baz: *mut Bar,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of Foo"][::std::mem::size_of::<Foo>() - 8usize];
     ["Alignment of Foo"][::std::mem::align_of::<Foo>() - 8usize];

--- a/bindgen-tests/tests/expectations/tests/no-std.rs
+++ b/bindgen-tests/tests/expectations/tests/no-std.rs
@@ -11,6 +11,7 @@ pub struct foo {
     pub b: libc::c_int,
     pub bar: *mut libc::c_void,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of foo"][::core::mem::size_of::<foo>() - 16usize];
     ["Alignment of foo"][::core::mem::align_of::<foo>() - 8usize];

--- a/bindgen-tests/tests/expectations/tests/no_copy_allowlisted.rs
+++ b/bindgen-tests/tests/expectations/tests/no_copy_allowlisted.rs
@@ -4,6 +4,7 @@
 pub struct NoCopy {
     pub i: ::std::os::raw::c_int,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of NoCopy"][::std::mem::size_of::<NoCopy>() - 4usize];
     ["Alignment of NoCopy"][::std::mem::align_of::<NoCopy>() - 4usize];

--- a/bindgen-tests/tests/expectations/tests/no_copy_opaque.rs
+++ b/bindgen-tests/tests/expectations/tests/no_copy_opaque.rs
@@ -5,6 +5,7 @@
 pub struct NoCopy {
     pub _bindgen_opaque_blob: u32,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of NoCopy"][::std::mem::size_of::<NoCopy>() - 4usize];
     ["Alignment of NoCopy"][::std::mem::align_of::<NoCopy>() - 4usize];

--- a/bindgen-tests/tests/expectations/tests/no_debug_allowlisted.rs
+++ b/bindgen-tests/tests/expectations/tests/no_debug_allowlisted.rs
@@ -4,6 +4,7 @@
 pub struct NoDebug {
     pub i: ::std::os::raw::c_int,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of NoDebug"][::std::mem::size_of::<NoDebug>() - 4usize];
     ["Alignment of NoDebug"][::std::mem::align_of::<NoDebug>() - 4usize];

--- a/bindgen-tests/tests/expectations/tests/no_debug_opaque.rs
+++ b/bindgen-tests/tests/expectations/tests/no_debug_opaque.rs
@@ -5,6 +5,7 @@
 pub struct NoDebug {
     pub _bindgen_opaque_blob: u32,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of NoDebug"][::std::mem::size_of::<NoDebug>() - 4usize];
     ["Alignment of NoDebug"][::std::mem::align_of::<NoDebug>() - 4usize];

--- a/bindgen-tests/tests/expectations/tests/no_default_allowlisted.rs
+++ b/bindgen-tests/tests/expectations/tests/no_default_allowlisted.rs
@@ -4,6 +4,7 @@
 pub struct NoDefault {
     pub i: ::std::os::raw::c_int,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of NoDefault"][::std::mem::size_of::<NoDefault>() - 4usize];
     ["Alignment of NoDefault"][::std::mem::align_of::<NoDefault>() - 4usize];

--- a/bindgen-tests/tests/expectations/tests/no_default_opaque.rs
+++ b/bindgen-tests/tests/expectations/tests/no_default_opaque.rs
@@ -5,6 +5,7 @@
 pub struct NoDefault {
     pub _bindgen_opaque_blob: u32,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of NoDefault"][::std::mem::size_of::<NoDefault>() - 4usize];
     ["Alignment of NoDefault"][::std::mem::align_of::<NoDefault>() - 4usize];

--- a/bindgen-tests/tests/expectations/tests/no_size_t_is_usize.rs
+++ b/bindgen-tests/tests/expectations/tests/no_size_t_is_usize.rs
@@ -8,6 +8,7 @@ pub struct A {
     pub offset: ssize_t,
     pub next: *mut A,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of A"][::std::mem::size_of::<A>() - 24usize];
     ["Alignment of A"][::std::mem::align_of::<A>() - 8usize];

--- a/bindgen-tests/tests/expectations/tests/non-type-params.rs
+++ b/bindgen-tests/tests/expectations/tests/non-type-params.rs
@@ -8,6 +8,7 @@ pub struct UsesArray {
     pub array_bool_8: [u8; 8usize],
     pub array_int_4: ArrayInt4,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of UsesArray"][::std::mem::size_of::<UsesArray>() - 40usize];
     ["Alignment of UsesArray"][::std::mem::align_of::<UsesArray>() - 4usize];

--- a/bindgen-tests/tests/expectations/tests/objc_interface_type.rs
+++ b/bindgen-tests/tests/expectations/tests/objc_interface_type.rs
@@ -25,6 +25,7 @@ pub trait IFoo: Sized + std::ops::Deref {}
 pub struct FooStruct {
     pub foo: Foo,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of FooStruct"][::std::mem::size_of::<FooStruct>() - 8usize];
     ["Alignment of FooStruct"][::std::mem::align_of::<FooStruct>() - 8usize];

--- a/bindgen-tests/tests/expectations/tests/only_bitfields.rs
+++ b/bindgen-tests/tests/expectations/tests/only_bitfields.rs
@@ -89,6 +89,7 @@ pub struct C {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of C"][::std::mem::size_of::<C>() - 1usize];
     ["Alignment of C"][::std::mem::align_of::<C>() - 1usize];

--- a/bindgen-tests/tests/expectations/tests/opaque-template-inst-member-2.rs
+++ b/bindgen-tests/tests/expectations/tests/opaque-template-inst-member-2.rs
@@ -13,6 +13,7 @@ pub struct ContainsOpaqueTemplate {
     pub mBlah: u32,
     pub mBaz: ::std::os::raw::c_int,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     [
         "Size of ContainsOpaqueTemplate",
@@ -34,6 +35,7 @@ pub struct InheritsOpaqueTemplate {
     pub _base: u8,
     pub wow: *mut ::std::os::raw::c_char,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     [
         "Size of InheritsOpaqueTemplate",

--- a/bindgen-tests/tests/expectations/tests/opaque-template-instantiation-namespaced.rs
+++ b/bindgen-tests/tests/expectations/tests/opaque-template-instantiation-namespaced.rs
@@ -26,6 +26,7 @@ pub mod root {
         pub struct Foo {
             pub c: ::std::os::raw::c_char,
         }
+        #[allow(clippy::unnecessary_operation, clippy::identity_op)]
         const _: () = {
             ["Size of Foo"][::std::mem::size_of::<Foo>() - 1usize];
             ["Alignment of Foo"][::std::mem::align_of::<Foo>() - 1usize];
@@ -36,6 +37,7 @@ pub mod root {
         pub struct Bar {
             pub i: ::std::os::raw::c_int,
         }
+        #[allow(clippy::unnecessary_operation, clippy::identity_op)]
         const _: () = {
             ["Size of Bar"][::std::mem::size_of::<Bar>() - 4usize];
             ["Alignment of Bar"][::std::mem::align_of::<Bar>() - 4usize];
@@ -46,6 +48,7 @@ pub mod root {
         pub struct ContainsInstantiation {
             pub not_opaque: root::zoidberg::Template<root::zoidberg::Foo>,
         }
+        #[allow(clippy::unnecessary_operation, clippy::identity_op)]
         const _: () = {
             [
                 "Size of ContainsInstantiation",
@@ -71,6 +74,7 @@ pub mod root {
         pub struct ContainsOpaqueInstantiation {
             pub opaque: u32,
         }
+        #[allow(clippy::unnecessary_operation, clippy::identity_op)]
         const _: () = {
             [
                 "Size of ContainsOpaqueInstantiation",
@@ -83,6 +87,7 @@ pub mod root {
             ][::std::mem::offset_of!(ContainsOpaqueInstantiation, opaque) - 0usize];
         };
     }
+    #[allow(clippy::unnecessary_operation, clippy::identity_op)]
     const _: () = {
         [
             "Size of template specialization: Template_open0_Foo_close0",

--- a/bindgen-tests/tests/expectations/tests/opaque-template-instantiation.rs
+++ b/bindgen-tests/tests/expectations/tests/opaque-template-instantiation.rs
@@ -19,6 +19,7 @@ impl<T> Default for Template<T> {
 pub struct ContainsInstantiation {
     pub not_opaque: Template<::std::os::raw::c_char>,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     [
         "Size of ContainsInstantiation",
@@ -44,6 +45,7 @@ impl Default for ContainsInstantiation {
 pub struct ContainsOpaqueInstantiation {
     pub opaque: u32,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     [
         "Size of ContainsOpaqueInstantiation",
@@ -55,6 +57,7 @@ const _: () = {
         "Offset of field: ContainsOpaqueInstantiation::opaque",
     ][::std::mem::offset_of!(ContainsOpaqueInstantiation, opaque) - 0usize];
 };
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     [
         "Size of template specialization: Template_open0_char_close0",

--- a/bindgen-tests/tests/expectations/tests/opaque-tracing.rs
+++ b/bindgen-tests/tests/expectations/tests/opaque-tracing.rs
@@ -9,6 +9,7 @@ extern "C" {
 pub struct Container {
     pub _bindgen_opaque_blob: [u32; 2usize],
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of Container"][::std::mem::size_of::<Container>() - 8usize];
     ["Alignment of Container"][::std::mem::align_of::<Container>() - 4usize];

--- a/bindgen-tests/tests/expectations/tests/opaque_in_struct.rs
+++ b/bindgen-tests/tests/expectations/tests/opaque_in_struct.rs
@@ -6,6 +6,7 @@
 pub struct opaque {
     pub _bindgen_opaque_blob: u32,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of opaque"][::std::mem::size_of::<opaque>() - 4usize];
     ["Alignment of opaque"][::std::mem::align_of::<opaque>() - 4usize];
@@ -15,6 +16,7 @@ const _: () = {
 pub struct container {
     pub contained: opaque,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of container"][::std::mem::size_of::<container>() - 4usize];
     ["Alignment of container"][::std::mem::align_of::<container>() - 4usize];

--- a/bindgen-tests/tests/expectations/tests/opaque_pointer.rs
+++ b/bindgen-tests/tests/expectations/tests/opaque_pointer.rs
@@ -6,6 +6,7 @@
 pub struct OtherOpaque {
     pub _bindgen_opaque_blob: u32,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of OtherOpaque"][::std::mem::size_of::<OtherOpaque>() - 4usize];
     ["Alignment of OtherOpaque"][::std::mem::align_of::<OtherOpaque>() - 4usize];
@@ -23,6 +24,7 @@ pub struct WithOpaquePtr {
     pub other: u32,
     pub t: OtherOpaque,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of WithOpaquePtr"][::std::mem::size_of::<WithOpaquePtr>() - 16usize];
     ["Alignment of WithOpaquePtr"][::std::mem::align_of::<WithOpaquePtr>() - 8usize];

--- a/bindgen-tests/tests/expectations/tests/packed-bitfield.rs
+++ b/bindgen-tests/tests/expectations/tests/packed-bitfield.rs
@@ -89,6 +89,7 @@ pub struct Date {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 3usize]>,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of Date"][::std::mem::size_of::<Date>() - 3usize];
     ["Alignment of Date"][::std::mem::align_of::<Date>() - 1usize];

--- a/bindgen-tests/tests/expectations/tests/packed-n-with-padding.rs
+++ b/bindgen-tests/tests/expectations/tests/packed-n-with-padding.rs
@@ -7,6 +7,7 @@ pub struct Packed {
     pub c: ::std::os::raw::c_char,
     pub d: ::std::os::raw::c_int,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of Packed"][::std::mem::size_of::<Packed>() - 10usize];
     ["Alignment of Packed"][::std::mem::align_of::<Packed>() - 2usize];

--- a/bindgen-tests/tests/expectations/tests/parm-union.rs
+++ b/bindgen-tests/tests/expectations/tests/parm-union.rs
@@ -4,6 +4,7 @@
 pub struct Struct {
     pub _address: u8,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of Struct"][::std::mem::size_of::<Struct>() - 1usize];
     ["Alignment of Struct"][::std::mem::align_of::<Struct>() - 1usize];

--- a/bindgen-tests/tests/expectations/tests/partial-specialization-and-inheritance.rs
+++ b/bindgen-tests/tests/expectations/tests/partial-specialization-and-inheritance.rs
@@ -18,6 +18,7 @@ extern "C" {
     #[link_name = "\u{1}_ZN5Usage13static_memberE"]
     pub static mut Usage_static_member: [u32; 2usize];
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of Usage"][::std::mem::size_of::<Usage>() - 1usize];
     ["Alignment of Usage"][::std::mem::align_of::<Usage>() - 1usize];

--- a/bindgen-tests/tests/expectations/tests/private.rs
+++ b/bindgen-tests/tests/expectations/tests/private.rs
@@ -6,6 +6,7 @@ pub struct HasPrivate {
     /// <div rustbindgen private></div>
     mIsPrivate: ::std::os::raw::c_int,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of HasPrivate"][::std::mem::size_of::<HasPrivate>() - 8usize];
     ["Alignment of HasPrivate"][::std::mem::align_of::<HasPrivate>() - 4usize];
@@ -23,6 +24,7 @@ pub struct VeryPrivate {
     mIsPrivate: ::std::os::raw::c_int,
     mIsAlsoPrivate: ::std::os::raw::c_int,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of VeryPrivate"][::std::mem::size_of::<VeryPrivate>() - 8usize];
     ["Alignment of VeryPrivate"][::std::mem::align_of::<VeryPrivate>() - 4usize];
@@ -41,6 +43,7 @@ pub struct ContradictPrivate {
     pub mNotPrivate: ::std::os::raw::c_int,
     mIsPrivate: ::std::os::raw::c_int,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of ContradictPrivate"][::std::mem::size_of::<ContradictPrivate>() - 8usize];
     [

--- a/bindgen-tests/tests/expectations/tests/private_fields.rs
+++ b/bindgen-tests/tests/expectations/tests/private_fields.rs
@@ -89,6 +89,7 @@ pub struct PubPriv {
     pub x: ::std::os::raw::c_int,
     y: ::std::os::raw::c_int,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of PubPriv"][::std::mem::size_of::<PubPriv>() - 8usize];
     ["Alignment of PubPriv"][::std::mem::align_of::<PubPriv>() - 4usize];
@@ -103,6 +104,7 @@ pub struct PrivateBitFields {
     _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
     pub __bindgen_padding_0: [u8; 3usize],
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of PrivateBitFields"][::std::mem::size_of::<PrivateBitFields>() - 4usize];
     [
@@ -167,6 +169,7 @@ pub struct PublicBitFields {
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
     pub __bindgen_padding_0: [u8; 3usize],
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of PublicBitFields"][::std::mem::size_of::<PublicBitFields>() - 4usize];
     ["Alignment of PublicBitFields"][::std::mem::align_of::<PublicBitFields>() - 4usize];
@@ -229,6 +232,7 @@ pub struct MixedBitFields {
     _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
     pub __bindgen_padding_0: [u8; 3usize],
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of MixedBitFields"][::std::mem::size_of::<MixedBitFields>() - 4usize];
     ["Alignment of MixedBitFields"][::std::mem::align_of::<MixedBitFields>() - 4usize];
@@ -288,6 +292,7 @@ impl MixedBitFields {
 pub struct Base {
     pub member: ::std::os::raw::c_int,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of Base"][::std::mem::size_of::<Base>() - 4usize];
     ["Alignment of Base"][::std::mem::align_of::<Base>() - 4usize];
@@ -298,6 +303,7 @@ const _: () = {
 pub struct InheritsPrivately {
     _base: Base,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of InheritsPrivately"][::std::mem::size_of::<InheritsPrivately>() - 4usize];
     [
@@ -309,6 +315,7 @@ const _: () = {
 pub struct InheritsPublically {
     pub _base: Base,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of InheritsPublically"][::std::mem::size_of::<InheritsPublically>() - 4usize];
     [
@@ -326,6 +333,7 @@ pub struct WithAnonStruct {
 pub struct WithAnonStruct__bindgen_ty_1 {
     pub a: ::std::os::raw::c_int,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     [
         "Size of WithAnonStruct__bindgen_ty_1",
@@ -342,6 +350,7 @@ const _: () = {
 pub struct WithAnonStruct__bindgen_ty_2 {
     pub b: ::std::os::raw::c_int,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     [
         "Size of WithAnonStruct__bindgen_ty_2",
@@ -353,6 +362,7 @@ const _: () = {
         "Offset of field: WithAnonStruct__bindgen_ty_2::b",
     ][::std::mem::offset_of!(WithAnonStruct__bindgen_ty_2, b) - 0usize];
 };
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of WithAnonStruct"][::std::mem::size_of::<WithAnonStruct>() - 8usize];
     ["Alignment of WithAnonStruct"][::std::mem::align_of::<WithAnonStruct>() - 4usize];
@@ -367,6 +377,7 @@ pub struct WithAnonUnion {
 pub union WithAnonUnion__bindgen_ty_1 {
     pub _address: u8,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     [
         "Size of WithAnonUnion__bindgen_ty_1",
@@ -384,6 +395,7 @@ impl Default for WithAnonUnion__bindgen_ty_1 {
         }
     }
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of WithAnonUnion"][::std::mem::size_of::<WithAnonUnion>() - 1usize];
     ["Alignment of WithAnonUnion"][::std::mem::align_of::<WithAnonUnion>() - 1usize];
@@ -408,6 +420,7 @@ pub struct Override {
     _bitfield_1: __BindgenBitfieldUnit<[u8; 2usize]>,
     pub __bindgen_padding_0: u16,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of Override"][::std::mem::size_of::<Override>() - 16usize];
     ["Alignment of Override"][::std::mem::align_of::<Override>() - 4usize];

--- a/bindgen-tests/tests/expectations/tests/ptr32-has-different-size.rs
+++ b/bindgen-tests/tests/expectations/tests/ptr32-has-different-size.rs
@@ -4,6 +4,7 @@
 pub struct TEST_STRUCT {
     pub ptr_32bit: u32,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of TEST_STRUCT"][::std::mem::size_of::<TEST_STRUCT>() - 4usize];
     ["Alignment of TEST_STRUCT"][::std::mem::align_of::<TEST_STRUCT>() - 4usize];

--- a/bindgen-tests/tests/expectations/tests/public-dtor.rs
+++ b/bindgen-tests/tests/expectations/tests/public-dtor.rs
@@ -4,6 +4,7 @@
 pub struct cv_Foo {
     pub _address: u8,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of cv_Foo"][::std::mem::size_of::<cv_Foo>() - 1usize];
     ["Alignment of cv_Foo"][::std::mem::align_of::<cv_Foo>() - 1usize];
@@ -23,6 +24,7 @@ impl cv_Foo {
 pub struct cv_Bar {
     pub _address: u8,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of cv_Bar"][::std::mem::size_of::<cv_Bar>() - 1usize];
     ["Alignment of cv_Bar"][::std::mem::align_of::<cv_Bar>() - 1usize];

--- a/bindgen-tests/tests/expectations/tests/redundant-packed-and-align.rs
+++ b/bindgen-tests/tests/expectations/tests/redundant-packed-and-align.rs
@@ -90,6 +90,7 @@ pub struct redundant_packed {
     pub a: u32,
     pub b: u32,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of redundant_packed"][::std::mem::size_of::<redundant_packed>() - 8usize];
     [
@@ -111,6 +112,7 @@ pub struct redundant_packed_bitfield {
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
     pub c: u32,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     [
         "Size of redundant_packed_bitfield",
@@ -179,6 +181,7 @@ pub union redundant_packed_union {
     pub a: u64,
     pub b: u32,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     [
         "Size of redundant_packed_union",
@@ -208,6 +211,7 @@ impl Default for redundant_packed_union {
 pub struct inner {
     pub a: u8,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of inner"][::std::mem::size_of::<inner>() - 2usize];
     ["Alignment of inner"][::std::mem::align_of::<inner>() - 2usize];
@@ -220,6 +224,7 @@ pub struct outer_redundant_packed {
     pub a: [inner; 2usize],
     pub b: u32,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     [
         "Size of outer_redundant_packed",
@@ -241,6 +246,7 @@ pub struct redundant_pragma_packed {
     pub a: u8,
     pub b: u16,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     [
         "Size of redundant_pragma_packed",

--- a/bindgen-tests/tests/expectations/tests/ref_argument_array.rs
+++ b/bindgen-tests/tests/expectations/tests/ref_argument_array.rs
@@ -12,6 +12,7 @@ pub struct nsID__bindgen_vtable {
 pub struct nsID {
     pub vtable_: *const nsID__bindgen_vtable,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of nsID"][::std::mem::size_of::<nsID>() - 8usize];
     ["Alignment of nsID"][::std::mem::align_of::<nsID>() - 8usize];

--- a/bindgen-tests/tests/expectations/tests/reparented_replacement.rs
+++ b/bindgen-tests/tests/expectations/tests/reparented_replacement.rs
@@ -12,6 +12,7 @@ pub mod root {
         pub struct Bar {
             pub bazz: ::std::os::raw::c_int,
         }
+        #[allow(clippy::unnecessary_operation, clippy::identity_op)]
         const _: () = {
             ["Size of Bar"][::std::mem::size_of::<Bar>() - 4usize];
             ["Alignment of Bar"][::std::mem::align_of::<Bar>() - 4usize];

--- a/bindgen-tests/tests/expectations/tests/replace_use.rs
+++ b/bindgen-tests/tests/expectations/tests/replace_use.rs
@@ -10,11 +10,13 @@ pub struct nsTArray {
 pub struct Test {
     pub a: nsTArray,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of Test"][::std::mem::size_of::<Test>() - 4usize];
     ["Alignment of Test"][::std::mem::align_of::<Test>() - 4usize];
     ["Offset of field: Test::a"][::std::mem::offset_of!(Test, a) - 0usize];
 };
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     [
         "Size of template specialization: nsTArray_open0_long_close0",

--- a/bindgen-tests/tests/expectations/tests/same_struct_name_in_different_namespaces.rs
+++ b/bindgen-tests/tests/expectations/tests/same_struct_name_in_different_namespaces.rs
@@ -10,6 +10,7 @@ pub struct JS_shadow_Zone {
     pub x: ::std::os::raw::c_int,
     pub y: ::std::os::raw::c_int,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of JS_shadow_Zone"][::std::mem::size_of::<JS_shadow_Zone>() - 8usize];
     ["Alignment of JS_shadow_Zone"][::std::mem::align_of::<JS_shadow_Zone>() - 4usize];

--- a/bindgen-tests/tests/expectations/tests/sentry-defined-multiple-times.rs
+++ b/bindgen-tests/tests/expectations/tests/sentry-defined-multiple-times.rs
@@ -21,6 +21,7 @@ pub mod root {
         pub struct sentry {
             pub i_am_plain_sentry: bool,
         }
+        #[allow(clippy::unnecessary_operation, clippy::identity_op)]
         const _: () = {
             ["Size of sentry"][::std::mem::size_of::<sentry>() - 1usize];
             ["Alignment of sentry"][::std::mem::align_of::<sentry>() - 1usize];
@@ -33,6 +34,7 @@ pub mod root {
         pub struct NotTemplateWrapper {
             pub _address: u8,
         }
+        #[allow(clippy::unnecessary_operation, clippy::identity_op)]
         const _: () = {
             [
                 "Size of NotTemplateWrapper",
@@ -46,6 +48,7 @@ pub mod root {
         pub struct NotTemplateWrapper_sentry {
             pub i_am_not_template_wrapper_sentry: ::std::os::raw::c_char,
         }
+        #[allow(clippy::unnecessary_operation, clippy::identity_op)]
         const _: () = {
             [
                 "Size of NotTemplateWrapper_sentry",
@@ -69,6 +72,7 @@ pub mod root {
         pub struct InlineNotTemplateWrapper_sentry {
             pub i_am_inline_not_template_wrapper_sentry: bool,
         }
+        #[allow(clippy::unnecessary_operation, clippy::identity_op)]
         const _: () = {
             [
                 "Size of InlineNotTemplateWrapper_sentry",
@@ -82,6 +86,7 @@ pub mod root {
                 InlineNotTemplateWrapper_sentry, i_am_inline_not_template_wrapper_sentry
             ) - 0usize];
         };
+        #[allow(clippy::unnecessary_operation, clippy::identity_op)]
         const _: () = {
             [
                 "Size of InlineNotTemplateWrapper",
@@ -110,6 +115,7 @@ pub mod root {
         pub struct OuterDoubleWrapper_InnerDoubleWrapper {
             pub _address: u8,
         }
+        #[allow(clippy::unnecessary_operation, clippy::identity_op)]
         const _: () = {
             [
                 "Size of OuterDoubleWrapper_InnerDoubleWrapper",
@@ -118,6 +124,7 @@ pub mod root {
                 "Alignment of OuterDoubleWrapper_InnerDoubleWrapper",
             ][::std::mem::align_of::<OuterDoubleWrapper_InnerDoubleWrapper>() - 1usize];
         };
+        #[allow(clippy::unnecessary_operation, clippy::identity_op)]
         const _: () = {
             [
                 "Size of OuterDoubleWrapper",
@@ -131,6 +138,7 @@ pub mod root {
         pub struct OuterDoubleWrapper_InnerDoubleWrapper_sentry {
             pub i_am_double_wrapper_sentry: ::std::os::raw::c_int,
         }
+        #[allow(clippy::unnecessary_operation, clippy::identity_op)]
         const _: () = {
             [
                 "Size of OuterDoubleWrapper_InnerDoubleWrapper_sentry",
@@ -161,6 +169,7 @@ pub mod root {
         pub struct OuterDoubleInlineWrapper_InnerDoubleInlineWrapper_sentry {
             pub i_am_double_wrapper_inline_sentry: ::std::os::raw::c_int,
         }
+        #[allow(clippy::unnecessary_operation, clippy::identity_op)]
         const _: () = {
             [
                 "Size of OuterDoubleInlineWrapper_InnerDoubleInlineWrapper_sentry",
@@ -179,6 +188,7 @@ pub mod root {
                 i_am_double_wrapper_inline_sentry
             ) - 0usize];
         };
+        #[allow(clippy::unnecessary_operation, clippy::identity_op)]
         const _: () = {
             [
                 "Size of OuterDoubleInlineWrapper_InnerDoubleInlineWrapper",
@@ -189,6 +199,7 @@ pub mod root {
             ][::std::mem::align_of::<OuterDoubleInlineWrapper_InnerDoubleInlineWrapper>()
                 - 1usize];
         };
+        #[allow(clippy::unnecessary_operation, clippy::identity_op)]
         const _: () = {
             [
                 "Size of OuterDoubleInlineWrapper",
@@ -213,6 +224,7 @@ pub mod root {
     pub struct sentry {
         pub i_am_outside_namespace_sentry: ::std::os::raw::c_int,
     }
+    #[allow(clippy::unnecessary_operation, clippy::identity_op)]
     const _: () = {
         ["Size of sentry"][::std::mem::size_of::<sentry>() - 4usize];
         ["Alignment of sentry"][::std::mem::align_of::<sentry>() - 4usize];

--- a/bindgen-tests/tests/expectations/tests/size_t_template.rs
+++ b/bindgen-tests/tests/expectations/tests/size_t_template.rs
@@ -4,6 +4,7 @@
 pub struct C {
     pub arr: [u32; 3usize],
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of C"][::std::mem::size_of::<C>() - 12usize];
     ["Alignment of C"][::std::mem::align_of::<C>() - 4usize];

--- a/bindgen-tests/tests/expectations/tests/sorted_items.rs
+++ b/bindgen-tests/tests/expectations/tests/sorted_items.rs
@@ -14,12 +14,14 @@ pub mod root {
         pub a: root::number,
         pub b: root::number,
     }
+    #[allow(clippy::unnecessary_operation, clippy::identity_op)]
     const _: () = {
         ["Size of Point"][::std::mem::size_of::<Point>() - 8usize];
         ["Alignment of Point"][::std::mem::align_of::<Point>() - 4usize];
         ["Offset of field: Point::x"][::std::mem::offset_of!(Point, x) - 0usize];
         ["Offset of field: Point::y"][::std::mem::offset_of!(Point, y) - 4usize];
     };
+    #[allow(clippy::unnecessary_operation, clippy::identity_op)]
     const _: () = {
         ["Size of Angle"][::std::mem::size_of::<Angle>() - 8usize];
         ["Alignment of Angle"][::std::mem::align_of::<Angle>() - 4usize];
@@ -41,12 +43,14 @@ pub mod root {
             pub a: root::ns::number,
             pub b: root::ns::number,
         }
+        #[allow(clippy::unnecessary_operation, clippy::identity_op)]
         const _: () = {
             ["Size of Point"][::std::mem::size_of::<Point>() - 8usize];
             ["Alignment of Point"][::std::mem::align_of::<Point>() - 4usize];
             ["Offset of field: Point::x"][::std::mem::offset_of!(Point, x) - 0usize];
             ["Offset of field: Point::y"][::std::mem::offset_of!(Point, y) - 4usize];
         };
+        #[allow(clippy::unnecessary_operation, clippy::identity_op)]
         const _: () = {
             ["Size of Angle"][::std::mem::size_of::<Angle>() - 8usize];
             ["Alignment of Angle"][::std::mem::align_of::<Angle>() - 4usize];

--- a/bindgen-tests/tests/expectations/tests/stdint_typedef.rs
+++ b/bindgen-tests/tests/expectations/tests/stdint_typedef.rs
@@ -7,6 +7,7 @@ extern "C" {
 pub struct Struct {
     pub field: u64,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of Struct"][::std::mem::size_of::<Struct>() - 8usize];
     ["Alignment of Struct"][::std::mem::align_of::<Struct>() - 8usize];

--- a/bindgen-tests/tests/expectations/tests/struct_containing_forward_declared_struct.rs
+++ b/bindgen-tests/tests/expectations/tests/struct_containing_forward_declared_struct.rs
@@ -4,6 +4,7 @@
 pub struct a {
     pub val_a: *mut b,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of a"][::std::mem::size_of::<a>() - 8usize];
     ["Alignment of a"][::std::mem::align_of::<a>() - 8usize];
@@ -23,6 +24,7 @@ impl Default for a {
 pub struct b {
     pub val_b: ::std::os::raw::c_int,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of b"][::std::mem::size_of::<b>() - 4usize];
     ["Alignment of b"][::std::mem::align_of::<b>() - 4usize];

--- a/bindgen-tests/tests/expectations/tests/struct_typedef.rs
+++ b/bindgen-tests/tests/expectations/tests/struct_typedef.rs
@@ -4,6 +4,7 @@
 pub struct typedef_named_struct {
     pub has_name: bool,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     [
         "Size of typedef_named_struct",
@@ -20,6 +21,7 @@ const _: () = {
 pub struct _bindgen_ty_1 {
     pub no_name: *mut ::std::os::raw::c_void,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of _bindgen_ty_1"][::std::mem::size_of::<_bindgen_ty_1>() - 8usize];
     ["Alignment of _bindgen_ty_1"][::std::mem::align_of::<_bindgen_ty_1>() - 8usize];

--- a/bindgen-tests/tests/expectations/tests/struct_typedef_ns.rs
+++ b/bindgen-tests/tests/expectations/tests/struct_typedef_ns.rs
@@ -11,6 +11,7 @@ pub mod root {
         pub struct typedef_struct {
             pub foo: ::std::os::raw::c_int,
         }
+        #[allow(clippy::unnecessary_operation, clippy::identity_op)]
         const _: () = {
             ["Size of typedef_struct"][::std::mem::size_of::<typedef_struct>() - 4usize];
             [
@@ -34,6 +35,7 @@ pub mod root {
         pub struct typedef_struct {
             pub foo: ::std::os::raw::c_int,
         }
+        #[allow(clippy::unnecessary_operation, clippy::identity_op)]
         const _: () = {
             ["Size of typedef_struct"][::std::mem::size_of::<typedef_struct>() - 4usize];
             [

--- a/bindgen-tests/tests/expectations/tests/struct_with_anon_struct.rs
+++ b/bindgen-tests/tests/expectations/tests/struct_with_anon_struct.rs
@@ -10,6 +10,7 @@ pub struct foo__bindgen_ty_1 {
     pub a: ::std::os::raw::c_int,
     pub b: ::std::os::raw::c_int,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of foo__bindgen_ty_1"][::std::mem::size_of::<foo__bindgen_ty_1>() - 8usize];
     [
@@ -22,6 +23,7 @@ const _: () = {
         "Offset of field: foo__bindgen_ty_1::b",
     ][::std::mem::offset_of!(foo__bindgen_ty_1, b) - 4usize];
 };
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of foo"][::std::mem::size_of::<foo>() - 8usize];
     ["Alignment of foo"][::std::mem::align_of::<foo>() - 4usize];

--- a/bindgen-tests/tests/expectations/tests/struct_with_anon_struct_array.rs
+++ b/bindgen-tests/tests/expectations/tests/struct_with_anon_struct_array.rs
@@ -11,6 +11,7 @@ pub struct foo__bindgen_ty_1 {
     pub a: ::std::os::raw::c_int,
     pub b: ::std::os::raw::c_int,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of foo__bindgen_ty_1"][::std::mem::size_of::<foo__bindgen_ty_1>() - 8usize];
     [
@@ -29,6 +30,7 @@ pub struct foo__bindgen_ty_2 {
     pub a: ::std::os::raw::c_int,
     pub b: ::std::os::raw::c_int,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of foo__bindgen_ty_2"][::std::mem::size_of::<foo__bindgen_ty_2>() - 8usize];
     [
@@ -41,6 +43,7 @@ const _: () = {
         "Offset of field: foo__bindgen_ty_2::b",
     ][::std::mem::offset_of!(foo__bindgen_ty_2, b) - 4usize];
 };
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of foo"][::std::mem::size_of::<foo>() - 208usize];
     ["Alignment of foo"][::std::mem::align_of::<foo>() - 4usize];

--- a/bindgen-tests/tests/expectations/tests/struct_with_anon_struct_pointer.rs
+++ b/bindgen-tests/tests/expectations/tests/struct_with_anon_struct_pointer.rs
@@ -10,6 +10,7 @@ pub struct foo__bindgen_ty_1 {
     pub a: ::std::os::raw::c_int,
     pub b: ::std::os::raw::c_int,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of foo__bindgen_ty_1"][::std::mem::size_of::<foo__bindgen_ty_1>() - 8usize];
     [
@@ -22,6 +23,7 @@ const _: () = {
         "Offset of field: foo__bindgen_ty_1::b",
     ][::std::mem::offset_of!(foo__bindgen_ty_1, b) - 4usize];
 };
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of foo"][::std::mem::size_of::<foo>() - 8usize];
     ["Alignment of foo"][::std::mem::align_of::<foo>() - 8usize];

--- a/bindgen-tests/tests/expectations/tests/struct_with_anon_union.rs
+++ b/bindgen-tests/tests/expectations/tests/struct_with_anon_union.rs
@@ -10,6 +10,7 @@ pub union foo__bindgen_ty_1 {
     pub a: ::std::os::raw::c_uint,
     pub b: ::std::os::raw::c_ushort,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of foo__bindgen_ty_1"][::std::mem::size_of::<foo__bindgen_ty_1>() - 4usize];
     [
@@ -31,6 +32,7 @@ impl Default for foo__bindgen_ty_1 {
         }
     }
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of foo"][::std::mem::size_of::<foo>() - 4usize];
     ["Alignment of foo"][::std::mem::align_of::<foo>() - 4usize];

--- a/bindgen-tests/tests/expectations/tests/struct_with_anon_unnamed_struct.rs
+++ b/bindgen-tests/tests/expectations/tests/struct_with_anon_unnamed_struct.rs
@@ -10,6 +10,7 @@ pub struct foo__bindgen_ty_1 {
     pub a: ::std::os::raw::c_uint,
     pub b: ::std::os::raw::c_uint,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of foo__bindgen_ty_1"][::std::mem::size_of::<foo__bindgen_ty_1>() - 8usize];
     [
@@ -22,6 +23,7 @@ const _: () = {
         "Offset of field: foo__bindgen_ty_1::b",
     ][::std::mem::offset_of!(foo__bindgen_ty_1, b) - 4usize];
 };
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of foo"][::std::mem::size_of::<foo>() - 8usize];
     ["Alignment of foo"][::std::mem::align_of::<foo>() - 4usize];

--- a/bindgen-tests/tests/expectations/tests/struct_with_anon_unnamed_union.rs
+++ b/bindgen-tests/tests/expectations/tests/struct_with_anon_unnamed_union.rs
@@ -10,6 +10,7 @@ pub union foo__bindgen_ty_1 {
     pub a: ::std::os::raw::c_uint,
     pub b: ::std::os::raw::c_ushort,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of foo__bindgen_ty_1"][::std::mem::size_of::<foo__bindgen_ty_1>() - 4usize];
     [
@@ -31,6 +32,7 @@ impl Default for foo__bindgen_ty_1 {
         }
     }
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of foo"][::std::mem::size_of::<foo>() - 4usize];
     ["Alignment of foo"][::std::mem::align_of::<foo>() - 4usize];

--- a/bindgen-tests/tests/expectations/tests/struct_with_bitfields.rs
+++ b/bindgen-tests/tests/expectations/tests/struct_with_bitfields.rs
@@ -92,6 +92,7 @@ pub struct bitfield {
     pub _bitfield_align_2: [u32; 0],
     pub _bitfield_2: __BindgenBitfieldUnit<[u8; 8usize]>,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of bitfield"][::std::mem::size_of::<bitfield>() - 16usize];
     ["Alignment of bitfield"][::std::mem::align_of::<bitfield>() - 4usize];

--- a/bindgen-tests/tests/expectations/tests/struct_with_nesting.rs
+++ b/bindgen-tests/tests/expectations/tests/struct_with_nesting.rs
@@ -18,6 +18,7 @@ pub struct foo__bindgen_ty_1__bindgen_ty_1 {
     pub c1: ::std::os::raw::c_ushort,
     pub c2: ::std::os::raw::c_ushort,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     [
         "Size of foo__bindgen_ty_1__bindgen_ty_1",
@@ -40,6 +41,7 @@ pub struct foo__bindgen_ty_1__bindgen_ty_2 {
     pub d3: ::std::os::raw::c_uchar,
     pub d4: ::std::os::raw::c_uchar,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     [
         "Size of foo__bindgen_ty_1__bindgen_ty_2",
@@ -60,6 +62,7 @@ const _: () = {
         "Offset of field: foo__bindgen_ty_1__bindgen_ty_2::d4",
     ][::std::mem::offset_of!(foo__bindgen_ty_1__bindgen_ty_2, d4) - 3usize];
 };
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of foo__bindgen_ty_1"][::std::mem::size_of::<foo__bindgen_ty_1>() - 4usize];
     [
@@ -78,6 +81,7 @@ impl Default for foo__bindgen_ty_1 {
         }
     }
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of foo"][::std::mem::size_of::<foo>() - 8usize];
     ["Alignment of foo"][::std::mem::align_of::<foo>() - 4usize];

--- a/bindgen-tests/tests/expectations/tests/struct_with_packing.rs
+++ b/bindgen-tests/tests/expectations/tests/struct_with_packing.rs
@@ -5,6 +5,7 @@ pub struct a {
     pub b: ::std::os::raw::c_char,
     pub c: ::std::os::raw::c_short,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of a"][::std::mem::size_of::<a>() - 3usize];
     ["Alignment of a"][::std::mem::align_of::<a>() - 1usize];

--- a/bindgen-tests/tests/expectations/tests/struct_with_struct.rs
+++ b/bindgen-tests/tests/expectations/tests/struct_with_struct.rs
@@ -10,6 +10,7 @@ pub struct foo__bindgen_ty_1 {
     pub x: ::std::os::raw::c_uint,
     pub y: ::std::os::raw::c_uint,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of foo__bindgen_ty_1"][::std::mem::size_of::<foo__bindgen_ty_1>() - 8usize];
     [
@@ -22,6 +23,7 @@ const _: () = {
         "Offset of field: foo__bindgen_ty_1::y",
     ][::std::mem::offset_of!(foo__bindgen_ty_1, y) - 4usize];
 };
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of foo"][::std::mem::size_of::<foo>() - 8usize];
     ["Alignment of foo"][::std::mem::align_of::<foo>() - 4usize];

--- a/bindgen-tests/tests/expectations/tests/template.rs
+++ b/bindgen-tests/tests/expectations/tests/template.rs
@@ -60,6 +60,7 @@ pub struct C {
     pub mArrayRef: B<*mut [::std::os::raw::c_int; 1usize]>,
     pub mBConstArray: B<[::std::os::raw::c_int; 1usize]>,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of C"][::std::mem::size_of::<C>() - 104usize];
     ["Alignment of C"][::std::mem::align_of::<C>() - 8usize];
@@ -152,6 +153,7 @@ impl<T> Default for Rooted<T> {
 pub struct RootedContainer {
     pub root: Rooted<*mut ::std::os::raw::c_void>,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of RootedContainer"][::std::mem::size_of::<RootedContainer>() - 24usize];
     ["Alignment of RootedContainer"][::std::mem::align_of::<RootedContainer>() - 8usize];
@@ -189,6 +191,7 @@ impl<T> Default for WithDtor<T> {
 pub struct PODButContainsDtor {
     pub member: WithDtorIntFwd,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of PODButContainsDtor"][::std::mem::size_of::<PODButContainsDtor>() - 4usize];
     [
@@ -218,6 +221,7 @@ pub struct Opaque {
 pub struct POD {
     pub opaque_member: u32,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of POD"][::std::mem::size_of::<POD>() - 4usize];
     ["Alignment of POD"][::std::mem::align_of::<POD>() - 4usize];
@@ -293,6 +297,7 @@ impl<T> Default for Incomplete<T> {
 pub struct Untemplated {
     pub _address: u8,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of Untemplated"][::std::mem::size_of::<Untemplated>() - 1usize];
     ["Alignment of Untemplated"][::std::mem::align_of::<Untemplated>() - 1usize];
@@ -370,6 +375,7 @@ impl<T> Default for ReplacedWithoutDestructorFwd<T> {
         }
     }
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     [
         "Size of template specialization: Foo_open0_int_int_close0",
@@ -378,6 +384,7 @@ const _: () = {
         "Align of template specialization: Foo_open0_int_int_close0",
     ][::std::mem::align_of::<Foo<::std::os::raw::c_int>>() - 8usize];
 };
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     [
         "Size of template specialization: B_open0_unsigned_int_close0",
@@ -386,6 +393,7 @@ const _: () = {
         "Align of template specialization: B_open0_unsigned_int_close0",
     ][::std::mem::align_of::<B<::std::os::raw::c_uint>>() - 4usize];
 };
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     [
         "Size of template specialization: B_open0_ptr_const_int_close0",
@@ -394,6 +402,7 @@ const _: () = {
         "Align of template specialization: B_open0_ptr_const_int_close0",
     ][::std::mem::align_of::<B<*const ::std::os::raw::c_int>>() - 8usize];
 };
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     [
         "Size of template specialization: B_open0_ptr_const_mozilla__Foo_close0",
@@ -402,6 +411,7 @@ const _: () = {
         "Align of template specialization: B_open0_ptr_const_mozilla__Foo_close0",
     ][::std::mem::align_of::<B<*const mozilla_Foo>>() - 8usize];
 };
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     [
         "Size of template specialization: B_open0_array1_ptr_const_mozilla__Foo_close0",
@@ -410,6 +420,7 @@ const _: () = {
         "Align of template specialization: B_open0_array1_ptr_const_mozilla__Foo_close0",
     ][::std::mem::align_of::<B<[*const mozilla_Foo; 1usize]>>() - 8usize];
 };
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     [
         "Size of template specialization: B_open0_const_int_close0",
@@ -418,6 +429,7 @@ const _: () = {
         "Align of template specialization: B_open0_const_int_close0",
     ][::std::mem::align_of::<B<::std::os::raw::c_int>>() - 4usize];
 };
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     [
         "Size of template specialization: B_open0_volatile_int_close0",
@@ -426,6 +438,7 @@ const _: () = {
         "Align of template specialization: B_open0_volatile_int_close0",
     ][::std::mem::align_of::<B<::std::os::raw::c_int>>() - 4usize];
 };
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     [
         "Size of template specialization: B_open0_const_bool_close0",
@@ -434,6 +447,7 @@ const _: () = {
         "Align of template specialization: B_open0_const_bool_close0",
     ][::std::mem::align_of::<B<bool>>() - 1usize];
 };
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     [
         "Size of template specialization: B_open0_const_char16_t_close0",
@@ -442,6 +456,7 @@ const _: () = {
         "Align of template specialization: B_open0_const_char16_t_close0",
     ][::std::mem::align_of::<B<u16>>() - 2usize];
 };
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     [
         "Size of template specialization: B_open0_array1_int_close0",
@@ -450,6 +465,7 @@ const _: () = {
         "Align of template specialization: B_open0_array1_int_close0",
     ][::std::mem::align_of::<B<[::std::os::raw::c_int; 1usize]>>() - 4usize];
 };
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     [
         "Size of template specialization: B_open0_array1_ptr_int_close0",
@@ -458,6 +474,7 @@ const _: () = {
         "Align of template specialization: B_open0_array1_ptr_int_close0",
     ][::std::mem::align_of::<B<[*mut ::std::os::raw::c_int; 1usize]>>() - 8usize];
 };
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     [
         "Size of template specialization: B_open0_ptr_array1_int_close0",
@@ -466,6 +483,7 @@ const _: () = {
         "Align of template specialization: B_open0_ptr_array1_int_close0",
     ][::std::mem::align_of::<B<*mut [::std::os::raw::c_int; 1usize]>>() - 8usize];
 };
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     [
         "Size of template specialization: B_open0_ref_int_close0",
@@ -474,6 +492,7 @@ const _: () = {
         "Align of template specialization: B_open0_ref_int_close0",
     ][::std::mem::align_of::<B<*mut ::std::os::raw::c_int>>() - 8usize];
 };
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     [
         "Size of template specialization: B_open0_ref_const_int_close0",
@@ -482,6 +501,7 @@ const _: () = {
         "Align of template specialization: B_open0_ref_const_int_close0",
     ][::std::mem::align_of::<B<*const ::std::os::raw::c_int>>() - 8usize];
 };
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     [
         "Size of template specialization: B_open0_ref_ptr_int_close0",
@@ -490,6 +510,7 @@ const _: () = {
         "Align of template specialization: B_open0_ref_ptr_int_close0",
     ][::std::mem::align_of::<B<*mut *mut ::std::os::raw::c_int>>() - 8usize];
 };
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     [
         "Size of template specialization: B_open0_ref_array1_int_close0",
@@ -498,6 +519,7 @@ const _: () = {
         "Align of template specialization: B_open0_ref_array1_int_close0",
     ][::std::mem::align_of::<B<*mut [::std::os::raw::c_int; 1usize]>>() - 8usize];
 };
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     [
         "Size of template specialization: B_open0_array1_const_int_close0",
@@ -506,6 +528,7 @@ const _: () = {
         "Align of template specialization: B_open0_array1_const_int_close0",
     ][::std::mem::align_of::<B<[::std::os::raw::c_int; 1usize]>>() - 4usize];
 };
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     [
         "Size of template specialization: Foo_open0_int_int_close0",
@@ -514,6 +537,7 @@ const _: () = {
         "Align of template specialization: Foo_open0_int_int_close0",
     ][::std::mem::align_of::<Foo<::std::os::raw::c_int>>() - 8usize];
 };
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     [
         "Size of template specialization: Rooted_open0_ptr_void_close0",
@@ -522,6 +546,7 @@ const _: () = {
         "Align of template specialization: Rooted_open0_ptr_void_close0",
     ][::std::mem::align_of::<Rooted<*mut ::std::os::raw::c_void>>() - 8usize];
 };
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     [
         "Size of template specialization: Rooted_open0_ptr_void_close0",
@@ -530,6 +555,7 @@ const _: () = {
         "Align of template specialization: Rooted_open0_ptr_void_close0",
     ][::std::mem::align_of::<Rooted<*mut ::std::os::raw::c_void>>() - 8usize];
 };
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     [
         "Size of template specialization: WithDtor_open0_int_close0",

--- a/bindgen-tests/tests/expectations/tests/template_instantiation_with_fn_local_type.rs
+++ b/bindgen-tests/tests/expectations/tests/template_instantiation_with_fn_local_type.rs
@@ -8,6 +8,7 @@ extern "C" {
     #[link_name = "\u{1}_Z1fv"]
     pub fn f();
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     [
         "Size of template specialization: Foo_open0_Bar_close0",
@@ -21,10 +22,12 @@ const _: () = {
 pub struct Baz {
     pub _address: u8,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of Baz"][::std::mem::size_of::<Baz>() - 1usize];
     ["Alignment of Baz"][::std::mem::align_of::<Baz>() - 1usize];
 };
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     [
         "Size of template specialization: Foo_open0_Boo_close0",
@@ -38,6 +41,7 @@ const _: () = {
 pub struct Bar {
     pub _address: u8,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of Bar"][::std::mem::size_of::<Bar>() - 1usize];
     ["Alignment of Bar"][::std::mem::align_of::<Bar>() - 1usize];
@@ -47,6 +51,7 @@ const _: () = {
 pub struct Boo {
     pub _address: u8,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of Boo"][::std::mem::size_of::<Boo>() - 1usize];
     ["Alignment of Boo"][::std::mem::align_of::<Boo>() - 1usize];

--- a/bindgen-tests/tests/expectations/tests/test_mixed_header_and_header_contents.rs
+++ b/bindgen-tests/tests/expectations/tests/test_mixed_header_and_header_contents.rs
@@ -31,6 +31,7 @@ pub struct Test {
     pub Ccu: UChar,
     pub Ccd: SChar,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of Test"][::std::mem::size_of::<Test>() - 12usize];
     ["Alignment of Test"][::std::mem::align_of::<Test>() - 1usize];

--- a/bindgen-tests/tests/expectations/tests/test_multiple_header_calls_in_builder.rs
+++ b/bindgen-tests/tests/expectations/tests/test_multiple_header_calls_in_builder.rs
@@ -25,6 +25,7 @@ pub struct Test {
     pub Ccu: UChar,
     pub Ccd: SChar,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of Test"][::std::mem::size_of::<Test>() - 12usize];
     ["Alignment of Test"][::std::mem::align_of::<Test>() - 1usize];

--- a/bindgen-tests/tests/expectations/tests/timex.rs
+++ b/bindgen-tests/tests/expectations/tests/timex.rs
@@ -90,6 +90,7 @@ pub struct timex {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 44usize]>,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of timex"][::std::mem::size_of::<timex>() - 48usize];
     ["Alignment of timex"][::std::mem::align_of::<timex>() - 4usize];
@@ -111,6 +112,7 @@ pub struct timex_named {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 44usize]>,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of timex_named"][::std::mem::size_of::<timex_named>() - 48usize];
     ["Alignment of timex_named"][::std::mem::align_of::<timex_named>() - 4usize];

--- a/bindgen-tests/tests/expectations/tests/type-referenced-by-allowlisted-function.rs
+++ b/bindgen-tests/tests/expectations/tests/type-referenced-by-allowlisted-function.rs
@@ -4,6 +4,7 @@
 pub struct dl_phdr_info {
     pub x: ::std::os::raw::c_int,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of dl_phdr_info"][::std::mem::size_of::<dl_phdr_info>() - 4usize];
     ["Alignment of dl_phdr_info"][::std::mem::align_of::<dl_phdr_info>() - 4usize];

--- a/bindgen-tests/tests/expectations/tests/type_alias_template_specialized.rs
+++ b/bindgen-tests/tests/expectations/tests/type_alias_template_specialized.rs
@@ -4,6 +4,7 @@
 pub struct Rooted {
     pub ptr: MaybeWrapped<::std::os::raw::c_int>,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of Rooted"][::std::mem::size_of::<Rooted>() - 4usize];
     ["Alignment of Rooted"][::std::mem::align_of::<Rooted>() - 4usize];
@@ -20,6 +21,7 @@ impl Default for Rooted {
 }
 /// <div rustbindgen replaces="MaybeWrapped"></div>
 pub type MaybeWrapped<a> = a;
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     [
         "Size of template specialization: MaybeWrapped_open0_int_close0",

--- a/bindgen-tests/tests/expectations/tests/typedef-pointer-overlap.rs
+++ b/bindgen-tests/tests/expectations/tests/typedef-pointer-overlap.rs
@@ -4,6 +4,7 @@
 pub struct foo {
     pub inner: ::std::os::raw::c_char,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of foo"][::std::mem::size_of::<foo>() - 1usize];
     ["Alignment of foo"][::std::mem::align_of::<foo>() - 1usize];
@@ -15,6 +16,7 @@ pub type foo_ptr = *const foo;
 pub struct bar {
     pub inner: ::std::os::raw::c_char,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of bar"][::std::mem::size_of::<bar>() - 1usize];
     ["Alignment of bar"][::std::mem::align_of::<bar>() - 1usize];
@@ -32,6 +34,7 @@ pub type baz_ptr = *mut baz;
 pub union cat {
     pub standard_issue: ::std::os::raw::c_int,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of cat"][::std::mem::size_of::<cat>() - 4usize];
     ["Alignment of cat"][::std::mem::align_of::<cat>() - 4usize];

--- a/bindgen-tests/tests/expectations/tests/typeref.rs
+++ b/bindgen-tests/tests/expectations/tests/typeref.rs
@@ -4,6 +4,7 @@
 pub struct mozilla_FragmentOrURL {
     pub mIsLocalRef: bool,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     [
         "Size of mozilla_FragmentOrURL",
@@ -20,6 +21,7 @@ const _: () = {
 pub struct mozilla_Position {
     pub _address: u8,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of mozilla_Position"][::std::mem::size_of::<mozilla_Position>() - 1usize];
     [
@@ -58,6 +60,7 @@ impl Default for mozilla_StyleShapeSource {
 pub struct Bar {
     pub mFoo: *mut nsFoo,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of Bar"][::std::mem::size_of::<Bar>() - 8usize];
     ["Alignment of Bar"][::std::mem::align_of::<Bar>() - 8usize];
@@ -76,6 +79,7 @@ impl Default for Bar {
 pub struct nsFoo {
     pub mBar: mozilla_StyleShapeSource,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of nsFoo"][::std::mem::size_of::<nsFoo>() - 8usize];
     ["Alignment of nsFoo"][::std::mem::align_of::<nsFoo>() - 8usize];
@@ -90,6 +94,7 @@ impl Default for nsFoo {
         }
     }
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     [
         "Size of template specialization: mozilla_StyleShapeSource_open0_int_close0",

--- a/bindgen-tests/tests/expectations/tests/underscore.rs
+++ b/bindgen-tests/tests/expectations/tests/underscore.rs
@@ -5,6 +5,7 @@ pub const __: ::std::os::raw::c_int = 10;
 pub struct ptr_t {
     pub __: [::std::os::raw::c_uchar; 8usize],
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of ptr_t"][::std::mem::size_of::<ptr_t>() - 8usize];
     ["Alignment of ptr_t"][::std::mem::align_of::<ptr_t>() - 1usize];

--- a/bindgen-tests/tests/expectations/tests/union-in-ns.rs
+++ b/bindgen-tests/tests/expectations/tests/union-in-ns.rs
@@ -8,6 +8,7 @@ pub mod root {
     pub union bar {
         pub baz: ::std::os::raw::c_int,
     }
+    #[allow(clippy::unnecessary_operation, clippy::identity_op)]
     const _: () = {
         ["Size of bar"][::std::mem::size_of::<bar>() - 4usize];
         ["Alignment of bar"][::std::mem::align_of::<bar>() - 4usize];

--- a/bindgen-tests/tests/expectations/tests/union_bitfield.rs
+++ b/bindgen-tests/tests/expectations/tests/union_bitfield.rs
@@ -90,6 +90,7 @@ pub union U4 {
     pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of U4"][::std::mem::size_of::<U4>() - 4usize];
     ["Alignment of U4"][::std::mem::align_of::<U4>() - 4usize];
@@ -138,6 +139,7 @@ pub union B {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of B"][::std::mem::size_of::<B>() - 4usize];
     ["Alignment of B"][::std::mem::align_of::<B>() - 4usize];

--- a/bindgen-tests/tests/expectations/tests/union_dtor.rs
+++ b/bindgen-tests/tests/expectations/tests/union_dtor.rs
@@ -4,6 +4,7 @@ pub union UnionWithDtor {
     pub mFoo: ::std::os::raw::c_int,
     pub mBar: *mut ::std::os::raw::c_void,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of UnionWithDtor"][::std::mem::size_of::<UnionWithDtor>() - 8usize];
     ["Alignment of UnionWithDtor"][::std::mem::align_of::<UnionWithDtor>() - 8usize];

--- a/bindgen-tests/tests/expectations/tests/union_fields.rs
+++ b/bindgen-tests/tests/expectations/tests/union_fields.rs
@@ -6,6 +6,7 @@ pub union nsStyleUnion {
     pub mFloat: f32,
     pub mPointer: *mut ::std::os::raw::c_void,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of nsStyleUnion"][::std::mem::size_of::<nsStyleUnion>() - 8usize];
     ["Alignment of nsStyleUnion"][::std::mem::align_of::<nsStyleUnion>() - 8usize];

--- a/bindgen-tests/tests/expectations/tests/union_with_anon_struct.rs
+++ b/bindgen-tests/tests/expectations/tests/union_with_anon_struct.rs
@@ -10,6 +10,7 @@ pub struct foo__bindgen_ty_1 {
     pub a: ::std::os::raw::c_uint,
     pub b: ::std::os::raw::c_uint,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of foo__bindgen_ty_1"][::std::mem::size_of::<foo__bindgen_ty_1>() - 8usize];
     [
@@ -22,6 +23,7 @@ const _: () = {
         "Offset of field: foo__bindgen_ty_1::b",
     ][::std::mem::offset_of!(foo__bindgen_ty_1, b) - 4usize];
 };
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of foo"][::std::mem::size_of::<foo>() - 8usize];
     ["Alignment of foo"][::std::mem::align_of::<foo>() - 4usize];

--- a/bindgen-tests/tests/expectations/tests/union_with_anon_struct_bitfield.rs
+++ b/bindgen-tests/tests/expectations/tests/union_with_anon_struct_bitfield.rs
@@ -95,6 +95,7 @@ pub struct foo__bindgen_ty_1 {
     pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of foo__bindgen_ty_1"][::std::mem::size_of::<foo__bindgen_ty_1>() - 4usize];
     [
@@ -151,6 +152,7 @@ impl foo__bindgen_ty_1 {
         __bindgen_bitfield_unit
     }
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of foo"][::std::mem::size_of::<foo>() - 4usize];
     ["Alignment of foo"][::std::mem::align_of::<foo>() - 4usize];

--- a/bindgen-tests/tests/expectations/tests/union_with_anon_union.rs
+++ b/bindgen-tests/tests/expectations/tests/union_with_anon_union.rs
@@ -10,6 +10,7 @@ pub union foo__bindgen_ty_1 {
     pub a: ::std::os::raw::c_uint,
     pub b: ::std::os::raw::c_ushort,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of foo__bindgen_ty_1"][::std::mem::size_of::<foo__bindgen_ty_1>() - 4usize];
     [
@@ -31,6 +32,7 @@ impl Default for foo__bindgen_ty_1 {
         }
     }
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of foo"][::std::mem::size_of::<foo>() - 4usize];
     ["Alignment of foo"][::std::mem::align_of::<foo>() - 4usize];

--- a/bindgen-tests/tests/expectations/tests/union_with_anon_unnamed_struct.rs
+++ b/bindgen-tests/tests/expectations/tests/union_with_anon_unnamed_struct.rs
@@ -13,6 +13,7 @@ pub struct pixel__bindgen_ty_1 {
     pub b: ::std::os::raw::c_uchar,
     pub a: ::std::os::raw::c_uchar,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     [
         "Size of pixel__bindgen_ty_1",
@@ -33,6 +34,7 @@ const _: () = {
         "Offset of field: pixel__bindgen_ty_1::a",
     ][::std::mem::offset_of!(pixel__bindgen_ty_1, a) - 3usize];
 };
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of pixel"][::std::mem::size_of::<pixel>() - 4usize];
     ["Alignment of pixel"][::std::mem::align_of::<pixel>() - 4usize];

--- a/bindgen-tests/tests/expectations/tests/union_with_anon_unnamed_union.rs
+++ b/bindgen-tests/tests/expectations/tests/union_with_anon_unnamed_union.rs
@@ -11,6 +11,7 @@ pub union foo__bindgen_ty_1 {
     pub b: ::std::os::raw::c_ushort,
     pub c: ::std::os::raw::c_uchar,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of foo__bindgen_ty_1"][::std::mem::size_of::<foo__bindgen_ty_1>() - 2usize];
     [
@@ -32,6 +33,7 @@ impl Default for foo__bindgen_ty_1 {
         }
     }
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of foo"][::std::mem::size_of::<foo>() - 4usize];
     ["Alignment of foo"][::std::mem::align_of::<foo>() - 4usize];

--- a/bindgen-tests/tests/expectations/tests/union_with_big_member.rs
+++ b/bindgen-tests/tests/expectations/tests/union_with_big_member.rs
@@ -5,6 +5,7 @@ pub union WithBigArray {
     pub a: ::std::os::raw::c_int,
     pub b: [::std::os::raw::c_int; 33usize],
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of WithBigArray"][::std::mem::size_of::<WithBigArray>() - 132usize];
     ["Alignment of WithBigArray"][::std::mem::align_of::<WithBigArray>() - 4usize];
@@ -30,6 +31,7 @@ pub union WithBigArray2 {
     pub a: ::std::os::raw::c_int,
     pub b: [::std::os::raw::c_char; 33usize],
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of WithBigArray2"][::std::mem::size_of::<WithBigArray2>() - 36usize];
     ["Alignment of WithBigArray2"][::std::mem::align_of::<WithBigArray2>() - 4usize];
@@ -55,6 +57,7 @@ pub union WithBigMember {
     pub a: ::std::os::raw::c_int,
     pub b: WithBigArray,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of WithBigMember"][::std::mem::size_of::<WithBigMember>() - 132usize];
     ["Alignment of WithBigMember"][::std::mem::align_of::<WithBigMember>() - 4usize];

--- a/bindgen-tests/tests/expectations/tests/union_with_nesting.rs
+++ b/bindgen-tests/tests/expectations/tests/union_with_nesting.rs
@@ -17,6 +17,7 @@ pub union foo__bindgen_ty_1__bindgen_ty_1 {
     pub b1: ::std::os::raw::c_ushort,
     pub b2: ::std::os::raw::c_ushort,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     [
         "Size of foo__bindgen_ty_1__bindgen_ty_1",
@@ -46,6 +47,7 @@ pub union foo__bindgen_ty_1__bindgen_ty_2 {
     pub c1: ::std::os::raw::c_ushort,
     pub c2: ::std::os::raw::c_ushort,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     [
         "Size of foo__bindgen_ty_1__bindgen_ty_2",
@@ -69,6 +71,7 @@ impl Default for foo__bindgen_ty_1__bindgen_ty_2 {
         }
     }
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of foo__bindgen_ty_1"][::std::mem::size_of::<foo__bindgen_ty_1>() - 4usize];
     [
@@ -84,6 +87,7 @@ impl Default for foo__bindgen_ty_1 {
         }
     }
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of foo"][::std::mem::size_of::<foo>() - 4usize];
     ["Alignment of foo"][::std::mem::align_of::<foo>() - 4usize];

--- a/bindgen-tests/tests/expectations/tests/union_with_non_copy_member.rs
+++ b/bindgen-tests/tests/expectations/tests/union_with_non_copy_member.rs
@@ -47,6 +47,7 @@ impl<T> ::std::cmp::Eq for __BindgenUnionField<T> {}
 pub struct NonCopyType {
     pub foo: ::std::os::raw::c_int,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of NonCopyType"][::std::mem::size_of::<NonCopyType>() - 4usize];
     ["Alignment of NonCopyType"][::std::mem::align_of::<NonCopyType>() - 4usize];
@@ -60,6 +61,7 @@ pub struct WithBindgenGeneratedWrapper {
     pub bar: __BindgenUnionField<::std::os::raw::c_int>,
     pub bindgen_union_field: u32,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     [
         "Size of WithBindgenGeneratedWrapper",
@@ -88,6 +90,7 @@ pub union WithManuallyDrop {
     pub non_copy_type: ::std::mem::ManuallyDrop<NonCopyType>,
     pub bar: ::std::mem::ManuallyDrop<::std::os::raw::c_int>,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of WithManuallyDrop"][::std::mem::size_of::<WithManuallyDrop>() - 4usize];
     [
@@ -115,6 +118,7 @@ pub struct WithDefaultWrapper {
     pub bar: __BindgenUnionField<::std::os::raw::c_int>,
     pub bindgen_union_field: u32,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of WithDefaultWrapper"][::std::mem::size_of::<WithDefaultWrapper>() - 4usize];
     [

--- a/bindgen-tests/tests/expectations/tests/unknown_attr.rs
+++ b/bindgen-tests/tests/expectations/tests/unknown_attr.rs
@@ -7,6 +7,7 @@ pub struct max_align_t {
     pub __bindgen_padding_0: u64,
     pub __clang_max_align_nonce2: ::std::os::raw::c_longlong,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of max_align_t"][::std::mem::size_of::<max_align_t>() - 32usize];
     ["Alignment of max_align_t"][::std::mem::align_of::<max_align_t>() - 16usize];

--- a/bindgen-tests/tests/expectations/tests/unsorted-items.rs
+++ b/bindgen-tests/tests/expectations/tests/unsorted-items.rs
@@ -12,6 +12,7 @@ pub struct Point {
     pub x: number,
     pub y: number,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of Point"][::std::mem::size_of::<Point>() - 8usize];
     ["Alignment of Point"][::std::mem::align_of::<Point>() - 4usize];
@@ -24,6 +25,7 @@ pub struct Angle {
     pub a: number,
     pub b: number,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of Angle"][::std::mem::size_of::<Angle>() - 8usize];
     ["Alignment of Angle"][::std::mem::align_of::<Angle>() - 4usize];

--- a/bindgen-tests/tests/expectations/tests/use-core.rs
+++ b/bindgen-tests/tests/expectations/tests/use-core.rs
@@ -8,6 +8,7 @@ pub struct foo {
     pub b: ::core::ffi::c_int,
     pub bar: *mut ::core::ffi::c_void,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of foo"][::core::mem::size_of::<foo>() - 16usize];
     ["Alignment of foo"][::core::mem::align_of::<foo>() - 8usize];
@@ -30,6 +31,7 @@ pub union _bindgen_ty_1 {
     pub bar: ::core::ffi::c_int,
     pub baz: ::core::ffi::c_long,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of _bindgen_ty_1"][::core::mem::size_of::<_bindgen_ty_1>() - 8usize];
     ["Alignment of _bindgen_ty_1"][::core::mem::align_of::<_bindgen_ty_1>() - 8usize];

--- a/bindgen-tests/tests/expectations/tests/var-tracing.rs
+++ b/bindgen-tests/tests/expectations/tests/var-tracing.rs
@@ -4,6 +4,7 @@
 pub struct Bar {
     pub m_baz: ::std::os::raw::c_int,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of Bar"][::std::mem::size_of::<Bar>() - 4usize];
     ["Alignment of Bar"][::std::mem::align_of::<Bar>() - 4usize];
@@ -30,6 +31,7 @@ extern "C" {
     #[link_name = "\u{1}_ZN3Baz3FOOE"]
     pub static Baz_FOO: [Bar; 0usize];
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of Baz"][::std::mem::size_of::<Baz>() - 1usize];
     ["Alignment of Baz"][::std::mem::align_of::<Baz>() - 1usize];

--- a/bindgen-tests/tests/expectations/tests/variadic-method.rs
+++ b/bindgen-tests/tests/expectations/tests/variadic-method.rs
@@ -8,6 +8,7 @@ extern "C" {
 pub struct Bar {
     pub _address: u8,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of Bar"][::std::mem::size_of::<Bar>() - 1usize];
     ["Alignment of Bar"][::std::mem::align_of::<Bar>() - 1usize];

--- a/bindgen-tests/tests/expectations/tests/vector.rs
+++ b/bindgen-tests/tests/expectations/tests/vector.rs
@@ -4,6 +4,7 @@
 pub struct foo {
     pub mMember: [::std::os::raw::c_longlong; 1usize],
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of foo"][::std::mem::size_of::<foo>() - 8usize];
     ["Alignment of foo"][::std::mem::align_of::<foo>() - 8usize];

--- a/bindgen-tests/tests/expectations/tests/virtual_dtor.rs
+++ b/bindgen-tests/tests/expectations/tests/virtual_dtor.rs
@@ -6,6 +6,7 @@ pub struct nsSlots__bindgen_vtable(::std::os::raw::c_void);
 pub struct nsSlots {
     pub vtable_: *const nsSlots__bindgen_vtable,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of nsSlots"][::std::mem::size_of::<nsSlots>() - 8usize];
     ["Alignment of nsSlots"][::std::mem::align_of::<nsSlots>() - 8usize];

--- a/bindgen-tests/tests/expectations/tests/virtual_interface.rs
+++ b/bindgen-tests/tests/expectations/tests/virtual_interface.rs
@@ -12,6 +12,7 @@ pub struct PureVirtualIFace__bindgen_vtable {
 pub struct PureVirtualIFace {
     pub vtable_: *const PureVirtualIFace__bindgen_vtable,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of PureVirtualIFace"][::std::mem::size_of::<PureVirtualIFace>() - 8usize];
     [
@@ -36,6 +37,7 @@ pub struct AnotherInterface__bindgen_vtable {
 pub struct AnotherInterface {
     pub vtable_: *const AnotherInterface__bindgen_vtable,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of AnotherInterface"][::std::mem::size_of::<AnotherInterface>() - 8usize];
     [
@@ -56,6 +58,7 @@ impl Default for AnotherInterface {
 pub struct Implementation {
     pub _base: PureVirtualIFace,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of Implementation"][::std::mem::size_of::<Implementation>() - 8usize];
     ["Alignment of Implementation"][::std::mem::align_of::<Implementation>() - 8usize];
@@ -75,6 +78,7 @@ pub struct DoubleImpl {
     pub _base: PureVirtualIFace,
     pub _base_1: AnotherInterface,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of DoubleImpl"][::std::mem::size_of::<DoubleImpl>() - 16usize];
     ["Alignment of DoubleImpl"][::std::mem::align_of::<DoubleImpl>() - 8usize];

--- a/bindgen-tests/tests/expectations/tests/virtual_overloaded.rs
+++ b/bindgen-tests/tests/expectations/tests/virtual_overloaded.rs
@@ -9,6 +9,7 @@ pub struct C__bindgen_vtable {
 pub struct C {
     pub vtable_: *const C__bindgen_vtable,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of C"][::std::mem::size_of::<C>() - 8usize];
     ["Alignment of C"][::std::mem::align_of::<C>() - 8usize];

--- a/bindgen-tests/tests/expectations/tests/vtable_recursive_sig.rs
+++ b/bindgen-tests/tests/expectations/tests/vtable_recursive_sig.rs
@@ -8,6 +8,7 @@ pub struct Base__bindgen_vtable {
 pub struct Base {
     pub vtable_: *const Base__bindgen_vtable,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of Base"][::std::mem::size_of::<Base>() - 8usize];
     ["Alignment of Base"][::std::mem::align_of::<Base>() - 8usize];
@@ -30,6 +31,7 @@ extern "C" {
 pub struct Derived {
     pub _base: Base,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of Derived"][::std::mem::size_of::<Derived>() - 8usize];
     ["Alignment of Derived"][::std::mem::align_of::<Derived>() - 8usize];

--- a/bindgen-tests/tests/expectations/tests/wasm-constructor-returns.rs
+++ b/bindgen-tests/tests/expectations/tests/wasm-constructor-returns.rs
@@ -4,6 +4,7 @@
 pub struct Foo {
     pub _address: u8,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of Foo"][::std::mem::size_of::<Foo>() - 1usize];
     ["Alignment of Foo"][::std::mem::align_of::<Foo>() - 1usize];

--- a/bindgen-tests/tests/expectations/tests/weird_bitfields.rs
+++ b/bindgen-tests/tests/expectations/tests/weird_bitfields.rs
@@ -111,6 +111,7 @@ pub struct Weird {
     pub _bitfield_2: __BindgenBitfieldUnit<[u8; 2usize]>,
     pub __bindgen_padding_0: [u8; 3usize],
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of Weird"][::std::mem::size_of::<Weird>() - 24usize];
     ["Alignment of Weird"][::std::mem::align_of::<Weird>() - 4usize];

--- a/bindgen-tests/tests/expectations/tests/what_is_going_on.rs
+++ b/bindgen-tests/tests/expectations/tests/what_is_going_on.rs
@@ -4,6 +4,7 @@
 pub struct UnknownUnits {
     pub _address: u8,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of UnknownUnits"][::std::mem::size_of::<UnknownUnits>() - 1usize];
     ["Alignment of UnknownUnits"][::std::mem::align_of::<UnknownUnits>() - 1usize];

--- a/bindgen-tests/tests/expectations/tests/win32-thiscall_nightly.rs
+++ b/bindgen-tests/tests/expectations/tests/win32-thiscall_nightly.rs
@@ -6,6 +6,7 @@
 pub struct Foo {
     pub _address: u8,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of Foo"][::std::mem::size_of::<Foo>() - 1usize];
     ["Alignment of Foo"][::std::mem::align_of::<Foo>() - 1usize];

--- a/bindgen-tests/tests/expectations/tests/zero-size-array-align.rs
+++ b/bindgen-tests/tests/expectations/tests/zero-size-array-align.rs
@@ -36,6 +36,7 @@ pub struct dm_deps {
     pub filler: ::std::os::raw::c_uint,
     pub device: __IncompleteArrayField<::std::os::raw::c_ulonglong>,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of dm_deps"][::std::mem::size_of::<dm_deps>() - 8usize];
     ["Alignment of dm_deps"][::std::mem::align_of::<dm_deps>() - 8usize];

--- a/bindgen-tests/tests/expectations/tests/zero-sized-array.rs
+++ b/bindgen-tests/tests/expectations/tests/zero-sized-array.rs
@@ -35,6 +35,7 @@ impl<T> ::std::fmt::Debug for __IncompleteArrayField<T> {
 pub struct ZeroSizedArray {
     pub arr: __IncompleteArrayField<::std::os::raw::c_char>,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of ZeroSizedArray"][::std::mem::size_of::<ZeroSizedArray>() - 0usize];
     ["Alignment of ZeroSizedArray"][::std::mem::align_of::<ZeroSizedArray>() - 1usize];
@@ -48,6 +49,7 @@ const _: () = {
 pub struct ContainsZeroSizedArray {
     pub zsa: ZeroSizedArray,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     [
         "Size of ContainsZeroSizedArray",
@@ -66,6 +68,7 @@ const _: () = {
 pub struct InheritsZeroSizedArray {
     pub _base: ZeroSizedArray,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     [
         "Size of InheritsZeroSizedArray",
@@ -80,6 +83,7 @@ const _: () = {
 pub struct DynamicallySizedArray {
     pub arr: __IncompleteArrayField<::std::os::raw::c_char>,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     [
         "Size of DynamicallySizedArray",
@@ -97,6 +101,7 @@ const _: () = {
 pub struct ContainsDynamicallySizedArray {
     pub dsa: DynamicallySizedArray,
 }
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     [
         "Size of ContainsDynamicallySizedArray",

--- a/bindgen/codegen/mod.rs
+++ b/bindgen/codegen/mod.rs
@@ -1313,6 +1313,7 @@ impl CodeGenerator for TemplateInstantiation {
                 // #size_of_expr < #size, the subtraction will overflow, both
                 // of which print enough information to see what has gone wrong.
                 result.push(quote! {
+                    #[allow(clippy::unnecessary_operation, clippy::identity_op)]
                     const _: () = {
                         [#size_of_err][#size_of_expr - #size];
                         [#align_of_err][#align_of_expr - #align];
@@ -2523,6 +2524,7 @@ impl CodeGenerator for CompInfo {
 
                     if compile_time {
                         result.push(quote! {
+                            #[allow(clippy::unnecessary_operation, clippy::identity_op)]
                             const _: () = {
                                 [#size_of_err][#size_of_expr - #size];
                                 #check_struct_align

--- a/bindgen/ir/item.rs
+++ b/bindgen/ir/item.rs
@@ -940,13 +940,13 @@ impl Item {
         // Only use local ids for enums, classes, structs and union types.  All
         // other items use their global ID.
         let ty_kind = self.kind().as_type().map(|t| t.kind());
-        if let Some(ty_kind) = ty_kind {
-            match *ty_kind {
-                TypeKind::Comp(..) |
-                TypeKind::TemplateInstantiation(..) |
-                TypeKind::Enum(..) => return self.local_id(ctx).to_string(),
-                _ => {}
-            }
+        if let Some(
+            TypeKind::Comp(..) |
+            TypeKind::TemplateInstantiation(..) |
+            TypeKind::Enum(..),
+        ) = ty_kind
+        {
+            return self.local_id(ctx).to_string();
         }
 
         // Note that this `id_` prefix prevents (really unlikely) collisions


### PR DESCRIPTION
fixes https://github.com/rust-lang/rust-bindgen/issues/2905