### PR TITLE
comp: Fix alignment of bitfields in some edge cases.

### DIFF
--- a/bindgen-integration/src/lib.rs
+++ b/bindgen-integration/src/lib.rs
@@ -178,19 +178,18 @@ fn test_bitfields_seventh() {
 fn test_bitfield_constructors() {
     use std::mem;
     let mut first = bindings::bitfields::First {
-        _bitfield_align_1: [],
         _bitfield_1: bindings::bitfields::First::new_bitfield_1(1, 2, 3),
     };
     assert!(unsafe { first.assert(1, 2, 3) });
 
     let mut second = bindings::bitfields::Second {
-        _bitfield_align_1: [],
+        _bindgen_align: [],
         _bitfield_1: bindings::bitfields::Second::new_bitfield_1(1337, true),
     };
     assert!(unsafe { second.assert(1337, true) });
 
     let mut third = bindings::bitfields::Third {
-        _bitfield_align_1: [],
+        _bindgen_align: [],
         _bitfield_1: bindings::bitfields::Third::new_bitfield_1(
             42,
             false,

--- a/bindgen-tests/tests/expectations/tests/bitfield-32bit-overflow.rs
+++ b/bindgen-tests/tests/expectations/tests/bitfield-32bit-overflow.rs
@@ -148,7 +148,6 @@ where
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct MuchBitfield {
-    pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 5usize]>,
 }
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]

--- a/bindgen-tests/tests/expectations/tests/bitfield-large.rs
+++ b/bindgen-tests/tests/expectations/tests/bitfield-large.rs
@@ -149,7 +149,6 @@ where
 #[repr(align(16))]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct HasBigBitfield {
-    pub _bitfield_align_1: [u64; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 16usize]>,
 }
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
@@ -213,7 +212,6 @@ impl HasBigBitfield {
 #[repr(align(16))]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct HasTwoBigBitfields {
-    pub _bitfield_align_1: [u64; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 16usize]>,
 }
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]

--- a/bindgen-tests/tests/expectations/tests/bitfield-linux-32.rs
+++ b/bindgen-tests/tests/expectations/tests/bitfield-linux-32.rs
@@ -145,19 +145,12 @@ where
         }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct Test {
     pub foo: u64,
-    pub _bitfield_align_1: [u64; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 8usize]>,
 }
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of Test"][::std::mem::size_of::<Test>() - 16usize];
-    ["Alignment of Test"][::std::mem::align_of::<Test>() - 4usize];
-    ["Offset of field: Test::foo"][::std::mem::offset_of!(Test, foo) - 0usize];
-};
 impl Test {
     #[inline]
     pub fn x(&self) -> u64 {

--- a/bindgen-tests/tests/expectations/tests/bitfield-template.rs
+++ b/bindgen-tests/tests/expectations/tests/bitfield-template.rs
@@ -146,166 +146,13 @@ where
     }
 }
 #[repr(C)]
-#[repr(align(8))]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct redundant_packed {
-    pub a: u32,
-    pub b: u32,
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of redundant_packed"][::std::mem::size_of::<redundant_packed>() - 8usize];
-    [
-        "Alignment of redundant_packed",
-    ][::std::mem::align_of::<redundant_packed>() - 8usize];
-    [
-        "Offset of field: redundant_packed::a",
-    ][::std::mem::offset_of!(redundant_packed, a) - 0usize];
-    [
-        "Offset of field: redundant_packed::b",
-    ][::std::mem::offset_of!(redundant_packed, b) - 4usize];
-};
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct redundant_packed_bitfield {
-    pub _bindgen_align: [u64; 0],
-    pub a: [u8; 3usize],
+#[derive(Debug, Copy, Clone)]
+pub struct foo<T> {
+    pub _phantom_0: ::std::marker::PhantomData<::std::cell::UnsafeCell<T>>,
+    pub member: T,
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
-    pub c: u32,
 }
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    [
-        "Size of redundant_packed_bitfield",
-    ][::std::mem::size_of::<redundant_packed_bitfield>() - 8usize];
-    [
-        "Alignment of redundant_packed_bitfield",
-    ][::std::mem::align_of::<redundant_packed_bitfield>() - 8usize];
-    [
-        "Offset of field: redundant_packed_bitfield::a",
-    ][::std::mem::offset_of!(redundant_packed_bitfield, a) - 0usize];
-    [
-        "Offset of field: redundant_packed_bitfield::c",
-    ][::std::mem::offset_of!(redundant_packed_bitfield, c) - 4usize];
-};
-impl redundant_packed_bitfield {
-    #[inline]
-    pub fn b0(&self) -> u8 {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u8) }
-    }
-    #[inline]
-    pub fn set_b0(&mut self, val: u8) {
-        unsafe {
-            let val: u8 = ::std::mem::transmute(val);
-            self._bitfield_1.set(0usize, 1u8, val as u64)
-        }
-    }
-    #[inline]
-    pub unsafe fn b0_raw(this: *const Self) -> u8 {
-        unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 1usize],
-                >>::raw_get(::std::ptr::addr_of!((*this)._bitfield_1), 0usize, 1u8) as u8,
-            )
-        }
-    }
-    #[inline]
-    pub unsafe fn set_b0_raw(this: *mut Self, val: u8) {
-        unsafe {
-            let val: u8 = ::std::mem::transmute(val);
-            <__BindgenBitfieldUnit<
-                [u8; 1usize],
-            >>::raw_set(
-                ::std::ptr::addr_of_mut!((*this)._bitfield_1),
-                0usize,
-                1u8,
-                val as u64,
-            )
-        }
-    }
-    #[inline]
-    pub fn b1(&self) -> u8 {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u8) }
-    }
-    #[inline]
-    pub fn set_b1(&mut self, val: u8) {
-        unsafe {
-            let val: u8 = ::std::mem::transmute(val);
-            self._bitfield_1.set(1usize, 1u8, val as u64)
-        }
-    }
-    #[inline]
-    pub unsafe fn b1_raw(this: *const Self) -> u8 {
-        unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 1usize],
-                >>::raw_get(::std::ptr::addr_of!((*this)._bitfield_1), 1usize, 1u8) as u8,
-            )
-        }
-    }
-    #[inline]
-    pub unsafe fn set_b1_raw(this: *mut Self, val: u8) {
-        unsafe {
-            let val: u8 = ::std::mem::transmute(val);
-            <__BindgenBitfieldUnit<
-                [u8; 1usize],
-            >>::raw_set(
-                ::std::ptr::addr_of_mut!((*this)._bitfield_1),
-                1usize,
-                1u8,
-                val as u64,
-            )
-        }
-    }
-    #[inline]
-    pub fn new_bitfield_1(b0: u8, b1: u8) -> __BindgenBitfieldUnit<[u8; 1usize]> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 1usize]> = Default::default();
-        __bindgen_bitfield_unit
-            .set(
-                0usize,
-                1u8,
-                {
-                    let b0: u8 = unsafe { ::std::mem::transmute(b0) };
-                    b0 as u64
-                },
-            );
-        __bindgen_bitfield_unit
-            .set(
-                1usize,
-                1u8,
-                {
-                    let b1: u8 = unsafe { ::std::mem::transmute(b1) };
-                    b1 as u64
-                },
-            );
-        __bindgen_bitfield_unit
-    }
-}
-#[repr(C)]
-#[repr(align(16))]
-#[derive(Copy, Clone)]
-pub union redundant_packed_union {
-    pub a: u64,
-    pub b: u32,
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    [
-        "Size of redundant_packed_union",
-    ][::std::mem::size_of::<redundant_packed_union>() - 16usize];
-    [
-        "Alignment of redundant_packed_union",
-    ][::std::mem::align_of::<redundant_packed_union>() - 16usize];
-    [
-        "Offset of field: redundant_packed_union::a",
-    ][::std::mem::offset_of!(redundant_packed_union, a) - 0usize];
-    [
-        "Offset of field: redundant_packed_union::b",
-    ][::std::mem::offset_of!(redundant_packed_union, b) - 0usize];
-};
-impl Default for redundant_packed_union {
+impl<T> Default for foo<T> {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
         unsafe {
@@ -314,59 +161,54 @@ impl Default for redundant_packed_union {
         }
     }
 }
-#[repr(C)]
-#[repr(align(2))]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct inner {
-    pub a: u8,
+impl<T> foo<T> {
+    #[inline]
+    pub fn b(&self) -> bool {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(0usize, 8u8) as u8) }
+    }
+    #[inline]
+    pub fn set_b(&mut self, val: bool) {
+        unsafe {
+            let val: u8 = ::std::mem::transmute(val);
+            self._bitfield_1.set(0usize, 8u8, val as u64)
+        }
+    }
+    #[inline]
+    pub unsafe fn b_raw(this: *const Self) -> bool {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 1usize],
+                >>::raw_get(::std::ptr::addr_of!((*this)._bitfield_1), 0usize, 8u8) as u8,
+            )
+        }
+    }
+    #[inline]
+    pub unsafe fn set_b_raw(this: *mut Self, val: bool) {
+        unsafe {
+            let val: u8 = ::std::mem::transmute(val);
+            <__BindgenBitfieldUnit<
+                [u8; 1usize],
+            >>::raw_set(
+                ::std::ptr::addr_of_mut!((*this)._bitfield_1),
+                0usize,
+                8u8,
+                val as u64,
+            )
+        }
+    }
+    #[inline]
+    pub fn new_bitfield_1(b: bool) -> __BindgenBitfieldUnit<[u8; 1usize]> {
+        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 1usize]> = Default::default();
+        __bindgen_bitfield_unit
+            .set(
+                0usize,
+                8u8,
+                {
+                    let b: u8 = unsafe { ::std::mem::transmute(b) };
+                    b as u64
+                },
+            );
+        __bindgen_bitfield_unit
+    }
 }
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of inner"][::std::mem::size_of::<inner>() - 2usize];
-    ["Alignment of inner"][::std::mem::align_of::<inner>() - 2usize];
-    ["Offset of field: inner::a"][::std::mem::offset_of!(inner, a) - 0usize];
-};
-#[repr(C)]
-#[repr(align(8))]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct outer_redundant_packed {
-    pub a: [inner; 2usize],
-    pub b: u32,
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    [
-        "Size of outer_redundant_packed",
-    ][::std::mem::size_of::<outer_redundant_packed>() - 8usize];
-    [
-        "Alignment of outer_redundant_packed",
-    ][::std::mem::align_of::<outer_redundant_packed>() - 8usize];
-    [
-        "Offset of field: outer_redundant_packed::a",
-    ][::std::mem::offset_of!(outer_redundant_packed, a) - 0usize];
-    [
-        "Offset of field: outer_redundant_packed::b",
-    ][::std::mem::offset_of!(outer_redundant_packed, b) - 4usize];
-};
-#[repr(C)]
-#[repr(align(4))]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct redundant_pragma_packed {
-    pub a: u8,
-    pub b: u16,
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    [
-        "Size of redundant_pragma_packed",
-    ][::std::mem::size_of::<redundant_pragma_packed>() - 4usize];
-    [
-        "Alignment of redundant_pragma_packed",
-    ][::std::mem::align_of::<redundant_pragma_packed>() - 4usize];
-    [
-        "Offset of field: redundant_pragma_packed::a",
-    ][::std::mem::offset_of!(redundant_pragma_packed, a) - 0usize];
-    [
-        "Offset of field: redundant_pragma_packed::b",
-    ][::std::mem::offset_of!(redundant_pragma_packed, b) - 2usize];
-};

