### PR TITLE
apply same rule to C and C-unwind in names_will_be_identical_after_mangling

### DIFF
--- a/bindgen/codegen/mod.rs
+++ b/bindgen/codegen/mod.rs
@@ -5863,7 +5863,7 @@ pub(crate) mod utils {
         let mangled_name = mangled_name.as_bytes();
 
         let (mangling_prefix, expect_suffix) = match call_conv {
-            Some(ClangAbi::Known(Abi::C)) |
+            Some(ClangAbi::Known(Abi::C) | ClangAbi::Known(Abi::CUnwind)) |
             // None is the case for global variables
             None => {
                 (b'_', false)


### PR DESCRIPTION
fix #3155

This fixes the issue if ABI is overrided to `C-unwind`. For other ABIs, this is not available anyway because bindgen does not mark the calling convention in the generated C code.