### PR TITLE
codegen: Fix typedefs inside constified modules.

### DIFF
--- a/bindgen-tests/tests/expectations/tests/constify-module-enums-basic.rs
+++ b/bindgen-tests/tests/expectations/tests/constify-module-enums-basic.rs
@@ -1,5 +1,7 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 pub mod foo {
+    #[allow(unused_imports)]
+    use super::*;
     pub type Type = ::std::os::raw::c_uint;
     pub const THIS: Type = 0;
     pub const SHOULD_BE: Type = 1;

--- a/bindgen-tests/tests/expectations/tests/constify-module-enums-namespace.rs
+++ b/bindgen-tests/tests/expectations/tests/constify-module-enums-namespace.rs
@@ -10,6 +10,8 @@ pub mod root {
             #[allow(unused_imports)]
             use self::super::super::super::root;
             pub mod foo {
+                #[allow(unused_imports)]
+                use super::*;
                 pub type Type = ::std::os::raw::c_uint;
                 pub const THIS: Type = 0;
                 pub const SHOULD_BE: Type = 1;

--- a/bindgen-tests/tests/expectations/tests/constify-module-enums-shadow-name.rs
+++ b/bindgen-tests/tests/expectations/tests/constify-module-enums-shadow-name.rs
@@ -1,5 +1,7 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 pub mod foo {
+    #[allow(unused_imports)]
+    use super::*;
     pub type Type = ::std::os::raw::c_uint;
     pub const Type: Type = 0;
     pub const Type_: Type = 1;

--- a/bindgen-tests/tests/expectations/tests/constify-module-enums-simple-alias.rs
+++ b/bindgen-tests/tests/expectations/tests/constify-module-enums-simple-alias.rs
@@ -1,5 +1,7 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 pub mod Foo {
+    #[allow(unused_imports)]
+    use super::*;
     pub type Type = ::std::os::raw::c_int;
     pub const Variant1: Type = 0;
     pub const Variant2: Type = 1;

--- a/bindgen-tests/tests/expectations/tests/constify-module-enums-simple-nonamespace.rs
+++ b/bindgen-tests/tests/expectations/tests/constify-module-enums-simple-nonamespace.rs
@@ -1,5 +1,7 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 pub mod one_Foo {
+    #[allow(unused_imports)]
+    use super::*;
     pub type Type = ::std::os::raw::c_int;
     pub const Variant1: Type = 0;
     pub const Variant2: Type = 1;

--- a/bindgen-tests/tests/expectations/tests/constify-module-enums-types.rs
+++ b/bindgen-tests/tests/expectations/tests/constify-module-enums-types.rs
@@ -1,5 +1,15 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
+pub type Uint = ::std::os::raw::c_uint;
+pub mod ExplicitTypeAlias {
+    #[allow(unused_imports)]
+    use super::*;
+    pub type Type = Uint;
+    pub const SOME_CONSTANT: Type = 0;
+    pub const SOME_OTHER_CONSTANT: Type = 1;
+}
 pub mod foo {
+    #[allow(unused_imports)]
+    use super::*;
     pub type Type = ::std::os::raw::c_uint;
     pub const THIS: Type = 0;
     pub const SHOULD_BE: Type = 1;
@@ -8,12 +18,16 @@ pub mod foo {
     pub const AND_ALSO_THIS: Type = 42;
 }
 pub mod anon_enum {
+    #[allow(unused_imports)]
+    use super::*;
     pub type Type = ::std::os::raw::c_uint;
     pub const Variant1: Type = 0;
     pub const Variant2: Type = 1;
     pub const Variant3: Type = 2;
 }
 pub mod ns1_foo {
+    #[allow(unused_imports)]
+    use super::*;
     pub type Type = ::std::os::raw::c_uint;
     pub const THIS: Type = 0;
     pub const SHOULD_BE: Type = 1;
@@ -21,6 +35,8 @@ pub mod ns1_foo {
     pub const ALSO_THIS: Type = 42;
 }
 pub mod ns2_Foo {
+    #[allow(unused_imports)]
+    use super::*;
     pub type Type = ::std::os::raw::c_int;
     pub const Variant1: Type = 0;
     pub const Variant2: Type = 1;
@@ -90,6 +106,8 @@ impl Default for Baz {
     }
 }
 pub mod one_Foo {
+    #[allow(unused_imports)]
+    use super::*;
     pub type Type = ::std::os::raw::c_int;
     pub const Variant1: Type = 0;
     pub const Variant2: Type = 1;

--- a/bindgen-tests/tests/expectations/tests/default-enum-style-constified-module.rs
+++ b/bindgen-tests/tests/expectations/tests/default-enum-style-constified-module.rs
@@ -1,5 +1,7 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 pub mod Foo {
+    #[allow(unused_imports)]
+    use super::*;
     pub type Type = ::std::os::raw::c_uint;
     pub const bar: Type = 0;
     pub const baz: Type = 1;

--- a/bindgen-tests/tests/expectations/tests/empty-enum.rs
+++ b/bindgen-tests/tests/expectations/tests/empty-enum.rs
@@ -6,6 +6,8 @@ pub enum EmptyRustified {
     __bindgen_cannot_repr_c_on_empty_enum = 0,
 }
 pub mod EmptyModule {
+    #[allow(unused_imports)]
+    use super::*;
     pub type Type = ::std::os::raw::c_uint;
 }
 #[repr(i8)]
@@ -15,6 +17,8 @@ pub enum EmptyClassRustified {
 }
 pub type EmptyClassConstified = ::std::os::raw::c_char;
 pub mod EmptyClassModule {
+    #[allow(unused_imports)]
+    use super::*;
     pub type Type = ::std::os::raw::c_char;
 }
 #[repr(i8)]
@@ -24,5 +28,7 @@ pub enum ForwardClassRustified {
 }
 pub type ForwardClassConstified = ::std::os::raw::c_char;
 pub mod ForwardClassModule {
+    #[allow(unused_imports)]
+    use super::*;
     pub type Type = ::std::os::raw::c_char;
 }

--- a/bindgen-tests/tests/expectations/tests/enum-default-bitfield.rs
+++ b/bindgen-tests/tests/expectations/tests/enum-default-bitfield.rs
@@ -84,6 +84,8 @@ impl ::std::ops::BitAndAssign for Foo {
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct Foo(pub ::std::os::raw::c_uint);
 pub mod Neg {
+    #[allow(unused_imports)]
+    use super::*;
     pub type Type = ::std::os::raw::c_int;
     pub const MinusOne: Type = -1;
     pub const One: Type = 1;

--- a/bindgen-tests/tests/expectations/tests/enum-default-consts.rs
+++ b/bindgen-tests/tests/expectations/tests/enum-default-consts.rs
@@ -26,6 +26,8 @@ pub const Foo_Bar: Foo = 0;
 pub const Foo_Qux: Foo = 1;
 pub type Foo = ::std::os::raw::c_uint;
 pub mod Neg {
+    #[allow(unused_imports)]
+    use super::*;
     pub type Type = ::std::os::raw::c_int;
     pub const MinusOne: Type = -1;
     pub const One: Type = 1;

--- a/bindgen-tests/tests/expectations/tests/enum-default-module.rs
+++ b/bindgen-tests/tests/expectations/tests/enum-default-module.rs
@@ -5,6 +5,8 @@ pub struct foo {
     pub member: foo__bindgen_ty_1::Type,
 }
 pub mod foo__bindgen_ty_1 {
+    #[allow(unused_imports)]
+    use super::*;
     pub type Type = ::std::os::raw::c_uint;
     pub const FOO_A: Type = 0;
     pub const FOO_B: Type = 1;
@@ -25,22 +27,30 @@ impl Default for foo {
     }
 }
 pub mod Foo {
+    #[allow(unused_imports)]
+    use super::*;
     pub type Type = ::std::os::raw::c_uint;
     pub const Bar: Type = 0;
     pub const Qux: Type = 1;
 }
 pub mod Neg {
+    #[allow(unused_imports)]
+    use super::*;
     pub type Type = ::std::os::raw::c_int;
     pub const MinusOne: Type = -1;
     pub const One: Type = 1;
 }
 pub mod NoDebug {
+    #[allow(unused_imports)]
+    use super::*;
     /// <div rustbindgen nodebug></div>
     pub type Type = ::std::os::raw::c_uint;
     pub const NoDebug1: Type = 0;
     pub const NoDebug2: Type = 1;
 }
 pub mod Debug {
+    #[allow(unused_imports)]
+    use super::*;
     /// <div rustbindgen derive="Debug"></div>
     pub type Type = ::std::os::raw::c_uint;
     pub const Debug1: Type = 0;

--- a/bindgen-tests/tests/expectations/tests/enum-default-rust.rs
+++ b/bindgen-tests/tests/expectations/tests/enum-default-rust.rs
@@ -34,6 +34,8 @@ pub enum Foo {
     Qux = 1,
 }
 pub mod Neg {
+    #[allow(unused_imports)]
+    use super::*;
     pub type Type = ::std::os::raw::c_int;
     pub const MinusOne: Type = -1;
     pub const One: Type = 1;

--- a/bindgen-tests/tests/expectations/tests/enum-doc-mod.rs
+++ b/bindgen-tests/tests/expectations/tests/enum-doc-mod.rs
@@ -1,5 +1,7 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 pub mod B {
+    #[allow(unused_imports)]
+    use super::*;
     /// Document enum
     pub type Type = ::std::os::raw::c_uint;
     /// Document field with three slashes

--- a/bindgen-tests/tests/expectations/tests/enum-no-debug-rust.rs
+++ b/bindgen-tests/tests/expectations/tests/enum-no-debug-rust.rs
@@ -34,6 +34,8 @@ pub enum Foo {
     Qux = 1,
 }
 pub mod Neg {
+    #[allow(unused_imports)]
+    use super::*;
     pub type Type = ::std::os::raw::c_int;
     pub const MinusOne: Type = -1;
     pub const One: Type = 1;

--- a/bindgen-tests/tests/expectations/tests/issue-1198-alias-rust-const-mod-bitfield-enum.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-1198-alias-rust-const-mod-bitfield-enum.rs
@@ -1,11 +1,15 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 pub mod MyDupeEnum {
+    #[allow(unused_imports)]
+    use super::*;
     pub type Type = ::std::os::raw::c_uint;
     pub const A: Type = 0;
     pub const A_alias: Type = 0;
     pub const B: Type = 1;
 }
 pub mod MyOtherDupeEnum {
+    #[allow(unused_imports)]
+    use super::*;
     pub type Type = ::std::os::raw::c_uint;
     pub const C: Type = 0;
     pub const C_alias: Type = 0;

--- a/bindgen-tests/tests/expectations/tests/issue-1198-alias-rust-const-mod-enum.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-1198-alias-rust-const-mod-enum.rs
@@ -1,11 +1,15 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 pub mod MyDupeEnum {
+    #[allow(unused_imports)]
+    use super::*;
     pub type Type = ::std::os::raw::c_uint;
     pub const A: Type = 0;
     pub const A_alias: Type = 0;
     pub const B: Type = 1;
 }
 pub mod MyOtherDupeEnum {
+    #[allow(unused_imports)]
+    use super::*;
     pub type Type = ::std::os::raw::c_uint;
     pub const C: Type = 0;
     pub const C_alias: Type = 0;

--- a/bindgen-tests/tests/expectations/tests/issue-1488-enum-new-type.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-1488-enum-new-type.rs
@@ -6,6 +6,8 @@ pub type Foo = ::std::os::raw::c_uint;
 #[derive(Debug, Copy, Clone)]
 pub struct FooAlias(pub Foo);
 pub mod Bar {
+    #[allow(unused_imports)]
+    use super::*;
     pub type Type = ::std::os::raw::c_uint;
     pub const C: Type = 0;
     pub const D: Type = 1;

--- a/bindgen-tests/tests/headers/constify-module-enums-types.hpp
+++ b/bindgen-tests/tests/headers/constify-module-enums-types.hpp
@@ -1,5 +1,11 @@
 // bindgen-flags: --constified-enum-module ".*"
 
+using Uint = unsigned;
+enum ExplicitTypeAlias : Uint {
+  SOME_CONSTANT,
+  SOME_OTHER_CONSTANT,
+};
+
 typedef enum foo {
   THIS,
   SHOULD_BE,

--- a/bindgen/codegen/mod.rs
+++ b/bindgen/codegen/mod.rs
@@ -3562,6 +3562,9 @@ impl EnumBuilder {
                 quote! {
                     // todo: Probably some attributes, e.g. `cfg` should apply to the `mod`.
                     pub mod #module_name {
+                        #[allow(unused_imports)]
+                        use super::*;
+
                         #( #attrs )*
                         pub type #enum_ident = #enum_repr;
 


### PR DESCRIPTION
Fixes #3272