### PR TITLE
Use v2 cargo resolver

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 members = [
     "bindgen",
     "bindgen-cli",
@@ -7,7 +8,6 @@ members = [
     "bindgen-tests/tests/quickchecking",
     "bindgen-tests/tests/expectations",
 ]
-
 default-members = [
     "bindgen",
     "bindgen-cli",
@@ -54,4 +54,3 @@ release = false
 [profile.dist]
 inherits = "release"
 lto = "thin"
-

--- a/bindgen/lib.rs
+++ b/bindgen/lib.rs
@@ -74,7 +74,6 @@ use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::rc::Rc;
 use std::str::FromStr;
-use std::sync::{Arc, OnceLock};
 
 // Some convenient typedefs for a fast hash map and hash set.
 type HashMap<K, V> = rustc_hash::FxHashMap<K, V>;
@@ -576,6 +575,8 @@ impl BindgenOptions {
 
 #[cfg(feature = "runtime")]
 fn ensure_libclang_is_loaded() {
+    use std::sync::{Arc, OnceLock};
+
     if clang_sys::is_loaded() {
         return;
     }


### PR DESCRIPTION
The 2021 usually implies resolver v2, and warns otherwise.