### PR TITLE
Derive `Debug` and eq. comparison traits for `InvalidRustTarget` enum

### DIFF
--- a/bindgen/features.rs
+++ b/bindgen/features.rs
@@ -67,6 +67,7 @@ enum Version {
     Nightly,
 }
 
+#[derive(Debug, PartialEq, Eq, Hash)]
 pub enum InvalidRustTarget {
     TooEarly,
 }


### PR DESCRIPTION
These traits are useful to get expressions like `RustTarget::stable(82, 0).unwrap()` to build, as `unwrap()` requires such a `Result` to implement `Debug`. The equality comparison traits may also be useful in cases where pattern matching the enum variants through e.g. `matches!` or match expressions is deemed less stylish. The `Hash` trait is also derived in case anyone wants to put these variants into a hash table based data structure.