### PR TITLE
Update documentation of Debian dependencies

### DIFF
--- a/book/src/requirements.md
+++ b/book/src/requirements.md
@@ -48,10 +48,10 @@ $ port install clang
 #### Debian-based Linuxes
 
 ```bash
-# apt install llvm-dev libclang-dev clang
+# apt install libclang-dev
 ```
 
-Ubuntu 18.04 provides the necessary packages directly.
+If you want to use the function `bindgen::Builder::dump_preprocessed_input`, then you also need the package `clang`.
 
 #### Arch
 


### PR DESCRIPTION
Bindgen doesn't need the llvm package at all and only needs the clang package for one function. I've tested this by running the bindgen tests on a fresh Debian installation.

I removed the line about Ubuntu because it is not relevant anymore.

closes #2934