### PR TITLE
Minor CLI documentation typo when running `bindgen --help`

### DIFF
--- a/bindgen/options/cli.rs
+++ b/bindgen/options/cli.rs
@@ -480,7 +480,7 @@ struct BindgenCommand {
     /// Derive custom traits on a `struct`. The CUSTOM value must be of the shape REGEX=DERIVE where DERIVE is a coma-separated list of derive macros.
     #[arg(long, value_name = "CUSTOM", value_parser = parse_custom_derive)]
     with_derive_custom_struct: Vec<(Vec<String>, String)>,
-    /// Derive custom traits on an `enum. The CUSTOM value must be of the shape REGEX=DERIVE where DERIVE is a coma-separated list of derive macros.
+    /// Derive custom traits on an `enum`. The CUSTOM value must be of the shape REGEX=DERIVE where DERIVE is a coma-separated list of derive macros.
     #[arg(long, value_name = "CUSTOM", value_parser = parse_custom_derive)]
     with_derive_custom_enum: Vec<(Vec<String>, String)>,
     /// Derive custom traits on a `union`. The CUSTOM value must be of the shape REGEX=DERIVE where DERIVE is a coma-separated list of derive macros.
@@ -492,7 +492,7 @@ struct BindgenCommand {
     /// Add custom attributes on a `struct`. The CUSTOM value must be of the shape REGEX=ATTRIBUTE where ATTRIBUTE is a coma-separated list of attributes.
     #[arg(long, value_name = "CUSTOM", value_parser = parse_custom_attribute)]
     with_attribute_custom_struct: Vec<(Vec<String>, String)>,
-    /// Add custom attributes on an `enum. The CUSTOM value must be of the shape REGEX=ATTRIBUTE where ATTRIBUTE is a coma-separated list of attributes.
+    /// Add custom attributes on an `enum`. The CUSTOM value must be of the shape REGEX=ATTRIBUTE where ATTRIBUTE is a coma-separated list of attributes.
     #[arg(long, value_name = "CUSTOM", value_parser = parse_custom_attribute)]
     with_attribute_custom_enum: Vec<(Vec<String>, String)>,
     /// Add custom attributes on a `union`. The CUSTOM value must be of the shape REGEX=ATTRIBUTE where ATTRIBUTE is a coma-separated list of attributes.


### PR DESCRIPTION
Noticed today when I ran `bindgen --help` that the backticks around `enum` on the descriptions for the `--with-derive-custom-enum` and `--with-attribute-custom-enum` options and improperly enclosed. This two-character PR fixes that.

![image](https://github.com/user-attachments/assets/12ecbf9f-4c40-43bc-a3fb-9146482db9d1)