### PR TITLE
Support nested flexible array members

### DIFF
--- a/bindgen-tests/tests/expectations/tests/nested_flexarray.rs
+++ b/bindgen-tests/tests/expectations/tests/nested_flexarray.rs
@@ -1,0 +1,271 @@
+#![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
+#![cfg(feature = "nightly")]
+#![feature(ptr_metadata, layout_for_ptr)]
+#[repr(C)]
+#[derive(Debug, Default)]
+pub struct Field<FAM: ?Sized = [::std::os::raw::c_int; 0]> {
+    pub count: ::std::os::raw::c_int,
+    pub data: FAM,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of Field"][::std::mem::size_of::<Field>() - 4usize];
+    ["Alignment of Field"][::std::mem::align_of::<Field>() - 4usize];
+    ["Offset of field: Field::count"][::std::mem::offset_of!(Field, count) - 0usize];
+    ["Offset of field: Field::data"][::std::mem::offset_of!(Field, data) - 4usize];
+};
+impl Field<[::std::os::raw::c_int]> {
+    pub fn layout(len: usize) -> ::std::alloc::Layout {
+        unsafe {
+            let p: *const Self = ::std::ptr::from_raw_parts(
+                ::std::ptr::null::<()>(),
+                len,
+            );
+            ::std::alloc::Layout::for_value_raw(p)
+        }
+    }
+    #[inline]
+    pub fn fixed(&self) -> (&Field<[::std::os::raw::c_int; 0]>, usize) {
+        unsafe {
+            let (ptr, len) = (self as *const Self).to_raw_parts();
+            (&*(ptr as *const Field<[::std::os::raw::c_int; 0]>), len)
+        }
+    }
+    #[inline]
+    pub fn fixed_mut(&mut self) -> (&mut Field<[::std::os::raw::c_int; 0]>, usize) {
+        unsafe {
+            let (ptr, len) = (self as *mut Self).to_raw_parts();
+            (&mut *(ptr as *mut Field<[::std::os::raw::c_int; 0]>), len)
+        }
+    }
+}
+impl Field<[::std::os::raw::c_int; 0]> {
+    /// Convert a sized prefix to an unsized structure with the given length.
+    ///
+    /// SAFETY: Underlying storage is initialized up to at least `len` elements.
+    pub unsafe fn flex_ref(&self, len: usize) -> &Field<[::std::os::raw::c_int]> {
+        Self::flex_ptr(self, len)
+    }
+    /// Convert a mutable sized prefix to an unsized structure with the given length.
+    ///
+    /// SAFETY: Underlying storage is initialized up to at least `len` elements.
+    #[inline]
+    pub unsafe fn flex_ref_mut(
+        &mut self,
+        len: usize,
+    ) -> &mut Field<[::std::os::raw::c_int]> {
+        Self::flex_ptr_mut(self, len).assume_init()
+    }
+    /// Construct DST variant from a pointer and a size.
+    ///
+    /// NOTE: lifetime of returned reference is not tied to any underlying storage.
+    /// SAFETY: `ptr` is valid. Underlying storage is fully initialized up to at least `len` elements.
+    #[inline]
+    pub unsafe fn flex_ptr<'unbounded>(
+        ptr: *const Self,
+        len: usize,
+    ) -> &'unbounded Field<[::std::os::raw::c_int]> {
+        &*::std::ptr::from_raw_parts(ptr as *const (), len)
+    }
+    /// Construct mutable DST variant from a pointer and a
+    /// size. The returned `&mut` reference is initialized
+    /// pointing to memory referenced by `ptr`, but there's
+    /// no requirement that that memory be initialized.
+    ///
+    /// NOTE: lifetime of returned reference is not tied to any underlying storage.
+    /// SAFETY: `ptr` is valid. Underlying storage has space for at least `len` elements.
+    #[inline]
+    pub unsafe fn flex_ptr_mut<'unbounded>(
+        ptr: *mut Self,
+        len: usize,
+    ) -> ::std::mem::MaybeUninit<&'unbounded mut Field<[::std::os::raw::c_int]>> {
+        let mut uninit = ::std::mem::MaybeUninit::<
+            &mut Field<[::std::os::raw::c_int]>,
+        >::uninit();
+        (uninit.as_mut_ptr() as *mut *mut Field<[::std::os::raw::c_int]>)
+            .write(::std::ptr::from_raw_parts_mut(ptr as *mut (), len));
+        uninit
+    }
+}
+#[repr(C)]
+#[derive(Debug, Default)]
+pub struct Name<FAM: ?Sized = [::std::os::raw::c_int; 0]> {
+    pub id: ::std::os::raw::c_int,
+    pub field: Field<FAM>,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of Name"][::std::mem::size_of::<Name>() - 8usize];
+    ["Alignment of Name"][::std::mem::align_of::<Name>() - 4usize];
+    ["Offset of field: Name::id"][::std::mem::offset_of!(Name, id) - 0usize];
+    ["Offset of field: Name::field"][::std::mem::offset_of!(Name, field) - 4usize];
+};
+impl Name<[::std::os::raw::c_int]> {
+    pub fn layout(len: usize) -> ::std::alloc::Layout {
+        unsafe {
+            let p: *const Self = ::std::ptr::from_raw_parts(
+                ::std::ptr::null::<()>(),
+                len,
+            );
+            ::std::alloc::Layout::for_value_raw(p)
+        }
+    }
+    #[inline]
+    pub fn fixed(&self) -> (&Name<[::std::os::raw::c_int; 0]>, usize) {
+        unsafe {
+            let (ptr, len) = (self as *const Self).to_raw_parts();
+            (&*(ptr as *const Name<[::std::os::raw::c_int; 0]>), len)
+        }
+    }
+    #[inline]
+    pub fn fixed_mut(&mut self) -> (&mut Name<[::std::os::raw::c_int; 0]>, usize) {
+        unsafe {
+            let (ptr, len) = (self as *mut Self).to_raw_parts();
+            (&mut *(ptr as *mut Name<[::std::os::raw::c_int; 0]>), len)
+        }
+    }
+}
+impl Name<[::std::os::raw::c_int; 0]> {
+    /// Convert a sized prefix to an unsized structure with the given length.
+    ///
+    /// SAFETY: Underlying storage is initialized up to at least `len` elements.
+    pub unsafe fn flex_ref(&self, len: usize) -> &Name<[::std::os::raw::c_int]> {
+        Self::flex_ptr(self, len)
+    }
+    /// Convert a mutable sized prefix to an unsized structure with the given length.
+    ///
+    /// SAFETY: Underlying storage is initialized up to at least `len` elements.
+    #[inline]
+    pub unsafe fn flex_ref_mut(
+        &mut self,
+        len: usize,
+    ) -> &mut Name<[::std::os::raw::c_int]> {
+        Self::flex_ptr_mut(self, len).assume_init()
+    }
+    /// Construct DST variant from a pointer and a size.
+    ///
+    /// NOTE: lifetime of returned reference is not tied to any underlying storage.
+    /// SAFETY: `ptr` is valid. Underlying storage is fully initialized up to at least `len` elements.
+    #[inline]
+    pub unsafe fn flex_ptr<'unbounded>(
+        ptr: *const Self,
+        len: usize,
+    ) -> &'unbounded Name<[::std::os::raw::c_int]> {
+        &*::std::ptr::from_raw_parts(ptr as *const (), len)
+    }
+    /// Construct mutable DST variant from a pointer and a
+    /// size. The returned `&mut` reference is initialized
+    /// pointing to memory referenced by `ptr`, but there's
+    /// no requirement that that memory be initialized.
+    ///
+    /// NOTE: lifetime of returned reference is not tied to any underlying storage.
+    /// SAFETY: `ptr` is valid. Underlying storage has space for at least `len` elements.
+    #[inline]
+    pub unsafe fn flex_ptr_mut<'unbounded>(
+        ptr: *mut Self,
+        len: usize,
+    ) -> ::std::mem::MaybeUninit<&'unbounded mut Name<[::std::os::raw::c_int]>> {
+        let mut uninit = ::std::mem::MaybeUninit::<
+            &mut Name<[::std::os::raw::c_int]>,
+        >::uninit();
+        (uninit.as_mut_ptr() as *mut *mut Name<[::std::os::raw::c_int]>)
+            .write(::std::ptr::from_raw_parts_mut(ptr as *mut (), len));
+        uninit
+    }
+}
+#[repr(C, packed)]
+pub struct NamePacked<FAM: ?Sized = [::std::os::raw::c_int; 0]> {
+    pub id: ::std::os::raw::c_int,
+    pub field: ::std::mem::ManuallyDrop<Field<FAM>>,
+}
+#[allow(clippy::unnecessary_operation, clippy::identity_op)]
+const _: () = {
+    ["Size of NamePacked"][::std::mem::size_of::<NamePacked>() - 8usize];
+    ["Alignment of NamePacked"][::std::mem::align_of::<NamePacked>() - 1usize];
+    ["Offset of field: NamePacked::id"][::std::mem::offset_of!(NamePacked, id) - 0usize];
+    [
+        "Offset of field: NamePacked::field",
+    ][::std::mem::offset_of!(NamePacked, field) - 4usize];
+};
+impl NamePacked<[::std::os::raw::c_int]> {
+    pub fn layout(len: usize) -> ::std::alloc::Layout {
+        unsafe {
+            let p: *const Self = ::std::ptr::from_raw_parts(
+                ::std::ptr::null::<()>(),
+                len,
+            );
+            ::std::alloc::Layout::for_value_raw(p)
+        }
+    }
+    #[inline]
+    pub fn fixed(&self) -> (&NamePacked<[::std::os::raw::c_int; 0]>, usize) {
+        unsafe {
+            let (ptr, len) = (self as *const Self).to_raw_parts();
+            (&*(ptr as *const NamePacked<[::std::os::raw::c_int; 0]>), len)
+        }
+    }
+    #[inline]
+    pub fn fixed_mut(&mut self) -> (&mut NamePacked<[::std::os::raw::c_int; 0]>, usize) {
+        unsafe {
+            let (ptr, len) = (self as *mut Self).to_raw_parts();
+            (&mut *(ptr as *mut NamePacked<[::std::os::raw::c_int; 0]>), len)
+        }
+    }
+}
+impl NamePacked<[::std::os::raw::c_int; 0]> {
+    /// Convert a sized prefix to an unsized structure with the given length.
+    ///
+    /// SAFETY: Underlying storage is initialized up to at least `len` elements.
+    pub unsafe fn flex_ref(&self, len: usize) -> &NamePacked<[::std::os::raw::c_int]> {
+        Self::flex_ptr(self, len)
+    }
+    /// Convert a mutable sized prefix to an unsized structure with the given length.
+    ///
+    /// SAFETY: Underlying storage is initialized up to at least `len` elements.
+    #[inline]
+    pub unsafe fn flex_ref_mut(
+        &mut self,
+        len: usize,
+    ) -> &mut NamePacked<[::std::os::raw::c_int]> {
+        Self::flex_ptr_mut(self, len).assume_init()
+    }
+    /// Construct DST variant from a pointer and a size.
+    ///
+    /// NOTE: lifetime of returned reference is not tied to any underlying storage.
+    /// SAFETY: `ptr` is valid. Underlying storage is fully initialized up to at least `len` elements.
+    #[inline]
+    pub unsafe fn flex_ptr<'unbounded>(
+        ptr: *const Self,
+        len: usize,
+    ) -> &'unbounded NamePacked<[::std::os::raw::c_int]> {
+        &*::std::ptr::from_raw_parts(ptr as *const (), len)
+    }
+    /// Construct mutable DST variant from a pointer and a
+    /// size. The returned `&mut` reference is initialized
+    /// pointing to memory referenced by `ptr`, but there's
+    /// no requirement that that memory be initialized.
+    ///
+    /// NOTE: lifetime of returned reference is not tied to any underlying storage.
+    /// SAFETY: `ptr` is valid. Underlying storage has space for at least `len` elements.
+    #[inline]
+    pub unsafe fn flex_ptr_mut<'unbounded>(
+        ptr: *mut Self,
+        len: usize,
+    ) -> ::std::mem::MaybeUninit<&'unbounded mut NamePacked<[::std::os::raw::c_int]>> {
+        let mut uninit = ::std::mem::MaybeUninit::<
+            &mut NamePacked<[::std::os::raw::c_int]>,
+        >::uninit();
+        (uninit.as_mut_ptr() as *mut *mut NamePacked<[::std::os::raw::c_int]>)
+            .write(::std::ptr::from_raw_parts_mut(ptr as *mut (), len));
+        uninit
+    }
+}
+impl Default for NamePacked<[::std::os::raw::c_int; 0]> {
+    fn default() -> Self {
+        let mut s = ::std::mem::MaybeUninit::<Self>::uninit();
+        unsafe {
+            ::std::ptr::write_bytes(s.as_mut_ptr(), 0, 1);
+            s.assume_init()
+        }
+    }
+}

