### PR TITLE
Change `Bindings::write()` to take `impl Write` instead of `&mut dyn Write`

### DIFF
--- a/bindgen-tests/tests/parse_callbacks/add_derives_callback/mod.rs
+++ b/bindgen-tests/tests/parse_callbacks/add_derives_callback/mod.rs
@@ -20,7 +20,7 @@ mod tests {
     }
 
     fn write_bindings_to_string(bindings: &Bindings) -> String {
-        let mut output = Vec::<u8>::new();
+        let mut output = vec![];
         bindings.write(&mut output).unwrap_or_else(|e| {
             panic!("Failed to write generated bindings: {e}")
         });

--- a/bindgen/lib.rs
+++ b/bindgen/lib.rs
@@ -927,17 +927,17 @@ impl Bindings {
 
     /// Write these bindings as source text to a file.
     pub fn write_to_file<P: AsRef<Path>>(&self, path: P) -> io::Result<()> {
-        let mut file = OpenOptions::new()
+        let file = OpenOptions::new()
             .write(true)
             .truncate(true)
             .create(true)
             .open(path.as_ref())?;
-        self.write(&mut file)?;
+        self.write(file)?;
         Ok(())
     }
 
     /// Write these bindings as source text to the given `Write`able.
-    pub fn write(&self, writer: &mut dyn Write) -> io::Result<()> {
+    pub fn write(&self, mut writer: impl Write) -> io::Result<()> {
         const NL: &str = if cfg!(windows) { "\r\n" } else { "\n" };
 
         if !self.options.disable_header_comment {


### PR DESCRIPTION
Noticed immediately after #3317 was merged:

Dynamic dispatch is not (always) needed here, and this way an owned `File` can trivially be moved into the function again like before without forcing a mutable borrow.  Noting that `Write` is even implemented on `&File`, which can now be more easily passed without having it under `mut`.
