### PR TITLE
codegen: Guarantee opaque type layout across all architectures

### DIFF
--- a/bindgen-tests/tests/expectations/tests/bitfield_large_overflow.rs
+++ b/bindgen-tests/tests/expectations/tests/bitfield_large_overflow.rs
@@ -1,9 +1,17 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
+#[derive(PartialEq, Eq, Copy, Clone, Debug, Hash)]
+#[repr(C, align(8))]
+pub struct __BindgenOpaqueArray8<T>(pub T);
+impl<T: Copy + Default, const N: usize> Default for __BindgenOpaqueArray8<[T; N]> {
+    fn default() -> Self {
+        Self([<T as Default>::default(); N])
+    }
+}
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct _bindgen_ty_1 {
     pub _bindgen_align: [u64; 0],
-    pub _bindgen_opaque_blob: [u64; 10usize],
+    pub _bindgen_opaque_blob: __BindgenOpaqueArray8<[u8; 80usize]>,
 }
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {

--- a/bindgen-tests/tests/expectations/tests/derive-debug-opaque-template-instantiation.rs
+++ b/bindgen-tests/tests/expectations/tests/derive-debug-opaque-template-instantiation.rs
@@ -1,17 +1,16 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
-/// If Bindgen could only determine the size and alignment of a
-/// type, it is represented like this.
-#[derive(PartialEq, Copy, Clone, Debug, Hash)]
+#[derive(PartialEq, Eq, Copy, Clone, Debug, Hash)]
 #[repr(C)]
-pub struct __BindgenOpaqueArray<T: Copy, const N: usize>(pub [T; N]);
-impl<T: Copy + Default, const N: usize> Default for __BindgenOpaqueArray<T, N> {
+pub struct __BindgenOpaqueArray<T>(pub T);
+impl<T: Copy + Default, const N: usize> Default for __BindgenOpaqueArray<[T; N]> {
     fn default() -> Self {
         Self([<T as Default>::default(); N])
     }
 }
 #[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
 pub struct Instance {
-    pub val: __BindgenOpaqueArray<u32, 50usize>,
+    pub val: __BindgenOpaqueArray<[u32; 50usize]>,
 }
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
@@ -19,17 +18,3 @@ const _: () = {
     ["Alignment of Instance"][::std::mem::align_of::<Instance>() - 4usize];
     ["Offset of field: Instance::val"][::std::mem::offset_of!(Instance, val) - 0usize];
 };
-impl Default for Instance {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-impl ::std::fmt::Debug for Instance {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "Instance {{ val: opaque }}")
-    }
-}

--- a/bindgen-tests/tests/expectations/tests/derive-debug-opaque.rs
+++ b/bindgen-tests/tests/expectations/tests/derive-debug-opaque.rs
@@ -1,29 +1,25 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
+#[derive(PartialEq, Eq, Copy, Clone, Debug, Hash)]
+#[repr(C)]
+pub struct __BindgenOpaqueArray<T>(pub T);
+impl<T: Copy + Default, const N: usize> Default for __BindgenOpaqueArray<[T; N]> {
+    fn default() -> Self {
+        Self([<T as Default>::default(); N])
+    }
+}
 #[repr(C)]
 #[repr(align(4))]
+#[derive(Debug, Default, Copy, Clone)]
 pub struct Opaque {
-    pub _bindgen_opaque_blob: [u32; 41usize],
+    pub _bindgen_opaque_blob: __BindgenOpaqueArray<[u32; 41usize]>,
 }
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {
     ["Size of Opaque"][::std::mem::size_of::<Opaque>() - 164usize];
     ["Alignment of Opaque"][::std::mem::align_of::<Opaque>() - 4usize];
 };
-impl Default for Opaque {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-impl ::std::fmt::Debug for Opaque {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "Opaque {{ opaque }}")
-    }
-}
 #[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
 pub struct OpaqueUser {
     pub opaque: Opaque,
 }
@@ -35,17 +31,3 @@ const _: () = {
         "Offset of field: OpaqueUser::opaque",
     ][::std::mem::offset_of!(OpaqueUser, opaque) - 0usize];
 };
