### PR TITLE
Fix `manual_let_else` and `single_match_else` lints

### DIFF
--- a/bindgen-tests/build.rs
+++ b/bindgen-tests/build.rs
@@ -12,10 +12,9 @@ pub fn main() {
     let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
     let headers_dir = manifest_dir.join("tests").join("headers");
 
-    let headers = match fs::read_dir(headers_dir) {
-        Ok(dir) => dir,
+    let Ok(headers) = fs::read_dir(headers_dir) else {
         // We may not have headers directory after packaging.
-        Err(..) => return,
+        return;
     };
 
     let entries =

--- a/bindgen-tests/tests/tests.rs
+++ b/bindgen-tests/tests/tests.rs
@@ -55,9 +55,10 @@ fn error_diff_mismatch(
 
     if let Some(var) = env::var_os("BINDGEN_TESTS_DIFFTOOL") {
         //usecase: var = "meld" -> You can hand check differences
-        let name = match filename.components().last() {
-            Some(std::path::Component::Normal(name)) => name,
-            _ => panic!("Why is the header variable so weird?"),
+        let Some(std::path::Component::Normal(name)) =
+            filename.components().last()
+        else {
+            panic!("Why is the header variable so weird?")
         };
         let actual_result_path =
             PathBuf::from(env::var("OUT_DIR").unwrap()).join(name);
@@ -581,29 +582,28 @@ fn test_macro_fallback_non_system_dir() {
 
     let actual = format_code(actual).unwrap();
 
-    let (expected_filename, expected) = match clang_version().parsed {
-        Some((9, _)) => {
-            let expected_filename = concat!(
-                env!("CARGO_MANIFEST_DIR"),
-                "/tests/expectations/tests/libclang-9/macro_fallback_non_system_dir.rs",
-            );
-            let expected = include_str!(concat!(
-                env!("CARGO_MANIFEST_DIR"),
-                "/tests/expectations/tests/libclang-9/macro_fallback_non_system_dir.rs",
-            ));
-            (expected_filename, expected)
-        }
-        _ => {
-            let expected_filename = concat!(
-                env!("CARGO_MANIFEST_DIR"),
-                "/tests/expectations/tests/test_macro_fallback_non_system_dir.rs",
-            );
-            let expected = include_str!(concat!(
-                env!("CARGO_MANIFEST_DIR"),
-                "/tests/expectations/tests/test_macro_fallback_non_system_dir.rs",
-            ));
-            (expected_filename, expected)
-        }
+    let (expected_filename, expected) = if let Some((9, _)) =
+        clang_version().parsed
+    {
+        let expected_filename = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/tests/expectations/tests/libclang-9/macro_fallback_non_system_dir.rs",
+        );
+        let expected = include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/tests/expectations/tests/libclang-9/macro_fallback_non_system_dir.rs",
+        ));
+        (expected_filename, expected)
+    } else {
+        let expected_filename = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/tests/expectations/tests/test_macro_fallback_non_system_dir.rs",
+        );
+        let expected = include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/tests/expectations/tests/test_macro_fallback_non_system_dir.rs",
+        ));
+        (expected_filename, expected)
     };
     let expected = format_code(expected).unwrap();
     if expected != actual {

--- a/bindgen/clang.rs
+++ b/bindgen/clang.rs
@@ -1886,9 +1886,7 @@ impl TranslationUnit {
 
     /// Save a translation unit to the given file.
     pub(crate) fn save(&mut self, file: &str) -> Result<(), CXSaveError> {
-        let file = if let Ok(cstring) = CString::new(file) {
-            cstring
-        } else {
+        let Ok(file) = CString::new(file) else {
             return Err(CXSaveError_Unknown);
         };
         let ret = unsafe {

--- a/bindgen/codegen/impl_debug.rs
+++ b/bindgen/codegen/impl_debug.rs
@@ -126,12 +126,7 @@ impl<'a> ImplDebug<'a> for Item {
             return None;
         }
 
-        let ty = match self.as_type() {
-            Some(ty) => ty,
-            None => {
-                return None;
-            }
-        };
+        let ty = self.as_type()?;
 
         fn debug_print(
             name: &str,

--- a/bindgen/codegen/mod.rs
+++ b/bindgen/codegen/mod.rs
@@ -1198,10 +1198,7 @@ impl CodeGenerator for Vtable<'_> {
                     let function_item = ctx.resolve_item(m.signature());
                     let function = function_item.expect_function();
                     let signature_item = ctx.resolve_item(function.signature());
-                    let signature = match signature_item.expect_type().kind() {
-                        TypeKind::Function(ref sig) => sig,
-                        _ => panic!("Function signature type mismatch"),
-                    };
+                    let TypeKind::Function(ref signature) = signature_item.expect_type().kind() else { panic!("Function signature type mismatch") };
 
                     // FIXME: Is there a canonical name without the class prepended?
                     let function_name = function_item.canonical_name(ctx);
@@ -1943,16 +1940,14 @@ impl<'a> FieldCodegen<'a> for Bitfield {
         let bitfield_ty_layout = bitfield_ty
             .layout(ctx)
             .expect("Bitfield without layout? Gah!");
-        let bitfield_int_ty = match helpers::integer_type(bitfield_ty_layout) {
-            Some(int_ty) => {
+        let bitfield_int_ty =
+            if let Some(int_ty) = helpers::integer_type(bitfield_ty_layout) {
                 *bitfield_representable_as_int = true;
                 int_ty
-            }
-            None => {
+            } else {
                 *bitfield_representable_as_int = false;
                 return;
-            }
-        };
+            };
 
         let bitfield_ty =
             bitfield_ty.to_rust_ty_or_opaque(ctx, bitfield_ty_item);
@@ -2974,10 +2969,7 @@ impl Method {
         }
         let function = function_item.expect_function();
         let times_seen = function.codegen(ctx, result, function_item);
-        let times_seen = match times_seen {
-            Some(seen) => seen,
-            None => return,
-        };
+        let Some(times_seen) = times_seen else { return };
         let signature_item = ctx.resolve_item(function.signature());
         let mut name = match self.kind() {
             MethodKind::Constructor => "new".into(),
@@ -2985,9 +2977,10 @@ impl Method {
             _ => function.name().to_owned(),
         };
 
-        let signature = match *signature_item.expect_type().kind() {
-            TypeKind::Function(ref sig) => sig,
-            _ => panic!("How in the world?"),
+        let TypeKind::Function(ref signature) =
+            *signature_item.expect_type().kind()
+        else {
+            panic!("How in the world?")
         };
 
         let supported_abi = signature.abi(ctx, Some(&*name)).is_ok();
@@ -3564,18 +3557,17 @@ impl CodeGenerator for Enum {
                 // * the representation couldn't be determined from the C source
                 // * it was explicitly requested as a bindgen option
 
-                let kind = match repr {
-                    Some(repr) => match *repr.canonical_type(ctx).kind() {
+                let kind = if let Some(repr) = repr {
+                    match *repr.canonical_type(ctx).kind() {
                         TypeKind::Int(int_kind) => int_kind,
                         _ => panic!("Unexpected type as enum repr"),
-                    },
-                    None => {
-                        warn!(
-                            "Guessing type of enum! Forward declarations of enums \
-                             shouldn't be legal!"
-                        );
-                        IntKind::Int
                     }
+                } else {
+                    warn!(
+                        "Guessing type of enum! Forward declarations of enums \
+                         shouldn't be legal!"
+                    );
+                    IntKind::Int
                 };
 
                 let signed = kind.is_signed();
@@ -4488,9 +4480,8 @@ impl CodeGenerator for Function {
 
         let signature_item = ctx.resolve_item(self.signature());
         let signature = signature_item.kind().expect_type().canonical_type(ctx);
-        let signature = match *signature.kind() {
-            TypeKind::Function(ref sig) => sig,
-            _ => panic!("Signature kind is not a Function: {signature:?}"),
+        let TypeKind::Function(ref signature) = *signature.kind() else {
+            panic!("Signature kind is not a Function: {signature:?}")
         };
 
         if is_internal {
@@ -4966,9 +4957,8 @@ impl CodeGenerator for ObjCInterface {
                     .expect_type()
                     .kind();
 
-                let parent = match parent {
-                    TypeKind::ObjCInterface(ref parent) => parent,
-                    _ => break,
+                let TypeKind::ObjCInterface(parent) = parent else {
+                    break;
                 };
                 parent_class = parent.parent_class;
 
@@ -5687,12 +5677,11 @@ pub(crate) mod utils {
             .map(|(name, ty)| {
                 let arg_ty = fnsig_argument_type(ctx, ty);
 
-                let arg_name = match *name {
-                    Some(ref name) => ctx.rust_mangle(name).into_owned(),
-                    None => {
-                        unnamed_arguments += 1;
-                        format!("arg{unnamed_arguments}")
-                    }
+                let arg_name = if let Some(ref name) = *name {
+                    ctx.rust_mangle(name).into_owned()
+                } else {
+                    unnamed_arguments += 1;
+                    format!("arg{unnamed_arguments}")
                 };
 
                 assert!(!arg_name.is_empty());
@@ -5731,12 +5720,11 @@ pub(crate) mod utils {
             .argument_types()
             .iter()
             .map(|&(ref name, _ty)| {
-                let arg_name = match *name {
-                    Some(ref name) => ctx.rust_mangle(name).into_owned(),
-                    None => {
-                        unnamed_arguments += 1;
-                        format!("arg{unnamed_arguments}")
-                    }
+                let arg_name = if let Some(ref name) = *name {
+                    ctx.rust_mangle(name).into_owned()
+                } else {
+                    unnamed_arguments += 1;
+                    format!("arg{unnamed_arguments}")
                 };
 
                 assert!(!arg_name.is_empty());

--- a/bindgen/codegen/serialize.rs
+++ b/bindgen/codegen/serialize.rs
@@ -72,9 +72,10 @@ impl<'a> CSerialize<'a> for Function {
             });
         }
 
-        let signature = match ctx.resolve_type(self.signature()).kind() {
-            TypeKind::Function(signature) => signature,
-            _ => unreachable!(),
+        let TypeKind::Function(signature) =
+            ctx.resolve_type(self.signature()).kind()
+        else {
+            unreachable!()
         };
 
         assert!(!signature.is_variadic());

--- a/bindgen/codegen/struct_layout.rs
+++ b/bindgen/codegen/struct_layout.rs
@@ -421,9 +421,8 @@ impl<'a> StructLayoutTracker<'a> {
             return false;
         }
 
-        let layout = match self.latest_field_layout {
-            Some(l) => l,
-            None => return false,
+        let Some(layout) = self.latest_field_layout else {
+            return false;
         };
 
         // If it was, we may or may not need to align, depending on what the

--- a/bindgen/features.rs
+++ b/bindgen/features.rs
@@ -368,22 +368,21 @@ impl FromStr for RustTarget {
             ));
         }
 
-        let (minor, patch) = match tail.split_once('.') {
-            Some((minor_str, patch_str)) => {
-                let Ok(minor) = minor_str.parse::<u64>() else {
-                    return Err(invalid_input(input, "the minor version number must be an unsigned 64-bit integer"));
-                };
-                let Ok(patch) = patch_str.parse::<u64>() else {
-                    return Err(invalid_input(input, "the patch version number must be an unsigned 64-bit integer"));
-                };
-                (minor, patch)
-            }
-            None => {
-                let Ok(minor) = tail.parse::<u64>() else {
-                    return Err(invalid_input(input, "the minor version number must be an unsigned 64-bit integer"));
-                };
-                (minor, 0)
-            }
+        let (minor, patch) = if let Some((minor_str, patch_str)) =
+            tail.split_once('.')
+        {
+            let Ok(minor) = minor_str.parse::<u64>() else {
+                return Err(invalid_input(input, "the minor version number must be an unsigned 64-bit integer"));
+            };
+            let Ok(patch) = patch_str.parse::<u64>() else {
+                return Err(invalid_input(input, "the patch version number must be an unsigned 64-bit integer"));
+            };
+            (minor, patch)
+        } else {
+            let Ok(minor) = tail.parse::<u64>() else {
+                return Err(invalid_input(input, "the minor version number must be an unsigned 64-bit integer"));
+            };
+            (minor, 0)
         };
 
         Self::stable(minor, patch).map_err(|err| invalid_input(input, err))

--- a/bindgen/ir/analysis/derive.rs
+++ b/bindgen/ir/analysis/derive.rs
@@ -540,31 +540,25 @@ impl DeriveTrait {
     }
 
     fn can_derive_vector(&self) -> CanDerive {
-        match self {
-            DeriveTrait::PartialEqOrPartialOrd => {
-                // FIXME: vectors always can derive PartialEq, but they should
-                // not derive PartialOrd:
-                // https://github.com/rust-lang-nursery/packed_simd/issues/48
-                trace!("    vectors cannot derive PartialOrd");
-                CanDerive::No
-            }
-            _ => {
-                trace!("    vector can derive {self}");
-                CanDerive::Yes
-            }
+        if *self == DeriveTrait::PartialEqOrPartialOrd {
+            // FIXME: vectors always can derive PartialEq, but they should
+            // not derive PartialOrd:
+            // https://github.com/rust-lang-nursery/packed_simd/issues/48
+            trace!("    vectors cannot derive PartialOrd");
+            CanDerive::No
+        } else {
+            trace!("    vector can derive {self}");
+            CanDerive::Yes
         }
     }
 
     fn can_derive_pointer(&self) -> CanDerive {
-        match self {
-            DeriveTrait::Default => {
-                trace!("    pointer cannot derive Default");
-                CanDerive::No
-            }
-            _ => {
-                trace!("    pointer can derive {self}");
-                CanDerive::Yes
-            }
+        if *self == DeriveTrait::Default {
+            trace!("    pointer cannot derive Default");
+            CanDerive::No
+        } else {
+            trace!("    pointer can derive {self}");
+            CanDerive::Yes
         }
     }
 

--- a/bindgen/ir/analysis/has_float.rs
+++ b/bindgen/ir/analysis/has_float.rs
@@ -105,12 +105,9 @@ impl<'ctx> MonotoneFramework for HasFloat<'ctx> {
         }
 
         let item = self.ctx.resolve_item(id);
-        let ty = match item.as_type() {
-            Some(ty) => ty,
-            None => {
-                trace!("    not a type; ignoring");
-                return ConstrainResult::Same;
-            }
+        let Some(ty) = item.as_type() else {
+            trace!("    not a type; ignoring");
+            return ConstrainResult::Same;
         };
 
         match *ty.kind() {

--- a/bindgen/ir/analysis/has_type_param_in_array.rs
+++ b/bindgen/ir/analysis/has_type_param_in_array.rs
@@ -108,12 +108,9 @@ impl<'ctx> MonotoneFramework for HasTypeParameterInArray<'ctx> {
         }
 
         let item = self.ctx.resolve_item(id);
-        let ty = match item.as_type() {
-            Some(ty) => ty,
-            None => {
-                trace!("    not a type; ignoring");
-                return ConstrainResult::Same;
-            }
+        let Some(ty) = item.as_type() else {
+            trace!("    not a type; ignoring");
+            return ConstrainResult::Same;
         };
 
         match *ty.kind() {
@@ -142,17 +139,14 @@ impl<'ctx> MonotoneFramework for HasTypeParameterInArray<'ctx> {
             TypeKind::Array(t, _) => {
                 let inner_ty =
                     self.ctx.resolve_type(t).canonical_type(self.ctx);
-                match *inner_ty.kind() {
-                    TypeKind::TypeParam => {
-                        trace!("    Array with Named type has type parameter");
-                        self.insert(id)
-                    }
-                    _ => {
-                        trace!(
-                            "    Array without Named type does have type parameter"
-                        );
-                        ConstrainResult::Same
-                    }
+                if let TypeKind::TypeParam = *inner_ty.kind() {
+                    trace!("    Array with Named type has type parameter");
+                    self.insert(id)
+                } else {
+                    trace!(
+                        "    Array without Named type does have type parameter"
+                    );
+                    ConstrainResult::Same
                 }
             }
 

--- a/bindgen/ir/context.rs
+++ b/bindgen/ir/context.rs
@@ -930,10 +930,7 @@ If you encounter an error missing from this list, please file an issue or a PR!"
 
         for (id, item) in self.items() {
             let kind = item.kind();
-            let ty = match kind.as_type() {
-                Some(ty) => ty,
-                None => continue,
-            };
+            let Some(ty) = kind.as_type() else { continue };
 
             if let TypeKind::UnresolvedTypeRef(ref ty, loc, parent_id) =
                 *ty.kind()
@@ -1070,9 +1067,8 @@ If you encounter an error missing from this list, please file an issue or a PR!"
 
             // Calls to `canonical_name` are expensive, so eagerly filter out
             // items that cannot be replaced.
-            let ty = match item.kind().as_type() {
-                Some(ty) => ty,
-                None => continue,
+            let Some(ty) = item.kind().as_type() else {
+                continue;
             };
 
             match *ty.kind() {
@@ -2524,9 +2520,8 @@ If you encounter an error missing from this list, please file an issue or a PR!"
                                 return false;
                             }
 
-                            let enum_ = match *ty.kind() {
-                                TypeKind::Enum(ref e) => e,
-                                _ => return false,
+                            let TypeKind::Enum(ref enum_) = *ty.kind() else {
+                                return false;
                             };
 
                             if ty.name().is_some() {

--- a/bindgen/ir/item.rs
+++ b/bindgen/ir/item.rs
@@ -582,9 +582,8 @@ impl Item {
 
         let mut parent = self.parent_id;
         loop {
-            let parent_item = match ctx.resolve_item_fallible(parent) {
-                Some(item) => item,
-                None => return false,
+            let Some(parent_item) = ctx.resolve_item_fallible(parent) else {
+                return false;
             };
 
             if parent_item.id() == ctx.root_module() {
@@ -978,9 +977,8 @@ impl Item {
         // Do not jump through aliases, except for aliases that point to a type
         // with the same name, since we dont generate coe for them.
         let item = self.id.into_resolver().through_type_refs().resolve(ctx);
-        let type_ = match *item.kind() {
-            ItemKind::Type(ref type_) => type_,
-            _ => return false,
+        let ItemKind::Type(ref type_) = *item.kind() else {
+            return false;
         };
 
         match *type_.kind() {
@@ -1077,9 +1075,8 @@ impl Item {
 
     /// Returns a prefix for the canonical name when C naming is enabled.
     fn c_naming_prefix(&self) -> Option<&str> {
-        let ty = match self.kind {
-            ItemKind::Type(ref ty) => ty,
-            _ => return None,
+        let ItemKind::Type(ref ty) = self.kind else {
+            return None;
         };
 
         Some(match ty.kind() {

--- a/bindgen/ir/template.rs
+++ b/bindgen/ir/template.rs
@@ -266,17 +266,14 @@ impl TemplateInstantiation {
             })
         };
 
-        let definition = match definition {
-            Some(def) => def,
-            None => {
-                if !ty.declaration().is_builtin() {
-                    warn!(
-                        "Could not find template definition for template \
+        let Some(definition) = definition else {
+            if !ty.declaration().is_builtin() {
+                warn!(
+                    "Could not find template definition for template \
                          instantiation"
-                    );
-                }
-                return None;
+                );
             }
+            return None;
         };
 
         let template_definition =

--- a/bindgen/ir/ty.rs
+++ b/bindgen/ir/ty.rs
@@ -865,20 +865,16 @@ impl Type {
                                     Some(location),
                                     ctx,
                                 );
-                                match complex {
-                                    Ok(complex) => TypeKind::Comp(complex),
-                                    Err(_) => {
-                                        warn!(
-                                            "Could not create complex type \
-                                             from class template or base \
-                                             specifier, using opaque blob"
-                                        );
-                                        let opaque =
-                                            Opaque::from_clang_ty(ty, ctx);
-                                        return Ok(ParseResult::New(
-                                            opaque, None,
-                                        ));
-                                    }
+                                if let Ok(complex) = complex {
+                                    TypeKind::Comp(complex)
+                                } else {
+                                    warn!(
+                                        "Could not create complex type \
+                                         from class template or base \
+                                         specifier, using opaque blob"
+                                    );
+                                    let opaque = Opaque::from_clang_ty(ty, ctx);
+                                    return Ok(ParseResult::New(opaque, None));
                                 }
                             }
                             CXCursor_TypeAliasTemplateDecl => {
@@ -926,16 +922,13 @@ impl Type {
                                     CXChildVisit_Continue
                                 });
 
-                                let inner_type = match inner {
-                                    Ok(inner) => inner,
-                                    Err(..) => {
-                                        warn!(
-                                            "Failed to parse template alias \
+                                let Ok(inner_type) = inner else {
+                                    warn!(
+                                        "Failed to parse template alias \
                                              {:?}",
-                                            location
-                                        );
-                                        return Err(ParseError::Continue);
-                                    }
+                                        location
+                                    );
+                                    return Err(ParseError::Continue);
                                 };
 
                                 TypeKind::TemplateAlias(inner_type, args)

--- a/bindgen/ir/var.rs
+++ b/bindgen/ir/var.rs
@@ -198,9 +198,8 @@ impl ClangSubItemParser for Var {
 
                 let value = parse_macro(ctx, &cursor);
 
-                let (id, value) = match value {
-                    Some(v) => v,
-                    None => return Err(ParseError::Continue),
+                let Some((id, value)) = value else {
+                    return Err(ParseError::Continue);
                 };
 
                 assert!(!id.is_empty(), "Empty macro name?");
@@ -338,9 +337,9 @@ impl ClangSubItemParser for Var {
                 // to look at the canonical type of the pointee too, and check
                 // is char, u8, or i8 I guess).
                 let value = if is_integer {
-                    let kind = match *canonical_ty.unwrap().kind() {
-                        TypeKind::Int(kind) => kind,
-                        _ => unreachable!(),
+                    let TypeKind::Int(kind) = *canonical_ty.unwrap().kind()
+                    else {
+                        unreachable!()
                     };
 
                     let mut val = cursor.evaluate().and_then(|v| v.as_int());

--- a/bindgen/regex_set.rs
+++ b/bindgen/regex_set.rs
@@ -115,9 +115,8 @@ impl RegexSet {
         S: AsRef<str>,
     {
         let s = string.as_ref();
-        let set = match self.set {
-            Some(ref set) => set,
-            None => return false,
+        let Some(ref set) = self.set else {
+            return false;
         };
 
         if !self.record_matches {


### PR DESCRIPTION
Used this to find issues, apply suggestions, and manually fixed a [clippy bug](https://github.com/rust-lang/rust-clippy/issues/13768)

```bash
cargo clippy --all-targets --workspace --exclude bindgen-integration --exclude tests_expectations -- -W clippy::manual_let_else -W clippy::single_match_else
```