### PR TITLE
Consolidate clippy configuration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,20 @@ similar = "2.2.1"
 syn = "2.0"
 tempfile = "3"
 
+[workspace.lints.rust]
+# unused_qualifications = "warn"
+
+[workspace.lints.clippy]
+# disallowed-names = "allow"
+# manual-c-str-literals = "allow"
+# missing-safety-doc = "allow"
+# op-ref = "allow"
+# ptr-offset-with-cast = "allow"
+# too-many-arguments = "allow"
+# transmute-int-to-bool = "allow"
+# unnecessary-cast = "allow"
+# useless-transmute  = "allow"
+
 # Config for 'cargo dist'
 [workspace.metadata.dist]
 # The preferred cargo-dist version to use in CI (Cargo.toml SemVer syntax)

--- a/bindgen-cli/Cargo.toml
+++ b/bindgen-cli/Cargo.toml
@@ -1,3 +1,5 @@
+lints.workspace = true
+
 [package]
 authors = [
     "The rust-bindgen project contributors",

--- a/bindgen-integration/Cargo.toml
+++ b/bindgen-integration/Cargo.toml
@@ -1,3 +1,5 @@
+lints.workspace = true
+
 [package]
 name = "bindgen-integration"
 description = "A package to test various bindgen features"

--- a/bindgen-tests/Cargo.toml
+++ b/bindgen-tests/Cargo.toml
@@ -1,3 +1,5 @@
+lints.workspace = true
+
 [package]
 name = "bindgen-tests"
 version = "0.1.0"

--- a/bindgen-tests/tests/expectations/Cargo.toml
+++ b/bindgen-tests/tests/expectations/Cargo.toml
@@ -16,17 +16,22 @@ block.workspace = true
 libloading.workspace = true
 objc.workspace = true
 
+# Both of these sections need to be copied here from the workspace because
+# Cargo currently does not allow overriding workspace settings in a member
 [lints.rust]
 ### FIXME: these might need to be fixed,
 ###   esp the calling convention, because it is a hard error now
 # deprecated = "allow"
 # invalid-value = "allow"
 # unsupported_calling_conventions = "allow"
+#
+# Different from the workspace
 dead_code = "allow"
 non-snake-case = "allow"
 non_camel_case_types = "allow"
 non_upper_case_globals = "allow"
 unexpected-cfgs = "allow"
+unused_qualifications = "allow"
 
 [lints.clippy]
 disallowed-names = "allow"

--- a/bindgen-tests/tests/quickchecking/Cargo.toml
+++ b/bindgen-tests/tests/quickchecking/Cargo.toml
@@ -1,3 +1,5 @@
+lints.workspace = true
+
 [package]
 name = "quickchecking"
 description = "Bindgen property tests with quickcheck. Generate random valid C code and pass it to the csmith/predicate.py script"

--- a/bindgen/Cargo.toml
+++ b/bindgen/Cargo.toml
@@ -1,3 +1,5 @@
+lints.workspace = true
+
 [package]
 authors = [
     "Jyun-Yan You <jyyou.tw@gmail.com>",


### PR DESCRIPTION
Move all clippy configurations to one central place, except for the expected tests - they seem to require their own handling for now due to a Cargo limitation.
