### PR TITLE
fix : make sure at least one header was provided

### DIFF
--- a/bindgen-tests/tests/tests.rs
+++ b/bindgen-tests/tests/tests.rs
@@ -564,6 +564,12 @@ fn test_mixed_header_and_header_contents() {
 }
 
 #[test]
+#[should_panic(expected = "No headers provided")]
+fn test_no_header_provided() {
+    let _ = builder().generate();
+}
+
+#[test]
 fn test_macro_fallback_non_system_dir() {
     let actual = builder()
         .header(concat!(

--- a/bindgen/lib.rs
+++ b/bindgen/lib.rs
@@ -336,6 +336,11 @@ impl Builder {
                 .map(String::into_boxed_str),
         );
 
+        assert!(
+            !self.options.input_headers.is_empty() ||
+                !self.options.input_header_contents.is_empty(),
+            "No headers provided"
+        );
         for header in &self.options.input_headers {
             self.options
                 .for_each_callback(|cb| cb.header_file(header.as_ref()));


### PR DESCRIPTION
This PR fixes  #3320 : 

- Makes sure at least one header is provided : file or content
- Add a test case

A better approach would be to qualify this case as `BindgenError` and return it, instead of asserting. 
let me know if this need to be done.