### PR TITLE
Mangle identifiers named 'gen' now that it's a reserved keyword

### DIFF
--- a/bindgen-tests/tests/expectations/tests/keywords.rs
+++ b/bindgen-tests/tests/expectations/tests/keywords.rs
@@ -88,6 +88,10 @@ unsafe extern "C" {
     pub static mut fn_: ::std::os::raw::c_int;
 }
 unsafe extern "C" {
+    #[link_name = "\u{1}gen"]
+    pub static mut gen_: ::std::os::raw::c_int;
+}
+unsafe extern "C" {
     #[link_name = "\u{1}impl"]
     pub static mut impl_: ::std::os::raw::c_int;
 }

--- a/bindgen-tests/tests/headers/keywords.h
+++ b/bindgen-tests/tests/headers/keywords.h
@@ -21,6 +21,7 @@ int box;
 int crate;
 int false;
 int fn;
+int gen;
 int impl;
 int in;
 int let;

--- a/bindgen/ir/context.rs
+++ b/bindgen/ir/context.rs
@@ -867,7 +867,7 @@ If you encounter an error missing from this list, please file an issue or a PR!"
                 "abstract" | "alignof" | "as" | "async" | "await" | "become" |
                     "box" | "break" | "const" | "continue" | "crate" | "do" |
                     "dyn" | "else" | "enum" | "extern" | "false" | "final" |
-                    "fn" | "for" | "if" | "impl" | "in" | "let" | "loop" |
+                    "fn" | "for" | "gen" | "if" | "impl" | "in" | "let" | "loop" |
                     "macro" | "match" | "mod" | "move" | "mut" | "offsetof" |
                     "override" | "priv" | "proc" | "pub" | "pure" | "ref" |
                     "return" | "Self" | "self" | "sizeof" | "static" |


### PR DESCRIPTION
This addresses https://github.com/rust-lang/rust-bindgen/issues/3093
