### PR TITLE
Add extra tests.

### DIFF
--- a/bindgen-tests/tests/expectations/tests/class_with_enum.rs
+++ b/bindgen-tests/tests/expectations/tests/class_with_enum.rs
@@ -1,0 +1,14 @@
+#![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct A {
+    pub _address: u8,
+}
+pub const A_B_B1: A_B = 0;
+pub const A_B_B2: A_B = 1;
+pub type A_B = ::std::os::raw::c_uint;
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of A"][::std::mem::size_of::<A>() - 1usize];
+    ["Alignment of A"][::std::mem::align_of::<A>() - 1usize];
+};

--- a/bindgen-tests/tests/expectations/tests/special-members.rs
+++ b/bindgen-tests/tests/expectations/tests/special-members.rs
@@ -1,0 +1,51 @@
+#![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
+#[repr(C)]
+#[derive(Debug, Default)]
+pub struct A {
+    pub _address: u8,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of A"][::std::mem::size_of::<A>() - 1usize];
+    ["Alignment of A"][::std::mem::align_of::<A>() - 1usize];
+};
+unsafe extern "C" {
+    #[link_name = "\u{1}_ZN1AC1Ev"]
+    pub fn A_A(this: *mut A);
+}
+unsafe extern "C" {
+    #[link_name = "\u{1}_ZN1AC1ERS_"]
+    pub fn A_A1(this: *mut A, arg1: *mut A);
+}
+unsafe extern "C" {
+    #[link_name = "\u{1}_ZN1AC1EOS_"]
+    pub fn A_A2(this: *mut A, arg1: *mut A);
+}
+unsafe extern "C" {
+    #[link_name = "\u{1}_ZN1AD1Ev"]
+    pub fn A_A_destructor(this: *mut A);
+}
+impl A {
+    #[inline]
+    pub unsafe fn new() -> Self {
+        let mut __bindgen_tmp = ::std::mem::MaybeUninit::uninit();
+        A_A(__bindgen_tmp.as_mut_ptr());
+        __bindgen_tmp.assume_init()
+    }
+    #[inline]
+    pub unsafe fn new1(arg1: *mut A) -> Self {
+        let mut __bindgen_tmp = ::std::mem::MaybeUninit::uninit();
+        A_A1(__bindgen_tmp.as_mut_ptr(), arg1);
+        __bindgen_tmp.assume_init()
+    }
+    #[inline]
+    pub unsafe fn new2(arg1: *mut A) -> Self {
+        let mut __bindgen_tmp = ::std::mem::MaybeUninit::uninit();
+        A_A2(__bindgen_tmp.as_mut_ptr(), arg1);
+        __bindgen_tmp.assume_init()
+    }
+    #[inline]
+    pub unsafe fn destruct(&mut self) {
+        A_A_destructor(self)
+    }
+}

--- a/bindgen-tests/tests/headers/class_with_enum.hpp
+++ b/bindgen-tests/tests/headers/class_with_enum.hpp
@@ -1,0 +1,7 @@
+class A {
+public:
+    enum B {
+        B1,
+        B2,
+    };
+};

--- a/bindgen-tests/tests/headers/special-members.hpp
+++ b/bindgen-tests/tests/headers/special-members.hpp
@@ -1,0 +1,7 @@
+class A {
+public:
+    A();
+    A(A&);
+    A(A&&);
+    ~A();
+};


### PR DESCRIPTION
These files aspects of bindgen behavior which may not be generally useful to most consumers but are more important to downstream postprocessors such as autocxx.

One of them tests enums embedded within classes, and the other tests various types of C++ constructor.

A later PR will aim to add callbacks indicating which type of C++ constructor it is, but for now, this is just a test to ensure they're all generated OK.

Part of https://github.com/google/autocxx/issues/124.