### PR TITLE
feat: add Debug,Clone,Eq traits to callback objects

### DIFF
--- a/bindgen-tests/build.rs
+++ b/bindgen-tests/build.rs
@@ -33,8 +33,12 @@ pub fn main() {
                 .replace(|c| !char::is_alphanumeric(c), "_")
                 .replace("__", "_")
                 .to_lowercase();
-            writeln!(dst, "test_header!(header_{func}, {:?});", entry.path())
-                .unwrap();
+            writeln!(
+                dst,
+                "test_header!(header_{func}, {});",
+                entry.path().display()
+            )
+            .unwrap();
         }
     }
 

--- a/bindgen/callbacks.rs
+++ b/bindgen/callbacks.rs
@@ -248,7 +248,7 @@ pub enum DiscoveredItem {
 
 /// Relevant information about a type to which new derive attributes will be added using
 /// [`ParseCallbacks::add_derives`].
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[non_exhaustive]
 pub struct DeriveInfo<'a> {
     /// The name of the type.
@@ -259,7 +259,7 @@ pub struct DeriveInfo<'a> {
 
 /// Relevant information about a type to which new attributes will be added using
 /// [`ParseCallbacks::add_attributes`].
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[non_exhaustive]
 pub struct AttributeInfo<'a> {
     /// The name of the type.
@@ -280,7 +280,7 @@ pub enum TypeKind {
 }
 
 /// A struct providing information about the item being passed to [`ParseCallbacks::generated_name_override`].
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[non_exhaustive]
 pub struct ItemInfo<'a> {
     /// The name of the item
@@ -290,7 +290,7 @@ pub struct ItemInfo<'a> {
 }
 
 /// An enum indicating the kind of item for an `ItemInfo`.
-#[derive(Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum ItemKind {
     /// A module
@@ -305,7 +305,7 @@ pub enum ItemKind {
 
 /// Relevant information about a field for which visibility can be determined using
 /// [`ParseCallbacks::field_visibility`].
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[non_exhaustive]
 pub struct FieldInfo<'a> {
     /// The name of the type.

--- a/bindgen/ir/context.rs
+++ b/bindgen/ir/context.rs
@@ -724,7 +724,7 @@ If you encounter an error missing from this list, please file an issue or a PR!"
             self.need_bitfield_allocation.push(id);
         }
 
-        let old_item = mem::replace(&mut self.items[id.0], Some(item));
+        let old_item = self.items[id.0].replace(item);
         assert!(
             old_item.is_none(),
             "should not have already associated an item with the given id"
@@ -827,7 +827,7 @@ If you encounter an error missing from this list, please file an issue or a PR!"
         self.add_item_to_module(&item);
 
         let id = item.id();
-        let old_item = mem::replace(&mut self.items[id.0], Some(item));
+        let old_item = self.items[id.0].replace(item);
         assert!(
             old_item.is_none(),
             "should not have already associated an item with the given id"
@@ -987,7 +987,7 @@ If you encounter an error missing from this list, please file an issue or a PR!"
 
         let result = f(self, &mut item);
 
-        let existing = mem::replace(&mut self.items[id.0], Some(item));
+        let existing = self.items[id.0].replace(item);
         assert!(existing.is_none());
 
         result
@@ -1434,7 +1434,7 @@ If you encounter an error missing from this list, please file an issue or a PR!"
         debug_assert!(item.kind().is_type());
         self.add_item_to_module(&item);
         let id = item.id();
-        let old_item = mem::replace(&mut self.items[id.0], Some(item));
+        let old_item = self.items[id.0].replace(item);
         assert!(old_item.is_none(), "Inserted type twice?");
     }
 

--- a/bindgen/lib.rs
+++ b/bindgen/lib.rs
@@ -980,7 +980,7 @@ impl Bindings {
     }
 
     /// Gets the rustfmt path to rustfmt the generated bindings.
-    fn rustfmt_path(&self) -> io::Result<Cow<'_, PathBuf>> {
+    fn rustfmt_path(&self) -> io::Result<Cow<'_, Path>> {
         debug_assert!(matches!(self.options.formatter, Formatter::Rustfmt));
         if let Some(ref p) = self.options.rustfmt_path {
             return Ok(Cow::Borrowed(p));


### PR DESCRIPTION
Add common traits like `Debug` to the callback objects like `ItemKind` and `ItemInfo`.