--- a/bindgen-tests/tests/expectations/tests/bitfield_align.rs
+++ b/bindgen-tests/tests/expectations/tests/bitfield_align.rs
@@ -146,11 +146,10 @@ where
     }
 }
 #[repr(C)]
-#[repr(align(4))]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct A {
+    pub _bindgen_align: [u32; 0],
     pub x: ::std::os::raw::c_uchar,
-    pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 2usize]>,
     pub y: ::std::os::raw::c_uchar,
 }
@@ -632,7 +631,7 @@ impl A {
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct B {
-    pub _bitfield_align_1: [u32; 0],
+    pub _bindgen_align: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
 }
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
@@ -744,7 +743,6 @@ impl B {
 #[derive(Debug, Default, Copy, Clone)]
 pub struct C {
     pub x: ::std::os::raw::c_uchar,
-    pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
     pub baz: ::std::os::raw::c_uint,
 }
@@ -856,10 +854,9 @@ impl C {
     }
 }
 #[repr(C)]
-#[repr(align(2))]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct Date1 {
-    pub _bitfield_align_1: [u8; 0],
+    pub _bindgen_align: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 3usize]>,
     pub __bindgen_padding_0: u8,
 }
@@ -1061,10 +1058,9 @@ impl Date1 {
     }
 }
 #[repr(C)]
-#[repr(align(2))]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct Date2 {
-    pub _bitfield_align_1: [u8; 0],
+    pub _bindgen_align: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
 }
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
@@ -1311,10 +1307,9 @@ impl Date2 {
     }
 }
 #[repr(C)]
-#[repr(align(2))]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct Date3 {
-    pub _bitfield_align_1: [u8; 0],
+    pub _bindgen_align: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 3usize]>,
     pub byte: ::std::os::raw::c_uchar,
 }

--- a/bindgen-tests/tests/expectations/tests/bitfield_align_2.rs
+++ b/bindgen-tests/tests/expectations/tests/bitfield_align_2.rs
@@ -157,7 +157,7 @@ pub enum MyEnum {
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct TaggedPtr {
-    pub _bitfield_align_1: [u64; 0],
+    pub _bindgen_align: [u64; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 8usize]>,
 }
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]

--- a/bindgen-tests/tests/expectations/tests/bitfield_large_overflow.rs
+++ b/bindgen-tests/tests/expectations/tests/bitfield_large_overflow.rs
@@ -1,8 +1,8 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[repr(C)]
-#[repr(align(8))]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct _bindgen_ty_1 {
+    pub _bindgen_align: [u64; 0],
     pub _bindgen_opaque_blob: [u64; 10usize],
 }
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]

--- a/bindgen-tests/tests/expectations/tests/bitfield_method_mangling.rs
+++ b/bindgen-tests/tests/expectations/tests/bitfield_method_mangling.rs
@@ -148,7 +148,7 @@ where
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct mach_msg_type_descriptor_t {
-    pub _bitfield_align_1: [u32; 0],
+    pub _bindgen_align: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
 }
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]

--- a/bindgen-tests/tests/expectations/tests/bitfield_pack_offset.rs
+++ b/bindgen-tests/tests/expectations/tests/bitfield_pack_offset.rs
@@ -146,369 +146,362 @@ where
     }
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct Struct {
-    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
+#[derive(Debug, Copy, Clone)]
+pub struct A {
+    pub name: [::std::os::raw::c_uchar; 7usize],
+    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 3usize]>,
+    pub maxYield: ::std::os::raw::c_uchar,
+    pub _bitfield_2: __BindgenBitfieldUnit<[u8; 1usize]>,
+    pub description1: *const ::std::os::raw::c_uchar,
 }
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
-    ["Size of Struct"][::std::mem::size_of::<Struct>() - 4usize];
-    ["Alignment of Struct"][::std::mem::align_of::<Struct>() - 1usize];
+    ["Size of A"][::std::mem::size_of::<A>() - 24usize];
+    ["Alignment of A"][::std::mem::align_of::<A>() - 8usize];
+    ["Offset of field: A::name"][::std::mem::offset_of!(A, name) - 0usize];
+    ["Offset of field: A::maxYield"][::std::mem::offset_of!(A, maxYield) - 10usize];
+    [
+        "Offset of field: A::description1",
+    ][::std::mem::offset_of!(A, description1) - 16usize];
 };
-impl Struct {
+impl Default for A {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}
+impl A {
     #[inline]
-    pub fn a(&self) -> ::std::os::raw::c_uchar {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u8) }
+    pub fn firmness(&self) -> ::std::os::raw::c_uchar {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(0usize, 4u8) as u8) }
     }
     #[inline]
