### PR TITLE
Use appropriate `rustfmt --format ...` param

### DIFF
--- a/bindgen/lib.rs
+++ b/bindgen/lib.rs
@@ -206,7 +206,7 @@ impl std::fmt::Display for Formatter {
             Self::Prettyplease => "prettyplease",
         };
 
-        s.fmt(f)
+        std::fmt::Display::fmt(&s, f)
     }
 }
 
@@ -996,6 +996,12 @@ impl Bindings {
         {
             cmd.args(["--config-path", path]);
         }
+
+        let edition = self
+            .options
+            .rust_edition
+            .unwrap_or_else(|| self.options.rust_target.latest_edition());
+        cmd.args(["--edition", &format!("{edition}")]);
 
         let mut child = cmd.spawn()?;
         let mut child_stdin = child.stdin.take().unwrap();


### PR DESCRIPTION
This fixes the issue with c-string literals which require edition 2021. Now the edition is automatically computed if not specified.

Fixes #3047