### PR TITLE
Inline more format args, spelink

### DIFF
--- a/bindgen-tests/build.rs
+++ b/bindgen-tests/build.rs
@@ -35,8 +35,7 @@ pub fn main() {
                     .to_lowercase();
                 writeln!(
                     dst,
-                    "test_header!(header_{}, {:?});",
-                    func,
+                    "test_header!(header_{func}, {:?});",
                     entry.path(),
                 )
                 .unwrap();

--- a/bindgen-tests/tests/parse_callbacks/mod.rs
+++ b/bindgen-tests/tests/parse_callbacks/mod.rs
@@ -52,7 +52,7 @@ impl ParseCallbacks for PrefixLinkNameParseCallback {
     ) -> Option<String> {
         self.prefix
             .as_deref()
-            .map(|prefix| format!("{}{}", prefix, item_info.name))
+            .map(|prefix| format!("{prefix}{}", item_info.name))
     }
 }
 

--- a/bindgen-tests/tests/quickchecking/src/lib.rs
+++ b/bindgen-tests/tests/quickchecking/src/lib.rs
@@ -9,7 +9,7 @@
 //! let generate_range: usize = 10; // Determines things like the length of
 //!                                 // arbitrary vectors generated.
 //! let header = fuzzers::HeaderC::arbitrary(&mut Gen::new(generate_range));
-//! println!("{}", header);
+//! println!("{header}");
 //! ```
 #![deny(missing_docs)]
 

--- a/bindgen-tests/tests/tests.rs
+++ b/bindgen-tests/tests/tests.rs
@@ -359,7 +359,7 @@ macro_rules! test_header {
             });
 
             if let Err(err) = result {
-                panic!("{}", err);
+                panic!("{err}");
             }
         }
     };

--- a/bindgen/clang.rs
+++ b/bindgen/clang.rs
@@ -1066,7 +1066,7 @@ impl ClangToken {
             // expressions, so we strip them down here.
             CXToken_Comment => return None,
             _ => {
-                warn!("Found unexpected token kind: {:?}", self);
+                warn!("Found unexpected token kind: {self:?}");
                 return None;
             }
         };
