### PR TITLE
enum: add support hash name for unnamed enum

### DIFF
--- a/bindgen/ir/enum_ty.rs
+++ b/bindgen/ir/enum_ty.rs
@@ -235,6 +235,19 @@ impl Enum {
             ctx.options().default_enum_style
         }
     }
+    /// generate hash from enum variants
+    pub(crate) fn variants_name_hash(&self) -> u64 {
+        use std::collections::hash_map::DefaultHasher;
+        use std::hash::{Hash, Hasher};
+
+        let mut hasher = DefaultHasher::new();
+
+        for variant in self.variants() {
+            variant.name().hash(&mut hasher);
+        }
+
+        hasher.finish()
+    }
 }
 
 /// A single enum variant, to be contained only in an enum.

--- a/bindgen/ir/ty.rs
+++ b/bindgen/ir/ty.rs
@@ -271,7 +271,25 @@ impl Type {
                 .sanitized_name(ctx)
                 .map(|name| format!("{prefix}_{name}").into())
         } else {
-            self.name().map(Self::sanitize_name)
+            match self.name() {
+                Some(name) => Some(Self::sanitize_name(name)),
+                None => match self.kind() {
+                    TypeKind::Enum(inner) => {
+                        if ctx.options().hash_unnamed_enum {
+                            Some(
+                                format!(
+                                    "bindgen_enum_{:x}",
+                                    inner.variants_name_hash()
+                                )
+                                .into(),
+                            )
+                        } else {
+                            None
+                        }
+                    }
+                    _ => None,
+                },
+            }
         }
     }
 

--- a/bindgen/options/cli.rs
+++ b/bindgen/options/cli.rs
@@ -321,6 +321,8 @@ struct BindgenCommand {
     /// Do not prepend the enum name to constant or newtype variants.
     #[arg(long)]
     no_prepend_enum_name: bool,
+    #[arg(long)]
+    hash_unnamed_enum: bool,
     /// Do not try to detect default include paths
     #[arg(long)]
     no_include_path_detection: bool,
@@ -611,6 +613,7 @@ where
         ignore_methods,
         no_convert_floats,
         no_prepend_enum_name,
+        hash_unnamed_enum,
         no_include_path_detection,
         fit_macro_constant_types,
         opaque_type,
@@ -898,6 +901,7 @@ where
             with_derive_ord => Builder::derive_ord,
             no_derive_default => |b, _| b.derive_default(false),
             no_prepend_enum_name => |b, _| b.prepend_enum_name(false),
+            hash_unnamed_enum => |b,_|b.hash_unnamed_enum(),
             no_include_path_detection => |b, _| b.detect_include_paths(false),
             fit_macro_constant_types => Builder::fit_macro_constants,
             time_phases,

--- a/bindgen/options/mod.rs
+++ b/bindgen/options/mod.rs
@@ -2283,4 +2283,17 @@ options! {
         },
         as_args: "--generate-private-functions",
     },
+    /// use hash name for unnamed enum
+    hash_unnamed_enum: bool {
+        default: false,
+        methods: {
+            /// Generate a hash-based name for unnamed enums,
+            /// using the hash of their variant names.
+            pub fn hash_unnamed_enum(mut self) -> Self {
+                self.options.hash_unnamed_enum = true;
+                self
+            }
+        },
+        as_args: "--hash-unnamed-enum",
+    }
 }


### PR DESCRIPTION

Occasionally, conflicts between header files necessitate running Bindgen separately on each and then merging the resulting bindings. Present bindgen_ty_{number} identifiers generated for unnamed enums cause naming conflicts.

This PR introduces support for hash-based naming for unnamed enums.

