### PR TITLE
Docs: Fix example code error

### DIFF
--- a/book/src/tutorial-3.md
+++ b/book/src/tutorial-3.md
@@ -30,7 +30,7 @@ fn main() {
         .header("wrapper.h")
         // Tell cargo to invalidate the built crate whenever any of the
         // included header files changed.
-        .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))
+        .parse_callbacks(Box::new(bindgen::CargoCallbacks))
         // Finish the builder and generate the bindings.
         .generate()
         // Unwrap the Result and panic on failure.


### PR DESCRIPTION
This is an example code that does not work based on the current version (bindgen = "0.65.1").