### PR TITLE
ci: Move forward Rust for Linux version

### DIFF
--- a/ci/test.sh
+++ b/ci/test.sh
@@ -154,7 +154,7 @@ if [ "$BINDGEN_RUST_FOR_LINUX_TEST" == "1" ]; then
   # and each update should only contain this change.
   #
   # Both commit hashes and tags are supported.
-  LINUX_VERSION=c13320499ba0efd93174ef6462ae8a7a2933f6e7
+  LINUX_VERSION=v6.12-rc5
 
   # Download Linux at a specific commit
   mkdir -p linux


### PR DESCRIPTION
The CI is hitting errors and warnings now [1], due to Rust 1.82.0 being used to build an older Linux kernel:

    warning: the feature `new_uninit` has been stable since 1.82.0 and no longer requires an attribute to enable
      --> rust/kernel/lib.rs:17:12
       |
    17 | #![feature(new_uninit)]
       |            ^^^^^^^^^^
       |
       = note: `#[warn(stable_features)]` on by default

    error[E0658]: use of unstable library feature 'box_uninit_write'
      --> rust/kernel/alloc/box_ext.rs:25:12
       |
    25 |         Ok(Box::write(b, x))
       |            ^^^^^^^^^^
       |
       = note: see issue #129397 <https://github.com/rust-lang/rust/issues/129397> for more information
       = help: add `#![feature(box_uninit_write)]` to the crate attributes to enable
       = note: this compiler was built on 2024-10-15; consider upgrading it if it is out of date

Which is due to the current commit hash being from the Linux v6.10 cycle, when we did not yet support several Rust versions.

Thus update the hash with a newer tag (the latest available) that does support several Rust versions, including the latest.

In any case, updating is a good idea since it has been a while since we introduced Rust for Linux in the CI, and the intention is to update it from time to time nevertheless.

Link: https://github.com/rust-lang/rust-bindgen/actions/runs/11637602211/job/32411071463?pr=2969#step:6:1362 [1]