### PR TITLE
Remove incorrect `size_t_is_usize` check

### DIFF
--- a/bindgen/codegen/mod.rs
+++ b/bindgen/codegen/mod.rs
@@ -993,13 +993,6 @@ impl CodeGenerator for Type {
                             layout.size,
                             ctx.target_pointer_size(),
                             );
-                        assert_eq!(
-                            layout.align,
-                            ctx.target_pointer_size(),
-                            "Target platform requires `--no-size_t-is-usize`. The alignment of `{spelling}` ({}) does not match the target pointer size ({})",
-                            layout.align,
-                            ctx.target_pointer_size(),
-                        );
                     }
                     return;
                 }


### PR DESCRIPTION
Don't require that the alignment of `size_t` equals pointer size when using the `size_t_is_usize` option. The purpose of this check was to make sure that `size_t` and `uintptr_t` are the same type, but the alignment and size don't have to match for that to be true. The code still checks that `size_t` has the same size as a pointer.

Clang's C API doesn't expose the target pointer alignment, so just remove the assert.

Fixes https://github.com/rust-lang/rust-bindgen/issues/3312