### PR TITLE
Move CLI options to `bindgen`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,6 +35,8 @@ dependencies = [
  "bitflags 2.2.1",
  "cexpr",
  "clang-sys",
+ "clap",
+ "clap_complete",
  "itertools",
  "log",
  "prettyplease",
@@ -51,8 +53,6 @@ name = "bindgen-cli"
 version = "0.70.1"
 dependencies = [
  "bindgen",
- "clap",
- "clap_complete",
  "env_logger 0.10.0",
  "log",
  "proc-macro2",
@@ -72,8 +72,6 @@ name = "bindgen-tests"
 version = "0.1.0"
 dependencies = [
  "bindgen",
- "clap",
- "clap_complete",
  "owo-colors",
  "prettyplease",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,6 @@ default-members = [
 
 # Dependencies shared between crates
 [workspace.dependencies]
-clap = { version = "4", features = ["derive"] }
-clap_complete = "4"
 shlex = "1"
 syn = "2.0" 
 proc-macro2 = { version = "1", default-features = false }

--- a/bindgen-cli/Cargo.toml
+++ b/bindgen-cli/Cargo.toml
@@ -24,8 +24,6 @@ bindgen = { path = "../bindgen", version = "=0.70.1",  default-features = false,
 env_logger = { version = "0.10.0", optional = true }
 log = { version = "0.4", optional = true }
 
-clap.workspace = true
-clap_complete.workspace = true
 proc-macro2.workspace = true
 shlex.workspace = true
 

--- a/bindgen-cli/main.rs
+++ b/bindgen-cli/main.rs
@@ -1,7 +1,6 @@
 use std::env;
 
-mod options;
-use crate::options::builder_from_flags;
+use bindgen::builder_from_flags;
 
 #[cfg(feature = "logging")]
 fn clang_version_check() {

--- a/bindgen-tests/Cargo.toml
+++ b/bindgen-tests/Cargo.toml
@@ -11,8 +11,6 @@ prettyplease = { version = "0.2.7", features = ["verbatim"] }
 similar = { version = "2.2.1", features = ["inline"] }
 tempfile = "3"
 
-clap.workspace = true
-clap_complete.workspace = true
 proc-macro2.workspace = true
 shlex.workspace = true
 syn.workspace = true

--- a/bindgen-tests/tests/tests.rs
+++ b/bindgen-tests/tests/tests.rs
@@ -7,10 +7,7 @@ use std::fs;
 use std::io::{BufRead, BufReader, Error, ErrorKind, Read, Write};
 use std::path::{Path, PathBuf};
 
-use crate::options::builder_from_flags;
-
-#[path = "../../bindgen-cli/options.rs"]
-mod options;
+use bindgen::builder_from_flags;
 
 mod parse_callbacks;
 
@@ -709,8 +706,7 @@ fn build_flags_output_helper(builder: &bindgen::Builder) {
     println!("{}", flags_str);
 
     let (builder, _output, _verbose) =
-        crate::options::builder_from_flags(command_line_flags.into_iter())
-            .unwrap();
+        builder_from_flags(command_line_flags.into_iter()).unwrap();
     builder.generate().expect("failed to generate bindings");
 }
 

--- a/bindgen/Cargo.toml
+++ b/bindgen/Cargo.toml
@@ -29,6 +29,8 @@ annotate-snippets = { version = "0.11.4", optional = true }
 bitflags = "2.2.1"
 cexpr = "0.6"
 clang-sys = { version = "1", features = ["clang_11_0"] }
+clap = { version = "4", features = ["derive"], optional = true }
+clap_complete = { version = "4", optional = true}
 itertools = { version = ">=0.10,<0.14", default-features = false }
 log = { version = "0.4", optional = true }
 prettyplease = { version = "0.2.7", optional = true, features = ["verbatim"] }
@@ -52,7 +54,7 @@ experimental = ["dep:annotate-snippets"]
 ## The following features are for internal use and they shouldn't be used if
 ## you're not hacking on bindgen
 # Features used by `bindgen-cli`
-__cli = []
+__cli = ["dep:clap", "dep:clap_complete"]
 # Features used for CI testing
 __testing_only_extra_assertions = []
 __testing_only_libclang_9 = []

--- a/bindgen/lib.rs
+++ b/bindgen/lib.rs
@@ -55,7 +55,6 @@ pub use ir::annotations::FieldVisibilityKind;
 pub use ir::function::Abi;
 #[cfg(feature = "__cli")]
 pub use options::cli::builder_from_flags;
-pub use regex_set::RegexSet;
 
 use codegen::CodegenError;
 use features::RustFeatures;

--- a/bindgen/lib.rs
+++ b/bindgen/lib.rs
@@ -50,11 +50,11 @@ mod regex_set;
 pub use codegen::{
     AliasVariation, EnumVariation, MacroTypeVariation, NonCopyUnionStyle,
 };
-#[cfg(feature = "__cli")]
-pub use features::RUST_TARGET_STRINGS;
 pub use features::{RustTarget, LATEST_STABLE_RUST};
 pub use ir::annotations::FieldVisibilityKind;
 pub use ir::function::Abi;
+#[cfg(feature = "__cli")]
+pub use options::cli::builder_from_flags;
 pub use regex_set::RegexSet;
 
 use codegen::CodegenError;

--- a/bindgen/options/as_args.rs
+++ b/bindgen/options/as_args.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use crate::RegexSet;
+use crate::regex_set::RegexSet;
 
 /// Trait used to turn [`crate::BindgenOptions`] fields into CLI args.
 pub(super) trait AsArgs {

--- a/bindgen/options/cli.rs
+++ b/bindgen/options/cli.rs
@@ -4,9 +4,10 @@ use crate::{
         AttributeInfo, DeriveInfo, ItemInfo, ParseCallbacks, TypeKind,
     },
     features::RUST_TARGET_STRINGS,
+    regex_set::RegexSet,
     Abi, AliasVariation, Builder, CodegenConfig, EnumVariation,
     FieldVisibilityKind, Formatter, MacroTypeVariation, NonCopyUnionStyle,
-    RegexSet, RustTarget, DEFAULT_ANON_FIELDS_PREFIX,
+    RustTarget, DEFAULT_ANON_FIELDS_PREFIX,
 };
 use clap::{
     error::{Error, ErrorKind},
@@ -1180,7 +1181,7 @@ where
         let name = emit_diagnostics.then_some(_name);
 
         for (derives, regex) in custom_derives {
-            let mut regex_set = RegexSet::new();
+            let mut regex_set = RegexSet::default();
             regex_set.insert(regex);
 
             #[cfg(feature = "experimental")]
@@ -1258,7 +1259,7 @@ where
         let name = emit_diagnostics.then_some(_name);
 
         for (attributes, regex) in custom_attributes {
-            let mut regex_set = RegexSet::new();
+            let mut regex_set = RegexSet::default();
             regex_set.insert(regex);
 
             #[cfg(feature = "experimental")]

--- a/bindgen/options/mod.rs
+++ b/bindgen/options/mod.rs
@@ -4,6 +4,8 @@
 #[macro_use]
 mod helpers;
 mod as_args;
+#[cfg(feature = "__cli")]
+pub(crate) mod cli;
 
 use crate::callbacks::ParseCallbacks;
 use crate::codegen::{

--- a/bindgen/regex_set.rs
+++ b/bindgen/regex_set.rs
@@ -6,7 +6,7 @@ use std::cell::Cell;
 
 /// A dynamic set of regular expressions.
 #[derive(Clone, Debug, Default)]
-pub struct RegexSet {
+pub(crate) struct RegexSet {
     items: Vec<Box<str>>,
     /// Whether any of the items in the set was ever matched. The length of this
     /// vector is exactly the length of `items`.
@@ -17,18 +17,13 @@ pub struct RegexSet {
 }
 
 impl RegexSet {
-    /// Create a new RegexSet
-    pub fn new() -> RegexSet {
-        RegexSet::default()
-    }
-
     /// Is this set empty?
-    pub fn is_empty(&self) -> bool {
+    pub(crate) fn is_empty(&self) -> bool {
         self.items.is_empty()
     }
 
     /// Insert a new regex into this set.
-    pub fn insert<S>(&mut self, string: S)
+    pub(crate) fn insert<S>(&mut self, string: S)
     where
         S: AsRef<str>,
     {
@@ -38,13 +33,13 @@ impl RegexSet {
     }
 
     /// Returns slice of String from its field 'items'
-    pub fn get_items(&self) -> &[Box<str>] {
+    pub(crate) fn get_items(&self) -> &[Box<str>] {
         &self.items
     }
 
     /// Returns an iterator over regexes in the set which didn't match any
     /// strings yet.
-    pub fn unmatched_items(&self) -> impl Iterator<Item = &str> {
+    pub(crate) fn unmatched_items(&self) -> impl Iterator<Item = &str> {
         self.items.iter().enumerate().filter_map(move |(i, item)| {
             if !self.record_matches || self.matched[i].get() {
                 return None;
@@ -59,7 +54,8 @@ impl RegexSet {
     /// Must be called before calling `matches()`, or it will always return
     /// false.
     #[inline]
-    pub fn build(&mut self, record_matches: bool) {
+    #[allow(unused)]
+    pub(crate) fn build(&mut self, record_matches: bool) {
         self.build_inner(record_matches, None)
     }
 
@@ -70,7 +66,7 @@ impl RegexSet {
     /// Must be called before calling `matches()`, or it will always return
     /// false.
     #[inline]
-    pub fn build_with_diagnostics(
+    pub(crate) fn build_with_diagnostics(
         &mut self,
         record_matches: bool,
         name: Option<&'static str>,
@@ -114,7 +110,7 @@ impl RegexSet {
     }
 
     /// Does the given `string` match any of the regexes in this set?
-    pub fn matches<S>(&self, string: S) -> bool
+    pub(crate) fn matches<S>(&self, string: S) -> bool
     where
         S: AsRef<str>,
     {


### PR DESCRIPTION
This is done in an effort to allow `bindgen` (the library) parse arguments from a configuration file just like #2917 does for `bindgen-cli`.