### PR TITLE
Allow `clippy::manual_c_str_literals`

### DIFF
--- a/bindgen-tests/tests/expectations/tests/strings_cstr.rs
+++ b/bindgen-tests/tests/expectations/tests/strings_cstr.rs
@@ -1,13 +1,13 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
-#[allow(unsafe_code)]
+#[allow(unsafe_code, clippy::manual_c_str_literals)]
 pub const MY_STRING_UTF8: &::std::ffi::CStr = unsafe {
     ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"Hello, world!\0")
 };
-#[allow(unsafe_code)]
+#[allow(unsafe_code, clippy::manual_c_str_literals)]
 pub const MY_STRING_INTERIOR_NULL: &::std::ffi::CStr = unsafe {
     ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"Hello,\0")
 };
-#[allow(unsafe_code)]
+#[allow(unsafe_code, clippy::manual_c_str_literals)]
 pub const MY_STRING_NON_UTF8: &::std::ffi::CStr = unsafe {
     ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"ABCDE\xFF\0")
 };

--- a/bindgen/codegen/mod.rs
+++ b/bindgen/codegen/mod.rs
@@ -737,7 +737,7 @@ impl CodeGenerator for Var {
                     {
                         result.push(quote! {
                             #(#attrs)*
-                            #[allow(unsafe_code)]
+                            #[allow(unsafe_code, clippy::manual_c_str_literals)]
                             pub const #canonical_ident: &#cstr_ty = unsafe {
                                 #cstr_ty::from_bytes_with_nul_unchecked(#bytes)
                             };


### PR DESCRIPTION
See #2994 

Attention - this is a quick fix, but #2996 fixes it in a more correct way - so perhaps this should NOT be merged?