### PR TITLE
Some updates to the cargo manifests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,14 @@ default-members = [
     "bindgen-tests",
 ]
 
+# Dependencies shared between crates
+[workspace.dependencies]
+clap = { version = "4", features = ["derive"] }
+clap_complete = "4"
+shlex = "1"
+syn = "2.0" 
+proc-macro2 = { version = "1", default-features = false }
+
 # Config for 'cargo dist'
 [workspace.metadata.dist]
 # The preferred cargo-dist version to use in CI (Cargo.toml SemVer syntax)

--- a/bindgen-cli/Cargo.toml
+++ b/bindgen-cli/Cargo.toml
@@ -21,12 +21,13 @@ name = "bindgen"
 
 [dependencies]
 bindgen = { path = "../bindgen", version = "=0.70.1",  default-features = false, features = ["__cli", "experimental", "prettyplease"] }
-clap = { version = "4", features = ["derive"] }
-clap_complete = "4"
 env_logger = { version = "0.10.0", optional = true }
 log = { version = "0.4", optional = true }
-proc-macro2 = { version = "1", default-features = false }
-shlex = "1"
+
+clap.workspace = true
+clap_complete.workspace = true
+proc-macro2.workspace = true
+shlex.workspace = true
 
 [features]
 default = ["logging", "runtime"]

--- a/bindgen-integration/Cargo.toml
+++ b/bindgen-integration/Cargo.toml
@@ -4,6 +4,7 @@ description = "A package to test various bindgen features"
 version = "0.1.0"
 authors = ["Emilio Cobos Álvarez <emilio@crisal.io>"]
 publish = false
+edition = "2018"
 build = "build.rs"
 
 [build-dependencies]

--- a/bindgen-tests/Cargo.toml
+++ b/bindgen-tests/Cargo.toml
@@ -6,15 +6,16 @@ publish = false
 
 [dev-dependencies]
 bindgen = { path = "../bindgen", features = ["__cli", "experimental"] }
-clap = { version = "4", features = ["derive"] }
-clap_complete = "4"
-shlex = "1"
-prettyplease = { version = "0.2.7", features = ["verbatim"] }
-proc-macro2 = { version = "1", default-features = false }
-syn = { version = "2.0" }
-tempfile = "3"
-similar = { version = "2.2.1", features = ["inline"] }
 owo-colors = "3.5.0"
+prettyplease = { version = "0.2.7", features = ["verbatim"] }
+similar = { version = "2.2.1", features = ["inline"] }
+tempfile = "3"
+
+clap.workspace = true
+clap_complete.workspace = true
+proc-macro2.workspace = true
+shlex.workspace = true
+syn.workspace = true
 
 [features]
 logging = ["bindgen/logging"]

--- a/bindgen/Cargo.toml
+++ b/bindgen/Cargo.toml
@@ -32,12 +32,13 @@ clang-sys = { version = "1", features = ["clang_11_0"] }
 itertools = { version = ">=0.10,<0.14", default-features = false }
 log = { version = "0.4", optional = true }
 prettyplease = { version = "0.2.7", optional = true, features = ["verbatim"] }
-proc-macro2 = { version = "1", default-features = false }
 quote = { version = "1", default-features = false }
 regex = { version = "1.5.3", default-features = false, features = ["std", "unicode-perl"] }
 rustc-hash = "1.0.1"
-shlex = "1"
-syn = { version = "2.0", features = ["full", "extra-traits", "visit-mut"] }
+
+proc-macro2.workspace = true
+shlex.workspace = true
+syn = { workspace = true, features = ["full", "extra-traits", "visit-mut"] }
 
 [features]
 default = ["logging", "prettyplease", "runtime"]


### PR DESCRIPTION
This introduces workspace dependencies to avoid unintentional mismatches of dependencies between crates and sets the edition for the `bindgen-integration` crate so we stop getting a warning about it