-    pub fn set_a(&mut self, val: ::std::os::raw::c_uchar) {
+    pub fn set_firmness(&mut self, val: ::std::os::raw::c_uchar) {
         unsafe {
             let val: u8 = ::std::mem::transmute(val);
-            self._bitfield_1.set(0usize, 1u8, val as u64)
+            self._bitfield_1.set(0usize, 4u8, val as u64)
         }
     }
     #[inline]
-    pub unsafe fn a_raw(this: *const Self) -> ::std::os::raw::c_uchar {
+    pub unsafe fn firmness_raw(this: *const Self) -> ::std::os::raw::c_uchar {
         unsafe {
             ::std::mem::transmute(
                 <__BindgenBitfieldUnit<
-                    [u8; 4usize],
-                >>::raw_get(::std::ptr::addr_of!((*this)._bitfield_1), 0usize, 1u8) as u8,
+                    [u8; 3usize],
+                >>::raw_get(::std::ptr::addr_of!((*this)._bitfield_1), 0usize, 4u8) as u8,
             )
         }
     }
     #[inline]
-    pub unsafe fn set_a_raw(this: *mut Self, val: ::std::os::raw::c_uchar) {
+    pub unsafe fn set_firmness_raw(this: *mut Self, val: ::std::os::raw::c_uchar) {
         unsafe {
             let val: u8 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
-                [u8; 4usize],
+                [u8; 3usize],
             >>::raw_set(
                 ::std::ptr::addr_of_mut!((*this)._bitfield_1),
                 0usize,
-                1u8,
+                4u8,
                 val as u64,
             )
         }
     }
     #[inline]
-    pub fn b(&self) -> ::std::os::raw::c_uchar {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(1usize, 1u8) as u8) }
+    pub fn color(&self) -> ::std::os::raw::c_uchar {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(4usize, 4u8) as u8) }
     }
     #[inline]
-    pub fn set_b(&mut self, val: ::std::os::raw::c_uchar) {
+    pub fn set_color(&mut self, val: ::std::os::raw::c_uchar) {
         unsafe {
             let val: u8 = ::std::mem::transmute(val);
-            self._bitfield_1.set(1usize, 1u8, val as u64)
+            self._bitfield_1.set(4usize, 4u8, val as u64)
         }
     }
     #[inline]
-    pub unsafe fn b_raw(this: *const Self) -> ::std::os::raw::c_uchar {
+    pub unsafe fn color_raw(this: *const Self) -> ::std::os::raw::c_uchar {
         unsafe {
             ::std::mem::transmute(
                 <__BindgenBitfieldUnit<
-                    [u8; 4usize],
-                >>::raw_get(::std::ptr::addr_of!((*this)._bitfield_1), 1usize, 1u8) as u8,
+                    [u8; 3usize],
+                >>::raw_get(::std::ptr::addr_of!((*this)._bitfield_1), 4usize, 4u8) as u8,
             )
         }
     }
     #[inline]
-    pub unsafe fn set_b_raw(this: *mut Self, val: ::std::os::raw::c_uchar) {
+    pub unsafe fn set_color_raw(this: *mut Self, val: ::std::os::raw::c_uchar) {
         unsafe {
             let val: u8 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
-                [u8; 4usize],
+                [u8; 3usize],
             >>::raw_set(
                 ::std::ptr::addr_of_mut!((*this)._bitfield_1),
-                1usize,
-                1u8,
+                4usize,
+                4u8,
                 val as u64,
             )
         }
     }
     #[inline]
-    pub fn c(&self) -> ::std::os::raw::c_uchar {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(2usize, 6u8) as u8) }
+    pub fn weedsBonus(&self) -> ::std::os::raw::c_ushort {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(8usize, 3u8) as u16) }
     }
     #[inline]
-    pub fn set_c(&mut self, val: ::std::os::raw::c_uchar) {
-        unsafe {
-            let val: u8 = ::std::mem::transmute(val);
-            self._bitfield_1.set(2usize, 6u8, val as u64)
-        }
-    }
-    #[inline]
-    pub unsafe fn c_raw(this: *const Self) -> ::std::os::raw::c_uchar {
-        unsafe {
-            ::std::mem::transmute(
-                <__BindgenBitfieldUnit<
-                    [u8; 4usize],
-                >>::raw_get(::std::ptr::addr_of!((*this)._bitfield_1), 2usize, 6u8) as u8,
-            )
-        }
-    }
-    #[inline]
-    pub unsafe fn set_c_raw(this: *mut Self, val: ::std::os::raw::c_uchar) {
-        unsafe {
-            let val: u8 = ::std::mem::transmute(val);
-            <__BindgenBitfieldUnit<
-                [u8; 4usize],
-            >>::raw_set(
-                ::std::ptr::addr_of_mut!((*this)._bitfield_1),
-                2usize,
-                6u8,
-                val as u64,
-            )
-        }
-    }
-    #[inline]
-    pub fn d(&self) -> ::std::os::raw::c_ushort {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(8usize, 16u8) as u16) }
-    }
-    #[inline]
-    pub fn set_d(&mut self, val: ::std::os::raw::c_ushort) {
+    pub fn set_weedsBonus(&mut self, val: ::std::os::raw::c_ushort) {
         unsafe {
             let val: u16 = ::std::mem::transmute(val);
-            self._bitfield_1.set(8usize, 16u8, val as u64)
+            self._bitfield_1.set(8usize, 3u8, val as u64)
         }
     }
     #[inline]
-    pub unsafe fn d_raw(this: *const Self) -> ::std::os::raw::c_ushort {
+    pub unsafe fn weedsBonus_raw(this: *const Self) -> ::std::os::raw::c_ushort {
         unsafe {
             ::std::mem::transmute(
                 <__BindgenBitfieldUnit<
-                    [u8; 4usize],
-                >>::raw_get(::std::ptr::addr_of!((*this)._bitfield_1), 8usize, 16u8)
+                    [u8; 3usize],
+                >>::raw_get(::std::ptr::addr_of!((*this)._bitfield_1), 8usize, 3u8)
                     as u16,
             )
         }
     }
     #[inline]
-    pub unsafe fn set_d_raw(this: *mut Self, val: ::std::os::raw::c_ushort) {
+    pub unsafe fn set_weedsBonus_raw(this: *mut Self, val: ::std::os::raw::c_ushort) {
         unsafe {
             let val: u16 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
-                [u8; 4usize],
+                [u8; 3usize],
             >>::raw_set(
                 ::std::ptr::addr_of_mut!((*this)._bitfield_1),
                 8usize,
-                16u8,
+                3u8,
                 val as u64,
             )
         }
     }
     #[inline]
-    pub fn e(&self) -> ::std::os::raw::c_uchar {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(24usize, 8u8) as u8) }
+    pub fn pestsBonus(&self) -> ::std::os::raw::c_ushort {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(11usize, 3u8) as u16) }
     }
     #[inline]
