### PR TITLE
Fix CI to NOT run publish on every pull request

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,7 @@ env:
 jobs:
   cargo-publish:
     runs-on: ubuntu-latest
-    if: ${{ (github.event.workflow_run.conclusion == 'success') && (github.event.workflow.name == 'Release') }}
+    if: ${{ !github.event.pull_request && (github.event.workflow_run.conclusion == 'success') && (github.event.workflow.name == 'Release') }}
     steps:
       - name: Print workflow event name
         run: echo "${{ github.event.workflow.name }}"


### PR DESCRIPTION
This fixes an issue introduced in #3041 - the `publish` workflow runs every time `release` workflow runs, but since 3041, release workflow also runs in a "testing" mode - thus causing failed publish (due to a missing github token). This could also result in an accidental crate publishing