### PR TITLE
Add rust language editions support

### DIFF
--- a/bindgen-tests/tests/expectations/tests/strings_cstr2.rs
+++ b/bindgen-tests/tests/expectations/tests/strings_cstr2.rs
@@ -1,4 +1,13 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
-pub const MY_STRING_UTF8: &::std::ffi::CStr = c"Hello, world!";
-pub const MY_STRING_INTERIOR_NULL: &::std::ffi::CStr = c"Hello,";
-pub const MY_STRING_NON_UTF8: &::std::ffi::CStr = c"ABCDE\xFF";
+#[allow(unsafe_code)]
+pub const MY_STRING_UTF8: &::std::ffi::CStr = unsafe {
+    ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"Hello, world!\0")
+};
+#[allow(unsafe_code)]
+pub const MY_STRING_INTERIOR_NULL: &::std::ffi::CStr = unsafe {
+    ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"Hello,\0")
+};
+#[allow(unsafe_code)]
+pub const MY_STRING_NON_UTF8: &::std::ffi::CStr = unsafe {
+    ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"ABCDE\xFF\0")
+};

--- a/bindgen-tests/tests/expectations/tests/strings_cstr2_2021.rs
+++ b/bindgen-tests/tests/expectations/tests/strings_cstr2_2021.rs
@@ -1,0 +1,4 @@
+#![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
+pub const MY_STRING_UTF8: &::std::ffi::CStr = c"Hello, world!";
+pub const MY_STRING_INTERIOR_NULL: &::std::ffi::CStr = c"Hello,";
+pub const MY_STRING_NON_UTF8: &::std::ffi::CStr = c"ABCDE\xFF";

--- a/bindgen-tests/tests/headers/strings_cstr2_2021.h
+++ b/bindgen-tests/tests/headers/strings_cstr2_2021.h
@@ -1,0 +1,5 @@
+// bindgen-flags: --rust-target=1.77 --rust-edition=2021 --generate-cstr
+
+const char* MY_STRING_UTF8 = "Hello, world!";
+const char* MY_STRING_INTERIOR_NULL = "Hello,\0World!";
+const char* MY_STRING_NON_UTF8 = "ABCDE\xFF";