-    pub fn set_e(&mut self, val: ::std::os::raw::c_uchar) {
+    pub fn set_pestsBonus(&mut self, val: ::std::os::raw::c_ushort) {
         unsafe {
-            let val: u8 = ::std::mem::transmute(val);
-            self._bitfield_1.set(24usize, 8u8, val as u64)
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set(11usize, 3u8, val as u64)
         }
     }
     #[inline]
-    pub unsafe fn e_raw(this: *const Self) -> ::std::os::raw::c_uchar {
+    pub unsafe fn pestsBonus_raw(this: *const Self) -> ::std::os::raw::c_ushort {
         unsafe {
             ::std::mem::transmute(
                 <__BindgenBitfieldUnit<
-                    [u8; 4usize],
-                >>::raw_get(::std::ptr::addr_of!((*this)._bitfield_1), 24usize, 8u8)
-                    as u8,
+                    [u8; 3usize],
+                >>::raw_get(::std::ptr::addr_of!((*this)._bitfield_1), 11usize, 3u8)
+                    as u16,
             )
         }
     }
     #[inline]
-    pub unsafe fn set_e_raw(this: *mut Self, val: ::std::os::raw::c_uchar) {
+    pub unsafe fn set_pestsBonus_raw(this: *mut Self, val: ::std::os::raw::c_ushort) {
         unsafe {
-            let val: u8 = ::std::mem::transmute(val);
+            let val: u16 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
-                [u8; 4usize],
+                [u8; 3usize],
             >>::raw_set(
                 ::std::ptr::addr_of_mut!((*this)._bitfield_1),
-                24usize,
-                8u8,
+                11usize,
+                3u8,
+                val as u64,
+            )
+        }
+    }
+    #[inline]
+    pub fn size(&self) -> ::std::os::raw::c_ushort {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(14usize, 10u8) as u16) }
+    }
+    #[inline]
+    pub fn set_size(&mut self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            self._bitfield_1.set(14usize, 10u8, val as u64)
+        }
+    }
+    #[inline]
+    pub unsafe fn size_raw(this: *const Self) -> ::std::os::raw::c_ushort {
+        unsafe {
+            ::std::mem::transmute(
+                <__BindgenBitfieldUnit<
+                    [u8; 3usize],
+                >>::raw_get(::std::ptr::addr_of!((*this)._bitfield_1), 14usize, 10u8)
+                    as u16,
+            )
+        }
+    }
+    #[inline]
+    pub unsafe fn set_size_raw(this: *mut Self, val: ::std::os::raw::c_ushort) {
+        unsafe {
+            let val: u16 = ::std::mem::transmute(val);
+            <__BindgenBitfieldUnit<
+                [u8; 3usize],
+            >>::raw_set(
+                ::std::ptr::addr_of_mut!((*this)._bitfield_1),
+                14usize,
+                10u8,
                 val as u64,
             )
         }
     }
     #[inline]
     pub fn new_bitfield_1(
-        a: ::std::os::raw::c_uchar,
-        b: ::std::os::raw::c_uchar,
-        c: ::std::os::raw::c_uchar,
-        d: ::std::os::raw::c_ushort,
-        e: ::std::os::raw::c_uchar,
-    ) -> __BindgenBitfieldUnit<[u8; 4usize]> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> = Default::default();
+        firmness: ::std::os::raw::c_uchar,
+        color: ::std::os::raw::c_uchar,
+        weedsBonus: ::std::os::raw::c_ushort,
+        pestsBonus: ::std::os::raw::c_ushort,
+        size: ::std::os::raw::c_ushort,
+    ) -> __BindgenBitfieldUnit<[u8; 3usize]> {
+        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 3usize]> = Default::default();
         __bindgen_bitfield_unit
             .set(
                 0usize,
-                1u8,
+                4u8,
                 {
-                    let a: u8 = unsafe { ::std::mem::transmute(a) };
-                    a as u64
+                    let firmness: u8 = unsafe { ::std::mem::transmute(firmness) };
+                    firmness as u64
                 },
             );
         __bindgen_bitfield_unit
             .set(
-                1usize,
-                1u8,
+                4usize,
+                4u8,
                 {
-                    let b: u8 = unsafe { ::std::mem::transmute(b) };
-                    b as u64
-                },
-            );
-        __bindgen_bitfield_unit
-            .set(
-                2usize,
-                6u8,
-                {
-                    let c: u8 = unsafe { ::std::mem::transmute(c) };
-                    c as u64
+                    let color: u8 = unsafe { ::std::mem::transmute(color) };
+                    color as u64
                 },
             );
         __bindgen_bitfield_unit
             .set(
                 8usize,
-                16u8,
+                3u8,
                 {
-                    let d: u16 = unsafe { ::std::mem::transmute(d) };
-                    d as u64
+                    let weedsBonus: u16 = unsafe { ::std::mem::transmute(weedsBonus) };
+                    weedsBonus as u64
                 },
             );
         __bindgen_bitfield_unit
             .set(
-                24usize,
-                8u8,
+                11usize,
+                3u8,
                 {
-                    let e: u8 = unsafe { ::std::mem::transmute(e) };
-                    e as u64
+                    let pestsBonus: u16 = unsafe { ::std::mem::transmute(pestsBonus) };
+                    pestsBonus as u64
+                },
+            );
+        __bindgen_bitfield_unit
+            .set(
+                14usize,
+                10u8,
+                {
+                    let size: u16 = unsafe { ::std::mem::transmute(size) };
+                    size as u64
                 },
             );
         __bindgen_bitfield_unit
     }
-}
-#[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct Inner {
-    pub _bindgen_align: [u16; 0],
-    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of Inner"][::std::mem::size_of::<Inner>() - 4usize];
-    ["Alignment of Inner"][::std::mem::align_of::<Inner>() - 2usize];
-};
-impl Inner {
     #[inline]
-    pub fn a(&self) -> ::std::os::raw::c_ushort {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(0usize, 16u8) as u16) }
+    pub fn minYield(&self) -> ::std::os::raw::c_uchar {
+        unsafe { ::std::mem::transmute(self._bitfield_2.get(0usize, 4u8) as u8) }
     }
     #[inline]