--- a/bindgen-tests/tests/headers/nested_flexarray.hpp
+++ b/bindgen-tests/tests/headers/nested_flexarray.hpp
@@ -1,0 +1,19 @@
+// bindgen-flags: --rust-target nightly --flexarray-dst --raw-line '#![cfg(feature = "nightly")]' --raw-line '#![feature(ptr_metadata, layout_for_ptr)]'
+
+// Test for nested flexible array members
+struct Field {
+    int count;
+    int data[];  // FAM
+};
+
+struct Name {
+    int id;
+    struct Field field;  // Last field is a struct with FAM
+};
+
+#pragma pack(1)
+struct NamePacked {
+    int id;
+    struct Field field;  // Last field is a struct with FAM, in a packed struct
+};
+#pragma pack()

--- a/bindgen/codegen/mod.rs
+++ b/bindgen/codegen/mod.rs
@@ -1540,6 +1540,28 @@ impl FieldCodegen<'_> for FieldData {
                     syn::parse_quote! { __IncompleteArrayField<#inner> }
                 }
             }
+        } else if let TypeKind::Comp(ref comp) = field_ty.kind() {
+            // Nested FAM: the field is a struct that itself has a FAM
+            // Only treat as FAM if it's the last field
+            if ctx.options().flexarray_dst &&
+                last_field &&
+                comp.flex_array_member(ctx).is_some()
+            {
+                let layout = parent_item.expect_type().layout(ctx);
+                let is_packed = parent.is_packed(ctx, layout.as_ref());
+                struct_layout.saw_flexible_array();
+
+                // For nested FAMs, we need to parameterize the field type with FAM
+                // For packed structs, wrap in ManuallyDrop
+                if is_packed {
+                    let prefix = ctx.trait_prefix();
+                    syn::parse_quote! { ::#prefix::mem::ManuallyDrop<#ty<FAM>> }
+                } else {
+                    syn::parse_quote! { #ty<FAM> }
+                }
+            } else {
+                ty
+            }
         } else {
             ty
         };


### PR DESCRIPTION
Add support for structs where the last field is itself a struct containing a flexible array member (FAM). For example:

    struct Name {
        int count;
        char name[];
    };

    struct Field {
        int id;
        struct Name name;  // Last field has a FAM
    };

The Name struct is generated with a generic FAM parameter:

    pub struct Name<FAM: ?Sized = [c_char; 0]> {
        pub count: c_int,
        pub name: FAM,
    }

And Field propagates this parameter to its nested field:

    pub struct Field<FAM: ?Sized = [c_char; 0]> {
        pub id: c_int,
        pub name: Name<FAM>,
    }

For packed structs, the nested FAM field is wrapped in ManuallyDrop since packed structs cannot directly contain DST fields:

    #[repr(C, packed)]
    pub struct FieldPacked<FAM: ?Sized = [c_char; 0]> {
        pub id: c_int,
        pub name: ::std::mem::ManuallyDrop<Name<FAM>>,
    }

Implementation:
- Enhanced flex_array_member() in ir/comp.rs to recursively detect when a struct's last field is a compound type with its own FAM
- Updated field code generation to parameterize nested FAM field types with <FAM> and wrap in ManuallyDrop for packed structs
- Added test cases for nested FAMs in both regular and packed structs

Related to #2936