### PR TITLE
Fix union layout when it contains 0 sized array.

### DIFF
--- a/bindgen-tests/tests/expectations/tests/union_with_zero_sized_array.rs
+++ b/bindgen-tests/tests/expectations/tests/union_with_zero_sized_array.rs
@@ -1,0 +1,68 @@
+#![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
+#[repr(C)]
+pub struct __BindgenUnionField<T>(::std::marker::PhantomData<T>);
+impl<T> __BindgenUnionField<T> {
+    #[inline]
+    pub const fn new() -> Self {
+        __BindgenUnionField(::std::marker::PhantomData)
+    }
+    #[inline]
+    pub unsafe fn as_ref(&self) -> &T {
+        ::std::mem::transmute(self)
+    }
+    #[inline]
+    pub unsafe fn as_mut(&mut self) -> &mut T {
+        ::std::mem::transmute(self)
+    }
+}
+impl<T> ::std::default::Default for __BindgenUnionField<T> {
+    #[inline]
+    fn default() -> Self {
+        Self::new()
+    }
+}
+impl<T> ::std::clone::Clone for __BindgenUnionField<T> {
+    #[inline]
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl<T> ::std::marker::Copy for __BindgenUnionField<T> {}
+impl<T> ::std::fmt::Debug for __BindgenUnionField<T> {
+    fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+        fmt.write_str("__BindgenUnionField")
+    }
+}
+impl<T> ::std::hash::Hash for __BindgenUnionField<T> {
+    fn hash<H: ::std::hash::Hasher>(&self, _state: &mut H) {}
+}
+impl<T> ::std::cmp::PartialEq for __BindgenUnionField<T> {
+    fn eq(&self, _other: &__BindgenUnionField<T>) -> bool {
+        true
+    }
+}
+impl<T> ::std::cmp::Eq for __BindgenUnionField<T> {}
+#[repr(C)]
+pub struct U {
+    pub d0: __BindgenUnionField<[::std::os::raw::c_char; 0usize]>,
+    pub d1: __BindgenUnionField<[::std::os::raw::c_char; 1usize]>,
+    pub d2: __BindgenUnionField<[::std::os::raw::c_char; 2usize]>,
+    pub bindgen_union_field: [u8; 2usize],
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of U"][::std::mem::size_of::<U>() - 2usize];
+    ["Alignment of U"][::std::mem::align_of::<U>() - 1usize];
+    ["Offset of field: U::d0"][::std::mem::offset_of!(U, d0) - 0usize];
+    ["Offset of field: U::d1"][::std::mem::offset_of!(U, d1) - 0usize];
+    ["Offset of field: U::d2"][::std::mem::offset_of!(U, d2) - 0usize];
+};
+impl Default for U {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}

--- a/bindgen-tests/tests/headers/union_with_zero_sized_array.h
+++ b/bindgen-tests/tests/headers/union_with_zero_sized_array.h
@@ -1,0 +1,5 @@
+union U {
+  char d0[0];
+  char d1[1];
+  char d2[2];
+};

--- a/bindgen/codegen/struct_layout.rs
+++ b/bindgen/codegen/struct_layout.rs
@@ -266,7 +266,12 @@ impl<'a> StructLayoutTracker<'a> {
             }
         };
 
-        self.latest_offset += field_layout.size;
+        if !is_union {
+            self.latest_offset += field_layout.size;
+        } else {
+            self.latest_offset =
+                cmp::max(self.latest_offset, field_layout.size);
+        }
         self.latest_field_layout = Some(field_layout);
         self.max_field_align =
             cmp::max(self.max_field_align, field_layout.align);


### PR DESCRIPTION
Fix #3068