-    pub fn set_a(&mut self, val: ::std::os::raw::c_ushort) {
+    pub fn set_minYield(&mut self, val: ::std::os::raw::c_uchar) {
         unsafe {
-            let val: u16 = ::std::mem::transmute(val);
-            self._bitfield_1.set(0usize, 16u8, val as u64)
+            let val: u8 = ::std::mem::transmute(val);
+            self._bitfield_2.set(0usize, 4u8, val as u64)
         }
     }
     #[inline]
-    pub unsafe fn a_raw(this: *const Self) -> ::std::os::raw::c_ushort {
+    pub unsafe fn minYield_raw(this: *const Self) -> ::std::os::raw::c_uchar {
         unsafe {
             ::std::mem::transmute(
                 <__BindgenBitfieldUnit<
-                    [u8; 4usize],
-                >>::raw_get(::std::ptr::addr_of!((*this)._bitfield_1), 0usize, 16u8)
-                    as u16,
+                    [u8; 1usize],
+                >>::raw_get(::std::ptr::addr_of!((*this)._bitfield_2), 0usize, 4u8) as u8,
             )
         }
     }
     #[inline]
-    pub unsafe fn set_a_raw(this: *mut Self, val: ::std::os::raw::c_ushort) {
+    pub unsafe fn set_minYield_raw(this: *mut Self, val: ::std::os::raw::c_uchar) {
         unsafe {
-            let val: u16 = ::std::mem::transmute(val);
+            let val: u8 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
-                [u8; 4usize],
+                [u8; 1usize],
             >>::raw_set(
-                ::std::ptr::addr_of_mut!((*this)._bitfield_1),
+                ::std::ptr::addr_of_mut!((*this)._bitfield_2),
                 0usize,
-                16u8,
+                4u8,
                 val as u64,
             )
         }
     }
     #[inline]
-    pub fn b(&self) -> ::std::os::raw::c_ushort {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(16usize, 16u8) as u16) }
+    pub fn waterBonus(&self) -> ::std::os::raw::c_uchar {
+        unsafe { ::std::mem::transmute(self._bitfield_2.get(4usize, 4u8) as u8) }
     }
     #[inline]
-    pub fn set_b(&mut self, val: ::std::os::raw::c_ushort) {
+    pub fn set_waterBonus(&mut self, val: ::std::os::raw::c_uchar) {
         unsafe {
-            let val: u16 = ::std::mem::transmute(val);
-            self._bitfield_1.set(16usize, 16u8, val as u64)
+            let val: u8 = ::std::mem::transmute(val);
+            self._bitfield_2.set(4usize, 4u8, val as u64)
         }
     }
     #[inline]
-    pub unsafe fn b_raw(this: *const Self) -> ::std::os::raw::c_ushort {
+    pub unsafe fn waterBonus_raw(this: *const Self) -> ::std::os::raw::c_uchar {
         unsafe {
             ::std::mem::transmute(
                 <__BindgenBitfieldUnit<
-                    [u8; 4usize],
-                >>::raw_get(::std::ptr::addr_of!((*this)._bitfield_1), 16usize, 16u8)
-                    as u16,
+                    [u8; 1usize],
+                >>::raw_get(::std::ptr::addr_of!((*this)._bitfield_2), 4usize, 4u8) as u8,
             )
         }
     }
     #[inline]
-    pub unsafe fn set_b_raw(this: *mut Self, val: ::std::os::raw::c_ushort) {
+    pub unsafe fn set_waterBonus_raw(this: *mut Self, val: ::std::os::raw::c_uchar) {
         unsafe {
-            let val: u16 = ::std::mem::transmute(val);
+            let val: u8 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
-                [u8; 4usize],
+                [u8; 1usize],
             >>::raw_set(
-                ::std::ptr::addr_of_mut!((*this)._bitfield_1),
-                16usize,
-                16u8,
+                ::std::ptr::addr_of_mut!((*this)._bitfield_2),
+                4usize,
+                4u8,
                 val as u64,
             )
         }
     }
     #[inline]
-    pub fn new_bitfield_1(
-        a: ::std::os::raw::c_ushort,
-        b: ::std::os::raw::c_ushort,
-    ) -> __BindgenBitfieldUnit<[u8; 4usize]> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> = Default::default();
+    pub fn new_bitfield_2(
+        minYield: ::std::os::raw::c_uchar,
+        waterBonus: ::std::os::raw::c_uchar,
+    ) -> __BindgenBitfieldUnit<[u8; 1usize]> {
+        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 1usize]> = Default::default();
         __bindgen_bitfield_unit
             .set(
                 0usize,
-                16u8,
+                4u8,
                 {
-                    let a: u16 = unsafe { ::std::mem::transmute(a) };
-                    a as u64
+                    let minYield: u8 = unsafe { ::std::mem::transmute(minYield) };
+                    minYield as u64
                 },
             );
         __bindgen_bitfield_unit
             .set(
-                16usize,
-                16u8,
+                4usize,
+                4u8,
                 {
-                    let b: u16 = unsafe { ::std::mem::transmute(b) };
-                    b as u64
+                    let waterBonus: u8 = unsafe { ::std::mem::transmute(waterBonus) };
+                    waterBonus as u64
                 },
             );
         __bindgen_bitfield_unit
     }
 }
-#[repr(C, packed)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct Outer {
-    pub inner: Inner,
-}
-#[allow(clippy::unnecessary_operation, clippy::identity_op)]
-const _: () = {
-    ["Size of Outer"][::std::mem::size_of::<Outer>() - 4usize];
-    ["Alignment of Outer"][::std::mem::align_of::<Outer>() - 1usize];
-    ["Offset of field: Outer::inner"][::std::mem::offset_of!(Outer, inner) - 0usize];
-};

--- a/bindgen-tests/tests/expectations/tests/blocklist_bitfield_unit.rs
+++ b/bindgen-tests/tests/expectations/tests/blocklist_bitfield_unit.rs
@@ -6,7 +6,6 @@ use bitfields::*;
 #[derive(Debug, Default, Copy, Clone)]
 pub struct C {
     pub x: ::std::os::raw::c_uchar,
-    pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
     pub baz: ::std::os::raw::c_uint,
 }

--- a/bindgen-tests/tests/expectations/tests/default_visibility_crate.rs
+++ b/bindgen-tests/tests/expectations/tests/default_visibility_crate.rs
@@ -154,7 +154,6 @@ pub struct Point {
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct Color {
-    pub(crate) _bitfield_align_1: [u8; 0],
     pub(crate) _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
 }
 impl Color {

--- a/bindgen-tests/tests/expectations/tests/default_visibility_private.rs
+++ b/bindgen-tests/tests/expectations/tests/default_visibility_private.rs
@@ -154,7 +154,6 @@ pub struct Point {
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct Color {
-    _bitfield_align_1: [u8; 0],
     _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
 }
 impl Color {

--- a/bindgen-tests/tests/expectations/tests/default_visibility_private_respects_cxx_access_spec.rs
+++ b/bindgen-tests/tests/expectations/tests/default_visibility_private_respects_cxx_access_spec.rs
@@ -154,7 +154,6 @@ pub struct Point {
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct Color {
-    _bitfield_align_1: [u8; 0],
     _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
 }
 impl Color {

--- a/bindgen-tests/tests/expectations/tests/derive-bitfield-method-same-name.rs
+++ b/bindgen-tests/tests/expectations/tests/derive-bitfield-method-same-name.rs
@@ -94,7 +94,6 @@ where
 #[derive(Copy, Clone)]
 pub struct Foo {
     pub large: [::std::os::raw::c_int; 33usize],
-    pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 2usize]>,
     pub __bindgen_padding_0: u16,
 }

--- a/bindgen-tests/tests/expectations/tests/derive-debug-bitfield-1-51.rs
+++ b/bindgen-tests/tests/expectations/tests/derive-debug-bitfield-1-51.rs
@@ -148,7 +148,6 @@ where
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct C {
-    pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
     pub large_array: [::std::os::raw::c_int; 50usize],
 }

--- a/bindgen-tests/tests/expectations/tests/derive-debug-bitfield-core.rs
+++ b/bindgen-tests/tests/expectations/tests/derive-debug-bitfield-core.rs
@@ -91,7 +91,6 @@ where
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct C {
-    pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
     pub large_array: [::std::os::raw::c_int; 50usize],
 }

--- a/bindgen-tests/tests/expectations/tests/derive-debug-bitfield.rs
+++ b/bindgen-tests/tests/expectations/tests/derive-debug-bitfield.rs
@@ -90,7 +90,6 @@ where
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct C {
-    pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
     pub large_array: [::std::os::raw::c_int; 50usize],
 }

--- a/bindgen-tests/tests/expectations/tests/derive-partialeq-bitfield.rs
+++ b/bindgen-tests/tests/expectations/tests/derive-partialeq-bitfield.rs
@@ -90,7 +90,6 @@ where
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct C {
-    pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
     pub large_array: [::std::os::raw::c_int; 50usize],
 }

--- a/bindgen-tests/tests/expectations/tests/divide-by-zero-in-struct-layout.rs
+++ b/bindgen-tests/tests/expectations/tests/divide-by-zero-in-struct-layout.rs
@@ -148,7 +148,6 @@ where
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct WithBitfield {
-    pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
     pub a: ::std::os::raw::c_uint,
 }
@@ -162,7 +161,6 @@ impl WithBitfield {
 #[repr(C, packed)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct WithBitfieldAndAttrPacked {
-    pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
     pub a: ::std::os::raw::c_uint,
 }
@@ -176,7 +174,6 @@ impl WithBitfieldAndAttrPacked {
 #[repr(C, packed)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct WithBitfieldAndPacked {
-    pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
     pub a: ::std::os::raw::c_uint,
 }

--- a/bindgen-tests/tests/expectations/tests/field-visibility-callback.rs
+++ b/bindgen-tests/tests/expectations/tests/field-visibility-callback.rs
@@ -150,7 +150,6 @@ where
 pub struct my_struct {
     pub a: ::std::os::raw::c_int,
     private_b: ::std::os::raw::c_int,
-    _bitfield_align_1: [u8; 0],
     _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
     __bindgen_padding_0: [u8; 3usize],
 }

--- a/bindgen-tests/tests/expectations/tests/field-visibility.rs
+++ b/bindgen-tests/tests/expectations/tests/field-visibility.rs
@@ -146,10 +146,9 @@ where
     }
 }
 #[repr(C)]
-#[repr(align(4))]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct my_struct1 {
-    _bitfield_align_1: [u8; 0],
+    pub _bindgen_align: [u32; 0],
     _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
     __bindgen_padding_0: [u8; 3usize],
 }
@@ -211,10 +210,9 @@ impl my_struct1 {
     }
 }
 #[repr(C)]
-#[repr(align(4))]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct my_struct2 {
-    pub _bitfield_align_1: [u8; 0],
+    pub _bindgen_align: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
     pub __bindgen_padding_0: [u8; 3usize],
 }

--- a/bindgen-tests/tests/expectations/tests/incomplete-array-padding.rs
+++ b/bindgen-tests/tests/expectations/tests/incomplete-array-padding.rs
@@ -178,7 +178,6 @@ impl<T> ::std::fmt::Debug for __IncompleteArrayField<T> {
 #[repr(C)]
 #[derive(Debug)]
 pub struct foo {
-    pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
     pub b: __IncompleteArrayField<*mut ::std::os::raw::c_void>,
 }

--- a/bindgen-tests/tests/expectations/tests/issue-1034.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-1034.rs
@@ -148,7 +148,6 @@ where
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct S2 {
-    pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 2usize]>,
 }
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]

--- a/bindgen-tests/tests/expectations/tests/issue-1076-unnamed-bitfield-alignment.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-1076-unnamed-bitfield-alignment.rs
@@ -148,7 +148,6 @@ where
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct S1 {
-    pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 3usize]>,
 }
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]