-impl Default for OpaqueUser {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-impl ::std::fmt::Debug for OpaqueUser {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-        write!(f, "OpaqueUser {{ opaque: {:?} }}", self.opaque)
-    }
-}

--- a/bindgen-tests/tests/expectations/tests/issue-3027.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-3027.rs
@@ -1,12 +1,10 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[allow(non_snake_case, non_camel_case_types, non_upper_case_globals)]
 pub mod root {
-    /// If Bindgen could only determine the size and alignment of a
-    /// type, it is represented like this.
-    #[derive(PartialEq, Copy, Clone, Debug, Hash)]
+    #[derive(PartialEq, Eq, Copy, Clone, Debug, Hash)]
     #[repr(C)]
-    pub struct __BindgenOpaqueArray<T: Copy, const N: usize>(pub [T; N]);
-    impl<T: Copy + Default, const N: usize> Default for __BindgenOpaqueArray<T, N> {
+    pub struct __BindgenOpaqueArray<T>(pub T);
+    impl<T: Copy + Default, const N: usize> Default for __BindgenOpaqueArray<[T; N]> {
         fn default() -> Self {
             Self([<T as Default>::default(); N])
         }
@@ -19,7 +17,7 @@ pub mod root {
         #[repr(C)]
         #[derive(Debug, Default, Copy, Clone)]
         pub struct C {
-            pub a: root::__BindgenOpaqueArray<u8, 3usize>,
+            pub a: root::__BindgenOpaqueArray<[u8; 3usize]>,
         }
         #[allow(clippy::unnecessary_operation, clippy::identity_op)]
         const _: () = {

--- a/bindgen-tests/tests/expectations/tests/issue-372.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-372.rs
@@ -1,12 +1,10 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[allow(non_snake_case, non_camel_case_types, non_upper_case_globals)]
 pub mod root {
-    /// If Bindgen could only determine the size and alignment of a
-    /// type, it is represented like this.
-    #[derive(PartialEq, Copy, Clone, Debug, Hash)]
-    #[repr(C)]
-    pub struct __BindgenOpaqueArray<T: Copy, const N: usize>(pub [T; N]);
-    impl<T: Copy + Default, const N: usize> Default for __BindgenOpaqueArray<T, N> {
+    #[derive(PartialEq, Eq, Copy, Clone, Debug, Hash)]
+    #[repr(C, align(8))]
+    pub struct __BindgenOpaqueArray8<T>(pub T);
+    impl<T: Copy + Default, const N: usize> Default for __BindgenOpaqueArray8<[T; N]> {
         fn default() -> Self {
             Self([<T as Default>::default(); N])
         }
@@ -74,8 +72,9 @@ pub mod root {
         ai = 11,
     }
     #[repr(C)]
+    #[derive(Debug, Default, Copy, Clone)]
     pub struct F {
-        pub w: root::__BindgenOpaqueArray<u64, 33usize>,
+        pub w: root::__BindgenOpaqueArray8<[u8; 264usize]>,
     }
     #[allow(clippy::unnecessary_operation, clippy::identity_op)]
     const _: () = {
@@ -83,13 +82,4 @@ pub mod root {
         ["Alignment of F"][::std::mem::align_of::<F>() - 8usize];
         ["Offset of field: F::w"][::std::mem::offset_of!(F, w) - 0usize];
     };
-    impl Default for F {
-        fn default() -> Self {
-            let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-            unsafe {
-                ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-                s.assume_init()
-            }
-        }
-    }
 }

--- a/bindgen-tests/tests/expectations/tests/issue-544-stylo-creduce-2.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-544-stylo-creduce-2.rs
@@ -1,10 +1,8 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
-/// If Bindgen could only determine the size and alignment of a
-/// type, it is represented like this.
-#[derive(PartialEq, Copy, Clone, Debug, Hash)]
+#[derive(PartialEq, Eq, Copy, Clone, Debug, Hash)]
 #[repr(C)]
-pub struct __BindgenOpaqueArray<T: Copy, const N: usize>(pub [T; N]);
-impl<T: Copy + Default, const N: usize> Default for __BindgenOpaqueArray<T, N> {
+pub struct __BindgenOpaqueArray<T>(pub T);
+impl<T: Copy + Default, const N: usize> Default for __BindgenOpaqueArray<[T; N]> {
     fn default() -> Self {
         Self([<T as Default>::default(); N])
     }
@@ -14,7 +12,7 @@ impl<T: Copy + Default, const N: usize> Default for __BindgenOpaqueArray<T, N> {
 pub struct Foo {
     pub member: *mut Foo_SecondAlias,
 }
-pub type Foo_FirstAlias = __BindgenOpaqueArray<u8, 0usize>;
+pub type Foo_FirstAlias = __BindgenOpaqueArray<[u8; 0usize]>;
 pub type Foo_SecondAlias = Foo;
 impl Default for Foo {
     fn default() -> Self {

--- a/bindgen-tests/tests/expectations/tests/layout_array.rs
+++ b/bindgen-tests/tests/expectations/tests/layout_array.rs
@@ -1,4 +1,12 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
+#[derive(PartialEq, Eq, Copy, Clone, Debug, Hash)]
+#[repr(C, align(8))]
+pub struct __BindgenOpaqueArray8<T>(pub T);
+impl<T: Copy + Default, const N: usize> Default for __BindgenOpaqueArray8<[T; N]> {
+    fn default() -> Self {
+        Self([<T as Default>::default(); N])
+    }
+}
 pub const RTE_CACHE_LINE_SIZE: u32 = 64;
 pub const RTE_MEMPOOL_OPS_NAMESIZE: u32 = 32;
 pub const RTE_MEMPOOL_MAX_OPS_IDX: u32 = 16;
@@ -125,7 +133,7 @@ pub struct rte_mempool_ops_table {
     pub sl: rte_spinlock_t,
     ///< Number of used ops structs in the table.
     pub num_ops: u32,
-    pub __bindgen_padding_0: [u64; 7usize],
+    pub __bindgen_padding_0: __BindgenOpaqueArray8<[u8; 56usize]>,
     /// Storage for all possible ops structs.
     pub ops: [rte_mempool_ops; 16usize],
 }

--- a/bindgen-tests/tests/expectations/tests/layout_large_align_field.rs
+++ b/bindgen-tests/tests/expectations/tests/layout_large_align_field.rs
@@ -1,4 +1,12 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
+#[derive(PartialEq, Eq, Copy, Clone, Debug, Hash)]
+#[repr(C, align(8))]
+pub struct __BindgenOpaqueArray8<T>(pub T);
+impl<T: Copy + Default, const N: usize> Default for __BindgenOpaqueArray8<[T; N]> {
+    fn default() -> Self {
+        Self([<T as Default>::default(); N])
+    }
+}
 #[repr(C)]
 #[derive(Default)]
 pub struct __IncompleteArrayField<T>(::std::marker::PhantomData<T>, [T; 0]);
@@ -286,7 +294,7 @@ pub struct rte_ip_frag_tbl {
     pub last: *mut ip_frag_pkt,
     ///< LRU list for table entries.
     pub lru: ip_pkt_list,
-    pub __bindgen_padding_0: u64,
+    pub __bindgen_padding_0: __BindgenOpaqueArray8<[u8; 8usize]>,
     ///< statistics counters.
     pub stat: ip_frag_tbl_stat,
     ///< hash table.

--- a/bindgen-tests/tests/expectations/tests/libclang-9/issue-544-stylo-creduce-2.rs
+++ b/bindgen-tests/tests/expectations/tests/libclang-9/issue-544-stylo-creduce-2.rs
@@ -1,10 +1,8 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
-/// If Bindgen could only determine the size and alignment of a
-/// type, it is represented like this.
-#[derive(PartialEq, Copy, Clone, Debug, Hash)]
+#[derive(PartialEq, Eq, Copy, Clone, Debug, Hash)]
 #[repr(C)]
-pub struct __BindgenOpaqueArray<T: Copy, const N: usize>(pub [T; N]);
-impl<T: Copy + Default, const N: usize> Default for __BindgenOpaqueArray<T, N> {
+pub struct __BindgenOpaqueArray<T>(pub T);
+impl<T: Copy + Default, const N: usize> Default for __BindgenOpaqueArray<[T; N]> {
     fn default() -> Self {
         Self([<T as Default>::default(); N])
     }
@@ -12,10 +10,10 @@ impl<T: Copy + Default, const N: usize> Default for __BindgenOpaqueArray<T, N> {
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct Foo {
-    pub member: *mut __BindgenOpaqueArray<u8, 0usize>,
+    pub member: *mut __BindgenOpaqueArray<[u8; 0usize]>,
 }
-pub type Foo_FirstAlias = __BindgenOpaqueArray<u8, 0usize>;
-pub type Foo_SecondAlias = __BindgenOpaqueArray<u8, 0usize>;
+pub type Foo_FirstAlias = __BindgenOpaqueArray<[u8; 0usize]>;
+pub type Foo_SecondAlias = __BindgenOpaqueArray<[u8; 0usize]>;
 impl Default for Foo {
     fn default() -> Self {
         let mut s = ::std::mem::MaybeUninit::<Self>::uninit();

--- a/bindgen-tests/tests/expectations/tests/non-type-params.rs
+++ b/bindgen-tests/tests/expectations/tests/non-type-params.rs
@@ -1,21 +1,19 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
-/// If Bindgen could only determine the size and alignment of a
-/// type, it is represented like this.
-#[derive(PartialEq, Copy, Clone, Debug, Hash)]
+#[derive(PartialEq, Eq, Copy, Clone, Debug, Hash)]
 #[repr(C)]
-pub struct __BindgenOpaqueArray<T: Copy, const N: usize>(pub [T; N]);
-impl<T: Copy + Default, const N: usize> Default for __BindgenOpaqueArray<T, N> {
+pub struct __BindgenOpaqueArray<T>(pub T);
+impl<T: Copy + Default, const N: usize> Default for __BindgenOpaqueArray<[T; N]> {
     fn default() -> Self {
         Self([<T as Default>::default(); N])
     }
 }
 pub type Array16 = u8;
-pub type ArrayInt4 = __BindgenOpaqueArray<u32, 4usize>;
+pub type ArrayInt4 = __BindgenOpaqueArray<[u32; 4usize]>;
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct UsesArray {
-    pub array_char_16: __BindgenOpaqueArray<u8, 16usize>,
-    pub array_bool_8: __BindgenOpaqueArray<u8, 8usize>,
+    pub array_char_16: __BindgenOpaqueArray<[u8; 16usize]>,
+    pub array_bool_8: __BindgenOpaqueArray<[u8; 8usize]>,
     pub array_int_4: ArrayInt4,
 }
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]

--- a/bindgen-tests/tests/expectations/tests/nsBaseHashtable.rs
+++ b/bindgen-tests/tests/expectations/tests/nsBaseHashtable.rs
@@ -1,10 +1,8 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
-/// If Bindgen could only determine the size and alignment of a
-/// type, it is represented like this.
-#[derive(PartialEq, Copy, Clone, Debug, Hash)]
+#[derive(PartialEq, Eq, Copy, Clone, Debug, Hash)]
 #[repr(C)]
-pub struct __BindgenOpaqueArray<T: Copy, const N: usize>(pub [T; N]);
-impl<T: Copy + Default, const N: usize> Default for __BindgenOpaqueArray<T, N> {
+pub struct __BindgenOpaqueArray<T>(pub T);
+impl<T: Copy + Default, const N: usize> Default for __BindgenOpaqueArray<[T; N]> {
     fn default() -> Self {
         Self([<T as Default>::default(); N])
     }
@@ -24,7 +22,7 @@ pub struct nsTHashtable {
 pub struct nsBaseHashtable {
     pub _address: u8,
 }
-pub type nsBaseHashtable_KeyType = __BindgenOpaqueArray<u8, 0usize>;
+pub type nsBaseHashtable_KeyType = __BindgenOpaqueArray<[u8; 0usize]>;
 pub type nsBaseHashtable_EntryType = nsBaseHashtableET;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]

--- a/bindgen-tests/tests/expectations/tests/objc_template.rs
+++ b/bindgen-tests/tests/expectations/tests/objc_template.rs
@@ -3,6 +3,14 @@
 use objc::{self, msg_send, sel, sel_impl, class};
 #[allow(non_camel_case_types)]
 pub type id = *mut objc::runtime::Object;
+#[derive(PartialEq, Eq, Copy, Clone, Debug, Hash)]
+#[repr(C, align(8))]
+pub struct __BindgenOpaqueArray8<T>(pub T);
+impl<T: Copy + Default, const N: usize> Default for __BindgenOpaqueArray8<[T; N]> {
+    fn default() -> Self {
+        Self([<T as Default>::default(); N])
+    }
+}
 #[repr(transparent)]
 #[derive(Debug, Copy, Clone)]
 pub struct Foo(pub id);
@@ -20,7 +28,7 @@ impl Foo {
 }
 impl<ObjectType: 'static> IFoo<ObjectType> for Foo {}
 pub trait IFoo<ObjectType: 'static>: Sized + std::ops::Deref {
-    unsafe fn get(&self) -> u64
+    unsafe fn get(&self) -> __BindgenOpaqueArray8<[u8; 8usize]>
     where
         <Self as std::ops::Deref>::Target: objc::Message + Sized,
     {
@@ -48,7 +56,10 @@ pub trait IFooMultiGeneric<
     KeyType: 'static,
     ObjectType: 'static,
 >: Sized + std::ops::Deref {
-    unsafe fn objectForKey_(&self, key: u64) -> u64
+    unsafe fn objectForKey_(
+        &self,
+        key: __BindgenOpaqueArray8<[u8; 8usize]>,
+    ) -> __BindgenOpaqueArray8<[u8; 8usize]>
     where
         <Self as std::ops::Deref>::Target: objc::Message + Sized,
     {

--- a/bindgen-tests/tests/expectations/tests/opaque-template-inst-member.rs
+++ b/bindgen-tests/tests/expectations/tests/opaque-template-inst-member.rs
@@ -1,10 +1,8 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
-/// If Bindgen could only determine the size and alignment of a
-/// type, it is represented like this.
-#[derive(PartialEq, Copy, Clone, Debug, Hash)]
+#[derive(PartialEq, Eq, Copy, Clone, Debug, Hash)]
 #[repr(C)]
-pub struct __BindgenOpaqueArray<T: Copy, const N: usize>(pub [T; N]);
-impl<T: Copy + Default, const N: usize> Default for __BindgenOpaqueArray<T, N> {
+pub struct __BindgenOpaqueArray<T>(pub T);
+impl<T: Copy + Default, const N: usize> Default for __BindgenOpaqueArray<[T; N]> {
     fn default() -> Self {
         Self([<T as Default>::default(); N])
     }
@@ -17,8 +15,9 @@ pub struct OpaqueTemplate {
 /** This should not end up deriving Debug/Hash because its `mBlah` field cannot derive
  Debug/Hash because the instantiation's definition cannot derive Debug/Hash.*/
 #[repr(C)]
+#[derive(Debug, Default, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct ContainsOpaqueTemplate {
-    pub mBlah: __BindgenOpaqueArray<u32, 101usize>,
+    pub mBlah: __BindgenOpaqueArray<[u32; 101usize]>,
     pub mBaz: ::std::os::raw::c_int,
 }
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
@@ -36,25 +35,12 @@ const _: () = {
         "Offset of field: ContainsOpaqueTemplate::mBaz",
     ][::std::mem::offset_of!(ContainsOpaqueTemplate, mBaz) - 404usize];
 };
-impl Default for ContainsOpaqueTemplate {
-    fn default() -> Self {
-        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
-        unsafe {
-            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
-            s.assume_init()
-        }
-    }
-}
-impl ::std::cmp::PartialEq for ContainsOpaqueTemplate {
-    fn eq(&self, other: &ContainsOpaqueTemplate) -> bool {
-        self.mBlah == other.mBlah && self.mBaz == other.mBaz
-    }
-}
 /** This should not end up deriving Debug/Hash either, for similar reasons, although
  we're exercising base member edges now.*/
 #[repr(C)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct InheritsOpaqueTemplate {
-    pub _base: __BindgenOpaqueArray<u8, 401usize>,
+    pub _base: __BindgenOpaqueArray<[u8; 401usize]>,
     pub wow: *mut ::std::os::raw::c_char,
 }
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
@@ -76,10 +62,5 @@ impl Default for InheritsOpaqueTemplate {
             ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
             s.assume_init()
         }
-    }
-}
-impl ::std::cmp::PartialEq for InheritsOpaqueTemplate {
-    fn eq(&self, other: &InheritsOpaqueTemplate) -> bool {
-        self._base == other._base && self.wow == other.wow
     }
 }

--- a/bindgen-tests/tests/expectations/tests/partial-specialization-and-inheritance.rs
+++ b/bindgen-tests/tests/expectations/tests/partial-specialization-and-inheritance.rs
@@ -1,10 +1,8 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
-/// If Bindgen could only determine the size and alignment of a
-/// type, it is represented like this.
-#[derive(PartialEq, Copy, Clone, Debug, Hash)]
+#[derive(PartialEq, Eq, Copy, Clone, Debug, Hash)]
 #[repr(C)]
-pub struct __BindgenOpaqueArray<T: Copy, const N: usize>(pub [T; N]);
-impl<T: Copy + Default, const N: usize> Default for __BindgenOpaqueArray<T, N> {
+pub struct __BindgenOpaqueArray<T>(pub T);
+impl<T: Copy + Default, const N: usize> Default for __BindgenOpaqueArray<[T; N]> {
     fn default() -> Self {
         Self([<T as Default>::default(); N])
     }
@@ -26,7 +24,7 @@ pub struct Usage {
 }
 unsafe extern "C" {
     #[link_name = "\u{1}_ZN5Usage13static_memberE"]
-    pub static mut Usage_static_member: __BindgenOpaqueArray<u32, 2usize>;
+    pub static mut Usage_static_member: __BindgenOpaqueArray<[u32; 2usize]>;
 }
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {

--- a/bindgen-tests/tests/expectations/tests/size_t_template.rs
+++ b/bindgen-tests/tests/expectations/tests/size_t_template.rs
@@ -1,10 +1,8 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
-/// If Bindgen could only determine the size and alignment of a
-/// type, it is represented like this.
-#[derive(PartialEq, Copy, Clone, Debug, Hash)]
+#[derive(PartialEq, Eq, Copy, Clone, Debug, Hash)]
 #[repr(C)]
-pub struct __BindgenOpaqueArray<T: Copy, const N: usize>(pub [T; N]);
-impl<T: Copy + Default, const N: usize> Default for __BindgenOpaqueArray<T, N> {
+pub struct __BindgenOpaqueArray<T>(pub T);
+impl<T: Copy + Default, const N: usize> Default for __BindgenOpaqueArray<[T; N]> {
     fn default() -> Self {
         Self([<T as Default>::default(); N])
     }
@@ -12,7 +10,7 @@ impl<T: Copy + Default, const N: usize> Default for __BindgenOpaqueArray<T, N> {
 #[repr(C)]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct C {
-    pub arr: __BindgenOpaqueArray<u32, 3usize>,
+    pub arr: __BindgenOpaqueArray<[u32; 3usize]>,
 }
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]
 const _: () = {

--- a/bindgen-tests/tests/expectations/tests/unknown_attr.rs
+++ b/bindgen-tests/tests/expectations/tests/unknown_attr.rs
@@ -1,10 +1,18 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
+#[derive(PartialEq, Eq, Copy, Clone, Debug, Hash)]
+#[repr(C, align(8))]
+pub struct __BindgenOpaqueArray8<T>(pub T);
+impl<T: Copy + Default, const N: usize> Default for __BindgenOpaqueArray8<[T; N]> {
+    fn default() -> Self {
+        Self([<T as Default>::default(); N])
+    }
+}
 #[repr(C)]
 #[repr(align(16))]
 #[derive(Debug, Default, Copy, Clone)]
 pub struct max_align_t {
     pub __clang_max_align_nonce1: ::std::os::raw::c_longlong,
-    pub __bindgen_padding_0: u64,
+    pub __bindgen_padding_0: __BindgenOpaqueArray8<[u8; 8usize]>,
     pub __clang_max_align_nonce2: ::std::os::raw::c_longlong,
 }
 #[allow(clippy::unnecessary_operation, clippy::identity_op)]

--- a/bindgen-tests/tests/expectations/tests/va_list_aarch64_linux.rs
+++ b/bindgen-tests/tests/expectations/tests/va_list_aarch64_linux.rs
@@ -1,18 +1,16 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
-/// If Bindgen could only determine the size and alignment of a
-/// type, it is represented like this.
-#[derive(PartialEq, Copy, Clone, Debug, Hash)]
-#[repr(C)]
-pub struct __BindgenOpaqueArray<T: Copy, const N: usize>(pub [T; N]);
-impl<T: Copy + Default, const N: usize> Default for __BindgenOpaqueArray<T, N> {
+#[derive(PartialEq, Eq, Copy, Clone, Debug, Hash)]
+#[repr(C, align(8))]
+pub struct __BindgenOpaqueArray8<T>(pub T);
+impl<T: Copy + Default, const N: usize> Default for __BindgenOpaqueArray8<[T; N]> {
     fn default() -> Self {
         Self([<T as Default>::default(); N])
     }
 }
-pub type va_list = __BindgenOpaqueArray<u64, 4usize>;
+pub type va_list = __BindgenOpaqueArray8<[u8; 32usize]>;
 unsafe extern "C" {
     pub fn vprintf(
         format: *const ::std::os::raw::c_char,
-        vlist: __BindgenOpaqueArray<u64, 4usize>,
+        vlist: __BindgenOpaqueArray8<[u8; 32usize]>,
     ) -> ::std::os::raw::c_int;
 }

--- a/bindgen/ir/analysis/derive.rs
+++ b/bindgen/ir/analysis/derive.rs
@@ -179,26 +179,11 @@ impl CannotDerive<'_> {
                 return CanDerive::No;
             }
 
-            let layout_can_derive =
-                ty.layout(self.ctx).map_or(CanDerive::Yes, |l| {
-                    l.opaque().array_size_within_derive_limit()
-                });
-
-            match layout_can_derive {
-                CanDerive::Yes => {
-                    trace!(
-                        "    we can trivially derive {} for the layout",
-                        self.derive_trait
-                    );
-                }
-                _ => {
-                    trace!(
-                        "    we cannot derive {} for the layout",
-                        self.derive_trait
-                    );
-                }
-            }
-            return layout_can_derive;
+            trace!(
+                "    we can trivially derive {} for the layout",
+                self.derive_trait
+            );
+            return CanDerive::Yes;
         }
 
         match *ty.kind() {
@@ -338,25 +323,11 @@ impl CannotDerive<'_> {
                             return CanDerive::No;
                         }
 
-                        let layout_can_derive =
-                            ty.layout(self.ctx).map_or(CanDerive::Yes, |l| {
-                                l.opaque().array_size_within_derive_limit()
-                            });
-                        match layout_can_derive {
-                            CanDerive::Yes => {
-                                trace!(
-                                    "    union layout can trivially derive {}",
-                                    self.derive_trait
-                                );
-                            }
-                            _ => {
-                                trace!(
-                                    "    union layout cannot derive {}",
-                                    self.derive_trait
-                                );
-                            }
-                        }
-                        return layout_can_derive;
+                        trace!(
+                            "    union layout can trivially derive {}",
+                            self.derive_trait
+                        );
+                        return CanDerive::Yes;
                     }
                 }
 

--- a/bindgen/ir/item.rs
+++ b/bindgen/ir/item.rs
@@ -12,7 +12,6 @@ use super::derive::{
 use super::dot::DotAttributes;
 use super::function::{Function, FunctionKind};
 use super::item_kind::ItemKind;
-use super::layout::Opaque;
 use super::module::Module;
 use super::template::{AsTemplateParam, TemplateParameters};
 use super::traversal::{EdgeKind, Trace, Tracer};
@@ -451,7 +450,7 @@ impl Item {
         ctx: &mut BindgenContext,
     ) -> TypeId {
         let location = ty.declaration().location();
-        let ty = Opaque::from_clang_ty(ty, ctx);
+        let ty = Type::new_opaque_from_clang_ty(ty, ctx);
         let kind = ItemKind::Type(ty);
         let parent = ctx.root_module().into();
         ctx.add_item(


### PR DESCRIPTION
Fixes https://github.com/rust-lang/rust-bindgen/issues/3279