### PR TITLE
Denote types with unused template params.

### DIFF
--- a/bindgen-tests/tests/parse_callbacks/item_discovery_callback/header_item_discovery.h
+++ b/bindgen-tests/tests/parse_callbacks/item_discovery_callback/header_item_discovery.h
@@ -26,3 +26,7 @@ enum NamedEnum {
 };
 
 typedef enum NamedEnum AliasOfNamedEnum;
+
+// Functions
+
+void named_function();

--- a/bindgen-tests/tests/parse_callbacks/item_discovery_callback/header_item_discovery.hpp
+++ b/bindgen-tests/tests/parse_callbacks/item_discovery_callback/header_item_discovery.hpp
@@ -1,0 +1,6 @@
+// Methods
+
+class SomeClass {
+public:
+    void named_method();
+};

--- a/bindgen-tests/tests/parse_callbacks/item_discovery_callback/header_item_discovery.hpp
+++ b/bindgen-tests/tests/parse_callbacks/item_discovery_callback/header_item_discovery.hpp
@@ -2,5 +2,15 @@
 
 class SomeClass {
 public:
+    SomeClass() = delete;
+    SomeClass(const SomeClass&) = default;
+    SomeClass(SomeClass&&);
     void named_method();
+    virtual void virtual_method();
+    virtual void pure_virtual_method() = 0;
+private:
+    void private_method();
+protected:
+    void protected_method();
+
 };

--- a/bindgen-tests/tests/parse_callbacks/item_discovery_callback/header_item_discovery_with_namespaces.hpp
+++ b/bindgen-tests/tests/parse_callbacks/item_discovery_callback/header_item_discovery_with_namespaces.hpp
@@ -1,0 +1,30 @@
+void a();
+
+namespace B {
+    void c();
+
+    namespace D {
+        void e();
+    }
+
+    // We should not report empty namespaces
+    namespace F {
+    }
+
+    namespace {
+        void g();
+    }
+
+    inline namespace H {
+        void i();
+        namespace J {
+            void k();
+        }
+    }
+
+    struct L {
+        struct M {
+
+        };
+    };
+};

