### PR TITLE
Don't require a `Box` wrapper on `Bindings::write()`

### DIFF
--- a/bindgen-cli/main.rs
+++ b/bindgen-cli/main.rs
@@ -29,7 +29,7 @@ pub fn main() {
     env_logger::init();
 
     match builder_from_flags(env::args()) {
-        Ok((builder, output, verbose)) => {
+        Ok((builder, mut output, verbose)) => {
             #[cfg(feature = "logging")]
             clang_version_check();
 
@@ -50,7 +50,7 @@ pub fn main() {
 
             let _ = std::panic::take_hook();
 
-            bindings.write(output).expect("Unable to write output");
+            bindings.write(&mut output).expect("Unable to write output");
         }
         Err(error) => {
             eprintln!("{error}");

--- a/bindgen-tests/tests/parse_callbacks/add_derives_callback/mod.rs
+++ b/bindgen-tests/tests/parse_callbacks/add_derives_callback/mod.rs
@@ -19,25 +19,11 @@ mod tests {
         }
     }
 
-    struct WriteAdapter<'a>(&'a mut Vec<u8>);
-
-    impl std::io::Write for WriteAdapter<'_> {
-        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-            self.0.extend_from_slice(buf);
-            Ok(buf.len())
-        }
-        fn flush(&mut self) -> std::io::Result<()> {
-            Ok(())
-        }
-    }
-
     fn write_bindings_to_string(bindings: &Bindings) -> String {
         let mut output = Vec::<u8>::new();
-        bindings
-            .write(Box::new(WriteAdapter(&mut output)))
-            .unwrap_or_else(|e| {
-                panic!("Failed to write generated bindings: {e}")
-            });
+        bindings.write(&mut output).unwrap_or_else(|e| {
+            panic!("Failed to write generated bindings: {e}")
+        });
         String::from_utf8(output).unwrap_or_else(|e| {
             panic!("Failed to convert generated bindings to string: {e}")
         })

--- a/bindgen/lib.rs
+++ b/bindgen/lib.rs
@@ -927,17 +927,17 @@ impl Bindings {
 
     /// Write these bindings as source text to a file.
     pub fn write_to_file<P: AsRef<Path>>(&self, path: P) -> io::Result<()> {
-        let file = OpenOptions::new()
+        let mut file = OpenOptions::new()
             .write(true)
             .truncate(true)
             .create(true)
             .open(path.as_ref())?;
-        self.write(Box::new(file))?;
+        self.write(&mut file)?;
         Ok(())
     }
 
     /// Write these bindings as source text to the given `Write`able.
-    pub fn write<'a>(&self, mut writer: Box<dyn Write + 'a>) -> io::Result<()> {
+    pub fn write(&self, writer: &mut dyn Write) -> io::Result<()> {
         const NL: &str = if cfg!(windows) { "\r\n" } else { "\n" };
 
         if !self.options.disable_header_comment {
@@ -1090,7 +1090,7 @@ fn rustfmt_non_fatal_error_diagnostic(msg: &str, _options: &BindgenOptions) {
 impl std::fmt::Display for Bindings {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut bytes = vec![];
-        self.write(Box::new(&mut bytes) as Box<dyn Write>)
+        self.write(&mut bytes)
             .expect("writing to a vec cannot fail");
         f.write_str(
             std::str::from_utf8(&bytes)


### PR DESCRIPTION
The function in question doesn't store the `dyn Write` trait object anywhere, allowing us to pass a plain `&mut dyn Write` (which is also implemented for `&mut Box<dyn Write>` allowing the existing CLI parser to operate normally).

This in turn no longer requires users of `bindgen` to wrap their `&mut File` or `&mut Vec<u8>` in a moved `Box` just to be able to give temporary mutable access to the `write() function`.
