### PR TITLE
Preserve doc comment when type alias is hidden

### DIFF
--- a/bindgen-tests/tests/expectations/tests/3119_overlapping_alias_comment.rs
+++ b/bindgen-tests/tests/expectations/tests/3119_overlapping_alias_comment.rs
@@ -1,0 +1,8 @@
+#![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
+/** This is a forward declared struct alias with overlapping names
+ and documentation.*/
+#[repr(C)]
+#[derive(Debug)]
+pub struct Struct {
+    _unused: [u8; 0],
+}

--- a/bindgen-tests/tests/headers/3119_overlapping_alias_comment.h
+++ b/bindgen-tests/tests/headers/3119_overlapping_alias_comment.h
@@ -1,0 +1,7 @@
+// bindgen-flags: --no-layout-tests
+
+/**
+ * This is a forward declared struct alias with overlapping names
+ * and documentation.
+ */
+typedef struct Struct Struct;

--- a/bindgen/codegen/mod.rs
+++ b/bindgen/codegen/mod.rs
@@ -2478,7 +2478,12 @@ impl CodeGenerator for CompInfo {
         let mut needs_debug_impl = false;
         let mut needs_partialeq_impl = false;
         let needs_flexarray_impl = flex_array_generic.is_some();
-        if let Some(comment) = item.comment(ctx) {
+        let type_id = item.id().expect_type_id(ctx);
+
+        if let Some(comment) = item
+            .comment(ctx)
+            .or_else(|| Self::get_typedef_fallback_comment(ctx, &type_id))
+        {
             attributes.push(attributes::doc(&comment));
         }
 
@@ -3064,6 +3069,48 @@ impl CompInfo {
                 #from_ptr_sized
             }
         }
+    }
+
+    /// Use a fallback comment from a type alias to this type if necessary
+    ///
+    /// The documentation for a type could get lost in the following circumstances:
+    ///
+    /// - We have a type and a type alias with the same canonical path
+    /// - The Documentation is only associated with the type alias
+    ///
+    /// In this case bindgen will not generate the type alias and the documentation would be lost.
+    /// To avoid this, we check here if there is any type alias to this type, which has
+    /// the same canonical path and return the comment as a fallback, if our type does
+    /// not have documentation.
+    fn get_typedef_fallback_comment(
+        ctx: &BindgenContext,
+        type_id: &crate::ir::context::TypeId,
+    ) -> Option<String> {
+        if !ctx.options().generate_comments {
+            return None;
+        }
+        let type_alias_comment = ctx
+            .items()
+            .filter(|(_id, alias)| {
+                let Some(this_ty) = alias.as_type() else {
+                    return false;
+                };
+                let TypeKind::Alias(alias_to) = this_ty.kind() else {
+                    return false;
+                };
+                //
+                match ctx.resolve_type(*alias_to).kind() {
+                    TypeKind::ResolvedTypeRef(resolved_typeid) => {
+                        resolved_typeid == type_id &&
+                            alias.canonical_path(ctx) ==
+                                type_id.canonical_path(ctx)
+                    }
+                    _ => false,
+                }
+            })
+            .filter_map(|(_id, item)| item.comment(ctx));
+        let alias_comment: Vec<String> = type_alias_comment.collect();
+        alias_comment.get(0).cloned()
     }
 }
 

--- a/bindgen/ir/item.rs
+++ b/bindgen/ir/item.rs
@@ -516,6 +516,13 @@ impl Item {
             .map(|comment| ctx.options().process_comment(comment))
     }
 
+    /// Set this item's raw comment if it does not already have one.
+    pub(crate) fn set_comment_if_none(&mut self, comment: String) {
+        if self.comment.is_none() {
+            self.comment = Some(comment);
+        }
+    }
+
     /// What kind of item is this?
     pub(crate) fn kind(&self) -> &ItemKind {
         &self.kind


### PR DESCRIPTION
If a type is not documented, but a type alias with the same canonical path is, then preserve the
documentation of the type alias onto the type, since otherwise it would be lost.

Fixes #3119