### PR TITLE
Configure an assign section in triagebot.toml to allow rustbot to assign PRs

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -26,3 +26,5 @@ trigger_files = [
     "**/*.cc",
     "**/*.hpp",
 ]
+
+[assign]


### PR DESCRIPTION
As per the [related Zulip thread](https://rust-lang.zulipchat.com/#narrow/channel/469104-wg-bindgen/topic/GH.20rustbot.20configuration.20in.20rust-bindgen/with/533464084).