### PR TITLE
CI fix - calling convention tests

### DIFF
--- a/bindgen-tests/tests/expectations/tests/abi-override.rs
+++ b/bindgen-tests/tests/expectations/tests/abi-override.rs
@@ -1,4 +1,5 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
+#![cfg(target = "i686-pc-windows-msvc")]
 unsafe extern "fastcall" {
     pub fn foo();
 }

--- a/bindgen-tests/tests/expectations/tests/mangling-win32.rs
+++ b/bindgen-tests/tests/expectations/tests/mangling-win32.rs
@@ -1,4 +1,5 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
+#![cfg(target = "i686-pc-windows-msvc")]
 unsafe extern "C" {
     pub fn foo();
 }

--- a/bindgen-tests/tests/headers/abi-override.h
+++ b/bindgen-tests/tests/headers/abi-override.h
@@ -1,4 +1,4 @@
-// bindgen-flags: --override-abi=foo=fastcall --override-abi=bar=stdcall --override-abi=boo=efiapi --override-abi=foobar=efiapi --override-abi qux=system
+// bindgen-flags: --override-abi=foo=fastcall --override-abi=bar=stdcall --override-abi=boo=efiapi --override-abi=foobar=efiapi --override-abi qux=system --raw-line '#![cfg(target = "i686-pc-windows-msvc")]'
 
 void foo();
 void bar();

--- a/bindgen-tests/tests/headers/mangling-win32.hpp
+++ b/bindgen-tests/tests/headers/mangling-win32.hpp
@@ -1,4 +1,4 @@
-// bindgen-flags: -- --target=i686-pc-win32
+// bindgen-flags: --raw-line '#![cfg(target = "i686-pc-windows-msvc")]' -- --target=i686-pc-win32
 
 extern "C" void foo();
 


### PR DESCRIPTION
Seems like recent compiler changes no longer allow invalid calling conventions