### PR TITLE
Make mangled name available to `generated_xxx_override`. Link name override no longer affected by generated name override.

### DIFF
--- a/bindgen-tests/tests/expectations/tests/generated_link_name_override.rs
+++ b/bindgen-tests/tests/expectations/tests/generated_link_name_override.rs
@@ -1,0 +1,13 @@
+#![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
+unsafe extern "C" {
+    #[link_name = "\u{1}prefix_kept_in_link_name_only_var_coolConstVariable_name"]
+    pub static var_coolConstVariable_name: ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    #[link_name = "\u{1}prefix_kept_in_link_name_only_var_coolVariable_name"]
+    pub static mut var_coolVariable_name: ::std::os::raw::c_int;
+}
+unsafe extern "C" {
+    #[link_name = "\u{1}_Z56prefix_kept_in_link_name_only_function_coolFunction_namei"]
+    pub fn function_coolFunction_name(x: ::std::os::raw::c_int);
+}

--- a/bindgen-tests/tests/headers/generated_link_name_override.hpp
+++ b/bindgen-tests/tests/headers/generated_link_name_override.hpp
@@ -1,0 +1,10 @@
+// bindgen-parse-callbacks: prefix-link-name-
+// bindgen-parse-callbacks: remove-function-prefix-prefix_kept_in_link_name_only_
+// prefix-link-name- with no value just ensures that the items are always given the link_name attribute.
+
+extern const int prefix_kept_in_link_name_only_var_coolConstVariable_name; 
+
+extern int prefix_kept_in_link_name_only_var_coolVariable_name;
+
+void prefix_kept_in_link_name_only_function_coolFunction_name(const int x);
+

--- a/bindgen/callbacks.rs
+++ b/bindgen/callbacks.rs
@@ -258,6 +258,8 @@ pub enum TypeKind {
 pub struct ItemInfo<'a> {
     /// The name of the item
     pub name: &'a str,
+    /// The mangled name of the item, if available
+    pub mangled_name: Option<&'a str>,
     /// The kind of item
     pub kind: ItemKind,
 }

--- a/bindgen/ir/function.rs
+++ b/bindgen/ir/function.rs
@@ -784,6 +784,14 @@ impl ClangSubItemParser for Function {
             // but seems easy enough to handle it here.
             name.push_str("_destructor");
         }
+
+        let link_name = context.options().last_callback(|callbacks| {
+            callbacks.generated_link_name_override(ItemInfo {
+                name: name.as_str(),
+                kind: ItemKind::Function,
+            })
+        });
+        
         if let Some(nm) = context.options().last_callback(|callbacks| {
             callbacks.generated_name_override(ItemInfo {
                 name: name.as_str(),
@@ -795,13 +803,6 @@ impl ClangSubItemParser for Function {
         assert!(!name.is_empty(), "Empty function name.");
 
         let mangled_name = cursor_mangling(context, &cursor);
-
-        let link_name = context.options().last_callback(|callbacks| {
-            callbacks.generated_link_name_override(ItemInfo {
-                name: name.as_str(),
-                kind: ItemKind::Function,
-            })
-        });
 
         let function = Self::new(
             name.clone(),

--- a/bindgen/ir/function.rs
+++ b/bindgen/ir/function.rs
@@ -784,25 +784,26 @@ impl ClangSubItemParser for Function {
             // but seems easy enough to handle it here.
             name.push_str("_destructor");
         }
+        let mangled_name = cursor_mangling(context, &cursor);
 
         let link_name = context.options().last_callback(|callbacks| {
             callbacks.generated_link_name_override(ItemInfo {
                 name: name.as_str(),
+                mangled_name: mangled_name.as_deref(),
                 kind: ItemKind::Function,
             })
         });
-        
+
         if let Some(nm) = context.options().last_callback(|callbacks| {
             callbacks.generated_name_override(ItemInfo {
                 name: name.as_str(),
+                mangled_name: mangled_name.as_deref(),
                 kind: ItemKind::Function,
             })
         }) {
             name = nm;
         }
         assert!(!name.is_empty(), "Empty function name.");
-
-        let mangled_name = cursor_mangling(context, &cursor);
 
         let function = Self::new(
             name.clone(),

--- a/bindgen/ir/var.rs
+++ b/bindgen/ir/var.rs
@@ -271,10 +271,12 @@ impl ClangSubItemParser for Var {
             }
             CXCursor_VarDecl => {
                 let mut name = cursor.spelling();
+                let mangling = cursor_mangling(ctx, &cursor);
 
                 let link_name = ctx.options().last_callback(|callbacks| {
                     callbacks.generated_link_name_override(ItemInfo {
                         name: name.as_str(),
+                        mangled_name: mangling.as_deref(),
                         kind: ItemKind::Var,
                     })
                 });
@@ -283,6 +285,7 @@ impl ClangSubItemParser for Var {
                     if let Some(nm) = ctx.options().last_callback(|callbacks| {
                         callbacks.generated_name_override(ItemInfo {
                             name: name.as_str(),
+                            mangled_name: mangling.as_deref(),
                             kind: ItemKind::Var,
                         })
                     }) {
@@ -365,7 +368,6 @@ impl ClangSubItemParser for Var {
                         .map(VarType::String)
                 };
 
-                let mangling = cursor_mangling(ctx, &cursor);
                 let var =
                     Var::new(name, mangling, link_name, ty, value, is_const);
 

--- a/bindgen/ir/var.rs
+++ b/bindgen/ir/var.rs
@@ -271,6 +271,14 @@ impl ClangSubItemParser for Var {
             }
             CXCursor_VarDecl => {
                 let mut name = cursor.spelling();
+
+                let link_name = ctx.options().last_callback(|callbacks| {
+                    callbacks.generated_link_name_override(ItemInfo {
+                        name: name.as_str(),
+                        kind: ItemKind::Var,
+                    })
+                });
+
                 if cursor.linkage() == CXLinkage_External {
                     if let Some(nm) = ctx.options().last_callback(|callbacks| {
                         callbacks.generated_name_override(ItemInfo {
@@ -288,13 +296,6 @@ impl ClangSubItemParser for Var {
                     warn!("Empty constant name?");
                     return Err(ParseError::Continue);
                 }
-
-                let link_name = ctx.options().last_callback(|callbacks| {
-                    callbacks.generated_link_name_override(ItemInfo {
-                        name: name.as_str(),
-                        kind: ItemKind::Var,
-                    })
-                });
 
                 let ty = cursor.cur_type();
 


### PR DESCRIPTION
Would fix #3107
- The name passed to `generated_link_name_override` is no longer first modified by `generated_name_override`
- Makes the mangled name for items available in `generated_link_name_override` and `generated_name_override`, by including it as a field on the passed `ItemInfo` parameter.