### PR TITLE
Add undefined behaviour warning to `rustified_non_exhaustive_enum`

### DIFF
--- a/bindgen/options/mod.rs
+++ b/bindgen/options/mod.rs
@@ -541,6 +541,11 @@ options! {
                 ///
                 /// This is similar to the [`Builder::rustified_enum`] style, but the `enum` is
                 /// tagged with the `#[non_exhaustive]` attribute.
+                ///
+                /// **Use this with caution**, creating an instance of a Rust `enum` with an
+                /// invalid value will cause undefined behaviour, even if it's tagged with
+                /// `#[non_exhaustive]`. To avoid this, use the [`Builder::newtype_enum`] style
+                /// instead.
                 pub fn rustified_non_exhaustive_enum<T: AsRef<str>>(mut self, arg: T) -> Builder {
                     self.options.rustified_non_exhaustive_enums.insert(arg);
                     self


### PR DESCRIPTION
Copies the undefined behaviour warning  on `rustified_enum` to `rustified_non_exhaustive_enum`, as discussed in  #3297.
This should make it clear that the latter can also be UB, even with `non_exhaustive`, without having to check the link to `rustified_enum`.