### PR TITLE
Allow constructor name override.

### DIFF
--- a/bindgen-tests/tests/expectations/tests/rename_constructor.rs
+++ b/bindgen-tests/tests/expectations/tests/rename_constructor.rs
@@ -1,0 +1,23 @@
+#![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct Foo {
+    pub _address: u8,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of Foo"][::std::mem::size_of::<Foo>() - 1usize];
+    ["Alignment of Foo"][::std::mem::align_of::<Foo>() - 1usize];
+};
+unsafe extern "C" {
+    #[link_name = "\u{1}_ZN3FooC1Ev"]
+    pub fn Foo_Foo(this: *mut Foo);
+}
+impl Foo {
+    #[inline]
+    pub unsafe fn create() -> Self {
+        let mut __bindgen_tmp = ::std::mem::MaybeUninit::uninit();
+        Foo_Foo(__bindgen_tmp.as_mut_ptr());
+        __bindgen_tmp.assume_init()
+    }
+}

--- a/bindgen-tests/tests/headers/rename_constructor.hpp
+++ b/bindgen-tests/tests/headers/rename_constructor.hpp
@@ -1,0 +1,6 @@
+// bindgen-parse-callbacks: rename-constructor
+
+class Foo {
+public:
+    Foo();
+};

--- a/bindgen-tests/tests/parse_callbacks/mod.rs
+++ b/bindgen-tests/tests/parse_callbacks/mod.rs
@@ -146,6 +146,20 @@ impl ParseCallbacks for WrapAsVariadicFn {
     }
 }
 
+#[derive(Debug)]
+pub(super) struct RenameConstructor;
+
+impl ParseCallbacks for RenameConstructor {
+    fn generated_name_override(&self, item_info: ItemInfo) -> Option<String> {
+        match item_info.kind {
+            ItemKind::Function if item_info.name == "new" => {
+                Some("create".into())
+            }
+            _ => None,
+        }
+    }
+}
+
 pub fn lookup(cb: &str) -> Box<dyn ParseCallbacks> {
     match cb {
         "enum-variant-rename" => Box::new(EnumVariantRename),
@@ -153,6 +167,7 @@ pub fn lookup(cb: &str) -> Box<dyn ParseCallbacks> {
             Box::new(BlocklistedTypeImplementsTrait)
         }
         "wrap-as-variadic-fn" => Box::new(WrapAsVariadicFn),
+        "rename-constructor" => Box::new(RenameConstructor),
         "type-visibility" => Box::new(TypeVisibility),
         call_back => {
             if let Some(prefix) =

--- a/bindgen/codegen/mod.rs
+++ b/bindgen/codegen/mod.rs
@@ -22,7 +22,7 @@ use super::BindgenOptions;
 
 use crate::callbacks::{
     AttributeInfo, DeriveInfo, DiscoveredItem, DiscoveredItemId, FieldInfo,
-    TypeKind as DeriveTypeKind,
+    ItemInfo, TypeKind as DeriveTypeKind,
 };
 use crate::codegen::error::Error;
 use crate::ir::analysis::{HasVtable, Sizedness};
@@ -3031,6 +3031,15 @@ impl Method {
             MethodKind::Destructor => "destruct".into(),
             _ => function.name().to_owned(),
         };
+
+        if let Some(nm) = ctx.options().last_callback(|callbacks| {
+            callbacks.generated_name_override(ItemInfo {
+                name: name.as_str(),
+                kind: crate::callbacks::ItemKind::Function,
+            })
+        }) {
+            name = nm;
+        }
 
         let TypeKind::Function(ref signature) =
             *signature_item.expect_type().kind()


### PR DESCRIPTION
This uses an existing callback to allow overriding of constructor name.

Part of https://github.com/google/autocxx/issues/124, though only necessary if we also do https://github.com/google/autocxx/pull/1456.