### PR TITLE
Allow itertools 0.14, bump Cargo.lock to it

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -339,9 +339,9 @@ checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itertools"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ clang-sys = "1"
 clap = "4"
 clap_complete = "4"
 env_logger = "0.10.0"
-itertools = { version = ">=0.10,<0.14", default-features = false }
+itertools = { version = ">=0.10,<0.15", default-features = false }
 libloading = "0.8"
 log = "0.4"
 objc = "0.2"


### PR DESCRIPTION
Closes #3092