### PR TITLE
Introduce `--rust-edition`

### DIFF
--- a/bindgen-tests/tests/expectations/tests/strings_cstr2_2018.rs
+++ b/bindgen-tests/tests/expectations/tests/strings_cstr2_2018.rs
@@ -1,0 +1,13 @@
+#![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
+#[allow(unsafe_code)]
+pub const MY_STRING_UTF8: &::std::ffi::CStr = unsafe {
+    ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"Hello, world!\0")
+};
+#[allow(unsafe_code)]
+pub const MY_STRING_INTERIOR_NULL: &::std::ffi::CStr = unsafe {
+    ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"Hello,\0")
+};
+#[allow(unsafe_code)]
+pub const MY_STRING_NON_UTF8: &::std::ffi::CStr = unsafe {
+    ::std::ffi::CStr::from_bytes_with_nul_unchecked(b"ABCDE\xFF\0")
+};

--- a/bindgen-tests/tests/headers/strings_cstr2_2018.h
+++ b/bindgen-tests/tests/headers/strings_cstr2_2018.h
@@ -1,0 +1,5 @@
+// bindgen-flags: --rust-target=1.77 --rust-edition=2018 --generate-cstr
+
+const char* MY_STRING_UTF8 = "Hello, world!";
+const char* MY_STRING_INTERIOR_NULL = "Hello,\0World!";
+const char* MY_STRING_NON_UTF8 = "ABCDE\xFF";

