### PR TITLE
Require libclang 9.0 or newer

### DIFF
--- a/bindgen/lib.rs
+++ b/bindgen/lib.rs
@@ -745,6 +745,18 @@ impl Bindings {
         ensure_libclang_is_loaded();
 
         #[cfg(feature = "runtime")]
+        match clang_sys::get_library().unwrap().version() {
+            None => {
+                warn!("Could not detect a Clang version, make sure you are using libclang 9 or newer");
+            }
+            Some(version) => {
+                if version < clang_sys::Version::V9_0 {
+                    warn!("Detected Clang version {version:?} which is unsupported and can cause invalid code generation, use libclang 9 or newer");
+                }
+            }
+        }
+
+        #[cfg(feature = "runtime")]
         debug!(
             "Generating bindings, libclang at {}",
             clang_sys::get_library().unwrap().path().display()

--- a/book/src/requirements.md
+++ b/book/src/requirements.md
@@ -7,7 +7,7 @@ This page lists the requirements for running `bindgen` and how to get them.
 `bindgen` leverages `libclang` to preprocess, parse, and type check C and C++
 header files.
 
-It is required to use Clang 5.0 or greater.
+It is required to use Clang 9.0 or greater.
 
 ### Installing Clang
 


### PR DESCRIPTION
Adds a check for the loaded libclang version and returns an error if the version is unsupported.