### PR TITLE
Add support for vectors that use "ext_vector_type" 

### DIFF
--- a/bindgen-tests/tests/expectations/tests/opencl_vector.rs
+++ b/bindgen-tests/tests/expectations/tests/opencl_vector.rs
@@ -1,0 +1,6 @@
+#![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
+pub type float4 = [f32; 4usize];
+pub type float2 = [f32; 2usize];
+unsafe extern "C" {
+    pub fn foo(a: float2, b: float2) -> float4;
+}

--- a/bindgen-tests/tests/headers/opencl_vector.h
+++ b/bindgen-tests/tests/headers/opencl_vector.h
@@ -1,0 +1,9 @@
+typedef float float4 __attribute__((ext_vector_type(4)));
+typedef float float2 __attribute__((ext_vector_type(2)));
+
+float4 foo(float2 a, float2 b) {
+  float4 c;
+  c.xz = a;
+  c.yw = b;
+  return c;
+}

--- a/bindgen/ir/ty.rs
+++ b/bindgen/ir/ty.rs
@@ -1117,7 +1117,7 @@ impl Type {
 
                     TypeKind::Comp(complex)
                 }
-                CXType_Vector => {
+                CXType_Vector | CXType_ExtVector => {
                     let inner = Item::from_ty(
                         ty.elem_type().as_ref().unwrap(),
                         location,


### PR DESCRIPTION
The SIMD header provided by Apple uses [ext_vector_type](https://clang.llvm.org/docs/LanguageExtensions.html#vectors-and-extended-vectors) to define vectors. Previously bindgen would generate an opaque type as seen [here](https://github.com/gfx-rs/metal-rs/blob/cce2b486dd39d19ba232e823148ee2c557e97e62/examples/texture/src/main.rs#L112). The vector extension seems to behave similar to the already defined vector, so it doesn't look like using that case overlooks anything. 