### PR TITLE
Fix broken intradoc link on `ParseCallbacks::header_file()`

### DIFF
--- a/bindgen/callbacks.rs
+++ b/bindgen/callbacks.rs
@@ -99,7 +99,7 @@ pub trait ParseCallbacks: fmt::Debug {
         None
     }
 
-    /// This will be called on every header filename passed to (`Builder::header`)[`crate::Builder::header`].
+    /// This will be called on every header filename passed to [`Builder::header`][crate::Builder::header].
     fn header_file(&self, _filename: &str) {}
 
     /// This will be called on every file inclusion, with the full path of the included file.


### PR DESCRIPTION
By having the `()[]` syntax the wrong way around, `rustdoc` seems to treat the leading ``(`link`)`` as text while picking up the ``[`link`]`` as an item via  ["Implied Shortcut Reference Links"](https://rust-lang.github.io/rfcs/1946-intra-rustdoc-links.html#implied-shortcut-reference-links).

<img width="841" height="79" alt="image" src="https://github.com/user-attachments/assets/dee8890a-1573-47df-b53b-ecc270b8bc83" />


Flip that to make the link render as expected again (and remove the unnecessary backticks in the link target).