### PR TITLE
Get the type's definition in CompInfo::from_ty

### DIFF
--- a/bindgen/ir/comp.rs
+++ b/bindgen/ir/comp.rs
@@ -1234,6 +1234,12 @@ impl CompInfo {
         );
 
         let mut cursor = ty.declaration();
+
+        // If there is a definition, that's what we want.
+        if let Some(def) = cursor.definition() {
+            cursor = def
+        }
+
         let mut kind = Self::kind_from_cursor(&cursor);
         if kind.is_err() {
             if let Some(location) = location {


### PR DESCRIPTION
In https://github.com/llvm/llvm-project/pull/147835, Clang's AST changed so that a TagType's decl will not necessarily refer to the type's definition, but to the exact declaration which produced the type.

For example, in

  typedef struct S T;
  struct S {
    int x;
  };

the 'struct S' type would refer to the incomplete type decl in the typedef, causing CompInfo to fail to see the type's definition.

This patch inserts a call to use the definition when available. It fixes the original test case in
https://github.com/rust-lang/rust-bindgen/issues/3275 and most of the test failures caused by the Clang change but not all.