--- a/bindgen-tests/tests/expectations/tests/issue-1947.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-1947.rs
@@ -150,11 +150,10 @@ pub type U16 = ::std::os::raw::c_ushort;
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct V56AMDY {
-    pub _bitfield_align_1: [u16; 0],
+    pub _bindgen_align: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 2usize]>,
     pub MADK: U8,
     pub MABR: U8,
-    pub _bitfield_align_2: [u16; 0],
     pub _bitfield_2: __BindgenBitfieldUnit<[u8; 3usize]>,
     pub _rB_: U8,
 }

--- a/bindgen-tests/tests/expectations/tests/issue-739-pointer-wide-bitfield.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-739-pointer-wide-bitfield.rs
@@ -149,7 +149,7 @@ where
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct Foo {
-    pub _bitfield_align_1: [u64; 0],
+    pub _bindgen_align: [u64; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 32usize]>,
 }
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]

--- a/bindgen-tests/tests/expectations/tests/issue-743.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-743.rs
@@ -146,96 +146,80 @@ where
     }
 }
 #[repr(C)]
-#[derive(Debug, Default, Copy, Clone)]
-pub struct Foo {
-    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
+#[derive(Debug, Copy, Clone)]
+pub struct S {
+    pub p: *mut ::std::os::raw::c_void,
+    pub b: bool,
+    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 2usize]>,
+    pub __bindgen_padding_0: [u8; 5usize],
 }
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
-    ["Size of Foo"][::std::mem::size_of::<Foo>() - 1usize];
-    ["Alignment of Foo"][::std::mem::align_of::<Foo>() - 1usize];
+    ["Size of S"][::std::mem::size_of::<S>() - 16usize];
+    ["Alignment of S"][::std::mem::align_of::<S>() - 8usize];
+    ["Offset of field: S::p"][::std::mem::offset_of!(S, p) - 0usize];
+    ["Offset of field: S::b"][::std::mem::offset_of!(S, b) - 8usize];
 };
-unsafe extern "C" {
-    #[link_name = "\u{1}_ZN3Foo4typeEv"]
-    pub fn Foo_type(this: *mut Foo) -> ::std::os::raw::c_char;
+impl Default for S {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
 }
-unsafe extern "C" {
-    #[link_name = "\u{1}_ZN3Foo9set_type_Ec"]
-    pub fn Foo_set_type_(this: *mut Foo, c: ::std::os::raw::c_char);
-}
-unsafe extern "C" {
-    #[link_name = "\u{1}_ZN3Foo8set_typeEc"]
-    pub fn Foo_set_type(this: *mut Foo, c: ::std::os::raw::c_char);
-}
-impl Foo {
+impl S {
     #[inline]
-    pub fn type__bindgen_bitfield(&self) -> ::std::os::raw::c_char {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(0usize, 3u8) as u8) }
+    pub fn u(&self) -> ::std::os::raw::c_uint {
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(0usize, 16u8) as u32) }
     }
     #[inline]
-    pub fn set_type__bindgen_bitfield(&mut self, val: ::std::os::raw::c_char) {
+    pub fn set_u(&mut self, val: ::std::os::raw::c_uint) {
         unsafe {
-            let val: u8 = ::std::mem::transmute(val);
-            self._bitfield_1.set(0usize, 3u8, val as u64)
+            let val: u32 = ::std::mem::transmute(val);
+            self._bitfield_1.set(0usize, 16u8, val as u64)
         }
     }
     #[inline]
-    pub unsafe fn type__bindgen_bitfield_raw(
-        this: *const Self,
-    ) -> ::std::os::raw::c_char {
+    pub unsafe fn u_raw(this: *const Self) -> ::std::os::raw::c_uint {
         unsafe {
             ::std::mem::transmute(
                 <__BindgenBitfieldUnit<
-                    [u8; 1usize],
-                >>::raw_get(::std::ptr::addr_of!((*this)._bitfield_1), 0usize, 3u8) as u8,
+                    [u8; 2usize],
+                >>::raw_get(::std::ptr::addr_of!((*this)._bitfield_1), 0usize, 16u8)
+                    as u32,
             )
         }
     }
     #[inline]
-    pub unsafe fn set_type__bindgen_bitfield_raw(
-        this: *mut Self,
-        val: ::std::os::raw::c_char,
-    ) {
+    pub unsafe fn set_u_raw(this: *mut Self, val: ::std::os::raw::c_uint) {
         unsafe {
-            let val: u8 = ::std::mem::transmute(val);
+            let val: u32 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
-                [u8; 1usize],
+                [u8; 2usize],
             >>::raw_set(
                 ::std::ptr::addr_of_mut!((*this)._bitfield_1),
                 0usize,
-                3u8,
+                16u8,
                 val as u64,
             )
         }
     }
     #[inline]
     pub fn new_bitfield_1(
-        type__bindgen_bitfield: ::std::os::raw::c_char,
-    ) -> __BindgenBitfieldUnit<[u8; 1usize]> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 1usize]> = Default::default();
+        u: ::std::os::raw::c_uint,
+    ) -> __BindgenBitfieldUnit<[u8; 2usize]> {
+        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 2usize]> = Default::default();
         __bindgen_bitfield_unit
             .set(
                 0usize,
-                3u8,
+                16u8,
                 {
-                    let type__bindgen_bitfield: u8 = unsafe {
-                        ::std::mem::transmute(type__bindgen_bitfield)
-                    };
-                    type__bindgen_bitfield as u64
+                    let u: u32 = unsafe { ::std::mem::transmute(u) };
+                    u as u64
                 },
             );
         __bindgen_bitfield_unit
-    }
-    #[inline]
-    pub unsafe fn type_(&mut self) -> ::std::os::raw::c_char {
-        Foo_type(self)
-    }
-    #[inline]
-    pub unsafe fn set_type_(&mut self, c: ::std::os::raw::c_char) {
-        Foo_set_type_(self, c)
-    }
-    #[inline]
-    pub unsafe fn set_type(&mut self, c: ::std::os::raw::c_char) {
-        Foo_set_type(self, c)
     }
 }

--- a/bindgen-tests/tests/expectations/tests/issue-816.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-816.rs
@@ -146,10 +146,9 @@ where
     }
 }
 #[repr(C)]
-#[repr(align(4))]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct capabilities {
-    pub _bitfield_align_1: [u8; 0],
+    pub _bindgen_align: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 16usize]>,
 }
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]

--- a/bindgen-tests/tests/expectations/tests/jsval_layout_opaque.rs
+++ b/bindgen-tests/tests/expectations/tests/jsval_layout_opaque.rs
@@ -245,7 +245,7 @@ pub union jsval_layout {
 #[repr(C)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct jsval_layout__bindgen_ty_1 {
-    pub _bitfield_align_1: [u64; 0],
+    pub _bindgen_align: [u64; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 8usize]>,
 }
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]

--- a/bindgen-tests/tests/expectations/tests/layout_align.rs
+++ b/bindgen-tests/tests/expectations/tests/layout_align.rs
@@ -219,12 +219,11 @@ impl Default for rte_kni_fifo {
     }
 }
 #[repr(C)]
