### PR TITLE
Report enums in ParseCallbacks.

### DIFF
--- a/bindgen-tests/tests/parse_callbacks/item_discovery_callback/header_item_discovery.h
+++ b/bindgen-tests/tests/parse_callbacks/item_discovery_callback/header_item_discovery.h
@@ -1,4 +1,4 @@
-// Unions
+// Structs
 void function_using_anonymous_struct(struct {} arg0);
 
 struct NamedStruct {
@@ -14,3 +14,15 @@ union NamedUnion {
 };
 
 typedef union NamedUnion AliasOfNamedUnion;
+
+// Enums
+
+// We don't include an anonymous enum because such enums
+// are not visible outside the function, and thus tend not
+// to be useful - bindgen doesn't handle them for this reason.
+
+enum NamedEnum {
+    Fish,
+};
+
+typedef enum NamedEnum AliasOfNamedEnum;

--- a/bindgen-tests/tests/parse_callbacks/item_discovery_callback/mod.rs
+++ b/bindgen-tests/tests/parse_callbacks/item_discovery_callback/mod.rs
@@ -61,6 +61,19 @@ pub fn test_item_discovery_callback() {
             },
         ),
         (
+            DiscoveredItemId::new(27),
+            DiscoveredItem::Alias {
+                alias_name: "AliasOfNamedEnum".to_string(),
+                alias_for: DiscoveredItemId::new(24),
+            },
+        ),
+        (
+            DiscoveredItemId::new(24),
+            DiscoveredItem::Enum {
+                final_name: "NamedEnum".to_string(),
+            },
+        ),
+        (
             DiscoveredItemId::new(30),
             DiscoveredItem::Struct {
                 original_name: None,
@@ -126,6 +139,9 @@ fn compare_item_info(
             expected,
             generated,
         ),
+        DiscoveredItem::Enum { .. } => {
+            compare_enum_info(expected_item, generated_item)
+        }
     }
 }
 
@@ -201,6 +217,30 @@ pub fn compare_union_info(
         }
         _ => false,
     }
+}
+
+pub fn compare_enum_info(
+    expected_item: &DiscoveredItem,
+    generated_item: &DiscoveredItem,
+) -> bool {
+    let DiscoveredItem::Enum {
+        final_name: expected_final_name,
+    } = expected_item
+    else {
+        unreachable!()
+    };
+
+    let DiscoveredItem::Enum {
+        final_name: generated_final_name,
+    } = generated_item
+    else {
+        unreachable!()
+    };
+
+    if !compare_names(expected_final_name, generated_final_name) {
+        return false;
+    }
+    true
 }
 
 pub fn compare_alias_info(

--- a/bindgen/callbacks.rs
+++ b/bindgen/callbacks.rs
@@ -217,7 +217,14 @@ pub enum DiscoveredItem {
 
         /// The identifier of the discovered type
         alias_for: DiscoveredItemId,
-    }, // functions, modules, etc.
+    },
+
+    /// Represents an enum.
+    Enum {
+        /// The final name of the generated binding
+        final_name: String,
+    },
+    // functions, modules, etc.
 }
 
 /// Relevant information about a type to which new derive attributes will be added using

--- a/bindgen/codegen/mod.rs
+++ b/bindgen/codegen/mod.rs
@@ -3770,6 +3770,15 @@ impl CodeGenerator for Enum {
         let repr = repr.to_rust_ty_or_opaque(ctx, item);
         let has_typedef = ctx.is_enum_typedef_combo(item.id());
 
+        ctx.options().for_each_callback(|cb| {
+            cb.new_item_found(
+                DiscoveredItemId::new(item.id().as_usize()),
+                DiscoveredItem::Enum {
+                    final_name: name.to_string(),
+                },
+            );
+        });
+
         let mut builder =
             EnumBuilder::new(&name, attrs, &repr, variation, has_typedef);
 


### PR DESCRIPTION
ParseCallbacks previously reported structs but not enums. Enhance it to do so. At the moment, little information is provided about enums - but bindgen doesn't handle (rare) anonymous enums so this seems the right amount of information to report. At the moment, effectively this just provides a mapping between name and DiscoveredItemId.

One of a number of PRs I'll be raising for https://github.com/google/autocxx/issues/124.

In future PRs I'll be hoping to add further callbacks which report more information based on DiscoveredItemId, so having the DiscoveredItemId for each enum is an important pre-requisite.