### PR TITLE
Update `proc-macro2` version requirement to `1.0.80`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ log = "0.4"
 objc = "0.2"
 owo-colors = "4.1.0"
 prettyplease = "0.2.7"
-proc-macro2 = "1"
+proc-macro2 = "1.0.80"
 quickcheck = "1.0"
 quote = { version = "1", default-features = false }
 regex = { version = "1.5.3", default-features = false }


### PR DESCRIPTION
This crate started using  `proc_macro2::Literal::c_string` (in #2996) which was added to `proc-macro2` in [1.0.80](https://github.com/dtolnay/proc-macro2/releases/tag/1.0.80). This PR bumps the version requirement for `proc-macro2` to reflect that.