-#[repr(align(8))]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct rte_eth_link {
+    pub _bindgen_align: [u64; 0],
     ///< ETH_SPEED_NUM_
     pub link_speed: u32,
-    pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
     pub __bindgen_padding_0: [u8; 3usize],
 }

--- a/bindgen-tests/tests/expectations/tests/layout_eth_conf.rs
+++ b/bindgen-tests/tests/expectations/tests/layout_eth_conf.rs
@@ -151,7 +151,6 @@ pub struct rte_eth_rxmode {
     pub max_rx_pkt_len: u32,
     ///< hdr buf size (header_split enabled).
     pub split_hdr_size: u16,
-    pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 2usize]>,
 }
 #[test]
@@ -425,7 +424,6 @@ pub struct rte_eth_txmode {
     ///< TX multi-queues mode.
     pub mq_mode: rte_eth_tx_mq_mode,
     pub pvid: u16,
-    pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
     pub __bindgen_padding_0: u8,
 }

--- a/bindgen-tests/tests/expectations/tests/layout_mbuf.rs
+++ b/bindgen-tests/tests/expectations/tests/layout_mbuf.rs
@@ -259,10 +259,9 @@ pub union rte_mbuf__bindgen_ty_2 {
     pub __bindgen_anon_1: rte_mbuf__bindgen_ty_2__bindgen_ty_1,
 }
 #[repr(C)]
-#[repr(align(4))]
 #[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct rte_mbuf__bindgen_ty_2__bindgen_ty_1 {
-    pub _bitfield_align_1: [u8; 0],
+    pub _bindgen_align: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
 }
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
@@ -820,11 +819,11 @@ pub union rte_mbuf__bindgen_ty_5 {
     pub __bindgen_anon_1: rte_mbuf__bindgen_ty_5__bindgen_ty_1,
 }
 #[repr(C)]
-#[repr(align(8))]
 #[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct rte_mbuf__bindgen_ty_5__bindgen_ty_1 {
-    pub _bitfield_align_1: [u16; 0],
+    pub _bindgen_align: [u64; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 7usize]>,
+    pub __bindgen_padding_0: u8,
 }
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {

--- a/bindgen-tests/tests/expectations/tests/only_bitfields.rs
+++ b/bindgen-tests/tests/expectations/tests/only_bitfields.rs
@@ -148,7 +148,6 @@ where
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct C {
-    pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
 }
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]

--- a/bindgen-tests/tests/expectations/tests/packed-bitfield.rs
+++ b/bindgen-tests/tests/expectations/tests/packed-bitfield.rs
@@ -148,7 +148,6 @@ where
 #[repr(C, packed)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct Date {
-    pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 3usize]>,
 }
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]

--- a/bindgen-tests/tests/expectations/tests/private_fields.rs
+++ b/bindgen-tests/tests/expectations/tests/private_fields.rs
@@ -159,10 +159,9 @@ const _: () = {
     ["Offset of field: PubPriv::y"][::std::mem::offset_of!(PubPriv, y) - 4usize];
 };
 #[repr(C)]
-#[repr(align(4))]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct PrivateBitFields {
-    pub _bitfield_align_1: [u8; 0],
+    pub _bindgen_align: [u32; 0],
     _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
     pub __bindgen_padding_0: [u8; 3usize],
 }
@@ -274,10 +273,9 @@ impl PrivateBitFields {
     }
 }
 #[repr(C)]
-#[repr(align(4))]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct PublicBitFields {
-    pub _bitfield_align_1: [u8; 0],
+    pub _bindgen_align: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
     pub __bindgen_padding_0: [u8; 3usize],
 }
@@ -387,10 +385,9 @@ impl PublicBitFields {
     }
 }
 #[repr(C)]
-#[repr(align(4))]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct MixedBitFields {
-    pub _bitfield_align_1: [u8; 0],
+    pub _bindgen_align: [u32; 0],
     _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
     pub __bindgen_padding_0: [u8; 3usize],
 }
@@ -628,7 +625,6 @@ pub struct Override {
     /// <div rustbindgen private></div>
     b: ::std::os::raw::c_uint,
     private_c: ::std::os::raw::c_uint,
-    pub _bitfield_align_1: [u8; 0],
     _bitfield_1: __BindgenBitfieldUnit<[u8; 2usize]>,
     pub __bindgen_padding_0: u16,
 }

--- a/bindgen-tests/tests/expectations/tests/struct_with_bitfields.rs
+++ b/bindgen-tests/tests/expectations/tests/struct_with_bitfields.rs
@@ -148,10 +148,8 @@ where
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct bitfield {
-    pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
     pub e: ::std::os::raw::c_int,
-    pub _bitfield_align_2: [u32; 0],
     pub _bitfield_2: __BindgenBitfieldUnit<[u8; 8usize]>,
 }
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]

--- a/bindgen-tests/tests/expectations/tests/timex.rs
+++ b/bindgen-tests/tests/expectations/tests/timex.rs
@@ -149,7 +149,6 @@ where
 #[derive(Debug, Copy, Clone)]
 pub struct timex {
     pub tai: ::std::os::raw::c_int,
-    pub _bitfield_align_1: [u8; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 44usize]>,
 }
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
@@ -171,7 +170,6 @@ impl Default for timex {
 #[derive(Debug, Copy, Clone)]
 pub struct timex_named {
     pub tai: ::std::os::raw::c_int,
-    pub _bitfield_align_1: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 44usize]>,
 }
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]

--- a/bindgen-tests/tests/expectations/tests/union_bitfield.rs
+++ b/bindgen-tests/tests/expectations/tests/union_bitfield.rs
@@ -146,10 +146,9 @@ where
     }
 }
 #[repr(C)]
