### PR TITLE
Remove warning for opaque forward declarations

### DIFF
--- a/bindgen/codegen/mod.rs
+++ b/bindgen/codegen/mod.rs
@@ -2315,7 +2315,9 @@ impl CodeGenerator for CompInfo {
                     });
                 }
                 None => {
-                    warn!("Opaque type without layout! Expect dragons!");
+                    if !forward_decl {
+                        warn!("Opaque type without layout! Expect dragons!");
+                    }
                 }
             }
         } else if !is_union && !zero_sized {


### PR DESCRIPTION
Forward declarations never have a known layout, so the warning makes no sense in that case.