### PR TITLE
Remove useless fallback

### DIFF
--- a/bindgen/ir/item.rs
+++ b/bindgen/ir/item.rs
@@ -1590,10 +1590,7 @@ impl Item {
             canonical_def.unwrap_or_else(|| ty.declaration())
         };
 
-        let comment = location
-            .raw_comment()
-            .or_else(|| decl.raw_comment())
-            .or_else(|| location.raw_comment());
+        let comment = location.raw_comment().or_else(|| decl.raw_comment());
 
         let annotations =
             Annotations::new(&decl).or_else(|| Annotations::new(&location));


### PR DESCRIPTION
We already tried `location.raw_comment()` first. 
Originally the last `or_else` branch debug printed `location.raw_comment()`, but the print was removed in c94367c8e9607d3b6d5cf80f0c589971dca40f7c.