--- a/bindgen-tests/tests/parse_callbacks/item_discovery_callback/mod.rs
+++ b/bindgen-tests/tests/parse_callbacks/item_discovery_callback/mod.rs
@@ -502,8 +502,8 @@ fn compare_item_info(
     generated: &ItemCache,
     expected_filename: &str,
 ) -> bool {
-    if std::mem::discriminant(&expected_item.item)
-        != std::mem::discriminant(&generated_item.0)
+    if std::mem::discriminant(&expected_item.item) !=
+        std::mem::discriminant(&generated_item.0)
     {
         return false;
     }
@@ -800,8 +800,8 @@ pub fn compare_mod_info(
         unreachable!()
     };
 
-    if expected_anonymous != generated_anonymous
-        || *expected_inline != *generated_inline
+    if expected_anonymous != generated_anonymous ||
+        *expected_inline != *generated_inline
     {
         return false;
     }

--- a/bindgen-tests/tests/parse_callbacks/item_discovery_callback/mod.rs
+++ b/bindgen-tests/tests/parse_callbacks/item_discovery_callback/mod.rs
@@ -845,11 +845,11 @@ pub fn compare_method_info(
         unreachable!()
     };
 
-    if expected_parent != generated_parent
-        || expected_cpp_explicit != generated_cpp_explicit
-        || expected_cpp_special_member != generated_cpp_special_member
-        || expected_cpp_virtual != generated_cpp_virtual
-        || expected_cpp_visibility != generated_cpp_visibility
+    if expected_parent != generated_parent ||
+        expected_cpp_explicit != generated_cpp_explicit ||
+        expected_cpp_special_member != generated_cpp_special_member ||
+        expected_cpp_virtual != generated_cpp_virtual ||
+        expected_cpp_visibility != generated_cpp_visibility
     {
         return false;
     }

--- a/bindgen-tests/tests/parse_callbacks/item_discovery_callback/mod.rs
+++ b/bindgen-tests/tests/parse_callbacks/item_discovery_callback/mod.rs
@@ -4,23 +4,57 @@ use std::rc::Rc;
 
 use regex::Regex;
 
-use bindgen::callbacks::{DiscoveredItem, DiscoveredItemId, ParseCallbacks};
+use bindgen::callbacks::{
+    DiscoveredItem, DiscoveredItemId, ParseCallbacks, SourceLocation,
+};
 use bindgen::Builder;
 
 #[derive(Debug, Default)]
 struct ItemDiscovery(Rc<RefCell<ItemCache>>);
 
-pub type ItemCache = HashMap<DiscoveredItemId, DiscoveredItem>;
+pub type ItemCache = HashMap<DiscoveredItemId, DiscoveredInformation>;
+
+#[derive(Debug)]
+pub struct DiscoveredInformation(DiscoveredItem, Option<SourceLocation>);
 
 impl ParseCallbacks for ItemDiscovery {
-    fn new_item_found(&self, _id: DiscoveredItemId, _item: DiscoveredItem) {
-        self.0.borrow_mut().insert(_id, _item);
+    fn new_item_found(
+        &self,
+        id: DiscoveredItemId,
+        item: DiscoveredItem,
+        source_location: Option<&SourceLocation>,
+    ) {
+        self.0
+            .borrow_mut()
+            .insert(id, DiscoveredInformation(item, source_location.cloned()));
     }
 }
 
+#[derive(Debug)]
+pub struct ItemExpectations {
+    item: DiscoveredItem,
+    source_location: Option<(usize, usize, usize)>,
+}
+
+impl ItemExpectations {
+    fn new(
+        item: DiscoveredItem,
+        line: usize,
+        col: usize,
+        byte_offset: usize,
+    ) -> Self {
+        Self {
+            item,
+            source_location: Some((line, col, byte_offset)),
+        }
+    }
+}
+
+type ExpectationMap = HashMap<DiscoveredItemId, ItemExpectations>;
+
 fn test_item_discovery_callback(
     header: &str,
-    expected: HashMap<DiscoveredItemId, DiscoveredItem>,
+    expected: HashMap<DiscoveredItemId, ItemExpectations>,
 ) {
     let discovery = ItemDiscovery::default();
     let info = Rc::clone(&discovery.0);
@@ -34,72 +68,117 @@ fn test_item_discovery_callback(
         .generate()
         .expect("TODO: panic message");
 
-    compare_item_caches(&info.borrow(), &expected);
+    compare_item_caches(&info.borrow(), &expected, header);
 }
 
 #[test]
 fn test_item_discovery_callback_c() {
-    let expected = ItemCache::from([
+    let expected = ExpectationMap::from([
         (
             DiscoveredItemId::new(10),
-            DiscoveredItem::Struct {
-                original_name: Some("NamedStruct".to_string()),
-                final_name: "NamedStruct".to_string(),
-            },
+            ItemExpectations::new(
+                DiscoveredItem::Struct {
+                    original_name: Some("NamedStruct".to_string()),
+                    final_name: "NamedStruct".to_string(),
+                },
+                4,
+                8,
+                73,
+            ),
         ),
         (
             DiscoveredItemId::new(11),
-            DiscoveredItem::Alias {
-                alias_name: "AliasOfNamedStruct".to_string(),
-                alias_for: DiscoveredItemId::new(10),
-            },
+            ItemExpectations::new(
+                DiscoveredItem::Alias {
+                    alias_name: "AliasOfNamedStruct".to_string(),
+                    alias_for: DiscoveredItemId::new(10),
+                },
+                7,
+                28,
+                118,
+            ),
         ),
         (
             DiscoveredItemId::new(20),
-            DiscoveredItem::Union {
-                original_name: Some("NamedUnion".to_string()),
-                final_name: "NamedUnion".to_string(),
-            },
+            ItemExpectations::new(
+                DiscoveredItem::Union {
+                    original_name: Some("NamedUnion".to_string()),
+                    final_name: "NamedUnion".to_string(),
+                },
+                13,
+                7,
+                209,
+            ),
         ),
         (
             DiscoveredItemId::new(21),
-            DiscoveredItem::Alias {
-                alias_name: "AliasOfNamedUnion".to_string(),
-                alias_for: DiscoveredItemId::new(20),
-            },
+            ItemExpectations::new(
+                DiscoveredItem::Alias {
+                    alias_name: "AliasOfNamedUnion".to_string(),
+                    alias_for: DiscoveredItemId::new(20),
+                },
+                16,
+                26,
+                251,
+            ),
         ),
         (
             DiscoveredItemId::new(27),
-            DiscoveredItem::Alias {
-                alias_name: "AliasOfNamedEnum".to_string(),
-                alias_for: DiscoveredItemId::new(24),
-            },
+            ItemExpectations::new(
+                DiscoveredItem::Alias {
+                    alias_name: "AliasOfNamedEnum".to_string(),
+                    alias_for: DiscoveredItemId::new(24),
+                },
+                28,
+                24,
+                515,
+            ),
         ),
         (
             DiscoveredItemId::new(24),
-            DiscoveredItem::Enum {
-                final_name: "NamedEnum".to_string(),
-            },
+            ItemExpectations::new(
+                DiscoveredItem::Enum {
+                    final_name: "NamedEnum".to_string(),
+                },
+                24,
+                6,
+                466,
+            ),
         ),
         (
             DiscoveredItemId::new(30),
-            DiscoveredItem::Struct {
-                original_name: None,
-                final_name: "_bindgen_ty_*".to_string(),
-            },
+            ItemExpectations::new(
+                DiscoveredItem::Struct {
+                    original_name: None,
+                    final_name: "_bindgen_ty_*".to_string(),
+                },
+                2,
+                38,
+                48,
+            ),
         ),
         (
             DiscoveredItemId::new(40),
-            DiscoveredItem::Union {
-                original_name: None,
-                final_name: "_bindgen_ty_*".to_string(),
-            },
+            ItemExpectations::new(
+                DiscoveredItem::Union {
+                    original_name: None,
+                    final_name: "_bindgen_ty_*".to_string(),
+                },
+                11,
+                37,
+                186,
+            ),
         ),
         (
             DiscoveredItemId::new(41),
-            DiscoveredItem::Function {
-                final_name: "named_function".to_string(),
-            },
+            ItemExpectations::new(
+                DiscoveredItem::Function {
+                    final_name: "named_function".to_string(),
+                },
+                32,
+                6,
+                553,
+            ),
         ),
     ]);
     test_item_discovery_callback(
@@ -108,40 +187,58 @@ fn test_item_discovery_callback_c() {
 
 #[test]
 fn test_item_discovery_callback_cpp() {
-    let expected = ItemCache::from([
+    let expected = ExpectationMap::from([
         (
             DiscoveredItemId::new(1),
-            DiscoveredItem::Struct {
-                original_name: Some("SomeClass".to_string()),
-                final_name: "SomeClass".to_string(),
-            },
+            ItemExpectations::new(
+                DiscoveredItem::Struct {
+                    original_name: Some("SomeClass".to_string()),
+                    final_name: "SomeClass".to_string(),
+                },
+                3,
+                7,
+                18,
+            ),
         ),
         (
             DiscoveredItemId::new(2),
-            DiscoveredItem::Method {
-                final_name: "named_method".to_string(),
-                parent: DiscoveredItemId::new(1),
-            },
+            ItemExpectations::new(
+                DiscoveredItem::Method {
+                    final_name: "named_method".to_string(),
+                    parent: DiscoveredItemId::new(1),
+                },
+                5,
+                10,
+                47,
+            ),
         ),
     ]);
     test_item_discovery_callback(
         "/tests/parse_callbacks/item_discovery_callback/header_item_discovery.hpp", expected);
 }
 
-pub fn compare_item_caches(generated: &ItemCache, expected: &ItemCache) {
+fn compare_item_caches(
+    generated: &ItemCache,
+    expected: &ExpectationMap,
+    expected_filename: &str,
+) {
     // We can't use a simple Eq::eq comparison because of two reasons:
     // - anonymous structs/unions will have a final name generated by bindgen which may change
     //   if the header file or the bindgen logic is altered
     // - aliases have a DiscoveredItemId that we can't directly compare for the same instability reasons
     for expected_item in expected.values() {
-        let found = generated.iter().find(|(_generated_id, generated_item)| {
-            compare_item_info(
-                expected_item,
-                generated_item,
-                expected,
-                generated,
-            )
-        });
+        let found =
+            generated
+                .iter()
+                .find(|(_generated_id, generated_item)| {
+                    compare_item_info(
+                        expected_item,
+                        generated_item,
+                        expected,
+                        generated,
+                        expected_filename,
+                    )
+                });
 
         assert!(
             found.is_some(),
@@ -151,40 +248,72 @@ pub fn compare_item_caches(generated: &ItemCache, expected: &ItemCache) {
 }
 
 fn compare_item_info(
-    expected_item: &DiscoveredItem,
-    generated_item: &DiscoveredItem,
-    expected: &ItemCache,
+    expected_item: &ItemExpectations,
+    generated_item: &DiscoveredInformation,
+    expected: &ExpectationMap,
     generated: &ItemCache,
+    expected_filename: &str,
 ) -> bool {
-    if std::mem::discriminant(expected_item) !=
-        std::mem::discriminant(generated_item)
+    if std::mem::discriminant(&expected_item.item)
+        != std::mem::discriminant(&generated_item.0)
     {
         return false;
     }
 
-    match generated_item {
+    let is_a_match = match generated_item.0 {
         DiscoveredItem::Struct { .. } => {
-            compare_struct_info(expected_item, generated_item)
+            compare_struct_info(&expected_item.item, &generated_item.0)
         }
         DiscoveredItem::Union { .. } => {
-            compare_union_info(expected_item, generated_item)
+            compare_union_info(&expected_item.item, &generated_item.0)
         }
         DiscoveredItem::Alias { .. } => compare_alias_info(
-            expected_item,
-            generated_item,
+            &expected_item.item,
+            &generated_item.0,
             expected,
             generated,
+            expected_filename,
         ),
         DiscoveredItem::Enum { .. } => {
-            compare_enum_info(expected_item, generated_item)
+            compare_enum_info(&expected_item.item, &generated_item.0)
         }
         DiscoveredItem::Function { .. } => {
-            compare_function_info(expected_item, generated_item)
+            compare_function_info(&expected_item.item, &generated_item.0)
         }
         DiscoveredItem::Method { .. } => {
-            compare_method_info(expected_item, generated_item)
+            compare_method_info(&expected_item.item, &generated_item.0)
+        }
+    };
+
+    if is_a_match {
+        // Compare source location
+        assert!(
+            generated_item.1.is_some()
+                == expected_item.source_location.is_some(),
+            "No source location provided when one was expected"
+        );
+        if let Some(generated_location) = generated_item.1.as_ref() {
+            let expected_location = expected_item.source_location.unwrap();
+            assert!(
+                generated_location
+                    .file_name
+                    .as_ref()
+                    .expect("No filename provided")
+                    .ends_with(expected_filename),
+                "Filename differed"
+            );
+            assert_eq!(
+                (
+                    generated_location.line,
+                    generated_location.col,
+                    generated_location.byte_offset
+                ),
+                expected_location,
+                "Line/col/offsets differ"
+            );
         }
     }
+    is_a_match
 }
 
 pub fn compare_names(expected_name: &str, generated_name: &str) -> bool {
@@ -288,8 +417,9 @@ pub fn compare_enum_info(
 pub fn compare_alias_info(
     expected_item: &DiscoveredItem,
     generated_item: &DiscoveredItem,
-    expected: &ItemCache,
+    expected: &ExpectationMap,
     generated: &ItemCache,
+    expected_filename: &str,
 ) -> bool {
     let DiscoveredItem::Alias {
         alias_name: expected_alias_name,
@@ -319,7 +449,13 @@ pub fn compare_alias_info(
         return false;
     };
 
-    compare_item_info(expected_aliased, generated_aliased, expected, generated)
+    compare_item_info(
+        expected_aliased,
+        generated_aliased,
+        expected,
+        generated,
+        expected_filename,
+    )
 }
 
 pub fn compare_function_info(

--- a/bindgen-tests/tests/parse_callbacks/item_discovery_callback/mod.rs
+++ b/bindgen-tests/tests/parse_callbacks/item_discovery_callback/mod.rs
@@ -227,18 +227,15 @@ fn compare_item_caches(
     //   if the header file or the bindgen logic is altered
     // - aliases have a DiscoveredItemId that we can't directly compare for the same instability reasons
     for expected_item in expected.values() {
-        let found =
-            generated
-                .iter()
-                .find(|(_generated_id, generated_item)| {
-                    compare_item_info(
-                        expected_item,
-                        generated_item,
-                        expected,
-                        generated,
-                        expected_filename,
-                    )
-                });
+        let found = generated.iter().find(|(_generated_id, generated_item)| {
+            compare_item_info(
+                expected_item,
+                generated_item,
+                expected,
+                generated,
+                expected_filename,
+            )
+        });
 
         assert!(
             found.is_some(),
@@ -254,8 +251,8 @@ fn compare_item_info(
     generated: &ItemCache,
     expected_filename: &str,
 ) -> bool {
-    if std::mem::discriminant(&expected_item.item)
-        != std::mem::discriminant(&generated_item.0)
+    if std::mem::discriminant(&expected_item.item) !=
+        std::mem::discriminant(&generated_item.0)
     {
         return false;
     }
@@ -288,8 +285,8 @@ fn compare_item_info(
     if is_a_match {
         // Compare source location
         assert!(
-            generated_item.1.is_some()
-                == expected_item.source_location.is_some(),
+            generated_item.1.is_some() ==
+                expected_item.source_location.is_some(),
             "No source location provided when one was expected"
         );
         if let Some(generated_location) = generated_item.1.as_ref() {

--- a/bindgen-tests/tests/parse_callbacks/item_discovery_callback/mod.rs
+++ b/bindgen-tests/tests/parse_callbacks/item_discovery_callback/mod.rs
@@ -18,7 +18,10 @@ impl ParseCallbacks for ItemDiscovery {
     }
 }
 
-fn test_item_discovery_callback(header: &str, expected: HashMap<DiscoveredItemId, DiscoveredItem>) {
+fn test_item_discovery_callback(
+    header: &str,
+    expected: HashMap<DiscoveredItemId, DiscoveredItem>,
+) {
     let discovery = ItemDiscovery::default();
     let info = Rc::clone(&discovery.0);
 
@@ -30,7 +33,6 @@ fn test_item_discovery_callback(header: &str, expected: HashMap<DiscoveredItemId
         .parse_callbacks(Box::new(discovery))
         .generate()
         .expect("TODO: panic message");
-
 
     compare_item_caches(&info.borrow(), &expected);
 }
@@ -103,7 +105,6 @@ fn test_item_discovery_callback_c() {
     test_item_discovery_callback(
         "/tests/parse_callbacks/item_discovery_callback/header_item_discovery.h", expected);
 }
-
 
 #[test]
 fn test_item_discovery_callback_cpp() {

--- a/bindgen-tests/tests/parse_callbacks/mod.rs
+++ b/bindgen-tests/tests/parse_callbacks/mod.rs
@@ -1,4 +1,5 @@
 mod item_discovery_callback;
+mod unused_template_param;
 
 use bindgen::callbacks::*;
 use bindgen::FieldVisibilityKind;

--- a/bindgen-tests/tests/parse_callbacks/unused_template_param.hpp
+++ b/bindgen-tests/tests/parse_callbacks/unused_template_param.hpp
@@ -1,0 +1,29 @@
+
+class NoTemplateParams {
+public:
+    int a;
+};
+
+template<class T>
+class UsesTemplateParam {
+public:
+    UsesTemplateParam(T);
+    T t;
+};
+
+template<class A>
+class IgnoresTemplateParam {
+public:
+    IgnoresTemplateParam();
+    int a;
+};
+
+typedef NoTemplateParams TypedefNoTemplateParam;
+using TypedefNoTemplateParam2 = NoTemplateParams;
+typedef UsesTemplateParam<int> TypedefUsesTemplateParam;
+using TypedefUsesTemplateParam2 = UsesTemplateParam<int>;
+template <class T>
+using TypedefUsesTemplateParam3 = UsesTemplateParam<T>;
+typedef IgnoresTemplateParam<int> TypedefIgnoresTemplateParam;
+template <class T>
+using TypedefIgnoresTemplateParam2 = IgnoresTemplateParam<T>;

--- a/bindgen-tests/tests/parse_callbacks/unused_template_param.rs
+++ b/bindgen-tests/tests/parse_callbacks/unused_template_param.rs
@@ -1,0 +1,79 @@
+use std::{
+    cell::RefCell,
+    collections::{HashMap, HashSet},
+    rc::Rc,
+};
+
+use bindgen::{
+    callbacks::{DiscoveredItem, DiscoveredItemId, ParseCallbacks},
+    Builder,
+};
+
+#[derive(Debug)]
+struct UnusedTemplateParamCallback(
+    Rc<RefCell<HashSet<DiscoveredItemId>>>,
+    Rc<RefCell<HashMap<DiscoveredItemId, String>>>,
+);
+
+impl ParseCallbacks for UnusedTemplateParamCallback {
+    fn denote_discards_template_param(&self, id: DiscoveredItemId) {
+        self.0.borrow_mut().insert(id);
+    }
+
+    fn new_item_found(
+        &self,
+        id: DiscoveredItemId,
+        item: DiscoveredItem,
+        _source_location: Option<&bindgen::callbacks::SourceLocation>,
+        _parent: Option<DiscoveredItemId>,
+    ) {
+        match item {
+            DiscoveredItem::Struct {
+                final_name: name, ..
+            } |
+            DiscoveredItem::Alias {
+                alias_name: name, ..
+            } => {
+                self.1.borrow_mut().insert(id, name);
+            }
+            _ => {}
+        }
+    }
+}
+
+/// This test could be combined with the `item_discovery_callback`
+/// test, but as this is a separate callback we'll keep the tests
+/// separate too.
+#[test]
+fn test_unused_template_param() {
+    let discovered = Rc::new(RefCell::new(HashSet::new()));
+    let names = Rc::new(RefCell::new(HashMap::new()));
+    let header_path = concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/tests/parse_callbacks/unused_template_param.hpp"
+    );
+    Builder::default()
+        .header(header_path)
+        .parse_callbacks(Box::new(UnusedTemplateParamCallback(
+            Rc::clone(&discovered),
+            Rc::clone(&names),
+        )))
+        .clang_arg("--std=c++11")
+        .generate()
+        .expect("TODO: panic message");
+
+    let reported_unused_template_parameter_item_names: HashSet<_> = discovered
+        .borrow()
+        .iter()
+        .map(|id| names.borrow().get(id).expect("Name not reported").clone())
+        .collect();
+
+    assert_eq!(
+        reported_unused_template_parameter_item_names,
+        HashSet::from([
+            "IgnoresTemplateParam".to_string(),
+            "TypedefIgnoresTemplateParam2".to_string()
+        ]),
+        "Different items than expected reported unused template params"
+    );
+}

--- a/bindgen/callbacks.rs
+++ b/bindgen/callbacks.rs
@@ -224,7 +224,22 @@ pub enum DiscoveredItem {
         /// The final name of the generated binding
         final_name: String,
     },
-    // functions, modules, etc.
+
+    /// A function or method.
+    Function {
+        /// The final name used.
+        final_name: String,
+    },
+
+    /// A method.
+    Method {
+        /// The final name used.
+        final_name: String,
+
+        /// Type to which this method belongs.
+        parent: DiscoveredItemId,
+    }
+    // modules, etc.
 }
 
 /// Relevant information about a type to which new derive attributes will be added using

--- a/bindgen/callbacks.rs
+++ b/bindgen/callbacks.rs
@@ -164,7 +164,7 @@ pub trait ParseCallbacks: fmt::Debug {
     }
 
     /// This will get called everytime an item (currently struct, union, and alias) is found with some information about it
-    fn new_item_found(&self, _id: DiscoveredItemId, _item: DiscoveredItem) {}
+    fn new_item_found(&self, _id: DiscoveredItemId, _item: DiscoveredItem, _source_location: Option<&SourceLocation>) {}
 
     // TODO add callback for ResolvedTypeRef
 }
@@ -303,4 +303,18 @@ pub struct FieldInfo<'a> {
     pub field_name: &'a str,
     /// The name of the type of the field.
     pub field_type_name: Option<&'a str>,
+}
+
+/// Location in the source code. Roughly equivalent to the same type
+/// within `clang_sys`.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SourceLocation {
+    /// Line number.
+    pub line: usize,
+    /// Column number within line.
+    pub col: usize,
+    /// Byte offset within file.
+    pub byte_offset: usize,
+    /// Filename, if known.
+    pub file_name: Option<String>,
 }

--- a/bindgen/callbacks.rs
+++ b/bindgen/callbacks.rs
@@ -238,8 +238,7 @@ pub enum DiscoveredItem {
 
         /// Type to which this method belongs.
         parent: DiscoveredItemId,
-    }
-    // modules, etc.
+    }, // modules, etc.
 }
 
 /// Relevant information about a type to which new derive attributes will be added using

--- a/bindgen/callbacks.rs
+++ b/bindgen/callbacks.rs
@@ -164,7 +164,13 @@ pub trait ParseCallbacks: fmt::Debug {
     }
 
     /// This will get called everytime an item (currently struct, union, and alias) is found with some information about it
-    fn new_item_found(&self, _id: DiscoveredItemId, _item: DiscoveredItem, _source_location: Option<&SourceLocation>) {}
+    fn new_item_found(
+        &self,
+        _id: DiscoveredItemId,
+        _item: DiscoveredItem,
+        _source_location: Option<&SourceLocation>,
+    ) {
+    }
 
     // TODO add callback for ResolvedTypeRef
 }

--- a/bindgen/callbacks.rs
+++ b/bindgen/callbacks.rs
@@ -185,6 +185,17 @@ pub trait ParseCallbacks: fmt::Debug {
     ) {
     }
 
+    /// Notes that this type does not use all the template params
+    /// which were present in C++. Sometimes those template parameters
+    /// are not useful in Rust because they don't actually impact the
+    /// data stored in the type, so bindgen drops them. But this also means
+    /// that the bindgen output does not contain full and comprehensive
+    /// output about the original nature of the C++ type, so higher level
+    /// code generators may wish to behave differently. For example,
+    /// it would not be OK to attempt to generate additional C++ code
+    /// based on this.
+    fn denote_discards_template_param(&self, _id: DiscoveredItemId) {}
+
     // TODO add callback for ResolvedTypeRef
 }
 

--- a/bindgen/clang.rs
+++ b/bindgen/clang.rs
@@ -927,6 +927,21 @@ impl Cursor {
         unsafe { clang_isVirtualBase(self.x) != 0 }
     }
 
+    // Is this cursor's referent a default constructor?
+    pub fn is_default_constructor(&self) -> bool {
+        unsafe { clang_CXXConstructor_isDefaultConstructor(self.x) != 0 }
+    }
+
+    // Is this cursor's referent a copy constructor?
+    pub fn is_copy_constructor(&self) -> bool {
+        unsafe { clang_CXXConstructor_isCopyConstructor(self.x) != 0 }
+    }
+
+    // Is this cursor's referent a move constructor?
+    pub fn is_move_constructor(&self) -> bool {
+        unsafe { clang_CXXConstructor_isMoveConstructor(self.x) != 0 }
+    }
+
     /// Try to evaluate this cursor.
     pub(crate) fn evaluate(&self) -> Option<EvalResult> {
         EvalResult::new(*self)

--- a/bindgen/codegen/mod.rs
+++ b/bindgen/codegen/mod.rs
@@ -6003,8 +6003,8 @@ pub(crate) mod utils {
     fn is_reportable_parent(ctx: &BindgenContext, item: &Item) -> bool {
         match item.kind() {
             ItemKind::Module(ref module) => {
-                !module.is_inline()
-                    || ctx.options().conservative_inline_namespaces
+                !module.is_inline() ||
+                    ctx.options().conservative_inline_namespaces
             }
             ItemKind::Type(t) => match t.kind() {
                 TypeKind::Comp(..) | TypeKind::Enum(..) => true,

--- a/bindgen/codegen/mod.rs
+++ b/bindgen/codegen/mod.rs
@@ -2502,10 +2502,7 @@ impl CodeGenerator for CompInfo {
                 },
             };
 
-            cb.new_item_found(
-                discovered_id,
-                discovered_item,
-            );
+            cb.new_item_found(discovered_id, discovered_item);
         });
 
         // The custom derives callback may return a list of derive attributes;
@@ -3071,10 +3068,15 @@ impl Method {
 
         method_names.insert(name.clone());
 
-        ctx.options().for_each_callback(|cb| cb.new_item_found(id, DiscoveredItem::Method {
-            parent: parent_id,
-            final_name: name.clone(),
-        }));
+        ctx.options().for_each_callback(|cb| {
+            cb.new_item_found(
+                id,
+                DiscoveredItem::Method {
+                    parent: parent_id,
+                    final_name: name.clone(),
+                },
+            )
+        });
 
         let mut function_name = function_item.canonical_name(ctx);
         if times_seen > 0 {
@@ -4667,7 +4669,7 @@ impl CodeGenerator for Function {
                 id,
                 DiscoveredItem::Function {
                     final_name: canonical_name.to_string(),
-                }
+                },
             );
         });
 

--- a/bindgen/codegen/mod.rs
+++ b/bindgen/codegen/mod.rs
@@ -5929,10 +5929,21 @@ pub(crate) mod utils {
         item: &Item,
         discovered_item_creator: impl Fn() -> crate::callbacks::DiscoveredItem,
     ) {
+        let source_location = item.location().map(|clang_location| {
+            let (file, line, col, byte_offset) = clang_location.location();
+            let file_name = file.name();
+            crate::callbacks::SourceLocation {
+                line,
+                col,
+                byte_offset,
+                file_name,
+            }
+        });
         ctx.options().for_each_callback(|cb| {
             cb.new_item_found(
                 DiscoveredItemId::new(item.id().as_usize()),
                 discovered_item_creator(),
+                source_location.as_ref(),
             );
         });
     }

--- a/bindgen/codegen/mod.rs
+++ b/bindgen/codegen/mod.rs
@@ -3077,12 +3077,14 @@ impl Method {
         utils::call_discovered_item_callback(ctx, function_item, || {
             let cpp_virtual = match function.kind() {
                 FunctionKind::Function => None,
-                FunctionKind::Method(method_kind) => if method_kind.is_pure_virtual() {
-                    Some(Virtualness::PureVirtual)
-                } else if method_kind.is_virtual() {
-                    Some(Virtualness::Virtual)
-                } else {
-                    None
+                FunctionKind::Method(method_kind) => {
+                    if method_kind.is_pure_virtual() {
+                        Some(Virtualness::PureVirtual)
+                    } else if method_kind.is_virtual() {
+                        Some(Virtualness::Virtual)
+                    } else {
+                        None
+                    }
                 }
             };
             DiscoveredItem::Method {

--- a/bindgen/codegen/mod.rs
+++ b/bindgen/codegen/mod.rs
@@ -2481,6 +2481,7 @@ impl CodeGenerator for CompInfo {
 
         let is_rust_union = is_union && struct_layout.is_rust_union();
 
+        let discovered_id = DiscoveredItemId::new(item.id().as_usize());
         ctx.options().for_each_callback(|cb| {
             let discovered_item = match self.kind() {
                 CompKind::Struct => DiscoveredItem::Struct {
@@ -2502,7 +2503,7 @@ impl CodeGenerator for CompInfo {
             };
 
             cb.new_item_found(
-                DiscoveredItemId::new(item.id().as_usize()),
+                discovered_id,
                 discovered_item,
             );
         });
@@ -2711,6 +2712,7 @@ impl CodeGenerator for CompInfo {
                         &mut method_names,
                         result,
                         self,
+                        discovered_id,
                     );
                 }
             }
@@ -2729,6 +2731,7 @@ impl CodeGenerator for CompInfo {
                         &mut method_names,
                         result,
                         self,
+                        discovered_id,
                     );
                 }
             }
@@ -2742,6 +2745,7 @@ impl CodeGenerator for CompInfo {
                         &mut method_names,
                         result,
                         self,
+                        discovered_id,
                     );
                 }
             }
@@ -2999,6 +3003,7 @@ impl Method {
         method_names: &mut HashSet<String>,
         result: &mut CodegenResult<'_>,
         _parent: &CompInfo,
+        parent_id: DiscoveredItemId,
     ) {
         assert!({
             let cc = &ctx.options().codegen_config;
@@ -3019,6 +3024,7 @@ impl Method {
 
         // First of all, output the actual function.
         let function_item = ctx.resolve_item(self.signature());
+        let id = DiscoveredItemId::new(function_item.id().as_usize());
         if !function_item.process_before_codegen(ctx, result) {
             return;
         }
@@ -3064,6 +3070,11 @@ impl Method {
         }
 
         method_names.insert(name.clone());
+
+        ctx.options().for_each_callback(|cb| cb.new_item_found(id, DiscoveredItem::Method {
+            parent: parent_id,
+            final_name: name.clone(),
+        }));
 
         let mut function_name = function_item.canonical_name(ctx);
         if times_seen > 0 {
@@ -4540,6 +4551,7 @@ impl CodeGenerator for Function {
     ) -> Self::Return {
         debug!("<Function as CodeGenerator>::codegen: item = {item:?}");
         debug_assert!(item.is_enabled_for_codegen(ctx));
+        let id = DiscoveredItemId::new(item.id().as_usize());
 
         let is_internal = matches!(self.linkage(), Linkage::Internal);
 
@@ -4650,6 +4662,14 @@ impl CodeGenerator for Function {
         if times_seen > 0 {
             write!(&mut canonical_name, "{times_seen}").unwrap();
         }
+        ctx.options().for_each_callback(|cb| {
+            cb.new_item_found(
+                id,
+                DiscoveredItem::Function {
+                    final_name: canonical_name.to_string(),
+                }
+            );
+        });
 
         let link_name_attr = self.link_name().or_else(|| {
             let mangled_name = mangled_name.unwrap_or(name);

--- a/bindgen/codegen/mod.rs
+++ b/bindgen/codegen/mod.rs
@@ -21,7 +21,8 @@ use self::struct_layout::StructLayoutTracker;
 use super::BindgenOptions;
 
 use crate::callbacks::{
-    AttributeInfo, DeriveInfo, DiscoveredItem, DiscoveredItemId, FieldInfo, TypeKind as DeriveTypeKind, Virtualness
+    AttributeInfo, DeriveInfo, DiscoveredItem, DiscoveredItemId, FieldInfo,
+    TypeKind as DeriveTypeKind, Virtualness,
 };
 use crate::codegen::error::Error;
 use crate::ir::analysis::{HasVtable, Sizedness};

--- a/bindgen/ir/comp.rs
+++ b/bindgen/ir/comp.rs
@@ -6,6 +6,7 @@ use super::analysis::Sizedness;
 use super::annotations::Annotations;
 use super::context::{BindgenContext, FunctionId, ItemId, TypeId, VarId};
 use super::dot::DotAttributes;
+use super::function::Visibility;
 use super::item::{IsOpaque, Item};
 use super::layout::Layout;
 use super::template::TemplateParameters;
@@ -63,6 +64,14 @@ impl MethodKind {
         )
     }
 
+    /// Is this virtual (pure or otherwise?)
+    pub(crate) fn is_virtual(self) -> bool {
+        matches!(
+            self,
+            MethodKind::Virtual { .. } | MethodKind::VirtualDestructor { .. }
+        )
+    }
+
     /// Is this a pure virtual method?
     pub(crate) fn is_pure_virtual(self) -> bool {
         match self {
@@ -71,6 +80,23 @@ impl MethodKind {
             _ => false,
         }
     }
+}
+
+/// The kind of C++ special member.
+// TODO: We don't currently cover copy assignment or move assignment operator
+// because libclang doesn't provide a way to query for them.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum SpecialMemberKind {
+    /// The default constructor.
+    DefaultConstructor,
+    /// A copy constructor.
+    CopyConstructor,
+    /// A move constructor.
+    MoveConstructor,
+    /// A destructor.
+    Destructor,
+    /// The assignment operator.
+    AssignmentOperator,
 }
 
 /// A struct representing a C++ method, either static, normal, or virtual.
@@ -993,6 +1019,10 @@ pub(crate) struct CompInfo {
     /// Whether this is a struct or a union.
     kind: CompKind,
 
+    /// The visibility of this struct or union if it was declared inside of
+    /// another type. Top-level types always have public visibility.
+    visibility: Visibility,
+
     /// The members of this struct or union.
     fields: CompFields,
 
@@ -1074,6 +1104,7 @@ impl CompInfo {
     pub(crate) fn new(kind: CompKind) -> Self {
         CompInfo {
             kind,
+            visibility: Visibility::Public,
             fields: CompFields::default(),
             template_params: vec![],
             methods: vec![],
@@ -1193,6 +1224,11 @@ impl CompInfo {
         }
     }
 
+    /// Returns the visibility of the type.
+    pub fn visibility(&self) -> Visibility {
+        self.visibility
+    }
+
     /// Returns whether we have a too large bitfield unit, in which case we may
     /// not be able to derive some of the things we should be able to normally
     /// derive.
@@ -1282,6 +1318,7 @@ impl CompInfo {
         debug!("CompInfo::from_ty({kind:?}, {cursor:?})");
 
         let mut ci = CompInfo::new(kind);
+        ci.visibility = Visibility::from(cursor.access_specifier());
         ci.is_forward_declaration =
             location.map_or(true, |cur| match cur.kind() {
                 CXCursor_ParmDecl => true,

--- a/bindgen/ir/enum_ty.rs
+++ b/bindgen/ir/enum_ty.rs
@@ -2,6 +2,7 @@
 
 use super::super::codegen::EnumVariation;
 use super::context::{BindgenContext, TypeId};
+use super::function::Visibility;
 use super::item::Item;
 use super::ty::{Type, TypeKind};
 use crate::clang;
@@ -32,6 +33,10 @@ pub(crate) struct Enum {
 
     /// The different variants, with explicit values.
     variants: Vec<EnumVariant>,
+
+    /// The visibility of this enum if it was declared inside of
+    /// another type. Top-level types always have public visibility.
+    pub(crate) visibility: Visibility,
 }
 
 impl Enum {
@@ -39,8 +44,13 @@ impl Enum {
     pub(crate) fn new(
         repr: Option<TypeId>,
         variants: Vec<EnumVariant>,
+        visibility: Visibility,
     ) -> Self {
-        Enum { repr, variants }
+        Enum {
+            repr,
+            variants,
+            visibility,
+        }
     }
 
     /// Get this enumeration's representation.
@@ -56,6 +66,7 @@ impl Enum {
     /// Construct an enumeration from the given Clang type.
     pub(crate) fn from_ty(
         ty: &clang::Type,
+        visibility: Visibility,
         ctx: &mut BindgenContext,
     ) -> Result<Self, ParseError> {
         use clang_sys::*;
@@ -147,7 +158,7 @@ impl Enum {
             }
             CXChildVisit_Continue
         });
-        Ok(Enum::new(repr, variants))
+        Ok(Enum::new(repr, variants, visibility))
     }
 
     fn is_matching_enum(

--- a/bindgen/ir/function.rs
+++ b/bindgen/ir/function.rs
@@ -1,6 +1,6 @@
 //! Intermediate representation for C/C++ functions and methods.
 
-use super::comp::MethodKind;
+use super::comp::{MethodKind, SpecialMemberKind};
 use super::context::{BindgenContext, TypeId};
 use super::dot::DotAttributes;
 use super::item::Item;
@@ -9,7 +9,9 @@ use super::ty::TypeKind;
 use crate::callbacks::{ItemInfo, ItemKind};
 use crate::clang::{self, ABIKind, Attribute};
 use crate::parse::{ClangSubItemParser, ParseError, ParseResult};
-use clang_sys::CXCallingConv;
+use clang_sys::{
+    CXCallingConv, CX_CXXAccessSpecifier, CX_CXXPrivate, CX_CXXProtected,
+};
 
 use quote::TokenStreamExt;
 use std::io;
@@ -70,6 +72,38 @@ pub(crate) enum Linkage {
     Internal,
 }
 
+/// C++ visibility.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum Visibility {
+    /// `public` visibility.
+    Public,
+    /// `protected` visibility.
+    Protected,
+    /// `private` visibility.
+    Private,
+}
+
+impl From<CX_CXXAccessSpecifier> for Visibility {
+    fn from(access_specifier: CX_CXXAccessSpecifier) -> Self {
+        if access_specifier == CX_CXXPrivate {
+            Visibility::Private
+        } else if access_specifier == CX_CXXProtected {
+            Visibility::Protected
+        } else {
+            Visibility::Public
+        }
+    }
+}
+
+/// Whether a C++ method has been explicitly defaulted or deleted.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum Explicitness {
+    /// Defaulted function, i.e. `=default`
+    Defaulted,
+    /// Deleted function, i.e. `=delete`
+    Deleted,
+}
+
 /// A function declaration, with a signature, arguments, and argument names.
 ///
 /// The argument names vector must be the same length as the ones in the
@@ -93,6 +127,15 @@ pub(crate) struct Function {
 
     /// The linkage of the function.
     linkage: Linkage,
+
+    /// C++ Special member kind, if applicable
+    special_member: Option<SpecialMemberKind>,
+
+    /// Whether it is private
+    visibility: Visibility,
+
+    // Whether it is `=delete` or `=default`
+    explicitness: Option<Explicitness>,
 }
 
 impl Function {
@@ -104,6 +147,9 @@ impl Function {
         signature: TypeId,
         kind: FunctionKind,
         linkage: Linkage,
+        special_member: Option<SpecialMemberKind>,
+        visibility: Visibility,
+        explicitness: Option<Explicitness>,
     ) -> Self {
         Function {
             name,
@@ -112,6 +158,9 @@ impl Function {
             signature,
             kind,
             linkage,
+            special_member,
+            visibility,
+            explicitness,
         }
     }
 
@@ -143,6 +192,22 @@ impl Function {
     /// Get this function's linkage.
     pub(crate) fn linkage(&self) -> Linkage {
         self.linkage
+    }
+
+    /// Get this function's C++ special member kind.
+    pub fn special_member(&self) -> Option<SpecialMemberKind> {
+        self.special_member
+    }
+
+    /// Whether it is private, protected or public
+    pub fn visibility(&self) -> Visibility {
+        self.visibility
+    }
+
+    /// Whether this is a function that's been deleted (=delete)
+    /// or defaulted (=default)
+    pub fn explicitness(&self) -> Option<Explicitness> {
+        self.explicitness
     }
 }
 
@@ -736,6 +801,8 @@ impl ClangSubItemParser for Function {
             return Err(ParseError::Continue);
         }
 
+        let visibility = Visibility::from(cursor.access_specifier());
+
         let linkage = cursor.linkage();
         let linkage = match linkage {
             CXLinkage_External | CXLinkage_UniqueExternal => Linkage::External,
@@ -803,6 +870,26 @@ impl ClangSubItemParser for Function {
             })
         });
 
+        let special_member = if cursor.is_default_constructor() {
+            Some(SpecialMemberKind::DefaultConstructor)
+        } else if cursor.is_copy_constructor() {
+            Some(SpecialMemberKind::CopyConstructor)
+        } else if cursor.is_move_constructor() {
+            Some(SpecialMemberKind::MoveConstructor)
+        } else if cursor.kind() == CXCursor_Destructor {
+            Some(SpecialMemberKind::Destructor)
+        } else {
+            None
+        };
+
+        let explicitness = if cursor.is_deleted_function() {
+            Some(Explicitness::Deleted)
+        } else if cursor.is_defaulted_function() {
+            Some(Explicitness::Defaulted)
+        } else {
+            None
+        };
+
         let function = Self::new(
             name.clone(),
             mangled_name,
@@ -810,6 +897,9 @@ impl ClangSubItemParser for Function {
             sig,
             kind,
             linkage,
+            special_member,
+            visibility,
+            explicitness,
         );
 
         Ok(ParseResult::New(function, Some(cursor)))

--- a/bindgen/ir/template.rs
+++ b/bindgen/ir/template.rs
@@ -156,6 +156,23 @@ pub(crate) trait TemplateParameters: Sized {
             .filter(|p| ctx.uses_template_parameter(id, *p))
             .collect()
     }
+
+    /// Returns whether all the template parameters are used.
+    fn has_unused_template_params(&self, ctx: &BindgenContext) -> bool
+    where
+        Self: AsRef<ItemId>,
+    {
+        assert!(
+            ctx.in_codegen_phase(),
+            "template parameter usage is not computed until codegen"
+        );
+
+        let id = *self.as_ref();
+        ctx.resolve_item(id)
+            .all_template_params(ctx)
+            .into_iter()
+            .any(|p| !ctx.uses_template_parameter(id, p))
+    }
 }
 
 /// A trait for things which may or may not be a named template type parameter.

--- a/bindgen/ir/ty.rs
+++ b/bindgen/ir/ty.rs
@@ -13,6 +13,7 @@ use super::template::{
 };
 use super::traversal::{EdgeKind, Trace, Tracer};
 use crate::clang::{self, Cursor};
+use crate::ir::function::Visibility;
 use crate::parse::{ParseError, ParseResult};
 use std::borrow::Cow;
 use std::io;
@@ -1086,7 +1087,10 @@ impl Type {
                     }
                 }
                 CXType_Enum => {
-                    let enum_ = Enum::from_ty(ty, ctx).expect("Not an enum?");
+                    let visibility =
+                        Visibility::from(cursor.access_specifier());
+                    let enum_ = Enum::from_ty(ty, visibility, ctx)
+                        .expect("Not an enum?");
 
                     if !is_anonymous {
                         let pretty_name = ty.spelling();


### PR DESCRIPTION
Downstream postprocessors such as autocxx may want to use bindgen's
representation of types to generate additional C++ code. bindgen is remarkably
faithful at passing through enough information to make this possible - but for
some C++ types, bindgen chooses to elide some template parameters. It's not
safe for additional C++ code to be generated which references that type.

This adds a callback by which such tools can recognize types where template
parameters have been elided like this, so that extra C++ is avoided.

This information could be provided in the existing
`new_item_found` callback, but it's very niche and unlikely to be used by
the majority of consumers, so a new callback is added instead.

An alternative approach here is to provide a mode to bindgen where it
*always* uses all template params, by adding additional `PhantomData`
fields to structs where those params are not currently used.
This is being prototyped in https://github.com/google/autocxx/pull/1425
but is unlikely to be successful, on the assumption that lots of the
templated types can't actually be properly represented by bindgen/Rust,
so the current strategy of discarding them is more likely to work
in the broad strokes.

This PR is built on top of #3146, which in turn is on top of various others.

Part of https://github.com/google/autocxx/issues/124