-#[repr(align(4))]
 #[derive(Copy, Clone)]
 pub union U4 {
-    pub _bitfield_align_1: [u8; 0],
+    pub _bindgen_align: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
 }
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
@@ -223,8 +222,8 @@ impl U4 {
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union B {
-    pub _bitfield_align_1: [u32; 0],
-    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
+    pub _bindgen_align: [u32; 0],
+    pub _bitfield_1: __BindgenBitfieldUnit<[u8; 1usize]>,
 }
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
@@ -257,7 +256,7 @@ impl B {
         unsafe {
             ::std::mem::transmute(
                 <__BindgenBitfieldUnit<
-                    [u8; 4usize],
+                    [u8; 1usize],
                 >>::raw_get(::std::ptr::addr_of!((*this)._bitfield_1), 0usize, 31u8)
                     as u32,
             )
@@ -268,7 +267,7 @@ impl B {
         unsafe {
             let val: u32 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
-                [u8; 4usize],
+                [u8; 1usize],
             >>::raw_set(
                 ::std::ptr::addr_of_mut!((*this)._bitfield_1),
                 0usize,
@@ -279,13 +278,13 @@ impl B {
     }
     #[inline]
     pub fn bar(&self) -> ::std::os::raw::c_uchar {
-        unsafe { ::std::mem::transmute(self._bitfield_1.get(31usize, 1u8) as u8) }
+        unsafe { ::std::mem::transmute(self._bitfield_1.get(0usize, 1u8) as u8) }
     }
     #[inline]
     pub fn set_bar(&mut self, val: ::std::os::raw::c_uchar) {
         unsafe {
             let val: u8 = ::std::mem::transmute(val);
-            self._bitfield_1.set(31usize, 1u8, val as u64)
+            self._bitfield_1.set(0usize, 1u8, val as u64)
         }
     }
     #[inline]
@@ -293,9 +292,8 @@ impl B {
         unsafe {
             ::std::mem::transmute(
                 <__BindgenBitfieldUnit<
-                    [u8; 4usize],
-                >>::raw_get(::std::ptr::addr_of!((*this)._bitfield_1), 31usize, 1u8)
-                    as u8,
+                    [u8; 1usize],
+                >>::raw_get(::std::ptr::addr_of!((*this)._bitfield_1), 0usize, 1u8) as u8,
             )
         }
     }
@@ -304,10 +302,10 @@ impl B {
         unsafe {
             let val: u8 = ::std::mem::transmute(val);
             <__BindgenBitfieldUnit<
-                [u8; 4usize],
+                [u8; 1usize],
             >>::raw_set(
                 ::std::ptr::addr_of_mut!((*this)._bitfield_1),
-                31usize,
+                0usize,
                 1u8,
                 val as u64,
             )
@@ -317,8 +315,8 @@ impl B {
     pub fn new_bitfield_1(
         foo: ::std::os::raw::c_uint,
         bar: ::std::os::raw::c_uchar,
-    ) -> __BindgenBitfieldUnit<[u8; 4usize]> {
-        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 4usize]> = Default::default();
+    ) -> __BindgenBitfieldUnit<[u8; 1usize]> {
+        let mut __bindgen_bitfield_unit: __BindgenBitfieldUnit<[u8; 1usize]> = Default::default();
         __bindgen_bitfield_unit
             .set(
                 0usize,
@@ -330,7 +328,7 @@ impl B {
             );
         __bindgen_bitfield_unit
             .set(
-                31usize,
+                0usize,
                 1u8,
                 {
                     let bar: u8 = unsafe { ::std::mem::transmute(bar) };

--- a/bindgen-tests/tests/expectations/tests/union_with_anon_struct_bitfield.rs
+++ b/bindgen-tests/tests/expectations/tests/union_with_anon_struct_bitfield.rs
@@ -154,7 +154,7 @@ pub union foo {
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct foo__bindgen_ty_1 {
-    pub _bitfield_align_1: [u32; 0],
+    pub _bindgen_align: [u32; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
 }
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]

--- a/bindgen-tests/tests/expectations/tests/weird_bitfields.rs
+++ b/bindgen-tests/tests/expectations/tests/weird_bitfields.rs
@@ -156,7 +156,6 @@ pub enum nsStyleSVGOpacitySource {
 #[derive(Debug, Copy, Clone)]
 pub struct Weird {
     pub mStrokeDasharrayLength: ::std::os::raw::c_uint,
-    pub _bitfield_align_1: [u16; 0],
     pub _bitfield_1: __BindgenBitfieldUnit<[u8; 4usize]>,
     pub mClipRule: ::std::os::raw::c_uchar,
     pub mColorInterpolation: ::std::os::raw::c_uchar,
@@ -169,7 +168,6 @@ pub struct Weird {
     pub mStrokeLinejoin: ::std::os::raw::c_uchar,
     pub mTextAnchor: ::std::os::raw::c_uchar,
     pub mTextRendering: ::std::os::raw::c_uchar,
-    pub _bitfield_align_2: [u8; 0],
     pub _bitfield_2: __BindgenBitfieldUnit<[u8; 2usize]>,
     pub __bindgen_padding_0: [u8; 3usize],
 }

--- a/bindgen-tests/tests/headers/bitfield-linux-32.hpp
+++ b/bindgen-tests/tests/headers/bitfield-linux-32.hpp
@@ -1,4 +1,4 @@
-// bindgen-flags: -- --target=i586-unknown-linux
+// bindgen-flags: --no-layout-tests -- --target=i586-unknown-linux
 
 typedef unsigned long long uint64_t;
 

--- a/bindgen-tests/tests/headers/bitfield-template.hpp
+++ b/bindgen-tests/tests/headers/bitfield-template.hpp
@@ -1,0 +1,4 @@
+template <typename T> struct foo {
+  T member;
+  bool b : 8;
+};

--- a/bindgen-tests/tests/headers/bitfield_pack_offset.h
+++ b/bindgen-tests/tests/headers/bitfield_pack_offset.h
@@ -1,0 +1,21 @@
+struct A {
+	const unsigned char        name[7];              /*     0     7 */
+	unsigned char              firmness:4;           /*     7: 0  1 */
+	unsigned char              color:4;              /*     7: 4  1 */
+	unsigned short             weedsBonus:3;         /*     8: 0  2 */
+	unsigned short             pestsBonus:3;         /*     8: 3  2 */
+	unsigned short             size:10;              /*     8: 6  2 */
+	unsigned char              maxYield;             /*    10     1 */
+	unsigned char              minYield:4;           /*    11: 0  1 */
+	unsigned char              waterBonus:4;         /*    11: 4  1 */
+
+	/* XXX 4 bytes hole, try to pack */
+
+	const unsigned char  *     description1;         /*    16     8 */
+
+	/* size: 24, cachelines: 1, members: 10 */
+	/* sum members: 16, holes: 1, sum holes: 4 */
+	/* sum bitfield members: 32 bits (4 bytes) */
+	/* last cacheline: 24 bytes */
+};
+

--- a/bindgen-tests/tests/headers/issue-743.h
+++ b/bindgen-tests/tests/headers/issue-743.h
@@ -1,0 +1,6 @@
+
+struct S {
+    void *p;
+    _Bool b;
+    unsigned u : 16;
+};

--- a/bindgen-tests/tests/headers/union_bitfield.h
+++ b/bindgen-tests/tests/headers/union_bitfield.h
@@ -1,10 +1,10 @@
 // bindgen-flags: --with-derive-hash --with-derive-partialeq --with-derive-eq --impl-partialeq
 
 union U4 {
-    unsigned derp : 1;
+	unsigned int               derp:1;             /*     0: 0  4 */
 };
 
 union B {
-    unsigned foo : 31;
-    unsigned char bar : 1;
+	unsigned int               foo:31;             /*     0: 0  4 */
+	unsigned char              bar:1;              /*     0: 0  1 */
 };

--- a/bindgen/codegen/struct_layout.rs
+++ b/bindgen/codegen/struct_layout.rs
@@ -45,23 +45,6 @@ pub(crate) fn align_to(size: usize, align: usize) -> usize {
     size + align - rem
 }
 
-/// Returns the lower power of two byte count that can hold at most n bits.
-pub(crate) fn bytes_from_bits_pow2(mut n: usize) -> usize {
-    if n == 0 {
-        return 0;
-    }
-
-    if n <= 8 {
-        return 1;
-    }
-
-    if !n.is_power_of_two() {
-        n = n.next_power_of_two();
-    }
-
-    n / 8
-}
-
 #[test]
 fn test_align_to() {
     assert_eq!(align_to(1, 1), 1);
@@ -69,20 +52,6 @@ fn test_align_to() {
     assert_eq!(align_to(1, 4), 4);
     assert_eq!(align_to(5, 1), 5);
     assert_eq!(align_to(17, 4), 20);
-}
-
-#[test]
-fn test_bytes_from_bits_pow2() {
-    assert_eq!(bytes_from_bits_pow2(0), 0);
-    for i in 1..9 {
-        assert_eq!(bytes_from_bits_pow2(i), 1);
-    }
-    for i in 9..17 {
-        assert_eq!(bytes_from_bits_pow2(i), 2);
-    }
-    for i in 17..33 {
-        assert_eq!(bytes_from_bits_pow2(i), 4);
-    }
 }
 
 impl<'a> StructLayoutTracker<'a> {


### PR DESCRIPTION
In order to properly compute the size of the bitfield for overaligned fields, we need to know the offset in the struct, not just in the allocation unit.

E.g., something like:

  char; // Byte 1
  char: 8; // Byte 2
  short: 16; // Bytes 3 and 4

Should align differently than:

  char: 8; // Byte 1
  short: 16; // Bytes 3 and 4

If we can't find the start offset in the struct, we fall back to our previous behavior (this can happen with C++ templates for example).

We remove some code related to `is_ms_struct`, which was effectively dead. If someone cares about it they can resurrect it.

We also don't align per-bitfield unit, but in order to mostly preserve behavior, we keep inserting a field at the beginning of the struct rather than using repr(align). Otherwise we hit #2179 in cases where we did not use to.

We might want to extend that approach to repr(align) stuff, in order to try to fix #2179 more often, but for now do the minimal change.

Fixes #1377
Fixes #3105
Fixes #743
Fixes #981
Fixes #1314