--- a/bindgen/features.rs
+++ b/bindgen/features.rs
@@ -139,6 +139,7 @@ impl std::error::Error for InvalidRustEdition {}
 define_rust_editions! {
     Edition2018(2018) => 31,
     Edition2021(2021) => 56,
+    Edition2024(2024) => 85,
 }
 
 impl RustTarget {
@@ -162,9 +163,9 @@ impl Default for RustEdition {
 /// This macro defines the [`RustTarget`] and [`RustFeatures`] types.
 macro_rules! define_rust_targets {
     (
-        Nightly => {$($nightly_feature:ident $(($nightly_edition:literal))* $(: #$issue:literal)?),* $(,)?} $(,)?
+        Nightly => {$($nightly_feature:ident $(($nightly_edition:literal))|* $(: #$issue:literal)?),* $(,)?} $(,)?
         $(
-            $variant:ident($minor:literal) => {$($feature:ident $(($edition:literal))* $(: #$pull:literal)?),* $(,)?},
+            $variant:ident($minor:literal) => {$($feature:ident $(($edition:literal))|* $(: #$pull:literal)?),* $(,)?},
         )*
         $(,)?
     ) => {
@@ -255,7 +256,7 @@ define_rust_targets! {
     },
     Stable_1_77(77) => {
         offset_of: #106655,
-        literal_cstr(2021): #117472,
+        literal_cstr(2021)|(2024): #117472,
     },
     Stable_1_73(73) => { thiscall_abi: #42202 },
     Stable_1_71(71) => { c_unwind_abi: #106075 },
@@ -405,6 +406,26 @@ impl Default for RustFeatures {
 #[cfg(test)]
 mod test {
     use super::*;
+
+    #[test]
+    fn release_versions_for_editions() {
+        assert_eq!(
+            "1.33".parse::<RustTarget>().unwrap().latest_edition(),
+            RustEdition::Edition2018
+        );
+        assert_eq!(
+            "1.56".parse::<RustTarget>().unwrap().latest_edition(),
+            RustEdition::Edition2021
+        );
+        assert_eq!(
+            "1.85".parse::<RustTarget>().unwrap().latest_edition(),
+            RustEdition::Edition2024
+        );
+        assert_eq!(
+            "nightly".parse::<RustTarget>().unwrap().latest_edition(),
+            RustEdition::Edition2024
+        );
+    }
 
     #[test]
     fn target_features() {

--- a/bindgen/options/cli.rs
+++ b/bindgen/options/cli.rs
@@ -3,7 +3,7 @@ use crate::{
     callbacks::{
         AttributeInfo, DeriveInfo, ItemInfo, ParseCallbacks, TypeKind,
     },
-    features::EARLIEST_STABLE_RUST,
+    features::{RustEdition, EARLIEST_STABLE_RUST},
     regex_set::RegexSet,
     Abi, AliasVariation, Builder, CodegenConfig, EnumVariation,
     FieldVisibilityKind, Formatter, MacroTypeVariation, NonCopyUnionStyle,
@@ -24,6 +24,10 @@ fn rust_target_help() -> String {
         "Version of the Rust compiler to target. Any Rust version after {EARLIEST_STABLE_RUST} is supported. Defaults to {}.",
         RustTarget::default()
     )
+}
+
+fn rust_edition_help() -> String {
+    format!("Rust edition to target. Defaults to the latest edition supported by the chosen Rust target. Possible values: ({}). ", RustEdition::ALL.map(|e| e.to_string()).join("|"))
 }
 
 fn parse_codegen_config(
@@ -334,6 +338,8 @@ struct BindgenCommand {
     module_raw_line: Vec<String>,
     #[arg(long, help = rust_target_help())]
     rust_target: Option<RustTarget>,
+    #[arg(long, value_name = "EDITION", help = rust_edition_help())]
+    rust_edition: Option<RustEdition>,
     /// Use types from Rust core instead of std.
     #[arg(long)]
     use_core: bool,
@@ -588,6 +594,7 @@ where
         raw_line,
         module_raw_line,
         rust_target,
+        rust_edition,
         use_core,
         conservative_inline_namespaces,
         allowlist_function,
@@ -821,6 +828,7 @@ where
             },
             header,
             rust_target,
+            rust_edition,
             default_enum_style,
             bitfield_enum,
             newtype_enum,

--- a/bindgen/options/mod.rs
+++ b/bindgen/options/mod.rs
@@ -12,7 +12,7 @@ use crate::codegen::{
     AliasVariation, EnumVariation, MacroTypeVariation, NonCopyUnionStyle,
 };
 use crate::deps::DepfileSpec;
-use crate::features::{RustFeatures, RustTarget};
+use crate::features::{RustEdition, RustFeatures, RustTarget};
 use crate::regex_set::RegexSet;
 use crate::Abi;
 use crate::Builder;
@@ -1609,9 +1609,26 @@ options! {
             args.push(rust_target.to_string());
         },
     },
+    /// The Rust edition to use for code generation.
+    rust_edition: Option<RustEdition> {
+        methods: {
+            /// Specify the Rust target edition.
+            ///
+            /// The default edition is the latest edition supported by the chosen Rust target.
+            pub fn rust_edition(mut self, rust_edition: RustEdition) -> Self {
+                self.options.rust_edition = Some(rust_edition);
+                self
+            }
+        }
+        as_args: |edition, args| {
+            if let Some(edition) =  edition {
+                args.push("--rust-edition".to_owned());
+                args.push(edition.to_string());
+            }
+        },
+    },
     /// Features to be enabled. They are derived from `rust_target`.
     rust_features: RustFeatures {
-        default: RustTarget::default().into(),
         methods: {},
         // This field cannot be set from the CLI,
         as_args: ignore,


### PR DESCRIPTION

This PR introduces the concept of Rust editions to bindgen so it can generate appropriate code based on the desired edition.

The motivation behind this PR comes from #2996 which allows bindgen to generate code with C-String literals, a feature that has been available since rust 1.77 but are gated behind the 2021 edition.

The changes in this PR are:

- Introduce the `--rust-edition` CLI argument and `Builder::rust_edition` method.
- Update bindgen internals to filter features based on the set edition. 
- Gate the `literal_cstr` feature behind the 2021 edition.

cc @nyurik @emilio 