### PR TITLE
Inline format args

### DIFF
--- a/bindgen-cli/main.rs
+++ b/bindgen-cli/main.rs
@@ -37,7 +37,7 @@ pub fn main() {
                 if verbose {
                     print_verbose_err()
                 }
-                eprintln!("{}", info);
+                eprintln!("{info}");
             }));
 
             let bindings =
@@ -48,7 +48,7 @@ pub fn main() {
             bindings.write(output).expect("Unable to write output");
         }
         Err(error) => {
-            eprintln!("{}", error);
+            eprintln!("{error}");
             std::process::exit(1);
         }
     };

--- a/bindgen-integration/build.rs
+++ b/bindgen-integration/build.rs
@@ -98,7 +98,7 @@ impl ParseCallbacks for MacroCallback {
             _ => {
                 // The system might provide lots of functional macros.
                 // Ensure we did not miss handling one that we meant to handle.
-                assert!(!name.starts_with("TESTMACRO_"), "name = {}", name);
+                assert!(!name.starts_with("TESTMACRO_"), "name = {name}");
             }
         }
     }
@@ -258,7 +258,7 @@ fn setup_wrap_static_fns_test() {
         .expect("Unable to generate bindings");
 
     println!("cargo:rustc-link-lib=static=wrap_static_fns"); // tell cargo to link libextern
-    println!("bindings generated: {}", bindings);
+    println!("bindings generated: {bindings}");
 
     let obj_path = out_path.join("wrap_static_fns.o");
     let lib_path = out_path.join("libwrap_static_fns.a");

--- a/bindgen-tests/tests/parse_callbacks/mod.rs
+++ b/bindgen-tests/tests/parse_callbacks/mod.rs
@@ -66,7 +66,7 @@ impl ParseCallbacks for EnumVariantRename {
         original_variant_name: &str,
         _variant_value: EnumVariantValue,
     ) -> Option<String> {
-        Some(format!("RENAMED_{}", original_variant_name))
+        Some(format!("RENAMED_{original_variant_name}"))
     }
 }
 
@@ -172,7 +172,7 @@ pub fn lookup(cb: &str) -> Box<dyn ParseCallbacks> {
                     ),
                 })
             } else {
-                panic!("Couldn't find name ParseCallbacks: {}", cb)
+                panic!("Couldn't find name ParseCallbacks: {cb}")
             }
         }
     }

--- a/bindgen-tests/tests/quickchecking/src/fuzzers.rs
+++ b/bindgen-tests/tests/quickchecking/src/fuzzers.rs
@@ -201,11 +201,11 @@ impl Arbitrary for DeclarationC {
 impl fmt::Display for DeclarationC {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
-            DeclarationC::FunctionPtrDecl(ref d) => write!(f, "{}", d),
-            DeclarationC::StructDecl(ref d) => write!(f, "{}", d),
-            DeclarationC::UnionDecl(ref d) => write!(f, "{}", d),
-            DeclarationC::VariableDecl(ref d) => write!(f, "{}", d),
-            DeclarationC::FunctionDecl(ref d) => write!(f, "{}", d),
+            DeclarationC::FunctionPtrDecl(ref d) => write!(f, "{d}"),
+            DeclarationC::StructDecl(ref d) => write!(f, "{d}"),
+            DeclarationC::UnionDecl(ref d) => write!(f, "{d}"),
+            DeclarationC::VariableDecl(ref d) => write!(f, "{d}"),
+            DeclarationC::FunctionDecl(ref d) => write!(f, "{d}"),
         }
     }
 }
@@ -225,9 +225,9 @@ impl fmt::Display for DeclarationListC {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut display = String::new();
         for decl in &self.decls {
-            display += &format!("{}", decl);
+            display += &format!("{decl}");
         }
-        write!(f, "{}", display)
+        write!(f, "{display}")
     }
 }
 
