### PR TITLE
process_comment: Use last defined callback

### DIFF
--- a/bindgen/lib.rs
+++ b/bindgen/lib.rs
@@ -582,9 +582,7 @@ impl BindgenOptions {
 
     fn process_comment(&self, comment: &str) -> String {
         let comment = comment::preprocess(comment);
-        self.parse_callbacks
-            .last()
-            .and_then(|cb| cb.process_comment(&comment))
+        self.last_callback(|cb| cb.process_comment(&comment))
             .unwrap_or(comment)
     }
 }


### PR DESCRIPTION
Instead of using the last registered callback, iterate through all callbacks and use the last one that was actually implemented and returned `Some()`.
This is essential when users register more than one parse callback.