### PR TITLE
Add callback to declare functions/statics safe

### DIFF
--- a/bindgen-tests/tests/expectations/tests/parsecb-declare-safe.rs
+++ b/bindgen-tests/tests/expectations/tests/parsecb-declare-safe.rs
@@ -1,0 +1,7 @@
+#![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
+unsafe extern "C" {
+    pub safe static my_safe_var: [::std::os::raw::c_int; 3usize];
+}
+unsafe extern "C" {
+    pub safe fn my_safe_func() -> ::std::os::raw::c_int;
+}

--- a/bindgen-tests/tests/headers/parsecb-declare-safe.h
+++ b/bindgen-tests/tests/headers/parsecb-declare-safe.h
@@ -1,0 +1,5 @@
+// bindgen-parse-callbacks: declare-safe
+
+const int my_safe_var[3] = {1,2,3};
+
+int my_safe_func();

--- a/bindgen-tests/tests/parse_callbacks/mod.rs
+++ b/bindgen-tests/tests/parse_callbacks/mod.rs
@@ -146,6 +146,28 @@ impl ParseCallbacks for WrapAsVariadicFn {
     }
 }
 
+#[derive(Debug)]
+struct DeclareSafe;
+
+impl ParseCallbacks for DeclareSafe {
+    fn declare_safe(&self, item_info: ItemInfo<'_>) -> Option<String> {
+        match item_info.kind {
+            ItemKind::Function => {
+                if item_info.name == "my_safe_func" {
+                    return Some("safe to call".to_owned());
+                }
+            }
+            ItemKind::Var => {
+                if item_info.name == "my_safe_var" {
+                    return Some("safe to access".to_owned());
+                }
+            }
+            _ => todo!(),
+        }
+        None
+    }
+}
+
 pub fn lookup(cb: &str) -> Box<dyn ParseCallbacks> {
     match cb {
         "enum-variant-rename" => Box::new(EnumVariantRename),
@@ -154,6 +176,7 @@ pub fn lookup(cb: &str) -> Box<dyn ParseCallbacks> {
         }
         "wrap-as-variadic-fn" => Box::new(WrapAsVariadicFn),
         "type-visibility" => Box::new(TypeVisibility),
+        "declare-safe" => Box::new(DeclareSafe),
         call_back => {
             if let Some(prefix) =
                 call_back.strip_prefix("remove-function-prefix-")

--- a/bindgen/callbacks.rs
+++ b/bindgen/callbacks.rs
@@ -129,6 +129,17 @@ pub trait ParseCallbacks: fmt::Debug {
         vec![]
     }
 
+    /// Allows declaring items as `safe`.
+    ///
+    /// The returned string will be prepended to the item as `Safety: ...` comment.
+    ///
+    /// When using [`Formatter::Prettyplease`][crate::Formatter::Prettyplease] to format code, non-doc comments are removed ([issue][doc_removal]).
+    ///
+    /// [doc_removal]: https://github.com/dtolnay/prettyplease/issues/50
+    fn declare_safe(&self, _item_info: ItemInfo<'_>) -> Option<String> {
+        None
+    }
+
     /// Provide a list of custom attributes.
     ///
     /// If no additional attributes are wanted, this function should return an
@@ -263,6 +274,7 @@ pub struct ItemInfo<'a> {
 }
 
 /// An enum indicating the kind of item for an `ItemInfo`.
+#[derive(Copy, Clone)]
 #[non_exhaustive]
 pub enum ItemKind {
     /// A Function


### PR DESCRIPTION
Since [Rust 1.82](https://blog.rust-lang.org/2024/10/17/Rust-1.82.0.html#safe-items-with-unsafe-extern), `extern` items can be marked as safe. This PR adds the ability to mark functions and statics in the generated bindings as `safe` via `ParseCallbacks`.
To fit into Rust's typical safety comment conventions, the callback returns a string that will be prepended to the generated item as safety comment.
Because`prettyplease` [does not support non-doc comments](https://github.com/dtolnay/prettyplease/issues/50), I added an additional test using `Formatter::Rustfmt`.