### PR TITLE
Changelog: Move --with-attribute-custom to unreleased

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -215,6 +215,7 @@
 --------------------------------------------------------------------------------
 # Unreleased
 ## Added
+- Add support for custom attributes (--with-attribute-custom, #2866)
 ## Changed
 - The `--wrap-static-fns` related options no longer require the experimental feature or flag.
 ## Removed
@@ -237,7 +238,6 @@
 - Add option to use DST structs for flexible arrays (--flexarray-dst, #2772).
 - Add option to dynamically load variables (#2812).
 - Add option in CLI to use rustified non-exhaustive enums (--rustified-non-exhaustive-enum, #2847).
-- Add support for custom attributes (--with-attribute-custom, #2866)
 ## Changed
 - Remove which and lazy-static dependencies (#2809, #2817).
 - Generate compile-time layout tests (#2787).


### PR DESCRIPTION
This option was added after the 0.70.1 release and is not available yet.