### PR TITLE
ci: Move forward Rust for Linux version to v6.15-rc4

### DIFF
--- a/ci/test.sh
+++ b/ci/test.sh
@@ -96,7 +96,7 @@ if [ "$BINDGEN_RUST_FOR_LINUX_TEST" == "1" ]; then
   # and each update should only contain this change.
   #
   # Both commit hashes and tags are supported.
-  LINUX_VERSION=v6.14
+  LINUX_VERSION=v6.15-rc4
 
   # Download Linux at a specific commit
   mkdir -p linux


### PR DESCRIPTION
A hopefully routine upgrade to Linux v6.15-rc4!

This matches the one getting merged for Rust's CI.