### PR TITLE
Clippify, and hide some lints in test output

### DIFF
--- a/bindgen-tests/tests/expectations/Cargo.toml
+++ b/bindgen-tests/tests/expectations/Cargo.toml
@@ -14,3 +14,23 @@ publish = false
 block = "0.1"
 libloading = "0.7"
 objc = "0.2"
+
+[lints.rust]
+### FIXME: these might need to be fixed,
+###   esp the calling convention, because it is a hard error now
+# deprecated = "allow"
+# invalid-value = "allow"
+# unsupported_calling_conventions = "allow"
+non-snake-case = "allow"
+unexpected-cfgs = "allow"
+
+[lints.clippy]
+disallowed-names = "allow"
+manual-c-str-literals = "allow"
+missing-safety-doc = "allow"
+op-ref = "allow"
+ptr-offset-with-cast = "allow"
+too-many-arguments = "allow"
+transmute-int-to-bool = "allow"
+unnecessary-cast = "allow"
+useless-transmute  = "allow"

--- a/bindgen/clang.rs
+++ b/bindgen/clang.rs
@@ -788,7 +788,7 @@ impl Cursor {
                 let found_attr = &mut found_attrs[idx];
                 if !*found_attr {
                     // `attr.name` and` attr.token_kind` are checked against unexposed attributes only.
-                    if attr.kind.map_or(false, |k| k == kind) ||
+                    if attr.kind == Some(kind) ||
                         (kind == CXCursor_UnexposedAttr &&
                             cur.tokens().iter().any(|t| {
                                 t.kind == attr.token_kind &&
@@ -1522,7 +1522,7 @@ impl Type {
         // Yep, the spelling of this containing type-parameter is extremely
         // nasty... But can happen in <type_traits>. Unfortunately I couldn't
         // reduce it enough :(
-        self.template_args().map_or(false, |args| args.len() > 0) &&
+        self.template_args().is_some_and(|args| args.len() > 0) &&
             !matches!(
                 self.declaration().kind(),
                 CXCursor_ClassTemplatePartialSpecialization |

--- a/bindgen/ir/analysis/derive.rs
+++ b/bindgen/ir/analysis/derive.rs
@@ -673,7 +673,7 @@ impl<'ctx> MonotoneFramework for CannotDerive<'ctx> {
                     let is_reached_limit =
                         |l: Layout| l.align > RUST_DERIVE_IN_ARRAY_LIMIT;
                     if !self.derive_trait.can_derive_large_array(self.ctx) &&
-                        ty.layout(self.ctx).map_or(false, is_reached_limit)
+                        ty.layout(self.ctx).is_some_and(is_reached_limit)
                     {
                         // We have to be conservative: the struct *could* have enough
                         // padding that we emit an array that is longer than

--- a/bindgen/ir/annotations.rs
+++ b/bindgen/ir/annotations.rs
@@ -213,7 +213,7 @@ impl Annotations {
             comment
                 .get_tag_attrs()
                 .next()
-                .map_or(false, |attr| attr.name == "rustbindgen")
+                .is_some_and(|attr| attr.name == "rustbindgen")
         {
             *matched = true;
             for attr in comment.get_tag_attrs() {

--- a/bindgen/ir/comment.rs
+++ b/bindgen/ir/comment.rs
@@ -58,7 +58,7 @@ fn preprocess_multi_line(comment: &str) -> String {
         .collect();
 
     // Remove the trailing line corresponding to the `*/`.
-    if lines.last().map_or(false, |l| l.trim().is_empty()) {
+    if lines.last().is_some_and(|l| l.trim().is_empty()) {
         lines.pop();
     }
 

--- a/bindgen/ir/comp.rs
+++ b/bindgen/ir/comp.rs
@@ -1753,7 +1753,7 @@ impl CompInfo {
             return (false, false);
         }
 
-        if layout.map_or(false, |l| l.size == 0) {
+        if layout.is_some_and(|l| l.size == 0) {
             return (false, false);
         }
 

--- a/bindgen/ir/context.rs
+++ b/bindgen/ir/context.rs
@@ -1148,7 +1148,7 @@ If you encounter an error missing from this list, please file an issue or a PR!"
                     .chain(Some(immut_self.root_module.into()))
                     .find(|id| {
                         let item = immut_self.resolve_item(*id);
-                        item.as_module().map_or(false, |m| {
+                        item.as_module().is_some_and(|m| {
                             m.children().contains(&replacement_id.into())
                         })
                     })
@@ -1289,9 +1289,7 @@ If you encounter an error missing from this list, please file an issue or a PR!"
                                 );
                                 self.resolve_item(ancestor)
                                     .as_module()
-                                    .map_or(false, |m| {
-                                        m.children().contains(&id)
-                                    })
+                                    .is_some_and(|m| m.children().contains(&id))
                             })
                     },
                     "{:?} should be in some ancestor module's children set",
@@ -1424,8 +1422,7 @@ If you encounter an error missing from this list, please file an issue or a PR!"
         self.used_template_parameters
             .as_ref()
             .expect("should have found template parameter usage if we're in codegen")
-            .get(&item)
-            .map_or(false, |items_used_params| items_used_params.contains(&template_param))
+            .get(&item).is_some_and(|items_used_params| items_used_params.contains(&template_param))
     }
 
     /// Return `true` if `item` uses any unbound, generic template parameters,
@@ -1444,7 +1441,7 @@ If you encounter an error missing from this list, please file an issue or a PR!"
                 "should have template parameter usage info in codegen phase",
             )
             .get(&item)
-            .map_or(false, |used| !used.is_empty())
+            .is_some_and(|used| !used.is_empty())
     }
 
     // This deserves a comment. Builtin types don't get a valid declaration, so

--- a/bindgen/ir/enum_ty.rs
+++ b/bindgen/ir/enum_ty.rs
@@ -73,7 +73,7 @@ impl Enum {
 
         let variant_ty =
             repr.and_then(|r| ctx.resolve_type(r).safe_canonical_type(ctx));
-        let is_bool = variant_ty.map_or(false, Type::is_bool);
+        let is_bool = variant_ty.is_some_and(Type::is_bool);
 
         // Assume signedness since the default type by the C standard is an int.
         let is_signed = variant_ty.map_or(true, |ty| match *ty.kind() {
@@ -310,14 +310,12 @@ impl EnumVariant {
     /// Returns whether this variant should be enforced to be a constant by code
     /// generation.
     pub(crate) fn force_constification(&self) -> bool {
-        self.custom_behavior
-            .map_or(false, |b| b == EnumVariantCustomBehavior::Constify)
+        self.custom_behavior == Some(EnumVariantCustomBehavior::Constify)
     }
 
     /// Returns whether the current variant should be hidden completely from the
     /// resulting rust enum.
     pub(crate) fn hidden(&self) -> bool {
-        self.custom_behavior
-            .map_or(false, |b| b == EnumVariantCustomBehavior::Hide)
+        self.custom_behavior == Some(EnumVariantCustomBehavior::Hide)
     }
 }

--- a/bindgen/ir/function.rs
+++ b/bindgen/ir/function.rs
@@ -749,9 +749,7 @@ impl ClangSubItemParser for Function {
         };
 
         if cursor.is_inlined_function() ||
-            cursor
-                .definition()
-                .map_or(false, |x| x.is_inlined_function())
+            cursor.definition().is_some_and(|x| x.is_inlined_function())
         {
             if !context.options().generate_inline_functions &&
                 !context.options().wrap_static_fns

--- a/bindgen/ir/item.rs
+++ b/bindgen/ir/item.rs
@@ -492,7 +492,7 @@ impl Item {
 
         self.ancestors(ctx)
             .filter(|id| {
-                ctx.resolve_item(*id).as_module().map_or(false, |module| {
+                ctx.resolve_item(*id).as_module().is_some_and(|module| {
                     !module.is_inline() ||
                         ctx.options().conservative_inline_namespaces
                 })
@@ -1058,7 +1058,7 @@ impl Item {
             .map(|id| ctx.resolve_item(id))
             .filter(|item| {
                 item.id() == target.id() ||
-                    item.as_module().map_or(false, |module| {
+                    item.as_module().is_some_and(|module| {
                         !module.is_inline() ||
                             ctx.options().conservative_inline_namespaces
                     })
@@ -1122,7 +1122,7 @@ impl IsOpaque for Item {
             "You're not supposed to call this yet"
         );
         self.annotations.opaque() ||
-            self.as_type().map_or(false, |ty| ty.is_opaque(ctx, self)) ||
+            self.as_type().is_some_and(|ty| ty.is_opaque(ctx, self)) ||
             ctx.opaque_by_name(self.path_for_allowlisting(ctx))
     }
 }
@@ -1133,14 +1133,14 @@ where
 {
     fn has_vtable(&self, ctx: &BindgenContext) -> bool {
         let id: ItemId = (*self).into();
-        id.as_type_id(ctx).map_or(false, |id| {
+        id.as_type_id(ctx).is_some_and(|id| {
             !matches!(ctx.lookup_has_vtable(id), HasVtableResult::No)
         })
     }
 
     fn has_vtable_ptr(&self, ctx: &BindgenContext) -> bool {
         let id: ItemId = (*self).into();
-        id.as_type_id(ctx).map_or(false, |id| {
+        id.as_type_id(ctx).is_some_and(|id| {
             matches!(ctx.lookup_has_vtable(id), HasVtableResult::SelfHasVtable)
         })
     }

--- a/bindgen/ir/layout.rs
+++ b/bindgen/ir/layout.rs
@@ -117,7 +117,7 @@ impl Opaque {
     pub(crate) fn array_size_within_derive_limit(&self) -> CanDerive {
         if self
             .array_size()
-            .map_or(false, |size| size <= RUST_DERIVE_IN_ARRAY_LIMIT)
+            .is_some_and(|size| size <= RUST_DERIVE_IN_ARRAY_LIMIT)
         {
             CanDerive::Yes
         } else {

--- a/bindgen/ir/ty.rs
+++ b/bindgen/ir/ty.rs
@@ -1217,8 +1217,7 @@ impl Type {
 
         let is_const = ty.is_const() ||
             (ty.kind() == CXType_ConstantArray &&
-                ty.elem_type()
-                    .map_or(false, |element| element.is_const()));
+                ty.elem_type().is_some_and(|element| element.is_const()));
 
         let ty = Type::new(name, layout, kind, is_const);
         // TODO: maybe declaration.canonical()?
@@ -1233,10 +1232,7 @@ impl Trace for Type {
     where
         T: Tracer,
     {
-        if self
-            .name()
-            .map_or(false, |name| context.is_stdint_type(name))
-        {
+        if self.name().is_some_and(|name| context.is_stdint_type(name)) {
             // These types are special-cased in codegen and don't need to be traversed.
             return;
         }

--- a/bindgen/ir/var.rs
+++ b/bindgen/ir/var.rs
@@ -311,7 +311,7 @@ impl ClangSubItemParser for Var {
                     ([CXType_ConstantArray, CXType_IncompleteArray]
                         .contains(&ty.kind()) &&
                         ty.elem_type()
-                            .map_or(false, |element| element.is_const()));
+                            .is_some_and(|element| element.is_const()));
 
                 let ty = match Item::from_ty(&ty, cursor, None, ctx) {
                     Ok(ty) => ty,
@@ -335,8 +335,8 @@ impl ClangSubItemParser for Var {
                     .safe_resolve_type(ty)
                     .and_then(|t| t.safe_canonical_type(ctx));
 
-                let is_integer = canonical_ty.map_or(false, |t| t.is_integer());
-                let is_float = canonical_ty.map_or(false, |t| t.is_float());
+                let is_integer = canonical_ty.is_some_and(|t| t.is_integer());
+                let is_float = canonical_ty.is_some_and(|t| t.is_float());
 
                 // TODO: We could handle `char` more gracefully.
                 // TODO: Strings, though the lookup is a bit more hard (we need

--- a/bindgen/lib.rs
+++ b/bindgen/lib.rs
@@ -1147,7 +1147,7 @@ pub fn clang_version() -> ClangVersion {
     let raw_v: String = clang::extract_clang_version();
     let split_v: Option<Vec<&str>> = raw_v
         .split_whitespace()
-        .find(|t| t.chars().next().map_or(false, |v| v.is_ascii_digit()))
+        .find(|t| t.chars().next().is_some_and(|v| v.is_ascii_digit()))
         .map(|v| v.split('.').collect());
     if let Some(v) = split_v {
         if v.len() >= 2 {


### PR DESCRIPTION
Happy clippy = happy developers

The test expectations generate a bunch of lints that are mostly irrelevant, at least at the moment, so might as well record them to avoid `cargo clippy` from reporting them.