### PR TITLE
Restrict release workflow to pushes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,6 @@ permissions:
 # If there's a prerelease-style suffix to the version, then the release(s)
 # will be marked as a prerelease.
 on:
-  pull_request:
   push:
     tags:
       - '**[0-9]+.[0-9]+.[0-9]+*'


### PR DESCRIPTION
The release workflow should not run on pull requests.
See e.g. https://github.com/rust-lang/rust-bindgen/actions/runs/11816897132 which was triggered by another pull request opened by me.