### PR TITLE
Precise macro value type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,21 @@ csmith-fuzzing/platform.info
 node_modules
 package-lock.json
 package.json
+
+# Common IDE settings and temporary files
+*.swp
+*.swo
+Session.vim
+.cproject
+.idea
+*.iml
+.vscode
+.project
+.vim/
+.helix/
+.zed/
+.favorites.json
+.settings/
+.vs/
+.dir-locals.el
+

--- a/bindgen-tests/tests/expectations/tests/issue-753.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-753.rs
@@ -1,4 +1,4 @@
 #![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
-pub const CONST: u32 = 5;
-pub const OTHER_CONST: u32 = 6;
-pub const LARGE_CONST: u32 = 1536;
+pub const CONST: ::std::os::raw::c_uint = 5;
+pub const OTHER_CONST: ::std::os::raw::c_uint = 6;
+pub const LARGE_CONST: ::std::os::raw::c_uint = 1536;

--- a/bindgen-tests/tests/expectations/tests/issue-923.rs
+++ b/bindgen-tests/tests/expectations/tests/issue-923.rs
@@ -1,0 +1,7 @@
+#![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]
+pub const ULONG_ZERO: ::std::os::raw::c_ulong = 0;
+pub const ULONGLONG_ZERO: ::std::os::raw::c_ulonglong = 0;
+pub const CHAR_ZERO: ::std::os::raw::c_char = 0;
+pub const FLOAT_LIT: f32 = 0.0;
+pub const DOUBLE_LIT: f64 = 0.0;
+pub const UINT_LIT: ::std::os::raw::c_uint = 2147483648;

--- a/bindgen-tests/tests/expectations/tests/libclang-9/issue-923.rs
+++ b/bindgen-tests/tests/expectations/tests/libclang-9/issue-923.rs
@@ -1,0 +1,1 @@
+#![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]

--- a/bindgen-tests/tests/expectations/tests/test_macro_fallback_non_system_dir.rs
+++ b/bindgen-tests/tests/expectations/tests/test_macro_fallback_non_system_dir.rs
@@ -1,6 +1,6 @@
-pub const CONST: u32 = 5;
-pub const OTHER_CONST: u32 = 6;
-pub const LARGE_CONST: u32 = 1536;
-pub const THE_CONST: u32 = 28;
-pub const MY_CONST: u32 = 69;
+pub const CONST: ::std::os::raw::c_uint = 5;
+pub const OTHER_CONST: ::std::os::raw::c_uint = 6;
+pub const LARGE_CONST: ::std::os::raw::c_uint = 1536;
+pub const THE_CONST: ::std::os::raw::c_uint = 28;
+pub const MY_CONST: ::std::os::raw::c_uint = 69;
 pub const NEGATIVE: i32 = -1;

--- a/bindgen-tests/tests/headers/issue-753.h
+++ b/bindgen-tests/tests/headers/issue-753.h
@@ -7,6 +7,6 @@
 
 #define CONST UINT32_C(5)
 #define OTHER_CONST UINT32_C(6)
-#define LARGE_CONST UINT32_C(6 << 8)
+#define LARGE_CONST (UINT32_C(6) << 8)
 
 #endif

--- a/bindgen-tests/tests/headers/issue-923.h
+++ b/bindgen-tests/tests/headers/issue-923.h
@@ -1,0 +1,13 @@
+// bindgen-flags: --macro-const-use-ctypes
+
+#ifndef ISSUE_923_H
+#define ISSUE_923_H
+
+#define ULONG_ZERO 0UL
+#define ULONGLONG_ZERO 0ULL
+#define CHAR_ZERO ((char)'\0')
+#define FLOAT_LIT 0.f
+#define DOUBLE_LIT ((double)0.f)
+#define UINT_LIT 0x80000000
+
+#endif

