### PR TITLE
Allow modifying macro tokens at parse time

### DIFF
--- a/bindgen-integration/build.rs
+++ b/bindgen-integration/build.rs
@@ -44,9 +44,9 @@ impl ParseCallbacks for MacroCallback {
                 assert_eq!(value, b"string");
                 *self.seen_hellos.lock().unwrap() += 1;
             }
-            "TESTMACRO_STRING_EXPANDED"
-            | "TESTMACRO_STRING"
-            | "TESTMACRO_INTEGER" => {
+            "TESTMACRO_STRING_EXPANDED" |
+            "TESTMACRO_STRING" |
+            "TESTMACRO_INTEGER" => {
                 // The integer test macro is, actually, not expected to show up here at all -- but
                 // should produce an error if it does.
                 assert_eq!(

--- a/bindgen-integration/cpp/Test.h
+++ b/bindgen-integration/cpp/Test.h
@@ -22,6 +22,8 @@
 #define TESTMACRO_STRING_EXPR ("string")
 #define TESTMACRO_STRING_FUNC_NON_UTF8(x) (x "ÿÿ") /* invalid UTF-8 on purpose */
 
+#define TESTMACRO_COLON_VALUE 1:2
+
 enum {
   MY_ANNOYING_MACRO =
 #define MY_ANNOYING_MACRO 1

--- a/bindgen-integration/src/lib.rs
+++ b/bindgen-integration/src/lib.rs
@@ -345,3 +345,9 @@ fn test_wrap_static_fns() {
         extern_bindings::wrap_as_variadic_fn2_wrapped(1, 2);
     }
 }
+
+#[test]
+fn test_colon_define() {
+    let gold: u32 = (1u32 << 16) | 2;
+    assert_eq!(gold, bindings::TESTMACRO_COLON_VALUE);
+}

--- a/bindgen/callbacks.rs
+++ b/bindgen/callbacks.rs
@@ -4,6 +4,8 @@ pub use crate::ir::analysis::DeriveTrait;
 pub use crate::ir::derive::CanDerive as ImplementsTrait;
 pub use crate::ir::enum_ty::{EnumVariantCustomBehavior, EnumVariantValue};
 pub use crate::ir::int::IntKind;
+pub use cexpr::token::Kind as TokenKind;
+pub use cexpr::token::Token;
 use std::fmt;
 
 /// An enum to allow ignoring parsing of macros.
@@ -47,6 +49,10 @@ pub trait ParseCallbacks: fmt::Debug {
         _item_info: ItemInfo<'_>,
     ) -> Option<String> {
         None
+    }
+
+    /// Modify the contents of a macro
+    fn modify_macro(&self, _name: &str, _tokens: &mut Vec<Token>) {
     }
 
     /// The integer kind an integer macro should have, given a name and the

--- a/bindgen/callbacks.rs
+++ b/bindgen/callbacks.rs
@@ -52,8 +52,7 @@ pub trait ParseCallbacks: fmt::Debug {
     }
 
     /// Modify the contents of a macro
-    fn modify_macro(&self, _name: &str, _tokens: &mut Vec<Token>) {
-    }
+    fn modify_macro(&self, _name: &str, _tokens: &mut Vec<Token>) {}
 
     /// The integer kind an integer macro should have, given a name and the
     /// value of that macro, or `None` if you want the default to be chosen.

--- a/bindgen/ir/var.rs
+++ b/bindgen/ir/var.rs
@@ -427,10 +427,10 @@ fn parse_macro(
 ) -> Option<(Vec<u8>, cexpr::expr::EvalResult)> {
     use cexpr::expr;
 
-    let cexpr_tokens = cursor.cexpr_tokens();
+    let mut cexpr_tokens = cursor.cexpr_tokens();
 
-    if let Some(callbacks) = ctx.options.parse_callbacks() {
-        callbacks.modify_macro(cursor.spelling(), &mut cexpr_tokens);
+    for callbacks in &ctx.options().parse_callbacks {
+        callbacks.modify_macro(&cursor.spelling(), &mut cexpr_tokens);
     }
 
     let parser = expr::IdentifierParser::new(ctx.parsed_macros());

--- a/bindgen/ir/var.rs
+++ b/bindgen/ir/var.rs
@@ -429,7 +429,7 @@ fn parse_macro(
 
     let cexpr_tokens = cursor.cexpr_tokens();
 
-    if let Some(callbacks) = ctx.parse_callbacks() {
+    if let Some(callbacks) = ctx.options.parse_callbacks() {
         callbacks.modify_macro(cursor.spelling(), &mut cexpr_tokens);
     }
 

--- a/bindgen/ir/var.rs
+++ b/bindgen/ir/var.rs
@@ -429,6 +429,10 @@ fn parse_macro(
 
     let cexpr_tokens = cursor.cexpr_tokens();
 
+    if let Some(callbacks) = ctx.parse_callbacks() {
+        callbacks.modify_macro(cursor.spelling(), &mut cexpr_tokens);
+    }
+
     let parser = expr::IdentifierParser::new(ctx.parsed_macros());
 
     match parser.macro_definition(&cexpr_tokens) {


### PR DESCRIPTION
This a rerun of PR #2119. The goal is to provide a callback to allow modifying the tokens when parsing macros to handle values that are non-standard. As described in the original PR, I have several header files which contains things like:

```c
#define FLAG_BITS            8:10
```

In my specific case, these values are later on used within a ternary operator. This PR enables transforming those values into a valid integer that generates a valid integer constant.