### PR TITLE
Added Debug information to layout error

### DIFF
--- a/bindgen/codegen/mod.rs
+++ b/bindgen/codegen/mod.rs
@@ -2339,6 +2339,17 @@ impl CodeGenerator for CompInfo {
         } else if is_union && !forward_decl {
             // TODO(emilio): It'd be nice to unify this with the struct path
             // above somehow.
+            if layout.is_none() {
+                let location_option = item.location();
+                let error = match location_option {
+                    Some(location) => format!(
+                        "Unable to get layout information from: {location}"
+                    ),
+                    None => "Unable to get layout information or location"
+                        .to_string(),
+                };
+                panic!("{}", error);
+            }
             let layout = layout.expect("Unable to get layout information?");
             if struct_layout.requires_explicit_align(layout) {
                 explicit_align = Some(layout.align);


### PR DESCRIPTION
This is a modification to panic with more user info on what file is causing the panic so it can be more easily excluded. In my case this was _Variadic_union causing the panic: "Unable to get layout information?" which now reads: "Unable to get layout information from: /usr/bin/../lib/gcc/x86_64-linux-gnu/12/../../../../include/c++/12/variant:369:11"

Which leads to this template 
![image](https://github.com/user-attachments/assets/98fba92c-669a-429a-a893-162e9a8deaa9)

For an easier exclusion / opaque type