@@ -2090,26 +2090,25 @@ pub(crate) fn ast_dump(c: &Cursor, depth: isize) -> CXChildVisitResult {
         let prefix = prefix.as_ref();
         print_indent(
             depth,
-            format!(" {}kind = {}", prefix, kind_to_str(c.kind())),
+            format!(" {prefix}kind = {}", kind_to_str(c.kind())),
         );
         print_indent(
             depth,
-            format!(" {}spelling = \"{}\"", prefix, c.spelling()),
+            format!(" {prefix}spelling = \"{}\"", c.spelling()),
         );
-        print_indent(depth, format!(" {}location = {}", prefix, c.location()));
+        print_indent(depth, format!(" {prefix}location = {}", c.location()));
         print_indent(
             depth,
-            format!(" {}is-definition? {}", prefix, c.is_definition()),
+            format!(" {prefix}is-definition? {}", c.is_definition()),
         );
         print_indent(
             depth,
-            format!(" {}is-declaration? {}", prefix, c.is_declaration()),
+            format!(" {prefix}is-declaration? {}", c.is_declaration()),
         );
         print_indent(
             depth,
             format!(
-                " {}is-inlined-function? {}",
-                prefix,
+                " {prefix}is-inlined-function? {}",
                 c.is_inlined_function()
             ),
         );
@@ -2118,11 +2117,7 @@ pub(crate) fn ast_dump(c: &Cursor, depth: isize) -> CXChildVisitResult {
         if templ_kind != CXCursor_NoDeclFound {
             print_indent(
                 depth,
-                format!(
-                    " {}template-kind = {}",
-                    prefix,
-                    kind_to_str(templ_kind)
-                ),
+                format!(" {prefix}template-kind = {}", kind_to_str(templ_kind)),
             );
         }
         if let Some(usr) = c.usr() {
@@ -2149,7 +2144,7 @@ pub(crate) fn ast_dump(c: &Cursor, depth: isize) -> CXChildVisitResult {
         if let Some(ty) = c.enum_type() {
             print_indent(
                 depth,
-                format!(" {}enum-type = {}", prefix, type_to_str(ty.kind())),
+                format!(" {prefix}enum-type = {}", type_to_str(ty.kind())),
             );
         }
         if let Some(val) = c.enum_val_signed() {
@@ -2158,13 +2153,13 @@ pub(crate) fn ast_dump(c: &Cursor, depth: isize) -> CXChildVisitResult {
         if let Some(ty) = c.typedef_type() {
             print_indent(
                 depth,
-                format!(" {}typedef-type = {}", prefix, type_to_str(ty.kind())),
+                format!(" {prefix}typedef-type = {}", type_to_str(ty.kind())),
             );
         }
         if let Some(ty) = c.ret_type() {
             print_indent(
                 depth,
-                format!(" {}ret-type = {}", prefix, type_to_str(ty.kind())),
+                format!(" {prefix}ret-type = {}", type_to_str(ty.kind())),
             );
         }
 
@@ -2214,16 +2209,16 @@ pub(crate) fn ast_dump(c: &Cursor, depth: isize) -> CXChildVisitResult {
         let prefix = prefix.as_ref();
 
         let kind = ty.kind();
-        print_indent(depth, format!(" {}kind = {}", prefix, type_to_str(kind)));
+        print_indent(depth, format!(" {prefix}kind = {}", type_to_str(kind)));
         if kind == CXType_Invalid {
             return;
         }
 
-        print_indent(depth, format!(" {}cconv = {}", prefix, ty.call_conv()));
+        print_indent(depth, format!(" {prefix}cconv = {}", ty.call_conv()));
 
         print_indent(
             depth,
-            format!(" {}spelling = \"{}\"", prefix, ty.spelling()),
+            format!(" {prefix}spelling = \"{}\"", ty.spelling()),
         );
         let num_template_args =
             unsafe { clang_Type_getNumTemplateArguments(ty.x) };
@@ -2240,7 +2235,7 @@ pub(crate) fn ast_dump(c: &Cursor, depth: isize) -> CXChildVisitResult {
         }
         print_indent(
             depth,
-            format!(" {}is-variadic? {}", prefix, ty.is_variadic()),
+            format!(" {prefix}is-variadic? {}", ty.is_variadic()),
         );
 
         let canonical = ty.canonical_type();

--- a/bindgen/codegen/bitfield_unit_tests.rs
+++ b/bindgen/codegen/bitfield_unit_tests.rs
@@ -88,8 +88,8 @@ macro_rules! bitfield_unit_get {
                 let actual = unit.get($start, $len);
 
                 println!();
-                println!("expected = {:064b}", expected);
-                println!("actual   = {:064b}", actual);
+                println!("expected = {expected:064b}");
+                println!("actual   = {actual:064b}");
 
                 assert_eq!(expected, actual);
             })*
@@ -191,7 +191,7 @@ macro_rules! bitfield_unit_set {
                 println!();
                 println!("set({}, {}, {:032b}", $start, $len, $val);
                 println!("expected = {:064b}", $expected);
-                println!("actual   = {:064b}", actual);
+                println!("actual   = {actual:064b}");
 
                 assert_eq!($expected, actual);
             )*

--- a/bindgen/codegen/helpers.rs
+++ b/bindgen/codegen/helpers.rs
@@ -355,7 +355,7 @@ pub(crate) mod ast_ty {
             return Ok(tokens);
         }
 
-        warn!("Unknown non-finite float number: {:?}", f);
+        warn!("Unknown non-finite float number: {f:?}");
         Err(())
     }
 

--- a/bindgen/codegen/impl_debug.rs
+++ b/bindgen/codegen/impl_debug.rs
@@ -2,6 +2,7 @@ use crate::ir::comp::{BitfieldUnit, CompKind, Field, FieldData, FieldMethods};
 use crate::ir::context::BindgenContext;
 use crate::ir::item::{HasTypeParamInArray, IsOpaque, Item, ItemCanonicalName};
 use crate::ir::ty::{TypeKind, RUST_DERIVE_IN_ARRAY_LIMIT};
+use std::fmt::Write as _;
 
 pub(crate) fn gen_debug_impl(
     ctx: &BindgenContext,
@@ -96,7 +97,7 @@ impl ImplDebug<'_> for BitfieldUnit {
             }
 
             if let Some(bitfield_name) = bitfield.name() {
-                format_string.push_str(&format!("{bitfield_name} : {{:?}}"));
+                let _ = write!(format_string, "{bitfield_name} : {{:?}}");
                 let getter_name = bitfield.getter_name();
                 let name_ident = ctx.rust_ident_raw(getter_name);
                 tokens.push(quote! {

--- a/bindgen/codegen/mod.rs
+++ b/bindgen/codegen/mod.rs
@@ -503,7 +503,7 @@ impl Item {
             // TODO(emilio, #453): Figure out what to do when this happens
             // legitimately, we could track the opaque stuff and disable the
             // assertion there I guess.
-            warn!("Found non-allowlisted item in code generation: {:?}", self);
+            warn!("Found non-allowlisted item in code generation: {self:?}");
         }
 
         result.set_seen(self.id());
@@ -521,7 +521,7 @@ impl CodeGenerator for Item {
         result: &mut CodegenResult<'_>,
         _extra: &(),
     ) {
-        debug!("<Item as CodeGenerator>::codegen: self = {:?}", self);
+        debug!("<Item as CodeGenerator>::codegen: self = {self:?}");
         if !self.process_before_codegen(ctx, result) {
             return;
         }
@@ -553,7 +553,7 @@ impl CodeGenerator for Module {
         result: &mut CodegenResult<'_>,
         item: &Item,
     ) {
-        debug!("<Module as CodeGenerator>::codegen: item = {:?}", item);
+        debug!("<Module as CodeGenerator>::codegen: item = {item:?}");
 
         let codegen_self = |result: &mut CodegenResult,
                             found_any: &mut bool| {
@@ -652,7 +652,7 @@ impl CodeGenerator for Var {
         item: &Item,
     ) {
         use crate::ir::var::VarType;
-        debug!("<Var as CodeGenerator>::codegen: item = {:?}", item);
+        debug!("<Var as CodeGenerator>::codegen: item = {item:?}");
         debug_assert!(item.is_enabled_for_codegen(ctx));
 
         let canonical_name = item.canonical_name(ctx);
@@ -829,7 +829,7 @@ impl CodeGenerator for Type {
         result: &mut CodegenResult<'_>,
         item: &Item,
     ) {
-        debug!("<Type as CodeGenerator>::codegen: item = {:?}", item);
+        debug!("<Type as CodeGenerator>::codegen: item = {item:?}");
         debug_assert!(item.is_enabled_for_codegen(ctx));
 
         match *self.kind() {
@@ -927,16 +927,14 @@ impl CodeGenerator for Type {
                         assert_eq!(
                             layout.size,
                             ctx.target_pointer_size(),
-                            "Target platform requires `--no-size_t-is-usize`. The size of `{}` ({}) does not match the target pointer size ({})",
-                            spelling,
+                            "Target platform requires `--no-size_t-is-usize`. The size of `{spelling}` ({}) does not match the target pointer size ({})",
                             layout.size,
                             ctx.target_pointer_size(),
                             );
                         assert_eq!(
                             layout.align,
                             ctx.target_pointer_size(),
-                            "Target platform requires `--no-size_t-is-usize`. The alignment of `{}` ({}) does not match the target pointer size ({})",
-                            spelling,
+                            "Target platform requires `--no-size_t-is-usize`. The alignment of `{spelling}` ({}) does not match the target pointer size ({})",
                             layout.align,
                             ctx.target_pointer_size(),
                         );
@@ -1146,7 +1144,7 @@ impl CodeGenerator for Type {
                 interface.codegen(ctx, result, item)
             }
             ref u @ TypeKind::UnresolvedTypeRef(..) => {
-                unreachable!("Should have been resolved after parsing {:?}!", u)
+                unreachable!("Should have been resolved after parsing {u:?}!")
             }
         }
     }
@@ -2097,7 +2095,7 @@ impl CodeGenerator for CompInfo {
         result: &mut CodegenResult<'_>,
         item: &Item,
     ) {
-        debug!("<CompInfo as CodeGenerator>::codegen: item = {:?}", item);
+        debug!("<CompInfo as CodeGenerator>::codegen: item = {item:?}");
         debug_assert!(item.is_enabled_for_codegen(ctx));
 
         // Don't output classes with template parameters that aren't types, and
@@ -2531,10 +2529,7 @@ impl CodeGenerator for CompInfo {
         // affect layout, so we're bad and pray to the gods for avoid sending
         // all the tests to shit when parsing things like max_align_t.
         if self.found_unknown_attr() {
-            warn!(
-                "Type {} has an unknown attribute that may affect layout",
-                canonical_ident
-            );
+            warn!("Type {canonical_ident} has an unknown attribute that may affect layout");
         }
 
         if all_template_params.is_empty() {
@@ -3544,7 +3539,7 @@ impl CodeGenerator for Enum {
         result: &mut CodegenResult<'_>,
         item: &Item,
     ) {
-        debug!("<Enum as CodeGenerator>::codegen: item = {:?}", item);
+        debug!("<Enum as CodeGenerator>::codegen: item = {item:?}");
         debug_assert!(item.is_enabled_for_codegen(ctx));
 
         let name = item.canonical_name(ctx);
@@ -3600,8 +3595,7 @@ impl CodeGenerator for Enum {
                     (false, 8) => IntKind::U64,
                     _ => {
                         warn!(
-                            "invalid enum decl: signed: {}, size: {}",
-                            signed, size
+                            "invalid enum decl: signed: {signed}, size: {size}"
                         );
                         IntKind::I32
                     }
@@ -4355,7 +4349,7 @@ impl TryToRustTy for Type {
                 Ok(syn::parse_quote! { #name })
             }
             ref u @ TypeKind::UnresolvedTypeRef(..) => {
-                unreachable!("Should have been resolved after parsing {:?}!", u)
+                unreachable!("Should have been resolved after parsing {u:?}!")
             }
         }
     }
@@ -4487,7 +4481,7 @@ impl CodeGenerator for Function {
         result: &mut CodegenResult<'_>,
         item: &Item,
     ) -> Self::Return {
-        debug!("<Function as CodeGenerator>::codegen: item = {:?}", item);
+        debug!("<Function as CodeGenerator>::codegen: item = {item:?}");
         debug_assert!(item.is_enabled_for_codegen(ctx));
 
         let is_internal = matches!(self.linkage(), Linkage::Internal);
@@ -4718,10 +4712,8 @@ fn unsupported_abi_diagnostic(
     error: &error::Error,
 ) {
     warn!(
-        "Skipping {}function `{}` because the {}",
+        "Skipping {}function `{fn_name}` because the {error}",
         if variadic { "variadic " } else { "" },
-        fn_name,
-        error
     );
 
     #[cfg(feature = "experimental")]
@@ -4731,10 +4723,8 @@ fn unsupported_abi_diagnostic(
         let mut diag = Diagnostic::default();
         diag.with_title(
             format!(
-                "Skipping {}function `{}` because the {}",
+                "Skipping {}function `{fn_name}` because the {error}",
                 if variadic { "variadic " } else { "" },
-                fn_name,
-                error
             ),
             Level::Warning,
         )
@@ -4774,8 +4764,7 @@ fn variadic_fn_diagnostic(
     _ctx: &BindgenContext,
 ) {
     warn!(
-        "Cannot generate wrapper for the static variadic function `{}`.",
-        fn_name,
+        "Cannot generate wrapper for the static variadic function `{fn_name}`."
     );
 
     #[cfg(feature = "experimental")]
@@ -4817,7 +4806,7 @@ fn objc_method_codegen(
     // This would ideally resolve the method into an Item, and use
     // Item::process_before_codegen; however, ObjC methods are not currently
     // made into function items.
-    let name = format!("{}::{}{}", rust_class_name, prefix, method.rust_name());
+    let name = format!("{rust_class_name}::{prefix}{}", method.rust_name());
     if ctx.options().blocklisted_items.matches(name) {
         return;
     }
@@ -4854,8 +4843,7 @@ fn objc_method_codegen(
         ctx.wrap_unsafe_ops(body)
     };
 
-    let method_name =
-        ctx.rust_ident(format!("{}{}", prefix, method.rust_name()));
+    let method_name = ctx.rust_ident(format!("{prefix}{}", method.rust_name()));
 
     methods.push(quote! {
         unsafe fn #method_name #sig where <Self as std::ops::Deref>::Target: objc::Message + Sized {
@@ -5095,10 +5083,9 @@ pub(crate) fn codegen(
         if let Some(path) = context.options().emit_ir_graphviz.as_ref() {
             match dot::write_dot_file(context, path) {
                 Ok(()) => info!(
-                    "Your dot file was generated successfully into: {}",
-                    path
+                    "Your dot file was generated successfully into: {path}"
                 ),
-                Err(e) => warn!("{}", e),
+                Err(e) => warn!("{e}"),
             }
         }
 
@@ -5108,7 +5095,7 @@ pub(crate) fn codegen(
                     "Your depfile was generated successfully into: {}",
                     spec.depfile_path.display()
                 ),
-                Err(e) => warn!("{}", e),
+                Err(e) => warn!("{e}"),
             }
         }
 

--- a/bindgen/codegen/serialize.rs
+++ b/bindgen/codegen/serialize.rs
@@ -114,7 +114,7 @@ impl<'a> CSerialize<'a> for Function {
         };
 
         // The name used for the wrapper self.
-        let wrap_name = format!("{}{}", name, ctx.wrap_static_fns_suffix());
+        let wrap_name = format!("{name}{}", ctx.wrap_static_fns_suffix());
 
         // The function's return type
         let (ret_item, ret_ty) = {

--- a/bindgen/codegen/struct_layout.rs
+++ b/bindgen/codegen/struct_layout.rs
@@ -148,7 +148,7 @@ impl<'a> StructLayoutTracker<'a> {
     }
 
     pub(crate) fn saw_bitfield_unit(&mut self, layout: Layout) {
-        debug!("saw bitfield unit for {}: {:?}", self.name, layout);
+        debug!("saw bitfield unit for {}: {layout:?}", self.name);
 
         self.align_to_latest_field(layout);
 
@@ -248,12 +248,9 @@ impl<'a> StructLayoutTracker<'a> {
             );
 
             debug!(
-                "align field {} to {}/{} with {} padding bytes {:?}",
-                field_name,
+                "align field {field_name} to {}/{} with {padding_bytes} padding bytes {field_layout:?}",
                 self.latest_offset,
                 field_offset.unwrap_or(0) / 8,
-                padding_bytes,
-                field_layout
             );
 
             let padding_align = if force_padding {
@@ -276,8 +273,7 @@ impl<'a> StructLayoutTracker<'a> {
         self.last_field_was_bitfield = false;
 
         debug!(
-            "Offset: {}: {} -> {}",
-            field_name,
+            "Offset: {field_name}: {} -> {}",
             self.latest_offset - field_layout.size,
             self.latest_offset
         );
@@ -312,8 +308,7 @@ impl<'a> StructLayoutTracker<'a> {
         }
 
         trace!(
-            "need a tail padding field for {}: offset {} -> size {}",
-            comp_name,
+            "need a tail padding field for {comp_name}: offset {} -> size {}",
             self.latest_offset,
             comp_layout.size
         );
@@ -325,10 +320,7 @@ impl<'a> StructLayoutTracker<'a> {
         &mut self,
         layout: Layout,
     ) -> Option<proc_macro2::TokenStream> {
-        debug!(
-            "pad_struct:\n\tself = {:#?}\n\tlayout = {:#?}",
-            self, layout
-        );
+        debug!("pad_struct:\n\tself = {self:#?}\n\tlayout = {layout:#?}");
 
         if layout.size < self.latest_offset {
             warn!(
@@ -368,7 +360,7 @@ impl<'a> StructLayoutTracker<'a> {
                 Layout::new(padding_bytes, layout.align)
             };
 
-            debug!("pad bytes to struct {}, {:?}", self.name, layout);
+            debug!("pad bytes to struct {}, {layout:?}", self.name);
 
             Some(self.padding_field(layout))
         } else {
@@ -437,8 +429,8 @@ impl<'a> StructLayoutTracker<'a> {
         // If it was, we may or may not need to align, depending on what the
         // current field alignment and the bitfield size and alignment are.
         debug!(
-            "align_to_bitfield? {}: {:?} {:?}",
-            self.last_field_was_bitfield, layout, new_field_layout
+            "align_to_bitfield? {}: {layout:?} {new_field_layout:?}",
+            self.last_field_was_bitfield,
         );
 
         // Avoid divide-by-zero errors if align is 0.

--- a/bindgen/deps.rs
+++ b/bindgen/deps.rs
@@ -18,7 +18,7 @@ impl DepfileSpec {
 
         let mut buf = format!("{}:", escape(&self.output_module));
         for file in deps {
-            buf = format!("{} {}", buf, escape(file));
+            buf = format!("{buf} {}", escape(file));
         }
         buf
     }

--- a/bindgen/ir/analysis/derive.rs
+++ b/bindgen/ir/analysis/derive.rs
@@ -112,10 +112,8 @@ impl CannotDerive<'_> {
     ) -> ConstrainResult {
         let id = id.into();
         trace!(
-            "inserting {:?} can_derive<{}>={:?}",
-            id,
+            "inserting {id:?} can_derive<{}>={can_derive:?}",
             self.derive_trait,
-            can_derive
         );
 
         if let CanDerive::Yes = can_derive {
@@ -168,7 +166,7 @@ impl CannotDerive<'_> {
             return CanDerive::No;
         }
 
-        trace!("ty: {:?}", ty);
+        trace!("ty: {ty:?}");
         if item.is_opaque(self.ctx, &()) {
             if !self.derive_trait.can_derive_union() &&
                 ty.is_union() &&
@@ -432,9 +430,9 @@ impl CannotDerive<'_> {
                     .unwrap_or_default();
 
                 match can_derive {
-                    CanDerive::Yes => trace!("    member {:?} can derive {}", sub_id, self.derive_trait),
-                    CanDerive::Manually => trace!("    member {:?} cannot derive {}, but it may be implemented", sub_id, self.derive_trait),
-                    CanDerive::No => trace!("    member {:?} cannot derive {}", sub_id, self.derive_trait),
+                    CanDerive::Yes => trace!("    member {sub_id:?} can derive {}", self.derive_trait),
+                    CanDerive::Manually => trace!("    member {sub_id:?} cannot derive {}, but it may be implemented", self.derive_trait),
+                    CanDerive::No => trace!("    member {sub_id:?} cannot derive {}", self.derive_trait),
                 }
 
                 *candidate.get_or_insert(CanDerive::Yes) |= can_derive;
@@ -527,15 +525,15 @@ impl DeriveTrait {
     fn can_derive_fnptr(&self, f: &FunctionSig) -> CanDerive {
         match (self, f.function_pointers_can_derive()) {
             (DeriveTrait::Copy, _) | (DeriveTrait::Default, _) | (_, true) => {
-                trace!("    function pointer can derive {}", self);
+                trace!("    function pointer can derive {self}");
                 CanDerive::Yes
             }
             (DeriveTrait::Debug, false) => {
-                trace!("    function pointer cannot derive {}, but it may be implemented", self);
+                trace!("    function pointer cannot derive {self}, but it may be implemented");
                 CanDerive::Manually
             }
             (_, false) => {
-                trace!("    function pointer cannot derive {}", self);
+                trace!("    function pointer cannot derive {self}");
                 CanDerive::No
             }
         }
@@ -551,7 +549,7 @@ impl DeriveTrait {
                 CanDerive::No
             }
             _ => {
-                trace!("    vector can derive {}", self);
+                trace!("    vector can derive {self}");
                 CanDerive::Yes
             }
         }
@@ -564,7 +562,7 @@ impl DeriveTrait {
                 CanDerive::No
             }
             _ => {
-                trace!("    pointer can derive {}", self);
+                trace!("    pointer can derive {self}");
                 CanDerive::Yes
             }
         }
@@ -597,7 +595,7 @@ impl DeriveTrait {
             }
             // === others ===
             _ => {
-                trace!("    simple type that can always derive {}", self);
+                trace!("    simple type that can always derive {self}");
                 CanDerive::Yes
             }
         }
@@ -658,7 +656,7 @@ impl<'ctx> MonotoneFramework for CannotDerive<'ctx> {
     }
 
     fn constrain(&mut self, id: ItemId) -> ConstrainResult {
-        trace!("constrain: {:?}", id);
+        trace!("constrain: {id:?}");
 
         if let Some(CanDerive::No) = self.can_derive.get(&id).cloned() {
             trace!("    already know it cannot derive {}", self.derive_trait);
@@ -697,7 +695,7 @@ impl<'ctx> MonotoneFramework for CannotDerive<'ctx> {
     {
         if let Some(edges) = self.dependencies.get(&id) {
             for item in edges {
-                trace!("enqueue {:?} into worklist", item);
+                trace!("enqueue {item:?} into worklist");
                 f(*item);
             }
         }

--- a/bindgen/ir/analysis/has_destructor.rs
+++ b/bindgen/ir/analysis/has_destructor.rs
@@ -161,7 +161,7 @@ impl<'ctx> MonotoneFramework for HasDestructorAnalysis<'ctx> {
     {
         if let Some(edges) = self.dependencies.get(&id) {
             for item in edges {
-                trace!("enqueue {:?} into worklist", item);
+                trace!("enqueue {item:?} into worklist");
                 f(*item);
             }
         }

--- a/bindgen/ir/analysis/has_float.rs
+++ b/bindgen/ir/analysis/has_float.rs
@@ -63,7 +63,7 @@ impl HasFloat<'_> {
 
     fn insert<Id: Into<ItemId>>(&mut self, id: Id) -> ConstrainResult {
         let id = id.into();
-        trace!("inserting {:?} into the has_float set", id);
+        trace!("inserting {id:?} into the has_float set");
 
         let was_not_already_in_set = self.has_float.insert(id);
         assert!(
@@ -97,7 +97,7 @@ impl<'ctx> MonotoneFramework for HasFloat<'ctx> {
     }
 
     fn constrain(&mut self, id: ItemId) -> ConstrainResult {
-        trace!("constrain: {:?}", id);
+        trace!("constrain: {id:?}");
 
         if self.has_float.contains(&id) {
             trace!("    already know it do not have float");
@@ -209,7 +209,7 @@ impl<'ctx> MonotoneFramework for HasFloat<'ctx> {
                 if args_have {
                     trace!(
                         "    template args have float, so \
-                         insantiation also has float"
+                         instantiation also has float"
                     );
                     return self.insert(id);
                 }
@@ -220,7 +220,7 @@ impl<'ctx> MonotoneFramework for HasFloat<'ctx> {
                 if def_has {
                     trace!(
                         "    template definition has float, so \
-                         insantiation also has"
+                         instantiation also has"
                     );
                     return self.insert(id);
                 }
@@ -237,7 +237,7 @@ impl<'ctx> MonotoneFramework for HasFloat<'ctx> {
     {
         if let Some(edges) = self.dependencies.get(&id) {
             for item in edges {
-                trace!("enqueue {:?} into worklist", item);
+                trace!("enqueue {item:?} into worklist");
                 f(*item);
             }
         }

--- a/bindgen/ir/analysis/has_type_param_in_array.rs
+++ b/bindgen/ir/analysis/has_type_param_in_array.rs
@@ -65,10 +65,7 @@ impl HasTypeParameterInArray<'_> {
 
     fn insert<Id: Into<ItemId>>(&mut self, id: Id) -> ConstrainResult {
         let id = id.into();
-        trace!(
-            "inserting {:?} into the has_type_parameter_in_array set",
-            id
-        );
+        trace!("inserting {id:?} into the has_type_parameter_in_array set");
 
         let was_not_already_in_set =
             self.has_type_parameter_in_array.insert(id);
@@ -103,7 +100,7 @@ impl<'ctx> MonotoneFramework for HasTypeParameterInArray<'ctx> {
     }
 
     fn constrain(&mut self, id: ItemId) -> ConstrainResult {
-        trace!("constrain: {:?}", id);
+        trace!("constrain: {id:?}");
 
         if self.has_type_parameter_in_array.contains(&id) {
             trace!("    already know it do not have array");
@@ -209,7 +206,7 @@ impl<'ctx> MonotoneFramework for HasTypeParameterInArray<'ctx> {
                 if args_have {
                     trace!(
                         "    template args have array, so \
-                         insantiation also has array"
+                         instantiation also has array"
                     );
                     return self.insert(id);
                 }
@@ -220,7 +217,7 @@ impl<'ctx> MonotoneFramework for HasTypeParameterInArray<'ctx> {
                 if def_has {
                     trace!(
                         "    template definition has array, so \
-                         insantiation also has"
+                         instantiation also has"
                     );
                     return self.insert(id);
                 }
@@ -237,7 +234,7 @@ impl<'ctx> MonotoneFramework for HasTypeParameterInArray<'ctx> {
     {
         if let Some(edges) = self.dependencies.get(&id) {
             for item in edges {
-                trace!("enqueue {:?} into worklist", item);
+                trace!("enqueue {item:?} into worklist");
                 f(*item);
             }
         }

--- a/bindgen/ir/analysis/has_vtable.rs
+++ b/bindgen/ir/analysis/has_vtable.rs
@@ -146,7 +146,7 @@ impl<'ctx> MonotoneFramework for HasVtableAnalysis<'ctx> {
     }
 
     fn constrain(&mut self, id: ItemId) -> ConstrainResult {
-        trace!("constrain {:?}", id);
+        trace!("constrain {id:?}");
 
         let item = self.ctx.resolve_item(id);
         let ty = match item.as_type() {
@@ -176,7 +176,7 @@ impl<'ctx> MonotoneFramework for HasVtableAnalysis<'ctx> {
                 }
 
                 let bases_has_vtable = info.base_members().iter().any(|base| {
-                    trace!("    comp has a base with a vtable: {:?}", base);
+                    trace!("    comp has a base with a vtable: {base:?}");
                     self.have_vtable.contains_key(&base.ty.into())
                 });
                 if bases_has_vtable {
@@ -200,7 +200,7 @@ impl<'ctx> MonotoneFramework for HasVtableAnalysis<'ctx> {
     {
         if let Some(edges) = self.dependencies.get(&id) {
             for item in edges {
-                trace!("enqueue {:?} into worklist", item);
+                trace!("enqueue {item:?} into worklist");
                 f(*item);
             }
         }

--- a/bindgen/ir/analysis/sizedness.rs
+++ b/bindgen/ir/analysis/sizedness.rs
@@ -127,7 +127,7 @@ impl SizednessAnalysis<'_> {
         id: TypeId,
         result: SizednessResult,
     ) -> ConstrainResult {
-        trace!("inserting {:?} for {:?}", result, id);
+        trace!("inserting {result:?} for {id:?}");
 
         if let SizednessResult::ZeroSized = result {
             return ConstrainResult::Same;
@@ -197,7 +197,7 @@ impl<'ctx> MonotoneFramework for SizednessAnalysis<'ctx> {
     }
 
     fn constrain(&mut self, id: TypeId) -> ConstrainResult {
-        trace!("constrain {:?}", id);
+        trace!("constrain {id:?}");
 
         if let Some(SizednessResult::NonZeroSized) =
             self.sized.get(&id).cloned()
@@ -322,7 +322,7 @@ impl<'ctx> MonotoneFramework for SizednessAnalysis<'ctx> {
     {
         if let Some(edges) = self.dependencies.get(&id) {
             for ty in edges {
-                trace!("enqueue {:?} into worklist", ty);
+                trace!("enqueue {ty:?} into worklist");
                 f(*ty);
             }
         }

--- a/bindgen/ir/analysis/template_params.rs
+++ b/bindgen/ir/analysis/template_params.rs
@@ -291,10 +291,8 @@ impl UsedTemplateParameters<'_> {
 
         for (arg, param) in args.iter().zip(params.iter()) {
             trace!(
-                "      instantiation's argument {:?} is used if definition's \
-                 parameter {:?} is used",
-                arg,
-                param
+                "      instantiation's argument {arg:?} is used if definition's \
+                 parameter {param:?} is used",
             );
 
             if used_by_def.contains(&param.into()) {
@@ -359,8 +357,7 @@ impl UsedTemplateParameters<'_> {
                     .cloned();
 
                 trace!(
-                    "      union with {:?}'s usage: {:?}",
-                    sub_id,
+                    "      union with {sub_id:?}'s usage: {:?}",
                     used_by_sub_id.clone().collect::<Vec<_>>()
                 );
 
@@ -524,8 +521,8 @@ impl<'ctx> MonotoneFramework for UsedTemplateParameters<'ctx> {
         // an analog to slice::split_at_mut.
         let mut used_by_this_id = self.take_this_id_usage_set(id);
 
-        trace!("constrain {:?}", id);
-        trace!("  initially, used set is {:?}", used_by_this_id);
+        trace!("constrain {id:?}");
+        trace!("  initially, used set is {used_by_this_id:?}");
 
         let original_len = used_by_this_id.len();
 
@@ -562,7 +559,7 @@ impl<'ctx> MonotoneFramework for UsedTemplateParameters<'ctx> {
             _ => self.constrain_join(&mut used_by_this_id, item),
         }
 
-        trace!("  finally, used set is {:?}", used_by_this_id);
+        trace!("  finally, used set is {used_by_this_id:?}");
 
         let new_len = used_by_this_id.len();
         assert!(
@@ -589,7 +586,7 @@ impl<'ctx> MonotoneFramework for UsedTemplateParameters<'ctx> {
     {
         if let Some(edges) = self.dependencies.get(&item) {
             for item in edges {
-                trace!("enqueue {:?} into worklist", item);
+                trace!("enqueue {item:?} into worklist");
                 f(*item);
             }
         }

--- a/bindgen/ir/comp.rs
+++ b/bindgen/ir/comp.rs
@@ -803,9 +803,8 @@ impl CompFields {
 
                     anon_field_counter += 1;
                     *name = Some(format!(
-                        "{}{}",
+                        "{}{anon_field_counter}",
                         ctx.options().anon_fields_prefix,
-                        anon_field_counter
                     ));
                 }
                 Field::Bitfields(ref mut bu) => {
@@ -1278,7 +1277,7 @@ impl CompInfo {
 
         let kind = kind?;
 
-        debug!("CompInfo::from_ty({:?}, {:?})", kind, cursor);
+        debug!("CompInfo::from_ty({kind:?}, {cursor:?})");
 
         let mut ci = CompInfo::new(kind);
         ci.is_forward_declaration =
@@ -1614,7 +1613,7 @@ impl CompInfo {
                 _ => CompKind::Struct,
             },
             _ => {
-                warn!("Unknown kind for comp type: {:?}", cursor);
+                warn!("Unknown kind for comp type: {cursor:?}");
                 return Err(ParseError::Continue);
             }
         })

--- a/bindgen/ir/context.rs
+++ b/bindgen/ir/context.rs
@@ -698,10 +698,7 @@ If you encounter an error missing from this list, please file an issue or a PR!"
         declaration: Option<Cursor>,
         location: Option<Cursor>,
     ) {
-        debug!(
-            "BindgenContext::add_item({:?}, declaration: {:?}, loc: {:?}",
-            item, declaration, location
-        );
+        debug!("BindgenContext::add_item({item:?}, declaration: {declaration:?}, loc: {location:?}");
         debug_assert!(
             declaration.is_some() ||
                 !item.kind().is_type() ||
@@ -753,8 +750,7 @@ If you encounter an error missing from this list, please file an issue or a PR!"
                 // Fortunately, we don't care about those types being
                 // duplicated, so we can just ignore them.
                 debug!(
-                    "Invalid declaration {:?} found for type {:?}",
-                    declaration,
+                    "Invalid declaration {declaration:?} found for type {:?}",
                     self.resolve_item_fallible(id)
                         .unwrap()
                         .kind()
@@ -768,10 +764,7 @@ If you encounter an error missing from this list, please file an issue or a PR!"
             } else if let Some(usr) = declaration.usr() {
                 TypeKey::Usr(usr)
             } else {
-                warn!(
-                    "Valid declaration with no USR: {:?}, {:?}",
-                    declaration, location
-                );
+                warn!("Valid declaration with no USR: {declaration:?}, {location:?}");
                 TypeKey::Declaration(declaration)
             };
 
@@ -822,10 +815,7 @@ If you encounter an error missing from this list, please file an issue or a PR!"
         item: Item,
         definition: clang::Cursor,
     ) {
-        debug!(
-            "BindgenContext::add_type_param: item = {:?}; definition = {:?}",
-            item, definition
-        );
+        debug!("BindgenContext::add_type_param: item = {item:?}; definition = {definition:?}");
 
         assert!(
             item.expect_type().is_type_param(),
@@ -1111,7 +1101,7 @@ If you encounter an error missing from this list, please file an issue or a PR!"
         }
 
         for (id, replacement_id) in replacements {
-            debug!("Replacing {:?} with {:?}", id, replacement_id);
+            debug!("Replacing {id:?} with {replacement_id:?}");
             let new_parent = {
                 let item_id: ItemId = id.into();
                 let item = self.items[item_id.0].as_mut().unwrap();
@@ -1283,10 +1273,7 @@ If you encounter an error missing from this list, please file an issue or a PR!"
                         id.ancestors(self)
                             .chain(Some(self.root_module.into()))
                             .any(|ancestor| {
-                                debug!(
-                                    "Checking if {:?} is a child of {:?}",
-                                    id, ancestor
-                                );
+                                debug!("Checking if {id:?} is a child of {ancestor:?}");
                                 self.resolve_item(ancestor)
                                     .as_module()
                                     .is_some_and(|m| m.children().contains(&id))
@@ -1452,7 +1439,7 @@ If you encounter an error missing from this list, please file an issue or a PR!"
     // If at some point we care about the memory here, probably a map TypeKind
     // -> builtin type ItemId would be the best to improve that.
     fn add_builtin_item(&mut self, item: Item) {
-        debug!("add_builtin_item: item = {:?}", item);
+        debug!("add_builtin_item: item = {item:?}");
         debug_assert!(item.kind().is_type());
         self.add_item_to_module(&item);
         let id = item.id();
@@ -1789,8 +1776,7 @@ If you encounter an error missing from this list, please file an issue or a PR!"
                 }
                 _ => {
                     warn!(
-                        "Found template arg cursor we can't handle: {:?}",
-                        child
+                        "Found template arg cursor we can't handle: {child:?}"
                     );
                     found_const_arg = true;
                 }
@@ -1841,7 +1827,7 @@ If you encounter an error missing from this list, please file an issue or a PR!"
         );
 
         // Bypass all the validations in add_item explicitly.
-        debug!("instantiate_template: inserting item: {:?}", item);
+        debug!("instantiate_template: inserting item: {item:?}");
         self.add_item_to_module(&item);
         debug_assert_eq!(with_id, item.id());
         self.items[with_id.0] = Some(item);
@@ -1874,16 +1860,12 @@ If you encounter an error missing from this list, please file an issue or a PR!"
         location: Option<clang::Cursor>,
     ) -> Option<TypeId> {
         use clang_sys::{CXCursor_TypeAliasTemplateDecl, CXCursor_TypeRef};
-        debug!(
-            "builtin_or_resolved_ty: {:?}, {:?}, {:?}, {:?}",
-            ty, location, with_id, parent_id
-        );
+        debug!("builtin_or_resolved_ty: {ty:?}, {location:?}, {with_id:?}, {parent_id:?}");
 
         if let Some(decl) = ty.canonical_declaration(location.as_ref()) {
             if let Some(id) = self.get_resolved_type(&decl) {
                 debug!(
-                    "Already resolved ty {:?}, {:?}, {:?} {:?}",
-                    id, decl, ty, location
+                    "Already resolved ty {id:?}, {decl:?}, {ty:?} {location:?}"
                 );
                 // If the declaration already exists, then either:
                 //
@@ -2204,19 +2186,14 @@ If you encounter an error missing from this list, please file an issue or a PR!"
     pub(crate) fn replace(&mut self, name: &[String], potential_ty: ItemId) {
         match self.replacements.entry(name.into()) {
             Entry::Vacant(entry) => {
-                debug!(
-                    "Defining replacement for {:?} as {:?}",
-                    name, potential_ty
-                );
+                debug!("Defining replacement for {name:?} as {potential_ty:?}");
                 entry.insert(potential_ty);
             }
             Entry::Occupied(occupied) => {
                 warn!(
-                    "Replacement for {:?} already defined as {:?}; \
-                     ignoring duplicate replacement definition as {:?}",
-                    name,
+                    "Replacement for {name:?} already defined as {:?}; \
+                     ignoring duplicate replacement definition as {potential_ty:?}",
                     occupied.get(),
-                    potential_ty
                 );
             }
         }
@@ -2313,10 +2290,8 @@ If you encounter an error missing from this list, please file an issue or a PR!"
                         //
                         // See also https://github.com/rust-lang/rust-bindgen/issues/1676.
                         warn!(
-                            "Ignored unknown namespace prefix '{}' at {:?} in {:?}",
+                            "Ignored unknown namespace prefix '{}' at {token:?} in {cursor:?}",
                             String::from_utf8_lossy(name),
-                            token,
-                            cursor
                         );
                     }
                 }
@@ -2496,7 +2471,7 @@ If you encounter an error missing from this list, please file an issue or a PR!"
                     }
 
                     let name = item.path_for_allowlisting(self)[1..].join("::");
-                    debug!("allowlisted_items: testing {:?}", name);
+                    debug!("allowlisted_items: testing {name:?}");
 
                     if self.options().allowlisted_items.matches(&name) {
                         return true;
@@ -3134,7 +3109,7 @@ impl TemplateParameters for PartialType {
 }
 
 fn unused_regex_diagnostic(item: &str, name: &str, _ctx: &BindgenContext) {
-    warn!("unused option: {} {}", name, item);
+    warn!("unused option: {name} {item}");
 
     #[cfg(feature = "experimental")]
     if _ctx.options().emit_diagnostics {

--- a/bindgen/ir/dot.rs
+++ b/bindgen/ir/dot.rs
@@ -52,10 +52,9 @@ where
 
                 match writeln!(
                     &mut dot_file,
-                    "{} -> {} [label={:?}, color={}];",
+                    "{} -> {} [label={edge_kind:?}, color={}];",
                     id.as_usize(),
                     sub_id.as_usize(),
-                    edge_kind,
                     if is_allowlisted { "black" } else { "gray" }
                 ) {
                     Ok(_) => {}

--- a/bindgen/ir/enum_ty.rs
+++ b/bindgen/ir/enum_ty.rs
@@ -59,7 +59,7 @@ impl Enum {
         ctx: &mut BindgenContext,
     ) -> Result<Self, ParseError> {
         use clang_sys::*;
-        debug!("Enum::from_ty {:?}", ty);
+        debug!("Enum::from_ty {ty:?}");
 
         if ty.kind() != CXType_Enum {
             return Err(ParseError::Continue);

--- a/bindgen/ir/function.rs
+++ b/bindgen/ir/function.rs
@@ -418,7 +418,7 @@ impl FunctionSig {
         ctx: &mut BindgenContext,
     ) -> Result<Self, ParseError> {
         use clang_sys::*;
-        debug!("FunctionSig::from_ty {:?} {:?}", ty, cursor);
+        debug!("FunctionSig::from_ty {ty:?} {cursor:?}");
 
         // Skip function templates
         let kind = cursor.kind();
@@ -596,7 +596,7 @@ impl FunctionSig {
         let abi = get_abi(call_conv);
 
         if abi.is_unknown() {
-            warn!("Unknown calling convention: {:?}", call_conv);
+            warn!("Unknown calling convention: {call_conv:?}");
         }
 
         Ok(Self {
@@ -726,7 +726,7 @@ impl ClangSubItemParser for Function {
             Some(k) => k,
         };
 
-        debug!("Function::parse({:?}, {:?})", cursor, cursor.cur_type());
+        debug!("Function::parse({cursor:?}, {:?})", cursor.cur_type());
         let visibility = cursor.visibility();
         if visibility != CXVisibility_Default {
             return Err(ParseError::Continue);

--- a/bindgen/ir/item.rs
+++ b/bindgen/ir/item.rs
@@ -1420,11 +1420,7 @@ impl Item {
             CXCursor_UsingDirective |
             CXCursor_StaticAssert |
             CXCursor_FunctionTemplate => {
-                debug!(
-                    "Unhandled cursor kind {:?}: {:?}",
-                    cursor.kind(),
-                    cursor
-                );
+                debug!("Unhandled cursor kind {:?}: {cursor:?}", cursor.kind(),);
                 Err(ParseError::Continue)
             }
 
@@ -1432,7 +1428,7 @@ impl Item {
                 let file = cursor.get_included_file_name();
                 match file {
                     None => {
-                        warn!("Inclusion of a nameless file in {:?}", cursor);
+                        warn!("Inclusion of a nameless file in {cursor:?}");
                     }
                     Some(included_file) => {
                         for cb in &ctx.options().parse_callbacks {
@@ -1450,9 +1446,8 @@ impl Item {
                 let spelling = cursor.spelling();
                 if !spelling.starts_with("operator") {
                     warn!(
-                        "Unhandled cursor kind {:?}: {:?}",
+                        "Unhandled cursor kind {:?}: {cursor:?}",
                         cursor.kind(),
-                        cursor
                     );
                 }
                 Err(ParseError::Continue)
@@ -1489,10 +1484,7 @@ impl Item {
         parent_id: Option<ItemId>,
         ctx: &mut BindgenContext,
     ) -> TypeId {
-        debug!(
-            "from_ty_or_ref_with_id: {:?} {:?}, {:?}, {:?}",
-            potential_id, ty, location, parent_id
-        );
+        debug!("from_ty_or_ref_with_id: {potential_id:?} {ty:?}, {location:?}, {parent_id:?}");
 
         if ctx.collected_typerefs() {
             debug!("refs already collected, resolving directly");
@@ -1512,11 +1504,11 @@ impl Item {
             &ty,
             Some(location),
         ) {
-            debug!("{:?} already resolved: {:?}", ty, location);
+            debug!("{ty:?} already resolved: {location:?}");
             return ty;
         }
 
-        debug!("New unresolved type reference: {:?}, {:?}", ty, location);
+        debug!("New unresolved type reference: {ty:?}, {location:?}");
 
         let is_const = ty.is_const();
         let kind = TypeKind::UnresolvedTypeRef(ty, location, parent_id);
@@ -1566,10 +1558,9 @@ impl Item {
         use clang_sys::*;
 
         debug!(
-            "Item::from_ty_with_id: {:?}\n\
-             \tty = {:?},\n\
-             \tlocation = {:?}",
-            id, ty, location
+            "Item::from_ty_with_id: {id:?}\n\
+             \tty = {ty:?},\n\
+             \tlocation = {location:?}",
         );
 
         if ty.kind() == clang_sys::CXType_Unexposed ||
@@ -1593,7 +1584,7 @@ impl Item {
         // ignore function bodies. See issue #2036.)
         if let Some(ref parent) = ty.declaration().fallible_semantic_parent() {
             if FunctionKind::from_cursor(parent).is_some() {
-                debug!("Skipping type declared inside function: {:?}", ty);
+                debug!("Skipping type declared inside function: {ty:?}");
                 return Ok(Item::new_opaque_type(id, ty, ctx));
             }
         }
@@ -1640,7 +1631,7 @@ impl Item {
                 .iter()
                 .find(|ty| *ty.decl() == declaration_to_look_for)
             {
-                debug!("Avoiding recursion parsing type: {:?}", ty);
+                debug!("Avoiding recursion parsing type: {ty:?}");
                 // Unchecked because we haven't finished this type yet.
                 return Ok(partial.id().as_type_id_unchecked());
             }

--- a/bindgen/ir/objc.rs
+++ b/bindgen/ir/objc.rs
@@ -87,7 +87,7 @@ impl ObjCInterface {
     /// and protocols are like PNSObject
     pub(crate) fn rust_name(&self) -> String {
         if let Some(ref cat) = self.category {
-            format!("{}_{}", self.name(), cat)
+            format!("{}_{cat}", self.name())
         } else if self.is_protocol {
             format!("P{}", self.name())
         } else {
@@ -147,8 +147,8 @@ impl ObjCInterface {
                     let needle = format!("P{}", c.spelling());
                     let items_map = ctx.items();
                     debug!(
-                        "Interface {} conforms to {}, find the item",
-                        interface.name, needle
+                        "Interface {} conforms to {needle}, find the item",
+                        interface.name,
                     );
 
                     for (id, item) in items_map {
@@ -163,10 +163,7 @@ impl ObjCInterface {
                                         ty.name()
                                     );
                                     if Some(needle.as_ref()) == ty.name() {
-                                        debug!(
-                                            "Found conforming protocol {:?}",
-                                            item
-                                        );
+                                        debug!("Found conforming protocol {item:?}");
                                         interface.conforms_to.push(id);
                                         break;
                                     }

--- a/bindgen/ir/ty.rs
+++ b/bindgen/ir/ty.rs
@@ -685,7 +685,7 @@ impl Type {
                 Some(location),
             );
             if let Some(ty) = already_resolved {
-                debug!("{:?} already resolved: {:?}", ty, location);
+                debug!("{ty:?} already resolved: {location:?}");
                 return Ok(ParseResult::AlreadyResolved(ty.into()));
             }
         }
@@ -700,8 +700,7 @@ impl Type {
         };
 
         debug!(
-            "from_clang_ty: {:?}, ty: {:?}, loc: {:?}",
-            potential_id, ty, location
+            "from_clang_ty: {potential_id:?}, ty: {ty:?}, loc: {location:?}"
         );
         debug!("currently_parsed_types: {:?}", ctx.currently_parsed_types());
 
@@ -776,7 +775,7 @@ impl Type {
                                     // etc.
                                     !canonical_ty.spelling().contains("type-parameter") =>
                 {
-                    debug!("Looking for canonical type: {:?}", canonical_ty);
+                    debug!("Looking for canonical type: {canonical_ty:?}");
                     return Self::from_clang_ty(
                         potential_id,
                         &canonical_ty,
@@ -797,10 +796,7 @@ impl Type {
                     // Same here, with template specialisations we can safely
                     // assume this is a Comp(..)
                     } else if ty.is_fully_instantiated_template() {
-                        debug!(
-                            "Template specialization: {:?}, {:?} {:?}",
-                            ty, location, canonical_ty
-                        );
+                        debug!("Template specialization: {ty:?}, {location:?} {canonical_ty:?}");
                         let complex = CompInfo::from_ty(
                             potential_id,
                             ty,
@@ -948,13 +944,7 @@ impl Type {
                                 let referenced = location.referenced().unwrap();
                                 let referenced_ty = referenced.cur_type();
 
-                                debug!(
-                                    "TemplateRef: location = {:?}; referenced = \
-                                        {:?}; referenced_ty = {:?}",
-                                    location,
-                                    referenced,
-                                    referenced_ty
-                                );
+                                debug!("TemplateRef: location = {location:?}; referenced = {referenced:?}; referenced_ty = {referenced_ty:?}");
 
                                 return Self::from_clang_ty(
                                     potential_id,
@@ -969,11 +959,7 @@ impl Type {
                                 let referenced_ty = referenced.cur_type();
                                 let declaration = referenced_ty.declaration();
 
-                                debug!(
-                                    "TypeRef: location = {:?}; referenced = \
-                                     {:?}; referenced_ty = {:?}",
-                                    location, referenced, referenced_ty
-                                );
+                                debug!("TypeRef: location = {location:?}; referenced = {referenced:?}; referenced_ty = {referenced_ty:?}");
 
                                 let id = Item::from_ty_or_ref_with_id(
                                     potential_id,
@@ -991,16 +977,11 @@ impl Type {
                             }
                             _ => {
                                 if ty.kind() == CXType_Unexposed {
-                                    warn!(
-                                        "Unexposed type {:?}, recursing inside, \
-                                          loc: {:?}",
-                                        ty,
-                                        location
-                                    );
+                                    warn!("Unexposed type {ty:?}, recursing inside, loc: {location:?}");
                                     return Err(ParseError::Recurse);
                                 }
 
-                                warn!("invalid type {:?}", ty);
+                                warn!("invalid type {ty:?}");
                                 return Err(ParseError::Continue);
                             }
                         }
@@ -1008,7 +989,7 @@ impl Type {
                 }
                 CXType_Auto => {
                     if canonical_ty == *ty {
-                        debug!("Couldn't find deduced type: {:?}", ty);
+                        debug!("Couldn't find deduced type: {ty:?}");
                         return Err(ParseError::Continue);
                     }
 
@@ -1203,10 +1184,8 @@ impl Type {
                 }
                 _ => {
                     warn!(
-                        "unsupported type: kind = {:?}; ty = {:?}; at {:?}",
+                        "unsupported type: kind = {:?}; ty = {ty:?}; at {location:?}",
                         ty.kind(),
-                        ty,
-                        location
                     );
                     return Err(ParseError::Continue);
                 }

--- a/bindgen/ir/var.rs
+++ b/bindgen/ir/var.rs
@@ -399,7 +399,7 @@ fn parse_macro_clang_fallback(
     }
 
     let ftu = ctx.try_ensure_fallback_translation_unit()?;
-    let contents = format!("int main() {{ {}; }}", cursor.spelling(),);
+    let contents = format!("int main() {{ {}; }}", cursor.spelling());
     ftu.reparse(&contents).ok()?;
     // Children of root node of AST
     let root_children = ftu.translation_unit().cursor().collect_children();
@@ -480,7 +480,7 @@ fn duplicated_macro_diagnostic(
     _location: crate::clang::SourceLocation,
     _ctx: &BindgenContext,
 ) {
-    warn!("Duplicated macro definition: {}", macro_name);
+    warn!("Duplicated macro definition: {macro_name}");
 
     #[cfg(feature = "experimental")]
     // FIXME (pvdrz & amanjeev): This diagnostic message shows way too often to be actually

--- a/bindgen/lib.rs
+++ b/bindgen/lib.rs
@@ -810,8 +810,7 @@ impl Bindings {
             };
 
             debug!(
-                "Trying to find clang with flags: {:?}",
-                clang_args_for_clang_sys
+                "Trying to find clang with flags: {clang_args_for_clang_sys:?}"
             );
 
             let clang = match clang_sys::support::Clang::find(
@@ -822,7 +821,7 @@ impl Bindings {
                 Some(clang) => clang,
             };
 
-            debug!("Found clang: {:?}", clang);
+            debug!("Found clang: {clang:?}");
 
             // Whether we are working with C or C++ inputs.
             let is_cpp = args_are_cpp(&options.clang_args) ||
@@ -881,7 +880,7 @@ impl Bindings {
             options.clang_args.push(f.name.to_str().unwrap().into())
         }
 
-        debug!("Fixed-up options: {:?}", options);
+        debug!("Fixed-up options: {options:?}");
 
         let time_phases = options.time_phases;
         let mut context = BindgenContext::new(options, &input_unsaved_files);
@@ -1045,7 +1044,7 @@ impl Bindings {
 }
 
 fn rustfmt_non_fatal_error_diagnostic(msg: &str, _options: &BindgenOptions) {
-    warn!("{}", msg);
+    warn!("{msg}");
 
     #[cfg(feature = "experimental")]
     if _options.emit_diagnostics {
@@ -1203,7 +1202,7 @@ fn get_target_dependent_env_var(
         }
         if let Ok(v) = env_var(
             parse_callbacks,
-            format!("{}_{}", var, target.replace('-', "_")),
+            format!("{var}_{}", target.replace('-', "_")),
         ) {
             return Some(v);
         }

--- a/bindgen/regex_set.rs
+++ b/bindgen/regex_set.rs
@@ -99,7 +99,7 @@ impl RegexSet {
         self.set = match RxSet::new(items) {
             Ok(x) => Some(x),
             Err(e) => {
-                warn!("Invalid regex in {:?}: {:?}", self.items, e);
+                warn!("Invalid regex in {:?}: {e:?}", self.items);
                 #[cfg(feature = "experimental")]
                 if let Some(name) = _name {
                     invalid_regex_warning(self, e, name);

--- a/bindgen/time.rs
+++ b/bindgen/time.rs
@@ -39,7 +39,7 @@ impl<'a> Timer<'a> {
                 (elapsed.subsec_nanos() as f64) / 1e6;
             let stderr = io::stderr();
             // Arbitrary output format, subject to change.
-            writeln!(stderr.lock(), "  time: {:>9.3} ms.\t{}", time, self.name)
+            writeln!(stderr.lock(), "  time: {time:>9.3} ms.\t{}", self.name)
                 .expect("timer write should not fail");
         }
     }

--- a/book/src/code-formatting.md
+++ b/book/src/code-formatting.md
@@ -47,8 +47,7 @@ fn main() {
 
     assert!(
         output.status.success(),
-        "Unsuccessful status code when running `rustup`: {:?}",
-        output
+        "Unsuccessful status code when running `rustup`: {output:?}",
     );
 
     let rustfmt_path =

--- a/book/src/tutorial-5.md
+++ b/book/src/tutorial-5.md
@@ -40,7 +40,7 @@ mod tests {
                 r if r == (BZ_PARAM_ERROR as _) => panic!("BZ_PARAM_ERROR"),
                 r if r == (BZ_MEM_ERROR as _) => panic!("BZ_MEM_ERROR"),
                 r if r == (BZ_OK as _) => {},
-                r => panic!("Unknown return value = {}", r),
+                r => panic!("Unknown return value = {r}"),
             }
 
             // Compress `input` into `compressed_output`.
@@ -55,7 +55,7 @@ mod tests {
                 r if r == (BZ_FINISH_OK as _) => panic!("BZ_FINISH_OK"),
                 r if r == (BZ_SEQUENCE_ERROR as _) => panic!("BZ_SEQUENCE_ERROR"),
                 r if r == (BZ_STREAM_END as _) => {},
-                r => panic!("Unknown return value = {}", r),
+                r => panic!("Unknown return value = {r}"),
             }
 
             // Finish the compression stream.
@@ -63,7 +63,7 @@ mod tests {
             match result {
                 r if r == (BZ_PARAM_ERROR as _) => panic!("BZ_PARAM_ERROR"),
                 r if r == (BZ_OK as _) => {},
-                r => panic!("Unknown return value = {}", r),
+                r => panic!("Unknown return value = {r}"),
             }
 
             // Construct a decompression stream.
@@ -76,7 +76,7 @@ mod tests {
                 r if r == (BZ_PARAM_ERROR as _) => panic!("BZ_PARAM_ERROR"),
                 r if r == (BZ_MEM_ERROR as _) => panic!("BZ_MEM_ERROR"),
                 r if r == (BZ_OK as _) => {},
-                r => panic!("Unknown return value = {}", r),
+                r => panic!("Unknown return value = {r}"),
             }
 
             // Decompress `compressed_output` into `decompressed_output`.
@@ -92,7 +92,7 @@ mod tests {
                 r if r == (BZ_MEM_ERROR as _) => panic!("BZ_MEM_ERROR"),
                 r if r == (BZ_OK as _) => panic!("BZ_OK"),
                 r if r == (BZ_STREAM_END as _) => {},
-                r => panic!("Unknown return value = {}", r),
+                r => panic!("Unknown return value = {r}"),
             }
 
             // Close the decompression stream.
@@ -100,7 +100,7 @@ mod tests {
             match result {
                 r if r == (BZ_PARAM_ERROR as _) => panic!("BZ_PARAM_ERROR"),
                 r if r == (BZ_OK as _) => {},
-                r => panic!("Unknown return value = {}", r),
+                r => panic!("Unknown return value = {r}"),
             }
 
             assert_eq!(input, &decompressed_output[..]);


### PR DESCRIPTION
* fixed `insantiation` -> `instantiation` in some logging
* inlined a lot of format arg to make them a bit more readable