--- a/bindgen-tests/tests/tests.rs
+++ b/bindgen-tests/tests/tests.rs
@@ -269,6 +269,16 @@ fn create_bindgen_builder(header: &Path) -> Result<BuilderState, Error> {
 
     let source = fs::File::open(header)?;
     let reader = BufReader::new(source);
+    let basename = header.file_name().unwrap();
+    let per_test_folder = format!(
+        "./{}",
+        basename
+            .to_str()
+            .unwrap()
+            .replace('_', "__")
+            .replace('.', "_")
+    );
+    fs::create_dir_all(&per_test_folder)?;
 
     // Scoop up bindgen-flags from test header
     let mut flags = Vec::with_capacity(2);
@@ -334,6 +344,8 @@ fn create_bindgen_builder(header: &Path) -> Result<BuilderState, Error> {
         "#![allow(dead_code, non_snake_case, non_camel_case_types, non_upper_case_globals)]",
         "--raw-line",
         "",
+        "--clang-macro-fallback-build-dir",
+        &per_test_folder,
     ];
 
     let args = prepend.iter().map(ToString::to_string).chain(flags);

--- a/bindgen/ir/context.rs
+++ b/bindgen/ir/context.rs
@@ -353,7 +353,7 @@ pub(crate) struct BindgenContext {
     /// hard errors while parsing duplicated macros, as well to allow macro
     /// expression parsing.
     ///
-    /// This needs to be an `std::HashMap` because the `cexpr` API requires it.
+    /// This needs to be an `std::HashMap` because the [`cexpr`] API requires it.
     parsed_macros: StdHashMap<Vec<u8>, cexpr::expr::EvalResult>,
 
     /// A map with all include locations.
@@ -2131,6 +2131,7 @@ If you encounter an error missing from this list, please file an issue or a PR!"
     }
 
     /// Get the currently parsed macros.
+    /// This map only contains macros accepted by [`cexpr`]
     pub(crate) fn parsed_macros(
         &self,
     ) -> &StdHashMap<Vec<u8>, cexpr::expr::EvalResult> {

--- a/bindgen/options/cli.rs
+++ b/bindgen/options/cli.rs
@@ -505,6 +505,10 @@ struct BindgenCommand {
     /// Use DSTs to represent structures with flexible array members.
     #[arg(long)]
     flexarray_dst: bool,
+    /// Resolve the true type of macro definition as constant and use
+    /// corresponding C types.
+    #[arg(long)]
+    macro_const_use_ctypes: bool,
     /// Derive custom traits on any kind of type. The CUSTOM value must be of the shape REGEX=DERIVE where DERIVE is a comma-separated list of derive macros.
     #[arg(long, value_name = "CUSTOM", value_parser = parse_custom_derive)]
     with_derive_custom: Vec<(Vec<String>, String)>,
@@ -697,6 +701,7 @@ where
         clang_macro_fallback,
         clang_macro_fallback_build_dir,
         flexarray_dst,
+        macro_const_use_ctypes,
         with_derive_custom,
         with_derive_custom_struct,
         with_derive_custom_enum,
@@ -1003,6 +1008,7 @@ where
             clang_macro_fallback => |b, _| b.clang_macro_fallback(),
             clang_macro_fallback_build_dir,
             flexarray_dst,
+            macro_const_use_ctypes => |b, _| b.macro_const_use_ctypes(),
             wrap_static_fns,
             wrap_static_fns_path,
             wrap_static_fns_suffix,

--- a/bindgen/options/mod.rs
+++ b/bindgen/options/mod.rs
@@ -1109,6 +1109,21 @@ options! {
         },
         as_args: "--ctypes-prefix",
     },
+    /// Use C platform-specific types for generated macro constants.
+    macro_const_use_ctypes: bool {
+        methods: {
+            /// Use C platform-specific types for generated macro constants.
+            ///
+            /// This implies `clang_macro_fallback` and takes precedence over
+            /// `default_macro_constant_type`.
+            pub fn macro_const_use_ctypes(mut self) -> Builder {
+                self.options.macro_const_use_ctypes = true;
+                self.options.clang_macro_fallback = true;
+                self
+            }
+        },
+        as_args: "--macro-const-use-ctypes",
+    }
     /// The prefix for anonymous fields.
     anon_fields_prefix: String {
         default: DEFAULT_ANON_FIELDS_PREFIX.into(),


### PR DESCRIPTION
Fix #923.
Fix #3200. This is due to a fallout from how `libclang` type would be processed with this patch.

This patch introduce a new generator flag `--macro-const-use-ctypes`, which resolves the macro definition expression to a precise type advised by Clang if activated.

A macro expansion result adapter is introduced to maintain compatibility with `cexpr`, which has a limited capacity to resolve to a precise C type.

There is a change to the testing code because up to this point our tests, which can be executed concurrently, use the same path to the precomputed headers. Since this patch introduces a second test that relies on `libclang` macro fallback, the precompiled headers from the two different tests would overwrite each other. The new addition is that the backing files are now temporarily stored at different directories named after the header files under tests.