### PR TITLE
Allow generating hidden visibility functions

### DIFF
--- a/bindgen-tests/tests/tests.rs
+++ b/bindgen-tests/tests/tests.rs
@@ -443,10 +443,7 @@ fn hidden_functions_builder() -> Builder {
 
 #[test]
 fn hidden_functions_are_skipped_by_default() {
-    let bindings = hidden_functions_builder()
-        .generate()
-        .unwrap()
-        .to_string();
+    let bindings = hidden_functions_builder().generate().unwrap().to_string();
 
     assert!(bindings.contains("pub fn visible_fn"));
     assert!(!bindings.contains("pub fn hidden_fn"));
@@ -454,10 +451,8 @@ fn hidden_functions_are_skipped_by_default() {
 
 #[test]
 fn hidden_functions_can_be_generated_when_enabled() {
-    let default_bindings = hidden_functions_builder()
-        .generate()
-        .unwrap()
-        .to_string();
+    let default_bindings =
+        hidden_functions_builder().generate().unwrap().to_string();
 
     let hidden_enabled = hidden_functions_builder()
         .generate_hidden_functions(true)

--- a/bindgen/ir/function.rs
+++ b/bindgen/ir/function.rs
@@ -730,7 +730,11 @@ impl ClangSubItemParser for Function {
 
         debug!("Function::parse({cursor:?}, {:?})", cursor.cur_type());
         let visibility = cursor.visibility();
-        if visibility != CXVisibility_Default {
+        let allow_hidden = context.options().generate_hidden_functions &&
+            (visibility == CXVisibility_Hidden ||
+                visibility == CXVisibility_Protected);
+
+        if visibility != CXVisibility_Default && !allow_hidden {
             return Err(ParseError::Continue);
         }
         if cursor.access_specifier() == CX_CXXPrivate &&

--- a/bindgen/options/mod.rs
+++ b/bindgen/options/mod.rs
@@ -2329,4 +2329,16 @@ options! {
         },
         as_args: "--generate-private-functions",
     },
+    /// Whether to allow generating functions that are marked with hidden or protected visibility.
+    generate_hidden_functions: bool {
+        methods: {
+            /// Set whether to generate functions that are not externally visible according to clang.
+            pub fn generate_hidden_functions(mut self, doit: bool) -> Self {
+                self.options.generate_hidden_functions = doit;
+                self
+            }
+
+        },
+        as_args: "--generate-hidden-functions",
+    },
 }


### PR DESCRIPTION
- add a generate_hidden_functions option so bindgen can keep functions that Clang marks with hidden/protected visibility (fixes https://github.com/rust-lang/rust-bindgen/issues/2989)
- allow Function::parse to honor the new option instead of dropping those declarations unconditionally