### PR TITLE
Make RustEdition public

### DIFF
--- a/bindgen/features.rs
+++ b/bindgen/features.rs
@@ -83,6 +83,7 @@ impl fmt::Display for InvalidRustTarget {
 macro_rules! define_rust_editions {
     ($($variant:ident($value:literal) => $minor:literal,)*) => {
         #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+        #[doc = "Represents Rust Edition for the generated bindings"]
         pub enum RustEdition {
             $(
                 #[doc = concat!("The ", stringify!($value), " edition of Rust.")]

--- a/bindgen/lib.rs
+++ b/bindgen/lib.rs
@@ -50,14 +50,14 @@ mod regex_set;
 pub use codegen::{
     AliasVariation, EnumVariation, MacroTypeVariation, NonCopyUnionStyle,
 };
-pub use features::{RustTarget, LATEST_STABLE_RUST};
+pub use features::{RustEdition, RustTarget, LATEST_STABLE_RUST};
 pub use ir::annotations::FieldVisibilityKind;
 pub use ir::function::Abi;
 #[cfg(feature = "__cli")]
 pub use options::cli::builder_from_flags;
 
 use codegen::CodegenError;
-use features::{RustEdition, RustFeatures};
+use features::RustFeatures;
 use ir::comment;
 use ir::context::{BindgenContext, ItemId};
 use ir::item::Item;


### PR DESCRIPTION
Making RustEdition public allows calling Builder::rust_edition() from the build.rs scripts.
+ Adding documentation to the RustEdition enum to not break linter rules.

Fixes #3012 