### PR TITLE
Fix `field_visibility` not called for new-type aliases

### DIFF
--- a/bindgen-tests/tests/expectations/tests/issue-2966.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-2966.rs
@@ -1,0 +1,10 @@
+#![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
+#[repr(transparent)]
+#[derive(Debug, Copy, Clone)]
+pub struct pub_var1(pub *const ::std::os::raw::c_char);
+#[repr(transparent)]
+#[derive(Debug, Copy, Clone)]
+pub struct pubcrate_var2(pub(crate) *const ::std::os::raw::c_char);
+#[repr(transparent)]
+#[derive(Debug, Copy, Clone)]
+pub struct private_var3(*const ::std::os::raw::c_char);

--- a/bindgen-tests/tests/headers/issue-2966.h
+++ b/bindgen-tests/tests/headers/issue-2966.h
@@ -1,0 +1,6 @@
+// bindgen-flags: --default-alias-style=new_type
+// bindgen-parse-callbacks: type-visibility
+
+typedef const char *  pub_var1;
+typedef const char *  pubcrate_var2;
+typedef const char *  private_var3;

--- a/bindgen/codegen/mod.rs
+++ b/bindgen/codegen/mod.rs
@@ -1099,13 +1099,21 @@ impl CodeGenerator for Type {
                     });
                 }
 
-                let access_spec =
-                    access_specifier(ctx.options().default_visibility);
                 tokens.append_all(match alias_style {
                     AliasVariation::TypeAlias => quote! {
                         = #inner_rust_type ;
                     },
                     AliasVariation::NewType | AliasVariation::NewTypeDeref => {
+                        let visibility = ctx
+                            .options()
+                            .last_callback(|cb| {
+                                cb.field_visibility(FieldInfo {
+                                    type_name: &item.canonical_name(ctx),
+                                    field_name: "0",
+                                })
+                            })
+                            .unwrap_or(ctx.options().default_visibility);
+                        let access_spec = access_specifier(visibility);
                         quote! {
                             (#access_spec #inner_rust_type) ;
                         }


### PR DESCRIPTION
The `field_visibility` callback is now called in case of alias new-type and new-type-deref with the type name and field_name set to `"0"`

This PR allows generation of different accessibility:

```c
typedef const char *  pub_var1;
typedef const char *  pubcrate_var2;
typedef const char *  private_var3;
```

```rust
pub struct pub_var1(pub *const ::std::os::raw::c_char);
pub struct pubcrate_var2(pub(crate) *const ::std::os::raw::c_char);
pub struct private_var3(*const ::std::os::raw::c_char);
```

Fixes #2966