### PR TITLE
Fix unsafe_op_in_unsafe_fn when using dynamic librarys and wrap_unsafe_ops

### DIFF
--- a/bindgen-tests/tests/expectations/tests/wrap_unsafe_ops_dynamic_loading_simple.rs
+++ b/bindgen-tests/tests/expectations/tests/wrap_unsafe_ops_dynamic_loading_simple.rs
@@ -22,7 +22,7 @@ impl TestLib {
     where
         P: AsRef<::std::ffi::OsStr>,
     {
-        let library = ::libloading::Library::new(path)?;
+        let library = unsafe { ::libloading::Library::new(path) }?;
         unsafe { Self::from_library(library) }
     }
     pub unsafe fn from_library<L>(library: L) -> Result<Self, ::libloading::Error>

--- a/bindgen-tests/tests/expectations/tests/wrap_unsafe_ops_dynamic_loading_simple.rs
+++ b/bindgen-tests/tests/expectations/tests/wrap_unsafe_ops_dynamic_loading_simple.rs
@@ -34,8 +34,7 @@ impl TestLib {
         let foo = unsafe { __library.get(b"foo\0") }.map(|sym| *sym);
         let bar = unsafe { __library.get(b"bar\0") }.map(|sym| *sym);
         let baz = unsafe { __library.get(b"baz\0") }.map(|sym| *sym);
-        let FLUX = __library
-            .get::<*mut ::std::os::raw::c_int>(b"FLUX\0")
+        let FLUX = unsafe { __library.get::<*mut ::std::os::raw::c_int>(b"FLUX\0") }
             .map(|sym| *sym);
         Ok(TestLib {
             __library,

--- a/bindgen-tests/tests/expectations/tests/wrap_unsafe_ops_dynamic_loading_simple.rs
+++ b/bindgen-tests/tests/expectations/tests/wrap_unsafe_ops_dynamic_loading_simple.rs
@@ -16,6 +16,7 @@ pub struct TestLib {
         unsafe extern "C" fn() -> ::std::os::raw::c_int,
         ::libloading::Error,
     >,
+    pub FLUX: Result<*mut ::std::os::raw::c_int, ::libloading::Error>,
 }
 impl TestLib {
     pub unsafe fn new<P>(path: P) -> Result<Self, ::libloading::Error>
@@ -33,11 +34,15 @@ impl TestLib {
         let foo = unsafe { __library.get(b"foo\0") }.map(|sym| *sym);
         let bar = unsafe { __library.get(b"bar\0") }.map(|sym| *sym);
         let baz = unsafe { __library.get(b"baz\0") }.map(|sym| *sym);
+        let FLUX = __library
+            .get::<*mut ::std::os::raw::c_int>(b"FLUX\0")
+            .map(|sym| *sym);
         Ok(TestLib {
             __library,
             foo,
             bar,
             baz,
+            FLUX,
         })
     }
     pub unsafe fn foo(
@@ -52,5 +57,8 @@ impl TestLib {
     }
     pub unsafe fn baz(&self) -> ::std::os::raw::c_int {
         unsafe { (self.baz.as_ref().expect("Expected function, got error."))() }
+    }
+    pub unsafe fn FLUX(&self) -> *mut ::std::os::raw::c_int {
+        *self.FLUX.as_ref().expect("Expected variable, got error.")
     }
 }

--- a/bindgen-tests/tests/headers/wrap_unsafe_ops_dynamic_loading_simple.h
+++ b/bindgen-tests/tests/headers/wrap_unsafe_ops_dynamic_loading_simple.h
@@ -3,3 +3,5 @@
 int foo(int x, int y);
 int bar(void *x);
 int baz();
+
+const int FLUX;

--- a/bindgen/codegen/dyngen.rs
+++ b/bindgen/codegen/dyngen.rs
@@ -83,6 +83,12 @@ impl DynamicItems {
         let init_fields = &self.init_fields;
         let struct_implementation = &self.struct_implementation;
 
+        let library_new = if ctx.options().wrap_unsafe_ops {
+            quote!(unsafe { ::libloading::Library::new(path) })
+        } else {
+            quote!(::libloading::Library::new(path))
+        };
+
         let from_library = if ctx.options().wrap_unsafe_ops {
             quote!(unsafe { Self::from_library(library) })
         } else {
@@ -100,7 +106,7 @@ impl DynamicItems {
                     path: P
                 ) -> Result<Self, ::libloading::Error>
                 where P: AsRef<::std::ffi::OsStr> {
-                    let library = ::libloading::Library::new(path)?;
+                    let library = #library_new?;
                     #from_library
                 }
 

--- a/bindgen/codegen/mod.rs
+++ b/bindgen/codegen/mod.rs
@@ -808,6 +808,7 @@ impl CodeGenerator for Var {
                         .to_rust_ty_or_opaque(ctx, &())
                         .into_token_stream(),
                     ctx.options().dynamic_link_require_all,
+                    ctx.options().wrap_unsafe_ops,
                 );
             } else {
                 result.push(tokens);


### PR DESCRIPTION
Closes https://github.com/rust-lang/rust-bindgen/issues/2957