### PR TITLE
ci: Move forward Rust for Linux version to v6.18-rc3

### DIFF
--- a/ci/test.sh
+++ b/ci/test.sh
@@ -96,7 +96,7 @@ if [ "$BINDGEN_RUST_FOR_LINUX_TEST" == "1" ]; then
   # and each update should only contain this change.
   #
   # Both commit hashes and tags are supported.
-  LINUX_VERSION=v6.17-rc2
+  LINUX_VERSION=v6.18-rc3
 
   # Download Linux at a specific commit
   mkdir -p linux


### PR DESCRIPTION
This upgrade is also needed now since Rust 1.91.0 got released, which blocks the CI [1] due to the change in the target spec format in upstream Rust [2]. Support for the new format was added in Linux v6.17-rc5 [3].

Link: https://github.com/rust-lang/rust-bindgen/pull/3307 [1]
Link: https://github.com/rust-lang/rust/pull/144443 [2]
Link: https://github.com/Rust-for-Linux/linux/commit/8851e27d2cb947ea8bbbe8e812068f7bf5cbd00b [3]