### PR TITLE
feat(dyngen): preconvert path to `OsStr` when opening the library

### DIFF
--- a/bindgen-tests/tests/expectations/tests/dynamic_loading_attributes.rs
+++ b/bindgen-tests/tests/expectations/tests/dynamic_loading_attributes.rs
@@ -12,6 +12,7 @@ impl TestLib {
     where
         P: AsRef<::std::ffi::OsStr>,
     {
+        let path = path.as_ref();
         let library = ::libloading::Library::new(path)?;
         Self::from_library(library)
     }

--- a/bindgen-tests/tests/expectations/tests/dynamic_loading_required.rs
+++ b/bindgen-tests/tests/expectations/tests/dynamic_loading_required.rs
@@ -15,6 +15,7 @@ impl TestLib {
     where
         P: AsRef<::std::ffi::OsStr>,
     {
+        let path = path.as_ref();
         let library = ::libloading::Library::new(path)?;
         Self::from_library(library)
     }

--- a/bindgen-tests/tests/expectations/tests/dynamic_loading_simple.rs
+++ b/bindgen-tests/tests/expectations/tests/dynamic_loading_simple.rs
@@ -22,6 +22,7 @@ impl TestLib {
     where
         P: AsRef<::std::ffi::OsStr>,
     {
+        let path = path.as_ref();
         let library = ::libloading::Library::new(path)?;
         Self::from_library(library)
     }

--- a/bindgen-tests/tests/expectations/tests/dynamic_loading_template.rs
+++ b/bindgen-tests/tests/expectations/tests/dynamic_loading_template.rs
@@ -12,6 +12,7 @@ impl TestLib {
     where
         P: AsRef<::std::ffi::OsStr>,
     {
+        let path = path.as_ref();
         let library = ::libloading::Library::new(path)?;
         Self::from_library(library)
     }

--- a/bindgen-tests/tests/expectations/tests/dynamic_loading_variable_required.rs
+++ b/bindgen-tests/tests/expectations/tests/dynamic_loading_variable_required.rs
@@ -9,6 +9,7 @@ impl TestLib {
     where
         P: AsRef<::std::ffi::OsStr>,
     {
+        let path = path.as_ref();
         let library = ::libloading::Library::new(path)?;
         Self::from_library(library)
     }

--- a/bindgen-tests/tests/expectations/tests/dynamic_loading_variable_simple.rs
+++ b/bindgen-tests/tests/expectations/tests/dynamic_loading_variable_simple.rs
@@ -9,6 +9,7 @@ impl TestLib {
     where
         P: AsRef<::std::ffi::OsStr>,
     {
+        let path = path.as_ref();
         let library = ::libloading::Library::new(path)?;
         Self::from_library(library)
     }

--- a/bindgen-tests/tests/expectations/tests/dynamic_loading_variable_with_allowlist.rs
+++ b/bindgen-tests/tests/expectations/tests/dynamic_loading_variable_with_allowlist.rs
@@ -9,6 +9,7 @@ impl TestLib {
     where
         P: AsRef<::std::ffi::OsStr>,
     {
+        let path = path.as_ref();
         let library = ::libloading::Library::new(path)?;
         Self::from_library(library)
     }

--- a/bindgen-tests/tests/expectations/tests/dynamic_loading_with_allowlist.rs
+++ b/bindgen-tests/tests/expectations/tests/dynamic_loading_with_allowlist.rs
@@ -19,6 +19,7 @@ impl TestLib {
     where
         P: AsRef<::std::ffi::OsStr>,
     {
+        let path = path.as_ref();
         let library = ::libloading::Library::new(path)?;
         Self::from_library(library)
     }

--- a/bindgen-tests/tests/expectations/tests/dynamic_loading_with_blocklist.rs
+++ b/bindgen-tests/tests/expectations/tests/dynamic_loading_with_blocklist.rs
@@ -54,6 +54,7 @@ impl TestLib {
     where
         P: AsRef<::std::ffi::OsStr>,
     {
+        let path = path.as_ref();
         let library = ::libloading::Library::new(path)?;
         Self::from_library(library)
     }

--- a/bindgen-tests/tests/expectations/tests/dynamic_loading_with_class.rs
+++ b/bindgen-tests/tests/expectations/tests/dynamic_loading_with_class.rs
@@ -51,6 +51,7 @@ impl TestLib {
     where
         P: AsRef<::std::ffi::OsStr>,
     {
+        let path = path.as_ref();
         let library = ::libloading::Library::new(path)?;
         Self::from_library(library)
     }

--- a/bindgen-tests/tests/expectations/tests/wrap_unsafe_ops_dynamic_loading_simple.rs
+++ b/bindgen-tests/tests/expectations/tests/wrap_unsafe_ops_dynamic_loading_simple.rs
@@ -23,6 +23,7 @@ impl TestLib {
     where
         P: AsRef<::std::ffi::OsStr>,
     {
+        let path = path.as_ref();
         let library = unsafe { ::libloading::Library::new(path) }?;
         unsafe { Self::from_library(library) }
     }

--- a/bindgen/codegen/dyngen.rs
+++ b/bindgen/codegen/dyngen.rs
@@ -106,6 +106,7 @@ impl DynamicItems {
                     path: P
                 ) -> Result<Self, ::libloading::Error>
                 where P: AsRef<::std::ffi::OsStr> {
+                    let path = path.as_ref();
                     let library = #library_new?;
                     #from_library
                 }


### PR DESCRIPTION
In libloading 0.9 the argument bound changed from `AsRef<OsStr>` to `libloading::AsFilename`. This was necessary in order to enable compilation of libloading for usecases that cannot depend on libstd. `libloading::AsFilename` supports most of the same types, but cannot be implemented generally for any `T: AsRef<OsStr>` due to the orphan rule.

This makes the generated code support both 0.8 and 0.9 versions of libloading transparently, and at the same time it also reduces the number of different instantiations of `Library::new`.

When bindgen is adjusted to work with libloading 0.9 only, it will be worthwhile to adjust the generation of `from_library` to use `c"string"` literals over `b"string\0"` ones as those can forgo any runtime checking of the argument(s). However we can't do it right while libloading 0.8 is still supported.