--- a/bindgen/codegen/mod.rs
+++ b/bindgen/codegen/mod.rs
@@ -728,7 +728,8 @@ impl CodeGenerator for Var {
                     if let Some(cstr) = cstr {
                         let cstr_ty = quote! { ::#prefix::ffi::CStr };
                         if rust_features.literal_cstr &&
-                            options.rust_edition >= RustEdition::Rust2021
+                            options.get_rust_edition() >=
+                                RustEdition::Rust2021
                         {
                             let cstr = proc_macro2::Literal::c_string(&cstr);
                             result.push(quote! {
@@ -3917,12 +3918,11 @@ impl std::str::FromStr for MacroTypeVariation {
 }
 
 /// Enum for the edition of Rust language to use.
-#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Debug, Default)]
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Debug)]
 pub enum RustEdition {
     /// Rust 2015 language edition
     Rust2015,
     /// Rust 2018 language edition
-    #[default]
     Rust2018,
     /// Rust 2021 language edition
     Rust2021,

--- a/bindgen/features.rs
+++ b/bindgen/features.rs
@@ -167,6 +167,7 @@ define_rust_targets! {
     Stable_1_71(71) => { c_unwind_abi: #106075 },
     Stable_1_68(68) => { abi_efiapi: #105795 },
     Stable_1_64(64) => { core_ffi_c: #94503 },
+    Stable_1_56(56) => { edition_2021: #88100 },
     Stable_1_51(51) => { raw_ref_macros: #80886 },
     Stable_1_59(59) => { const_cstr: #54745 },
     Stable_1_47(47) => { larger_arrays: #74060 },
@@ -174,6 +175,7 @@ define_rust_targets! {
     Stable_1_40(40) => { non_exhaustive: #44109 },
     Stable_1_36(36) => { maybe_uninit: #60445 },
     Stable_1_33(33) => { repr_packed_n: #57049 },
+    // Stable_1_31(31) => { edition_2018: #54057 },
 }
 
 /// Latest stable release of Rust that is supported by bindgen

--- a/bindgen/features.rs
+++ b/bindgen/features.rs
@@ -161,7 +161,7 @@ define_rust_targets! {
     },
     Stable_1_77(77) => {
         offset_of: #106655,
-        literal_cstr: #117472,
+        literal_cstr: #117472,  // Edition 2021+ only
     },
     Stable_1_73(73) => { thiscall_abi: #42202 },
     Stable_1_71(71) => { c_unwind_abi: #106075 },

--- a/bindgen/lib.rs
+++ b/bindgen/lib.rs
@@ -531,7 +531,7 @@ impl BindgenOptions {
 
     /// Update rust edition version
     pub fn set_rust_edition(&mut self, rust_edition: RustEdition) {
-        self.rust_edition = rust_edition;
+        self.rust_edition = Some(rust_edition);
     }
 
     /// Update rust target version

--- a/bindgen/lib.rs
+++ b/bindgen/lib.rs
@@ -64,6 +64,7 @@ use ir::item::Item;
 use options::BindgenOptions;
 use parse::ParseError;
 
+use crate::codegen::RustEdition;
 use std::borrow::Cow;
 use std::collections::hash_map::Entry;
 use std::env;
@@ -526,6 +527,11 @@ impl BindgenOptions {
         for regex_set in self.abi_overrides.values_mut().chain(regex_sets) {
             regex_set.build(record_matches);
         }
+    }
+
+    /// Update rust edition version
+    pub fn set_rust_edition(&mut self, rust_edition: RustEdition) {
+        self.rust_edition = rust_edition;
     }
 
     /// Update rust target version

--- a/bindgen/options/cli.rs
+++ b/bindgen/options/cli.rs
@@ -19,13 +19,6 @@ use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::{fs::File, process::exit};
 
-fn rust_edition_help() -> String {
-    format!(
-        "Version of the Rust language edition. Defaults to {}.",
-        RustEdition::default()
-    )
-}
-
 fn rust_target_help() -> String {
     format!(
         "Version of the Rust compiler to target. Any Rust version after {EARLIEST_STABLE_RUST} is supported. Defaults to {}.",
@@ -339,7 +332,8 @@ struct BindgenCommand {
     /// Add a RAW_LINE of Rust code to a given module with name MODULE_NAME.
     #[arg(long, number_of_values = 2, value_names = ["MODULE_NAME", "RAW_LINE"])]
     module_raw_line: Vec<String>,
-    #[arg(long, help = rust_edition_help())]
+    /// Version of the Rust language edition. Defaults to 2018 if used from CLI, unless target version does not support it. Defaults to current crate's edition if used from API.
+    #[arg(long)]
     rust_edition: Option<RustEdition>,
     #[arg(long, help = rust_target_help())]
     rust_target: Option<RustTarget>,

--- a/bindgen/options/cli.rs
+++ b/bindgen/options/cli.rs
@@ -7,7 +7,7 @@ use crate::{
     regex_set::RegexSet,
     Abi, AliasVariation, Builder, CodegenConfig, EnumVariation,
     FieldVisibilityKind, Formatter, MacroTypeVariation, NonCopyUnionStyle,
-    RustTarget,
+    RustEdition, RustTarget,
 };
 use clap::{
     error::{Error, ErrorKind},
@@ -18,6 +18,13 @@ use std::io;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::{fs::File, process::exit};
+
+fn rust_edition_help() -> String {
+    format!(
+        "Version of the Rust language edition. Defaults to {}.",
+        RustEdition::default()
+    )
+}
 
 fn rust_target_help() -> String {
     format!(
@@ -332,6 +339,8 @@ struct BindgenCommand {
     /// Add a RAW_LINE of Rust code to a given module with name MODULE_NAME.
     #[arg(long, number_of_values = 2, value_names = ["MODULE_NAME", "RAW_LINE"])]
     module_raw_line: Vec<String>,
+    #[arg(long, help = rust_edition_help())]
+    rust_edition: Option<RustEdition>,
     #[arg(long, help = rust_target_help())]
     rust_target: Option<RustTarget>,
     /// Use types from Rust core instead of std.
@@ -587,6 +596,7 @@ where
         output,
         raw_line,
         module_raw_line,
+        rust_edition,
         rust_target,
         use_core,
         conservative_inline_namespaces,
@@ -820,6 +830,7 @@ where
                 exit(0)
             },
             header,
+            rust_edition,
             rust_target,
             default_enum_style,
             bitfield_enum,

--- a/bindgen/options/mod.rs
+++ b/bindgen/options/mod.rs
@@ -1595,8 +1595,7 @@ options! {
         as_args: |value, args| (!value).as_args(args, "--no-prepend-enum-name"),
     },
     /// Version of the Rust compiler to target.
-    rust_edition: RustEdition {
-        default: RustEdition::default(),
+    rust_edition: Option<RustEdition> {
         methods: {
             /// Specify the Rust edition version.
             ///
@@ -1607,8 +1606,10 @@ options! {
             }
         },
         as_args: |rust_edition, args| {
-            args.push("--rust-edition".to_owned());
-            args.push(rust_edition.to_string());
+            if let Some(rust_edition) = rust_edition {
+                args.push("--rust-edition".to_owned());
+                args.push(rust_edition.to_string());
+            }
         },
     },
     /// Version of the Rust compiler to target.
@@ -2166,5 +2167,19 @@ options! {
             }
         },
         as_args: "--clang-macro-fallback-build-dir",
+    }
+}
+
+impl BindgenOptions {
+    /// Get default Rust edition, unless it is set by the user
+    pub fn get_rust_edition(&self) -> RustEdition {
+        self.rust_edition.unwrap_or_else(|| {
+            if !self.rust_features.edition_2021 {
+                RustEdition::Rust2018
+            } else {
+                // For now, we default to 2018, but this might need to be rethought
+                RustEdition::Rust2018
+            }
+        })
     }
 }

--- a/bindgen/options/mod.rs
+++ b/bindgen/options/mod.rs
@@ -10,6 +10,7 @@ pub(crate) mod cli;
 use crate::callbacks::ParseCallbacks;
 use crate::codegen::{
     AliasVariation, EnumVariation, MacroTypeVariation, NonCopyUnionStyle,
+    RustEdition,
 };
 use crate::deps::DepfileSpec;
 use crate::features::{RustFeatures, RustTarget};
@@ -1592,6 +1593,23 @@ options! {
             }
         },
         as_args: |value, args| (!value).as_args(args, "--no-prepend-enum-name"),
+    },
+    /// Version of the Rust compiler to target.
+    rust_edition: RustEdition {
+        default: RustEdition::default(),
+        methods: {
+            /// Specify the Rust edition version.
+            ///
+            /// The default edition is 2018.
+            pub fn rust_edition(mut self, rust_edition: RustEdition) -> Self {
+                self.options.set_rust_edition(rust_edition);
+                self
+            }
+        },
+        as_args: |rust_edition, args| {
+            args.push("--rust-edition".to_owned());
+            args.push(rust_edition.to_string());
+        },
     },
     /// Version of the Rust compiler to target.
     rust_target: RustTarget {


### PR DESCRIPTION
Introduce a new `--rust-edition` parameter with allowed values 2015, 2018, 2021, and 2024. This allows different code generation depending on the language target.

In this PR, the C-string literals are now generated differently depending on the language edition (literals like `c"example"` are not available before 2021)

The default language edition uses logic:
* if `--rust-target` is before [1.31.0](https://doc.rust-lang.org/edition-guide/rust-2018/index.html), use `2015`
* if `--rust-target` version is before [1.56.0](https://doc.rust-lang.org/edition-guide/rust-2021/index.html), use `2018`
* use 2018 as default otherwise

In the future, it would be good to add these, if possible:
* if compiled as a cli utility, use 2018 to reduce compatibility issues (?)
* if used as a lib from `build.rs`, detect current edition (is this possible?), and use the one of the `build.rs`