### PR TITLE
Generate C-String literals `c"example"` instead of unsafe code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,9 +436,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.60"
+version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dec2b086b7a862cf4de201096214fa870344cf922b2b30c167badb3af3195406"
+checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
 dependencies = [
  "unicode-ident",
 ]

--- a/bindgen-tests/tests/expectations/tests/strings_cstr2.rs
+++ b/bindgen-tests/tests/expectations/tests/strings_cstr2.rs
@@ -1,0 +1,4 @@
+#![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
+pub const MY_STRING_UTF8: &::std::ffi::CStr = c"Hello, world!";
+pub const MY_STRING_INTERIOR_NULL: &::std::ffi::CStr = c"Hello,";
+pub const MY_STRING_NON_UTF8: &::std::ffi::CStr = c"ABCDE\xFF";

--- a/bindgen-tests/tests/headers/strings_cstr2.h
+++ b/bindgen-tests/tests/headers/strings_cstr2.h
@@ -1,0 +1,5 @@
+// bindgen-flags: --rust-target=1.77 --generate-cstr
+
+const char* MY_STRING_UTF8 = "Hello, world!";
+const char* MY_STRING_INTERIOR_NULL = "Hello,\0World!";
+const char* MY_STRING_NON_UTF8 = "ABCDE\xFF";

--- a/bindgen/features.rs
+++ b/bindgen/features.rs
@@ -159,7 +159,10 @@ define_rust_targets! {
         ptr_metadata: #81513,
         layout_for_ptr: #69835,
     },
-    Stable_1_77(77) => { offset_of: #106655 },
+    Stable_1_77(77) => {
+        offset_of: #106655,
+        literal_cstr: #117472,
+    },
     Stable_1_73(73) => { thiscall_abi: #42202 },
     Stable_1_71(71) => { c_unwind_abi: #106075 },
     Stable_1_68(68) => { abi_efiapi: #105795 },


### PR DESCRIPTION
When `generate_cstr` is enabled, and the target rust version is >= 1.77, generate `c"..."` literals instead of the unsafe `from_bytes_with_nul_unchecked` calls.  Note that this requires 2021 edition, but since this is not on by default, and CStr support is relatively recent, i think it is ok to tie them together

Note that this also resolves the Clippy 1.83's [manual_c_str_literals](https://rust-lang.github.io/rust-clippy/master/index.html#/manual_c_str_literals) issue


Fixes #2994