@@ -347,7 +347,7 @@ impl fmt::Display for ArrayDimensionC {
 /// identifiers unique.
 impl MakeUnique for BasicTypeDeclarationC {
     fn make_unique(&mut self, stamp: usize) {
-        self.ident_id += &format!("_{}", stamp);
+        self.ident_id += &format!("_{stamp}");
     }
 }
 
@@ -384,7 +384,7 @@ impl fmt::Display for BasicTypeDeclarationC {
 /// identifiers unique.
 impl MakeUnique for StructDeclarationC {
     fn make_unique(&mut self, stamp: usize) {
-        self.ident_id += &format!("_{}", stamp);
+        self.ident_id += &format!("_{stamp}");
     }
 }
 
@@ -432,7 +432,7 @@ impl fmt::Display for StructDeclarationC {
 /// identifiers unique.
 impl MakeUnique for UnionDeclarationC {
     fn make_unique(&mut self, stamp: usize) {
-        self.ident_id += &format!("_{}", stamp);
+        self.ident_id += &format!("_{stamp}");
     }
 }
 
@@ -480,7 +480,7 @@ impl fmt::Display for UnionDeclarationC {
 /// FunctionPointerDeclarationC identifiers unique.
 impl MakeUnique for FunctionPointerDeclarationC {
     fn make_unique(&mut self, stamp: usize) {
-        self.ident_id += &format!("_{}", stamp);
+        self.ident_id += &format!("_{stamp}");
     }
 }
 
@@ -517,7 +517,7 @@ impl fmt::Display for FunctionPointerDeclarationC {
 /// identifiers unique.
 impl MakeUnique for FunctionPrototypeC {
     fn make_unique(&mut self, stamp: usize) {
-        self.ident_id += &format!("_{}", stamp);
+        self.ident_id += &format!("_{stamp}");
     }
 }
 
@@ -589,11 +589,11 @@ impl fmt::Display for ParameterListC {
         let mut display = String::new();
         for (i, p) in self.params.iter().enumerate() {
             match i {
-                0 => display += &format!("{}", p),
-                _ => display += &format!(",{}", p),
+                0 => display += &format!("{p}"),
+                _ => display += &format!(",{p}"),
             }
         }
-        write!(f, "{}", display)
+        write!(f, "{display}")
     }
 }
 
@@ -614,9 +614,9 @@ impl fmt::Display for HeaderC {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut display = String::new();
         for decl in &self.def.decls {
-            display += &format!("{}", decl);
+            display += &format!("{decl}");
         }
-        write!(f, "{}", display)
+        write!(f, "{display}")
     }
 }
 
@@ -624,7 +624,7 @@ impl fmt::Display for HeaderC {
 /// generated C code rather than the data structures that contain it.
 impl fmt::Debug for HeaderC {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self)
+        write!(f, "{self}")
     }
 }
 

--- a/bindgen-tests/tests/quickchecking/src/lib.rs
+++ b/bindgen-tests/tests/quickchecking/src/lib.rs
@@ -81,7 +81,7 @@ fn bindgen_prop(header: fuzzers::HeaderC) -> TestResult {
     match run_predicate_script(header) {
         Ok(o) => TestResult::from_bool(o.status.success()),
         Err(e) => {
-            println!("{:?}", e);
+            println!("{e:?}");
             TestResult::from_bool(false)
         }
     }

--- a/bindgen-tests/tests/tests.rs
+++ b/bindgen-tests/tests/tests.rs
@@ -40,9 +40,9 @@ fn error_diff_mismatch(
     filename: &Path,
 ) -> Result<(), Error> {
     println!("diff expected generated");
-    println!("--- expected: {:?}", filename);
+    println!("--- expected: {filename:?}");
     if let Some(header) = header {
-        println!("+++ generated from: {:?}", header);
+        println!("+++ generated from: {header:?}");
     }
 
     show_diff(expected, actual);
@@ -153,9 +153,9 @@ fn compare_generated_header(
                     } else if maj >= 9 {
                         "9".to_owned()
                     } else {
-                        format!("{}.{}", maj, min)
+                        format!("{maj}.{min}")
                     };
-                    expectation.push(format!("libclang-{}", version_str));
+                    expectation.push(format!("libclang-{version_str}"));
                 }
             }
         }
@@ -194,7 +194,7 @@ fn compare_generated_header(
         Ok(bindings) => format_code(bindings.to_string()).map_err(|err| {
             Error::new(
                 ErrorKind::Other,
-                format!("Cannot parse the generated bindings: {}", err),
+                format!("Cannot parse the generated bindings: {err}"),
             )
         })?,
         Err(_) => "/* error generating bindings */\n".into(),
@@ -219,7 +219,7 @@ fn compare_generated_header(
         if let Err(e) =
             compare_generated_header(header, roundtrip_builder, false)
         {
-            return Err(Error::new(ErrorKind::Other, format!("Checking CLI flags roundtrip errored! You probably need to fix Builder::command_line_flags. {}", e)));
+            return Err(Error::new(ErrorKind::Other, format!("Checking CLI flags roundtrip errored! You probably need to fix Builder::command_line_flags. {e}")));
         }
     }
 
@@ -703,7 +703,7 @@ fn build_flags_output_helper(builder: &bindgen::Builder) {
         .map(|x| format!("{}", shlex::try_quote(x).unwrap()))
         .collect();
     let flags_str = flags_quoted.join(" ");
-    println!("{}", flags_str);
+    println!("{flags_str}");
 
     let (builder, _output, _verbose) =
         builder_from_flags(command_line_flags.into_iter()).unwrap();

--- a/bindgen/clang.rs
+++ b/bindgen/clang.rs
@@ -1636,7 +1636,7 @@ impl fmt::Display for SourceLocation {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let (file, line, col, _) = self.location();
         if let Some(name) = file.name() {
-            write!(f, "{}:{}:{}", name, line, col)
+            write!(f, "{name}:{line}:{col}")
         } else {
             "builtin definitions".fmt(f)
         }
@@ -1645,7 +1645,7 @@ impl fmt::Display for SourceLocation {
 
 impl fmt::Debug for SourceLocation {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self)
+        write!(f, "{self}")
     }
 }
 
@@ -2126,15 +2126,15 @@ pub(crate) fn ast_dump(c: &Cursor, depth: isize) -> CXChildVisitResult {
             );
         }
         if let Some(usr) = c.usr() {
-            print_indent(depth, format!(" {}usr = \"{}\"", prefix, usr));
+            print_indent(depth, format!(" {prefix}usr = \"{usr}\""));
         }
         if let Ok(num) = c.num_args() {
-            print_indent(depth, format!(" {}number-of-args = {}", prefix, num));
+            print_indent(depth, format!(" {prefix}number-of-args = {num}"));
         }
         if let Some(num) = c.num_template_args() {
             print_indent(
                 depth,
-                format!(" {}number-of-template-args = {}", prefix, num),
+                format!(" {prefix}number-of-template-args = {num}"),
             );
         }
 
@@ -2143,7 +2143,7 @@ pub(crate) fn ast_dump(c: &Cursor, depth: isize) -> CXChildVisitResult {
                 Some(w) => w.to_string(),
                 None => "<unevaluable>".to_string(),
             };
-            print_indent(depth, format!(" {}bit-width = {}", prefix, width));
+            print_indent(depth, format!(" {prefix}bit-width = {width}"));
         }
 
         if let Some(ty) = c.enum_type() {
@@ -2153,7 +2153,7 @@ pub(crate) fn ast_dump(c: &Cursor, depth: isize) -> CXChildVisitResult {
             );
         }
         if let Some(val) = c.enum_val_signed() {
-            print_indent(depth, format!(" {}enum-val = {}", prefix, val));
+            print_indent(depth, format!(" {prefix}enum-val = {val}"));
         }
         if let Some(ty) = c.typedef_type() {
             print_indent(
@@ -2231,16 +2231,12 @@ pub(crate) fn ast_dump(c: &Cursor, depth: isize) -> CXChildVisitResult {
             print_indent(
                 depth,
                 format!(
-                    " {}number-of-template-args = {}",
-                    prefix, num_template_args
+                    " {prefix}number-of-template-args = {num_template_args}"
                 ),
             );
         }
         if let Some(num) = ty.num_elements() {
-            print_indent(
-                depth,
-                format!(" {}number-of-elements = {}", prefix, num),
-            );
+            print_indent(depth, format!(" {prefix}number-of-elements = {num}"));
         }
         print_indent(
             depth,

--- a/bindgen/codegen/bitfield_unit_tests.rs
+++ b/bindgen/codegen/bitfield_unit_tests.rs
@@ -33,7 +33,7 @@ fn bitfield_unit_get_bit() {
     }
 
     println!();
-    println!("bits = {:?}", bits);
+    println!("bits = {bits:?}");
     assert_eq!(
         bits,
         &[

--- a/bindgen/codegen/error.rs
+++ b/bindgen/codegen/error.rs
@@ -36,12 +36,11 @@ impl fmt::Display for Error {
             Error::UnsupportedAbi(abi) => {
                  write!(
                     f,
-                    "{} ABI is not supported by the configured Rust target.",
-                    abi
+                    "{abi} ABI is not supported by the configured Rust target."
                 )
             }
             Error::InvalidPointerSize { ty_name, ty_size, ptr_size } => {
-                write!(f, "The {} pointer type has size {} but the current target's pointer size is {}.", ty_name, ty_size, ptr_size)
+                write!(f, "The {ty_name} pointer type has size {ty_size} but the current target's pointer size is {ptr_size}.")
             }
         }
     }

--- a/bindgen/codegen/helpers.rs
+++ b/bindgen/codegen/helpers.rs
@@ -68,7 +68,7 @@ pub(crate) mod attributes {
         let name: Cow<'_, str> = if MANGLE {
             name.into()
         } else {
-            format!("\u{1}{}", name).into()
+            format!("\u{1}{name}").into()
         };
 
         quote! {
@@ -375,7 +375,7 @@ pub(crate) mod ast_ty {
                 None => {
                     unnamed_arguments += 1;
                     let name =
-                        ctx.rust_ident(format!("arg{}", unnamed_arguments));
+                        ctx.rust_ident(format!("arg{unnamed_arguments}"));
                     quote! { #name }
                 }
             })

--- a/bindgen/codegen/serialize.rs
+++ b/bindgen/codegen/serialize.rs
@@ -45,7 +45,7 @@ impl<'a> CSerialize<'a> for Item {
                 func.serialize(ctx, (self, extra), stack, writer)
             }
             kind => Err(CodegenError::Serialize {
-                msg: format!("Cannot serialize item kind {:?}", kind),
+                msg: format!("Cannot serialize item kind {kind:?}"),
                 loc: get_loc(self),
             }),
         }
@@ -102,7 +102,7 @@ impl<'a> CSerialize<'a> for Function {
                     } else {
                         Some((
                             opt_name.unwrap_or_else(|| {
-                                let name = format!("arg_{}", count);
+                                let name = format!("arg_{count}");
                                 count += 1;
                                 name
                             }),
@@ -131,15 +131,15 @@ impl<'a> CSerialize<'a> for Function {
         const INDENT: &str = "    ";
 
         // Write `wrap_name(args`.
-        write!(writer, " {}(", wrap_name)?;
+        write!(writer, " {wrap_name}(")?;
         serialize_args(&args, ctx, writer)?;
 
         if wrap_as_variadic.is_none() {
             // Write `) { name(` if the function returns void and `) { return name(` if it does not.
             if ret_ty.is_void() {
-                write!(writer, ") {{ {}(", name)?;
+                write!(writer, ") {{ {name}(")?;
             } else {
-                write!(writer, ") {{ return {}(", name)?;
+                write!(writer, ") {{ return {name}(")?;
             }
         } else {
             // Write `, ...) {`
@@ -165,7 +165,7 @@ impl<'a> CSerialize<'a> for Function {
             if !ret_ty.is_void() {
                 write!(writer, "ret = ")?;
             }
-            write!(writer, "{}(", name)?;
+            write!(writer, "{name}(")?;
         }
 
         // Get the arguments names and insert at the right place if necessary `ap`
@@ -179,7 +179,7 @@ impl<'a> CSerialize<'a> for Function {
 
         // Write `arg_names);`.
         serialize_sep(", ", args.iter(), ctx, writer, |name, _, buf| {
-            write!(buf, "{}", name).map_err(From::from)
+            write!(buf, "{name}").map_err(From::from)
         })?;
         #[rustfmt::skip]
         write!(writer, ");{}", if wrap_as_variadic.is_none() { " " } else { "\n" })?;
@@ -257,8 +257,7 @@ impl<'a> CSerialize<'a> for Type {
                     int_kind => {
                         return Err(CodegenError::Serialize {
                             msg: format!(
-                                "Cannot serialize integer kind {:?}",
-                                int_kind
+                                "Cannot serialize integer kind {int_kind:?}"
                             ),
                             loc: get_loc(item),
                         })
@@ -294,9 +293,9 @@ impl<'a> CSerialize<'a> for Type {
             TypeKind::Alias(type_id) => {
                 if let Some(name) = self.name() {
                     if self.is_const() {
-                        write!(writer, "const {}", name)?;
+                        write!(writer, "const {name}")?;
                     } else {
-                        write!(writer, "{}", name)?;
+                        write!(writer, "{name}")?;
                     }
                 } else {
                     type_id.serialize(ctx, (), stack, writer)?;
@@ -304,7 +303,7 @@ impl<'a> CSerialize<'a> for Type {
             }
             TypeKind::Array(type_id, length) => {
                 type_id.serialize(ctx, (), stack, writer)?;
-                write!(writer, " [{}]", length)?
+                write!(writer, " [{length}]")?
             }
             TypeKind::Function(signature) => {
                 if self.is_const() {
@@ -320,7 +319,7 @@ impl<'a> CSerialize<'a> for Type {
 
                 write!(writer, " (")?;
                 while let Some(item) = stack.pop() {
-                    write!(writer, "{}", item)?;
+                    write!(writer, "{item}")?;
                 }
                 write!(writer, ")")?;
 
@@ -367,8 +366,8 @@ impl<'a> CSerialize<'a> for Type {
                 let name = item.canonical_name(ctx);
 
                 match comp_info.kind() {
-                    CompKind::Struct => write!(writer, "struct {}", name)?,
-                    CompKind::Union => write!(writer, "union {}", name)?,
+                    CompKind::Struct => write!(writer, "struct {name}")?,
+                    CompKind::Union => write!(writer, "union {name}")?,
                 };
             }
             TypeKind::Enum(_enum_ty) => {
@@ -377,11 +376,11 @@ impl<'a> CSerialize<'a> for Type {
                 }
 
                 let name = item.canonical_name(ctx);
-                write!(writer, "enum {}", name)?;
+                write!(writer, "enum {name}")?;
             }
             ty => {
                 return Err(CodegenError::Serialize {
-                    msg: format!("Cannot serialize type kind {:?}", ty),
+                    msg: format!("Cannot serialize type kind {ty:?}"),
                     loc: get_loc(item),
                 })
             }
@@ -390,7 +389,7 @@ impl<'a> CSerialize<'a> for Type {
         if !stack.is_empty() {
             write!(writer, " ")?;
             while let Some(item) = stack.pop() {
-                write!(writer, "{}", item)?;
+                write!(writer, "{item}")?;
             }
         }
 

--- a/bindgen/codegen/struct_layout.rs
+++ b/bindgen/codegen/struct_layout.rs
@@ -407,7 +407,7 @@ impl<'a> StructLayoutTracker<'a> {
         self.padding_count += 1;
 
         let padding_field_name = Ident::new(
-            &format!("__bindgen_padding_{}", padding_count),
+            &format!("__bindgen_padding_{padding_count}"),
             Span::call_site(),
         );
 

--- a/bindgen/diagnostics.rs
+++ b/bindgen/diagnostics.rs
@@ -93,10 +93,10 @@ impl<'a> Diagnostic<'a> {
             let hide_warning = "\r        \r";
             let string = dl.to_string();
             for line in string.lines() {
-                println!("cargo:warning={}{}", hide_warning, line);
+                println!("cargo:warning={hide_warning}{line}");
             }
         } else {
-            eprintln!("{}\n", dl);
+            eprintln!("{dl}\n");
         }
     }
 }
@@ -126,8 +126,7 @@ impl<'a> Slice<'a> {
         line: usize,
         col: usize,
     ) -> &mut Self {
-        write!(name, ":{}:{}", line, col)
-            .expect("Writing to a string cannot fail");
+        write!(name, ":{line}:{col}").expect("Writing to a string cannot fail");
         self.filename = Some(name);
         self.line = Some(line);
         self

--- a/bindgen/features.rs
+++ b/bindgen/features.rs
@@ -334,8 +334,7 @@ mod test {
     fn test_invalid_target(input: &str) {
         assert!(
             input.parse::<RustTarget>().is_err(),
-            "{} should be an invalid target",
-            input
+            "{input} should be an invalid target"
         );
     }
 

--- a/bindgen/ir/analysis/has_destructor.rs
+++ b/bindgen/ir/analysis/has_destructor.rs
@@ -58,9 +58,8 @@ impl HasDestructorAnalysis<'_> {
         let was_not_already_in_set = self.have_destructor.insert(id);
         assert!(
             was_not_already_in_set,
-            "We shouldn't try and insert {:?} twice because if it was \
-             already in the set, `constrain` should have exited early.",
-            id
+            "We shouldn't try and insert {id:?} twice because if it was \
+             already in the set, `constrain` should have exited early."
         );
         ConstrainResult::Changed
     }

--- a/bindgen/ir/analysis/has_float.rs
+++ b/bindgen/ir/analysis/has_float.rs
@@ -68,9 +68,8 @@ impl HasFloat<'_> {
         let was_not_already_in_set = self.has_float.insert(id);
         assert!(
             was_not_already_in_set,
-            "We shouldn't try and insert {:?} twice because if it was \
-             already in the set, `constrain` should have exited early.",
-            id
+            "We shouldn't try and insert {id:?} twice because if it was \
+             already in the set, `constrain` should have exited early."
         );
 
         ConstrainResult::Changed

--- a/bindgen/ir/analysis/has_type_param_in_array.rs
+++ b/bindgen/ir/analysis/has_type_param_in_array.rs
@@ -74,9 +74,8 @@ impl HasTypeParameterInArray<'_> {
             self.has_type_parameter_in_array.insert(id);
         assert!(
             was_not_already_in_set,
-            "We shouldn't try and insert {:?} twice because if it was \
-             already in the set, `constrain` should have exited early.",
-            id
+            "We shouldn't try and insert {id:?} twice because if it was \
+             already in the set, `constrain` should have exited early."
         );
 
         ConstrainResult::Changed

--- a/bindgen/ir/analysis/mod.rs
+++ b/bindgen/ir/analysis/mod.rs
@@ -370,7 +370,7 @@ mod tests {
     fn monotone() {
         let g = Graph::make_test_graph();
         let reachable = analyze::<ReachableFrom>(&g);
-        println!("reachable = {:#?}", reachable);
+        println!("reachable = {reachable:#?}");
 
         fn nodes<A>(nodes: A) -> HashSet<Node>
         where
@@ -388,7 +388,7 @@ mod tests {
         expected.insert(Node(6), nodes([8]));
         expected.insert(Node(7), nodes([3, 4, 5, 6, 7, 8]));
         expected.insert(Node(8), nodes([]));
-        println!("expected = {:#?}", expected);
+        println!("expected = {expected:#?}");
 
         assert_eq!(reachable, expected);
     }

--- a/bindgen/ir/annotations.rs
+++ b/bindgen/ir/annotations.rs
@@ -28,7 +28,7 @@ impl FromStr for FieldVisibilityKind {
             "private" => Ok(Self::Private),
             "crate" => Ok(Self::PublicCrate),
             "public" => Ok(Self::Public),
-            _ => Err(format!("Invalid visibility kind: `{}`", s)),
+            _ => Err(format!("Invalid visibility kind: `{s}`")),
         }
     }
 }

--- a/bindgen/ir/comp.rs
+++ b/bindgen/ir/comp.rs
@@ -782,7 +782,7 @@ impl CompFields {
                     getter
                 };
                 let setter = {
-                    let setter = format!("set_{}", bitfield_name);
+                    let setter = format!("set_{bitfield_name}");
                     let mut setter = ctx.rust_mangle(&setter).to_string();
                     if has_method(methods, ctx, &setter) {
                         setter.push_str("_bindgen_bitfield");
@@ -1466,7 +1466,7 @@ impl CompInfo {
 
                     let field_name = match ci.base_members.len() {
                         0 => "_base".into(),
-                        n => format!("_base_{}", n),
+                        n => format!("_base_{n}"),
                     };
                     let type_id =
                         Item::from_ty_or_ref(cur.cur_type(), cur, None, ctx);

--- a/bindgen/ir/context.rs
+++ b/bindgen/ir/context.rs
@@ -1294,8 +1294,7 @@ If you encounter an error missing from this list, please file an issue or a PR!"
                                     })
                             })
                     },
-                    "{:?} should be in some ancestor module's children set",
-                    id
+                    "{id:?} should be in some ancestor module's children set"
                 );
             }
         }
@@ -1515,7 +1514,7 @@ If you encounter an error missing from this list, please file an issue or a PR!"
         let item_id = item_id.into();
         match self.resolve_item_fallible(item_id) {
             Some(item) => item,
-            None => panic!("Not an item: {:?}", item_id),
+            None => panic!("Not an item: {item_id:?}"),
         }
     }
 
@@ -2035,8 +2034,7 @@ If you encounter an error missing from this list, please file an issue or a PR!"
                     CXType_LongDouble => FloatKind::LongDouble,
                     CXType_Float128 => FloatKind::Float128,
                     _ => panic!(
-                        "Non floating-type complex? {:?}, {:?}",
-                        ty, float_type,
+                        "Non floating-type complex? {ty:?}, {float_type:?}",
                     ),
                 };
                 TypeKind::Complex(float_kind)
@@ -3147,11 +3145,11 @@ fn unused_regex_diagnostic(item: &str, name: &str, _ctx: &BindgenContext) {
 
         Diagnostic::default()
             .with_title(
-                format!("Unused regular expression: `{}`.", item),
+                format!("Unused regular expression: `{item}`."),
                 Level::Warning,
             )
             .add_annotation(
-                format!("This regular expression was passed to `{}`.", name),
+                format!("This regular expression was passed to `{name}`."),
                 Level::Note,
             )
             .display();

--- a/bindgen/ir/enum_ty.rs
+++ b/bindgen/ir/enum_ty.rs
@@ -79,7 +79,7 @@ impl Enum {
         let is_signed = variant_ty.map_or(true, |ty| match *ty.kind() {
             TypeKind::Int(ref int_kind) => int_kind.is_signed(),
             ref other => {
-                panic!("Since when enums can be non-integers? {:?}", other)
+                panic!("Since when enums can be non-integers? {other:?}")
             }
         });
 

--- a/bindgen/ir/function.rs
+++ b/bindgen/ir/function.rs
@@ -158,11 +158,7 @@ impl DotAttributes for Function {
         if let Some(ref mangled) = self.mangled_name {
             let mangled: String =
                 mangled.chars().flat_map(|c| c.escape_default()).collect();
-            writeln!(
-                out,
-                "<tr><td>mangled name</td><td>{}</td></tr>",
-                mangled
-            )?;
+            writeln!(out, "<tr><td>mangled name</td><td>{mangled}</td></tr>")?;
         }
 
         Ok(())
@@ -209,7 +205,7 @@ impl FromStr for Abi {
             "win64" => Ok(Self::Win64),
             "C-unwind" => Ok(Self::CUnwind),
             "system" => Ok(Self::System),
-            _ => Err(format!("Invalid or unknown ABI {:?}", s)),
+            _ => Err(format!("Invalid or unknown ABI {s:?}")),
         }
     }
 }
@@ -261,8 +257,7 @@ impl quote::ToTokens for ClangAbi {
         match *self {
             Self::Known(abi) => abi.to_tokens(tokens),
             Self::Unknown(cc) => panic!(
-                "Cannot turn unknown calling convention to tokens: {:?}",
-                cc
+                "Cannot turn unknown calling convention to tokens: {cc:?}"
             ),
         }
     }

--- a/bindgen/ir/item.rs
+++ b/bindgen/ir/item.rs
@@ -727,7 +727,7 @@ impl Item {
         to.push_str(&self.canonical_name(ctx));
         if let ItemKind::Type(ref ty) = *self.kind() {
             if let TypeKind::TemplateInstantiation(ref inst) = *ty.kind() {
-                to.push_str(&format!("_open{}_", level));
+                to.push_str(&format!("_open{level}_"));
                 for arg in inst.template_arguments() {
                     arg.into_resolver()
                         .through_type_refs()
@@ -735,7 +735,7 @@ impl Item {
                         .push_disambiguated_name(ctx, to, level + 1);
                     to.push('_');
                 }
-                to.push_str(&format!("close{}", level));
+                to.push_str(&format!("close{level}"));
             }
         }
     }
@@ -801,7 +801,7 @@ impl Item {
 
                 if let Some(idx) = self.overload_index(ctx) {
                     if idx > 0 {
-                        write!(&mut name, "{}", idx).unwrap();
+                        write!(&mut name, "{idx}").unwrap();
                     }
                 }
 

--- a/bindgen/ir/objc.rs
+++ b/bindgen/ir/objc.rs
@@ -262,10 +262,7 @@ impl ObjCMethod {
                     // unless it is `crate`, `self`, `super` or `Self`, so we try to add the `_`
                     // suffix to it and parse it.
                     if ["crate", "self", "super", "Self"].contains(&name) {
-                        Some(Ident::new(
-                            &format!("{}_", name),
-                            Span::call_site(),
-                        ))
+                        Some(Ident::new(&format!("{name}_"), Span::call_site()))
                     } else {
                         Some(Ident::new(name, Span::call_site()))
                     }
@@ -278,11 +275,11 @@ impl ObjCMethod {
                     Some(
                         syn::parse_str::<Ident>(name)
                             .or_else(|err| {
-                                syn::parse_str::<Ident>(&format!("r#{}", name))
+                                syn::parse_str::<Ident>(&format!("r#{name}"))
                                     .map_err(|_| err)
                             })
                             .or_else(|err| {
-                                syn::parse_str::<Ident>(&format!("{}_", name))
+                                syn::parse_str::<Ident>(&format!("{name}_"))
                                     .map_err(|_| err)
                             })
                             .expect("Invalid identifier"),
@@ -302,9 +299,7 @@ impl ObjCMethod {
         // Check right amount of arguments
         assert!(
             args.len() == split_name.len() - 1,
-            "Incorrect method name or arguments for objc method, {:?} vs {:?}",
-            args,
-            split_name
+            "Incorrect method name or arguments for objc method, {args:?} vs {split_name:?}"
         );
 
         // Get arguments without type signatures to pass to `msg_send!`

--- a/bindgen/ir/traversal.rs
+++ b/bindgen/ir/traversal.rs
@@ -287,8 +287,7 @@ impl<'ctx> TraversalStorage<'ctx> for Paths<'ctx> {
             }
             path.reverse();
             panic!(
-                "Found reference to dangling id = {:?}\nvia path = {:?}",
-                item, path
+                "Found reference to dangling id = {item:?}\nvia path = {path:?}"
             );
         }
 

--- a/bindgen/ir/ty.rs
+++ b/bindgen/ir/ty.rs
@@ -261,7 +261,7 @@ impl Type {
             TypeKind::Pointer(inner) => Some((inner, Cow::Borrowed("ptr"))),
             TypeKind::Reference(inner) => Some((inner, Cow::Borrowed("ref"))),
             TypeKind::Array(inner, length) => {
-                Some((inner, format!("array{}", length).into()))
+                Some((inner, format!("array{length}").into()))
             }
             _ => None,
         };
@@ -269,7 +269,7 @@ impl Type {
             ctx.resolve_item(inner)
                 .expect_type()
                 .sanitized_name(ctx)
-                .map(|name| format!("{}_{}", prefix, name).into())
+                .map(|name| format!("{prefix}_{name}").into())
         } else {
             self.name().map(Self::sanitize_name)
         }

--- a/bindgen/ir/var.rs
+++ b/bindgen/ir/var.rs
@@ -113,11 +113,7 @@ impl DotAttributes for Var {
         }
 
         if let Some(ref mangled) = self.mangled_name {
-            writeln!(
-                out,
-                "<tr><td>mangled name</td><td>{}</td></tr>",
-                mangled
-            )?;
+            writeln!(out, "<tr><td>mangled name</td><td>{mangled}</td></tr>")?;
         }
 
         Ok(())
@@ -320,8 +316,7 @@ impl ClangSubItemParser for Var {
                             matches!(ty.kind(), CXType_Auto | CXType_Unexposed),
                             "Couldn't resolve constant type, and it \
                              wasn't an nondeductible auto type or unexposed \
-                             type: {:?}",
-                            ty
+                             type: {ty:?}"
                         );
                         return Err(e);
                     }

--- a/bindgen/lib.rs
+++ b/bindgen/lib.rs
@@ -191,7 +191,7 @@ impl FromStr for Formatter {
             "rustfmt" => Ok(Self::Rustfmt),
             #[cfg(feature = "prettyplease")]
             "prettyplease" => Ok(Self::Prettyplease),
-            _ => Err(format!("`{}` is not a valid formatter", s)),
+            _ => Err(format!("`{s}` is not a valid formatter")),
         }
     }
 }
@@ -627,10 +627,10 @@ impl std::fmt::Display for BindgenError {
                 write!(f, "header '{}' does not exist.", h.display())
             }
             BindgenError::ClangDiagnostic(message) => {
-                write!(f, "clang diagnosed error: {}", message)
+                write!(f, "clang diagnosed error: {message}")
             }
             BindgenError::Codegen(err) => {
-                write!(f, "codegen error: {}", err)
+                write!(f, "codegen error: {err}")
             }
         }
     }
@@ -748,7 +748,7 @@ impl Bindings {
         if !explicit_target && !is_host_build {
             options.clang_args.insert(
                 0,
-                format!("--target={}", effective_target).into_boxed_str(),
+                format!("--target={effective_target}").into_boxed_str(),
             );
         };
 
@@ -872,9 +872,7 @@ impl Bindings {
             debug_assert_eq!(
                 context.target_pointer_size(),
                 std::mem::size_of::<*mut ()>(),
-                "{:?} {:?}",
-                effective_target,
-                HOST_TARGET
+                "{effective_target:?} {HOST_TARGET:?}"
             );
         }
 
@@ -928,8 +926,7 @@ impl Bindings {
             }
             Err(err) => {
                 eprintln!(
-                    "Failed to run rustfmt: {} (non-fatal, continuing)",
-                    err
+                    "Failed to run rustfmt: {err} (non-fatal, continuing)"
                 );
                 writer.write_all(self.module.to_string().as_bytes())?;
             }
@@ -1097,7 +1094,7 @@ fn parse(context: &mut BindgenContext) -> Result<(), BindgenError> {
             error.push_str(&msg);
             error.push('\n');
         } else {
-            eprintln!("clang diag: {}", msg);
+            eprintln!("clang diag: {msg}");
         }
     }
 
@@ -1183,7 +1180,7 @@ fn get_target_dependent_env_var(
     var: &str,
 ) -> Option<String> {
     if let Ok(target) = env_var(parse_callbacks, "TARGET") {
-        if let Ok(v) = env_var(parse_callbacks, format!("{}_{}", var, target)) {
+        if let Ok(v) = env_var(parse_callbacks, format!("{var}_{target}")) {
             return Some(v);
         }
         if let Ok(v) = env_var(
@@ -1250,16 +1247,16 @@ impl Default for CargoCallbacks {
 impl callbacks::ParseCallbacks for CargoCallbacks {
     fn header_file(&self, filename: &str) {
         if self.rerun_on_header_files {
-            println!("cargo:rerun-if-changed={}", filename);
+            println!("cargo:rerun-if-changed={filename}");
         }
     }
 
     fn include_file(&self, filename: &str) {
-        println!("cargo:rerun-if-changed={}", filename);
+        println!("cargo:rerun-if-changed={filename}");
     }
 
     fn read_env_var(&self, key: &str) {
-        println!("cargo:rerun-if-env-changed={}", key);
+        println!("cargo:rerun-if-env-changed={key}");
     }
 }
 
@@ -1303,7 +1300,7 @@ fn commandline_flag_unit_test_function() {
     .iter()
     .map(|&x| x.into())
     .collect::<Vec<String>>();
-    println!("{:?}", command_line_flags);
+    println!("{command_line_flags:?}");
 
     assert!(test_cases.iter().all(|x| command_line_flags.contains(x)));
 }

--- a/bindgen/options/cli.rs
+++ b/bindgen/options/cli.rs
@@ -41,7 +41,7 @@ fn parse_codegen_config(
             otherwise => {
                 return Err(Error::raw(
                     ErrorKind::InvalidValue,
-                    format!("Unknown codegen item kind: {}", otherwise),
+                    format!("Unknown codegen item kind: {otherwise}"),
                 ));
             }
         }
@@ -688,7 +688,7 @@ where
             for item in self.regex_set.get_items() {
                 args.extend_from_slice(&[
                     flag.to_owned(),
-                    format!("{}={}", item, derives),
+                    format!("{item}={derives}"),
                 ]);
             }
 
@@ -728,7 +728,7 @@ where
             for item in self.regex_set.get_items() {
                 args.extend_from_slice(&[
                     flag.to_owned(),
-                    format!("{}={}", item, attributes),
+                    format!("{item}={attributes}"),
                 ]);
             }
 

--- a/bindgen/options/mod.rs
+++ b/bindgen/options/mod.rs
@@ -2013,7 +2013,7 @@ options! {
             for (abi, set) in overrides {
                 for item in set.get_items() {
                     args.push("--override-abi".to_owned());
-                    args.push(format!("{}={}", item, abi));
+                    args.push(format!("{item}={abi}"));
                 }
             }
         },

--- a/bindgen/regex_set.rs
+++ b/bindgen/regex_set.rs
@@ -94,7 +94,7 @@ impl RegexSet {
         record_matches: bool,
         _name: Option<&'static str>,
     ) {
-        let items = self.items.iter().map(|item| format!("^({})$", item));
+        let items = self.items.iter().map(|item| format!("^({item})$"));
         self.record_matches = record_matches;
         self.set = match RxSet::new(items) {
             Ok(x) => Some(x),
@@ -189,7 +189,7 @@ fn invalid_regex_warning(
     }
 
     diagnostic.add_annotation(
-        format!("This regular expression was passed via `{}`.", name),
+        format!("This regular expression was passed via `{name}`."),
         Level::Note,
     );
 


### PR DESCRIPTION
Ran this to auto-inline all format args:

```
cargo clippy --workspace --fix --all-targets -- -A clippy::all -W clippy::uninlined_format_args
```