### PR TITLE
Fix `if_not_else` lint

### DIFF
--- a/bindgen/clang.rs
+++ b/bindgen/clang.rs
@@ -216,10 +216,10 @@ impl Cursor {
             })
             .or_else(|| {
                 let canonical = self.canonical();
-                if canonical != *self {
-                    canonical.num_template_args()
-                } else {
+                if canonical == *self {
                     None
+                } else {
+                    canonical.num_template_args()
                 }
             })
     }
@@ -1447,10 +1447,10 @@ impl Type {
     /// elements.
     pub(crate) fn num_elements(&self) -> Option<usize> {
         let num_elements_returned = unsafe { clang_getNumElements(self.x) };
-        if num_elements_returned != -1 {
-            Some(num_elements_returned as usize)
-        } else {
+        if num_elements_returned == -1 {
             None
+        } else {
+            Some(num_elements_returned as usize)
         }
     }
 

--- a/bindgen/codegen/mod.rs
+++ b/bindgen/codegen/mod.rs
@@ -2777,13 +2777,13 @@ impl CodeGenerator for CompInfo {
                 item,
                 &ty_for_impl,
             ) {
-                let partialeq_bounds = if !generic_param_names.is_empty() {
+                let partialeq_bounds = if generic_param_names.is_empty() {
+                    quote! {}
+                } else {
                     let bounds = generic_param_names.iter().map(|t| {
                         quote! { #t: PartialEq }
                     });
                     quote! { where #( #bounds ),* }
-                } else {
-                    quote! {}
                 };
 
                 let prefix = ctx.trait_prefix();
@@ -3444,10 +3444,10 @@ impl<'a> EnumBuilder<'a> {
                 emitted_any_variants,
                 ..
             } => {
-                let variants = if !emitted_any_variants {
-                    quote!(__bindgen_cannot_repr_c_on_empty_enum = 0)
-                } else {
+                let variants = if emitted_any_variants {
                     tokens
+                } else {
+                    quote!(__bindgen_cannot_repr_c_on_empty_enum = 0)
                 };
 
                 quote! {

--- a/bindgen/ir/analysis/derive.rs
+++ b/bindgen/ir/analysis/derive.rs
@@ -722,6 +722,6 @@ pub(crate) fn as_cannot_derive_set(
 ) -> HashSet<ItemId> {
     can_derive
         .into_iter()
-        .filter_map(|(k, v)| if v != CanDerive::Yes { Some(k) } else { None })
+        .filter_map(|(k, v)| if v == CanDerive::Yes { None } else { Some(k) })
         .collect()
 }

--- a/bindgen/ir/analysis/mod.rs
+++ b/bindgen/ir/analysis/mod.rs
@@ -343,10 +343,10 @@ mod tests {
             }
 
             let new_size = self.reachable[&node].len();
-            if original_size != new_size {
-                ConstrainResult::Changed
-            } else {
+            if original_size == new_size {
                 ConstrainResult::Same
+            } else {
+                ConstrainResult::Changed
             }
         }
 

--- a/bindgen/ir/analysis/template_params.rs
+++ b/bindgen/ir/analysis/template_params.rs
@@ -570,10 +570,10 @@ impl<'ctx> MonotoneFramework for UsedTemplateParameters<'ctx> {
         self.used.insert(id, Some(used_by_this_id));
         extra_assert!(self.used.values().all(|v| v.is_some()));
 
-        if new_len != original_len {
-            ConstrainResult::Changed
-        } else {
+        if new_len == original_len {
             ConstrainResult::Same
+        } else {
+            ConstrainResult::Changed
         }
     }
 

--- a/bindgen/ir/annotations.rs
+++ b/bindgen/ir/annotations.rs
@@ -232,10 +232,10 @@ impl Annotations {
                     "derive" => self.derives.push(attr.value),
                     "attribute" => self.attributes.push(attr.value),
                     "private" => {
-                        self.visibility_kind = if attr.value != "false" {
-                            Some(FieldVisibilityKind::Private)
-                        } else {
+                        self.visibility_kind = if attr.value == "false" {
                             Some(FieldVisibilityKind::Public)
+                        } else {
+                            Some(FieldVisibilityKind::Private)
                         };
                     }
                     "accessor" => {

--- a/bindgen/lib.rs
+++ b/bindgen/lib.rs
@@ -1123,10 +1123,10 @@ fn parse(context: &mut BindgenContext) -> Result<(), BindgenError> {
 
     if context.options().emit_ast {
         fn dump_if_not_builtin(cur: &clang::Cursor) -> CXChildVisitResult {
-            if !cur.is_builtin() {
-                clang::ast_dump(cur, 0)
-            } else {
+            if cur.is_builtin() {
                 CXChildVisit_Continue
+            } else {
+                clang::ast_dump(cur, 0)
             }
         }
         cursor.visit(|cur| dump_if_not_builtin(&cur));


### PR DESCRIPTION
Using negations in the `if` makes them a bit harder to read... and there is a lint for that :)

```
cargo clippy --workspace --exclude bindgen-integration --exclude tests_expectations -- -W clippy::if_not_else
```