### PR TITLE
Fix deprecated constant in docs example

### DIFF
--- a/book/src/non-system-libraries.md
+++ b/book/src/non-system-libraries.md
@@ -20,8 +20,6 @@ library:
 use std::env;
 use std::path::PathBuf;
 
-use bindgen::CargoCallbacks;
-
 fn main() {
     // This is the directory where the `c` library is located.
     let libdir_path = PathBuf::from("hello")
@@ -86,7 +84,7 @@ fn main() {
         .header(headers_path_str)
         // Tell cargo to invalidate the built crate whenever any of the
         // included header files changed.
-        .parse_callbacks(Box::new(CargoCallbacks::new()))
+        .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))
         // Finish the builder and generate the bindings.
         .generate()
         // Unwrap the Result and panic on failure.


### PR DESCRIPTION
This PR addresses and removes the usage of a deprecated constant in the documentation example.

Specifically, the deprecated `bindgen::CargoCallbacks` constant was replaced with the correct `bindgen::CargoCallbacks::new()` in the docs example.