### PR TITLE
ci: use stable again moving forward Rust for Linux job

### DIFF
--- a/.github/workflows/bindgen.yml
+++ b/.github/workflows/bindgen.yml
@@ -154,7 +154,7 @@ jobs:
       - name: Install stable
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.85.1
+          toolchain: stable
       - name: Install libtinfo
         if: matrix.os == 'ubuntu-latest'
         run: |

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -96,7 +96,7 @@ if [ "$BINDGEN_RUST_FOR_LINUX_TEST" == "1" ]; then
   # and each update should only contain this change.
   #
   # Both commit hashes and tags are supported.
-  LINUX_VERSION=v6.14-rc1
+  LINUX_VERSION=v6.14
 
   # Download Linux at a specific commit
   mkdir -p linux

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -125,13 +125,13 @@ CONFIG_KUNIT=y
 CONFIG_RUST_KERNEL_DOCTESTS=y
 EOF
 
-  make -C linux KBUILD_VERBOSE=1 LLVM=1 -j$(($(nproc) + 1)) \
+  make -C linux LLVM=1 -j$(($(nproc) + 1)) \
       rustavailable \
       defconfig \
       rfl-for-bindgen-ci.config
 
   # Build Rust for Linux
-  make -C linux LLVM=1 KBUILD_VERBOSE=1 -j$(($(nproc) + 1)) \
+  make -C linux LLVM=1 -j$(($(nproc) + 1)) \
       samples/rust/rust_minimal.o \
       samples/rust/rust_print_main.o \
       drivers/net/phy/ax88796b_rust.o


### PR DESCRIPTION
See individual commits.

Fixes: https://github.com/rust-lang/rust-bindgen/issues/3188