### PR TITLE
Update tutorial

### DIFF
--- a/.github/workflows/deploy-book.yml
+++ b/.github/workflows/deploy-book.yml
@@ -15,7 +15,7 @@ jobs:
 
       - name: Test book
         run: |
-          curl -L https://github.com/rust-lang/mdBook/releases/download/v0.4.5/mdbook-v0.4.5-x86_64-unknown-linux-gnu.tar.gz | tar xz
+          curl -L https://github.com/rust-lang/mdBook/releases/download/v0.4.34/mdbook-v0.4.34-x86_64-unknown-linux-gnu.tar.gz | tar xz
           ./mdbook build book
           ./mdbook test book
 

--- a/book/src/tutorial-1.md
+++ b/book/src/tutorial-1.md
@@ -10,7 +10,7 @@ You can always check the latest version at
 
 ```toml
 [build-dependencies]
-bindgen = "0.65.1"
+bindgen = "0.71.0"
 ```
 
 > ⚠️ **Warning**

--- a/book/src/tutorial-3.md
+++ b/book/src/tutorial-3.md
@@ -30,7 +30,7 @@ fn main() {
         .header("wrapper.h")
         // Tell cargo to invalidate the built crate whenever any of the
         // included header files changed.
-        .parse_callbacks(Box::new(bindgen::CargoCallbacks))
+        .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))
         // Finish the builder and generate the bindings.
         .generate()
         // Unwrap the Result and panic on failure.


### PR DESCRIPTION
Use the latest verison of mBook to fix copy to clipboard
Before this copy code to clipboard on pages with playground ([tutorial-5](https://rust-lang.github.io/rust-bindgen/tutorial-5.html)) was copying the hidden lines

Update to the latest version of bindgen
Change code example to resolve the deprecation warning on `CargoCallbacks`