### PR TITLE
Remove unused which-rustfmt feature

### DIFF
--- a/bindgen/Cargo.toml
+++ b/bindgen/Cargo.toml
@@ -47,8 +47,6 @@ default = ["logging", "prettyplease", "runtime"]
 logging = ["dep:log"]
 static = ["clang-sys/static"]
 runtime = ["clang-sys/runtime"]
-# This feature is no longer used for anything and should be removed in bindgen 0.70
-which-rustfmt = []
 experimental = ["dep:annotate-snippets"]
 
 ## The following features are for internal use and they shouldn't be used if


### PR DESCRIPTION
Hello, Foxie here. I was reading bindgen's `Cargo.toml` file while I'm searching workaround for unrelated problem and found comment indicating `which-rustfmt` feature should be removed by 0.70 release but its already 0.71.1 and it persists.

Because it is 0.71.1 already, I do think this removal was missed as I couldn't find any open/closed PR which mentioned "Remove which-rustfmt".